### PR TITLE
test(uipath-agents): align inline_builtin_tool assertions with sibling inline tests

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/check_inline_builtin_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/check_inline_builtin_tool.py
@@ -2,22 +2,27 @@
 """Inline agent + built-in tool check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.tool.*` node (exact built-in suffix
-     under-asserted — use prefix match).
-  2. Edge wires agent.tool -> tool.input.
-  3. Inline agent dir has at least one resource.json under its
-     resources/ tree matching the built-in tool registry:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.tool.builtin.<key>` node whose
+     `inputs.source` matches the sub-folder UUID of the inline agent's
+     resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.tool -> tool.input.
+  4. Every internal tool resource.json under the inline agent's
+     resources/ tree matches the built-in tool registry:
        - $resourceType == "tool"
        - type == "internal"
        - referenceKey is null
        - properties.toolType in {analyze-attachments, load-attachments,
                                  deep-rag, batch-transform}
-     and at least one of them has toolType == "analyze-attachments"
-     (the specific built-in the prompt requested).
+  5. The resource wired to the flow node is the "Analyze Files"
+     built-in (toolType == "analyze-attachments" — the specific
+     built-in the prompt requested).
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -25,13 +30,18 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from _shared.inline_wiring import (  # noqa: E402
     assert_edge,
     find_autonomous_agent_node,
+    find_inline_resource,
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
+    resolve_resource_source,
 )
 
 FLOW_PATH = Path(os.getcwd()) / "DocsFlowSol" / "DocsFlow" / "DocsFlow.flow"
-TOOL_NODE_PREFIX = "uipath.agent.resource.tool."
+BUILTIN_TOOL_NODE_TYPE_PREFIX = "uipath.agent.resource.tool.builtin."
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_TOOL_TYPE = "analyze-attachments"
 BUILTIN_TOOL_TYPES = {
     "analyze-attachments",
     "load-attachments",
@@ -43,8 +53,29 @@ BUILTIN_TOOL_TYPES = {
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    tool_node = find_resource_node(flow, node_type_prefix=TOOL_NODE_PREFIX)
+    tool_node = find_resource_node(flow, node_type_prefix=BUILTIN_TOOL_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {tool_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    tool_source = resolve_resource_source(tool_node)
+    if not UUID_RE.match(tool_source):
+        sys.exit(
+            f"FAIL: {tool_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {tool_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -55,7 +86,6 @@ def main() -> None:
     )
     print("OK: agent 'tool' handle is wired to built-in tool node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     resources_dir = agent_dir / "resources"
     if not resources_dir.is_dir():
         sys.exit(f"FAIL: {resources_dir} does not exist — no resources/ directory")
@@ -83,13 +113,26 @@ def main() -> None:
             'expected at least one resource.json with $resourceType="tool" '
             'and type="internal"'
         )
-    if "analyze-attachments" not in seen_tool_types:
+
+    resource_path, _resource = find_inline_resource(
+        agent_dir,
+        lambda d: (
+            d.get("$resourceType") == "tool"
+            and d.get("type") == "internal"
+            and (d.get("properties") or {}).get("toolType") == EXPECTED_TOOL_TYPE
+        ),
+        description=f'built-in "Analyze Files" tool (toolType={EXPECTED_TOOL_TYPE!r})',
+    )
+    if resource_path.parent.name != tool_source:
         sys.exit(
-            f'FAIL: prompt asked for "Analyze Files" (toolType '
-            f'"analyze-attachments"), but it was not enabled. '
-            f'Got toolTypes: {seen_tool_types}'
+            f"FAIL: tool node inputs.source UUID {tool_source!r} does not match "
+            f"the resource sub-folder name {resource_path.parent.name!r}"
         )
-    print('OK: "Analyze Files" (toolType="analyze-attachments") is enabled on the inline agent')
+    print(
+        f"OK: tool node inputs.source={tool_source!r} matches resource sub-folder "
+        f"({resource_path.relative_to(Path(os.getcwd()))})"
+    )
+    print(f'OK: "Analyze Files" (toolType={EXPECTED_TOOL_TYPE!r}) is enabled and wired in the flow')
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -6,8 +6,8 @@ description: >
   Verifies the tool resource.json under the inline agent's UUID
   subdirectory uses `type: "internal"`, `referenceKey: null`, and
   `properties.toolType` set to one of the four documented built-in
-  tool keys. Verifies a `uipath.agent.resource.tool.*` flow node is
-  wired to the autonomous agent node's `tool` handle.
+  tool keys. Verifies a `uipath.agent.resource.tool.builtin.<key>`
+  flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e, mode:build, low-code, inline-flow]
 
 run_limits:
@@ -31,7 +31,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -39,7 +39,31 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the built-in tool manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the built-in tool node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.tool\.builtin\.'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
@@ -67,7 +91,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -85,7 +109,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Inline built-in tool: resource.json shape (type=internal, toolType) + flow node + tool-handle edge"
+    description: "Inline built-in tool: resource.json shape (type=internal, toolType) + flow node (tool.builtin.*) + tool-handle edge"
     command: "python3 $TASK_DIR/check_inline_builtin_tool.py"
     timeout: 30
     expected_exit_code: 0


### PR DESCRIPTION
## Summary

Brings `tests/tasks/uipath-agents/lowcode/inline_builtin_tool/` up to the assertion level of its sibling inline tests (`inline_context_index`, `inline_external_agent_tool`):

- **Node discovery criteria added** — `uip maestro flow registry search`, `registry get` for the `uipath.agent.resource.tool.builtin.*` manifest, and `registry get` for `uipath.agent.autonomous`, matching the sibling tests' discovery assertions. Criterion weights normalized to the sibling `1.5` convention.
- **Check script: `inputs.source` wiring** — the autonomous node's and tool node's `inputs.source` must be UUID-shaped, and the tool node's source must match the sub-folder of the matched `resource.json`. Previously the flow node and the resource file were validated independently and never tied together, so a flow wired to a dangling UUID passed.
- **Tighter node match** — the tool node is matched by the `uipath.agent.resource.tool.builtin.` prefix instead of the generic `uipath.agent.resource.tool.` prefix (the old docstring itself flagged this as under-asserted), and the wired resource must be the requested `analyze-attachments` built-in rather than merely appearing somewhere in the resources tree.
- The builtin-specific sweep validating every internal tool resource (`referenceKey: null`, `toolType` in the four-key registry) is kept.

Tenant-discovery criteria (`uip solution resource list/get`) are intentionally omitted — built-in tools come from the static registry, not a deployed tenant resource.

## Passing-run claim

`coder-eval run tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml -e experiments/default.yaml` — run `runs/2026-06-10_17-01-23`, task `skill-agent-inline-builtin-tool`: **11/11 criteria passed, weighted score 1.000, status SUCCESS** (895s, 1 iteration). All three new discovery criteria and the strengthened check script passed on this fresh run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)