### PR TITLE
fix: remove deprecated --use-studio flag from uip rpa commands

### DIFF
--- a/.claude/rules/content-quality.md
+++ b/.claude/rules/content-quality.md
@@ -32,7 +32,7 @@ This repository's primary audience is AI coding agents, not humans. Write accord
 
 Example:
 ```bash
-uip rpa get-errors --file-path "<FILE_PATH>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa get-errors --file-path "<FILE_PATH>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 ## Cross-Platform Awareness

--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -70,7 +70,7 @@ From tools list, extract tool `name` and `version` from each row.
 | Skill context | What to capture | Limits |
 |---|---|---|
 | **Flow** | `uip maestro flow validate <file> --output json`, `.flow` file content, directory listing | `.flow`: first 150 lines; directory: max 30 entries |
-| **RPA** (`.cs` or `.xaml`) | `project.json` dependencies, `uip rpa validate --output json --use-studio`, list of workflow files (`.cs` and/or `.xaml`) | File list: max 20 files; `project.json`: dependencies section only; failing workflow: first 150 lines |
+| **RPA** (`.cs` or `.xaml`) | `project.json` dependencies, `uip rpa validate --output json`, list of workflow files (`.cs` and/or `.xaml`) | File list: max 20 files; `project.json`: dependencies section only; failing workflow: first 150 lines |
 | **Agents** | `pyproject.toml`, `bindings.json` (redact connection values), directory listing | `bindings.json`: redact all values; directory: max 30 entries |
 | **Apps** | `package.json` (name, version, dependencies only), `.uipath/` listing | `package.json`: name + version + dependencies only |
 | **Platform** | `uip login status --output json` output only | Strip tokens from output |

--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -163,7 +163,7 @@ Report **all** results — Errors, Warnings, and Info — in the final review re
 2. For **each** entry point file, run validation yourself:
 
 ```bash
