### PR TITLE
fix: upgrade IS skills to optimise and fix evals (#ENGCE-58112)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/greenfield.md
@@ -296,6 +296,8 @@ uip maestro flow node configure "<ProjectName>.flow" "<httpNodeId>" --detail '<D
 
 `<DETAIL_JSON>` is node-type-specific — the schema is owned by each CLI-owned node's plugin, not duplicated here: HTTP → [http/impl.md](plugins/http/impl.md#critical-use-node-configure), connectors → [connector/impl.md](plugins/connector/impl.md), connector triggers → [connector-trigger/impl.md](plugins/connector-trigger/impl.md). Tail-append one `node configure` per CLI-owned node added in T1, using the node IDs captured from T1's chained output. Drop the entire `node configure` segment if no CLI-owned nodes exist.
 
+> **The plugin `impl.md` is authoritative — follow its full procedure, not just its `--detail` schema, and let it override this turn map.** A plugin may prescribe steps the three-turn collapse does not show — most importantly a **pre-`configure` live fetch** whose output you must read before you can author `--detail` (the value depends on the live response, so it cannot be guessed or copied from a doc example). When `impl.md` defines such a step, run it in its **own turn before T3** and build `--detail` from its result; do not batch it into the chain, skip it, or hand-author the payload. An empty or static base response is expected for these steps and is not a signal the step is unavailable. This is general to every CLI-owned node type — defer to the owning `impl.md` rather than assuming static config.
+
 **On validate failure:** one `Edit` turn to fix, then re-chain `validate && format` in one Bash. Do not validate after every individual Edit during T2 — intermediate states are expected to be invalid.
 
 ### Common error categories

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -118,8 +118,12 @@ uip is resources list "<connector-key>" --connection-id "<connection-id>" --outp
 
 Run `is resources describe` to fetch and cache the full operation metadata, then **read the cached metadata file** for complete field details including descriptions, types, references, and query/path parameters. The describe summary omits some of this.
 
+**Read `<objectName>` from the node definition in `definitions[]` (written by `node add`) — do not guess it from the node-type suffix.**
+
 ```bash
-# 1. Describe to trigger fetch + cache (extract the objectName from the connector node type)
+# 1. Describe to trigger fetch + cache (objectName = the activity's API object, NOT the node-type suffix)
+#    Read <objectName> from the node definition FIRST (see note below) — do not batch this
+#    call with `node add` / `registry get`; those calls PRODUCE the objectName this one consumes.
 uip is resources describe "<connector-key>" "<objectName>" \
   --connection-id "<id>" --operation Create --output json
 # -> response includes metadataFile path
@@ -127,6 +131,10 @@ uip is resources describe "<connector-key>" "<objectName>" \
 # 2. Read the full cached metadata
 cat <metadataFile path from response>
 ```
+
+> **`<objectName>` is the activity's API object name, not the node-type's trailing segment — and NOT a case-conversion of it.** Read it from the node definition copied into `definitions[]` by `node add`: `model.context[]` entry `{name:"objectName", value:"…"}` (or the `objectName` field inside the `configuration` `=jsonString:` blob). Never derive it by transforming the node-type suffix — kebab→snake (`send-email` → `send_email`) and kebab→Pascal are both guesses and both 404. Example: node type `…google-gmail.send-email` has objectName `SendEmail` (not `send_email`); `…teams.send-bot-direct-message` has objectName `bot_direct_messages` (not `send-bot-direct-message`). A 404 means wrong objectName — re-read it from the definition and retry; do NOT treat the 404 as "describe unavailable" and skip the step. Skipping describe loses `requestFields[].reference.filterPattern` and other IS-level metadata that `registry get` does not carry (see Step 4).
+>
+> **Sequence, don't parallelize, the objectName-dependent calls.** `<objectName>` is an OUTPUT of `node add` (it lands in `definitions[]`). Read that value before calling `is resources describe` — do not place `describe` in the same parallel Bash batch as `node add` or `registry get`, or you'll have nothing to pass but a guess. This is the failure mode behind the snake-case 404 above.
 
 The full metadata contains:
 - **`availableOperations[].method`** and **`availableOperations[].path`** — HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get`.
@@ -159,7 +167,9 @@ uip is resources run list "uipath-salesforce-slack" "curated_channels?types=publ
 
 The `<id>` in `--connection-id "<id>"` MUST be the connection bound to **this** flow (the one picked in Step 1), not any other connection you've used in another flow. Use the resolved IDs (not display names) — from this very `run list` call — in the flow's node `inputs`. When multiple matches exist, present them via `AskUserQuestion` with one option per match plus **"Something else"** as the last option (see the AskUserQuestion dropdown rule in [SKILL.md](../../../../../SKILL.md)).
 
-> **Paginate when looking up by name.** Use `Data.Pagination.HasMore` / `NextPageToken` with `--query "nextPage=<token>"`. Short-circuit on match. Do NOT conclude "not found" until `HasMore` is `"false"`. See [resources.md#pagination](../../../../../../uipath-platform/references/integration-service/resources.md#pagination).
+> **Filter server-side before paginating.** If the field's `reference` carries a `filterPattern` (e.g. Teams `userId`: `"$filter=startswith(userPrincipalName,'{filter}')"`), substitute the search term for `{filter}` and pass the result as `--query` — one targeted call instead of walking a large directory. `filterPattern` appears only in `is resources describe` output; the flow `registry get` reference object strips it (keeps only `objectName`/`lookupValue`/`lookupNames`/`path`/`childPath`), so read it from the Step 3 describe metadata. Guessed params (`searchTerm=`/`where=`/`filter=`) are silently ignored. See [reference-resolution.md — Search References (filterPattern)](../../../../../../uipath-platform/references/integration-service/reference-resolution.md#search-references-filterpattern).
+
+> **Paginate only when there is no `filterPattern`.** Use `Data.Pagination.HasMore` / `NextPageToken` with `--query "nextPage=<token>"`. Short-circuit on match. Do NOT conclude "not found" until `HasMore` is `"false"`. See [resources.md#pagination](../../../../../../uipath-platform/references/integration-service/resources.md#pagination).
 
 **Read [/uipath:uipath-platform — Integration Service — resources.md](../../../../../../uipath-platform/references/integration-service/resources.md) for the full reference-resolution workflow** (pagination, describe failures, fallbacks).
 

--- a/skills/uipath-platform/references/integration-service/reference-resolution.md
+++ b/skills/uipath-platform/references/integration-service/reference-resolution.md
@@ -148,7 +148,9 @@ Some reference fields point to **search endpoints** that require user input as a
 
 ### How to detect
 
-If `reference.filterPattern` exists, the reference is a **search endpoint** — a plain `list` call without the filter will return no results or an error.
+If `reference.filterPattern` exists, the reference supports server-side filtering. Omitting the filter does NOT reliably error — some connectors (Microsoft Graph-backed: Teams, Outlook) return the **entire unfiltered collection** instead (thousands of rows, 50/page). Arbitrary query params (`searchTerm=`, `where=`, `filter=`) are silently ignored — only the exact `filterPattern` key filters. Always apply it; never brute-force paginate a large directory when a `filterPattern` exists.
+
+`filterPattern` is surfaced only by `uip is resources describe` (IS-level metadata). Representations that strip it (e.g. Maestro flow `registry get` reference object, which keeps only `objectName`/`lookupValue`/`lookupNames`/`path`/`childPath`) are not authoritative — re-describe at IS level before concluding a reference cannot be filtered.
 
 ### Resolution workflow (search)
 
@@ -177,6 +179,22 @@ User says: "Create a ticket for product Widget Pro"
    ```
    → `{ "productCode": "WP-100", "id": "1892000000056007" }`
 3. **Use** the `lookupValue` (`id`) → `"1892000000056007"` in `--body`
+
+### Example: Resolving a Microsoft Teams user (OData `$filter`)
+
+`filterPattern` may be a full OData `$filter` expression, not just `key={filter}`. Same mechanic: substitute `{filter}`, pass the whole string as `--query`.
+
+1. **Describe** the activity's object (e.g. `bot_direct_messages`) → `userId` reference has `filterPattern: "$filter=startswith(userPrincipalName,'{filter}')"`
+2. **Substitute and pass as `--query`.** Single-quote the value so the shell does not expand the literal `$`:
+   ```bash
+   uip is resources run list "uipath-microsoft-teams" "users" \
+     --connection-id "<id>" \
+     --query '$filter=startswith(userPrincipalName,'"'"'jane.doe'"'"')' --output json
+   ```
+   → one row: `{ "id": "7a621d6b-…", "userPrincipalName": "jane.doe@example.com" }`
+3. **Use** `lookupValue` (`id`) as the resolved value.
+
+Without the `$filter` this `/users` listing returns the full tenant directory (50/page, thousands of rows). A dedicated by-key endpoint (e.g. Teams `user-by-email/{email}`) is a fallback only when no `filterPattern` exists.
 
 > **If the user doesn't provide a search term**, ask them. Search references cannot be resolved without user input — do NOT call the search endpoint with an empty filter.
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
@@ -48,7 +48,7 @@ _JSONSTRING_PREFIX = "=jsonString:"
 
 _EXPECTED_BODY = {
     "to": "baishali13@gmail.com",
-    "importance": "medium", # this is the enum field under test
+    "importance": "high", # this is the enum field under test
 }
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -17,7 +17,7 @@ initial_prompt: |
     - to:        "baishali13@gmail.com"
     - subject:   "weather today"
     - body:      "Weather update for today."
-    - importance: "medium"   (this is the enum field under test)
+    - importance: "high"   (this is the enum field under test)
   Add a Decision node to check whether the call succeeded.
   Route failure to a Terminate node with error message "Enum test failed".
   Route success to a final action that logs "Enum test passed".


### PR DESCRIPTION
## Summary

Upgrades the Integration Service connector skills to fix recurring eval failures around **objectName resolution**, **reference filtering**, and **node-configure sequencing**. Also corrects the enum eval to use a non-default value.

Jira: ENGCE-58112

## Changes

### Skill: `uipath-maestro-flow`

- **`greenfield.md`** — Adds a callout that the plugin `impl.md` is authoritative: agents must follow its full procedure (not just the `--detail` schema) and let it override the three-turn map. Calls out the **pre-`configure` live fetch** step that must run in its own turn before T3, since `--detail` depends on the live response and cannot be hand-authored.
- **`plugins/connector/impl.md`**
  - `<objectName>` must be **read from the node definition** in `definitions[]` (written by `node add`) — never guessed from the node-type suffix. kebab→snake and kebab→Pascal conversions both 404 (e.g. `send-bot-direct-message` → `bot_direct_messages`, not `send-bot-direct-message`). A 404 means wrong objectName, not "describe unavailable."
  - **Sequence, don't parallelize**, the objectName-dependent calls — `describe` consumes the objectName that `node add` produces, so it cannot share a parallel Bash batch.
  - **Filter server-side before paginating** when a field's `reference` carries a `filterPattern`; only paginate when no `filterPattern` exists.

### Skill: `uipath-platform`

- **`integration-service/reference-resolution.md`**
  - Clarifies `filterPattern` detection: omitting the filter does **not** reliably error — Microsoft Graph-backed connectors (Teams, Outlook) return the entire unfiltered collection. Only the exact `filterPattern` key filters; arbitrary params are silently ignored.
  - Notes `filterPattern` is surfaced only by `uip is resources describe`; representations that strip it (Maestro flow `registry get`) are not authoritative.
  - Adds a **Microsoft Teams user resolution** example using a full OData `$filter` expression, with correct shell quoting of the literal `$`.

### Tests: `uipath-maestro-flow/connector_features`

- **`enum.yaml`** / **`check_enum_flow.py`** — Changes the enum field under test from `"medium"` (default-looking) to `"high"`, and updates the expected-body assertion to match.

## Test plan

- [x] `enum.yaml` eval passes with the updated `"high"` expected value.
