### PR TITLE
fix(uipath-admin): make admin e2e/smoke tests idempotent

### DIFF
--- a/tests/tasks/uipath-admin/check_smtp_settings.py
+++ b/tests/tasks/uipath-admin/check_smtp_settings.py
@@ -14,12 +14,13 @@ logging.basicConfig(level=logging.INFO, format="check_smtp: %(message)s")
 def main():
     data = run_cli(["admin", "smtp", "get"])
     if not data or data.get("Result") != "Success":
-        fail("smtp get did not return Success")
+        fail(f"smtp get did not return Success — raw: {data}")
 
     smtp_data = data.get("Data", {})
-    host = smtp_data.get("host") or ""
+    # CLI returns PascalCase keys (Host, Port, EnableSsl, etc.)
+    host = smtp_data.get("Host") or smtp_data.get("host") or ""
     if not host:
-        fail("SMTP host is empty — settings not configured")
+        fail(f"SMTP host is empty — settings not configured. Data keys: {list(smtp_data.keys())}")
 
     ok(f"SMTP configured with host={host}")
 

--- a/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
+++ b/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
@@ -15,6 +15,9 @@ initial_prompt: |
   Folders scope, then set up GitHub Actions OIDC federation for
   repo myorg/myrepo on the main branch.
 
+  If an external app with this name already exists, delete it first,
+  then create the new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -15,6 +15,9 @@ initial_prompt: |
   Set up a new "Invoice Processing Team" group containing the first
   two users in the org, verify membership, then remove the second user.
 
+  If a group with this name already exists, delete it first,
+  then create the new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
@@ -14,6 +14,8 @@ initial_prompt: |
   Onboard john.doe@example.com (John Doe) and add them to the
   "Automation Developer" group once provisioned.
 
+  If this user already exists, remove them first, then re-invite.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/identity_federated_credentials_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_federated_credentials_smoke.yaml
@@ -14,6 +14,9 @@ initial_prompt: |
   app (client ID: ci-pipeline-app) so GitHub Actions in repo
   myorg/myrepo (main branch) can authenticate without a client secret.
 
+  If a federated credential already exists on this app, delete it first,
+  then create a new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
@@ -14,6 +14,9 @@ initial_prompt: |
   read access to Folders, expiring 90 days from now. Then list my tokens
   to confirm it was created.
 
+  If a token with this description already exists, revoke it first,
+  then create the new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
@@ -14,6 +14,9 @@ initial_prompt: |
   Onboard an unattended invoice-processing robot ("smoke-e2e-bot" /
   "Smoke E2E Bot") and add it to the "Automation Users" group.
 
+  If a robot account with this name already exists, delete it first,
+  then create the new one.
+
   Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:


### PR DESCRIPTION
## Summary
- **6 tests** failed because the agent found pre-existing resources (left over from prior runs where cleanup failed) and skipped the `create` commands, failing `command_executed` criteria. Added "delete first if exists" instructions to all resource-creating test prompts: federated credentials e2e + smoke, group membership e2e, human onboarding e2e, robot onboarding e2e, PAT lifecycle e2e.
- **SMTP configure e2e** failed because `check_smtp_settings.py` looked for lowercase `"host"` but the CLI returns PascalCase `"Host"`. Fixed key lookup to handle both casings. Also improved error diagnostics.

## Root cause
Same class of bug as #1086 (robot account smoke idempotency). Agents are smart enough to discover existing resources and skip creation — which is helpful in production but breaks tests that grade on `command_executed` criteria.

## Test plan
- [ ] Re-run all 7 failing admin tasks from the 2026-06-04 evalboard run
- [ ] Verify `skill-admin-smtp-configure-e2e` check script finds `Host` (PascalCase)
- [ ] Verify idempotent prompts cause agents to delete-then-recreate even when resources exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)