### PR TITLE
docs(cli): require --yes on destructive command examples

### DIFF
--- a/skills/uipath-agents/references/lowcode/project-lifecycle.md
+++ b/skills/uipath-agents/references/lowcode/project-lifecycle.md
@@ -244,7 +244,7 @@ uip solution deploy activate "<DEPLOYMENT_NAME>" --output json
 ### Uninstall Deployment
 
 ```bash
-uip solution deploy uninstall "<DEPLOYMENT_NAME>" --output json
+uip solution deploy uninstall "<DEPLOYMENT_NAME>" --yes --output json
 ```
 
 ### Bundle for Upload
@@ -445,6 +445,6 @@ All solution lifecycle operations go through `uip solution` CLI. Never call Auto
 | Publish | `uip solution publish ./dist/<PKG>.zip --output json` | Any directory | — |
 | Deploy | `uip solution deploy run --name ... --output json` | Any directory | `DeploymentSucceeded`, `DeploymentFailed`, `ValidationFailed` |
 | Activate | `uip solution deploy activate "<NAME>" --output json` | Any directory | `SuccessfulActivate`, `FailedActivate` |
-| Uninstall | `uip solution deploy uninstall "<NAME>" --output json` | Any directory | `SuccessfulUninstall`, `FailedUninstall` |
+| Uninstall | `uip solution deploy uninstall "<NAME>" --yes --output json` | Any directory | `SuccessfulUninstall`, `FailedUninstall` |
 | Deploy status | `uip solution deploy status <pipeline-deployment-id> --output json` | Any directory | — |
 | List deployments | `uip solution deploy list --output json` | Any directory | — |

--- a/skills/uipath-platform/references/orchestrator/resources.md
+++ b/skills/uipath-platform/references/orchestrator/resources.md
@@ -62,7 +62,7 @@ Libraries are tenant-scoped -- no folder context needed.
 | `uip or libraries versions <package-id>` | List all versions of a library by package ID (the `Title` from `list` output). Curated rows like `list`; `--all-fields` for raw. Fails with `Library not found` when the package ID doesn't exist (instead of an empty success). |
 | `uip or libraries upload --file <path>` | Upload a `.nupkg` library package to the tenant feed. The file must exist (checked client-side). The default shared feed is read-only on many tenants — if upload fails with a read-only/feed-not-found error, enable Tenant Libraries in tenant settings or target a writable feed with `--feed-id` (`uip or feeds list`). |
 | `uip or libraries download <key> --destination <path>` | Download a `.nupkg` to local disk. `--destination` creates missing parent dirs and overwrites an existing file. |
-| `uip or libraries delete <key>` | Delete a specific library version. Key format is `PackageId:Version` (validated client-side). |
+| `uip or libraries delete <key> --yes` | Delete a specific library version. Key format is `PackageId:Version` (validated client-side). |
 
 ```bash
 # List libraries (first 500). Default --limit is 50; bump it for tenants with many libraries.

--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -88,8 +88,8 @@ uip or folders move "Finance/Invoicing" --parent "Operations" --output json
 uip or folders move <folder-key-guid> --root --output json   # promote to top level
 
 # Delete an empty folder (recursive removal must be explicit)
-uip or folders delete "Finance/Invoicing" --output json
-uip or folders delete <folder-key-guid> --output json
+uip or folders delete "Finance/Invoicing" --yes --output json
+uip or folders delete <folder-key-guid> --yes --output json
 ```
 
 The `--all` flag enables filtering options (`--type`, `--name`, `--path`, `--top-level`, `--sort-by`). Without `--all`, only folders the current user is assigned to are returned.
@@ -141,7 +141,7 @@ uip or roles users <role-key> --add-users <user-key-1>,<user-key-2> --output jso
 uip or roles users <role-key> --remove-users <user-key-1> --output json
 
 # Delete a role. Static built-in roles (Folder Administrator etc.) cannot be deleted.
