### PR TITLE
fix(uipath-rpa): relax retry-scope eval criteria + cover RetryScope in scope-body table

### DIFF
--- a/skills/uipath-rpa/references/legacy/common-pitfalls.md
+++ b/skills/uipath-rpa/references/legacy/common-pitfalls.md
@@ -37,7 +37,7 @@ These classic activities **must** be placed inside a specific parent scope:
 
 ## Scope Activities Require ActivityAction Body (CRITICAL for XAML Generation)
 
-Scope activities (Excel Application Scope, ExcelProcessScopeX, ExcelApplicationCard, Word Application Scope, etc.) do **NOT** accept direct children. They require an `ActivityAction<T>` body wrapper with a `DelegateInArgument`. Placing activities directly inside the scope element will fail validation.
+Scope activities (Excel Application Scope, ExcelProcessScopeX, ExcelApplicationCard, Word Application Scope, etc.) do **NOT** accept direct children. They require an `ActivityAction<T>` body wrapper with a `DelegateInArgument`. `RetryScope` follows the same wrap-the-body rule but uses a bare `ActivityAction` (no `x:TypeArguments`, no `DelegateInArgument`) — see the per-activity table below. Placing activities directly inside the scope element will fail validation.
 
 **Wrong — direct children (fails validation):**
 ```xml
@@ -75,6 +75,7 @@ Scope activities (Excel Application Scope, ExcelProcessScopeX, ExcelApplicationC
 | `PowerPointApplicationScope` | (PowerPoint handle type) | `PowerPointApplication` | PowerPoint COM scope |
 | `TryCatch` | (special — `Catches` collection) | — | Not ActivityAction, but has nested body structure |
 | `Parallel` | (multiple `Branches`) | — | Each branch is a separate Sequence |
+| `RetryScope` | _(none — bare `<ActivityAction>`)_ | — | Body property is `.ActivityBody` (not `.Body`); `ActivityAction` takes no type argument or `DelegateInArgument` |
 
 **`find-activities` now returns `Body` info** when an activity requires an `ActivityAction<T>` body — check the output before writing XAML for scope activities.
 

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -180,22 +180,39 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # Edit shape: Retry Scope correctly wraps the Excel read
-  - type: run_command
+  # Edit shape: Retry Scope correctly wraps the Excel read.
+  # Accept any prefix (ui:, uca:, excel:, uea:, ueab:, none) on <RetryScope>
+  # and any of the canonical Excel read activity classes — Interop
+  # (ExcelApplicationScope / ExcelReadRange), Portable
+  # (UiPath.Excel.Activities.ReadRange), or Modern StudioX
+  # (ExcelApplicationCard / ReadRangeX) — also with any prefix.
+  - type: file_check
     description: "Main.xaml has a Retry Scope that nests the Excel read inside its body"
-    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); sys.exit(0 if re.search(r'<(?:ui:|uca:|uic:)?RetryScope\\b[^>]*>[\\s\\S]*?<(?:ui:|uea:|ueab:)?(?:ExcelApplicationScope|ExcelReadRange)\\b[\\s\\S]*?</(?:ui:|uca:|uic:)?RetryScope>', s) else 1)\""
-    timeout: 5
-    expected_exit_code: 0
+    path: "InvoiceReader/Main.xaml"
+    patterns:
+      - pattern: '<(?:\w+:)?RetryScope\b[\s\S]*?<(?:\w+:)?(?:ExcelApplicationScope|ExcelReadRange|ReadRange|ReadRangeX|ExcelApplicationCard)\b[\s\S]*?</(?:\w+:)?RetryScope>'
+        must_match: true
     weight: 2.5
     pass_threshold: 1.0
 
-  # Retry Scope is configured: 3 retries, 5-second interval (TimeSpan
-  # value "00:00:05" or numeric 5).
-  - type: run_command
+  # Retry Scope is configured: 3 retries, 5-second interval. Studio emits
+  # NumberOfRetries / RetryInterval either as XML attributes (e.g.
+  # NumberOfRetries="3") OR as property elements with a wrapped
+  # InArgument + VisualBasicValue (required when the value is a VB
+  # expression rather than a literal). Both forms are functionally
+  # equivalent and produce the same UiRobot retry behavior — accept both.
+  - type: file_check
     description: "Retry Scope is configured with NumberOfRetries=3 and a 5-second RetryInterval"
-    command: "python -c \"import re,sys; s=open('InvoiceReader/Main.xaml',encoding='utf-8').read(); ok = re.search(r'NumberOfRetries=\\W?[\\[\\(]?\\s*3\\s*[\\]\\)]?\\W', s) and re.search(r'RetryInterval=\\W?[\\[\\(]?\\s*(?:00:00:05|TimeSpan\\.FromSeconds\\(5\\)|New TimeSpan\\(0,\\s*0,\\s*5\\))[\\]\\)]?\\W', s); sys.exit(0 if ok else 1)\""
-    timeout: 5
-    expected_exit_code: 0
+    path: "InvoiceReader/Main.xaml"
+    patterns:
+      # NumberOfRetries = 3 in either attribute form or property-element form.
+      - pattern: '(?:NumberOfRetries\s*=\s*"\s*[\[\(]?\s*3\s*[\]\)]?\s*")|(?:<(?:\w+:)?RetryScope\.NumberOfRetries>[\s\S]*?(?:ExpressionText|Value)\s*=\s*"\s*3\s*"[\s\S]*?</(?:\w+:)?RetryScope\.NumberOfRetries>)'
+        must_match: true
+      # RetryInterval = 5 seconds, expressed as the TimeSpan literal
+      # 00:00:05, the VB expression TimeSpan.FromSeconds(5), or
+      # New TimeSpan(0, 0, 5) — in either attribute form or property-element form.
+      - pattern: '(?:RetryInterval\s*=\s*"\s*[\[\(]?\s*(?:00:00:05|TimeSpan\.FromSeconds\(\s*5\s*\)|New\s+TimeSpan\(\s*0\s*,\s*0\s*,\s*5\s*\))\s*[\]\)]?\s*")|(?:<(?:\w+:)?RetryScope\.RetryInterval>[\s\S]*?(?:00:00:05|TimeSpan\.FromSeconds\(\s*5\s*\)|New\s+TimeSpan\(\s*0\s*,\s*0\s*,\s*5\s*\))[\s\S]*?</(?:\w+:)?RetryScope\.RetryInterval>)'
+        must_match: true
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

The `skill-rpa-legacy-refactor-with-retry-scope-e2e` task was false-negativing valid Studio-emitted XAML in two of its `file_check` criteria, and the underlying cause traces back to a gap in the legacy reference docs.

**Eval criteria fix** (`refactor_with_retry_scope_e2e.yaml`):
- "Retry Scope nests Excel read" only recognized `ExcelApplicationScope` / `ExcelReadRange` (Interop). Agents that emit `excel:ReadRange` — the modern `UiPath.Excel.Activities.ReadRange` Portable class, documented as valid standalone in `Excel.md` — failed the regex.
- "NumberOfRetries=3 / RetryInterval=5s" only matched the attribute form. Studio emits both as property elements with `InArgument` + `VisualBasicValue` when the value is a VB expression — functionally equivalent (verified on UiRobot: 3 attempts at the configured interval).
- Switched both checks from inline `python -c` shell commands to the `file_check` criterion type (no shell escaping). New patterns accept any prefix on `<RetryScope>` and on the Excel-read child, recognize Portable `ReadRange` and Modern `ReadRangeX` in addition to the Interop classes, and accept both attribute and property-element forms.

**Doc fix** (`common-pitfalls.md`):
- `UiPath.Core.Activities.RetryScope` has the same ActivityAction-body requirement as the other scope activities but wasn't listed alongside them — bodies authored as direct children pass `uip rpa-legacy validate` but blow up at UiRobot runtime with `Cannot set unknown member 'RetryScope.Implementation'`. Added RetryScope to the preamble list and a row in the "Common Scope Body Patterns" table noting the two quirks that diverge from the rest: body property is `.ActivityBody` (not `.Body`) and the `ActivityAction` takes no type argument or DelegateInArgument.

Surfaced by RCA on two failed coder-evalboard runs of this task (2026-06-04, 2026-06-05) where the agent produced validate-clean but non-runnable XAML.

## Test plan

- [ ] Reviewer confirms the relaxed regex patterns still reject the original baseline negative cases (no RetryScope, wrong interval, etc.)
- [ ] Re-run `skill-rpa-legacy-refactor-with-retry-scope-e2e` on the next coder-evalboard run and confirm the two formerly-flaky criteria now PASS on agents that emit the property-element form / `excel:ReadRange`