### PR TITLE
docs(test-coverage): operate/diagnose archetype lens + mode-balanced scoring

### DIFF
--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -98,6 +98,61 @@ Determine what environment each skill requires to be testable. Use the same phra
 
 Tag each skill with its dependencies. This informs which tests are feasible to write and run in CI.
 
+### 2f. Classify each capability by mode (Coding Agents Scorecard)
+
+Label every component, workflow step, and critical rule with the mode(s) it serves. Multi-label allowed — a `validate` step is both `build` and `diagnose`.
+
+- **build** — creating, designing, editing, deploying (init, scaffold, pack, edit, validate-during-build, deploy)
+- **operate** — running, triggering, managing live instances/connectors/integrations (run, trigger, invoke, manage connections)
+- **diagnose** — investigating faults, inspecting traces, debugging (get-errors, logs, trace inspect, debug)
+
+These labels define each mode's denominator in Phase 4f-mode. Most build-heavy skills come out build-dominant — expected. A skill that clearly teaches an `operate` or `diagnose` surface but has zero capabilities labeled that mode is itself a finding (surface it in the gaps).
+
+**Labeling subtlety — `validate` and `list`/`get` are mode-dependent.** A capability's mode follows the *intent the skill teaches*, not the verb:
+- `validate` / `build` run on a **fresh artifact during authoring** → `build`. The same command run on a **pre-broken artifact to surface and fix errors** (the autonomous validate→read-errors→fix loop) → also `diagnose`. Tag both; a build-only test does NOT cover the diagnose loop.
+- `list` / `get` / `status` as a **happy-path step** → the mode of the step it serves. The same read used to **triage a fault** ("list jobs `--state Faulted`", "get incidents before deciding") → `diagnose`.
+- `run` / `invoke` / `deploy` of a **deployed, live artifact** → `operate`, even when the build skill owns the command.
+
+#### 2f-i. Operate & diagnose surface checklist (apply to EVERY skill)
+
+Build coverage is almost always the strong mode; `operate` and `diagnose` are where real gaps hide and where a skill's SKILL.md mentions a surface that no test touches. The archetypes below recur across ≥2 skills. For each skill, walk both lists: if the SKILL.md / references teach the surface (even in a reference, not just the main body), it is a labeled capability for that mode — and if no test exercises it, it is a `None` that feeds the Phase 4f-mode denominator and the Phase 4i mode gap. Cite the specific archetype in the gap title (e.g. "Missing `operate` coverage in uipath-rpa — run/invoke + deploy-activate untested").
+
+**Operate archetypes — does any test exercise…**
+
+| # | Archetype | Surface pattern (skill-agnostic) |
+|---|---|---|
+| O1 | **Run / invoke a deployed artifact** | start a job/process/agent/flow/test-case by key → returns execution id (`jobs start`, `tm testcases run`, `flow debug`, `api-workflow run`, `codedagent deploy`+invoke) |
+| O2 | **Deploy + activate as separate steps** | `deploy run` then stand-alone `deploy activate` / `deploy status` poll (esp. after `--skip-activate`); `deploy config link/unlink`; `deploy uninstall` |
+| O3 | **File sync push / pull** | `codedagent`/`codedapp push` + `pull` roundtrip; `solution upload` to Studio Web / workspace |
+| O4 | **Instance lifecycle** | pause / resume / cancel / retry a *running* instance (`maestro flow|case instance …`, BPMN job lifecycle beyond start+stop, `jobs stop`+retry) |
+| O5 | **Queue operations** | add items, requeue / review failed items, set deadline / SLA on a live queue |
+| O6 | **Trigger create + fire (non-cron)** | create a **queue** or **API** trigger and verify it fires — not just time-based cron |
+| O7 | **Connection create + test** | create an IS OAuth connection (`is connections create <key>`) + `ping`/test on a live tenant |
+| O8 | **Enable / disable a live resource** | toggle tenant service, webhook, IP-restriction enforcement, or BYO-LLM config on/off and verify state change |
+| O9 | **Publish / register a live version** | publish IXP model version, BYO-LLM config, or `packages upload` so it becomes the live version |
+| O10 | **License / seat assignment** | assign user/group license bundles, set tenant allocation, read consumables |
+| O11 | **Eval run + poll + fetch results** | start a Studio Web eval against a deployed flow/agent, poll to done, fetch scored results |
+
+**Diagnose archetypes — does any test exercise…**
+
+| # | Archetype | Surface pattern (skill-agnostic) |
+|---|---|---|
+| D1 | **Validate → read errors → fix loop on a PRE-BROKEN artifact** | feed a deliberately broken file, assert the agent reads structured errors and fixes the root cause, then re-validates clean (NOT happy-path validate) |
+| D2 | **Incident / fault read on a failed runtime instance** | `instance incidents` / `instance variables` / job faults after a failed run, without rerunning |
+| D3 | **Job / execution log retrieval** | `jobs logs <id> --output json`, `tm executions get` / step-log drill-down on a faulted run |
+| D4 | **Trace / span inspection** | `traces spans get <trace-id>` as a standalone diagnostic (LLM/tool calls, token counts), not a build/operate side effect |
+| D5 | **Audit query filtered for triage** | `audit … events --status Failure` / by user / by time window to answer "who did X / what changed" |
+| D6 | **Effective-access / authorization check** | folder-scoped `authorization check-access <user>`, `deployed-policy get --user-id` — "why can't user X do Y" |
+| D7 | **Connectivity / health check** | BYO-LLM `--force-refresh` / reprobe, `is connections list --all-folders`, dead-connection audit |
+| D8 | **Failure-mode / error-code classification** | match an error code / exception (e.g. `MST-9107`, `CS0103`, exit codes) to a known catalog and recommend the fix branch |
+| D9 | **Model / metric quality inspection** | `get-metrics` + `list-models`, per-field F1 / precision / recall to explain bad extraction |
+| D10 | **Schema / contract-drift detection** | out-of-sync `bindings_v2.json`, `entry-points` drift, camelCase/naming mismatch surfaced by validate |
+| D11 | **Read-only discovery for triage** | `login status`, `list --state Faulted`, `get` before mutating — inspecting state to scope a fault |
+
+**Two recurring meta-findings to always check (emit as gaps when present):**
+- **Tag-drift on operate/diagnose:** a skill's only operate/diagnose tests are tagged `mode:build` (or carry no `mode:*` at all) — fires the Phase 4f-mode tag cross-check. Common on catalog skills (`uipath-tasks`, `uipath-data-fabric`, `uipath-ixp`) where every task inherited `mode:build`.
+- **Surface-without-test:** SKILL.md/references document an operate/diagnose command (e.g. `maestro case instance`, `rpa debug start`, `solution deploy activate`) that has zero covering tests — the most common source of `operate`/`diagnose` `None`s.
+
 ## Phase 3 — Extract test coverage
 
 ### 3a. Parse each test YAML
