### PR TITLE
test(uipath-maestro-flow): skip salesforce_opportunity_list

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/salesforce_opportunity_list/salesforce_opportunity_list.yaml
@@ -9,7 +9,19 @@ description: >
   object-name resolution, connection binding, and live execution. The IS Salesforce
   connector returns flattened records (top-level `Id`, `Name`, …), so the checker
   asserts a non-empty array of objects carrying a Salesforce `Id`.
-tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node, connector, uipath-salesforce-sfdc]
+tags:
+  [
+    uipath-maestro-flow,
+    e2e,
+    mode:operate,
+    lifecycle:generate,
+    shape:single-node,
+    connector,
+    uipath-salesforce-sfdc,
+  ]
+skip: true
+# Blocked: requires a live tenant Salesforce connection and real Opportunity.
+# Often required re-athentificate due to vendor security policy, thus the task is not maintainable for long term.
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Summary

Skip the `salesforce_opportunity_list` e2e task.

## Why

- Requires a live tenant Salesforce connection and a real Opportunity record.
- Frequently needs re-authentication due to vendor security policy, making the task unmaintainable long term.

## Change

Adds `skip: true` with an explanatory comment to the task YAML.