### PR TITLE
test(uipath-maestro-flow): de-flake IxP activation — skill-activation eval + thresholded plugin-routing [RE-12420]

### DIFF
--- a/tests/tasks/activation/uipath-maestro-flow.jsonl
+++ b/tests/tasks/activation/uipath-maestro-flow.jsonl
@@ -45,3 +45,13 @@
 {"id": "uipath-maestro-flow-045", "prompt": "I have a `.flow` file I generated locally. Import it into my existing Studio Web solution.", "expected_skill": "uipath-maestro-flow"}
 {"id": "uipath-maestro-flow-046", "prompt": "Add a script node after the loop that logs the iteration inputs and outputs as JSON.", "expected_skill": "uipath-maestro-flow"}
 {"id": "uipath-maestro-flow-047", "prompt": "Write Jint JavaScript logic for a script node", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-048", "prompt": "What IxP models can I access in maestro?", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-049", "prompt": "What document extractors can I add to this flow?", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-050", "prompt": "List the published IxP extractors available to my .flow", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-051", "prompt": "Which IxP runtime projects can I wire into a Maestro flow node?", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-052", "prompt": "Show me the IxP document-understanding models I can use in maestro", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-053", "prompt": "What are my options for IxP nodes in a Maestro flow?", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-054", "prompt": "Add an IxP node to my flow that reads PDF invoices from a SharePoint folder and extracts the structured fields so the next step can post them to SAP", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-055", "prompt": "Build a UiPath Flow that pulls vendor name, invoice number, date, and total out of PDF invoices in a SharePoint folder, then posts the result to our accounting system", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-056", "prompt": "Add a document-extraction step to my flow that reads receipt images from a folder and pulls out merchant, date, and total", "expected_skill": "uipath-maestro-flow"}
+{"id": "uipath-maestro-flow-057", "prompt": "I have a Maestro flow. Add an IxP node that classifies incoming PDF forms and extracts their fields before the next step", "expected_skill": "uipath-maestro-flow"}

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -13,8 +13,8 @@ description: >
   exactly the skill behaviour under test.
 
   Per-row strictness comes from a run_command that switches on the row dir
-  in $(pwd) (dataset-fanout cwd is <run>/artifacts/<task_id>/<row_id>[/<iter>]/,
-  see comment in activation.yaml) and asserts BOTH the chosen NodeType
+  in $(pwd) (dataset-fanout cwd is <run>/artifacts/<task_id>/<row_id>[/<iter>]/)
+  and asserts BOTH the chosen NodeType
   prefix AND the inputs.modelName match the published model for that row.
 
   Validate-only: no `uip maestro flow debug`. The expected NodeType prefixes
@@ -70,7 +70,7 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  # Same `../..` cwd rationale as activation.yaml:107-112: dataset-fanout cwd
+  # `../..` cwd rationale: dataset-fanout cwd
   # is <run>/artifacts/<outer_task_id>/<row_id>[/<iter>]/, so artifacts written
   # by the agent live two levels up at most.
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -56,6 +56,13 @@ initial_prompt: |
   - Exploration + an attempted node-add is enough — you do not need to build a working flow.
 
 success_criteria:
+  # What this checks: did the agent search the registry for IxP nodes?
+  # Passes (case-insensitive) when the agent ran either:
+  #   • `registry list`                   — list all nodes, or
+  #   • `registry search|list|get <term>` — <term> contains ixp / document / extract
+  #                                         (prefix match, so extract → extraction)
+  # routing_listing.yaml drops `get` (read-only). Keep in sync with
+  # scaffold_minimal.yaml, scaffold_multinode.yaml, routing_listing.yaml.
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -1,18 +1,18 @@
-task_id: skill-flow-ixp-activation
+task_id: skill-flow-ixp-routing
 description: >
-  IxP activation — 2 positive activation tests (explicit, invoice-extraction)
-  fanned out via `dataset.rows`. Each row carries a distinct user prompt; success
-  criteria are identical across all rows.
+  IxP routing (positive) — document-extraction build prompts fanned out via
+  `dataset.rows`. Each row carries a distinct user prompt; success criteria are
+  identical across all rows.
 
-  Scope: did the skill get called, not did it work. Assertions verify the agent
-  invoked the uipath-maestro-flow Skill and ran the right CLI-command patterns
-  (registry search for uipath.ixp.*, node-add against uipath.ixp.* or
-  core.logic.mock) — NOT whether the resulting flow is correct or would execute.
+  Scope: did the agent route to the IxP plugin, not did the flow work.
+  Assertions verify the agent ran the right CLI-command patterns (registry
+  search for uipath.ixp.*) and landed a uipath.ixp.* or core.logic.mock node —
+  NOT whether the resulting flow is correct or would execute.
 
   Failure here is signal about SKILL.md or the IxP Plugin Index entry —
   do NOT relax assertions; feed findings back in.
 
-tags: [uipath-maestro-flow, smoke, activation, ixp]
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, node:ixp]
 dataset:
   rows:
     - id: explicit
