### PR TITLE
fix(uipath-agents): add missing mode:build tag to coded-agent task YAMLs

### DIFF
--- a/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/e2e_scaffold_graph.yaml
@@ -8,7 +8,7 @@ description: >
   uipath.platform.context_grounding, uses plain interrupt() from
   langgraph.types — and does NOT instantiate UiPath() at module top
   level.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding, mode:build]
 max_iterations: 1
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/batch_transform_coded/smoke_trigger.yaml
@@ -4,7 +4,7 @@ description: >
   user asks to add LLM-filled columns to a CSV from a Python coded
   agent (LangGraph). Verifies the skill fires for the
   Python-coded-agent + CSV signal pair.
-tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding]
+tags: [uipath-agents, smoke, coded, lifecycle:discover, context-grounding, mode:build]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-agents/coded/antipattern_build_system/antipattern_build_system.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_build_system/antipattern_build_system.yaml
@@ -5,7 +5,7 @@ description: >
   pyproject (with `hatchling` declared as the build backend), and
   the skill must drive the agent to detect the violation and remove
   the section before any further work.
-tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern, mode:build]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/antipattern_module_level_llm.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_module_level_llm/antipattern_module_level_llm.yaml
@@ -5,7 +5,7 @@ description: >
   LangGraph `main.py` with `llm = UiPathChat(...)` at column zero,
   and the skill must drive the agent to refactor the construction
   inside a node body before `uip codedagent init` is run.
-tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern, mode:build]
 
 run_limits:
   expected_turns: 9

--- a/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -4,7 +4,7 @@ description: >
   — `from uipath import UiPath` is wrong and raises `ImportError`
   at module-import time. The correct path is `from uipath.platform
   import UiPath`. The skill must drive the agent to fix the import.
-tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
+tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern, mode:build]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/bindings_asset_subtypes.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_asset_subtypes/bindings_asset_subtypes.yaml
@@ -7,7 +7,7 @@ description: >
   the inference is high-confidence, emit `metadata.SubType` matching
   the type annotation (`stringAsset` / `integerAsset` /
   `booleanAsset`).
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings, mode:build]
 
 run_limits:
   expected_turns: 11

--- a/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -8,7 +8,7 @@ description: >
   the load-bearing assertion is that no binding ends up with a
   fabricated `EntryPointUniqueId` that doesn't match either real
   entrypoint.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings, mode:build]
 
 run_limits:
   expected_turns: 13

--- a/tests/tasks/uipath-agents/coded/bindings_queue_app_index/bindings_queue_app_index.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_queue_app_index/bindings_queue_app_index.yaml
@@ -6,7 +6,7 @@ description: >
   verifies one binding entry per resource with the right key
   construction (`<name>.<folder_path>` for most, bare
   `<connection_key>` for connections) and metadata fields.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings, mode:build]
 
 run_limits:
   expected_turns: 11

--- a/tests/tasks/uipath-agents/coded/bindings_sync.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_sync.yaml
@@ -4,7 +4,7 @@ description: >
   all Python files in a project (including helper modules), resolve module-level
   constants, and produce a correct bindings.json. Tests that the skill teaches
   scanning beyond main.py and constant resolution.
-tags: [uipath-agents, smoke, coded, bindings]
+tags: [uipath-agents, smoke, coded, bindings, mode:build]
 
 run_limits:
   expected_turns: 15

--- a/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
@@ -5,7 +5,7 @@ description: >
   `langgraph.json` entry-point config, and that the agent ran locally
   for two turns. Lazy-LLM-init invariant (Critical Rule C4) still
   applies.
-tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-langgraph]
+tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-langgraph, mode:build]
 
 run_limits:
   expected_turns: 20

--- a/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/conversational_agent_llamaindex.yaml
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/conversational_agent_llamaindex.yaml
@@ -5,7 +5,7 @@ description: >
   `llama_index.json` entry-point config, and that the agent ran locally
   for two turns. Lazy-LLM-init invariant (Critical Rule C4) still
   applies.
-tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-llamaindex]
+tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-llamaindex, mode:build]
 
 run_limits:
   expected_turns: 22

--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
@@ -7,7 +7,7 @@ description: >
   the package was built — a "version already exists" publish conflict
   does not fail the task. Exercises the production packaging path the
   rest of the suite never reaches.
-tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy]
+tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy, mode:build]
 
 run_limits:
   expected_turns: 43

--- a/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
@@ -4,7 +4,7 @@ description: >
   a custom evaluator with `uip codedagent add evaluator`, implement it, and
   register it with `uip codedagent register evaluator` to generate the JSON
   spec. The evaluator must be wired into an eval set and run successfully.
-tags: [uipath-agents, smoke, coded, lifecycle:validate, feature:eval]
+tags: [uipath-agents, smoke, coded, lifecycle:validate, feature:eval, mode:build]
 
 run_limits:
   expected_turns: 49

--- a/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_exact_match/eval_exact_match.yaml
@@ -7,7 +7,7 @@ description: >
   `id`, and run `uip codedagent eval --no-report` against a
   deterministic Simple Function agent. All test cases must score 1.0
   and report PASSED in the output file.
-tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
+tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval, mode:build]
 
 run_limits:
   expected_turns: 23

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -8,7 +8,7 @@ description: >
   (`uipath-llm-judge-trajectory-similarity`) — and runs them against
   a LangGraph classifier with `--no-report` and `--mocker-cache` so
   the judges are reproducible.
-tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
+tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval, mode:build]
 
 run_limits:
   expected_turns: 34

--- a/tests/tasks/uipath-agents/coded/file_attachment_input/file_attachment_input.yaml
+++ b/tests/tasks/uipath-agents/coded/file_attachment_input/file_attachment_input.yaml
@@ -5,7 +5,7 @@ description: >
   model and runs `uip codedagent init` so `entry-points.json` emits the
   `x-uipath-resource-kind: JobAttachment` schema that Studio Web and
   Orchestrator use to render a file picker at runtime.
-tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:framework-simple]
+tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:framework-simple, mode:build]
 
 run_limits:
   expected_turns: 33

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
@@ -5,7 +5,7 @@ description: >
   `CreateEscalation` from `uipath.platform.common`, compiles the
   graph with a `MemorySaver` checkpointer, and emits the `app`
   binding for the Action Center app the escalation targets.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:hitl-coded, mode:build]
 
 run_limits:
   expected_turns: 29

--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/langgraph_classifier.yaml
@@ -8,7 +8,7 @@ description: >
   `ImportError`), lets `uip codedagent init` regenerate the schema
   from the actual code, and runs the classifier end-to-end via
   `uip codedagent run agent`.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-langgraph, feature:schema-sync]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-langgraph, feature:schema-sync, mode:build]
 
 run_limits:
   expected_turns: 36

--- a/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_workflow/llamaindex_workflow.yaml
@@ -7,7 +7,7 @@ description: >
   schemas, instantiates `UiPathOpenAI` lazily inside a step
   (Critical Rule C4), and runs the workflow end-to-end via
   `uip codedagent run`.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-llamaindex]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-llamaindex, mode:build]
 
 run_limits:
   expected_turns: 26

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
@@ -8,7 +8,7 @@ description: >
   and `_openai_shared.set_default_openai_client` are deferred
   (Critical Rule C4 — module-level setup breaks
   `uip codedagent init`), and runs the triage agent end-to-end.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents, mode:build]
 
 run_limits:
   expected_turns: 33

--- a/tests/tasks/uipath-agents/coded/process_invoke/process_invoke.yaml
+++ b/tests/tasks/uipath-agents/coded/process_invoke/process_invoke.yaml
@@ -5,7 +5,7 @@ description: >
   `uipath.platform.common`, calls it from a LangGraph node with both
   `name` and `process_folder_path` set, and emits the `process`
   binding for the invoked process.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:process-invocation]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:process-invocation, mode:build]
 
 run_limits:
   expected_turns: 30

--- a/tests/tasks/uipath-agents/coded/simple_echo/simple_echo.yaml
+++ b/tests/tasks/uipath-agents/coded/simple_echo/simple_echo.yaml
@@ -6,7 +6,7 @@ description: >
   `entry-points.json` with Pydantic-derived schemas, then runs
   `uip codedagent run main` to execute deterministically (no LLM,
   no cloud auth needed).
-tags: [uipath-agents, smoke, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple]
+tags: [uipath-agents, smoke, coded, lifecycle:generate, lifecycle:execute, feature:framework-simple, mode:build]
   # Default smoke max_turns is 20, but the full scaffold -> init -> run
   # loop (uv venv, uv sync, uip codedagent setup, uip codedagent new,
   # rewrite main.py, init, run, write marker) lands at ~25 turns even

--- a/tests/tasks/uipath-agents/coded/subtype_credential_asset/subtype_credential_asset.yaml
+++ b/tests/tasks/uipath-agents/coded/subtype_credential_asset/subtype_credential_asset.yaml
@@ -8,7 +8,7 @@ description: >
   is required so `uipath push` creates a credential-asset virtual
   placeholder (not a string asset) when the asset doesn't yet exist
   in Orchestrator.
-tags: [uipath-agents, e2e, coded, bindings]
+tags: [uipath-agents, e2e, coded, bindings, mode:build]
 
 run_limits:
   expected_turns: 13

--- a/tests/tasks/uipath-agents/coded/tracing_redaction/tracing_redaction.yaml
+++ b/tests/tasks/uipath-agents/coded/tracing_redaction/tracing_redaction.yaml
@@ -4,7 +4,7 @@ description: >
   `@traced(name=..., input_processor=..., output_processor=...)` to
   a function that handles sensitive data so both the input and the
   output are redacted before they reach the trace store.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:trace]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:trace, mode:build]
 
 run_limits:
   expected_turns: 31

--- a/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
+++ b/tests/tasks/uipath-agents/deeprag_coded/e2e_scaffold_graph.yaml
@@ -7,7 +7,7 @@ description: >
   from uipath.platform.context_grounding, uses plain interrupt() from
   langgraph.types — passes is_ephemeral_index=True on CreateDeepRag,
   and does NOT instantiate UiPath() at module top level.
-tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding]
+tags: [uipath-agents, e2e, coded, lifecycle:generate, context-grounding, mode:build]
 max_iterations: 1
 
 initial_prompt: |


### PR DESCRIPTION
## Summary

- 26 coded-agent task YAMLs were missing the required `mode:*` tag from the tag taxonomy
- Added `mode:build` to each; existing `mode:diagnose` and `mode:operate` tasks were left unchanged

## Test plan

- [ ] Verify `make tags TAGS="mode:build uipath-agents"` picks up the newly tagged tasks
- [ ] Confirm no previously-tagged tasks were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)