### PR TITLE
fix(uipath-admin): poll for API eventual consistency in check scripts

### DIFF
--- a/tests/tasks/uipath-admin/_shared/admin_helpers.py
+++ b/tests/tasks/uipath-admin/_shared/admin_helpers.py
@@ -53,6 +53,22 @@ def find_one(data: dict, needle: str, fields: list[str]) -> dict | None:
     return matches[0] if matches else None
 
 
+def poll(fn, max_attempts: int = 4, delay: int = 5):
+    """Retry fn() up to max_attempts times with delay between attempts.
+
+    Returns the first truthy result. Returns None after all attempts fail.
+    Handles eventual consistency in tenant APIs.
+    """
+    for i in range(max_attempts):
+        result = fn()
+        if result:
+            return result
+        if i < max_attempts - 1:
+            logger.info("Attempt %d/%d returned falsy — retrying in %ds", i + 1, max_attempts, delay)
+            time.sleep(delay)
+    return None
+
+
 def fail(message: str):
     """Print FAIL message and exit 1."""
     print(f"FAIL: {message}")

--- a/tests/tasks/uipath-admin/check_federated_credential.py
+++ b/tests/tasks/uipath-admin/check_federated_credential.py
@@ -6,20 +6,22 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, find_one, fail, ok
+from admin_helpers import run_cli, find_one, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_fedcred: %(message)s")
 
 
 def main():
-    # Find the external app
-    apps = run_cli(["admin", "external-apps", "list"])
-    if not apps or apps.get("Result") != "Success":
-        fail("external-apps list did not return Success")
+    # Find the external app (poll for eventual consistency)
+    def find_app():
+        apps = run_cli(["admin", "external-apps", "list"])
+        if not apps or apps.get("Result") != "Success":
+            return None
+        return find_one(apps, "e2e-federated-app", ["name"])
 
-    app = find_one(apps, "e2e-federated-app", ["name"])
+    app = poll(find_app)
     if not app:
-        fail("External app 'e2e-federated-app' not found")
+        fail("External app 'e2e-federated-app' not found after retries")
 
     client_id = app.get("id")
     if not client_id:

--- a/tests/tasks/uipath-admin/check_group_membership.py
+++ b/tests/tasks/uipath-admin/check_group_membership.py
@@ -6,19 +6,22 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, find_one, fail, ok
+from admin_helpers import run_cli, find_one, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_group: %(message)s")
 
 
 def main():
-    data = run_cli(["admin", "groups", "list"])
-    if not data or data.get("Result") != "Success":
-        fail("groups list did not return Success")
+    # Poll for eventual consistency
+    def find_group():
+        data = run_cli(["admin", "groups", "list"])
+        if not data or data.get("Result") != "Success":
+            return None
+        return find_one(data, "Invoice Processing Team", ["name", "displayName"])
 
-    target = find_one(data, "Invoice Processing Team", ["name", "displayName"])
+    target = poll(find_group)
     if not target:
-        fail("'Invoice Processing Team' group not found")
+        fail("'Invoice Processing Team' group not found after retries")
 
     group_id = target.get("id")
     if not group_id:

--- a/tests/tasks/uipath-admin/check_pat_created.py
+++ b/tests/tasks/uipath-admin/check_pat_created.py
@@ -6,23 +6,24 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, fail, ok
+from admin_helpers import run_cli, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_pat: %(message)s")
 
 
 def main():
-    data = run_cli(["admin", "pat", "list"])
-    if not data or data.get("Result") != "Success":
-        fail("pat list did not return Success")
+    # Poll for eventual consistency
+    def find_pat():
+        data = run_cli(["admin", "pat", "list"])
+        if not data or data.get("Result") != "Success":
+            return None
+        return any(
+            "e2e-test-pat" in (t.get("description") or "")
+            for t in data.get("Data", [])
+        )
 
-    found = any(
-        "e2e-test-pat" in (t.get("description") or "")
-        for t in data.get("Data", [])
-    )
-
-    if not found:
-        fail("PAT with description 'e2e-test-pat' not found")
+    if not poll(find_pat):
+        fail("PAT with description 'e2e-test-pat' not found after retries")
 
     ok("PAT 'e2e-test-pat' exists")
 