-uip or roles delete <role-key> --output json
+uip or roles delete <role-key> --yes --output json
 ```
 
 `roles user-permissions` is the right command for "what can this user actually do here" debugging; it accounts for inherited folder roles and tenant overrides. `roles user-roles` is the inverse — given a user, which role assignments exist.

--- a/skills/uipath-platform/references/orchestrator/tenant-admin.md
+++ b/skills/uipath-platform/references/orchestrator/tenant-admin.md
@@ -72,7 +72,7 @@ Calendars define non-working days (holidays, company shutdowns). Time triggers r
 | `uip or calendars get <key>` | Get calendar details including excluded dates. |
 | `uip or calendars create <name>` | Create a calendar. Use `--time-zone` (defaults to UTC). |
 | `uip or calendars update <key>` | Update name or timezone (`--name`, `--time-zone`). |
-| `uip or calendars delete <key>` | Delete a calendar. |
+| `uip or calendars delete <key> --yes` | Delete a calendar. |
 
 ```bash
 # Create a calendar for US holidays

--- a/skills/uipath-platform/references/orchestrator/work-with-storage.md
+++ b/skills/uipath-platform/references/orchestrator/work-with-storage.md
@@ -166,7 +166,7 @@ uip or bucket-files download <bucket-key> "reports/summary.csv" \
 
 # Delete a file
 uip or bucket-files delete <bucket-key> "reports/summary.csv" \
-  --folder-path "Finance" --output json
+  --folder-path "Finance" --yes --output json
 ```
 
 Without `--destination`, `download` writes content to stdout. Use `-d` as shorthand.

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -18,7 +18,7 @@
   default and do not expose this flag.
 
 **Confirmation & non-interactive behavior:**
-The CLI is non-interactive by default and never prompts. Destructive commands (deletes, removals, uninstalls) require `--yes` to proceed — and overwrite operations require `--force` — otherwise they fail fast with a structured error instead of asking for confirmation. To enable interactive prompts for human use, pass the global `--interactive` flag or set `core.interactive` once with `uip config set interactive auto`.
+The CLI is non-interactive by default and never prompts. Destructive commands (deletes, removals, uninstalls) require `--yes` to proceed — and overwrite operations require `--force` — otherwise they fail fast with a structured error instead of asking for confirmation. To enable interactive prompts for human use, pass the global `--interactive` flag or set `core.interactive` once with `uip config set core.interactive auto`.
 
 ---
 

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -17,6 +17,9 @@
   resource commands (assets, queues, buckets, etc.) return the full DTO by
   default and do not expose this flag.
 
+**Confirmation & non-interactive behavior:**
+The CLI is non-interactive by default and never prompts. Destructive commands (deletes, removals, uninstalls) require `--yes` to proceed — and overwrite operations require `--force` — otherwise they fail fast with a structured error instead of asking for confirmation. To enable interactive prompts for human use, pass the global `--interactive` flag or set `core.interactive` once with `uip config set interactive auto`.
+
 ---
 
 ## Authentication
@@ -113,7 +116,7 @@ LLM execution trace observability and feedback annotation. See [traces/traces.md
 | `uip traces feedback list` | List feedback, optionally filtered by trace/span/agent/sentiment |
 | `uip traces feedback list detailed` | Feedback with span context, plus time-range/category/sort filters |
 | `uip traces feedback update <id>` | Change sentiment, comment, or categories |
-| `uip traces feedback delete <id>` | Remove feedback |
+| `uip traces feedback delete <id> --yes` | Remove feedback |
 
 ---
 

--- a/skills/uipath-solution/references/activate-and-manage.md
+++ b/skills/uipath-solution/references/activate-and-manage.md
@@ -89,10 +89,10 @@ Find `<deployment-key>` with `uip solution deploy list`. On success the output i
 Remove a deployment, including all provisioned resources and the Orchestrator folder:
 
 ```bash
-uip solution deploy uninstall "MyDeployment" --output json
+uip solution deploy uninstall "MyDeployment" --yes --output json
 
 # With custom polling
