### PR TITLE
test(uipath-maestro-flow): convert IxP activation tasks to thresholded integration tests

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation.yaml
@@ -12,7 +12,7 @@ description: >
   Failure here is signal about SKILL.md or the IxP Plugin Index entry —
   do NOT relax assertions; feed findings back in.
 
-tags: [uipath-maestro-flow, smoke, activation, ixp]
+tags: [uipath-maestro-flow, integration, activation, ixp]
 dataset:
   rows:
     - id: explicit
@@ -27,6 +27,22 @@ dataset:
         date, total amount, and line items out of PDF invoices saved in a
         SharePoint folder, then posts the result to our accounting system.
 
+    - id: receipts
+      prompt: >-
+        Add a document-extraction step to my flow that reads receipt images
+        from a folder and pulls out merchant, date, and total.
+
+    - id: contracts
+      prompt: >-
+        Build a flow that extracts party names, effective date, and the
+        termination clause from PDF contracts, then routes them to an approval
+        step.
+
+    - id: forms-classify
+      prompt: >-
+        I have a Maestro flow. Add an IxP node that classifies incoming PDF
+        forms and extracts their fields before the next step.
+
 initial_prompt: |
   ${row.prompt}
 
@@ -40,20 +56,12 @@ initial_prompt: |
   - Exploration + an attempted node-add is enough — you do not need to build a working flow.
 
 success_criteria:
-  - type: skill_triggered
-    skill_name: "uipath-maestro-flow"
-    expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
     min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.70}
 
   # Greps the actual .flow artifact rather than the command stream — the
   # command_executed checker truncates tool params at 2000 chars, which hides
@@ -64,8 +72,7 @@ success_criteria:
     description: "Agent added an IxP or core.logic.mock placeholder node to a .flow file (per references/plugins/ixp/impl.md)"
     command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
     expected_exit_code: 0
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.70}
 
 run_limits:
   max_turns: 40

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_listing.yaml
@@ -3,22 +3,39 @@ description: >
   IxP listing activation — user asks what IxP models / runtime projects are
   available from a Maestro flow. Read-only Q&A, not a build task.
 
-  Asserts the agent invoked the uipath-maestro-flow Skill and ran the IxP
-  registry-search listing command (per references/plugins/ixp/impl.md —
-  Listing Published Models). Also asserts the agent did NOT take the build
-  path: no .flow file should be created for a listing question.
+  Asserts the agent ran the IxP registry-search listing command (per
+  references/plugins/ixp/impl.md — Listing Published Models). Also asserts the
+  agent did NOT take the build path: no .flow file should be created for a
+  listing question.
 
   Failure here is signal about the IxP plugin's Listing Published Models /
   Listing Available Models sections — do NOT relax assertions, tighten the
   copy.
 
-tags: [uipath-maestro-flow, smoke, activation, ixp, listing]
+tags: [uipath-maestro-flow, integration, activation, ixp, listing]
 
 dataset:
   rows:
-    - id: ixp-models
-      prompt: >-
-        What IxP models can I access in maestro?
+    - id: r01
+      prompt: "What IxP models can I access in maestro?"
+    - id: r02
+      prompt: "What document extractors can I add to this flow?"
+    - id: r03
+      prompt: "List the published IxP extractors available to my .flow"
+    - id: r04
+      prompt: "Which IxP runtime projects can I wire into a Maestro flow node?"
+    - id: r05
+      prompt: "What extraction models are available to my Maestro flow?"
+    - id: r06
+      prompt: "Show me the IxP document-understanding models I can use in maestro"
+    - id: r07
+      prompt: "Which document-extraction models can this flow call?"
+    - id: r08
+      prompt: "What are my options for IxP nodes in a Maestro flow?"
+    - id: r09
+      prompt: "Can you list the IxP models I can add to my flow?"
+    - id: r10
+      prompt: "What published IxP extractors can a flow node reference?"
 
 initial_prompt: |
   ${row.prompt}
@@ -28,20 +45,12 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
 
 success_criteria:
-  - type: skill_triggered
-    skill_name: "uipath-maestro-flow"
-    expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: command_executed
     description: "Agent searched the registry for IxP node types (listing path)"
     tool_name: "Bash"
     command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list)\b[^\n]*ixp'
     min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.70}
 
   # Inverted check: a listing/Q&A task should NOT create a .flow file.
   # `! find ... | grep -q .` exits 0 when no .flow file is found (PASS)
@@ -50,8 +59,7 @@ success_criteria:
     description: "No .flow file was created (listing is read-only Q&A, not a build task)"
     command: '! find . -name "*.flow" -type f | grep -q .'
     expected_exit_code: 0
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.90}
 
 run_limits:
   max_turns: 20

--- a/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/activation_negative.yaml
@@ -14,7 +14,7 @@ description: >
   Failure here means activation copy is too broad — tighten the trigger
   signals, do NOT relax assertions.
 