@@ -27,6 +27,22 @@ dataset:
         date, total amount, and line items out of PDF invoices saved in a
         SharePoint folder, then posts the result to our accounting system.
 
+    - id: receipts
+      prompt: >-
+        Add a document-extraction step to my flow that reads receipt images
+        from a folder and pulls out merchant, date, and total.
+
+    - id: contracts
+      prompt: >-
+        Build a flow that extracts party names, effective date, and the
+        termination clause from PDF contracts, then routes them to an approval
+        step.
+
+    - id: forms-classify
+      prompt: >-
+        I have a Maestro flow. Add an IxP node that classifies incoming PDF
+        forms and extracts their fields before the next step.
+
 initial_prompt: |
   ${row.prompt}
 
@@ -40,20 +56,12 @@ initial_prompt: |
   - Exploration + an attempted node-add is enough — you do not need to build a working flow.
 
 success_criteria:
-  - type: skill_triggered
-    skill_name: "uipath-maestro-flow"
-    expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
+    command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.85}
 
   # Greps the actual .flow artifact rather than the command stream — the
   # command_executed checker truncates tool params at 2000 chars, which hides
@@ -64,8 +72,7 @@ success_criteria:
     description: "Agent added an IxP or core.logic.mock placeholder node to a .flow file (per references/plugins/ixp/impl.md)"
     command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
     expected_exit_code: 0
-    weight: 2.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.85}
 
 run_limits:
   max_turns: 80

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
@@ -1,0 +1,67 @@
+task_id: skill-flow-ixp-routing-listing
+description: >
+  IxP listing routing — user asks what IxP models / runtime projects are
+  available from a Maestro flow. Read-only Q&A, not a build task.
+
+  Asserts the agent ran the IxP registry-search listing command (per
+  references/plugins/ixp/impl.md — Listing Published Models). Also asserts the
+  agent did NOT take the build path: no .flow file should be created for a
+  listing question.
+
+  Failure here is signal about the IxP plugin's Listing Published Models /
+  Listing Available Models sections — do NOT relax assertions, tighten the
+  copy.
+
+tags: [uipath-maestro-flow, integration, mode:operate, lifecycle:discover, node:ixp]
+
+dataset:
+  rows:
+    - id: r01
+      prompt: "What IxP models can I access in maestro?"
+    - id: r02
+      prompt: "What document extractors can I add to this flow?"
+    - id: r03
+      prompt: "List the published IxP extractors available to my .flow"
+    - id: r04
+      prompt: "Which IxP runtime projects can I wire into a Maestro flow node?"
+    - id: r05
+      prompt: "What extraction models are available to my Maestro flow?"
+    - id: r06
+      prompt: "Show me the IxP document-understanding models I can use in maestro"
+    - id: r07
+      prompt: "Which document-extraction models can this flow call?"
+    - id: r08
+      prompt: "What are my options for IxP nodes in a Maestro flow?"
+    - id: r09
+      prompt: "Can you list the IxP models I can add to my flow?"
+    - id: r10
+      prompt: "What published IxP extractors can a flow node reference?"
+
+initial_prompt: |
+  ${row.prompt}
+
+  Important:
+  - The `uip` CLI is already available.
+  - Use `--output json` on all uip commands.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent searched the registry for IxP node types (listing path)"
+    tool_name: "Bash"
+    command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list)\b[^\n]*\b(ixp|document|extract))'
+    min_count: 1
+    suite_thresholds: {mean: 0.85}
+
+  # Inverted check: a listing/Q&A task should NOT create a .flow file.
+  # `! find ... | grep -q .` exits 0 when no .flow file is found (PASS)
+  # and 1 when one exists (FAIL).
+  - type: run_command
+    description: "No .flow file was created (listing is read-only Q&A, not a build task)"
+    command: '! find . -name "*.flow" -type f | grep -q .'
+    expected_exit_code: 0
+    suite_thresholds: {mean: 0.85}
+
+run_limits:
+  max_turns: 20
+  turn_timeout: 300
+  task_timeout: 300

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
@@ -45,6 +45,7 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
 
 success_criteria:
