### PR TITLE
test(uipath-maestro-flow): drop `smoke` tag from 3 flaky live-run tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -6,7 +6,7 @@ description: >
   no upload, no run. Tests whether the skill teaches the correct local-CRUD
   workflow and `--output json` discipline on every `uip maestro flow eval`
   command.
-tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval]
+tags: [uipath-maestro-flow, mode:build, lifecycle:generate, feature:eval]
 
 run_limits:
   expected_turns: 20

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -6,7 +6,7 @@ description: >
   requires the agent to refuse auto-upload, surface the missing prerequisite,
   and ask the user to authorize an upload. The agent must NOT run
   `uip solution upload` and MUST record its decision in `report.json`.
-tags: [uipath-maestro-flow, smoke, mode:operate, lifecycle:execute, feature:eval]
+tags: [uipath-maestro-flow, mode:operate, lifecycle:execute, feature:eval]
 
 run_limits:
   expected_turns: 26

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -5,7 +5,7 @@ description: >
   production bar — overriding the stale gpt-4o scaffold default, writing a
   non-placeholder system prompt, and declaring a typed outputSchema. Guards
   against shipping the toy scaffold a customer would otherwise inherit.
-tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, node:inline-agent]
+tags: [uipath-maestro-flow, mode:build, lifecycle:generate, node:inline-agent]
 
 run_limits:
   expected_turns: 32


### PR DESCRIPTION
## Why

The pre-merge **"Run skill smoke tests"** gate enforces a 95% pass rate over ~15 **live agent runs**. Three live tasks are flaking and intermittently blocking unrelated PRs (most recently #1301, the Open-Meteo weather-checker fix, which is approved and otherwise green):

- `skill-flow-eval-local-crud` — `evaluate/local_crud.yaml`
- `skill-flow-eval-no-auto-upload` — `evaluate/no_auto_upload.yaml`
- `skill-flow-inline-agent-robust` — `smoke/inline_agent_robust.yaml`

**Evidence of non-determinism** — two consecutive runs of the *same* #1301 commit (`ab097d0a`), no code change between them:

| Run | Pass rate | Failed tasks |
|---|---|---|
| 1 | 80.0% (12/15) | eval-local-crud, eval-no-auto-upload, inline-agent-robust |
| 2 (re-run) | 86.7% (13/15) | eval-local-crud, inline-agent-robust |

The victim set and the pass rate both move with no change; `eval-no-auto-upload` recovered on its own. At a 95% bar over 15 live tasks, any two flaky live runs trip the whole gate. These three are heavy live executions — live Studio Web eval runs for the eval pair, a live inline-agent build for the third — which don't belong in a fast, deterministic, **blocking** pre-merge gate.

## What

Removes **only** the `smoke` tag from the three task YAMLs. Every other tag is kept (`uipath-maestro-flow`, `feature:eval` / `node:inline-agent`, `mode:*`, `lifecycle:*`).

- The smoke gate selects tasks via `coder-eval run … --tags smoke` (`.github/workflows/smoke-skills.yml:348`). Dropping the tag is exactly "stop running these in the pre-merge gate."
- The **full daily suite runs all tasks regardless of tag**, so these three keep their coverage there (they ran in `2026-06-05_04-04-37`, 462 tasks) — only the blocking gate stops invoking them.
- **12 maestro-flow smoke tasks remain**, so the skill keeps smoke coverage and triggers no "coverage gap" warning.

## Diff

3 files, 3 lines — the `smoke,` token removed from each `tags:` list. No prose, criteria, or logic changes.

## Owners — please confirm you're OK dropping these from the **blocking pre-merge** gate (they still run daily)

- @mjnovice — the two `evaluate/*` eval tasks (you tagged them `smoke` in #1163 "Tag and stabilize Flow eval scenarios"; they've since proven flaky in the gate). cc Scott Florentino.
- @rockymadden — `inline_agent_robust` (#1270).

If you'd rather keep them in smoke and stabilize the underlying flakiness instead, say so and I'll close this — this PR is purely about unblocking the gate, not removing coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)