### PR TITLE
docs(uipath-maestro-flow): close ENGCE-57901 gaps #3 and #4 in connector/impl.md

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -146,6 +146,8 @@ The full metadata contains:
 
 **Run whenever the activity has a parent-field-driven schema** — an api-type ObjectAction in `objectActions[]` or `connectorMethodInfo.design.actions[]` (see Step 6c's support table). Applies to **every** operation with such an action — Create/Edit/Update for parent-driven required body fields AND Get/Retrieve/Query for the response-schema fields downstream nodes will reference. The base `describe` returns only static metadata; this step runs the matching ObjectAction against the live connection so the cache you author in Step 6c is a replay of a real call, not a fabrication.
 
+> **Ping is not a gate for Step 3a.** If `uip is connections ping <id>` returns 424 or 5xx but `uip maestro flow registry get` returns a connector with `actionType: "api"` / `ActionType: "Api"`, STILL attempt Step 3a. The design-action endpoint is independent of the ping endpoint and frequently succeeds when ping does not. Abort Step 3a only if the `is resources describe -f ...` call itself returns 4xx/5xx — and in that case surface the user-actionable message from § Debug → Common Errors (`Connection ping failed` row). Do NOT fabricate `customFieldsRequestDetails` from prompt context as a fallback — that is the silent-corruption mode tracked in ENGCE-57901.
+
 Pass parent values via `-f, --field` — see [/uipath:uipath-platform — resources.md > Parent-Field-Driven Custom Fields (api-type ObjectActions)](../../../../../../uipath-platform/references/integration-service/resources.md#parent-field-driven-custom-fields-api-type-objectactions) for the full procedure, flag table, merge semantics, and error recovery.
 
 > **Skipping is not free even when the runtime call works.** For Get/Retrieve the upstream API returns data regardless — runtime stays green. The fetch is what makes Step 6c's `customFieldsRequestDetails` honest: without it, Studio Web has no schema to render the activity's custom fields, and any downstream `$vars.<thisNode>.output.<custom-field>` resolves to undefined. `flow validate` does not catch this — it surfaces as silent design-time corruption (MST-9107-class).
@@ -471,6 +473,22 @@ JSON
 
 The CLI embeds the payload verbatim in `essentialConfiguration.customFieldsRequestDetails` inside the `=jsonString:` blob. Top-level `inputs.detail.customFieldsRequestDetails` is NOT set — the field lives only inside `essentialConfiguration`.
 
+#### Step 6c attestation — confirm the cache came from a live describe
+
+**Before reporting the task done, inspect the configured node's `essentialConfiguration.customFieldsRequestDetails`.** If present (non-null, non-empty `parameterValues`), your final message MUST contain one of these lines verbatim:
+
+- `STEP_3A_CONFIRMED: ran uip is resources describe <connector> <method> --connection-id <id> --operation <op> -f <parent>=<value> ... (step <N>)`
+- `STEP_3A_SKIPPED: <reason — e.g. no api-type ObjectAction for this activity, connection unreachable on describe, no-live-tenant mode>`
+
+`<N>` is the concrete tool-call sequence number of the describe invocation in this conversation's transcript. A vague claim ("I ran it earlier") is not an attestation — the step number is the forcing function.
+
+If `customFieldsRequestDetails` is present but you cannot produce a real `STEP_3A_CONFIRMED` with a concrete step number, the cache is fabricated. Either:
+
+1. Remove `customFieldsRequestDetails` from `--detail` and re-run `node configure` (acceptable in no-live-tenant mode — emit `STEP_3A_SKIPPED` with that reason), OR
+2. Run Step 3a now, author the cache from the live response, re-run `node configure`, then attest.
+
+`flow validate` does NOT catch this — fabricated caches surface only on re-open in Studio Web or at debug time (MST-9107-class). See ENGCE-57901.
+
 ---
 
 ## IS CLI Commands
@@ -665,7 +683,7 @@ For connector-trigger flows, the same pattern applies — top-level `bindings[]`
 | Error | Cause | Fix |
 | --- | --- | --- |
 | No connection found | Connection not bound — top-level `bindings[]` missing or `resourceKey` doesn't match the node | Run Step 1 above to bind a connection; verify both entries (`ConnectionId` + `FolderKey`) are in the top-level `bindings[]` |
-| Connection ping failed | Connection expired or misconfigured | Re-authenticate the connection in the IS portal |
+| Connection ping failed (424 / 5xx on `uip is connections ping`) | Connection expired or misconfigured — OR ping endpoint is unhealthy while design-action endpoint still works | Re-authenticate the connection in the IS portal. **Before falling back: still attempt Step 3a's `uip is resources describe ... -f <parent>=<value>` against the same connection.** Ping and design-action hit different endpoints. If `describe` also returns 4xx/5xx, surface to the user verbatim: `"Connection '<name>' cannot reach the <connector> design endpoint. Fix it in the UiPath UI: Integration Service → Connections → <connector> → reconnect or re-authorize, then retry."` Do NOT fabricate `customFieldsRequestDetails` from prompt context — see Step 3a and Step 6c attestation. |
 | Missing `inputs.detail` | Node added but not configured | Run `uip maestro flow node configure` with the detail JSON (Step 6) |
 | Reference field has display name instead of ID | `uip is resources run list` was skipped | Resolve the reference field to get the actual ID (Step 4) |
 | Node faults at runtime with "resource not found" or similar after a clean build and validate | Reference field uses an ID scoped to a **different** connection (common when copying from a prior flow in the same session — e.g., a Slack channel ID from workspace A pasted into a node bound to workspace B's connection) | Re-run `uip is resources run list "<connector-key>" "<objectName>" --connection-id <CURRENT_CONNECTION_ID>`, extract the fresh ID, update `bodyParameters` / `queryParameters` in `--detail`, re-run `node configure`, re-debug. See Step 4 and the top-level Anti-Pattern on reference-ID reuse in [SKILL.md](../../../../../SKILL.md). |


### PR DESCRIPTION
## Summary

Closes the two gaps left open after the prior ENGCE-57901 work in `uipath-maestro-flow` `connector/impl.md`:

- **#3 — Step 6c attestation.** Mandatory `STEP_3A_CONFIRMED: ...` / `STEP_3A_SKIPPED: ...` line (with a concrete tool-call step number) whenever `customFieldsRequestDetails` is populated. Forces the agent to either prove the cache came from a live `uip is resources describe -f <parent>=<value>` call, or explicitly mark it skipped with a reason. `flow validate` cannot catch fabricated caches; this attestation makes the gap visible in the agent transcript and pickable by eval criteria.
- **#4 — Ping-fail red herring.** New blockquote at the top of Step 3a making explicit that `connections ping` 424/5xx is **not** a gate — agent must still attempt the describe because the design-action endpoint is independent of ping. The `Connection ping failed` row in the error table now carries the user-actionable UI-config message and the explicit "do NOT fabricate `customFieldsRequestDetails`" rule.

## Why this matters

Per the eval comparison in ENGCE-57901, the **`skill-flow-ipe-generate-schema` task** is the cleanest signal that the prior skill changes work — same tenant connection on May 14 (FAIL 0.800) and June 10 (SUCCESS 1.000), criteria unchanged, behavior flipped purely from the skill steering. But the **`skill-flow-ipe-path-params` task** turning green is confounded — May had zero Jira connections, June has one. The two gaps closed here are exactly the ones that would prevent regression in adverse conditions (no-connection tenants, ping-but-not-describe failures): they force Step 3a adherence regardless of environment.

## Changes

| File | Change |
|---|---|
| `skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md` | + Step 3a "Ping is not a gate" blockquote (~line 148) |
|  | + `#### Step 6c attestation` subsection at end of Step 6c (~line 474) |
|  | Δ `Connection ping failed` row in `## Debug → Common Errors` table — replaces bare "re-authenticate" with: still attempt Step 3a, surface UI-config message on describe failure, no fabrication fallback (~line 686) |

Diff: 1 file changed, 19 insertions(+), 1 deletion(-)

## What's NOT in this PR

- **#1 (inline `-f` example in Step 3a).** The cross-skill link to `uipath-platform/.../resources.md` is preserved. Inlining the full procedure is a separate change with a larger blast radius (Step 3a would need its own example block; both sides risk drift). Tracking as a follow-up.
- **Eval criterion** to grep agent_output for `STEP_3A_CONFIRMED:` whenever `customFieldsRequestDetails` is populated. Belongs in `tests/tasks/uipath-maestro-flow/connector_features/` — separate PR after this one lands so we can confirm the attestation copy on a re-run first.

## Test plan

- [ ] CI: `validate-skills.yml`, `verb-gate.yml`, `lint-tasks.yml`, `activation-gate.yml` pass
- [ ] Re-run `skill-flow-ipe-generate-schema` and `skill-flow-ipe-path-params` against this branch — confirm the agent emits `STEP_3A_CONFIRMED:` with a real step number when the cache is populated
- [ ] Re-run `skill-flow-ipe-path-params` on a tenant with **zero** Jira connections — confirm agent emits `STEP_3A_SKIPPED: no-live-tenant mode` or runs Step 3a successfully, rather than falling back to a stringified `inputs.detail`
- [ ] Eyeball Step 3a's flow on re-render: heading → "what it is" → ping caveat → "how to call with `-f`" → skip-cost warning → ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)
