### PR TITLE
MST-10845: docs(uipath-maestro-case): require strict equality in =js: expression…

### DIFF
--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -64,6 +64,10 @@ Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime 
 
 > **JIT object mode (out of scope for this version).** When an activity's `inputMetadata.inputMode === "jitObject"` (synthetic HTTP request bodies, generic body-passthrough activities), the whole connector body becomes one `=js:({...})` expression with bare JS variable references inline. The skill currently routes synthetic HTTP through `queryParameters` instead. JIT-mode authoring is not documented in this version.
 
+### Equality operators
+
+In any `=js:` expression use **strict** `===` / `!==`, never loose `==` / `!=`. JS eval coerces types on loose equality (`vars.flag == "true"` is truthy for the string `"true"`), which silently breaks boolean/number routing. Canonical: `=js:vars.approved === true`.
+
 ### Conservative rule for `=metadata.X`
 
 The lookup-path resolver has NO `=metadata.` branch — plain `=metadata.X` is NOT resolved at runtime. **Always wrap as `=js:metadata.X`** (or `=js:(metadata.X)` if the sink requires parens). The FE design-time picker may classify `=metadata.X` as "variable" type, but that's a UI hint, not a runtime contract.

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -444,12 +444,14 @@ All tasks inside a stage share this envelope. Per-type `data` fields live in eac
 | `displayName` | string? | Human-readable label shown in the UI |
 | `type` | string | Task type — see task plugins under `plugins/tasks/` |
 | `data` | object | Type-specific configuration — see corresponding plugin's `impl-json.md`. For connector tasks, `data.bindings` references the root-level bindings array. |
-| `skipCondition` | string? | Expression — skip the task when truthy |
+| `skipCondition` | string? | `=js:` expression — skip the task when truthy. Use strict equality ([`bindings-and-expressions.md`](bindings-and-expressions.md#equality-operators)). |
 | `entryConditions` | TaskEntryCondition[]? | See §3. Written by the task-entry-conditions plugin from the SDD's authored Entry Condition rows — applied uniformly across task types (no auto-injection by task type). |
 | `shouldRunOnlyOnce` | boolean? | Run the task at most once per case, even if the stage is re-entered |
 | `shouldRunOnReEntry` | boolean? | *(deprecated — use `shouldRunOnlyOnce`)* Re-run when stage is re-entered |
 | `isRequired` | boolean? | Whether the task must complete for the stage to complete |
 | `description` | string? | Task description |
+
+> **Envelope fields are top-level, not `data`.** Every field above except `data` lives directly on the task object — `skipCondition`, `entryConditions`, `shouldRunOnlyOnce`, `isRequired`, etc. are siblings of `data`, never nested inside it. `data` holds only the type-specific config defined by the task's plugin.
 
 **Positioning:** tasks have no `x`/`y`. They live in `stageNode.data.tasks[laneIndex][]` — a 2D array where the outer index is the lane (rendering column) and the inner index is the order within the lane. Default convention: one task per lane. Exception: within a `runs-sequentially` group, tasks that should run in parallel share the same lane (shared lane = parallel siblings, carries execution semantics).
 

--- a/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
@@ -261,8 +261,8 @@ success_criteria:
     description: "Both branch expressions reference the approved boolean"
     path: "VendorApprovalCase/VendorApprovalCase/caseplan.json"
     includes:
-      - "approved == true"
-      - "approved == false"
+      - "vars.approved === true"
+      - "vars.approved === false"
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
@@ -197,8 +197,8 @@ success_criteria:
     description: "Both branch expressions present on Review's exits"
     path: "LeaveRequestCase/LeaveRequestCase/caseplan.json"
     includes:
-      - "approved == true"
-      - "approved == false"
+      - "vars.approved === true"
+      - "vars.approved === false"
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
docs(uipath-maestro-case): require strict equality in =js: expressions

Add an "Equality operators" section to bindings-and-expressions.md mandating
strict === / !== over loose == / != — loose equality coerces types and
silently breaks boolean/number routing (e.g. vars.flag == "true").

In case-schema.md, document skipCondition as a =js: expression using strict
equality, and clarify that envelope fields (skipCondition, entryConditions,
shouldRunOnlyOnce, isRequired, ...) are siblings of data, never nested in it.

Update the hitl boolean-routing tasks' file_contains assertions to grep the
canonical `vars.approved === true` / `=== false` instead of the loose
`approved == true` shorthand.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
