### PR TITLE
docs: reflect skills install agent auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm -g install @uipath/cli
 uip skills install
 ```
 
-Select the skills you need from the wizard. Skills are installed into your coding agent's directory and ready to use.
+`uip skills install` finds the AI coding agents installed on your machine and installs the skills for all of them, into each agent's directory, ready to use. If it can't find any agent, it asks which one to target. To install for just one agent, pass `--agent <name>` (e.g. `--agent claude`).
 
 <details>
 <summary>Don't have Node.js installed?</summary>
@@ -148,7 +148,7 @@ The command prints the recommended JSON and offers to merge it into your setting
 
 ### Google Gemini CLI
 
-Gemini CLI is supported by `uip skills install` — pick **Gemini CLI** when the wizard prompts for a target and skills are wired up automatically.
+Gemini CLI is supported by `uip skills install`. If the Gemini CLI is on your PATH, it's detected automatically and skills are wired up. If no agent is detected, pick **Gemini CLI** when prompted.
 
 ### OpenAI Codex CLI
 


### PR DESCRIPTION
## What

Updates the README to match the new `uip skills install` behavior: it now finds the AI coding agents installed on your machine and installs skills for **all of them**, instead of always showing a selection wizard.

- **Quick Start**: replaced "Select the skills you need from the wizard" with a description of auto-detection, the no-agent-found fallback, and the `--agent <name>` override.
- **Google Gemini CLI**: Gemini is auto-detected when its CLI is on PATH; the manual "pick Gemini CLI when the wizard prompts" only applies when no agent is detected.

https://github.com/UiPath/cli/pull/2454

## Why

The CLI change in UiPath/cli#2451 makes `uip skills install` (with no `--agent`) auto-detect installed agents and install for all of them. The picker now only appears as a fallback when nothing is detected, so the old "wizard" wording is stale.

Docs-only; no skill content changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)