+  # IxP registry-search check (omits `get`) — see routing.yaml for the pattern breakdown.
   - type: command_executed
     description: "Agent searched the registry for IxP node types (listing path)"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
@@ -1,4 +1,4 @@
-task_id: skill-flow-ixp-activation-negative
+task_id: skill-flow-ixp-routing-negative
 description: >
   Negative IxP routing — verifies the agent does NOT add a uipath.ixp.*
   node when the user asks for a Maestro flow with no document-extraction
@@ -11,10 +11,10 @@ description: >
   plugin index / planning copy / SKILL.md must be tight enough that the
   agent does not over-trigger.
 
-  Failure here means activation copy is too broad — tighten the trigger
+  Failure here means routing copy is too broad — tighten the trigger
   signals, do NOT relax assertions.
 
-tags: [uipath-maestro-flow, smoke, activation, ixp, negative]
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, node:ixp]
 
 dataset:
   rows:
@@ -23,6 +23,34 @@ dataset:
       prompt: >-
         Create a flow with a manual trigger and an HTTP node that calls
         api.stripe.com, then a script node that logs the response.
+    - id: slack-summary
+      prompt: >-
+        Create a flow with a scheduled trigger that posts a daily summary
+        message to Slack.
+    - id: sf-update
+      prompt: >-
+        Build a flow that reads open Salesforce opportunities and updates the
+        stage field on each one.
+    - id: http-webhook
+      prompt: >-
+        Create a flow with an HTTP trigger that validates a JSON payload in a
+        script node and returns a status code.
+    - id: gsheet-loop
+      prompt: >-
+        Build a flow that loops over rows in a Google Sheet and sends each row
+        to an HTTP endpoint.
+    - id: queue-write
+      prompt: >-
+        Create a flow with a manual trigger that writes a record to an
+        Orchestrator queue.
+    - id: teams-decision
+      prompt: >-
+        Build a flow that branches on an input variable and notifies Teams in
+        the matching branch.
+    - id: delay-email
+      prompt: >-
+        Create a flow with a timer trigger that waits 10 minutes, then sends an
+        Outlook email.
 
 initial_prompt: |
   ${row.prompt}
@@ -37,14 +65,7 @@ initial_prompt: |
   - Exploration + an attempted node-add is enough — you do not need to build a working flow.
 
 success_criteria:
-  - type: skill_triggered
-    skill_name: "uipath-maestro-flow"
-    expected_skill: "uipath-maestro-flow"
-    description: "Parent uipath-maestro-flow Skill fired (IxP-only routing is what this suite tests)"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  # Inverted twin of the positive activation.yaml grep.
+  # Inverted twin of the positive routing.yaml grep.
   # `shell=True` in coder_eval Sandbox.run_command means `!` works as a bash
   # negator: grep -q exits 0 on match → ! flips to 1 (FAIL); exits 1 on
   # no-match → ! flips to 0 (PASS).
@@ -52,8 +73,7 @@ success_criteria:
     description: "No uipath.ixp.* node landed in any .flow file (negative IxP routing)"
     command: '! grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"uipath\.ixp" --include="*.flow" .'
     expected_exit_code: 0
-    weight: 3.0
-    pass_threshold: 1.0
+    suite_thresholds: {mean: 0.85}
 
 run_limits:
   max_turns: 25

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -36,6 +36,7 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # IxP registry-search check — see routing.yaml for the pattern breakdown.
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -1,15 +1,15 @@
-task_id: skill-flow-ixp-smoke-scaffold-minimal
+task_id: skill-flow-ixp-scaffold-minimal
 description: >
-  Smoke: minimal scaffold — manual trigger → IxP extract → script (logs "ok")
+  Integration: minimal scaffold — manual trigger → IxP extract → script (logs "ok")
   → validate. Tests that the agent picks the IxP plugin, authors a single
   extraction node via Direct JSON, and produces a flow that passes
   `uip maestro flow validate`.
 
   Validate-only: no `uip maestro flow debug`. IxP runtime requires a tenant
-  deployment which CI does not have; smoke verifies offline structural
+  deployment which CI does not have; this verifies offline structural
   correctness only.
 
-tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:single-node, node:ixp]
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:single-node, node:ixp]
 initial_prompt: |
   Create a new Maestro Flow project called "Smoke" with a manual trigger, an
   extract node, and a script node that just logs "ok". Wire the extracted
@@ -39,7 +39,7 @@ success_criteria:
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
+    command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -1,6 +1,6 @@
-task_id: skill-flow-ixp-smoke-scaffold-multinode
+task_id: skill-flow-ixp-scaffold-multinode
 description: >