-tags: [uipath-maestro-flow, smoke, activation, ixp, negative]
+tags: [uipath-maestro-flow, integration, activation, ixp, negative]
 
 dataset:
   rows:
@@ -23,6 +23,34 @@ dataset:
       prompt: >-
         Create a flow with a manual trigger and an HTTP node that calls
         api.stripe.com, then a script node that logs the response.
+    - id: slack-summary
+      prompt: >-
+        Create a flow with a scheduled trigger that posts a daily summary
+        message to Slack.
+    - id: sf-update
+      prompt: >-
+        Build a flow that reads open Salesforce opportunities and updates the
+        stage field on each one.
+    - id: http-webhook
+      prompt: >-
+        Create a flow with an HTTP trigger that validates a JSON payload in a
+        script node and returns a status code.
+    - id: gsheet-loop
+      prompt: >-
+        Build a flow that loops over rows in a Google Sheet and sends each row
+        to an HTTP endpoint.
+    - id: queue-write
+      prompt: >-
+        Create a flow with a manual trigger that writes a record to an
+        Orchestrator queue.
+    - id: teams-decision
+      prompt: >-
+        Build a flow that branches on an input variable and notifies Teams in
+        the matching branch.
+    - id: delay-email
+      prompt: >-
+        Create a flow with a timer trigger that waits 10 minutes, then sends an
+        Outlook email.
 
 initial_prompt: |
   ${row.prompt}
@@ -37,13 +65,6 @@ initial_prompt: |
   - Exploration + an attempted node-add is enough — you do not need to build a working flow.
 
 success_criteria:
-  - type: skill_triggered
-    skill_name: "uipath-maestro-flow"
-    expected_skill: "uipath-maestro-flow"
-    description: "Parent uipath-maestro-flow Skill fired (IxP-only routing is what this suite tests)"
-    weight: 1.0
-    pass_threshold: 1.0
-
   # Inverted twin of the positive activation.yaml grep.
   # `shell=True` in coder_eval Sandbox.run_command means `!` works as a bash
   # negator: grep -q exits 0 on match → ! flips to 1 (FAIL); exits 1 on
@@ -52,8 +73,7 @@ success_criteria:
     description: "No uipath.ixp.* node landed in any .flow file (negative IxP routing)"
     command: '! grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"uipath\.ixp" --include="*.flow" .'
     expected_exit_code: 0
-    weight: 3.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.90}
 
 run_limits:
   max_turns: 25


### PR DESCRIPTION
## Why

The IxP activation smoke tasks gated a **probabilistic** decision (skill routing / agent behavior) on **one or two must-pass rows**. A single probabilistic miss red-lined the smoke gate on unrelated PRs.

Skill activation and read-only behavior are not deterministic per-prompt, so a single-row binary gate in a hard, blocking smoke run is the wrong shape. This PR makes two changes:

1. **Demote `smoke` → `integration`** so these no longer block the smoke gate.
2. **Convert to the activation-eval pattern** — many phrasings, gated on an aggregate pass-rate where individual misses are tolerated but a real regression moves the mean below threshold.

## What changed

Multi-row + `suite_thresholds.mean` format, replacing per-row `weight`/`pass_threshold` gating. Drop the `skill_triggered` criterion — cold routing is owned by the cross-skill activation eval, and the behavioral criteria (registry search, node landed / not landed) already imply activation.

| Task | Rows | Criteria (thresholded) |
|------|------|------------------------|
| `activation_listing.yaml` | 1 → 10 listing phrasings | registry-search `mean ≥ 0.70`, no-build `mean ≥ 0.90` |
| `activation.yaml` | 2 → 5 build-intent rows | registry-search `mean ≥ 0.70`, node-landed `mean ≥ 0.70` |
| `activation_negative.yaml` | 1 → 8 no-document flows | no IxP node landed `mean ≥ 0.90` |

The diff is scoped to the test format: tier tag, rows, `suite_thresholds`, and dropping `skill_triggered`. The only prose change is one description clause in `activation_listing.yaml` that became inaccurate once `skill_triggered` was removed. `run_limits` are unchanged.

## Validation

Run locally on `claude-sonnet-4-6` (no LLM judge — pure `command_executed`/`run_command` checks):

| Task | Gate | Means |
|------|------|-------|
| `activation_listing` | **PASS** (80%) | registry-search 0.80, no-build 1.00 |
| `activation_negative` | **PASS** (100%) | no-IxP-node 1.00 |
| `activation` | **PASS** (100%) | registry-search 1.00, node-landed 1.00 |

The listing run is the clearest demonstration: 8/10 phrasings ran `registry search`, 2 answered from the loaded skill without it (neither took the wrong `uip ixp projects` path) — exactly the probabilistic variance the `mean ≥ 0.70` gate is designed to absorb, and which a single-row gate would have flaked on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)