@@ -112,7 +167,7 @@ tags            — array carrying values from the Tag Taxonomy dimensions
                   [skill, tier, mode:X, shape:X, node:..., resource, connector, windows, feature:...]
                     skill      — uipath-<name>                                (required, flat)
                     tier       — smoke | integration | e2e                    (required, flat)
-                    mode       — mode:{build|operate|troubleshoot}                (required)
+                    mode       — mode:{build|operate|diagnose}                  (required; see Phase 2f for mode definitions)
                     shape      — shape:{single-node|multi-node}              (flow-building tests)
                     node       — node:{decision|switch|subflow|terminate|loop|transform|hitl} (0..n)
                     resource   — flat boolean marker (present iff task uses a resource node) (0..1)
@@ -231,6 +286,27 @@ Formula: `overall = sum(applicable_weight_i * dimension_pct_i) / sum(applicable_
 
 For skills with **no tests**: overall = 0% (skip the Score Contribution table — every dimension contributes 0).
 
+### 4f-mode. Per-mode coverage (scored slices, reported beside Overall)
+
+Report a coverage score for **each** Coding Agents Scorecard mode (`build`, `operate`, `diagnose`) alongside the Overall. Mode is orthogonal to the scored dimensions — do NOT add it as a weighted dimension (that double-counts against Workflow steps; see Phase 4h). Instead **re-slice the same capability inventory by the Phase 2f mode labels** and re-run the Phase 4f weighted formula per slice:
+
+1. For mode `m`, take only the components / workflow steps / critical rules labeled `m`.
+2. Compute each dimension's direct-only coverage within that slice; renormalize the applicable weights over the dimensions present in the slice (same N/A handling as Phase 4f).
+3. `mode_pct(m)` = that weighted number.
+
+Cases:
+- Mode has labeled capabilities, zero covering tests → **0%**.
+- Mode has no labeled capabilities in this skill → **N/A** (e.g. a pure-build catalog skill with no diagnose surface). N/A modes do not fire the Phase 4i mode gap.
+- Overall (Phase 4f) is unchanged — it is **NOT** the mean of the three modes (slices differ in size). Report both; they will not match, by design.
+
+**Tag cross-check.** A capability counts toward `mode_pct(m)` from its Phase 2f label, regardless of which test covers it. But if a mode-`m` capability is covered *only* by tests not tagged `mode:m`, the test's mode tag is wrong — emit a consistency flag (name the test). This keeps the coverage slices aligned with the `mode:*` tags that `/generate-confluence-scorecard` slices eval by, so per-mode coverage and per-mode eval pair correctly.
+
+**Mode-balanced & mode-floor headlines (report beside the capability Overall).** The capability Overall is build-dominated by construction — the inventory is mostly build capabilities, so a skill can read "healthy" (e.g. 79%) while `operate`/`diagnose` sit near 0%, because those modes are a small slice of each dimension's denominator. To make that blindness legible without changing the Overall, compute and report two derived figures from the per-mode slices:
+- **Mode-balanced** = arithmetic mean of `mode_pct(m)` over the modes that are **not N/A** (i.e. modes the skill actually has a surface for). A skill with `diagnose` N/A averages only `build` + `operate`.
+- **Mode-floor** = `min` of `mode_pct(m)` over the not-N/A modes — the worst-covered real mode. This is the single number that exposes a 0% mode.
+
+Report both beside the Overall in the per-skill Summary, the SUMMARY Overview, and `coverage.json` (`mode_balanced`, `mode_floor`). They are **descriptive, not a new weighted score** — the Overall is still the Phase 4f capability number. Rule of thumb for readers: a high Overall with a low Mode-floor = build-solid but mode-blind; that gap is the action item, and the Phase 4i mode gap already names which archetype to test. Skills with no tests → `0`/`0`; planned skills → `—`.
+
 ### 4g. Test-density troubleshooting (sidecar, not scored)
 
 Report these alongside the Summary table to flag structural fragility that a high coverage score might hide. None of these feed the weighted score — they're red-flag indicators for readers.
@@ -244,7 +320,7 @@ Report these alongside the Summary table to flag structural fragility that a hig
 
 For each skill that has at least one test, compute which values from the Tag Taxonomy are exercised. Report the variable dimensions (the `skill` dimension is trivially covered and `tier` is already reported in the Summary table):
 
-- **Mode** — tick each of `mode:build`, `mode:operate`, `mode:diagnose` if any test carries that tag. All three are expected eventually for most skills; missing modes surface as gaps.
+- **Mode** — now a **scored slice** (Phase 4f-mode), not a sidecar tick. Report it in the Per-Mode Coverage table, not here.
 - **Shape** — tick each of `shape:single-node`, `shape:multi-node` (applies to flow-building skills only).
 - **Node** — list values present under `node:*` for skills where that axis applies.
 - **Resource / Connector / Windows** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`, `windows`) for skills where they apply.
