### PR TITLE
fix(uipath-agents): default coded smoke eval to output-based, not trajectory

### DIFF
--- a/skills/uipath-agents/references/coded/frameworks/langgraph-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/langgraph-integration.md
@@ -143,7 +143,7 @@ llm = UiPathAzureChatOpenAI(
 )
 ```
 
-**Model names:** Pass the model identifier as a string. Use `sdk.agenthub.get_available_llm_models()` to list the models available in your tenant.
+**Model names:** Pass the model identifier as a string. Run `uip codedagent list-models` to list the models available in your tenant.
 
 **Features:**
 - No API key needed — uses UiPath authentication
@@ -214,7 +214,7 @@ result: Analysis = Analysis.model_validate(raw_dict)
 | Multi-vendor flexibility (OpenAI, Anthropic, Google) | `UiPathChat` |
 | Specialized domains (e.g., code) | `UiPathChat` with a Claude model |
 
-Call `sdk.agenthub.get_available_llm_models()` to see the model strings available in your tenant and pass the exact `model_name` to the class constructor.
+Run `uip codedagent list-models` to see the model strings available in your tenant and pass the exact `model_name` to the class constructor.
 
 ---
 

--- a/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
@@ -106,7 +106,7 @@ from uipath_llamaindex.llms import UiPathOpenAI, OpenAIModel
 llm = UiPathOpenAI(model=OpenAIModel.GPT_4O_2024_11_20)
 ```
 
-The enum is `OpenAIModel` (singular). `GeminiModel` and `BedrockModel` are also available from `uipath_llamaindex.llms` for non-OpenAI vendors. Use `sdk.agenthub.get_available_llm_models()` to list the models available in your tenant.
+The enum is `OpenAIModel` (singular). `GeminiModel` and `BedrockModel` are also available from `uipath_llamaindex.llms` for non-OpenAI vendors. Run `uip codedagent list-models` to list the models available in your tenant.
 
 ---
 

--- a/skills/uipath-agents/references/coded/lifecycle/evaluate.md
+++ b/skills/uipath-agents/references/coded/lifecycle/evaluate.md
@@ -40,23 +40,25 @@ evaluations/
 ├── eval-sets/
 │   └── smoke-test.json              # Test cases
 └── evaluators/
