### PR TITLE
fix(uipath-agents): unblock escalation guardrail test — UA header + substring app match [AL-450]

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -286,7 +286,10 @@ import os, sys, json, urllib.request, urllib.error
 key = sys.argv[1]
 base = f"{os.environ['UIPATH_URL']}/{os.environ['UIPATH_ORGANIZATION_ID']}/apps_/default/api/v1/default"
 hdr = {"Authorization": "Bearer " + os.environ["UIPATH_ACCESS_TOKEN"],
-       "X-Uipath-Tenantid": os.environ["UIPATH_TENANT_ID"], "Accept": "application/json"}
+       "X-Uipath-Tenantid": os.environ["UIPATH_TENANT_ID"], "Accept": "application/json",
+       # The Apps API gateway rejects the default "Python-urllib/x.y" User-Agent with 403.
+       # Send an explicit UA so this call doesn't false-fail (curl works because it sets one).
+       "User-Agent": "uipath-guardrail-verify"}
 def get(u):
     try:
         return json.load(urllib.request.urlopen(urllib.request.Request(u, headers=hdr)))

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -21,9 +21,10 @@ initial_prompt: |
   Create a UiPath low-code agent "ComplianceAgent" for handling user requests
   about financial data. Add a guardrail that detects PII — specifically
   email addresses and phone numbers — and instead of blocking, escalates
-  violations to a human reviewer via the
-  "Tool.Guardrail.Escalation.Action.App" app, notifying
-  reviewer@example.com. The solution should be named "EscalateSol".
+  violations to a human reviewer via the deployed Action Center app whose
+  name contains "Guardrail.Escalation.Action.App" (match it even if the
+  deployed name carries a prefix or a version suffix such as ".2"),
+  notifying reviewer@example.com. The solution should be named "EscalateSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -8,7 +8,7 @@ description: >
   `uip solution resource list` to look up the escalation app, and
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
-tags: [uipath-agents, smoke, low-code, guardrail]
+tags: [uipath-agents, e2e, low-code, guardrail]
 
 agent:
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -8,7 +8,7 @@ description: >
   `uip solution resource list` to look up the escalation app, and
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
-tags: [uipath-agents, e2e, low-code, guardrail]
+tags: [uipath-agents, smoke, low-code, guardrail]
 
 agent:
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the


### PR DESCRIPTION
## What changed?

Follow-up to #1224 (AL-450). The nightly `skill-agent-guardrail-escalation-app` (ROPC-bot, `codereval/DefaultTenant`) was still failing `MAX_TURNS_EXHAUSTED`. Root-caused to two issues, both fixed here:

1. **Verifier false 403 (skill).** The escalation action-schema verifier in `guardrails.md` called the Apps API with bare `urllib`, whose default `Python-urllib/x.y` User-Agent the gateway rejects with **403** (curl/browser UA return **200**). The bogus `API_ERROR` defeated the verifier's stop-and-report path → the agent distrusted it and thrashed to MAX_TURNS. **Fix:** add an explicit `User-Agent` header to the verifier request.

2. **Brittle app-name match (test).** The prompt hard-named `Tool.Guardrail.Escalation.Action.App`, but the deployed fixture is `Guardrail.Escalation.Action.App` (no prefix). **Fix:** reword the prompt to target any deployed *Workflow Action* app whose name **contains** `Guardrail.Escalation.Action.App` — tolerant of a `Tool.` prefix or a `.2` version suffix. The grading script (`check_escalation_app.py`) is already name-agnostic.

## How has this been tested?

Verified directly against the CI tenant (`codereval/DefaultTenant`) via the `uip` CLI as a logged-in user:

- **UA fix:** extracted the verifier verbatim from `guardrails.md` and ran it against the real deployed app → `OK` / exit 0 (was **403** before the header); bogus key → `NO_APP` / exit 1. Reproduced the urllib-403-vs-curl-200 split on this tenant to confirm the root cause.
- **Substring match:** `uip solution resource list --kind App --source remote --search "Guardrail.Escalation.Action.App"` returns the deployed app (`Type=Workflow Action`, Folder `Shared`); substring also covers `.2` / `Tool.` variants.
- **App is a valid guardrail target:** its action-schema has all 8 required inputs, 3 outputs, 2 outcomes.
- **End-to-end (in flight):** dispatched `run-coder-eval.yml` on this branch (ROPC-bot identity, the actual failing path), scoped to this task — https://github.com/UiPath/skills/actions/runs/27193518641. Will confirm green before merge.

Note: `coder-eval` is not installed locally and the local CLI can't impersonate the ROPC bot, so the authoritative end-to-end check is the dispatched CI run above.

## Are there any breaking changes?

- [x] None — documentation/test changes only (skill reference + one task prompt).

Closes AL-450