### PR TITLE
Fix LLM Gateway test tags and add 5 new coverage tasks

### DIFF
--- a/tests/tasks/uipath-platform/llmgateway/audit_dead_connections_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/audit_dead_connections_smoke.yaml
@@ -1,0 +1,48 @@
+task_id: skill-platform-llmgateway-audit-dead-connections
+description: >
+  Smoke test: agent uses the uipath-platform skill to audit BYO LLM
+  configurations and surface ones pointing at non-Enabled Integration Service
+  connections via `byo-connections list --include-connection-details`.
+  Verifies the agent reaches for the audit recipe in the Diagnostics section.
+tags: [uipath-platform, smoke, mode:diagnose, mode:troubleshoot, lifecycle:discover]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Audit our tenant's BYO LLM configurations. I want to know which configs are
+  pointing at Integration Service connections that are no longer in `Enabled`
+  state — those are the silent failures.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands WILL fail with auth errors — that is expected. You
+    MUST still run the audit command. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - Do NOT mutate any configuration — this is a read-only audit.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed BYO configs with --include-connection-details"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+list(?=[\s\S]*--include-connection-details)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent filtered output for non-Enabled connection state"
+    tool_name: "Bash"
+    command_pattern: '--output-filter\s+["''][^"'']*connectionState[^"'']*'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT mutate any BYO configuration"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+(create|update|delete)\b'
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
@@ -5,7 +5,7 @@ description: >
   `byo-connections create` invocation. Verifies the agent constructs the right
   CLI shape (single-mapping for AnyModelWithOwnAdditions) and runs prerequisite
   discovery before the create. Auth errors are expected in CI.
-tags: [uipath-platform, smoke, llmgateway, byo-connections, lifecycle:create]
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup]
 
 run_limits:
   expected_turns: 14

--- a/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
@@ -1,0 +1,39 @@
+task_id: skill-platform-llmgateway-delete-force
+description: >
+  Smoke test: agent uses the uipath-platform skill to delete a BYO LLM
+  configuration. Verifies the agent knows `delete` requires `--force` (the
+  command refuses to delete without it) and does not fall back to `update
+  --no-enabled` as a soft-delete substitute.
+tags: [uipath-platform, smoke, mode:operate, lifecycle:setup]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Permanently remove BYO LLM configuration
+  `7afd7d89-a35d-4057-669b-3f3de2233812` from the tenant.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. The delete WILL fail with an auth error — that is expected.
+    Do NOT retry or attempt to login.
+  - Use `--output json`.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked delete with --force on the correct configuration id"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+delete\s+7afd7d89-a35d-4057-669b-3f3de2233812(?=[\s\S]*--force)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on the delete call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+delete\s+\S+(?=[\s\S]*--output\s+json)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
@@ -1,0 +1,51 @@
+task_id: skill-platform-llmgateway-get-force-refresh
+description: >
+  Smoke test: agent uses the uipath-platform skill to diagnose a failing BYO
+  LLM configuration by re-resolving the underlying Integration Service
+  connection state via `byo-connections get <id> --force-refresh`. Verifies the
+  agent reaches for the diagnostic verb instead of immediately re-creating the
+  config or trying to re-authenticate.
+tags: [uipath-platform, smoke, mode:diagnose, mode:troubleshoot, lifecycle:discover]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  My BYO LLM configuration `f7c93a8d-2b14-49e7-a013-08dc7f6e1234` was working
+  yesterday but agent calls started failing this morning with auth errors from
+  OpenAI. Help me figure out whether the underlying Integration Service
+  connection is still healthy.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands WILL fail with auth errors — that is expected. You
+    MUST still run the diagnostic commands. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - Do NOT delete or re-create the configuration — this is a read-only
+    diagnosis.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched the BYO config with --force-refresh to re-resolve connection state"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+get\s+\S+(?=[\s\S]*--force-refresh)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on the get call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+get\s+\S+(?=[\s\S]*--output\s+json)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT attempt to delete or re-create the configuration"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+(delete|create)\b'
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
@@ -5,7 +5,7 @@ description: >
   `uip llm-configuration byo-connections list-product-configs`. Verifies the
   agent knows to query the discovery endpoint before attempting a create, and
   that it filters with --product / --feature when given a specific feature.
-tags: [uipath-platform, smoke, llmgateway, byo-connections, discovery]
+tags: [uipath-platform, smoke, mode:build, lifecycle:discover]
 
 run_limits:
   expected_turns: 10

--- a/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
@@ -4,7 +4,7 @@ description: >
   product configurations on the tenant via `uip llm-configuration byo-connections
   list`. Verifies the agent uses the read-only list command and knows the
   `--include-connection-details` flag for resolving connector metadata.
-tags: [uipath-platform, smoke, llmgateway, byo-connections, lifecycle:discover]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
 run_limits:
   expected_turns: 13