--- a/tests/tasks/uipath-admin/check_robot_account.py
+++ b/tests/tasks/uipath-admin/check_robot_account.py
@@ -6,18 +6,21 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, find_one, fail, ok
+from admin_helpers import run_cli, find_one, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_robot: %(message)s")
 
 
 def main():
-    data = run_cli(["admin", "robot-accounts", "list", "--search", "smoke-e2e-bot"])
-    if not data or data.get("Result") != "Success":
-        fail("robot-accounts list did not return Success")
+    # Poll for eventual consistency
+    def find_robot():
+        data = run_cli(["admin", "robot-accounts", "list", "--search", "smoke-e2e-bot"])
+        if not data or data.get("Result") != "Success":
+            return None
+        return find_one(data, "smoke-e2e-bot", ["name"])
 
-    if not find_one(data, "smoke-e2e-bot", ["name"]):
-        fail("Robot account 'smoke-e2e-bot' not found")
+    if not poll(find_robot):
+        fail("Robot account 'smoke-e2e-bot' not found after retries")
 
     ok("Robot account 'smoke-e2e-bot' exists")
 

--- a/tests/tasks/uipath-admin/check_smtp_settings.py
+++ b/tests/tasks/uipath-admin/check_smtp_settings.py
@@ -6,21 +6,24 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, fail, ok
+from admin_helpers import run_cli, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_smtp: %(message)s")
 
 
 def main():
-    data = run_cli(["admin", "smtp", "get"])
-    if not data or data.get("Result") != "Success":
-        fail(f"smtp get did not return Success — raw: {data}")
+    # Poll for eventual consistency
+    def find_host():
+        data = run_cli(["admin", "smtp", "get"])
+        if not data or data.get("Result") != "Success":
+            return None
+        smtp_data = data.get("Data", {})
+        # CLI returns PascalCase keys (Host, Port, EnableSsl, etc.)
+        return smtp_data.get("Host") or smtp_data.get("host") or None
 
-    smtp_data = data.get("Data", {})
-    # CLI returns PascalCase keys (Host, Port, EnableSsl, etc.)
-    host = smtp_data.get("Host") or smtp_data.get("host") or ""
+    host = poll(find_host)
     if not host:
-        fail(f"SMTP host is empty — settings not configured. Data keys: {list(smtp_data.keys())}")
+        fail("SMTP host is empty — settings not configured after retries")
 
     ok(f"SMTP configured with host={host}")
 

--- a/tests/tasks/uipath-admin/check_user_invited.py
+++ b/tests/tasks/uipath-admin/check_user_invited.py
@@ -6,18 +6,21 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli, find_one, fail, ok
+from admin_helpers import run_cli, find_one, poll, fail, ok
 
 logging.basicConfig(level=logging.INFO, format="check_user: %(message)s")
 
 
 def main():
-    data = run_cli(["admin", "users", "list", "--search", "john.doe@example.com"])
-    if not data or data.get("Result") != "Success":
-        fail("users list did not return Success")
+    # Poll for eventual consistency
+    def find_user():
+        data = run_cli(["admin", "users", "list", "--search", "john.doe@example.com"])
+        if not data or data.get("Result") != "Success":
+            return None
+        return find_one(data, "john.doe@example.com", ["email", "userName"])
 
-    if not find_one(data, "john.doe@example.com", ["email", "userName"]):
-        fail("john.doe@example.com not found in users list")
+    if not poll(find_user):
+        fail("john.doe@example.com not found in users list after retries")
 
     ok("john.doe@example.com found in users list")
 


### PR DESCRIPTION
## Summary
- Added `poll()` helper to `admin_helpers.py` — retries a callable up to 4 times with 5s delay between attempts
- Updated all 6 check scripts (`check_federated_credential.py`, `check_group_membership.py`, `check_pat_created.py`, `check_robot_account.py`, `check_smtp_settings.py`, `check_user_invited.py`) to use `poll()` for resource lookups

## Root cause
After merging #1275 (idempotency fix), the agent now correctly deletes stale resources and re-creates them. However, the alpha tenant API has eventual consistency — newly created resources aren't immediately visible in list responses. The check scripts ran a single list call and failed because the resource hadn't propagated yet. The evalboard flagged this as "tenant API propagation delay pattern."

## Test plan
- [ ] Re-run the 7 admin tasks from the 2026-06-05 evalboard run
- [ ] Verify check scripts retry and find resources after propagation delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)