### PR TITLE
fix(tests/maestro-flow): correct paginated_reference_lookup eval matchers

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -35,7 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip is resources run list ... curated_channels` more than once (pagination loop ran)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+uipath-salesforce-slack\s+curated_channels'
+    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+"?uipath-salesforce-slack"?\s+"?curated_channels'
     min_count: 2
     weight: 3.0
     pass_threshold: 1.0
@@ -66,7 +66,7 @@ success_criteria:
     description: "Flow wires the Slack send-message-to-channel node with the resolved Slack id for channel `simple` (C083AN4E61E)"
     path: "SlackPaginationTest/SlackPaginationTest/SlackPaginationTest.flow"
     includes:
-      - '"send-message-to-channel"'
+      - 'uipath.connector.uipath-salesforce-slack.send-message-to-channel'
       - '"C083AN4E61E"'
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

`tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml` (added in #1059 / #1253) was failing in the daily eval run with a weighted score of 0.64, despite the agent behaving correctly. Two `success_criteria` matchers had false negatives.

## Failure analysis

Source: `task.json` from the daily eval artifact (`skill-flow-paginated-reference-lookup/00`).

| # | Criterion (weight) | Score | Root cause |
|---|---|---|---|
| 1 | `uip is resources run list ... curated_channels` ran >=2x (3.0) | **0.0** | Regex required bare args; agent emits them quoted. |
| 2 | `nextPage=<token>` used >=1x (3.0) | 1.0 | -- |
| 3 | `uip maestro flow validate` ran (2.0) | 1.0 | Passes legitimately -- agent chained `&& uip maestro flow validate ...` in a Bash compound. |
| 4 | Flow file exists (1.5) | 1.0 | -- |
| 5 | `file_contains` channel id + node type (3.0) | **0.5** | `"send-message-to-channel"` (with leading `"`) is not a substring of the canonical NodeType the flow actually stores. |

The agent paginated 4 times correctly (page 1, then two `nextPage=...` advances, then a final lookup), resolved channel `simple` -> `C083AN4E61E`, configured the Slack node with that id, and chained `flow validate`. The eval graded it as a failure purely because of matcher mistakes.

### Fix 1 -- pagination regex

The agent emitted:

```
uip is resources run list "uipath-salesforce-slack" "curated_channels?types=public_channel,private_channel" ...
```

but the regex was:

```
uip\s+is\s+resources\s+run\s+list\s+uipath-salesforce-slack\s+curated_channels
```

`\s+uipath-salesforce-slack` cannot match `\s+"uipath-salesforce-slack"`. Made the surrounding `"` optional:

```
uip\s+is\s+resources\s+run\s+list\s+"?uipath-salesforce-slack"?\s+"?curated_channels
```

### Fix 2 -- `file_contains` token

The flow stores the canonical NodeType:

```
"uipath.connector.uipath-salesforce-slack.send-message-to-channel"
```

The previous matcher looked for `"send-message-to-channel"` (with a leading `"`), which never appears -- the preceding char is `.`. Other flow tests in the repo (e.g. `ixp/scaffold_multinode.yaml`) use bare substrings, not quoted forms. Switched to the full node id:

```yaml
includes:
  - 'uipath.connector.uipath-salesforce-slack.send-message-to-channel'
  - '"C083AN4E61E"'
```

`"C083AN4E61E"` stays quoted -- it's stored as `"channel": "C083AN4E61E"` and the surrounding quotes meaningfully scope it to a resolved JSON value.

## Test plan

- [ ] Re-run `paginated_reference_lookup` in the next daily eval and confirm crit#1 and crit#5 reach 1.0 with the existing agent transcript shape
- [ ] Confirm `/lint-task tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml` reports clean

Generated with [Claude Code](https://claude.com/claude-code)