-uip solution deploy uninstall "MyDeployment" --timeout 600 --poll-interval 10000 --output json
+uip solution deploy uninstall "MyDeployment" --timeout 600 --poll-interval 10000 --yes --output json
 ```
 
 | Option | Description | Default |
@@ -155,7 +155,7 @@ Use `--destination <path>` for the local output file or directory. Reserve `--ou
 Remove a specific version of a published package from the solution feed:
 
 ```bash
-uip solution packages delete "MySolution" "1.0.0" --output json
+uip solution packages delete "MySolution" "1.0.0" --yes --output json
 ```
 
 Arguments: `<package-name> <package-version>`. This deletes only the specified version, not all versions of the package.
@@ -165,7 +165,7 @@ Arguments: `<package-name> <package-version>`. This deletes only the specified v
 Remove a solution from Studio Web (browser-based editor). This is separate from deployment management:
 
 ```bash
-uip solution delete <solution-id> --output json
+uip solution delete <solution-id> --yes --output json
 ```
 
 This removes the solution from Studio Web. It does **not** affect any deployed instances in Orchestrator.
@@ -181,14 +181,14 @@ List deployments, uninstall an old one, and clean up the published package versi
 uip solution deploy list --limit 20 --output json
 
 # Uninstall the old deployment
-uip solution deploy uninstall "MySolution-v1" --output json
+uip solution deploy uninstall "MySolution-v1" --yes --output json
 
 # Verify it was removed
 uip solution deploy list --output json
 
 # Clean up the old package version from the feed
 uip solution packages list --output json
-uip solution packages delete "MySolution" "1.0.0" --output json
+uip solution packages delete "MySolution" "1.0.0" --yes --output json
 ```
 
 ---

--- a/skills/uipath-solution/references/develop-solution.md
+++ b/skills/uipath-solution/references/develop-solution.md
@@ -439,7 +439,7 @@ If the `SolutionId` in `.uipx` matches an existing Studio Web solution, the uplo
 Remove a solution from Studio Web by its UUID (returned by `upload`).
 
 ```bash
-uip solution delete <solution-id> --output json
+uip solution delete <solution-id> --yes --output json
 ```
 
 Deletes the Studio Web copy only -- local files and published packages are not affected.

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -44,7 +44,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm project list --filter <NAME_OR_KEY>` | Find a project by name or key. |
 | `uip tm project create --name <PROJECT_NAME> --project-key <PROJECT_KEY>` | Create a new Test Manager project. |
 | `uip tm project update --project-key <PROJECT_KEY> --name <PROJECT_NAME>` | Update project name or description. |
-| `uip tm project delete --project-key <PROJECT_KEY>` | Delete a Test Manager project. |
+| `uip tm project delete --project-key <PROJECT_KEY> --yes` | Delete a Test Manager project. |
 | `uip tm project set-default-folder --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | Set the default Orchestrator folder for a project. |
 | `uip tm project clear-default-folder --project-key <PROJECT_KEY>` | Clear the default Orchestrator folder from a project. |
 | `uip tm project owners list --project-key <PROJECT_KEY> [<PROJECT_KEY> ...]` | List the owners of one or more Test Manager projects. |
@@ -72,7 +72,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm testcases create --project-key <PROJECT_KEY> --name <TEST_CASE_NAME>` | Create a new test case in a Test Manager project. |
 | `uip tm testcases list --project-key <PROJECT_KEY>` | List all test cases in a Test Manager project. Optional `--filter <text>` — matches name or key by PREFIX, not substring. |
 | `uip tm testcases update --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY> --name <TEST_CASE_NAME>` | Update a test case name, description, precondition, or postcondition (at least one field required). |
-| `uip tm testcases delete --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY>` | Delete a test case by its key. |
+| `uip tm testcases delete --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY> --yes` | Delete a test case by its key. |
 | `uip tm testcases link-automation --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY> --folder-key <FOLDER_KEY> --package-name <PACKAGE_NAME> --test-name <TEST_NAME>` | Link an Orchestrator package automation to a test case. |
 | `uip tm testcases unlink-automation --project-key <PROJECT_KEY> --test-case-key <TEST_CASE_KEY>` | Unlink the automation from a test case. |
 | `uip tm testcases list-automations --project-key <PROJECT_KEY> --folder-key <FOLDER_KEY>` | List test entry points available in an Orchestrator folder (optional: `--package-name <PACKAGE_NAME>` to filter). |
