### PR TITLE
test(agents): add openai-agents input-shape gate and strict-input eval

### DIFF
--- a/skills/uipath-agents/references/coded/frameworks/openai-agents-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/openai-agents-integration.md
@@ -4,6 +4,8 @@ A lightweight integration for running OpenAI Agents SDK agents on the UiPath pla
 
 > **Note:** This is a streamlined integration focused on agent execution and streaming. It does **not** support Human-in-the-Loop (HITL), state persistence/checkpointing, or UiPath process invocation from within agents. For workflows that need those features, use the [LangGraph](langgraph-integration.md) or [LlamaIndex](llamaindex-integration.md) integrations instead.
 
+> **STOP — input shape decides framework fit.** OpenAI Agents accept **only** a `messages` conversation input ([Input](#input) § CONSTRAINT). When the requested input is not a conversation, do NOT map it onto `messages` and proceed — STOP before scaffolding, tell the user, and let them choose another framework (e.g. [LangGraph](langgraph-integration.md)).
+
 ## Scaffolding a New Project
 
 If there is **no existing agent code**, scaffold an OpenAI Agents project with:

--- a/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
+++ b/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
@@ -1,0 +1,65 @@
+task_id: skill-agent-coded-strict-input-no-messages
+description: >
+  Negative framework-fit smoke test: the user explicitly asks for an OpenAI
+  Agents coded agent but with a hard input contract — a single field and no
+  `messages`. OpenAI Agents cannot express that (its runner forces a required
+  `messages` field), so the agent must recognise the conflict, explain that
+  OpenAI Agents is not a fit, and suggest a different framework — without
+  scaffolding an OpenAI Agents project or silently falling back to a plain
+  function.
+tags: [uipath-agents, smoke, mode:build, coded, lifecycle:discover, feature:framework-openai-agents]
+
+run_limits:
+  expected_turns: 3
+
+initial_prompt: |
+  Build me a UiPath coded agent using OpenAI Agents. It takes an address and
+  breaks it down into its parts — street, city, postal code, and country.
+
+  It'll be called by another automation that passes the address in a single
+  named input field called `address` — it's not a chatbot, there's no
+  conversation and no chat history.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent consulted the uipath-agents skill"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent recognises OpenAI Agents cannot satisfy a messages-free input and suggests an alternative"
+    include_agent_output: true
+    prompt: |
+      The user asked for an OpenAI Agents coded agent whose input is a single
+      named field (`address`), invoked programmatically by another automation —
+      explicitly NOT a chatbot and with no conversation.
+
+      OpenAI Agents cannot satisfy this: its runner only accepts conversation
+      input, so `uip codedagent init` always emits a required `messages` field
+      in the input schema. The correct response is to explain this constraint
+      and recommend a different coded-agent framework (e.g. LangGraph) that can
+      express a messages-free, typed input contract.
+
+      Score 1.0 if the agent clearly states that OpenAI Agents cannot produce an
+      input schema without `messages` (so it cannot meet the named/non-chat input
+      contract) AND surfaces a different framework as the way to get it. It is
+      fine if the agent also offers a `messages`-based OpenAI Agents workaround as
+      an additional option — as long as the limitation is stated clearly and the
+      alternative is presented, that still scores 1.0.
+      Score 0.5 if the agent mentions the `messages` limitation but neither clearly
+      states OpenAI Agents cannot meet the contract nor surfaces an alternative.
+      Score 0.0 if the agent silently builds an OpenAI Agents project as if it
+      satisfies the request (e.g. maps the input into `messages` without flagging
+      the limitation), claims OpenAI Agents can produce a messages-free schema, or
+      silently falls back to a plain Coded Function without explaining anything.
+    weight: 3.0
+    pass_threshold: 0.8
+
+  - type: command_not_executed
+    description: "Agent did not scaffold a project despite the infeasible request"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- add a decision gate at the top of the OpenAI Agents reference: the runner accepts only a `messages` conversation input, so the agent must surface this and let the user choose another framework when the requested input is not a conversation, instead of mapping the input onto `messages` and proceeding
- add a smoke eval covering that case: a user asks for an OpenAI Agents agent with a named, non-conversational input; the agent must recognise OpenAI Agents cannot express that and recommend an alternative rather than building it
- graded by an `llm_judge` on the agent's explanation plus a deterministic `command_not_executed` anchor that no project was scaffolded

## Why

agents were reading the existing messages constraint but still building OpenAI Agents projects for non-conversational inputs by routing the data through `messages`. stating it as an explicit stop-and-handoff at framework-selection time, and guarding it with an eval, is what changes and locks in the behavior.