### PR TITLE
Update skill statuses

### DIFF
--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -18,17 +18,17 @@
   },
   "skills": {
     "uipath-admin": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-agents": {
-      "status": "stable",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-api-workflow": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -38,7 +38,7 @@
       "last_synced": null
     },
     "uipath-data-fabric": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -53,47 +53,47 @@
       "last_synced": null
     },
     "uipath-governance": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-human-in-the-loop": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-ixp": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-maestro-bpmn": {
-      "status": "stable",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-maestro-case": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-maestro-flow": {
-      "status": "stable",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-mcp-servers": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-planner": {
-      "status": "stable",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-platform": {
-      "status": "stable",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -103,12 +103,12 @@
       "last_synced": null
     },
     "uipath-rpa": {
-      "status": "stable",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-solution": {
-      "status": "stable",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
@@ -118,12 +118,12 @@
       "last_synced": null
     },
     "uipath-test": {
-      "status": "preview",
+      "status": "in-development",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },
     "uipath-troubleshoot": {
-      "status": "stable",
+      "status": "preview",
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     }


### PR DESCRIPTION
Updates `assets/skill-status.json` with reviewed status for each skill (`stable` / `preview` / `in-development`).

## Changes (17)

| Skill | Old → New |
|---|---|
| uipath-admin | preview → in-development |
| uipath-agents | stable → in-development |
| uipath-api-workflow | preview → in-development |
| uipath-data-fabric | preview → in-development |
| uipath-governance | preview → in-development |
| uipath-human-in-the-loop | preview → in-development |
| uipath-ixp | preview → in-development |
| uipath-maestro-bpmn | stable → in-development |
| uipath-maestro-case | preview → in-development |
| uipath-maestro-flow | stable → in-development |
| uipath-mcp-servers | preview → in-development |
| uipath-planner | stable → preview |
| uipath-platform | stable → preview |
| uipath-rpa | stable → preview |
| uipath-solution | stable → preview |
| uipath-test | preview → in-development |
| uipath-troubleshoot | stable → preview |

Unchanged: uipath-coded-apps (preview), uipath-design (preview), uipath-feedback (stable), uipath-review (preview), uipath-tasks (preview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)