### PR TITLE
test(uipath-maestro-bpmn): bump turn_timeout on contract_variant_wrappers

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
@@ -9,6 +9,7 @@ tags: [uipath-maestro-bpmn, integration, lifecycle:generate, contract:xml, node:
 run_limits:
   expected_turns: 20
   max_turns: 90
+  turn_timeout: 1200
 initial_prompt: |
   Load and follow the uipath-maestro-bpmn skill.
 


### PR DESCRIPTION
## Summary
- BPMN suite was at 16/17 PASS on `main`. Only `skill-bpmn-contract-variant-wrappers` failed.
- Root cause: the agent's first turn (authoring a single BPMN file with 15+ wrapper variants + BPMN DI) consistently exceeds the nightly experiment's 900s default `turn_timeout`. GH Action run 27183145889 confirms the cutoff at exactly 900s (`Turn timeout reached mid-stream`).
- Fix: bump `turn_timeout` to 1200s, matching what sibling authoring tasks (`api_workflow_task`, `business_rule_task`, `script_jint_lifecycle`) already use for comparable scope.

## Validation
- Diagnostic run before fix (16/17): https://github.com/UiPath/skills/actions/runs/27183145889
- Validation run after fix (in progress): https://github.com/UiPath/skills/actions/runs/27208029939

## Test plan
- [x] Linted task with `scripts/check-cli-verbs.py` — no findings.
- [x] `coder-eval plan` validates the YAML.
- [ ] Full BPMN suite passes 17/17 on the validation GH Action run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