-    └── llm-judge-trajectory.json    # Evaluator config
+    └── llm-judge-output.json        # Evaluator config
 ```
 
 Every evaluator referenced in an eval set's `evaluatorRefs` must have a matching config file in `evaluations/evaluators/` — the `id` in the config must match the `evaluatorRefs` value exactly. Evaluators are auto-discovered from this directory.
 
-Example `evaluations/evaluators/llm-judge-trajectory.json`:
+Pick by output type: deterministic/structured → `uipath-exact-match` / `uipath-contains` / `uipath-json-similarity`; natural language → `uipath-llm-judge-output-semantic-similarity` (shown below). Use trajectory/tool-call evaluators only for multi-step / tool-using agents — they score 0.0 on single-step agents. Full guide: [evaluators.md](evaluations/evaluators.md), [best-practices.md](evaluations/best-practices.md).
+
+Example `evaluations/evaluators/llm-judge-output.json`:
 
 ```json
 {
   "version": "1.0",
-  "id": "LLMJudgeTrajectoryEvaluator",
-  "evaluatorTypeId": "uipath-llm-judge-trajectory-similarity",
+  "id": "LLMJudgeOutputEvaluator",
+  "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
   "evaluatorConfig": {
-    "name": "LLMJudgeTrajectoryEvaluator",
+    "name": "LLMJudgeOutputEvaluator",
     "model": "gpt-4o-mini-2024-07-18",
     "defaultEvaluationCriteria": {
-      "expectedAgentBehavior": "Agent should process the input and return a response."
+      "expectedOutput": {"<output_field>": "A correct, on-topic response for the given input."}
     }
   }
 }

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -118,40 +118,43 @@ Then STOP and wait. On reply, run the matching one-shot login from [../authentic
    Skip init only when the edit is purely inside node bodies / helpers (logic, prompts, business rules) and leaves every schema and the entry signature byte-identical. Then test locally with `uip codedagent run <ENTRYPOINT> '<input>'` (use the entrypoint name from `entry-points.json`, e.g., `main`).
 7. **Evaluate** — Run `uip codedagent eval <ENTRYPOINT> evaluations/eval-sets/smoke-test.json --no-report`. Idempotent by `has_evaluators` / `has_smoke_set`: create the missing one(s) only — **never overwrite an existing evaluator config or smoke set**, the user may have tuned them.
 
-   **Note:** `uipath-llm-judge-trajectory-similarity` requires emitted trace spans to populate `AgentRunHistory`. Plain `StateGraph` agents without explicit OpenTelemetry tracing produce empty history → all cases score 0.0 even on successful runs. If the smoke set scores 0.0, verify the agent actually executed (via local `uip codedagent run`) before treating it as a logic failure; consider an output-only evaluator for non-conversational graphs.
+   **Default the smoke evaluator to an output-based type, never a trajectory or tool-call evaluator** (those score 0.0 on single-step agents — use them only for multi-step / tool-using agents). Pick:
 
-   **If `has_evaluators == false`**, create `evaluations/evaluators/llm-judge-trajectory.json`. If the default `model` below is not available in the user's tenant, call `sdk.agenthub.get_available_llm_models()` and substitute a `model_name` from the returned list.
+   - **Deterministic or structured output** (a fixed string, number, or JSON shape) → `uipath-exact-match`, `uipath-contains`, or `uipath-json-similarity`. No LLM, no tenant model needed, binary/continuous scoring. Prefer this whenever the task allows it.
+   - **Natural-language output** (summaries, reports, free text) → `uipath-llm-judge-output-semantic-similarity` (`LLMJudgeOutputEvaluator`). Scores output semantics, works without tracing.
+
+   **If `has_evaluators == false`**, create `evaluations/evaluators/llm-judge-output.json` (default for NL output; swap to a deterministic type above when the output is fixed/structured). For any `uipath-llm-judge-*` type, if the default `model` below is not available in the user's tenant, run `uip codedagent list-models` and substitute an available model name.
 
    ```json
    {
      "version": "1.0",
-     "id": "LLMJudgeTrajectoryEvaluator",
-     "evaluatorTypeId": "uipath-llm-judge-trajectory-similarity",
+     "id": "LLMJudgeOutputEvaluator",
+     "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
      "evaluatorConfig": {
-       "name": "LLMJudgeTrajectoryEvaluator",
+       "name": "LLMJudgeOutputEvaluator",
        "model": "gpt-4o-mini-2024-07-18",
        "defaultEvaluationCriteria": {
-         "expectedAgentBehavior": "Agent should process the input and return a response."
+         "expectedOutput": {"<output_field>": "A correct, on-topic response for the given input."}
        }
      }
    }
    ```
 
-   **If `has_smoke_set == false`**, create `evaluations/eval-sets/smoke-test.json` with 2-3 test cases based on the agent's input schema (version is string `"1.0"`, top-level `id`/`name` required, test cases in `evaluations` array):
+   **If `has_smoke_set == false`**, create `evaluations/eval-sets/smoke-test.json` with 2-3 test cases based on the agent's input/output schema (version is string `"1.0"`, top-level `id`/`name` required, test cases in `evaluations` array). Key each case's criteria on the evaluator `id` you created above, and shape `expectedOutput` to match the agent's actual output field(s):
    ```json
    {
      "version": "1.0",
      "id": "smoke-test",
      "name": "Smoke Test",
-     "evaluatorRefs": ["LLMJudgeTrajectoryEvaluator"],
+     "evaluatorRefs": ["LLMJudgeOutputEvaluator"],
      "evaluations": [
        {
          "id": "test-1",
          "name": "Basic test",
-         "inputs": {"field": "value"},
+         "inputs": {"<input_field>": "value"},
          "evaluationCriterias": {
-           "LLMJudgeTrajectoryEvaluator": {
-             "expectedAgentBehavior": "Agent should process the input and return a response."
+           "LLMJudgeOutputEvaluator": {
+             "expectedOutput": {"<output_field>": "A correct, on-topic response for this input."}
            }
          }
        }

--- a/tests/tasks/uipath-agents/coded/eval_smoke_default_output/check_eval_smoke_default_output.py
+++ b/tests/tasks/uipath-agents/coded/eval_smoke_default_output/check_eval_smoke_default_output.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Eval-lifecycle check: greenfield smoke-evaluator default must be output-based.
+
+A plain single-LLM-call agent (`summarizer`) with no @traced spans and no tool
+calls has no meaningful execution trajectory. A trajectory or tool-call
+evaluator scores against emitted spans / AgentRunHistory and returns 0.0 on
+such an agent even when it runs perfectly — so the skill must NOT default the
+smoke evaluator to one of those. The correct default is output-based:
+semantic-similarity for natural-language output, or a deterministic
+exact-match / contains / json-similarity evaluator.
+
+Checks:
+  1. `summarizer/evaluations/evaluators/<file>.json` has a non-empty `id` and
+     an `evaluatorTypeId` in the allowed OUTPUT-based set.
+  2. NO evaluator config under `evaluations/evaluators/` uses a trajectory or
+     tool-call `evaluatorTypeId`.
+  3. The eval set's `evaluatorRefs` reference the output-based evaluator id,
+     it has >= 2 test cases, and each case keys its `evaluationCriterias` on
+     that id and carries `expectedOutput` (not `expectedAgentBehavior`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+ROOT = find_project_root("summarizer")
+
+OUTPUT_BASED_TYPES = {
+    "uipath-llm-judge-output-semantic-similarity",
+    "uipath-llm-judge-output-strict-json-similarity",
+    "uipath-exact-match",
+    "uipath-contains",
+    "uipath-json-similarity",
+}
+
+FORBIDDEN_TYPE_PREFIXES = (
+    "uipath-llm-judge-trajectory",
+    "uipath-tool-call",
+)
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def _is_forbidden(type_id: str) -> bool:
+    return any(type_id.startswith(p) for p in FORBIDDEN_TYPE_PREFIXES)
+
+
+def check_evaluators() -> str:
+    directory = ROOT / "evaluations" / "evaluators"
+    if not directory.is_dir():
+        sys.exit(f"FAIL: {directory} does not exist")
+    files = sorted(p for p in directory.glob("*.json") if p.is_file())
+    if not files:
+        sys.exit(f"FAIL: {directory} contains no evaluator .json files")
+
+    output_based_id = None
+    for path in files:
+        doc = _load_json(path)
+        type_id = doc.get("evaluatorTypeId")
+        if _is_forbidden(type_id or ""):
+            sys.exit(
+                f"FAIL: {path.name} uses a trajectory/tool-call evaluator "
+                f"({type_id!r}). A single-step structured-IO agent produces an "
+                f"empty AgentRunHistory, so this scores 0.0 on success. The "
+                f"smoke evaluator must default to an output-based type."
+            )
+        if type_id in OUTPUT_BASED_TYPES and doc.get("id"):
+            output_based_id = doc["id"]
+
+    if not output_based_id:
+        sys.exit(
+            f"FAIL: no output-based evaluator found under {directory}. "
+            f"Expected one of {sorted(OUTPUT_BASED_TYPES)}."
+        )
+    print(f"OK: smoke evaluator defaults to output-based type, id={output_based_id!r}; no trajectory/tool-call evaluators present")
+    return output_based_id
+
+
+def check_eval_set(evaluator_id: str) -> None:
+    directory = ROOT / "evaluations" / "eval-sets"
+    if not directory.is_dir():
+        sys.exit(f"FAIL: {directory} does not exist")
+    files = sorted(p for p in directory.glob("*.json") if p.is_file())
+    if not files:
+        sys.exit(f"FAIL: {directory} contains no eval-set .json files")
+
+    # Find the eval set that references our output-based evaluator.
+    target = None
+    for path in files:
+        doc = _load_json(path)
+        if evaluator_id in (doc.get("evaluatorRefs") or []):
+            target = (path, doc)
+            break
+    if target is None:
+        sys.exit(
+            f"FAIL: no eval set references the output-based evaluator id "
+            f"{evaluator_id!r} in `evaluatorRefs`."
+        )
+    path, doc = target
+
+    if doc.get("version") != "1.0":
+        sys.exit(f'FAIL: eval set version should be "1.0", got {doc.get("version")!r}')
+    cases = doc.get("evaluations") or []
+    if len(cases) < 2:
+        sys.exit(f"FAIL: eval set must have at least 2 test cases, got {len(cases)}")
+    for i, case in enumerate(cases):
+        crit = case.get("evaluationCriterias") or {}
+        if evaluator_id not in crit:
+            sys.exit(
+                f'FAIL: eval set test case {i} (`{case.get("id", "?")}`) does '
+                f'not key its evaluationCriterias on {evaluator_id!r}. '
+                f'Got keys: {list(crit.keys())}'
+            )
+        entry = crit[evaluator_id] or {}
+        if "expectedAgentBehavior" in entry and "expectedOutput" not in entry:
+            sys.exit(
+                f'FAIL: test case {i} uses `expectedAgentBehavior` (a '
+                f'trajectory-evaluator field) on an output-based evaluator. '
+                f'Output-based evaluators expect `expectedOutput`.'
+            )
+        if "expectedOutput" not in entry:
+            sys.exit(
+                f'FAIL: test case {i} is missing `expectedOutput` for the '
+                f'output-based evaluator {evaluator_id!r}.'
+            )
+    print(f"OK: eval set {path.name} references {evaluator_id!r} across {len(cases)} cases, each with expectedOutput")
+
+
+def main() -> None:
+    if not ROOT.is_dir():
+        sys.exit(f"FAIL: project directory {ROOT} does not exist")
+    evaluator_id = check_evaluators()
+    check_eval_set(evaluator_id)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/eval_smoke_default_output/eval_smoke_default_output.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_smoke_default_output/eval_smoke_default_output.yaml
@@ -1,0 +1,39 @@
+task_id: skill-agent-coded-eval-smoke-default-output
+description: >
+  Greenfield default-evaluator choice. A plain single-LLM-call agent with
+  NO @traced spans and NO tool calls asks only for "a smoke eval set".
+  Verifies the skill defaults the smoke evaluator to an OUTPUT-based type
+  (uipath-llm-judge-output-semantic-similarity, or a deterministic
+  uipath-exact-match / uipath-contains / uipath-json-similarity) and does
+  NOT scaffold a trajectory or tool-call evaluator — those score against
+  emitted trace spans / AgentRunHistory and return 0.0 on an agent with no
+  meaningful trajectory, which is the trap this default avoids.
+tags: [uipath-agents, e2e, coded, lifecycle:validate, feature:eval]
+
+run_limits:
+  expected_turns: 22
+  turn_timeout: 1200
+
+initial_prompt: |
+  I've got chunks of text I want boiled down to a short paragraph each. Can you
+  build me a small coded agent for that — call it `summarizer`, takes some text
+  in and hands back a one-paragraph summary. Once it's running, set up a quick
+  eval with a couple of test cases so I can sanity-check it locally. No need to
+  deploy it anywhere.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the project with uip codedagent new"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+new'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Smoke evaluator defaults to an output-based type, never a trajectory/tool-call evaluator"
+    command: "python3 $TASK_DIR/check_eval_smoke_default_output.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- coded-agents quickstart + `evaluate.md` now default the smoke evaluator to an output-based type (`uipath-llm-judge-output-semantic-similarity`, or deterministic `exact-match`/`contains`/`json-similarity`) instead of a trajectory evaluator
- adds `eval_smoke_default_output` to lock that default in
- prefer `uip codedagent list-models` for available models discovery

## Why

a trajectory evaluator scores against `AgentRunHistory`, which is empty for a single-step structured-IO agent, so the first smoke eval a new user runs returned 0.0 on a working agent. output-based evaluators score the result directly. verified live: trajectory scores 1.0 on a real tool-using agent and 0.0 on a single-step one (even with `@traced`); output evaluator scores correctly on both.