### PR TITLE
test(uipath-agents): align inline_external_escalation assertions with sibling inline tests

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
@@ -2,16 +2,25 @@
 """Inline agent + external escalation (ActionCenter) check.
 
 Validates:
-  1. Flow has a `uipath.agent.autonomous` node and a
-     `uipath.agent.resource.escalation` node.
-  2. Edge wires agent.escalation -> escalation.input.
-  3. Inline agent dir has at least one escalation resource.json under
-     its resources/ tree with:
+  1. Flow has a `uipath.agent.autonomous` node whose `inputs.source`
+     matches the sub-folder UUID of the inline agent under the flow
+     project.
+  2. Flow has a `uipath.agent.resource.escalation` node whose
+     `inputs.source` matches the sub-folder UUID of the inline agent's
+     resource (under `<inline-agent-uuid>/resources/`).
+  3. Edge wires agent.escalation -> escalation.input.
+  4. Inline agent dir has an escalation resource.json under its
+     resources/ tree with:
        - $resourceType == "escalation"
        - id is a UUID-shaped string
        - isEnabled is truthy
        - channels contains at least one entry with
-         type == "actionCenter" (lowercase) and a non-empty name
+         type == "actionCenter" (lowercase) bound to the deployed
+         "FraudEscalation" app: properties.appName == "FraudEscalation",
+         properties.folderName == "Shared/uipath-agents/FraudEscalation"
+         (the deployed Orchestrator folder of the app), and
+         properties.resourceKey is a UUID-shaped non-empty string
+         (copied from `uip solution resource list`'s `Key`)
 
   Note: the escalation resource.json format does not expose a
   `location` field — the solution-vs-external distinction is captured
@@ -20,6 +29,7 @@ Validates:
 """
 
 import os
+import re
 import sys
 from pathlib import Path
 
@@ -31,10 +41,15 @@ from _shared.inline_wiring import (  # noqa: E402
     find_resource_node,
     load_json,
     resolve_inline_agent_dir,
+    resolve_resource_source,
 )
 
 FLOW_PATH = Path(os.getcwd()) / "FraudFlowSol" / "FraudFlow" / "FraudFlow.flow"
 ESCALATION_NODE_TYPE = "uipath.agent.resource.escalation"
+UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
+
+EXPECTED_APP_NAME = "FraudEscalation"
+EXPECTED_FOLDER_NAME = "Shared/uipath-agents/FraudEscalation"
 
 
 def main() -> None:
@@ -42,6 +57,27 @@ def main() -> None:
     agent_node = find_autonomous_agent_node(flow)
     escalation_node = find_resource_node(flow, node_type=ESCALATION_NODE_TYPE)
     print(f"OK: flow has {agent_node['type']} and {escalation_node['type']} nodes")
+
+    agent_source = (agent_node.get("inputs") or {}).get("source")
+    if not isinstance(agent_source, str) or not UUID_RE.match(agent_source):
+        sys.exit(
+            f"FAIL: {agent_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent's sub-folder name, got {agent_source!r}"
+        )
+    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
+    if agent_dir.name != agent_source:
+        sys.exit(
+            f"FAIL: inputs.source UUID {agent_source!r} does not match "
+            f"the inline agent sub-folder name {agent_dir.name!r}"
+        )
+    print(f"OK: autonomous node inputs.source={agent_source!r} matches inline agent sub-folder")
+
+    escalation_source = resolve_resource_source(escalation_node)
+    if not UUID_RE.match(escalation_source):
+        sys.exit(
+            f"FAIL: {escalation_node['type']} inputs.source must be a UUID matching "
+            f"the inline agent resource's sub-folder name, got {escalation_source!r}"
+        )
 
     assert_edge(
         flow,
@@ -52,14 +88,23 @@ def main() -> None:
     )
     print("OK: agent 'escalation' handle is wired to escalation node's 'input' handle")
 
-    agent_dir = resolve_inline_agent_dir(FLOW_PATH, agent_node)
     path, data = find_inline_resource(
         agent_dir,
         lambda d: d.get("$resourceType") == "escalation",
         description='escalation resource ($resourceType=="escalation")',
     )
+    if path.parent.name != escalation_source:
+        sys.exit(
+            f"FAIL: escalation node inputs.source UUID {escalation_source!r} does not match "
+            f"the resource sub-folder name {path.parent.name!r}"
+        )
+    print(
+        f"OK: escalation node inputs.source={escalation_source!r} matches resource sub-folder "
+        f"({path.relative_to(Path(os.getcwd()))})"
+    )
+
     rid = data.get("id")
-    if not isinstance(rid, str) or "-" not in rid:
+    if not isinstance(rid, str) or not UUID_RE.match(rid):
         sys.exit(f"FAIL: escalation id missing or malformed at {path}: {rid!r}")
     if not data.get("isEnabled"):
         sys.exit(f"FAIL: escalation isEnabled must be truthy at {path}")
@@ -77,6 +122,34 @@ def main() -> None:
             f"and a non-empty name"
         )
     print(f"OK: escalation resource at {path.name} is valid (id={rid}, {len(ac)} actionCenter channel(s))")
