### PR TITLE
fix(uipath-review): pass project dir positionally to `uip agent/codedagent review`

### DIFF
--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -242,8 +242,8 @@ Run the review command for the agent type, once, capturing JSON:
 
 | Agent type | Command |
 |---|---|
-| Low-code (`agent.json`) | `uip agent review --project-dir "<PROJECT_DIR>" --output json` |
-| Coded (`main.py` + framework config) | `uip codedagent review --project-dir "<PROJECT_DIR>" --output json` |
+| Low-code (`agent.json`) | `uip agent review "<PROJECT_DIR>" --output json` |
+| Coded (`main.py` + framework config) | `uip codedagent review "<PROJECT_DIR>" --output json` |
 | Agent-builder coded layout (`agent.json` + `main.py`) | run **both** commands |
 
 The CLI runs every deterministic static check — structural/schema, placeholder cross-refs, eval counts/diversity, secret & import regex, framework symbol existence, eval-run analysis, packaging/git hygiene — and returns them in rule format. Parse `Data.Issues[]`; each issue is `{RuleId, Category, Severity, Description, File, SuggestedFix}`. Carry each into the report **verbatim** — do not re-derive, rename, or re-rank. These rule IDs are authoritative as emitted by the CLI; they are **not** listed in the skill catalog.

--- a/skills/uipath-review/references/agents/agents-coded-rules.md
+++ b/skills/uipath-review/references/agents/agents-coded-rules.md
@@ -2,7 +2,7 @@
 
 Judgment rules for **coded** agents (Python — `main.py` + framework config). Each rule requires the agent to read source and reason — what a regex/AST-emulation/file-walk cannot decide reliably. Same row schema as elsewhere — see [`../rule-format.md`](../rule-format.md).
 
-> **This catalog is judgment-only.** Run `uip codedagent review --project-dir "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5) — it returns the deterministic coded findings (pyproject/dependency/python-version gates, import & secret regex, framework symbol existence, bare-except, eval-run analysis, `.venv` packaging, git-tracked secrets) in the same rule format. Then apply the rules below, which the CLI cannot do.
+> **This catalog is judgment-only.** Run `uip codedagent review "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5) — it returns the deterministic coded findings (pyproject/dependency/python-version gates, import & secret regex, framework symbol existence, bare-except, eval-run analysis, `.venv` packaging, git-tracked secrets) in the same rule format. Then apply the rules below, which the CLI cannot do.
 
 Read [`../rule-format.md`](../rule-format.md) and [`../rule-catalog-workflow.md`](../rule-catalog-workflow.md) first.
 

--- a/skills/uipath-review/references/agents/agents-lowcode-rules.md
+++ b/skills/uipath-review/references/agents/agents-lowcode-rules.md
@@ -2,7 +2,7 @@
 
 Judgment rules for **low-code** agents (`agent.json`). Each rule requires the agent to read source and reason — what a regex/count/schema-walk cannot decide reliably. Same row schema as elsewhere — see [`../rule-format.md`](../rule-format.md).
 
-> **This catalog is judgment-only.** Run `uip agent review --project-dir "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5) — it returns the deterministic low-code findings (structural gates, schema-property presence, placeholder cross-refs, eval counts/diversity, version/runtime/location checks) in the same rule format. Then apply the rules below, which the CLI cannot do.
+> **This catalog is judgment-only.** Run `uip agent review "<PROJECT_DIR>" --output json` **first** (SKILL.md Step 2.5) — it returns the deterministic low-code findings (structural gates, schema-property presence, placeholder cross-refs, eval counts/diversity, version/runtime/location checks) in the same rule format. Then apply the rules below, which the CLI cannot do.
 
 Read [`../rule-format.md`](../rule-format.md) and [`../rule-catalog-workflow.md`](../rule-catalog-workflow.md) first.
 

--- a/skills/uipath-review/references/rule-catalog-workflow.md
+++ b/skills/uipath-review/references/rule-catalog-workflow.md
@@ -13,8 +13,8 @@ Run the review command for the agent type, once, capturing JSON:
 
 | Agent type | Command |
 |---|---|
-| Low-code (`agent.json`) | `uip agent review --project-dir "<PROJECT_DIR>" --output json` |
-| Coded (`main.py` + framework config) | `uip codedagent review --project-dir "<PROJECT_DIR>" --output json` |
+| Low-code (`agent.json`) | `uip agent review "<PROJECT_DIR>" --output json` |
+| Coded (`main.py` + framework config) | `uip codedagent review "<PROJECT_DIR>" --output json` |
 
 Parse the JSON. Findings live under `Data.Issues[]`; each issue is:
 

--- a/skills/uipath-review/references/rule-format.md
+++ b/skills/uipath-review/references/rule-format.md
@@ -58,8 +58,8 @@ Allowed `status` values:
 The agent runs the review command once per agent, capturing JSON:
 
 ```bash
-uip agent review --project-dir "<PROJECT_DIR>" --output json        # low-code
-uip codedagent review --project-dir "<PROJECT_DIR>" --output json   # coded
+uip agent review "<PROJECT_DIR>" --output json        # low-code
+uip codedagent review "<PROJECT_DIR>" --output json   # coded
 ```
 
 It returns `Data.Issues[]` — deterministic findings keyed by `RuleId`, in the same severity/category/description/file/fix shape as a catalog row. The agent carries these into the report verbatim. The catalog does not list these `RuleId`s; the CLI's registry is their source of truth.


### PR DESCRIPTION
## What

The `uip agent review` / `uip codedagent review` CLI takes the project directory as a **positional** argument, not via `--project-dir`. This corrects every documented invocation in the `uipath-review` skill so agents copy the right command.

## Changes

All occurrences now read `uip [agent|codedagent] review "<PROJECT_DIR>" --output json`:

- `SKILL.md` — Step 2.5a command table
- `references/rule-format.md` — review-CLI code block
- `references/rule-catalog-workflow.md` — Step 2.5a command table
- `references/agents/agents-lowcode-rules.md` — judgment-only callout
- `references/agents/agents-coded-rules.md` — judgment-only callout

`grep -rn "review --project-dir" skills/uipath-review/` now returns nothing.

## Notes

Docs-only; no behavior or test changes. The review test tasks match `uip\s+(agent|codedagent)\s+review` (flag-agnostic), so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)