### PR TITLE
test(uipath-agents): point escalation tasks at deployed FraudEscalation app

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/external_escalation/check_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/check_external_escalation.py
@@ -2,7 +2,7 @@
 """External escalation (ActionCenter) resource check.
 
 Validates:
-  1. resources/FraudEscalationQueue/resource.json declares an escalation:
+  1. resources/FraudEscalation/resource.json declares an escalation:
        - $resourceType == "escalation"
        - id is a UUID-shaped non-empty string
        - name is a non-empty string
@@ -27,7 +27,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(os.getcwd()) / "FraudSol" / "FraudTriageAgent"
-RESOURCE = ROOT / "resources" / "FraudEscalationQueue" / "resource.json"
+RESOURCE = ROOT / "resources" / "FraudEscalation" / "resource.json"
 
 
 def load(path: Path) -> dict:

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -17,7 +17,7 @@ initial_prompt: |
   Create a UiPath low-code agent "FraudTriageAgent" that accepts a required
   `transaction` (object) and returns a `verdict` (string). When the
   agent is uncertain, it must escalate to a human reviewer via an
-  EXISTING EXTERNAL ActionCenter app named "FraudEscalationQueue" that
+  EXISTING EXTERNAL ActionCenter app named "FraudEscalation" that
   is already deployed to the Orchestrator "Shared" folder (not inside
   this solution). Model this as an escalation resource on the agent.
   The solution should be named "FraudSol".
@@ -25,7 +25,7 @@ initial_prompt: |
   When writing the escalation resource.json, set `isEnabled` to true so
   the escalation is active for the agent. Set `properties.folderPath`
   to the literal string "Shared" (the live Orchestrator folder where
-  FraudEscalationQueue is deployed) — never use placeholder values
+  FraudEscalation is deployed) — never use placeholder values
   like "solution_folder".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
@@ -84,8 +84,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_exists
-    description: "FraudEscalationQueue external escalation resource.json was created"
-    path: "FraudSol/FraudTriageAgent/resources/FraudEscalationQueue/resource.json"
+    description: "FraudEscalation external escalation resource.json was created"
+    path: "FraudSol/FraudTriageAgent/resources/FraudEscalation/resource.json"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -16,7 +16,7 @@ run_limits:
 initial_prompt: |
   Create a UiPath Flow project "FraudFlow" that uses an inline low-code agent
   to triage transactions and escalate uncertain cases to an EXISTING
-  EXTERNAL ActionCenter app named "FraudEscalationQueue" already
+  EXTERNAL ActionCenter app named "FraudEscalation" already
   deployed to the Orchestrator "Shared" folder (not inside this
   solution). Wire the escalation as a resource on the inline agent.
   The solution should be named "FraudFlowSol".


### PR DESCRIPTION
## Summary

The lowcode external-escalation eval tasks referenced an ActionCenter app named **`FraudEscalationQueue`**, which was never deployed to the tenant. This repoints them at **`FraudEscalation`** — the external ActionCenter app that is now actually deployed in the Orchestrator `Shared` folder — so the tasks resolve against a real resource.

## Changes

Renamed all `FraudEscalationQueue` references to `FraudEscalation` in:

- `tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml` — prompt app name, `file_exists` description + path (`resources/FraudEscalation/resource.json`)
- `tests/tasks/uipath-agents/lowcode/external_escalation/check_external_escalation.py` — docstring + `RESOURCE` path constant
- `tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml` — prompt app name

The `inline_external_escalation` check script globs the agent's `resources/` tree rather than hardcoding the app name, so it needed no change. The solution-internal escalation tasks (`solution_escalation`, `inline_solution_escalation`) never referenced this app and are untouched.

## Validation

Rebased onto latest `main` and ran both escalation tasks under `experiments/default.yaml`:

| Task | Status | Score | Criteria |
|------|--------|-------|----------|
| `external_escalation` | ✅ SUCCESS | 1.000 | 9/9 |
| `inline_external_escalation` | ✅ SUCCESS | 1.000 | 8/8 |

**2/2 passed.** Verified the renamed app resolves end-to-end: the sandbox created `resources/FraudEscalation/resource.json` (no stale `FraudEscalationQueue` dir), and both the `file_exists` path check (weight 2.5) and the `check_external_escalation.py` resource-shape check (weight 5.0) pass.

> An earlier run (before rebasing) showed `external_escalation` failing 8/9 on the `.agent-builder/agent.json` regeneration check. That was unrelated to this rename — it is resolved on current `main` via #1066, which adds a `uip agent refresh` step + criterion that regenerates the derived `.agent-builder/` files. Both tasks pass cleanly once rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)