@@ -87,7 +87,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm testcases list-result-history --project-key <PROJECT_KEY> --test-case-id <TEST_CASE_ID>` | List test case log result history for a specific test case. Optional `--only-failed`, `--filter`, `--limit`, `--offset`. |
 | `uip tm testcases run --project-key <PROJECT_KEY> --test-case-id <TEST_CASE_ID> --name <EXECUTION_NAME> --execution-type <manual\|automated\|none\|mixed>` | Start a new execution for one or more test cases. **Uses `--test-case-id <UUID>` (space-separated for multiple).** Optional `--async`, `--folder-key`, `--robot-user-key`, `--machine-key`. |
 | `uip tm testcases add --test-set-key <TEST_SET_KEY> (--test-case-keys <KEY1> <KEY2> … \| --labels <Label1> <Label2> …)` | Add test cases to a test set — by explicit keys, OR every test case carrying at least one of the given labels. Both selectors are variadic and **space-separated**: `--test-case-keys DEMO:1 DEMO:2`, `--labels PW_Tag_smoke "PW_Suite_Checkout flow"` (quote names containing spaces). Keys additionally accept the comma form (`DEMO:1,DEMO:2`); **labels do not** — `--labels A,B` is read as one label named `A,B` and matches nothing. Label matching is OR, exact and case-sensitive. The two selectors are mutually exclusive. |
-| `uip tm testcases remove --test-set-key <TEST_SET_KEY> --test-case-keys <KEY1,KEY2,...>` | Remove test cases from a test set (comma-separated keys). |
+| `uip tm testcases remove --test-set-key <TEST_SET_KEY> --test-case-keys <KEY1,KEY2,...> --yes` | Remove test cases from a test set (comma-separated keys). |
 
 > **Flag shapes for test case and step identifiers — do not interchange:**
 > - `--test-case-id <UUID>` — used by `run`, `steps list`, `steps add`, `list-result-history`. Get the UUID from `uip tm testcases list --output json` (`Id` field).
@@ -102,7 +102,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm testsets create --project-key <PROJECT_KEY> --name <TEST_SET_NAME>` | Create a new test set in a Test Manager project. |
 | `uip tm testsets list --project-key <PROJECT_KEY>` | List test sets in a Test Manager project. Optional `--filter <text>`, `--folder-key`, `--include-last-execution`. |
 | `uip tm testsets update --test-set-key <TEST_SET_KEY> --name <TEST_SET_NAME>` | Update a test set name or description. |
-| `uip tm testsets delete --test-set-key <TEST_SET_KEY>` | Delete a test set by its key. |
+| `uip tm testsets delete --test-set-key <TEST_SET_KEY> --yes` | Delete a test set by its key. |
 | `uip tm testsets list-testcases --project-key <PROJECT_KEY> --test-set-key <TEST_SET_KEY>` | List test cases assigned to a test set. |
 | `uip tm testsets run --test-set-key <TEST_SET_KEY>` | Run a test set and return the execution ID. Optional `--execution-type <automated\|manual\|mixed\|none>` (default `automated`), `--input-path <FILE>` for parameter overrides. For Playwright test sets, optional `--playwright-projects <names...>` — see the note below. |
 | `uip tm testsets playwright-context --test-set-key <TEST_SET_KEY>` | Probe whether a test set is a Playwright test set: returns `IsPlaywright` plus the available and selected Playwright project names. |
@@ -190,7 +190,7 @@ Custom fields are project-scoped field definitions you attach to **Requirement**
 | `uip tm customfield get --project-key <PROJECT_KEY> --field-id <UUID>` | Get a custom field definition by UUID, OR identify by `--name <NAME> --object-type <TYPE>`. |
 | `uip tm customfield create --project-key <PROJECT_KEY> --name <NAME> --data-type <Text\|Label> (--object-type <Requirement\|TestCase\|TestSet> \| --scope-list <type...>)` | Create a new custom field definition. Pass `--object-type` for a single-scope field, OR `--scope-list <Requirement TestCase TestSet>` (variadic, mutually exclusive) for multi-scope. Optional `--description <text>`, `--value-hints <text>`, `--default-value <text>`. |
 | `uip tm customfield update --project-key <PROJECT_KEY> --field-id <UUID>` | Update a custom field definition. Identify by `--field-id` OR by `--name + --object-type`. Optional `--rename-to <name>`, `--description`, `--default-value`, `--value-hints`. Unspecified fields keep current values. |
