### PR TITLE
test(uipath-troubleshoot): clean recorder artifacts out of three scenario mock fixtures

### DIFF
--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/fixtures/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/fixtures/mocks/responses/manifest.json
@@ -31,11 +31,6 @@
       "file": "or-processes-list-folder-key-1965a46b-db4e-469e-aaaa-7e0b379.json"
     },
     {
-      "match": "or libraries list --output json",
-      "file": "or-libraries-list-output-json.json",
-      "exit_code": 1
-    },
-    {
       "match": "docsai ask",
       "passthrough": true,
       "_doc": "Per CLAUDE.md: docsai queries always passthrough — query strings vary between runs and canned responses go stale. Cached per-query within a run."

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/fixtures/mocks/responses/or-libraries-list-output-json.json
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/fixtures/mocks/responses/or-libraries-list-output-json.json
@@ -1,1 +1,0 @@
-claude-opus-4-7[1m] is temporarily unavailable, so auto mode cannot determine the safety of Bash right now. Wait briefly and then try this action again. If it keeps failing, continue with other tasks that don't require this action and come back to it later. Note: reading files, searching code, and other read-only operations do not require the classifier and can still be used.

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
@@ -40,21 +40,17 @@ success_criteria:
     weight: 1.0
 
   - type: llm_judge
-    description: "Agent reached the same root cause as RESOLUTION.md and recorded it in investigation state"
+    description: "Agent reached the same root cause as RESOLUTION.md"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
     include_tool_calls: true
-    files:
-      - .local/investigations/state.json
-      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
-      reference outcome (the attached RESOLUTION.md). The conclusion in the
-      agent's final response is what you grade (Dimensions A and B); the
-      attached investigation state files contribute only the bounded
-      deductions in Dimension C.
+      reference outcome (the attached RESOLUTION.md). Grade ONLY the agent's
+      final response to the user — NOT which playbook it routed through and
+      NOT what it wrote into internal investigation state files.
 
       DIMENSION A -- Required findings
         The agent's final response must cover ALL of the following. Each
@@ -80,16 +76,7 @@ success_criteria:
           - Asserts a root cause without citing the Main.xaml content
             or the job log.
 
-      DIMENSION C -- Investigation state (bounded deductions)
-        Check the attached state files; deduct exactly 0.1 per miss
-        (max total deduction 0.2):
-          1. `state.json.matched_playbooks` contains a path ending in
-             `runtime-exceptions/playbooks/argument-null-exception.md`.
-             Neighboring-playbook reads during exploration are fine.
-          2. `hypotheses.json` has an entry with `is_root_cause: true`
-             corresponding to the Assign-null finding.
-
-      SCORING RUBRIC (base score from Dimensions A and B):
+      SCORING RUBRIC (single score):
         1.0  Correct root cause, all required findings, no fabrication.
         0.8  Correct root cause + all required findings, minor
              fabrication or one finding only implicit.
@@ -99,11 +86,10 @@ success_criteria:
         0.2  Recognized the surface (exception/activity) but wrong or
              missing root cause.
         0.0  Misdiagnosed or got blocked.
-      Final score = base score minus Dimension C deductions (floor 0.0).
 
       Return JSON:
         {"score": <float>, "rationale": "<one sentence>",
-         "findings": ["dim A item 1: ...", "dim B: ...", "dim C: ..."]}
+         "findings": ["dim A item 1: ...", "dim B: ...", ...]}
 
 # Auto-answer the troubleshooting skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
@@ -40,7 +40,7 @@ success_criteria:
     weight: 1.0
 
   - type: llm_judge
-    description: "Agent reached the same root cause as RESOLUTION.md"
+    description: "Agent matched the correct playbook AND reached the same conclusion as RESOLUTION.md"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
@@ -40,41 +40,34 @@ success_criteria:
     weight: 1.0
 
   - type: llm_judge
-    description: "Agent matched the correct playbook AND reached the same conclusion as RESOLUTION.md"
+    description: "Agent reached the same root cause as RESOLUTION.md"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
     include_tool_calls: true
-    files:
-      - .local/investigations/state.json
-      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
-      reference outcome (the attached RESOLUTION.md).
+      reference outcome (the attached RESOLUTION.md). Grade ONLY the agent's
+      final response to the user — NOT which playbook it routed through and
+      NOT what it wrote into internal investigation state files.
 
