### PR TITLE
feat(maestro-flow): add architecture decision guidance to flow planning

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/brownfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/brownfield.md
@@ -4,6 +4,21 @@ Recipe-driven journey for targeted changes to an existing `.flow` file. Author t
 
 > **Greenfield (creating a new flow) uses a different journey.** If the `.flow` file does not yet exist, see [greenfield.md](greenfield.md) instead.
 
+## Converting an existing project to Maestro
+
+A frequent request: *"Can my existing project — e.g. a low-code agent plus a coded (C#) RPA rule engine — become a Maestro flow, and what would the structure look like?"*
+
+There is **no automatic "turn this project into a flow" conversion, and you shouldn't want one.** You don't rewrite the project into a flow — you **re-host the orchestration and keep the parts**:
+
+1. **Keep the executors as-is.** Existing coded/RPA components and any existing agent stay their own artifacts. They are **not** rewritten into Maestro — they become **resource nodes** the flow calls (`uipath.core.rpa-workflow.*`, `uipath.core.agent.*`). See the relevant plugin's `planning.md`.
+2. **Lift only the orchestration into Maestro.** The control flow currently implicit in the rule engine (what runs first, what waits, what branches) becomes the explicit flow topology — trigger → steps → decisions → end.
+3. **Make every wait a first-class node.** Anything the old code did with sleeps, polling loops, or "check again later" becomes a Maestro wait/delay/HITL/`create-and-wait` node — that visibility is the whole reason to move.
+4. **Publish (or keep in-solution), then reference.** Each executor is published or kept as a sibling project so the flow's registry resolves it (`registry list --local` for in-solution).
+
+Resulting structure: a **thin flow** that is mostly trigger + waits + branches, delegating the real work to the existing RPA and agent artifacts. To author it, treat the flow as greenfield ([greenfield.md](greenfield.md)) with those artifacts discovered as resource nodes during [planning-arch.md](planning-arch.md).
+
+> **Migrate when** the project has long waits, human approvals, parallel branches, or needs per-case visibility. **Don't migrate** a short, fully-automated, fire-once script — Maestro adds orchestration overhead it won't repay. Apply the [Is Maestro the Right Home?](planning-arch.md#before-you-build-is-maestro-the-right-home) gate first.
+
 ## Read this first
 
 > **Before each node you add or modify, classify it as user-owned or CLI-owned (see [CAPABILITY.md — Node ownership](../CAPABILITY.md#node-ownership--who-authors-the-node)). Connector activities, connector triggers, and `core.action.http.v2` are CLI-only — use `uip maestro flow node add` + `uip maestro flow node configure`, never Edit. Hand-writing these will fail `flow validate`.** The same risk applies when *adding* a connector node to an existing flow as when building a new one.

--- a/skills/uipath-maestro-flow/references/author/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/references/planning-arch.md
@@ -9,6 +9,36 @@ Discover available capabilities, then design the flow topology — select node t
 
 ---
 
+## Before You Build: Is Maestro the Right Home?
+
+Run this gate **before** designing the topology. Maestro is the right tool for a *long-running case* — but not every automation is one, and reaching for a flow by default leads to orchestration overhead that a simpler design would avoid. If the answer below is "queue + Action Center," stop here and hand the work to [/uipath:uipath-rpa](/uipath:uipath-rpa) + [/uipath:uipath-platform](/uipath:uipath-platform) instead of authoring a flow.
+
+### The one question
+
+> **Where does the case live right now — and where should it live between steps?**
+
+A business case (an invoice being approved, a claim being recovered, an onboarding in progress) needs a home for its state while it waits. There are two legitimate homes:
+
+- **One durable instance — Maestro.** A single orchestrated process holds the whole case, survives every wait, and shows you exactly where each case is at any moment.
+- **Scattered across infrastructure — a queue + Action Center state machine.** The case's state lives spread across queue items, asset values, and Action Center tasks; whichever robot picks the work up next reassembles it. RPA does the steps, a queue carries the work between them, Action Center holds the human-wait, and the "state" is implicit in which queue/task the item currently sits in.
+
+### Decision table
+
+| Factor | Lean **Maestro flow** | Lean **queue + Action Center state machine** |
+|---|---|---|
+| Number of distinct waits in the lifecycle | Several waits / branches / parallel paths | A **single** human-wait or external-wait |
+| Per-case visibility | You need to see "where is case #1234 right now" | Per-item queue status is enough |
+| Branching & parallelism | Real branching, fan-out/merge, SLAs | Mostly linear: do work → wait → finish |
+| Who maintains it | Team comfortable with orchestration as a first-class artifact | RPA-only team, existing queue infrastructure |
+| Cross-product composition | Coordinates RPA + Agents + connectors + humans | Pure RPA + Action Center, no agent reasoning |
+| Cost of the orchestration layer | Justified by the above | Overhead you won't repay for a one-shot process |
+
+**Rule of thumb:** a **single-wait** lifecycle (do work → wait for one approval → finish) is a legitimate and *simpler* job for a queue + Action Center state machine. **Multi-wait, branched, or visibility-critical** lifecycles are where Maestro earns its keep. Both are valid — choose deliberately, not by habit.
+
+> **Converting an existing RPA project to Maestro?** You don't rewrite the project into a flow — you keep the executors and lift only the orchestration. See [brownfield.md — Converting an existing project to Maestro](brownfield.md#converting-an-existing-project-to-maestro).
+
+---
+
 ## Process
 
 1. Analyze the user's requirements
@@ -293,11 +323,26 @@ Use a downstream Decision/Switch only for **content-based routing on a successfu
 
 ### Orchestration (Mixed Resources)
 
+The canonical composition when more than one product is in play. Default division of labor — most "where does this step go?" questions resolve against it:
+
+> **RPA = hands. Maestro = conductor. Agents = brain. Humans approve.**
+
+- **Maestro orchestrates** — owns the case, the waits, the branching, the SLA, the long-running state (this flow).
+- **RPA executes** — mechanical work against systems with no clean API (desktop apps, terminals, legacy web) — a `uipath.core.rpa-workflow.*` resource node. See [rpa/planning.md](plugins/rpa/planning.md).
+- **Agents reason** — judgment calls: classify, summarize, decide which branch a fuzzy input belongs to — an agent node. See [agent/planning.md](plugins/agent/planning.md) / [inline-agent/planning.md](plugins/inline-agent/planning.md).
+- **Humans approve** — a HITL / human-task node wraps the point where a person must look before the case continues. See [hitl/planning.md](plugins/hitl/planning.md).
+
+Worked example — extract, classify, and route with one human approval branch:
+
 ```
-Trigger -> Script (prepare) -> RPA Process (extract) -> Agent (classify) -> Decision
-  |-- approved -> Script (format) -> End
-  |-- rejected -> Human Task (review) -> End
+Trigger -> Script (prepare) -> RPA Process (extract from legacy app) -> Agent (classify) -> Decision (confidence high)
+  |-- true  -> Script (format) -> End (auto-approved)
+  |-- false -> HITL (human approves or rejects) -> Decision (approved)
+                 |-- true  -> Script (format) -> End (approved)
+                 |-- false -> Script (log rejection) -> End (rejected)
 ```
+
+Here Maestro holds the case across the agent call and the human wait; RPA does the extraction the source app gives no API for; the agent makes the confidence call; the human is the gate only when the agent is unsure. Each non-Maestro piece is a separate published (or in-solution) artifact the flow references as a node — you do **not** rebuild them inside the flow.
 
 ### Scheduled Batch Processing
 
@@ -306,6 +351,30 @@ Scheduled Trigger -> HTTP (fetch batch) -> Loop
   |-- Queue Create (per item) -> (loopBack)
   |-- success -> Script (summary) -> End
 ```
+
+### No-API Source (RPA Feeder Bridge)
+
+When the source application has **no API and no connector** (legacy desktop app, terminal, mainframe screen), the flow cannot be triggered by the source directly. Bridge it: a **scheduled RPA bot scrapes the source and drops the result onto something Maestro can watch** — a Queue or a Storage Bucket — and the flow triggers off that.
+
+```
+[Scheduled RPA bot]  (outside the flow — uipath-rpa + a time trigger)
+   scrape legacy app -> push item to Queue (or file to Bucket)
+        |
+        v
+Queue/Bucket item created
+        |
+        v
+Maestro flow trigger -> Process item -> ... -> End
+```
+
+Two ways to wire the Maestro side:
+
+- **Queue → flow:** the RPA bot calls `Add Queue Item`; the flow is started by a queue trigger (configured in Orchestrator — see [/uipath:uipath-platform](/uipath:uipath-platform)) or polls/consumes the queue. Best when each scraped row is a separate case.
+- **Bucket → flow:** the RPA bot uploads a file; a scheduled flow picks it up. Best for batch drops.
+
+> **Tradeoff — polling latency equals the scraper schedule.** The case starts no sooner than the next RPA run. A bot scheduled every 15 minutes means up to 15 minutes of trigger latency. There is no event from a no-API source, so "real-time" is not achievable this way — tighten the RPA schedule to lower latency, at the cost of more bot runs. If the source *does* expose an event/webhook or has a connector, prefer a connector trigger ([connector-trigger/planning.md](plugins/connector-trigger/planning.md)) over this bridge.
+
+The scraper bot itself is an RPA project ([/uipath:uipath-rpa](/uipath:uipath-rpa)) with a time trigger ([/uipath:uipath-platform](/uipath:uipath-platform)); only the consuming flow belongs to this skill.
 
 ---
 


### PR DESCRIPTION
Closes [STUD-80263](https://uipath.atlassian.net/browse/STUD-80263).

Adds decision-level guidance the agent previously answered only from general knowledge, placed where flow authors already read it. No new skill — cross-product guidance lives inside the skill that owns flow authoring, avoiding a new activation surface and the no-cross-reference isolation concern.

### planning-arch.md
- **"Is Maestro the Right Home?" gate** — Maestro flow vs queue + Action Center state machine, framed by *"where does the case live?"*. Directs handoff to RPA + platform when a flow is overkill (single-wait lifecycle).
- **"No-API Source (RPA Feeder Bridge)"** topology pattern — scheduled RPA scraper → Queue/Bucket → Maestro trigger, with the *polling latency = scraper schedule* tradeoff.
- **Expanded mixed-resource composition** — RPA = hands, Maestro = conductor, Agents = brain, with a worked HITL approval branch.

### brownfield.md
- **"Converting an existing project to Maestro"** — re-host the orchestration, keep executors as resource nodes; no rewrite.

### Verification
Docs-only (+87/−3, 2 files). Ran the skill's maintenance suite: links 737/0 broken, anchors 184/0 bad; depth/orphans/template/versions clean. (`check-uip-commands.sh` fails on a pre-existing Python-version error inside the checker, unrelated to this change.)

[STUD-80263]: https://uipath.atlassian.net/browse/STUD-80263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