### PR TITLE
docs(uipath-rpa): fix DataService.Activities doc links + Scope wording

### DIFF
--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/CreateEntityRecord.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/CreateEntityRecord.md
@@ -44,7 +44,7 @@ Creates a new record in a Data Fabric entity.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## Field Binding — Two Required Components
 
@@ -76,7 +76,7 @@ Studio syncs `SelectedFields` → `InputEntityInFieldView` on file load, keeping
 
 ## XAML Example (VB.NET expression language)
 
-> This snippet uses the `udam:` prefix (`RecordState`, `DynamicEntityField`). Ensure `xmlns:udam` is declared on the root `<Activity>` element — see [overview — XAML Namespace Declarations](overview.md#xaml-namespace-declarations).
+> This snippet uses the `udam:` prefix (`RecordState`, `DynamicEntityField`). Ensure `xmlns:udam` is declared on the root `<Activity>` element — see [overview — XAML Namespace Declarations](../overview.md#xaml-namespace-declarations).
 
 ```xml
 <uda:CreateEntityRecord

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/CreateMultipleEntityRecords.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/CreateMultipleEntityRecords.md
@@ -42,7 +42,7 @@ Creates multiple records in a Data Fabric entity in a single batch operation.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteEntityRecord.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteEntityRecord.md
@@ -29,7 +29,7 @@ Deletes a record from a Data Fabric entity by record ID.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteFileFromRecordField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteFileFromRecordField.md
@@ -34,7 +34,7 @@ Deletes a file attachment from a file-type field on an entity record.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, **omit these properties entirely** — the members do not exist on the activity in standalone scope. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) are inherited from `BaseEntityActivity` and exist on every activity, but only apply when the project has a SolutionId. For standalone projects, omit them — they're ignored outside solution context. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 
@@ -53,4 +53,4 @@ Deletes a file attachment from a file-type field on an entity record.
 ```
 
 - `Field` — bare string, not expression-wrapped. Use the field name exactly as it appears in `EntitiesStore.json`
-- Studio explicitly serializes unused nullable properties as `{x:Null}` — include `InputEntity`, `OutputEntity` (do not include `ScopeValue`/`SolutionEntityKey`/`SolutionEntityName` in standalone projects — the members do not exist on the activity)
+- Studio explicitly serializes unused nullable properties as `{x:Null}` — include `InputEntity`, `OutputEntity` (omit `ScopeValue`/`SolutionEntityKey`/`SolutionEntityName` in standalone projects — they're ignored outside solution context)

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteMultipleEntityRecords.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DeleteMultipleEntityRecords.md
@@ -40,7 +40,7 @@ Deletes multiple records from a Data Fabric entity by their IDs.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 No `ExpansionDepth` or `OutputRecords` — delete returns only failed record IDs, not entity objects.
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DownloadFileFromRecordField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/DownloadFileFromRecordField.md
@@ -34,7 +34,7 @@ Downloads a file from a file-type field on an entity record.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, **omit these properties entirely** — the members do not exist on the activity in standalone scope. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) are inherited from `BaseEntityActivity` and exist on every activity, but only apply when the project has a SolutionId. For standalone projects, omit them — they're ignored outside solution context. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 
@@ -53,7 +53,7 @@ Downloads a file from a file-type field on an entity record.
 
 - `Field` — bare string, not expression-wrapped. Use the field name exactly as it appears in `EntitiesStore.json`
 - `FilePath` — set to `{x:Null}` when using `DownloadedFileResource` (preferred). If saving to a specific path, use a bare string: `FilePath="C:\downloads\output.pdf"`
-- Studio explicitly serializes unused nullable properties as `{x:Null}` — include them for properties that exist on the activity (do not include `ScopeValue`/`SolutionEntityKey`/`SolutionEntityName` in standalone projects)
+- Studio explicitly serializes unused nullable properties as `{x:Null}` — include them for properties applicable to the activity (omit `ScopeValue`/`SolutionEntityKey`/`SolutionEntityName` in standalone projects — they're ignored outside solution context)
 
 ### Variable Declaration
 
@@ -61,7 +61,7 @@ Downloads a file from a file-type field on an entity record.
 <Variable x:TypeArguments="upr:ILocalResource" Name="downloadedFileResource" />
 ```
 
-Requires `xmlns:upr="clr-namespace:UiPath.Platform.ResourceHandling;assembly=UiPath.Platform"` on the root `<Activity>` element. See [overview — XAML Namespace Declarations](overview.md#xaml-namespace-declarations).
+Requires `xmlns:upr="clr-namespace:UiPath.Platform.ResourceHandling;assembly=UiPath.Platform"` on the root `<Activity>` element. See [overview — XAML Namespace Declarations](../overview.md#xaml-namespace-declarations).
 
 ## Round-Trip Pattern (Download → Upload)
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/GetEntityRecordById.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/GetEntityRecordById.md
@@ -33,7 +33,7 @@ Retrieves a single record from a Data Fabric entity by its ID.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/QueryEntityRecords.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/QueryEntityRecords.md
@@ -40,7 +40,7 @@ Queries records from a Data Fabric entity with optional filtering, sorting, and 
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example (no filter)
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UpdateEntityRecord.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UpdateEntityRecord.md
@@ -45,7 +45,7 @@ Updates an existing record in a Data Fabric entity.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## Field Binding — Two Required Components
 
@@ -77,7 +77,7 @@ Studio syncs `SelectedFields` → `InputEntityInFieldView` on file load, keeping
 
 ## XAML Example (VB.NET expression language)
 
-> This snippet uses the `udam:` prefix (`RecordState`, `DynamicEntityField`). Ensure `xmlns:udam` is declared on the root `<Activity>` element — see [overview — XAML Namespace Declarations](overview.md#xaml-namespace-declarations).
+> This snippet uses the `udam:` prefix (`RecordState`, `DynamicEntityField`). Ensure `xmlns:udam` is declared on the root `<Activity>` element — see [overview — XAML Namespace Declarations](../overview.md#xaml-namespace-declarations).
 
 ```xml
 <uda:UpdateEntityRecord

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UpdateMultipleEntityRecords.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UpdateMultipleEntityRecords.md
@@ -42,7 +42,7 @@ Updates multiple records in a Data Fabric entity in a single batch operation.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, omit them. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UploadFileToRecordField.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/activities/UploadFileToRecordField.md
@@ -36,7 +36,7 @@ Uploads a file to a file-type field on an entity record.
 | `ContinueOnError` | `InArgument<bool>` | No | `false` | Continue workflow on error |
 | `TimeoutInMs` | `InArgument<int>` | No | `30000` | Timeout in milliseconds |
 
-> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) only apply when the project has a SolutionId. For standalone projects, **omit these properties entirely** — the members do not exist on the activity in standalone scope. See [overview — Solution Scope Properties](overview.md#solution-scope-properties-conditional) and [Solution Context](overview.md#solution-context-folder-vs-tenant-scope).
+> **Solution scope properties** (`ScopeValue`, `SolutionEntityKey`, `SolutionEntityName`) are inherited from `BaseEntityActivity` and exist on every activity, but only apply when the project has a SolutionId. For standalone projects, omit them — they're ignored outside solution context. See [overview — Solution Scope Properties](../overview.md#solution-scope-properties-conditional) and [Solution Context](../overview.md#solution-context-folder-vs-tenant-scope).
 
 ## XAML Example — Upload from FilePath
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/overview.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/overview.md
@@ -88,7 +88,7 @@ xmlns:local="clr-namespace:<ProjectName>;assembly=DataService.<ProjectName>"
 ```
 
 - The `local` namespace **must** include `assembly=DataService.<ProjectName>`. Without the assembly qualifier, the XAML parser cannot locate entity types: `Cannot create unknown type '{clr-namespace:<ProjectName>}EntityName'`.
-- The `upr` namespace is required for file activity variables — `DownloadFileFromRecordField.DownloadedFileResource` outputs `upr:ILocalResource`. See [DownloadFileFromRecordField](DownloadFileFromRecordField.md).
+- The `upr` namespace is required for file activity variables — `DownloadFileFromRecordField.DownloadedFileResource` outputs `upr:ILocalResource`. See [DownloadFileFromRecordField](activities/DownloadFileFromRecordField.md).
 
 Namespace imports for `TextExpression.NamespacesForImplementation`:
 ```xml


### PR DESCRIPTION
## Summary

Mirrors the Copilot review feedback addressed in [Entities-Desktop PR #537](https://github.com/UiPath/Entities-Desktop/pull/537) so the source-of-truth docs in this repo don't keep regenerating broken links downstream when synced.

- Prefix activities/*.md cross-links to `overview.md` with `../` (these files live under `activities/`, so bare `overview.md` doesn't resolve)
- `overview.md` line 91 — `DownloadFileFromRecordField` link gets `activities/` prefix
- Correct the Scope* property note in `UploadFileToRecordField`, `DownloadFileFromRecordField`, `DeleteFileFromRecordField` (including the parenthetical in `DeleteFileFromRecordField`): the properties are inherited from `BaseEntityActivity` and exist on every activity regardless of solution context — they're just ignored outside solution scope, not absent

## Test plan

- [ ] Markdown links resolve from `activities/*.md` to `../overview.md#...` anchors
- [ ] `overview.md` link to `activities/DownloadFileFromRecordField.md` resolves
- [ ] Scope property wording reads accurately for activities that inherit from `BaseEntityActivity`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
