### PR TITLE
fix(tests): install @uipath/agent-tool from alpha feed in CI sandbox

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -38,6 +38,7 @@ RUN set -euo pipefail && \
     uip tools install @uipath/orchestrator-tool && \
     uip tools install @uipath/integrationservice-tool && \
     uip tools install @uipath/maestro-tool && \
+    uip tools install @uipath/agent-tool && \
     # AgentHub command group ships as a separate plugin (CLI fetches it lazily).
     # Pre-install from the same @alpha feed so live `uip agenthub …` MCP e2e
     # tasks don't hit a missing-plugin 401.

--- a/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml
@@ -45,6 +45,7 @@ pre_run:
       uip tools install @uipath/orchestrator-tool;
       uip tools install @uipath/integrationservice-tool;
       uip tools install @uipath/maestro-tool;
+      uip tools install @uipath/agent-tool;
       uip tools install @uipath/resource-tool;
       uip tools install @uipath/docsai-tool;
       uip tools install @uipath/traces-tool;


### PR DESCRIPTION
## What

Pre-install `@uipath/agent-tool` from the `@alpha` feed alongside the other tool plugins in both CI sandbox entry points:

- `tests/docker/Dockerfile` — the alpha-feed tool plugin install block
- `tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml` — the `pre_run` tool installs

## Why

Agent-related `uip` CLI commands need the `@uipath/agent-tool` plugin present. Without pre-installing it, the plugin is resolved lazily at runtime and can fail in the sandboxed test image. Installing it from the same `@alpha` feed as the sibling tools keeps the toolset consistent and avoids missing-plugin lookups during test runs.

## Changes

Both edits add a single line:

```
uip tools install @uipath/agent-tool
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)