-  Smoke: multi-script fan-out from an IxP extraction — manual trigger →
+  Integration: multi-script fan-out from an IxP extraction — manual trigger →
   IxP extract → 3 script nodes (postReceipt, sendToValidation, logError).
   Tests that the agent picks IxP, authors the extraction node, and wires
   three downstream scripts that consume the extraction result.
@@ -16,7 +16,7 @@ description: >
 
   Validate-only: no `uip maestro flow debug`.
 
-tags: [uipath-maestro-flow, smoke, lifecycle:generate, shape:multi-node, node:ixp]
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:multi-node, node:ixp]
 initial_prompt: |
   Create a flow called "ReceiptIntake" with a manual trigger, an extractor
   node, and add three script nodes named `postReceipt`, `sendToValidation`,
@@ -45,7 +45,7 @@ success_criteria:
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
+    command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -42,6 +42,7 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # IxP registry-search check — see routing.yaml for the pattern breakdown.
   - type: command_executed
     description: "Agent searched the registry for IxP node types"
     tool_name: "Bash"


### PR DESCRIPTION
Jira: RE-12420.

## Why

The IxP **smoke** tasks gated *probabilistic* agent behaviour (which skill/plugin fires, which node lands, which discovery command runs) on one or two must-pass rows, so a single miss red-lined the blocking smoke gate on unrelated PRs. The fix is to split coverage by the distinct things being tested, and stop hard-gating any of it on the smoke run.

## What changed

**1. Skill-level activation → nightly activation eval**
At skill-selection time the agent doesn't know flow plugins exist, so "what IxP models can I use in maestro" is a `uipath-maestro-flow` *skill* positive. Added 10 IxP-phrased rows (listing + document-extraction build intents) to `tests/tasks/activation/uipath-maestro-flow.jsonl`.

**2. Plugin-level routing → non-blocking integration**
- Demoted the three IxP routing tasks `smoke` → `integration`.
- Renamed `activation*.yaml` → `routing*.yaml` and dropped the `activation` tag — they no longer assert skill activation (the `skill_triggered` criterion is gone); "activation" is reserved for the skill-selection eval above. They test plugin/node routing within the skill.
- Fan each prompt across many phrasings via `dataset.rows`, gated on aggregate `suite_thresholds.mean >= 0.85` instead of per-row pass/fail. `routing_listing.yaml` (10 rows), `routing.yaml` (5), `routing_negative.yaml` (8).

**3. IxP scaffold tasks → non-blocking integration**
- Demoted the two IxP scaffold smoke tasks `smoke` → `integration` and renamed `smoke_01_scaffold_minimal.yaml` → `scaffold_minimal.yaml`, `smoke_02_scaffold_multinode.yaml` → `scaffold_multinode.yaml` (task_ids drop `smoke`). These were the tasks actually red-lining the smoke gate, via the same probabilistic registry-search assertion.
- Added the required `mode:build` tag; descriptions reworded "Smoke" → "Integration".

**4. Fixed the registry-search assertion regex (all IxP tasks)**
The old case-sensitive `(search|list|get)\b[^\n]*ixp` false-negated *correct* behaviour — e.g. `registry search "IxP"` (casing), a bare `registry list` (list-all), or a topical `search "extraction"`/`"document"` that never put the literal `ixp` on the line. Replaced with a case-insensitive pattern that accepts a bare `registry list` and requires only a topical stem (`ixp|document|extract`) on a `search`/`list`/`get`. Applied across `routing*.yaml` and `scaffold_*.yaml`. Listing `command_executed` mean: **0.80 → 1.00**.

**5. Documented the regex inline**
A single plain-language breakdown of the pattern lives in `routing.yaml`; the other IxP tasks carry a one-line pointer to it (no duplicated explanation). Addresses review feedback that the regex was hard to read.

## Validation

Run locally on `claude-sonnet-4-6` (the nightly CI model) — pure `command_executed`/`run_command` checks, no LLM judge:

| Task | Gate | Means |
|------|------|-------|
| `routing_listing` | PASS | command_executed 1.00 · no-build 1.00 |
| `routing` | PASS | command_executed 1.00 · node-landed 1.00 |
| `routing_negative` | PASS | no-IxP-node 1.00 |

Skill-activation rows separately verified: `recall.yes 1.0` (10/10 fire `uipath-maestro-flow`). The `scaffold_*` tasks now run as non-blocking `integration` (no longer in the smoke gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