-      DIMENSION A -- Correct playbook (argument-null-exception)
-        `state.json.matched_playbooks` must contain a path ending in
-        `runtime-exceptions/playbooks/argument-null-exception.md`.
-        Neighboring-playbook reads during exploration are fine.
-
-      DIMENSION B -- Required findings
-        The agent's last response and `hypotheses.json` together must
-        cover ALL of the following. Each missing item is a half-point off
-        within this dimension.
+      DIMENSION A -- Required findings
+        The agent's final response must cover ALL of the following. Each
+        missing item is a half-point off within this dimension.
           1. Exception `System.ArgumentNullException`, parameter `'path'`,
              raised at the `Copy File` activity in `Main.xaml`.
           2. Job key `0686cab1-35c6-4d92-aed2-c91d9c275524`, release
              `ERN`, folder `Shared`.
           3. Root cause = the explicit `Assign myVar = null` upstream of
              `Copy File` (NOT a missing In argument, NOT a config/asset
-             lookup, NOT a runtime/platform fault).
-          4. H3 (caller-supplied In argument) explicitly eliminated with
-             evidence (`InputArguments={}` and release has no input args).
-          5. `hypotheses.json` has an entry with `is_root_cause: true`
-             corresponding to the Assign-null finding.
+             lookup, NOT a runtime/platform fault), citing the Main.xaml
+             content or the job log as evidence.
+          4. The caller-supplied-In-argument alternative is ruled out
+             (e.g. `InputArguments={}` / the release defines no input
+             arguments).
 
-      DIMENSION C -- Anti-fabrication
+      DIMENSION B -- Anti-fabrication
         Penalize any of these:
           - Claims an Orchestrator auto-retry policy for faulted jobs
             (none exists).
@@ -84,18 +77,19 @@ success_criteria:
             or the job log.
 
       SCORING RUBRIC (single score):
-        1.0  All three dimensions clean.
-        0.8  Right playbook + all required findings, minor fabrication.
-        0.6  Right playbook; 1 required finding missing OR moderate
+        1.0  Correct root cause, all required findings, no fabrication.
+        0.8  Correct root cause + all required findings, minor
+             fabrication or one finding only implicit.
+        0.6  Correct root cause; 1 required finding missing OR moderate
              fabrication.
-        0.4  Right playbook only; findings substantially incomplete.
-        0.2  Recognized the surface but neither matched the playbook nor
-             produced the required findings.
+        0.4  Correct root cause but findings substantially incomplete.
+        0.2  Recognized the surface (exception/activity) but wrong or
+             missing root cause.
         0.0  Misdiagnosed or got blocked.
 
       Return JSON:
         {"score": <float>, "rationale": "<one sentence>",
-         "findings": ["dim A: ...", "dim B item 1: ...", ...]}
+         "findings": ["dim A item 1: ...", "dim B: ...", ...]}
 
 # Auto-answer the troubleshooting skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /

--- a/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/argument-null-exception/task.yaml
@@ -40,17 +40,21 @@ success_criteria:
     weight: 1.0
 
   - type: llm_judge
-    description: "Agent reached the same root cause as RESOLUTION.md"
+    description: "Agent reached the same root cause as RESOLUTION.md and recorded it in investigation state"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
     include_tool_calls: true
+    files:
+      - .local/investigations/state.json
+      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
-      reference outcome (the attached RESOLUTION.md). Grade ONLY the agent's
-      final response to the user — NOT which playbook it routed through and
-      NOT what it wrote into internal investigation state files.
+      reference outcome (the attached RESOLUTION.md). The conclusion in the
+      agent's final response is what you grade (Dimensions A and B); the
+      attached investigation state files contribute only the bounded
+      deductions in Dimension C.
 
       DIMENSION A -- Required findings
         The agent's final response must cover ALL of the following. Each
@@ -76,7 +80,16 @@ success_criteria:
           - Asserts a root cause without citing the Main.xaml content
             or the job log.
 
-      SCORING RUBRIC (single score):
+      DIMENSION C -- Investigation state (bounded deductions)
+        Check the attached state files; deduct exactly 0.1 per miss
+        (max total deduction 0.2):
+          1. `state.json.matched_playbooks` contains a path ending in
+             `runtime-exceptions/playbooks/argument-null-exception.md`.
+             Neighboring-playbook reads during exploration are fine.
+          2. `hypotheses.json` has an entry with `is_root_cause: true`
+             corresponding to the Assign-null finding.
+
+      SCORING RUBRIC (base score from Dimensions A and B):
         1.0  Correct root cause, all required findings, no fabrication.
         0.8  Correct root cause + all required findings, minor
              fabrication or one finding only implicit.