-| `uip tm customfield delete --project-key <PROJECT_KEY> --field-ids <UUID...>` | Delete one or more custom field definitions by UUID (variadic), OR singleton by `--name + --object-type`. |
+| `uip tm customfield delete --project-key <PROJECT_KEY> --field-ids <UUID...> --yes` | Delete one or more custom field definitions by UUID (variadic), OR singleton by `--name + --object-type`. |
 
 #### Custom Field — Label-type rows
 
@@ -202,7 +202,7 @@ All `customfield label` verbs require `--object-type <Requirement\|TestCase\|Tes
 | `uip tm customfield label get --project-key <PROJECT_KEY> --object-type <TYPE> --label-id <UUID>` | Get a single label row by UUID. |
 | `uip tm customfield label create --project-key <PROJECT_KEY> --object-type <TYPE> --object-id <UUID> --values '{"Field":["v1","v2"]}'` | Upsert a label row on one object. `--values` is a JSON object mapping field names to string arrays. |
 | `uip tm customfield label add --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> --values <value...>` | Append values to a label field across multiple objects. Optional `--replace-existing-values` for authoritative-set semantics. |
-| `uip tm customfield label remove --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> (--values <value...> \| --remove-all-values)` | Remove values from a label field across multiple objects. |
+| `uip tm customfield label remove --project-key <PROJECT_KEY> --object-type <TYPE> --custom-field-name <NAME> --object-ids <UUID...> (--values <value...> \| --remove-all-values) --yes` | Remove values from a label field across multiple objects. |
 
 #### Custom Field — Text-type rows
 
@@ -214,7 +214,7 @@ All `customfield value` verbs require `--object-type <Requirement\|TestCase\|Tes
 | `uip tm customfield value get --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID>` | Get a value row by UUID, OR by `--name + --object-id`. |
 | `uip tm customfield value create --project-key <PROJECT_KEY> --object-type <TYPE> --name <FIELD_NAME> --object-id <UUID> --data-type <Text\|Label>` | Create a value row. Optional `--value <text>` for the initial content. The `--data-type` must match the existing field definition. |
 | `uip tm customfield value update --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID> --value <text>` | Update a value row by UUID, OR by `--name + --object-id`. Use `--clear` to set the value to empty. |
-| `uip tm customfield value delete --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID>` | Delete a value row by UUID, OR by `--name + --object-id`. |
+| `uip tm customfield value delete --project-key <PROJECT_KEY> --object-type <TYPE> --value-id <UUID> --yes` | Delete a value row by UUID, OR by `--name + --object-id`. |
 
 ### Object Label Commands
 
@@ -225,7 +225,7 @@ Object labels are tag-style metadata applied to Requirement, TestCase, TestSet, 
 | `uip tm objectlabel list --project-key <PROJECT_KEY> --object-type <Requirement\|TestCase\|TestSet\|TestExecution\|TestCaseLog>` | List distinct label names for one `--object-type` (paginated). Optional `--object-ids <UUID...>`, `--label-types <UserLabel\|SystemLabel\|InternalLabel ...>`, `--filter <text>`, `--sort-by`, `--limit`, `--offset`. |
 | `uip tm objectlabel get --project-key <PROJECT_KEY> --label-id <UUID>` | Get a single label-assignment row by UUID. |
 | `uip tm objectlabel add --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> --labels <name...>` | Attach labels to objects (variadic; one-to-one, one-to-many, many-to-many). Optional `--remove-other-labels` for authoritative-set semantics. |
-| `uip tm objectlabel remove --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> (--labels <name...> \| --remove-all-labels)` | Detach labels from objects. `--labels` and `--remove-all-labels` are mutually exclusive. |
+| `uip tm objectlabel remove --project-key <PROJECT_KEY> --object-type <TYPE> --object-ids <UUID...> (--labels <name...> \| --remove-all-labels) --yes` | Detach labels from objects. `--labels` and `--remove-all-labels` are mutually exclusive. |
 
 ## Critical Rules
 

