### PR TITLE
fix(release): npmjs publish via OIDC trusted publishing + provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,19 +80,30 @@ jobs:
     needs: [guard]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # OIDC trusted publishing — no NPM_TOKEN. The npmjs trusted publisher
+      # for @uipath/skills must name this repo (UiPath/skills) and workflow
+      # (publish.yml). npm exchanges this OIDC token for publish credentials.
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: "22.x"
-          registry-url: "https://registry.npmjs.org"
-          scope: "@uipath"
 
-      # setup-node above wrote `@uipath:registry=https://registry.npmjs.org/`
-      # + auth into the runner .npmrc. `@uipath/skills` is scoped, so npm
-      # resolves the publish target from that scoped registry — a `--registry`
-      # flag would be ignored (it only sets the unscoped default).
-      - name: Publish to npmjs
-        run: npm publish --access public --tag latest
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Node 22 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1.
+      - name: Upgrade npm for trusted publishing
+        run: |
+          npm install -g npm@latest
+          echo "npm $(npm --version) / node $(node --version)"
+
+      # No auth token and no setup-node registry-url — a token would make npm
+      # use token auth and bypass OIDC. We only pin the scoped package to
+      # npmjs; credentials come from the OIDC exchange. `--provenance` attaches
+      # a signed build attestation (allowed because the repo is public and the
+      # job has id-token: write); package.json `repository.url` must match.
+      - name: Publish to npmjs (OIDC trusted publishing)
+        run: |
+          npm config set @uipath:registry https://registry.npmjs.org/
+          npm publish --access public --provenance --tag latest

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -37,22 +37,22 @@ Both tracks are **manually triggered** — there is no auto-publish on push to `
 
 ### Registry routing
 
-`@uipath/skills` is a **scoped** package, so each publish job sets the target registry through the **scoped registry** that `actions/setup-node` writes (`@uipath:registry=<url>` + auth) — not a `--registry` flag (which only sets the *unscoped* default and is ignored for scoped packages). For the same reason there is **no committed `.npmrc` and no `publishConfig.registry`**: a static scoped-registry line would override the per-job target (and would break `npm install` for anyone cloning this public repo).
+`@uipath/skills` is a **scoped** package, so the publish target is set via the **scoped registry** (`@uipath:registry=<url>`) — not a `--registry` flag (which only sets the *unscoped* default and is ignored for scoped packages). There is **no committed `.npmrc` and no `publishConfig.registry`**: a static scoped-registry line would override the per-job target (and break `npm install` for anyone cloning this public repo).
 
-| Job | `registry-url` (setup-node) | Result |
-|-----|------------------------------|--------|
-| `publish-alpha` | `https://npm.pkg.github.com` | publishes to GitHub Packages |
-| `publish-release` | `https://registry.npmjs.org` | publishes to npmjs |
+| Job | registry | Auth |
+|-----|----------|------|
+| `publish-alpha` | GitHub Packages (`npm.pkg.github.com`) | built-in `GITHUB_TOKEN` |
+| `publish-release` | npmjs (`registry.npmjs.org`) | **OIDC trusted publishing** (no token) + signed `--provenance` |
 
 ## Cutting a stable release
 
 1. Bump `package.json` to the target version (match the CLI minor line), run `npm run version:sync`, merge.
 2. Create a GitHub Release tagged `v<version>` → `publish.yml` publishes to npmjs.
 
-## Required secrets / setup (TODO before first publish)
+## Required setup
 
-- [ ] **`NPM_TOKEN`** — npmjs **granular** automation token scoped to **`@uipath/skills` only** (least privilege — not the whole `@uipath` org). For stable releases.
-- [ ] Confirm the npm package name/scope: **`@uipath/skills`** (assumed).
+- [x] **npmjs Trusted Publishing** — configure a GitHub Actions trusted publisher on the `@uipath/skills` package (npmjs → package → Settings → Trusted Publisher): repository `UiPath/skills`, workflow `publish.yml`. No `NPM_TOKEN` secret is used — the `publish-release` job authenticates via OIDC (`id-token: write`). Do **not** set `NODE_AUTH_TOKEN`; a token makes npm bypass OIDC and (with 2FA) fail `EOTP`.
+- [x] Package name/scope confirmed: **`@uipath/skills`** (published).
 - [x] Seed version confirmed: **`1.196.0`** (current CLI minor line). Automating the ongoing CLI↔skills lockstep is tracked in PILOT-5518.
 
-> The alpha track needs no secret — `publish-alpha` uses the built-in `GITHUB_TOKEN` with `packages: write`.
+> The alpha track also needs no secret — `publish-alpha` uses the built-in `GITHUB_TOKEN` with `packages: write`.


### PR DESCRIPTION
Forward-ports the publish pipeline from `release/v1.195` (verified working — `@uipath/skills@1.195.1` published to npmjs via this exact flow).

## Change
`publish-release` (npmjs) now uses **OIDC trusted publishing** instead of `NPM_TOKEN`:
- adds `id-token: write`
- upgrades npm to ≥ 11.5.1 (OIDC requirement)
- drops the token + `setup-node` registry-url; pins only the scoped `@uipath:registry`
- adds signed `--provenance`

No `NPM_TOKEN` secret needed. The **alpha** track (GitHub Packages via `GITHUB_TOKEN`) is unchanged.

## Scope
Pipeline-only: `publish.yml` + the trusted-publishing docs in `RELEASE.md`. Version numbers are left at main's current `1.196` — the 195/196 line and the plugin/marketplace unification remain separate (PILOT-5516/5518).

## Prereq (already done on npmjs)
A GitHub Actions trusted publisher must exist on the `@uipath/skills` package: owner `UiPath`, repo `skills`, workflow `publish.yml`, no environment. (Casing matters — `UiPath`, not `uipath`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)