### PR TITLE
test: drop coded tag from rpa coded test case task

### DIFF
--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -5,7 +5,7 @@ description: >
   hooks plus a coded test case with Given-When-Then structure, testing-service
   assertions, and a project.json fileInfoCollection entry. Covers both the
   hooks pattern and the coded test case workflow in one task.
-tags: [uipath-rpa, windows, smoke, coded, hooks, test-case]
+tags: [uipath-rpa, windows, smoke, hooks, test-case]
 
 run_limits:
   expected_turns: 22


### PR DESCRIPTION
## Summary
- remove the `coded` tag from the rpa coded-test-case task so `coded` is reserved for coded-agent tasks
- keeps coverage and pass-rate reporting for `coded` scoped to coded agents only