--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -60,7 +60,7 @@ Common `uip tm` commands organized by resource type.
 | `uip tm requirements get --project-key <PROJECT_KEY> (--requirement-id <uuid> \| --requirement-key <key>)` | Get a requirement by UUID or key (mutually exclusive). |
 | `uip tm requirements create --project-key <PROJECT_KEY> --name <name>` | Create a new requirement. |
 | `uip tm requirements update --project-key <PROJECT_KEY> --requirement-id <uuid>` | Update a requirement name or description (at least one of `--name` or `--description` required). |
-| `uip tm requirements delete --project-key <PROJECT_KEY> --requirement-ids <uuid...>` | Delete one or more requirements (variadic). |
+| `uip tm requirements delete --project-key <PROJECT_KEY> --requirement-ids <uuid...> --yes` | Delete one or more requirements (variadic). |
 | `uip tm requirements export --project-key <PROJECT_KEY> --output-file <path>` | Export requirements to an .xlsx file. |
 | `uip tm requirements list-testcase-ids --project-key <PROJECT_KEY> --requirement-id <uuid>` | List the test case UUIDs assigned to a requirement. |
 | `uip tm requirements testcases --project-key <PROJECT_KEY> --requirement-id <uuid> (--add-testcase-ids <uuid...> \| --remove-testcase-ids <uuid...>)` | Attach or detach test cases on a requirement (mutually exclusive). |

--- a/tests/tasks/uipath-agents/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-agents/_shared/cleanup_solutions.py
@@ -3,7 +3,7 @@
 
 Wired in via ``post_run`` in agent e2e task YAMLs. Runs from the sandbox CWD
 after evaluation completes; finds every ``.uipx`` file under it, reads
-``SolutionId``, and best-effort deletes each via ``uip solution delete``.
+``SolutionId``, and best-effort deletes each via ``uip solution delete --yes``.
 ``.uipx`` files without a ``SolutionId`` are skipped.
 
 Cleanup policy is controlled by the ``AGENT_E2E_CLEANUP`` env var:
@@ -70,7 +70,8 @@ def main() -> int:
 
         if policy == "never":
             logger.info(
-                "AGENT_E2E_CLEANUP=never; preserving %s (delete later with: uip solution delete %s)",
+                "AGENT_E2E_CLEANUP=never; preserving %s "
+                "(delete later with: uip solution delete %s --yes --output json)",
                 sid,
                 sid,
             )

--- a/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py
@@ -3,7 +3,7 @@
 
 Wired in via ``post_run`` in case e2e task YAMLs. Runs from the sandbox CWD
 after evaluation completes; finds every ``.uipx`` file under it, reads
-``SolutionId``, and best-effort deletes each via ``uip solution delete``.
+``SolutionId``, and best-effort deletes each via ``uip solution delete --yes``.
 ``.uipx`` files without a ``SolutionId`` are skipped.
 
 Cleanup policy is controlled by the ``CASE_E2E_CLEANUP`` env var:

--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -3,7 +3,7 @@
 
 Wired in via ``post_run`` in flow e2e task YAMLs. Runs from the sandbox CWD
 after evaluation completes; finds every ``.uipx`` file under it, reads
-``SolutionId``, and best-effort deletes each via ``uip solution delete``.
+``SolutionId``, and best-effort deletes each via ``uip solution delete --yes``.
 ``.uipx`` files without a ``SolutionId`` are skipped.
 
 Cleanup policy is controlled by the ``FLOW_E2E_CLEANUP`` env var:
@@ -70,7 +70,8 @@ def main() -> int:
 
         if policy == "never":
             logger.info(
-                "FLOW_E2E_CLEANUP=never; preserving %s (delete later with: uip solution delete %s)",
+                "FLOW_E2E_CLEANUP=never; preserving %s "
+                "(delete later with: uip solution delete %s --yes --output json)",
                 sid,
                 sid,
             )