+
+    bound = [
+        c for c in ac
+        if (c.get("properties") or {}).get("appName") == EXPECTED_APP_NAME
+    ]
+    if not bound:
+        sys.exit(
+            f"FAIL: no actionCenter channel is bound to the deployed app "
+            f"{EXPECTED_APP_NAME!r} (properties.appName) — got appNames: "
+            f"{[(c.get('properties') or {}).get('appName') for c in ac]}"
+        )
+    props = bound[0].get("properties") or {}
+    fname = props.get("folderName")
+    if fname != EXPECTED_FOLDER_NAME:
+        sys.exit(
+            f"FAIL: channel properties.folderName should be {EXPECTED_FOLDER_NAME!r} "
+            f"(the deployed Orchestrator folder of {EXPECTED_APP_NAME}), got {fname!r}"
+        )
+    rkey = props.get("resourceKey")
+    if not isinstance(rkey, str) or not UUID_RE.match(rkey):
+        sys.exit(
+            f"FAIL: channel properties.resourceKey must be a UUID-shaped string "
+            f"copied from `uip solution resource list`'s `Key`, got {rkey!r}"
+        )
+    print(
+        f"OK: actionCenter channel is bound to appName={EXPECTED_APP_NAME!r}, "
+        f"folderName={EXPECTED_FOLDER_NAME!r}, resourceKey={rkey!r}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
@@ -20,7 +20,7 @@ Validates:
          properties.folderName == "Shared/uipath-agents/FraudEscalation"
          (the deployed Orchestrator folder of the app), and
          properties.resourceKey is a UUID-shaped non-empty string
-         (copied from `uip solution resource list`'s `Key`)
+         (copied from `uip solution resources list`'s `Key`)
 
   Note: the escalation resource.json format does not expose a
   `location` field — the solution-vs-external distinction is captured
@@ -144,7 +144,7 @@ def main() -> None:
     if not isinstance(rkey, str) or not UUID_RE.match(rkey):
         sys.exit(
             f"FAIL: channel properties.resourceKey must be a UUID-shaped string "
-            f"copied from `uip solution resource list`'s `Key`, got {rkey!r}"
+            f"copied from `uip solution resources list`'s `Key`, got {rkey!r}"
         )
     print(
         f"OK: actionCenter channel is bound to appName={EXPECTED_APP_NAME!r}, "

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -5,8 +5,10 @@ description: >
   agent that escalates uncertain cases to an EXTERNAL ActionCenter app
   already deployed to Orchestrator (not inside this solution).
   Verifies the escalation resource.json under the inline agent's UUID
-  subdirectory + a `uipath.agent.resource.escalation` flow node wired
-  to the autonomous agent node's `escalation` handle.
+  subdirectory has an actionCenter channel bound to the deployed
+  "FraudEscalation" app (appName, folderName, UUID resourceKey), and that a
+  `uipath.agent.resource.escalation` flow node is wired to the
+  autonomous agent node's `escalation` handle.
 tags: [uipath-agents, e2e, mode:build, low-code, inline-flow]
 
 run_limits:
@@ -31,7 +33,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+init'
     min_count: 1
-    weight: 1.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -39,7 +41,39 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+init\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered the FraudEscalation app identity with uip solution resource list --kind App"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+resource\s+list\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched the flow registry for the escalation node manifest"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the escalation node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.resource\.escalation'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the inline autonomous agent node manifest from the flow registry"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+get\s+.*uipath\.agent\.autonomous'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
@@ -67,7 +101,7 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+validate\s+.*--inline-in-flow'
     min_count: 1
-    weight: 2.0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
@@ -85,7 +119,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Inline external escalation: resource.json shape + escalation flow node + escalation-handle edge"
+    description: "Inline external escalation: resource.json shape (actionCenter channel, appName, folderName, resourceKey) + escalation flow node + escalation-handle edge"
     command: "python3 $TASK_DIR/check_inline_external_escalation.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -45,9 +45,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent discovered the FraudEscalation app identity with uip solution resource list --kind App"
+    description: "Agent discovered the FraudEscalation app identity with uip solution resources list --kind App"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+resource\s+list\b'
+    command_pattern: 'uip\s+solution\s+resources\s+list\b.*--kind\s+App'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Brings `tests/tasks/uipath-agents/lowcode/inline_external_escalation/` up to the assertion level of its sibling inline tests (`inline_context_index`, `inline_external_agent_tool`, `inline_builtin_tool`):

- **Tenant-discovery criterion added** — `uip solution resource list` for discovering the external FraudEscalation app, the external-resource counterpart of the siblings' `--kind Index` / `--kind Process` criteria.
- **Node-discovery criteria added** — `uip maestro flow registry search`, `registry get uipath.agent.resource.escalation`, and `registry get uipath.agent.autonomous`, matching the siblings' discovery assertions. Criterion weights normalized to the sibling `1.5` convention.
- **Check script: `inputs.source` wiring** — the autonomous node's and escalation node's `inputs.source` must be UUID-shaped, and the escalation node's source must match the sub-folder of the matched `resource.json`. Previously the flow node and the resource file were validated independently and never tied together, so a flow wired to a dangling UUID passed.
- **Channel pinned to the deployed app** — the `actionCenter` channel must be bound to the prompt-named app: `properties.appName == "FraudEscalation"`, `properties.folderName == "Shared/uipath-agents/FraudEscalation"`, and a UUID-shaped `properties.resourceKey`. Previously any actionCenter channel passed, so a hallucinated app binding scored full marks. (Parallel to the siblings' `processName`/`indexName` + `folderPath` + `referenceKey` assertions.)
- Upgraded the weak `"-" in id` check to a full UUID regex.

A `uip solution resource get` criterion is intentionally omitted (unlike the siblings): the observed agent fetches the app's action schema via the Apps API directly rather than via `resource get`.

## Checklist

- [ ] Run a coder-eval pipeline check for this task (`coder-eval run tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml -e experiments/default.yaml`) and attach the passing-run claim before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)