@@ -259,7 +335,8 @@ Run these checks and emit findings into the "Coverage Gaps — Priority Ranked" 
 | Signal | Condition | Priority | Gap title template |
 |---|---|---|---|
 | **Edit-scenario gap** | The skill teaches an edit workflow (it documents modifying an existing artifact — common for `uipath-maestro-flow`, `uipath-rpa`, `uipath-agents`) but no test exercises that scenario (no task under `tests/tasks/<skill>/edit/` and no `initial_prompt` describes modifying an existing artifact). | **High** | "Editing existing `<artifact>`" |
-| **Mode gap** | The skill has tests but does not exercise all three modes (`mode:build`, `mode:operate`, `mode:diagnose`) where they're plausibly applicable. Catalog skills may legitimately stop at `mode:operate`; flag for the writer to confirm. | **Medium** | "Missing `<mode>` coverage" |
+| **Mode gap** | A mode with a non-trivial labeled capability surface (Phase 2f) is below threshold coverage (Phase 4f-mode). N/A modes (no surface) do not fire — a catalog skill with no `diagnose` surface is not penalized. **Name the specific Phase 2f-i archetype(s) untested** (e.g. O4 instance lifecycle, D1 validate→fix loop). | **High** if a mode with a real surface sits at 0%; **Medium** otherwise | "Missing `<mode>` coverage — `<archetype>` untested" |
+| **Mode tag-drift** | A skill's operate/diagnose capability is covered *only* by tests tagged `mode:build` or carrying no `mode:*` (Phase 4f-mode cross-check / Phase 2f-i meta-finding). | **Medium** | "Re-tag `<test>` as `mode:<operate\|diagnose>`" |
 | **Negative-test gap** | The skill's SKILL.md lists ≥3 anti-patterns and zero tests assert on any of them. | **High** | "Negative tests for anti-patterns" |
 | **Tier gap** | The skill has tests but is missing a tier (smoke-only, integration-only, or e2e-only). | **High** (if smoke or e2e is missing — those are the minimum bar), **Medium** (integration missing) | "Missing `<tier>` tier" |
 
