### PR TITLE
docs(uipath-agents): replace low-code `uip agent push` with `uip solution upload`

### DIFF
--- a/skills/uipath-agents/references/lowcode/evaluations/evaluate.md
+++ b/skills/uipath-agents/references/lowcode/evaluations/evaluate.md
@@ -20,7 +20,7 @@ uip agent eval run results <run_id> --set "Default Evaluation Set" --only-failed
 - Agent project initialized (`uip agent init <path>`)
 - `entry-points.json` present (defines `input`/`output` schema that test case `--inputs`/`--expected` must conform to)
 - `uip agent validate --output json` passes (validate also checks evals and evaluators)
-- Agent pushed to Studio Web (`uip agent push`) — required for running evals (the Agent Runtime executes test cases in the cloud)
+- Agent's solution uploaded to Studio Web (`uip solution upload`) — required for running evals (the Agent Runtime executes test cases in the cloud)
 
 Local operations (managing evaluators, eval sets, test cases) do **not** require authentication or a cloud connection. Only `uip agent eval run *` commands require cloud connectivity.
 
@@ -61,7 +61,7 @@ CLI-added evaluators are written as `evaluator-<uuid8>.json` (first 8 hex chars 
 |--------|-------------------------------|------------------------------|
 | Execution | Local Python process | Cloud-based via Agent Runtime |
 | Auth required | Only for `--report` | Always (cloud execution) |
-| Prerequisite | `entry-points.json` | `uip agent push` |
+| Prerequisite | `entry-points.json` | `uip solution upload` |
 | Mocking | `@mockable()` decorator + declarative | Simulation instructions only |
 | CLI prefix | `uip codedagent eval` | `uip agent eval` |
 
@@ -69,7 +69,7 @@ CLI-added evaluators are written as `evaluator-<uuid8>.json` (first 8 hex chars 
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| Solution ID could not be resolved | Agent not pushed to Studio Web | Run `uip agent push --output json`, or pass `--solution-id <id>` explicitly to `uip agent eval run start` |
+| Solution ID could not be resolved | Agent's solution not uploaded to Studio Web | Run `uip solution upload . --output json` (add `--force` to replace an existing cloud solution), or pass `--solution-id <id>` explicitly to `uip agent eval run start` |
 | `No evaluators found` | Empty `evals/evaluators/` directory | Run `uip agent eval evaluator add` or re-init with `uip agent init` |
 | `No test cases in eval set` | Eval set has no evaluations | Run `uip agent eval add` to add test cases |
 | `Unknown evaluator type "X"` | Wrong case on `--type` value | Use kebab-case only: `semantic-similarity`, `trajectory` |
@@ -79,12 +79,12 @@ CLI-added evaluators are written as `evaluator-<uuid8>.json` (first 8 hex chars 
 | Eval run timeout (with `--wait`) | Agent taking too long or stuck | Increase `--timeout` or check agent health in Studio Web. Note: this only stops the local CLI from blocking; the run continues server-side — query with `uip agent eval run status <run_id>` |
 | Validate fails with eval errors | Eval set references an evaluator that no longer exists, OR evaluator JSON missing required field, OR `category`/`type` mismatch (see [evaluators.md](evaluators.md) § What `uip agent validate` Checks) | Re-run `uip agent eval evaluator list` and reconcile `evaluatorRefs`; fix per the validate error message |
 
-The two model-resolution errors above are **runtime checks in the cloud eval worker**, not validate-time checks — `uip agent validate` will not catch them. They surface only after `uip agent eval run start`. To pre-empt them, inspect each evaluator's `model` field locally before pushing.
+The two model-resolution errors above are **runtime checks in the cloud eval worker**, not validate-time checks — `uip agent validate` will not catch them. They surface only after `uip agent eval run start`. To pre-empt them, inspect each evaluator's `model` field locally before uploading.
 
 ## Anti-patterns
 
-- **Don't run `uip agent eval run start` before `uip agent push`.** The Agent Runtime executes against the pushed agent. Local edits to `agent.json` after the last push will not be reflected in the run.
-- **Don't skip `uip agent validate` before push.** Validate checks `evals/` and `evaluators/`; broken eval JSON will not block push but will surface as runtime errors.
+- **Don't run `uip agent eval run start` before `uip solution upload`.** The Agent Runtime executes against the uploaded agent. Local edits to `agent.json` after the last upload will not be reflected in the run.
+- **Don't skip `uip agent validate` before upload.** Validate checks `evals/` and `evaluators/`; broken eval JSON will not block upload but will surface as runtime errors.
 - **Don't hand-edit `id` or `evaluatorRefs` UUIDs.** Eval sets reference evaluators by UUID. Renaming an evaluator file or copy-pasting a UUID across evaluators silently breaks resolution.
 - **Don't expect filenames to match `<name>`.** CLI-generated evaluator files use `evaluator-<uuid8>.json`, not `<name>.json`. Look up evaluators by the `name` field inside the JSON, not by filename.
 - **Don't pass `--type` in PascalCase.** The CLI rejects `SemanticSimilarity`. Only kebab-case is accepted.

--- a/skills/uipath-agents/references/lowcode/evaluations/evaluation-sets.md
+++ b/skills/uipath-agents/references/lowcode/evaluations/evaluation-sets.md
@@ -148,6 +148,6 @@ The `source` field indicates how the test case was created. CLI-added test cases
 ## Anti-patterns
 
 - **Don't hand-write `evalSetId` or test case `id` UUIDs.** Use `uip agent eval add` so the CLI keeps `evaluations[].evalSetId` consistent with the parent eval set's `id`.
-- **Don't add `--inputs` keys that are not in `entry-points.json`.** The runtime will reject the test case at execution time. Run `uip agent validate` to catch this before push.
+- **Don't add `--inputs` keys that are not in `entry-points.json`.** The runtime will reject the test case at execution time. Run `uip agent validate` to catch this before upload.
 - **Don't set `--expected '{}'` (empty) and `--expected-agent-behavior ""` together.** The semantic-similarity evaluator scores against an empty `{{ExpectedOutput}}`; the trajectory evaluator scores against an empty `{{ExpectedAgentBehavior}}`. Every run scores low for non-actionable reasons.
 - **Don't set the `source` field manually.** Owned by CLI and Studio Web; hand-edits may be overwritten on the next sync.

--- a/skills/uipath-agents/references/lowcode/evaluations/evaluators.md
+++ b/skills/uipath-agents/references/lowcode/evaluations/evaluators.md
@@ -261,7 +261,7 @@ These errors surface only after `uip agent eval run start` — `uip agent valida
 | `Evaluator '<id>' is an LLM-based evaluator but 'model' is not set in its evaluatorConfig. Specify a valid model name (e.g. 'claude-haiku-4-5-20251001').` | Evaluator JSON has empty/missing `model` (and is not `same-as-agent`). The worker fail-fasts before calling the LLM gateway. | Set `model` in the evaluator JSON to a model available in your tenant, or set `"model": "same-as-agent"` and ensure `agent.json` has a model. |
 | `'same-as-agent' model option requires agent settings. Ensure agent.json contains valid model settings.` | Evaluator uses `"same-as-agent"` but `agent.json` has no resolvable model. | Set `model` in `agent.json`, or override the evaluator with an explicit model. |
 
-**Pre-empt locally:** before push, run
+**Pre-empt locally:** before upload, run
 
 ```bash
 uip agent eval evaluator list --path ./my-agent --output json --output-filter '[?model==`""` || model==null]'

--- a/skills/uipath-agents/references/lowcode/evaluations/running-evaluations.md
+++ b/skills/uipath-agents/references/lowcode/evaluations/running-evaluations.md
@@ -2,7 +2,7 @@
 
 Execute evaluations against the Agent Runtime, check status, view results, and compare runs.
 
-All run commands require the agent to be pushed to Studio Web first (`uip agent push`). The Agent Runtime executes test cases in the cloud using the pushed agent definition.
+All run commands require the agent's solution to be uploaded to Studio Web first (`uip solution upload`). The Agent Runtime executes test cases in the cloud using the uploaded agent definition.
 
 ## Start an Eval Run
 
@@ -18,7 +18,7 @@ uip agent eval run start --set "<eval_set_name>" --path <agent_dir> --wait --out
 | `--path <path>` | No | Agent project directory | `.` |
 | `--wait` | No | Block until the run completes, then print results | `false` |
 | `--timeout <seconds>` | No | Maximum time to block when `--wait` is set | `600` (10 min) |
-| `--solution-id <id>` | No | Override solution ID for this run | Auto-resolved from the pushed-agent state |
+| `--solution-id <id>` | No | Override solution ID for this run | Auto-resolved from the uploaded solution state |
 
 Without `--wait`, the command returns immediately with `Code: AgentEvalRunStarted`:
 
@@ -174,8 +174,8 @@ uip agent eval add greeting-test \
 # 2. Validate (catches schema drift, missing evaluator refs, broken eval JSON)
 uip agent validate --path ./my-agent --output json
 
-# 3. Push agent to Studio Web (required before running evals)
-uip agent push --path ./my-agent --output json
+# 3. Upload the agent's solution to Studio Web (required before running evals)
+uip solution upload . --output json   # add --force to replace an existing cloud solution
 
 # 4. Run and wait
 uip agent eval run start \
@@ -189,9 +189,9 @@ uip agent eval run results <run_id> \
   --only-failed --verbose \
   --path ./my-agent --output json
 
-# 6. Make changes, validate, push, re-run, compare
+# 6. Make changes, validate, re-upload, re-run, compare
 uip agent validate --path ./my-agent --output json
-uip agent push --path ./my-agent --output json
+uip solution upload . --force --output json   # --force replaces the existing cloud solution in place
 uip agent eval run start --set "Default Evaluation Set" --path ./my-agent --wait --output json
 uip agent eval run compare <new_run_id> --compare-to <old_run_id> \
   --set "Default Evaluation Set" --path ./my-agent --output json
@@ -199,9 +199,9 @@ uip agent eval run compare <new_run_id> --compare-to <old_run_id> \
 
 ## Anti-patterns
 
-- **Don't run `eval run start` without `uip agent push` first.** The Agent Runtime executes against the pushed agent, not local files. Local edits made after the last push will not affect results.
+- **Don't run `eval run start` without `uip solution upload` first.** The Agent Runtime executes against the uploaded agent, not local files. Local edits made after the last upload will not affect results.
 - **Don't assume `--timeout` cancels the server-side run.** It only stops the local CLI from blocking. The run continues and can be inspected with `run status`.
-- **Don't skip `uip agent validate` between edits and push.** Validate catches eval-set / evaluator drift that push will accept silently and the runtime will reject.
+- **Don't skip `uip agent validate` between edits and upload.** Validate catches eval-set / evaluator drift that upload will accept silently and the runtime will reject.
 - **Don't compare runs from different eval sets.** `compare` aligns by test case `name` within the eval set; cross-set deltas are meaningless.
 - **Don't rely on `Score` alone — inspect `EvaluatorScores`.** A 0.86 aggregate can mask a faithful-but-wrong agent (high semantic, low trajectory). Use `--verbose` to read justifications when scores look surprising.
 - **Don't mix score scales across evaluators in the same eval set.** Defaults written by `uip agent init` use 0–100 prompts; defaults written by `evaluator add` use 0–1 prompts. The runtime DTO normalizes to 0–100, but mixed-scale prompts produce confusing per-evaluator scores. Decide on one scale per eval set and edit prompts to match.


### PR DESCRIPTION
## What

The `uipath-agents` skill referenced `uip agent push` to import a low-code agent into Studio Web. That verb is redundant — `uip solution upload` achieves the same result and is already the canonical low-code → Studio Web path everywhere else in the skill (`coded-vs-lowcode-guide.md`, `project-lifecycle.md`).

This migrates the remaining stragglers in the low-code **eval docs** to `uip solution upload`.

## Why it's not a literal swap

Verified both commands against the local CLI (1.196.0):

| | `uip agent push` | `uip solution upload` |
|---|---|---|
| Path arg | agent dir or `.uis` | **solution dir w/ `.uipx`**, `.uipx`, or `.uis` |
| Bare agent dir? | ✅ | ❌ `No .uipx file found … Run 'uip solution init' first` |
| Re-upload when cloud solution exists | new / `--overwrite <id>` | **refused unless `--force`** (replaces in place, stable SolutionId) |
| `--path` flag | ❌ does not exist | ❌ does not exist |

So the edits:
- Upload now targets the **solution root** (`.`), not the agent dir.
- **Re-uploads use `--force`** (the cloud solution exists after the first upload; `--force` replaces in place, preserving the SolutionId that `uip agent eval run start` auto-resolves).
- **Fixes a latent bug:** the old `uip agent push --path ./my-agent` used a `--path` flag that doesn't exist on that verb (it's a positional) — it would fail against CLI 1.196.0.

## Files changed (4)

- `references/lowcode/evaluations/running-evaluations.md` — prereq, `--solution-id` note, workflow steps 3 & 6, 2 anti-patterns
- `references/lowcode/evaluations/evaluate.md` — prerequisite, "Key Differences" row, troubleshooting row, runtime-check note, 2 anti-patterns
- `references/lowcode/evaluations/evaluation-sets.md`, `references/lowcode/evaluations/evaluators.md` — bare "push" → "upload" consistency

## Out of scope

`uip codedagent push` (coded agents) is a different command and is **untouched**.

## Verification

- `grep "agent push"` (excl. `codedagent`) across the skill → 0 results
- `grep -i push` in `references/lowcode/` → 0 results
- Both `uip agent push` and `uip solution upload` confirmed present locally; path semantics and `--force` behavior validated empirically

🤖 Generated with [Claude Code](https://claude.com/claude-code)