### PR TITLE
docs(uipath-troubleshoot): test scenarios are faithful-replay, not regression tests at creation

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -1,6 +1,6 @@
 # tests/tasks/uipath-troubleshoot — Test Scenario Generator
 
-This directory contains regression tests for the `uipath-troubleshoot` skill. Each scenario replays a real troubleshooting investigation against a `uip` CLI mock so the agent's reasoning is exercised without hitting a real UiPath tenant.
+This directory contains faithful-replay test scenarios for the `uipath-troubleshoot` skill. Each scenario replays a real troubleshooting investigation against a `uip` CLI mock so the agent's reasoning is exercised without hitting a real UiPath tenant. A scenario for a new failure class is new acceptance coverage when first added; once committed and green it serves as a regression guard against future skill/playbook changes.
 
 This file tells you (Claude or a contributor) how to **add a new scenario** from a real session you just resolved.
 
@@ -8,7 +8,7 @@ This file tells you (Claude or a contributor) how to **add a new scenario** from
 
 Trigger:
 
-- You ran the `uipath-troubleshoot` skill against a real failing job, reached a verified resolution, and want to lock the case in as a regression test.
+- You ran the `uipath-troubleshoot` skill against a real failing job, reached a verified resolution, and want to lock the case in as a faithful-replay scenario (a regression guard going forward).
 - A user reports a new failure class not yet covered by an existing scenario.
 
 Skip:


### PR DESCRIPTION
## What

Corrects terminology in `tests/tasks/uipath-troubleshoot/CLAUDE.md`. These are **faithful-replay test scenarios**, not "regression tests" by definition: a scenario for a new failure class is new acceptance coverage when first added, and only serves as a regression guard once committed and green. Two lines changed (intro paragraph + the matching trigger bullet).