--- a/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
@@ -1,0 +1,52 @@
+task_id: skill-platform-llmgateway-reprobe-validation
+description: >
+  Smoke test: agent uses the uipath-platform skill to force a fresh server-side
+  validation probe on an existing BYO LLM configuration via an idempotent
+  `byo-connections update` re-write. Verifies the agent knows update always
+  re-runs `POST .../validate` and uses it as a diagnose recipe for
+  isAvailable / isCompatible probe failures.
+tags: [uipath-platform, smoke, mode:diagnose, mode:troubleshoot, lifecycle:setup]
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Configuration `e5723bb8-fbc2-4317-c7d7-08de803bc010` is currently registered
+  for product=agenthub feature=agenthub-llm-call with model
+  gpt-4o-2024-08-06, connector-type OpenAi, api-flavor OpenAiResponses, and
+  connection-id `1a2b3c4d-5678-90ab-cdef-1234567890ab`. The vendor key was
+  rotated overnight. Force the LLM Gateway to re-probe whether the model is
+  still reachable through the rotated key — without changing any mapping
+  fields.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands WILL fail with auth errors — that is expected. You
+    MUST still run the re-probe command. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent issued an idempotent update with the same mapping fields to trigger re-validation"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+(?=[\s\S]*--llm-name\s+gpt-4o-2024-08-06)(?=[\s\S]*--connector-type\s+OpenAi)(?=[\s\S]*--api-flavor\s+OpenAiResponses)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on the update call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+(?=[\s\S]*--output\s+json)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT delete or re-create the configuration"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+(delete|create)\b'
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
@@ -1,0 +1,58 @@
+task_id: skill-platform-llmgateway-update-full-put
+description: >
+  Smoke test: agent uses the uipath-platform skill to change one mapping in a
+  multi-mapping BYO LLM configuration. Verifies the agent understands `update`
+  is full-PUT — every mapping the customer wants in the resulting record must
+  be supplied on the call, not just the one being changed.
+tags: [uipath-platform, smoke, mode:operate, lifecycle:setup]
+
+run_limits:
+  expected_turns: 12
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Configuration `c1d2e3f4-1111-2222-3333-444455556666` is a multi-mapping BYO
+  LLM record for product=uipath-ecs feature=uipath-ecs-batch-transform-web-search.
+  Today it contains two mappings:
+
+  - llm-name=gemini-2.5-flash, llm-identifier=gemini-2.5-flash,
+    connector-type=GoogleVertex, api-flavor=GeminiGenerateContent,
+    connection-id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+  - llm-name=gemini-2.5-flash-lite, llm-identifier=gemini-2.5-flash,
+    connector-type=GoogleVertex, api-flavor=GeminiGenerateContent,
+    connection-id=aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
+
+  Upgrade the second mapping's llm-identifier from `gemini-2.5-flash` to
+  `gemini-2.5-flash-002`. Leave the first mapping exactly as it is.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. The update WILL fail with an auth error — that is expected.
+    Do NOT retry or attempt to login.
+  - Use `--output json`.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent re-supplied the unchanged first mapping in the update call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+c1d2e3f4-1111-2222-3333-444455556666(?=[\s\S]*--mapping\s+[''"][^''"]*llm-name=gemini-2\.5-flash,[^''"]*llm-identifier=gemini-2\.5-flash,)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent supplied the updated second mapping with the new llm-identifier"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+c1d2e3f4-1111-2222-3333-444455556666(?=[\s\S]*--mapping\s+[''"][^''"]*llm-name=gemini-2\.5-flash-lite,[^''"]*llm-identifier=gemini-2\.5-flash-002,)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on the update call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+(?=[\s\S]*--output\s+json)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Tag-taxonomy fixes + new test coverage for the LLM Gateway / BYO LLM slice.

### Required-tag fixes (existing 3 tasks)

Every coder_eval task must carry `skill` + `tier` + \`mode:*\` + \`lifecycle:*\` per [tests/README.md § Tag Taxonomy](tests/README.md). The existing three llmgateway tasks were missing the \`mode:*\` tag entirely and using non-vocabulary tags (\`llmgateway\`, \`byo-connections\`, \`discovery\`, \`lifecycle:create\`).

| File | New tags |
|---|---|
| [`create_validate_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml) | \`mode:build, lifecycle:setup\` |
| [`list_product_configs_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml) | \`mode:build, lifecycle:discover\` |
| [`list_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/list_smoke.yaml) | \`mode:operate, lifecycle:discover\` |

### New tasks (5)

| File | Mode | Lifecycle | Purpose |
|---|---|---|---|
| [`get_force_refresh_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml) | diagnose | discover | Diagnose a failing BYO config via \`get <id> --force-refresh\` |
| [`audit_dead_connections_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/audit_dead_connections_smoke.yaml) | diagnose | discover | Tenant audit for configs pointing at non-Enabled IS connections |
| [`reprobe_validation_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml) | diagnose | setup | Force fresh server-side validation via idempotent \`update\` |
| [`delete_force_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml) | operate | setup | Verify agent uses \`--force\` on delete |
| [`update_full_put_smoke.yaml`](tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml) | operate | setup | Change one mapping in a multi-mapping config (full-PUT semantics) |

After this PR, LLM Gateway test coverage by mode is **2 build / 3 operate / 3 diagnose** (vs. 1 build / 1 operate / 0 diagnose before).

### Vocabulary note: \`mode:diagnose\` + \`mode:troubleshoot\`

Each diagnose-mode task carries **both** \`mode:diagnose\` AND \`mode:troubleshoot\`. The Coding Agents Scorecard column on Confluence is labeled \"Troubleshoot\" while the taxonomy in \`tests/README.md\` says \`mode:diagnose\`. Tagging both lets the analysis pipeline credit the tasks under whichever vocabulary it consumes. This technically violates the README rule \"one value per singular dimension\" — flagging here so reviewers can decide which name wins and harmonize the two in a follow-up.

### Validation

- [x] All 8 task YAMLs parse.
- [x] All regex \`command_pattern\`s compile.
- [x] All required tags present (skill, tier, mode:\*, lifecycle:\*) per tests/README.md.
- [x] Regex patterns match the actual CLI signatures from \`uip llm-configuration byo-connections --help\`.
- [ ] coder_eval execution gated to CI — local run blocked by Python 3.13 requirement, missing API keys, and missing UiPath auth setup. The smoke-skills.yml workflow on this PR is the real validation.

## Test plan

- [ ] CI runs the new tasks under \`smoke-skills.yml\`.
- [ ] Each diagnose task scores ≥1.0 (pass) — auth errors are expected; the criteria check command shape, not tenant state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)