@@ -289,6 +366,8 @@ Create `tests/reports/` if needed.
       "paths": {"covered": 3, "total": 3, "pct": 100},
       "weights": {"components": 45, "workflow": 25, "rules": 15, "paths": 15},
       "contribution": {"components": 12.6, "workflow": 16.8, "rules": 3.2, "paths": 15.0},
+      "mode_coverage": {"build": {"pct": 31, "covered": 8, "total": 26}, "operate": {"pct": 0, "covered": 0, "total": 4}, "diagnose": null},
+      "mode_balanced": 16, "mode_floor": 0,
       "top_untested": ["triggers 0/3", "IS connectors 0/2", "run/publish 2/8"],
       "infra": "Requires Windows + Studio"
     },
@@ -297,7 +376,7 @@ Create `tests/reports/` if needed.
 }
 ```
 
-Use `null` for N/A dimensions (e.g. `"rules": null` for a catalog skill, `"paths": null` for single-path). The `contribution` values must match the per-skill Score Contribution tables and sum to `overall_pct`. Single-skill runs may write/refresh just that skill's entry; do not blank the others.
+Use `null` for N/A dimensions (e.g. `"rules": null` for a catalog skill, `"paths": null` for single-path). The `contribution` values must match the per-skill Score Contribution tables and sum to `overall_pct`. `mode_coverage` carries one object per mode (`{pct, covered, total}`) or `null` for a mode with no capability surface (Phase 4f-mode) — this is the per-mode coverage `/generate-confluence-scorecard` pairs with its per-mode eval. `mode_balanced` (mean of non-N/A mode pcts) and `mode_floor` (min of non-N/A mode pcts) are the descriptive headlines from Phase 4f-mode — integers, or omitted/`null` for planned skills. Single-skill runs may write/refresh just that skill's entry; do not blank the others.
 
 **Output rules:**
 
@@ -344,6 +423,8 @@ Use this template when the skill has at least one test task.
 | Workflow steps covered | X / Y (Z%) |
 | Critical rules covered (direct) | X / Y (Z%) *or* N/A (no Critical Rules section) |
 | Path coverage | X / Y (Z%) *or* N/A (single-path skill) |
+| Per-mode coverage (B/O/D) | 31% / 0% / N/A *(scored slices — see Per-Mode Coverage; reported beside Overall, not folded in)* |
+| Mode-balanced / floor | 16% / 0% *(mean & min of non-N/A mode slices — exposes mode blindness the Overall dilutes; descriptive, not scored)* |
 | **Estimated overall coverage** | **Z%** (weights: Comp W1% / Steps W2% / Rules W3% / Path W4% — renormalized over applicable dimensions) |
 
 Anti-patterns are inventoried in the Anti-Patterns section below but are **not** part of the overall score (see Phase 4e).
@@ -414,6 +495,18 @@ Applicable only when the skill documents ≥2 implementation paths. Otherwise wr
 | Coded (C#) | Yes | skill-rpa-coded-test-case |
 | XAML | No | — |
 
+### Per-Mode Coverage (scored slices)
+
+Re-slices the capability inventory by the Phase 2f mode labels and re-runs the weighted formula per slice (Phase 4f-mode). Reported beside — never folded into — the Overall. `N/A` = the skill has no capability surface for that mode.
+
+| Mode | Capabilities (covered/total) | Coverage % | Covering tests |
+|------|------------------------------|-----------|----------------|
+| `build` | 8/26 | 31% | skill-flow-calculator, skill-flow-init-validate, … |
+| `operate` | 0/4 | 0% | — |
+| `diagnose` | — | N/A | — |
+
+⚠ *tag mismatch:* emit a bullet when a capability's only covering test carries the wrong `mode:*` tag (Phase 4f-mode cross-check) — name the test and the expected mode.
+
 ### Anti-Patterns (X/Y covered — troubleshooting only, NOT in overall score)
 
 | # | Anti-Pattern | Covered | Test(s) | Notes |
@@ -424,13 +517,7 @@ Applicable only when the skill documents ≥2 implementation paths. Otherwise wr
 
 Sidecar troubleshooting — see Phase 4h. Not part of the weighted overall score.
 
-**Mode**
-
-| Value | Tests | Status |
-|---|---|---|
-| `mode:build` | skill-flow-calculator, skill-flow-init-validate, skill-flow-add-node, … | ✓ |
-| `mode:operate` | — | ✗ |
-| `mode:diagnose` | — | ✗ |
+**Mode** — scored separately in the **Per-Mode Coverage** section above; not repeated as a sidecar tick.
 
 **Shape** (flow-building tests only)
 
@@ -589,14 +676,14 @@ Produce this whenever more than one skill is analyzed (including `all` mode).
 
 ## Overview
 
-| Skill | Tests | Components (direct) | Workflow | Rules | Paths | Overall | Tests/Comp (med) | Top untested buckets | Infra |
-|-------|-------|---------------------|----------|-------|-------|---------|------------------|----------------------|-------|
-| uipath-maestro-flow | 49 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 1/2 (50%) | 33% | 2 | control-flow 5/7, queue 0/2, resource 0/3 | Requires cloud auth |
-| uipath-rpa | 2 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 1/2 (50%) | 8% | 0 | triggers 0/3, IS connectors 0/2, run/publish 2/8 | Requires Windows + Studio |
-| uipath-platform | 5 | 2/12 (17%) | N/A | N/A | N/A | 17% | 0 | orchestrator-admin 7/15, jobs-adv 0/4 | Requires cloud auth |
-| uipath-document-understanding | 0 | — / — (0%) | — | — | — | **0%** (planned) | — | — (planned) | Skill folder not yet created |
+| Skill | Tests | Components (direct) | Workflow | Rules | Paths | Overall | Mode B/O/D | Bal/Floor | Tests/Comp (med) | Top untested buckets | Infra |
+|-------|-------|---------------------|----------|-------|-------|---------|------------|-----------|------------------|----------------------|-------|
+| uipath-maestro-flow | 49 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 1/2 (50%) | 33% | 33/0/— | 17/0 | 2 | control-flow 5/7, queue 0/2, resource 0/3 | Requires cloud auth |
+| uipath-rpa | 2 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 1/2 (50%) | 8% | 8/0/— | 4/0 | 0 | triggers 0/3, IS connectors 0/2, run/publish 2/8 | Requires Windows + Studio |
+| uipath-platform | 5 | 2/12 (17%) | N/A | N/A | N/A | 17% | 17/17/— | 17/17 | 0 | orchestrator-admin 7/15, jobs-adv 0/4 | Requires cloud auth |
+| uipath-document-understanding | 0 | — / — (0%) | — | — | — | **0%** (planned) | — | — | — | — (planned) | Skill folder not yet created |
 
-Overall is weighted and renormalized across applicable dimensions (see Phase 4e). N/A cells mean the skill is missing that dimension (e.g. no Critical Rules section, single-path skill, catalog skill with no workflow steps) — weights redistribute proportionally. Planned-but-missing skills (no `skills/<name>/` folder yet) are scored at 0% and tagged "(planned)" in the Overall column; they appear in the same table — do not split them out, so the gap is impossible to overlook. **Top untested buckets** (Phase 4a) names the 2–3 largest `None` groups dragging each skill's score, so a reader can see *why* the coverage number is low without opening the per-skill report; full detail lives in each report's Untested Features section.
+Overall is weighted and renormalized across applicable dimensions (see Phase 4e). N/A cells mean the skill is missing that dimension (e.g. no Critical Rules section, single-path skill, catalog skill with no workflow steps) — weights redistribute proportionally. Planned-but-missing skills (no `skills/<name>/` folder yet) are scored at 0% and tagged "(planned)" in the Overall column; they appear in the same table — do not split them out, so the gap is impossible to overlook. **Top untested buckets** (Phase 4a) names the 2–3 largest `None` groups dragging each skill's score, so a reader can see *why* the coverage number is low without opening the per-skill report; full detail lives in each report's Untested Features section. **Mode B/O/D** is the compact per-mode coverage (`build`/`operate`/`diagnose`, Phase 4f-mode) — `—` marks an N/A mode (no capability surface); these are scored beside Overall, never folded into it. **Bal/Floor** is Mode-balanced (mean of non-N/A mode slices) / Mode-floor (min of them, Phase 4f-mode): a high Overall with a low Floor flags a build-solid but mode-blind skill.
 
 **Totals:** N tests across M skills (P planned, not yet authored). X components inventoried, Y directly tested (Z%). A workflow steps, B covered. C critical rules, D directly tested. E multi-path skills, F with full path coverage. Anti-patterns are inventoried per skill but intentionally excluded from the overall score.
 


### PR DESCRIPTION
## What

Enriches the `/test-coverage` command so it surfaces **operate/diagnose blind spots** that the build-dominated capability Overall hides today. No source skills or tests change — only the command file. (`tests/reports/` outputs are gitignored, so they're not in this PR.)

## Why

A build-heavy skill can score a healthy Overall (e.g. `uipath-agents` 79%) while two of the three Coding-Agents-Scorecard modes sit near zero (operate 14%, diagnose 11%). The Overall is capability-weighted and the inventory is mostly build capabilities, so an untested operate/diagnose surface barely dents it. The reader can't see the blindness from the headline.

## Changes

- **Phase 2f-i — operate/diagnose archetype checklist** applied to every skill: 11 operate archetypes (`O1`–`O11`) and 11 diagnose archetypes (`D1`–`D11`), each a skill-agnostic surface pattern. If a skill *teaches* the surface (even only in a reference) and no test exercises it, it counts as an untested capability in that mode's denominator. Plus an intent-based labeling note (happy-path `validate` = build; validate-a-broken-artifact = diagnose; `list` to triage a fault = diagnose; `run`/`deploy` of a live artifact = operate).
- **Phase 4f-mode — Mode-balanced & Mode-floor headlines** reported beside the unchanged Overall:
  - **Mode-balanced** = mean of the non-N/A mode slices
  - **Mode-floor** = min of them (the number that exposes a 0% mode)

  Descriptive only — the Overall stays the Phase 4f capability number. A high Overall with a low Floor = build-solid but mode-blind.
- **Phase 4i signals** — the Mode-gap now cites the specific untested archetype; new **Mode tag-drift** signal flags operate/diagnose tests mistagged `mode:build` or untagged (common on catalog skills like `uipath-tasks`, `uipath-data-fabric`, `uipath-ixp`), which also undercounts the Confluence scorecard's per-mode eval slices.
- **Propagation** into the per-skill report template, the `coverage.json` schema (`mode_balanced` / `mode_floor`), and the SUMMARY Overview (`Bal/Floor` column).

## Scope / risk

Documentation-only change to one agent-facing command (`.claude/commands/test-coverage.md`, +105/-18). No skill, test, or hook behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)