--- a/tests/tasks/uipath-maestro-flow/canary/canary.py
+++ b/tests/tasks/uipath-maestro-flow/canary/canary.py
@@ -152,7 +152,15 @@ def cleanup(solution_id: str | None) -> None:
         print(f"$ uip solution delete {solution_id}", flush=True)
         try:
             r = subprocess.run(
-                ["uip", "solution", "delete", solution_id, "--output", "json"],
+                [
+                    "uip",
+                    "solution",
+                    "delete",
+                    solution_id,
+                    "--yes",
+                    "--output",
+                    "json",
+                ],
                 capture_output=True,
                 text=True,
                 timeout=DELETE_TIMEOUT,

--- a/tests/tasks/uipath-maestro-flow/canary/canary.py
+++ b/tests/tasks/uipath-maestro-flow/canary/canary.py
@@ -16,7 +16,7 @@ Hardcoded inputs in Canary/Canary/Canary.flow:
 
 Lifecycle: Canary.uipx is gitignored — bootstrapped from UIPX_TEMPLATE at
 start (no SolutionId → CLI always imports fresh), then cleaned up in
-finally (uip solution delete + local file removal).
+finally (uip solution delete --yes + local file removal).
 """
 
 import json
@@ -36,7 +36,7 @@ DELETE_TIMEOUT = 60
 # Projects[0].Id must match the projectKey committed in
 # Canary/resources/solution_folder/*/Canary.json — those files reference it.
 # SolutionId is generated fresh per run in bootstrap_uipx() so each run
-# imports a new solution that cleanup() tears down via uip solution delete.
+# imports a new solution that cleanup() tears down via uip solution delete --yes.
 UIPX_TEMPLATE = {
     "DocVersion": "1.0.0",
     "StudioMinVersion": "2025.10.0",
@@ -149,7 +149,7 @@ def bootstrap_uipx() -> None:
 
 def cleanup(solution_id: str | None) -> None:
     if solution_id:
-        print(f"$ uip solution delete {solution_id}", flush=True)
+        print(f"$ uip solution delete {solution_id} --yes --output json", flush=True)
         try:
             r = subprocess.run(
                 [

--- a/tests/tasks/uipath-mcp-servers/README.md
+++ b/tests/tasks/uipath-mcp-servers/README.md
@@ -70,7 +70,7 @@ uip agenthub mcp-tools create-resource --mcp <slug> --name "<name>" --descriptio
 uip agenthub mcp-tools get --name "<tool>" --mcp <slug> --folder-path <folder> --output json
 uip agenthub mcp-tools update <tool-id> --mcp <slug> --folder-path <folder> --description "<text>" \
   --metadata "<json>" --input-schema "<json>" --output-schema "<json>" --dry-run --output json
-uip agenthub mcp-tools delete <tool-id> --mcp <slug> --folder-key <guid> --output json
+uip agenthub mcp-tools delete <tool-id> --mcp <slug> --folder-key <guid> --yes --output json
 ```
 
 Then translate the captured shapes into the per-scenario `manifest.json` + response files using synthetic values.

--- a/tests/tasks/uipath-mcp-servers/_shared/cleanup_mcp_server.py
+++ b/tests/tasks/uipath-mcp-servers/_shared/cleanup_mcp_server.py
@@ -40,7 +40,7 @@ def main():
         print("SKIP: no 'slug' key in report.json")
         sys.exit(0)
 
-    cmd = ["uip", "agenthub", "mcp", "delete", slug]
+    cmd = ["uip", "agenthub", "mcp", "delete", slug, "--yes"]
     if report.get("folder_key"):
         cmd += ["--folder-key", report["folder_key"]]
     else:

--- a/tests/tasks/uipath-mcp-servers/_shared/cleanup_mcp_server.py
+++ b/tests/tasks/uipath-mcp-servers/_shared/cleanup_mcp_server.py
@@ -5,7 +5,7 @@ Post-run cleanup: delete the AgentHub MCP server an e2e task created.
 Reads report.json (CWD), written by the agent:
   {"slug": "<server-slug>", "folder_path": "Shared"}   # or "folder_key": "<guid>"
 
-Deletes via the authed CLI: `uip agenthub mcp delete <slug> --folder-path|--folder-key ...`.
+Deletes via the authed CLI: `uip agenthub mcp delete <slug> --folder-path|--folder-key ... --yes`.
 Idempotent — a missing server counts as already-clean. Exit 0 ALWAYS: cleanup failures never
 fail the test (matches uipath-platform/data-fabric/_shared/cleanup_entities.py). Locally without a tenant
 this is a no-op.

--- a/tests/tasks/uipath-test/customfield_definition_crud_smoke.yaml
+++ b/tests/tasks/uipath-test/customfield_definition_crud_smoke.yaml
@@ -81,9 +81,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete delete command: `uip tm customfield delete --project-key HEALTH (--field-ids <uuid> | --name \"Eval Reviewer Team\" --object-type Requirement) --output json`"
+    description: "Complete delete command: `uip tm customfield delete --project-key HEALTH (--field-ids <uuid> | --name \"Eval Reviewer Team\" --object-type Requirement) --yes --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*(--field-ids\s+\S+|--object-type\s+Requirement))uip\s+tm\s+customfield\s+delete'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*(--field-ids\s+\S+|--object-type\s+Requirement))(?=.*--yes)uip\s+tm\s+customfield\s+delete'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/objectlabel_lifecycle_integration.yaml
+++ b/tests/tasks/uipath-test/objectlabel_lifecycle_integration.yaml
@@ -66,9 +66,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete detach command removing only eval-smoke: `uip tm objectlabel remove --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-smoke`"
+    description: "Complete detach command removing only eval-smoke: `uip tm objectlabel remove --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-smoke --yes`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-smoke)uip\s+tm\s+objectlabel\s+remove'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-smoke)(?=.*--yes)uip\s+tm\s+objectlabel\s+remove'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/requirement_crud_smoke.yaml
+++ b/tests/tasks/uipath-test/requirement_crud_smoke.yaml
@@ -58,9 +58,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete delete command: `uip tm requirements delete --project-key HEALTH --requirement-ids <uuid>`"
+    description: "Complete delete command: `uip tm requirements delete --project-key HEALTH --requirement-ids <uuid> --yes`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-ids\s+\S+)uip\s+tm\s+requirements?\s+delete'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-ids\s+\S+)(?=.*--yes)uip\s+tm\s+requirements?\s+delete'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
Reflects **UiPath/cli#2420** (Agent-readiness #2: non-interactive-safe CLI). That PR makes the CLI non-interactive by default and requires `--yes` on destructive commands (fail-closed, no prompt). This updates the skills docs and test-task fixtures to match.

## What changed
- **Added `--yes`** to every documented invocation + test fixture for the commands the CLI PR changed:
  - orchestrator `or … delete` (assets, buckets, bucket-files, calendars, folders, libraries, machines, processes, queue-items, queues, roles, triggers, webhooks)
  - resource `webhooks delete` (cleanup fixtures)
  - ixp (`data-types`/`documents`/`groups`/`fields delete`), agenthub `mcp-tools delete` / `mcp delete`
  - test-manager (`project`/`customfield`/`customfieldvalue`/`customfieldlabel`/`objectlabel`/`testset(s)`/`testcase(s) delete`+`remove`)
  - solution (`delete`, `packages delete`, `deploy uninstall`)
  - traces `feedback delete`
- **data-fabric:** `entities`/`choice-sets`/`choice-set-values delete` switched `--confirm` → `--yes` (kept `--reason`); `records`/`files delete` gained `--yes --reason` (now required).
- **uip-commands.md:** added a short note documenting the non-interactive default, `--yes`/`--force`, and the `--interactive` flag / `core.interactive` config.
- **Test-task fixtures** (`tests/tasks/**` YAML + Python cleanup/canary scripts) updated so they keep working against the new CLI.

## Deliberately NOT changed
The CLI PR did not touch these, so their docs are unchanged: `admin *`, `gov access-policy`/`gov aops-policy delete`, `or sessions delete`, and reversible **local** edits (`agent memory/context/eval/io/tool/escalation remove`, `solution project remove`, `solution resource remove`, flow/case authoring removes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)