@@ -86,10 +99,11 @@ success_criteria:
         0.2  Recognized the surface (exception/activity) but wrong or
              missing root cause.
         0.0  Misdiagnosed or got blocked.
+      Final score = base score minus Dimension C deductions (floor 0.0).
 
       Return JSON:
         {"score": <float>, "rationale": "<one sentence>",
-         "findings": ["dim A item 1: ...", "dim B: ...", ...]}
+         "findings": ["dim A item 1: ...", "dim B: ...", "dim C: ..."]}
 
 # Auto-answer the troubleshooting skill's AskUserQuestion calls so the test runs
 # end-to-end without a human. The simulator always picks the recommended /

--- a/tests/tasks/uipath-troubleshoot/queue-items-failing-test/fixtures/mocks/responses/or-queues-list-folder-key-1965a46b-db4e-469e-aaaa-7e0b.json
+++ b/tests/tasks/uipath-troubleshoot/queue-items-failing-test/fixtures/mocks/responses/or-queues-list-folder-key-1965a46b-db4e-469e-aaaa-7e0b.json
@@ -1,5 +1,3 @@
-Tool factory already registered for project type 'Flow', skipping.
-[ERROR] Failed to load tool traces-tool (version: 0.9.0, path: ): Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@uipath/common' imported from 
 {
   "Result": "Failure",
   "Message": "Error listing queues",

--- a/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/fixtures/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/fixtures/mocks/responses/manifest.json
@@ -35,10 +35,6 @@
       "file": "or-jobs-logs-3ecaa4ef-a1ab-4376-ae06-d3b942362e6f-level-erro.json"
     },
     {
-      "match": "or assets list --folder-key 7f984a6b-1138-40fb-b48e-2c3ddf02b8f0 --output json",
-      "file": "or-assets-list-folder-key-7f984a6b-1138-40fb-b48e-2c3ddf02b8.json"
-    },
-    {
       "match": "or --help",
       "file": "or-help.json"
     },

--- a/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/fixtures/mocks/responses/or-assets-list-folder-key-7f984a6b-1138-40fb-b48e-2c3ddf02b8.json
+++ b/tests/tasks/uipath-troubleshoot/rpa-preflight-failure/fixtures/mocks/responses/or-assets-list-folder-key-7f984a6b-1138-40fb-b48e-2c3ddf02b8.json
@@ -1,5 +1,0 @@
-{
-  "Result": "ValidationError",
-  "Message": "error: unknown command 'assets'\n(Did you mean users?)",
-  "Instructions": "Check command arguments and options. Use --help for usage information."
-}


### PR DESCRIPTION
Three troubleshoot scenario fixtures froze recorder-environment garbage into the faithful replay as if it were tenant behavior. All three became reachable again after #1196 migrated mock matches from the retired `resource` verbs to `or`. One commit per scenario:

1. **argument-null-exception** - the `or libraries list` rule served a captured agent-harness outage message ("claude-opus-4-7[1m] is temporarily unavailable... wait briefly and try again", exit 1) as CLI stdout; the recorded session never received real CLI output for this call. Rule dropped; falls through to the permissive `unmocked_default` (`[]`). Local run after fix: status=SUCCESS, score 0.925 (skill_triggered 1.0, llm_judge 0.90).

2. **queue-items-failing-test** - the `--name` fixture had two lines of recorder-machine plugin noise ("Tool factory already registered...", traces-tool ERR_MODULE_NOT_FOUND) prepended to the genuine HTTP-400 payload, making stdout unparseable as JSON and inviting fabricated "CLI installation problem" findings. Noise stripped; recorded payload kept verbatim.

3. **rpa-preflight-failure** - the `or assets list` rule replayed "unknown command 'assets'" recorded during the or/resource rename churn. The command is valid on every current CLI, so the mock contradicted the skill and baited retry loops. Rule dropped; falls through to `unmocked_default`.

Manifest verifier after all three: 71/71 shapes valid, exit 0. Run Coder Eval dispatched on this branch for all three scenarios (argument-null-exception: run 27271738839; queue-items + rpa-preflight: run 27272117761).
