### PR TITLE
docs(uipath-solution): Automation Suite compat matrix + project-types-by-version

### DIFF
--- a/skills/uipath-solution/SKILL.md
+++ b/skills/uipath-solution/SKILL.md
@@ -10,6 +10,8 @@ Create, pack, publish, deploy, and manage UiPath Solution packages (`.uipx`) via
 
 > **Use the CLI. Don't roll your own REST for solution ops.** Hand-rolling HTTP calls misses the `X-UIPATH-OrganizationUnitId` folder header, OData filter shape, pagination envelope, `pipelinesInstall` deploy semantics, retry behavior, and the `Result/Code/Data` output contract. The CLI is the source of truth.
 
+> **Platform support.** Solutions runs on Automation Cloud and on self-hosted Automation Suite **from `2.2510.0` onward**; not on Standalone Orchestrator. Available project types vary by AS version (Maestro self-hosted only from `2.2510.2`). Compat matrix + project-type-by-version table → [Solution Overview — Platform availability](references/solution-overview.md#platform-availability).
+
 ## When to Use This Skill
 
 - User has a `.uipx` solution and wants to pack / publish / deploy / activate / upload

--- a/skills/uipath-solution/references/solution-overview.md
+++ b/skills/uipath-solution/references/solution-overview.md
@@ -29,15 +29,16 @@ Full delivery-option matrix: [Product and feature availability across delivery o
 
 #### Available project types by Automation Suite version
 
-Which project types a Solution can bundle/deploy on self-hosted Automation Suite depends on the AS version — the backing products land in different releases of the `2.2510` line.
+This table is about the **Solutions feature** (`.uipx` bundling/deploy). Which project types a Solution can bundle/deploy on self-hosted Automation Suite depends on the AS version — the backing products land in different releases of the `2.2510` line.
 
-| Automation Suite version | Solution project types available |
+| Automation Suite version | Project types deployable **as a Solution** (`.uipx`) |
 |---|---|
-| `< 2.2510.0` | None — Solutions is not on Automation Suite |
+| `< 2.2510.0` | None as a Solution — the Solutions feature is not on Automation Suite yet. **RPA still runs**: processes / libraries / tests deploy to Orchestrator directly (classic publish → deploy), as they have on Automation Suite since well before Solutions |
 | `2.2510.0`+ | RPA workflow (cross-platform / Windows — **not** Windows-Legacy), App, API workflow, Agent, Agentic process |
 | `2.2510.2`+ | adds Maestro (self-hosted): agentic-orchestration / BPMN-process runtime |
 
-- Same project-type set as cloud, gated by AS version. Standalone is unsupported at any version.
+- Pre-`2.2510.0` is a gap in the **Solutions packaging path only** — Orchestrator (and RPA on it) is supported on every Automation Suite version, including Standalone.
+- From `2.2510.0`+, same Solution project-type set as cloud, gated by AS version. The Solutions feature itself is unsupported on Standalone at any version.
 - Agent / agentic-process / API-workflow runtimes ship across the `2.2510` patch line; confirm exact patch level against each product's Automation Suite release notes.
 - Sources: [AS `2.2510.0` product bundle](https://docs.uipath.com/automation-suite/automation-suite/2.2510/release-notes/automation-suite-on-eks-aks-2-2510-0) · [Solutions on Automation Suite](https://docs.uipath.com/solutions-management/automation-suite/2.2510/user-guide/solutions-management-overview) · [Maestro on Automation Suite `2.2510.2`](https://docs.uipath.com/maestro/automation-suite/2.2510/release-notes/2-2510-2).
 

--- a/skills/uipath-solution/references/solution-overview.md
+++ b/skills/uipath-solution/references/solution-overview.md
@@ -15,6 +15,32 @@ A UiPath Solution is a container that groups multiple automation projects (proce
 - **Configuration management** -- Apply environment-specific configuration at deploy time
 - **Multi-environment promotion** -- Move solutions through dev, staging, and production
 
+### Platform availability
+
+Solutions runs on Automation Cloud and — from **Automation Suite `2.2510.0`** onward — self-hosted Automation Suite. Not available on Standalone Orchestrator.
+
+| Delivery option | Solutions |
+|---|---|
+| Automation Cloud / Automation Cloud Dedicated | ✅ |
+| Automation Suite (self-hosted) | ✅ from `2.2510.0` (added to the AS product portfolio in that release) |
+| Standalone | ❌ |
+
+Full delivery-option matrix: [Product and feature availability across delivery options](https://docs.uipath.com/overview/other/latest/overview/product-and-feature-availability-across-delivery-options).
+
+#### Available project types by Automation Suite version
+
+Which project types a Solution can bundle/deploy on self-hosted Automation Suite depends on the AS version — the backing products land in different releases of the `2.2510` line.
+
+| Automation Suite version | Solution project types available |
+|---|---|
+| `< 2.2510.0` | None — Solutions is not on Automation Suite |
+| `2.2510.0`+ | RPA workflow (cross-platform / Windows — **not** Windows-Legacy), App, API workflow, Agent, Agentic process |
+| `2.2510.2`+ | adds Maestro (self-hosted): agentic-orchestration / BPMN-process runtime |
+
+- Same project-type set as cloud, gated by AS version. Standalone is unsupported at any version.
+- Agent / agentic-process / API-workflow runtimes ship across the `2.2510` patch line; confirm exact patch level against each product's Automation Suite release notes.
+- Sources: [AS `2.2510.0` product bundle](https://docs.uipath.com/automation-suite/automation-suite/2.2510/release-notes/automation-suite-on-eks-aks-2-2510-0) · [Solutions on Automation Suite](https://docs.uipath.com/solutions-management/automation-suite/2.2510/user-guide/solutions-management-overview) · [Maestro on Automation Suite `2.2510.2`](https://docs.uipath.com/maestro/automation-suite/2.2510/release-notes/2-2510-2).
+
 ### Solution File Structure
 
 ```


### PR DESCRIPTION
## What

Adds a small **compatibility matrix** to the `uipath-solution` skill highlighting whether Solutions is supported on **Automation Suite**, plus a **project-type-by-version** table.

- `references/solution-overview.md` → new `### Platform availability` section:
  - Delivery-option matrix (Cloud / Cloud Dedicated ✅, Automation Suite ✅ from `2.2510.0`, Standalone ❌ *for the Solutions feature*).
  - `#### Available project types by Automation Suite version` table.
- `SKILL.md` → one highlighted callout + pointer (no duplicated table — table lives only in the reference).

## Project-types-deployable-as-a-Solution by AS version

| Automation Suite version | Project types deployable **as a Solution** (`.uipx`) |
|---|---|
| `< 2.2510.0` | None as a Solution — Solutions feature not on AS yet. **RPA still runs** via Orchestrator directly (classic publish → deploy), as on every AS version |
| `2.2510.0`+ | RPA workflow (cross-platform / Windows — not Windows-Legacy), App, API workflow, Agent, Agentic process |
| `2.2510.2`+ | adds Maestro (self-hosted): agentic-orchestration / BPMN-process runtime |

> The `.uipx` packaging/deploy path is gated to `2.2510.0`. Orchestrator — and RPA on it — ships on every Automation Suite version (including Standalone); only the Solutions feature is version-gated.

## Verification

Every claim cross-checked against UiPath docs (verbatim where a table could be mis-summarized):

| Source | Fact |
|---|---|
| [Cross-delivery availability matrix](https://docs.uipath.com/overview/other/latest/overview/product-and-feature-availability-across-delivery-options) (9 cols, mapped by hand) | Solutions ✅ on Automation Suite; ❌ on Standalone. Orchestrator ✅ on every option incl. Standalone |
| [AS `2.2510.0` product bundle](https://docs.uipath.com/automation-suite/automation-suite/2.2510/release-notes/automation-suite-on-eks-aks-2-2510-0) | Solutions GA `2.2510.0`; Studio Web / Orchestrator / IS / Apps / Test Manager bundled at `2.2510.0`; Maestro & Agents absent from that bundle |
| [Studio Web — Debugging solutions (AS 2.2510)](https://docs.uipath.com/studio-web/automation-suite/2.2510/user-guide/debugging-solutions) | Solution project types: RPA workflow, API workflow, App, Agentic process, Agent |
| [Maestro on AS `2.2510.2`](https://docs.uipath.com/maestro/automation-suite/2.2510/release-notes/2-2510-2) | Maestro self-hosted only from `2.2510.2` |
| [Solutions on Automation Suite](https://docs.uipath.com/solutions-management/automation-suite/2.2510/user-guide/solutions-management-overview) | "cross-platform or Windows RPA projects (Windows-Legacy not supported), agents, agentic processes, API workflows" |

A naive yes/no would have been wrong both ways — the Solutions cloud feature-availability page omits Automation Suite (it's a cloud-only component-dependency table, not a denial), while the canonical matrix says ✅ with a `2.2510.0` floor and Maestro gated to `2.2510.2`.

## Notes
- Repo content-quality rule cautions against stale version-specific info → every version floor links to the source doc.
- No skill description change; `hooks/validate-skill-descriptions.sh` passes (exit 0).
- Self-contained; no cross-skill references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)