-uip rpa validate --file-path "<ENTRY_FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa validate --file-path "<ENTRY_FILE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 3. **Then run a project-level build** to catch what `validate` misses (unknown member names like `NGetText.Value`, invalid enum values like `Operator="StartsWith"`, member resolution / CacheMetadata failures, attribute-form C# expression JIT failures):
@@ -184,7 +184,7 @@ uip rpa build "<PROJECT_DIR>" --log-level Warn --output json
 The Workflow Analyzer checks code quality rules (ST-NMG naming, ST-DBP design, ST-MRD maintainability, ST-USG usage, ST-SEC security, ST-REL reliability). Run it explicitly:
 
 ```bash
-uip rpa analyze --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa analyze --project-dir "<PROJECT_DIR>" --output json
 ```
 
 If `uip rpa analyze` is not available, `uip rpa validate` includes Workflow Analyzer results. Check the output for all rule violations:

--- a/skills/uipath-review/references/review-workflow-guide.md
+++ b/skills/uipath-review/references/review-workflow-guide.md
@@ -131,7 +131,7 @@ cat "<PROJECT_DIR>/project.json" | python3 -c "import json,sys; d=json.load(sys.
 
 ```bash
 # Run for EACH entry point file discovered above
-uip rpa validate --file-path "<ENTRY_FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa validate --file-path "<ENTRY_FILE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 **Step 3 — Report ALL results:**

--- a/skills/uipath-review/references/rpa/rpa-review-checklist.md
+++ b/skills/uipath-review/references/rpa/rpa-review-checklist.md
@@ -55,7 +55,7 @@ Comprehensive quality checklist for UiPath RPA projects — coded workflows (C#)
 
 | Check | Severity | How to Verify |
 |---|---|---|
-| All referenced packages are installable | Critical | `uip rpa packages install --use-studio` |
+| All referenced packages are installable | Critical | `uip rpa packages install` |
 | No unused packages | Warning | Workflow Analyzer rule ST-USG-010 |
 | Version constraints use proper syntax (`[1.0.0]`, `[1.0.0, 2.0.0)`) | Warning | Read project.json dependencies |
 | No package version conflicts | Critical | Check for multiple versions of same package family |
@@ -99,7 +99,7 @@ Comprehensive quality checklist for UiPath RPA projects — coded workflows (C#)
 
 | Check | Severity | How to Verify |
 |---|---|---|
-| All `.xaml` files pass validation | Critical | `uip rpa validate --file-path "<FILE>" --project-dir "<DIR>" --output json --use-studio` |
+| All `.xaml` files pass validation | Critical | `uip rpa validate --file-path "<FILE>" --project-dir "<DIR>" --output json` |
 | Expression language in all XAML files matches `project.json` setting | Critical | Check `expressionLanguage` consistency |
 | No C# syntax in VB.NET projects | Warning | If `expressionLanguage` is `VisualBasic`, grep all `.xaml` for C# patterns: `!=`, `&&`, `\|\|`, `null` (VB uses `Nothing`), `$"` (interpolated strings), `=>` (lambda), `//` (comments), `typeof()` (VB uses `GetType()`). These compile-fail or silently misbehave. |
 | No activities with default display names ("Sequence", "Assign", "If") | Warning | Workflow Analyzer rule ST-MRD-002 |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AppendRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AppendRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `DestinationRange`, `HasHeaders`, `DestinationHasHeaders`, `PasteOptions`, `Transpose`, `StartingColumnName="{x:Null}"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFillX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFillX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `StartRange` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFitX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/AutoFitX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `Columns`, `Rows` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangeDataRangeModification.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangeDataRangeModification.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Range` (nested inside `UpdateChartX` body) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangePivotTableDataSourceX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ChangePivotTableDataSourceX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `PivotTable="[Excel.Sheet(&quot;Sheet1&quot;).PivotTable(&quot;PivotName&quot;)]"`, `NewSourceRange` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ClearRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ClearRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `TargetRange`, `HasHeaders` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CopyPasteRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CopyPasteRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `DestinationRange`, `PasteOptions="All"`, `Transpose="False"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreatePivotTableXv2.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreatePivotTableXv2.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `DestinationRange`, `TableName`, `LayoutRowType`, `ValuesMode`; body `ActivityAction` (no type args), child `ueab:PivotTableFieldX` inside |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreateTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/CreateTableX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `HasHeaders`, `OutTableName`, `TableName="{x:Null}"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnName`, `HasHeaders` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteRowsX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `DeleteRowsOption="Specific"`, `RowPositions`, `HasHeaders` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DeleteSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet="[Excel.Sheet(&quot;SheetName&quot;)]"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DuplicateSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/DuplicateSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SheetToDuplicate`, `NewSheetName` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroArgumentX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroArgumentX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ArgumentValue` (nested inside `ExecuteMacroX` body) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExecuteMacroX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `MacroName`; `Result` via child `OutArgument`; body contains `ueab:ExecuteMacroArgumentX` children |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExportExcelToCsvX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ExportExcelToCsvX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `TargetRange`, `FilePath` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FillRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FillRangeX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `DestinationRange="[Excel.Sheet(s).Range(&quot;B11&quot;)]"`, `Value="[&quot;SUM(B1:B10)&quot;]"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterPivotTableX.md
@@ -11,4 +11,4 @@ xmlns:ueabf="clr-namespace:UiPath.Excel.Activities.Business.Filter;assembly=UiPa
 |---------------|
 | `Table="[Excel.Sheet(...).PivotTable(&quot;Name&quot;)]"`, `ColumnName`, `ClearFilter`; child `FilterArgument` uses `ueabf:FilterArgument` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FilterX.md
@@ -11,4 +11,4 @@ xmlns:ueabf="clr-namespace:UiPath.Excel.Activities.Business.Filter;assembly=UiPa
 |---------------|
 | `Range`, `ColumnName`, `HasHeaders`, `ClearFilter`; child `FilterX.FilterArgument` uses `ueabf:FilterArgument` or `ueabf:AdvancedFilterArgument` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindFirstLastDataRowX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindFirstLastDataRowX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnName`, `FirstRowIndex`, `LastRowIndex`, `HasHeaders`, `ConfigureLastRowAs`, `BlankRowsToSkip` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindReplaceValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FindReplaceValueX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `WhereToSearch="[Excel.Sheet(...)]"`, `ValueToFind`, `ReplaceWith`, `Operation="Replace\|FindOnly"`, `LookIn="Values"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FormatRangeX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/FormatRangeX.md
@@ -4,6 +4,6 @@
 
 | Key Attributes |
 |---------------|
-| `Range` + child elements `Alignment`, `Font`, `Format`, `NumberFormat` (use `uip rpa activities get-default-xaml --use-studio` for child structure) |
+| `Range` + child elements `Alignment`, `Font`, `Format`, `NumberFormat` (use `uip rpa activities get-default-xaml` for child structure) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range="[Excel.Sheet(...)]"`, `NewColumnName`, `RelativeColumnName`, `RelativePosition="After\|Before"`, `HasHeaders="True"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertExcelChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertExcelChartX.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Range`, `InsertIntoSheet`, `InsertedChart` (output, type `ue:IChartRef`), `ChartCategory`, `ChartType`, `ChartHeight`, `ChartWidth`, `Left`, `Top` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertRowsX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertRowsX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range="[Excel.Sheet(...)]"`, `InsertPosition="End\|Beginning"`, `NbOfRows`, `HasHeaders="True"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InsertSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `Name="NewSheet"`, `ReferenceNewSheetAs="[outNewSheet]"` — variable type `ue:ISheetRef` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAArgumentX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAArgumentX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ArgumentValue` (nested inside `InvokeVBAX` body) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/InvokeVBAX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `CodeFilePath`, `EntryMethodName`, `Result="{x:Null}"`; body contains `ueab:InvokeVBAArgumentX` children |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/LookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/LookupX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `Label`, `ResultRange="{x:Null}"`, output via `Value` child `OutArgument` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/PivotTableFieldX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/PivotTableFieldX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `FieldName`, `Function="Sum"`, `Type="Row"` (nested inside `CreatePivotTableXv2` body) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ProtectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ProtectSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet="[Excel.Sheet(...)]"`, `Password`, `SecurePassword="{x:Null}"`, `AdditionalPermissions` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellFormulaX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellFormulaX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell`, `SaveTo="[outFormula]"` (direct attribute) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellValueX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/ReadCellValueX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell="[CurrentRow.ByIndex(0)]"`, `GetFormattedText`, output via `SaveTo` child `OutArgument` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RefreshPivotTableX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RefreshPivotTableX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Table="[Excel.Sheet(...).PivotTable(...)]"`, `LayoutRowType="{x:Null}"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RemoveDuplicatesX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RemoveDuplicatesX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `ColumnsCompareMode="AllColumns"`, `Columns` child list |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RenameSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/RenameSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `From="[Excel.Sheet(&quot;OldName&quot;)]"`, `To="NewName"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveAsPdfX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveAsPdfX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"`, `DestinationPdfPath`, `SaveQuality="StandardQuality"`, `EndPage="{x:Null}"`, `StartPage="{x:Null}"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveExcelFileX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SaveExcelFileX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Workbook="[Excel]"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortColumnX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortColumnX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `ColumnName`, `SortDirection="Ascending"` (nested inside `SortX` body) |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/SortX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Range`, `HasHeaders`; body `ActivityAction` (no type args), child `ueab:SortColumnX` inside |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UnprotectSheetX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UnprotectSheetX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Sheet`, `Password`, `SecurePassword="{x:Null}"` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UpdateChartX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/UpdateChartX.md
@@ -11,4 +11,4 @@ xmlns:ueabc="clr-namespace:UiPath.Excel.Activities.Business.ChartModifications;a
 |---------------|
 | `Chart`; body `ActivityAction` (no type args), child `ueabc:ChangeDataRangeModification` inside |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/VLookupX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/VLookupX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `SourceRange`, `Label`, `ExactMatch`, `ColumnIndex="{x:Null}"`, output via `Value` child `OutArgument` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/WriteCellX.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/WriteCellX.md
@@ -6,4 +6,4 @@
 |---------------|
 | `Cell="[Excel.Sheet(&quot;Sheet1&quot;).Cell(&quot;A1&quot;)]"`, `Value` |
 
-Use `uip rpa activities get-default-xaml --use-studio` for full XAML.
+Use `uip rpa activities get-default-xaml` for full XAML.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Excel.Activities/3.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Excel Activities
 
-Excel activity patterns for `UiPath.Excel.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Excel activity patterns for `UiPath.Excel.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed patterns from real workflows only.
 
 ## Package
 
@@ -46,7 +46,7 @@ Namespace imports needed in `TextExpression.NamespacesForImplementation`:
 | Handle variable types | `ue:ISheetRef` (InsertSheetX output), `ue:IChartRef` (InsertExcelChartX output) |
 | Classic standalone | No scope — `WorkbookPath` on each activity; set `WorkbookPathResource="{x:Null}"` |
 | `ForEachRow` (classic) | One arg: `DelegateInArgument x:TypeArguments="sd:DataRow" Name="CurrentRow"` |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |
 
 ## Common Pitfalls
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.GSuite.Activities/3.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML GSuite Activities
 
-Google Suite activity patterns for `UiPath.GSuite.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Google Suite activity patterns for `UiPath.GSuite.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed patterns from real workflows only.
 
 ## Triggers in this package
 
@@ -46,4 +46,4 @@ Use `uip is connections list --output json` to obtain the connection GUID. If no
 | `ForEachEmailConnections` | Three-arg body: `Argument1` (`GmailMessage` `"CurrentEmail"`), `Argument2` (`Int32` `"CurrentEmailIndex"`) |
 | `ForEachFileFolderConnections` | One-arg body: `CurrentItem` as `GDriveRemoteItem` |
 | `RowAddedToSheetBottom` | Generic type param `System.Data.DataRow`; output `AddedRow: DataRow` |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Mail.Activities/2.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Outlook Mail Activities (UiPath.Mail.Activities)
 
-Classic Outlook mail activity patterns for `UiPath.Mail.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed namespace and attribute patterns from real workflows only. **Not for `UiPath.MicrosoftOffice365.Activities`** — see `msoffice365-outlook-activities.md` for O365.
+Classic Outlook mail activity patterns for `UiPath.Mail.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed namespace and attribute patterns from real workflows only. **Not for `UiPath.MicrosoftOffice365.Activities`** — see `msoffice365-outlook-activities.md` for O365.
 
 ## Package
 
@@ -68,4 +68,4 @@ Without IS connection, omit `UseISConnection` and the child element entirely.
 | `ForEachEmailX` | Two args: `Argument1` (`snm:MailMessage` `"CurrentMail"`) + `Argument2` (`x:Int32` `"CurrentIndex"`) |
 | `SaveMailAttachments` | Uses `ui:` prefix even inside modern scope — it's a classic activity |
 | Email properties | `CurrentMail.Subject`, `CurrentMail.SenderEmailAddress()`, `CurrentMail.Date()`, `CurrentMail.Priority.AsText()`, `CurrentMail.Attachments.Count` |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/SendMailConnections.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/SendMailConnections.md
@@ -40,6 +40,6 @@ Null attributes: `ArgumentAttachmentPaths`, `AttachmentList`, `Bcc`, `Cc`, `Conn
 </umam:SendMailConnections>
 ```
 
-Additional BackupSlot children (get full structure from `uip rpa activities get-default-xaml --use-studio`):
+Additional BackupSlot children (get full structure from `uip rpa activities get-default-xaml`):
 - `AttachmentsArg` — type `umame:AttachmentInputMode`
 - `InputTypeArg` — type `umame:BodyInputType`

--- a/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.MicrosoftOffice365.Activities/3.8/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Outlook Mail Activities
 
-Office 365 Outlook mail activity patterns for `UiPath.MicrosoftOffice365.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed namespace and attribute patterns from real workflows only.
+Office 365 Outlook mail activity patterns for `UiPath.MicrosoftOffice365.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed namespace and attribute patterns from real workflows only.
 
 ## Package
 
@@ -39,5 +39,5 @@ Use `uip is connections list --output json` to obtain the connection GUID. If no
 | Recipients | `<CSharpValue x:TypeArguments="scg:IEnumerable(x:String)">new string[]{"a@b.com"}</CSharpValue>` |
 | FilterExpression booleans | Backtick-quoted: `` `true` ``, `` `false` `` |
 | FilterExpression AND | `&amp;&amp;` (XML-escaped `&&`) |
-| BackupSlot (SendMail) | `MailboxArg` child required; `AttachmentsArg` and `InputTypeArg` also needed — use `uip rpa activities get-default-xaml --use-studio` for full structure |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| BackupSlot (SendMail) | `MailboxArg` child required; `AttachmentsArg` and `InputTypeArg` also needed — use `uip rpa activities get-default-xaml` for full structure |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Presentations.Activities/2.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML PowerPoint Presentation Activities
 
-PowerPoint activity patterns for `UiPath.Presentations.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+PowerPoint activity patterns for `UiPath.Presentations.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed patterns from real workflows only.
 
 **Target:** Windows only (not Cross-platform / Studio Web Portable).
 
@@ -72,4 +72,4 @@ The scope body passes an `IPresentationQuickHandle` as a delegate argument (conv
 | Save vs SaveAs | `AutoSave="True"` on scope saves on close; use `SavePresentationFileAs` to save to a different path/format |
 | Macros | Use `RunMacro` with nested `RunMacroArgument` children for each argument |
 | Windows only | `UiPath.Presentations.Activities` does not support Cross-platform / Studio Web Portable target |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/25.10/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.System.Activities/25.10/activities/overview.md
@@ -90,4 +90,4 @@ xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 - **Direction:** IN (read-only), OUT (write-only), IN/OUT (read-write)
 - **Case Sensitive:** Argument names are case-sensitive
 
-These activities are part of `UiPath.System.Activities` (always installed). You can write them directly **without** calling `uip rpa activities get-default-xaml --use-studio`. Use the templates as-is — just replace the placeholder expressions with your actual logic.
+These activities are part of `UiPath.System.Activities` (always installed). You can write them directly **without** calling `uip rpa activities get-default-xaml`. Use the templates as-is — just replace the placeholder expressions with your actual logic.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Word.Activities/2.5/activities/overview.md
@@ -1,6 +1,6 @@
 # XAML Word Document Activities
 
-Word document activity patterns for `UiPath.Word.Activities`. Always get full XAML from `uip rpa activities get-default-xaml --use-studio` — this file covers confirmed patterns from real workflows only.
+Word document activity patterns for `UiPath.Word.Activities`. Always get full XAML from `uip rpa activities get-default-xaml` — this file covers confirmed patterns from real workflows only.
 
 **Target:** Windows only (not Cross-platform / Studio Web Portable).
 
@@ -106,4 +106,4 @@ xmlns:ui="http://schemas.uipath.com/workflow/activities"
 | Export to PDF | Use `WordExportToPdf` inside scope; set `ReplaceExisting="True"` to overwrite |
 | Save vs SaveAs | `AutoSave="True"` on scope saves on close; use `WordSaveAs` to save to a different path |
 | Windows only | `UiPath.Word.Activities` does not support Cross-platform / Studio Web Portable target |
-| Full XAML | Always use `uip rpa activities get-default-xaml --use-studio` for complete activity XAML |
+| Full XAML | Always use `uip rpa activities get-default-xaml` for complete activity XAML |

--- a/skills/uipath-rpa/references/testing-guide.md
+++ b/skills/uipath-rpa/references/testing-guide.md
@@ -160,7 +160,7 @@ Three commands attach different data source types to a test case. All three regi
 #### `test-data add-variation` — File-based (JSON)
 
 ```bash
-uip rpa test-data add-variation --test-case-path "<TEST_CASE_FILE>" --data-variation-path "<DATA_FILE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa test-data add-variation --test-case-path "<TEST_CASE_FILE>" --data-variation-path "<DATA_FILE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -172,7 +172,7 @@ Parses fields from the JSON file and creates one argument per field with matchin
 
 **Example:**
 ```bash
-uip rpa test-data add-variation --test-case-path "TestProcessInvoice.cs" --data-variation-path ".variations/InvoiceData.json" --project-dir "C:\MyProject" --output json --use-studio
+uip rpa test-data add-variation --test-case-path "TestProcessInvoice.cs" --data-variation-path ".variations/InvoiceData.json" --project-dir "C:\MyProject" --output json
 ```
 
 #### `test-data add-queue` — Orchestrator Test Data Queue
@@ -180,7 +180,7 @@ uip rpa test-data add-variation --test-case-path "TestProcessInvoice.cs" --data-
 > **Prerequisite:** Use the **uipath-platform** skill to discover queue details (name, ID, folder) before calling this command.
 
 ```bash
-uip rpa test-data add-queue --test-case-path "<TEST_CASE_FILE>" --queue-name "<QUEUE_NAME>" --folder-path "<FOLDER>" --queue-id <ID> --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa test-data add-queue --test-case-path "<TEST_CASE_FILE>" --queue-name "<QUEUE_NAME>" --folder-path "<FOLDER>" --queue-id <ID> --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -194,7 +194,7 @@ Creates an `IDictionary<string, object>` argument named after the queue (camelCa
 
 **Example:**
 ```bash
-uip rpa test-data add-queue --test-case-path "TestLoanApproval.cs" --queue-name "loan_applications" --folder-path "Shared" --queue-id 123 --project-dir "C:\MyProject" --output json --use-studio
+uip rpa test-data add-queue --test-case-path "TestLoanApproval.cs" --queue-name "loan_applications" --folder-path "Shared" --queue-id 123 --project-dir "C:\MyProject" --output json
 ```
 
 > **Critical:** Do NOT rename the auto-generated test data queue argument. If you change its name, data retrieval silently fails.
@@ -206,7 +206,7 @@ uip rpa test-data add-queue --test-case-path "TestLoanApproval.cs" --queue-name 
 > 2. **Install the target entity into the project** if not already installed — `uip rpa data-fabric-entities install --add "<ENTITY_NAME>" --project-dir "<PROJECT_DIR>" --output json`. `test-data add-entity` requires the entity's generated type to exist in the project. See [cli-reference.md § Data Fabric Entities](cli-reference.md#commands----data-fabric-entities).
 
 ```bash
-uip rpa test-data add-entity --test-case-path "<TEST_CASE_FILE>" --entity-name "<ENTITY_NAME>" --entity-type-name "<ENTITY_TYPE>" --project-dir "<PROJECT_DIR>" --output json --use-studio
+uip rpa test-data add-entity --test-case-path "<TEST_CASE_FILE>" --entity-name "<ENTITY_NAME>" --entity-type-name "<ENTITY_TYPE>" --project-dir "<PROJECT_DIR>" --output json
 ```
 
 | Parameter | Required | Description |
@@ -219,7 +219,7 @@ Creates an argument of the entity type named after the entity (camelCase). Requi
 
 **Example:**
 ```bash
-uip rpa test-data add-entity --test-case-path "TestLoanApproval.cs" --entity-name "LoanApplication" --entity-type-name "LoanApplication" --project-dir "C:\MyProject" --output json --use-studio
+uip rpa test-data add-entity --test-case-path "TestLoanApproval.cs" --entity-name "LoanApplication" --entity-type-name "LoanApplication" --project-dir "C:\MyProject" --output json
 ```
 
 ### Data-Driven Testing Best Practices

--- a/skills/uipath-rpa/references/trigger-pattern-guide.md
+++ b/skills/uipath-rpa/references/trigger-pattern-guide.md
@@ -97,7 +97,7 @@ Structural shape (placeholders in angle brackets — fill from `get-default-xaml
         <!-- One or more local trigger activities. Get full XAML via:
                uip rpa activities get-default-xaml \
                  --activity-class-name <FullClassName> \
-                 --project-dir "<PROJECT_DIR>" --use-studio --output json -->
+                 --project-dir "<PROJECT_DIR>" --output json -->
         <<TriggerPrefix>:<TriggerClassName> DisplayName="..." ... />
       </ui:TriggerScope.Triggers>
       <ui:TriggerScope.Action>

--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -21,7 +21,7 @@ initial_prompt: |
   The working directory starts empty. Scaffold the project with
   `uip rpa init --name "LoginTests" --location "." --template-id TestAutomationProjectTemplate`.
   Studio Desktop is NOT available — skip any CLI commands that require
-  --use-studio. Focus on generating the correct files and project.json updates.
+  a running Studio Desktop instance. Focus on generating the correct files and project.json updates.
 
   Use `UiPath.Testing.Activities` version `[25.4.1]` (newer 25.10.x
   releases synthesize a bootloader that breaks the build on this

--- a/tests/tasks/uipath-rpa/xaml_test_case.yaml
+++ b/tests/tasks/uipath-rpa/xaml_test_case.yaml
@@ -18,7 +18,7 @@ initial_prompt: |
   The working directory starts empty. Scaffold the project with
   `uip rpa init --name "LoginTests" --location "." --template-id TestAutomationProjectTemplate`.
   Studio Desktop is NOT available — skip any CLI commands that require
-  --use-studio.
+  a running Studio Desktop instance.
 
   Requirements:
   - Create one XAML test case at `LoginTests/TestLoginSuccess.xaml` that

--- a/tests/tasks/uipath-troubleshoot/healing-agent-recommendation-only/RESOLUTION.md
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-recommendation-only/RESOLUTION.md
@@ -33,7 +33,7 @@ Immediate fix:
   - Source: `references/activity-packages/ui-automation/playbooks/selector-failure-healing-fix.md` → `interpretations/healing-agent-data.md` § "Applying `update-target` Fixes".
 2. After editing, validate the workflow compiles cleanly.
   - Why: HA's selector was never tested at runtime (recommendation-only mode), so the only safety net before redeploying is a clean compile plus a manual rerun.
-  - Where: `uip rpa get-errors --file-path "Google.xaml" --output json --use-studio`.
+  - Where: `uip rpa get-errors --file-path "Google.xaml" --output json`.
   - Who: RPA developer.
   - Source: `interpretations/healing-agent-data.md` § "Applying `update-target` Fixes" step 5.
 

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/RESOLUTION.md
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/RESOLUTION.md
@@ -43,7 +43,7 @@ Immediate fix:
    - Who: RPA developer.
    - Source: `references/activity-packages/ui-automation/playbooks/disabled-element.md` § Resolution → branch (D).
 
-After applying the fix, validate the workflow: `uip rpa get-errors --file-path "ClickCase.xaml" --output json --use-studio`.
+After applying the fix, validate the workflow: `uip rpa get-errors --file-path "ClickCase.xaml" --output json`.
 
 ### Orchestrator (Propagation)
 1. Restart the job from Orchestrator after the `ClickCase.xaml` fix is published.

--- a/tests/tasks/uipath-troubleshoot/uia-node-not-found/RESOLUTION.md
+++ b/tests/tasks/uipath-troubleshoot/uia-node-not-found/RESOLUTION.md
@@ -55,7 +55,7 @@ Pick one of the three branches below (in order of preference). All three address
    - Who: RPA developer.
    - Source: `references/activity-packages/ui-automation/playbooks/selector-failure-healing-disabled.md` § Resolution → "If wrong-page scope (authoring defect)".
 
-After applying any of the three options, validate the workflow: `uip rpa get-errors --file-path "" --output json --use-studio`.
+After applying any of the three options, validate the workflow: `uip rpa get-errors --file-path "" --output json`.
 
 ### Orchestrator (Propagation)
 1. Restart the job from Orchestrator after the TO.xaml fix is published.
@@ -128,7 +128,7 @@ Three available remediation branches (apply ONE):
   C) Change AttachMode from 'ByInstance' to a mode that opens/navigates (e.g., 'OpenIfNotRunning') AND set TargetApp.Url to the Doodles archive URL.
 
 After the change, validate with:
-  uip rpa get-errors --file-path "" --output json --use-studio
+  uip rpa get-errors --file-path "" --output json
 ```
 
 **Warning:** Healing Agent was enabled on this run but could not produce a recovered selector — the live page never contained the target element, so there is no HA suggestion to apply. The fix must be made at the parent scope (NApplicationCard "Edge Google") in TO.xaml, not on the Click's selector. Enabling Healing Agent does not fix wrong-page-scope defects.


### PR DESCRIPTION
## What

Removes the `--use-studio` flag from every `uip rpa` command example across the repo (64 files, 80 lines).

## Why

`--use-studio` is **deprecated and has no effect**. Verified against the shipping rpa-tool source (`RpaTool/rpa-tool` v1.1.0, commit `9b07b692ff` / STUD-79565):

- The CLI arg is read in exactly one place (`index.ts:49`) and only emits a stderr deprecation warning when `UIPATH_STUDIO_PID` is set.
- The Studio backend is now driven solely by the `UIPATH_RPA_TOOL_USE_STUDIO=1` env var; Studio routing is automatic via `UIPATH_STUDIO_PID`. The flag never feeds the resolution logic.

Keeping it in docs is inaccurate and, in integrated-terminal mode, the stderr warning can pollute the `--output json` that skills like `uipath-review` parse and grade on.

## Changes

- **Command examples** — flag stripped in `uipath-review`, `uipath-rpa` (activity-docs, testing-guide, trigger-pattern), `uipath-feedback`, the `.claude/rules/content-quality.md` example, and `uipath-troubleshoot` test fixtures.
- **Prose** — the two `uipath-rpa` test-case prompts referenced the flag in prose ("skip commands that require `--use-studio`") and were rephrased to "require a running Studio Desktop instance" to preserve intent without naming the dead flag.

## Risk

None — no behavior change. Removing the flag touches neither the env vars nor the requested backend, so command resolution is identical. Mechanical sweep verified: every command-line change differs by exactly ` --use-studio` (automated old-vs-new comparison, zero mismatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)