### PR TITLE
fix(uipath-maestro-flow): correct $vars check in ixp invoice greenfield e2e [RE-12430]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -87,7 +87,7 @@ success_criteria:
 
   - type: run_command
     description: "Generated flow references the IxP extraction output via $vars (downstream consumption)"
-    command: 'grep -rqE "\$vars\." --include="*.flow" .'
+    command: 'grep -rqF ''$vars.'' --include="*.flow" .'
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
The `$vars` downstream-consumption check was double-quoted, so bash turned `\$` into a leading-`$` regex anchor and it never matched — failing the task on every run regardless of agent output. Switch to a fixed-string match (`-F`), matching the `["$vars."]` convention used by the sibling ixp smoke tasks.

Ran `skill-flow-ixp-e2e-invoice-extraction-greenfield` locally on `claude-sonnet-4-6` (CI model) and it passed: 8/8 criteria, score 1.000 (was 7/8, 0.906 before the fix).

Resolves RE-12430.

🤖 Generated with [Claude Code](https://claude.com/claude-code)