### PR TITLE
fix(uipath-test): pin report_generation eval to CLAIM:23 test set

### DIFF
--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -7,14 +7,14 @@ description: >
   report to `test-report-qa-<TODAY>.md` (the skill's default filename for
   today's date), and (d) the report body contains the QA-persona structural
   sections taught by references/test-result-report-guide.md (regression
-  analysis + the full pass/fail/none breakdown) and references the target
-  test set. The prompt does not name a specific test set so the test runs
-  against any tenant; the agent picks one with data. The skill — not the
-  prompt — must teach the filename convention, the persona-specific
-  sections, and the `--output json` flag. Note: when the chosen test set
-  has no executions, the skill correctly stops before running
-  `list-testcaselogs` (Critical Rule #4), so that command is not asserted
-  here; the report is expected to render the empty-data sections honestly.
+  analysis + the full pass/fail breakdown) and references the target
+  test set. The prompt targets the CLAIM project's test set CLAIM:23.
+  The skill — not the prompt — must teach the filename
+  convention, the persona-specific sections, and the `--output json` flag.
+  Note: when the test set has no executions, the skill correctly
+  stops before running `list-testcaselogs` (Critical Rule #4), so that
+  command is not asserted here; the report is expected to render the
+  empty-data sections honestly.
 tags: [uipath-test, integration, mode:operate, lifecycle:generate, feature:test-case]
 
 run_limits:
@@ -24,10 +24,9 @@ run_limits:
 initial_prompt: |
   Before starting, load the uipath-test skill and follow its workflow.
 
-  Generate a **QA Engineer** test report from one of my UiPath Test Manager
-  test sets. Pick a test set that actually has data so the report is
-  meaningful, and save the report file in the current working directory
-  using the default filename convention from the skill.
+  Generate a **QA Engineer** test report from my UiPath Test Manager "CLAIM"
+  project — use the test set CLAIM:23. Save the report file in the current
+  working directory using the default filename convention from the skill.
 
 success_criteria:
   - type: command_executed
@@ -55,7 +54,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "QA persona report contains skill-taught structural sections (regression + full pass/fail/none breakdown) and references the test set"
+    description: "QA persona report contains skill-taught structural sections (regression + full pass/fail breakdown) and references the test set"
     command: |
       python3 -c "
       import glob, re, sys
@@ -67,7 +66,7 @@ success_criteria:
       checks = {
           'markdown header anchor': re.search(r'(?m)^#{1,3}\s+\S', body) is not None,
           'regression section taught by skill': re.search(r'(?im)^#{1,4}.*regression', body) is not None,
-          'full pass/fail/none breakdown taught by skill': all(t in lower for t in ['passed', 'failed', 'none']),
+          'full pass/fail breakdown taught by skill': all(t in lower for t in ['passed', 'failed']),
           'test set referenced in body': re.search(r'(?i)test\s*set', body) is not None,
       }
       missing = [k for k, ok in checks.items() if not ok]


### PR DESCRIPTION
## Summary

Pins the `uipath-test` skill integration test `tests/tasks/uipath-test/report_generation.yaml` to a specific, populated test set and relaxes the structural check so a fully passing/failing set still satisfies it.

- **Pin to CLAIM:23** — the prompt now targets the **CLAIM** project and uses test set **CLAIM:23** specifically, instead of "any test set with data".
- **Relax breakdown check** — the success-criteria Python check now requires a `passed`/`failed` breakdown (drops the `none` token).
- **Doc alignment** — updates the task `description` and the success-criteria label to match; strips trailing whitespace; fixes a `bod`→`body` typo in the regression-section check.

## Trade-off

This makes the eval tenant-specific (requires a CLAIM project with test set CLAIM:23) — a deliberate choice for deterministic data over tenant-agnostic discovery.

## Validation

- YAML parses (`yaml.safe_load`).
- Embedded success-criteria Python compiles.
- No trailing whitespace; description/label/check are internally consistent; no SHOPFLOW leftovers.

## Jira

[TMHUB-32038](https://uipath.atlassian.net/browse/TMHUB-32038)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TMHUB-32038]: https://uipath.atlassian.net/browse/TMHUB-32038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