### PR TITLE
fix(tests/uipath-solution): bump seed pre-run timeout; move solution ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,8 +64,8 @@
 /tests/tasks/uipath-planner/ @RaduAna-Maria
 
 # Solution skill (uip solution lifecycle)
-/skills/uipath-solution/ @RaduAna-Maria @UiPath/team-merlot @UiPath/team-orange
-/tests/tasks/uipath-solution/ @RaduAna-Maria @UiPath/team-merlot @UiPath/team-orange
+/skills/uipath-solution/ @UiPath/team-merlot @UiPath/team-orange
+/tests/tasks/uipath-solution/ @UiPath/team-merlot @UiPath/team-orange
 
 # Design skill (PDD → SDD authoring)
 /skills/uipath-design/ @RaduAna-Maria @UiPath/team-merlot @UiPath/team-orange

--- a/tests/tasks/uipath-solution/config_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-solution/config_lifecycle_e2e.yaml
@@ -10,7 +10,7 @@ agent:
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"
-    timeout: 10
+    timeout: 30
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/cleanup.py"

--- a/tests/tasks/uipath-solution/deploy_round_trip_e2e.yaml
+++ b/tests/tasks/uipath-solution/deploy_round_trip_e2e.yaml
@@ -10,7 +10,7 @@ agent:
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py"
-    timeout: 10
+    timeout: 30
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/cleanup.py"


### PR DESCRIPTION
## Summary

Two `uipath-solution` e2e tasks were failing at the pre-run stage (status=ERROR, `iterations=0` — the agent never started):

- `skill-solution-config-e2e`
- `skill-solution-deploy-e2e`

Both source the **platform-owned** seed at `tests/tasks/uipath-platform/seed.py`. Its `ensure_parent_folder()` makes live Orchestrator calls (`uip or folders get` / `create`), each allowed 60s internally. But both tasks capped the *whole* pre-run at `timeout: 10` — shorter than a single auth + network round trip — so the seed was killed mid-call:

```
RuntimeError: Pre-run command timed out after 10s:
  'python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/seed.py'
```

## Changes

- Bump the seed pre-run `timeout` from `10` → `30` in both task YAMLs, matching the other e2e tasks that use this same seed.
- Drop `@RaduAna-Maria` from the `uipath-solution` skill/test `CODEOWNERS` entries, leaving `@UiPath/team-merlot` and `@UiPath/team-orange` as owners.

## Notes

- Both tasks correctly stay on `uipath-solution` — they exercise the `uip solution` config/deploy lifecycle, not PDD/SDD authoring (`uipath-design`).
- The failure was a pre-run harness misconfig, unrelated to the solution/design skill split.
- Out of scope but worth a follow-up: the same too-tight `timeout: 10` on this shared seed also appears in several `uipath-platform` tasks (`orchestrator/audit_logs_e2e`, `orchestrator/role_lifecycle_e2e`, `orchestrator/folders_hierarchy_e2e`, `resources/webhook_e2e`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
