### PR TITLE
Add Agent Hub (uipath-agenthub) to test-coverage and generate-confluence-scorecard commands

### DIFF
--- a/.claude/commands/generate-confluence-scorecard.md
+++ b/.claude/commands/generate-confluence-scorecard.md
@@ -159,6 +159,7 @@ Do not edit this embedded table on the fly; report drift so a human updates the 
 | Integration Service (uip is) | `uipath-platform/integration-service` | 5 dedicated + cross-cutting connector tasks in flow/agents |
 | HITL (uip hitl) | `uipath-human-in-the-loop` | no `uip hitl` verb; +`uipath-maestro-flow/hitl` cross-cutting |
 | Low & Code Agents | `uipath-agents` | |
+| Agent Hub (uip agenthub) | `uipath-agenthub` | |
 | IXP | `uipath-ixp` | |
 | RPA / Studio / Computer Vision | `uipath-rpa` (incl. `legacy/`) | three product rows share one skill |
 | Data Fabric (df / entities) | `uipath-data-fabric` | |
@@ -235,7 +236,7 @@ import re, glob
 from collections import defaultdict
 RULES = [(r'^uip (maestro )?flow\b','Flow'),(r'^uip (maestro )?bpmn\b','BPMN'),
  (r'^uip (maestro )?case\b','Case Management'),(r'^uip is\b','Integration Service'),
- (r'^uip (agent|codedagent)\b','Low & Code Agents'),(r'^uip ixp\b','IXP'),
+ (r'^uip (agent|codedagent)\b','Low & Code Agents'),(r'^uip agenthub\b','Agent Hub'),(r'^uip ixp\b','IXP'),
  (r'^uip rpa(-uia)?\b','RPA / Studio / CV'),(r'^uip (df|entities)\b','Data Fabric'),
  (r'^uip api-workflow\b','API Workflow'),(r'^uip codedapp\b','Coded Apps'),
  (r'^uip (or|orchestrator|resource)\b','Orchestrator'),(r'^uip context-grounding\b','ECS'),

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -37,6 +37,7 @@ These skills are expected to ship but have no folder under `skills/` yet. Treat 
 | `uipath-marketplace` | UiPath Marketplace component publish/consume |
 | `uipath-process-mining` | Process Mining (event logs, conformance, dashboards) |
 | `uipath-task-mining` | Task Mining (recordings, task analysis) |
+| `uipath-agenthub` | Agent Hub (build, publish, and manage UiPath agents) |
 
 ## Phase 2 — Extract the skill's capability inventory
 


### PR DESCRIPTION
## Summary

- **`generate-confluence-scorecard.md`** — added `Agent Hub (uip agenthub)` as a new product row in the canonical product→skill mapping table, placed immediately after the "Low & Code Agents" row. Also added `(r'^uip agenthub\b','Agent Hub')` to Appendix A's `RULES` list so the CLI-surface cross-cutting scan correctly attributes `uip agenthub` commands to the Agent Hub product row.
- **`test-coverage.md`** — added `uipath-agenthub` to the Planned Skills Registry with domain hint `"Agent Hub (build, publish, and manage UiPath agents)"`. This ensures every `all`-mode coverage run surfaces Agent Hub at 0% (planned) until the skill folder ships.

## Notes

- **Docs-only change** — no skill files, test YAMLs, or scripts modified.
- **Self-healing registry** — once `skills/uipath-agenthub/` lands, Phase 1's existence check in `test-coverage.md` automatically routes the skill into normal extraction. No further edit to the Planned Skills Registry is needed at that point; only remove the entry if the skill is intentionally cancelled.

## Test plan

- [ ] Verify `generate-confluence-scorecard.md` mapping table contains the new Agent Hub row between Low & Code Agents and IXP.
- [ ] Verify Appendix A `RULES` list contains `(r'^uip agenthub\b','Agent Hub')`.
- [ ] Verify `test-coverage.md` Planned Skills Registry contains `uipath-agenthub`.
- [ ] Run `/test-coverage all` locally and confirm Agent Hub appears in the summary at `0% (planned)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)