### PR TITLE
fix(uipath-maestro-flow): loosen bindings multi-connector node-count criteria

### DIFF
--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -32,19 +32,23 @@ initial_prompt: |
       echo '{"a":"<conn-id-1>","ka":"<connector-key-1>","b":"<conn-id-2>","kb":"<connector-key-2>"}' > conn_ids.json
 
 success_criteria:
+  # min_count: 1 (not 2) — agents commonly chain two `uip ... node add` calls
+  # into a single Bash invocation with `&&`, which the checker counts as one
+  # match (re.search returns the first hit). Behavioral checks below verify
+  # both nodes actually exist in the flow.
   - type: command_executed
-    description: "Agent added two connector nodes"
+    description: "Agent used `uip flow node add` at least once"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+add"
-    min_count: 2
+    min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent configured two nodes"
+    description: "Agent used `uip flow node configure` at least once"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 2
+    min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary
- Lower the two `command_executed` proxies in `tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml` from `min_count: 2` to `min_count: 1`.
- Add an inline comment documenting the chaining trap so the criteria don't get tightened back.

## Why
The `command_executed` checker (`coder_eval/criteria/command_executed.py`) counts matching **Bash tool invocations**, not pattern occurrences within a command string — it uses `pattern.search(cmd_text)`, which returns at most one match per invocation. When the agent chains both `uip maestro flow node add` calls into a single Bash command with `&&` (a perfectly reasonable thing to do), only one match is counted, scoring 0.50 and failing the `min_count: 2` threshold — even when the resulting flow is correct.

This false-failed `skill-flow-bindings-multi-connector-independence` at a weighted score of 0.967 (6/7 criteria pass) on a clean run: the produced flow had both connector nodes, both connections wired, no empty bindings, and no triplet duplicates. The five behavioral `run_command` checks already prove two distinct connector nodes with two distinct connections were added, so the invocation-count proxies are redundant.

Per `.claude/rules/test-writing.md` § *Grade Behavior, Not Self-Reports* — `command_executed` here grades *how* the agent invoked the CLI rather than *what* the flow ended up containing. Lowering to `min_count: 1` keeps a low-weight "did the agent use the CLI at all" signal without false-failing on chained invocations.

## Test plan
- [ ] Trigger the `Run Coder Eval` workflow against this branch with `task_globs: tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml` and confirm the task passes (weighted score 1.0, 7/7).
- [ ] Spot-check that the change is YAML-only and the other four bindings tasks in the same folder are untouched.

Generated with [Claude Code](https://claude.com/claude-code)
