### PR TITLE
feat(uipath-admin): document audit export --file-format csv + add CSV tests

### DIFF
--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-admin
-description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
+description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP or single-CSV exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -53,7 +53,7 @@ Activate on both **explicit audit requests** and **natural-language investigatio
 
 - **Explicit** — `uip admin audit` commands; list sources / targets / types; query, filter, paginate, or export events; CSV/ZIP dump of audit history for a window.
 - **Query audit events** — list event sources, filter events by source / target / type / user / status / time window at org or tenant scope
-- **Export audit events** — chunked ZIP download from the long-term store, per UTC day, with atomic abort on any chunk failure
+- **Export audit events** — chunked download from the long-term store (one call per UTC day, atomic abort on any chunk failure) as a ZIP of day-wise JSON files (default) or a single merged CSV via `--file-format csv`
 - **Membership / license phrasings** — "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit"
 - **Sign-in / authentication phrasings** — "failed/successful logins", "login history for user X", "who's been signing in"
 - **Tenant-activity phrasings** — "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity"
@@ -109,7 +109,7 @@ Each rule is the agent contract. Per-area detail is in the linked reference file
 27. **Bound the time window, ISO 8601 in UTC.** Don't call `audit <scope> events` without `--from-date` and `--to-date` on a noisy tenant. Accepted formats: date-only (`2026-04-01`) or with time (`2026-04-01T14:30:00Z`). **`--to-date` is inclusive of the exact instant** — to capture a full final day, pass the start of the next day or `T23:59:59.999Z`.
 28. **`--tenant-id` is silently ignored on `org`-scoped audit commands.** If you find yourself reaching for it on `audit org events`, switch to `audit tenant` instead.
 29. **On 401 from audit, do NOT retry.** The token is missing the `Audit.Read` scope; tell the user to `uip logout && uip login`.
-30. **`audit <scope> export` writes a ZIP from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are all required; dates per Rule 27. **Never overwrite a path the user did not explicitly approve** — surface the resolved `--output-file` and confirm before running.
+30. **`audit <scope> export` writes a ZIP (default) or a single merged CSV from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are all required; dates per Rule 27. **`--file-format <zip|csv>`** selects the shape: `zip` (default) is one JSON file per UTC day; `csv` merges every event into one CSV — pick `csv` when the user wants a flat spreadsheet/Excel-friendly dump and `zip` for archival or per-day JSON. Match the `--output-file` extension to the format (`.zip` / `.csv`). **Never overwrite a path the user did not explicitly approve** — surface the resolved `--output-file` and confirm before running.
 
 ### IP Restriction
 

--- a/skills/uipath-admin/references/audit-commands.md
+++ b/skills/uipath-admin/references/audit-commands.md
@@ -26,7 +26,7 @@ uip admin audit
 |---|---|
 | `audit <scope> sources` | array of `AuditEventSourceDto` |
 | `audit <scope> events` | object `{auditEvents, next, previous}` |
-| `audit <scope> export` | object `{Path, Bytes, Format, Days, NonEmptyDays}` |
+| `audit <scope> export` | object `{Path, Bytes, Format, Days, NonEmptyDays}` (+ `Events` when `--file-format csv`) |
 
 `events` is the one verb that legitimately returns an object — pagination cursors live alongside the rows. Full shape detail per verb in the sections below.
 
@@ -138,13 +138,22 @@ uip admin audit tenant events --from-date 2026-04-22T00:00:00Z --to-date 2026-04
 
 ## uip admin audit `<scope>` export
 
-Stream a ZIP from the long-term audit store covering `[--from-date, --to-date]`.
+Export the long-term audit store covering `[--from-date, --to-date]` — as a ZIP of day-wise JSON files (default) or a single merged CSV.
 
 ```bash
+# Default — ZIP of one JSON file per UTC day
 uip admin audit tenant export \
   --from-date 2026-01-01 \
   --to-date 2026-02-01 \
   --output-file ./audit-jan.zip \
+  --output json
+
+# Single merged CSV of every event
+uip admin audit tenant export \
+  --from-date 2026-01-01 \
+  --to-date 2026-02-01 \
+  --file-format csv \
+  --output-file ./audit-jan.csv \
   --output json
 ```
 
@@ -152,17 +161,19 @@ uip admin audit tenant export \
 
 | Flag | Required | Description |
 |---|---|---|
-| `--output-file <path>` | **yes** | Where to write the ZIP. Parent dir is created if missing; existing file is overwritten. Resolved to absolute internally. |
+| `--output-file <path>` | **yes** | Where to write the export. Parent dir is created if missing; existing file is overwritten. Resolved to absolute internally. Match the extension to `--file-format` (`.zip` / `.csv`). |
 | `--from-date <iso>` | **yes** | Start of time interval. Both bounds are required by Commander before any HTTP call. |
 | `--to-date <iso>` | **yes** | End of time interval. |
+| `--file-format <zip\|csv>` | no | Output shape. `zip` (default) = one JSON file per UTC day inside a ZIP. `csv` = every event merged into a single RFC 4180 CSV under a shared header. Invalid values fail before any HTTP call with `Invalid --file-format '<v>'. Use 'zip' or 'csv'.` |
 | `--login-validity <minutes>` | no | Token-refresh hint. |
 | `--tenant-id <guid>` | no | **Tenant scope only.** Override the active tenant. |
 
 **Output `Code`:** `AuditOrgExport` / `AuditTenantExport`.
 
-**Output `Data`:**
+**Output `Data`:** `Format` echoes the chosen `--file-format`. The CSV path adds `Events` (total rows written, excluding the header); the ZIP path omits it.
 
 ```json
+// --file-format zip (default)
 {
   "Path": "C:\\absolute\\path\\to\\audit-jan.zip",
   "Bytes": 1841,
@@ -170,14 +181,25 @@ uip admin audit tenant export \
   "Days": 31,
   "NonEmptyDays": 27
 }
+
+// --file-format csv
+{
+  "Path": "C:\\absolute\\path\\to\\audit-jan.csv",
+  "Bytes": 98765,
+  "Format": "csv",
+  "Days": 31,
+  "NonEmptyDays": 27,
+  "Events": 1234
+}
 ```
 
 **Implementation notes (worth knowing for diagnostic conversations):**
 
-- The CLI issues **one HTTP call per UTC day** inside `[from, to]` and aggregates the per-day responses into a single output ZIP. Mirrors the `audit-dowload-from-longterm-store.sh` pattern in the AuditService repo.
-- Per-day entries land at the **root of the output ZIP** named `<YYYY-MM-DD>.txt` (no folder prefix). Each `.txt` is a JSON array of events with PascalCase keys (`Id`, `CreatedOn`, `EventType`, …).
-- On any single-day HTTP failure, **no file is written** and the error message identifies which day failed. Earlier successful chunks are not preserved.
-- `Days` reports the total number of UTC days requested; `NonEmptyDays` reports how many actually had events. A long export with `NonEmptyDays: 0` means the window was entirely idle, not that the export failed.
+- Both formats share the same fetch: the CLI issues **one HTTP call per UTC day** inside `[from, to]` and aggregates the per-day responses. Mirrors the `audit-dowload-from-longterm-store.sh` pattern in the AuditService repo.
+- **ZIP (default):** per-day entries land at the **root of the output ZIP** named `<YYYY-MM-DD>.txt` (no folder prefix). Each `.txt` is a JSON array of events with PascalCase keys (`Id`, `CreatedOn`, `EventType`, …).
+- **CSV:** the same per-day JSON arrays are parsed and merged into **one** RFC 4180 CSV (CRLF line endings, header row first). Columns follow the long-term-store field order — `Id, CreatedOn, OrganizationId, TenantId, ActorId, ActorName, ActorEmail, ActorDetails, EventType, EventSource, EventTarget, EventDetails, Status, ClientInfo` — with any extra server fields appended (union across events) so no data is dropped. `Status` is the numeric enum (`0`=Success, `1`=Failure); nested objects (e.g. `ClientInfo`) are JSON-stringified into the cell. String cells beginning with `= + - @` (or TAB/CR) are prefixed with a single quote to neutralize spreadsheet formula injection.
+- On any single-day HTTP failure (or, for CSV, a day whose payload is not valid JSON), **no file is written** and the error message identifies which day failed. Earlier successful chunks are not preserved (atomic export).
+- `Days` reports the total number of UTC days requested; `NonEmptyDays` reports how many actually had data. A long export with `NonEmptyDays: 0` means the window was entirely idle, not that the export failed. For CSV, `Events: 0` yields a header-only file.
 
 ---
 
@@ -187,7 +209,7 @@ These appear on every command (not just audit) — set at the program level by t
 
 | Flag | Description |
 |---|---|
-| `--output <table\|json\|yaml\|plain>` | Format of the success/failure envelope on stdout. Defaults to `json`. The ZIP body of `export` is unaffected — `--output` only controls the metadata envelope. |
+| `--output <table\|json\|yaml\|plain>` | Format of the success/failure envelope on stdout. Defaults to `json`. The export file body (ZIP or CSV) is unaffected — `--output` only controls the metadata envelope, NOT `--file-format`. |
 | `--output-filter <jmespath>` | JMESPath query applied to the envelope before printing. Useful for `events`/`sources`. Less useful for `export` (envelope is small). |
 | `--log-level <debug\|info\|warn\|error>` | Logger threshold. Logs go to stderr. |
 | `--log-file <path>` | Redirect logs from stderr to a file. |

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -174,7 +174,7 @@ For each event:
 
 **User asks:** "Export everything for compliance for Q4." / "I need the full audit log for January for the security review." / "Pull last month's events for tenant X as a ZIP."
 
-**Approach:** `export` straight to a ZIP. No need to query `events` first unless the user wants a preview.
+**Approach:** `export` straight to a file. Default is a ZIP of day-wise JSON files; add `--file-format csv` for a single merged CSV when the user wants a flat, spreadsheet/Excel-friendly dump. No need to query `events` first unless the user wants a preview. Match the `--output-file` extension to the format (`.zip` / `.csv`).
 
 ### Step 1 — Confirm scope and window
 
@@ -183,11 +183,19 @@ If the user is ambiguous about scope, ask once. For compliance reviews, **both**
 ### Step 2 — Export
 
 ```bash
-# Tenant scope — most events
+# Tenant scope — most events (default ZIP of day-wise JSON files)
 uip admin audit tenant export \
   --from-date 2026-01-01 \
   --to-date   2026-02-01 \
   --output-file ./audit-tenant-2026-01.zip \
+  --output json
+
+# Tenant scope as a single merged CSV (flat, Excel-friendly)
+uip admin audit tenant export \
+  --from-date 2026-01-01 \
+  --to-date   2026-02-01 \
+  --file-format csv \
+  --output-file ./audit-tenant-2026-01.csv \
   --output json
 
 # Org scope — admin events (memberships, license, tenant lifecycle)
@@ -198,9 +206,11 @@ uip admin audit org export \
   --output json
 ```
 
-The CLI issues one HTTP call per UTC day under the hood and aggregates daily responses into a flat ZIP. `Days` and `NonEmptyDays` in the result tell you how many calendar days had events.
+The CLI issues one HTTP call per UTC day under the hood. ZIP aggregates the daily responses into a flat ZIP; CSV parses the same daily JSON and merges every event into one CSV. `Days` and `NonEmptyDays` in the result tell you how many calendar days had data; for CSV, `Events` reports the total row count.
 
-### Step 3 — Verify the ZIP
+### Step 3 — Verify the export
+
+**ZIP** — list the per-day entries:
 
 ```bash
 unzip -l ./audit-tenant-2026-01.zip
@@ -217,6 +227,15 @@ audit-tenant-2026-01.zip
 ```
 
 Each `.txt` is a JSON array of audit events with **PascalCase** keys (`Id`, `CreatedOn`, `OrganizationId`, `ActorId`, `ActorName`, `EventType`, …) — different from the camelCase shape returned by the live `events` endpoint. Note this in the user's hand-off if they're going to feed the dump into other tooling.
+
+**CSV** — inspect the header and row count:
+
+```bash
+head -1 ./audit-tenant-2026-01.csv          # shared header (PascalCase columns)
+python3 -c "import csv; print(sum(1 for _ in csv.reader(open('./audit-tenant-2026-01.csv'))) - 1, 'rows')"
+```
+
+One header row, then every event across all days as a data row (same PascalCase column names as the ZIP's JSON keys). The row count should match `Events` in the result envelope.
 
 Edge cases the CLI handles automatically — surface in your hand-off only if they appear:
 
@@ -282,14 +301,14 @@ Two or more signals? Run them in sequence and stitch the results in the final re
 - **`tenant` events without an active tenant fail loudly.** If `uip login` has no tenant selected, every tenant-scoped command throws. Either re-`uip login` and pick a tenant, or pass `--tenant-id <guid>` on every call.
 - **`events` cursor pagination is chronologically reversed from intuition.** `next` = newer (often null), `previous` = older (the typical "load more"). The CLI tool follows `previous` automatically when you bump `--limit > 200` — don't re-implement this in the agent.
 - **Date-only ISO strings are interpreted as UTC midnight.** `--from-date 2026-01-01` means `2026-01-01T00:00:00Z`. To capture the full final day in `--to-date`, use `2026-02-01` (exclusive next day) or `2026-01-31T23:59:59.999Z`.
-- **The export ZIP's per-day files are JSON, not CSV, and use PascalCase keys.** Different from the camelCase live `events` endpoint. Don't paste an export directly into a parser expecting the live shape.
+- **Export format depends on `--file-format`.** The default `zip` holds one **JSON** file per UTC day (not CSV) with **PascalCase** keys; `--file-format csv` produces a single merged **CSV** whose header uses those same PascalCase field names. Both differ from the camelCase live `events` endpoint — don't paste an export into a parser expecting the live shape. In the CSV, `Status` is numeric (`0`/`1`) and `ClientInfo` is a JSON-stringified cell.
 - **Org sources and tenant sources are different sets.** Don't reuse a GUID from `org sources` in a `tenant events` query — the filter will silently match nothing.
 
 ## Output Etiquette — after an audit query or export
 
 After every `events` or `export` call, surface the following before waiting for the user's next-step choice. Do not chain mutations.
 
-1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days` or `Wrote 123,456 bytes to /path/to/audit.zip (3 days, 2 non-empty)`.
+1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days`, `Wrote 123,456 bytes to /path/to/audit.zip (3 days, 2 non-empty)`, or for CSV `Wrote 98,765 bytes to /path/to/audit.csv (1,234 events across 3 days, 2 non-empty)`.
 2. **Scope used** (`org` or `tenant`) and any `--tenant-id` override.
 3. **Time window** — explicit ISO bounds, even if they came from a relative phrase ("last 7 days").
 4. **Filters applied** — sources, types, users, status.

--- a/tests/tasks/uipath-admin/audit_export_csv_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_export_csv_smoke.yaml
@@ -1,0 +1,46 @@
+task_id: skill-admin-audit-export-csv-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to run a
+  minimal `export` with `--file-format csv` against a small window.
+  Validates the three required flags (`--from-date`, `--to-date`,
+  `--output-file`) plus the new `--file-format csv` selector, and that
+  the agent picks a `.csv` output path inside the working directory.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, mode:operate, audit, export]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  An admin needs a single CSV of all tenant audit events from yesterday
+  to open in Excel for a quick review. Write the CSV to
+  ./audit-yesterday.csv in the current working directory.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip admin audit tenant export` with --from-date, --to-date, --output-file, AND --file-format csv"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)(?=.*--file-format\s+csv\b)'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent's CSV export targeted the requested ./audit-yesterday.csv path"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b.*--output-file\s+\.?/?audit-yesterday\.csv'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
@@ -1,0 +1,90 @@
+task_id: skill-admin-audit-export-csv-verify-e2e
+description: >
+  End-to-end test (artifact verification tier): agent drives
+  `uip admin audit tenant export --file-format csv` to produce a real
+  single CSV, then verifies (a) the CSV exists, (b) it is a well-formed
+  CSV with a header row carrying the documented PascalCase columns, and
+  (c) every data row has the same column count as the header.
+
+  This is the CSV counterpart to `audit_export_verify_e2e.yaml` (which
+  validates the default ZIP). The underlying long-term-store data is the
+  same; this task asserts the CSV-specific serialization is correct
+  (single merged file, shared header, aligned rows). The format-agnostic
+  "export IDs are a subset of live events" fidelity check is already
+  covered by the ZIP verify task and is not duplicated here.
+
+  Whole-day granularity note: `uip admin audit ... export` issues one
+  HTTP call per UTC day inside [--from-date, --to-date]. For CSV those
+  per-day events are merged into one file, so the row count is the sum
+  across the window's days.
+
+  LTS lag note: the export reads from the long-term store, which lags
+  the live `events` endpoint. We pin the window to dates at least 48h in
+  the past so LTS has caught up.
+
+  Blocker: this task requires the `--file-format` option to exist in the
+  published `@uipath/cli` (UiPath/cli#2438 must ship + publish first, on
+  top of #1372 which adds `uip admin audit`). Until then the export step
+  fails with `unknown option '--file-format'` (or `unknown command
+  'audit'`).
+tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
+
+initial_prompt: |
+  Export tenant audit events for the 3-day window from 5 days ago
+  through 2 days ago (UTC, whole days) to ./audit-window.csv in the
+  current working directory, as a single merged CSV (not a ZIP).
+  Resolve the dates with `date -u -d '5 days ago' +%Y-%m-%d` and
+  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the run
+  date.
+
+  Important:
+  - The `uip` CLI is available and connected via env-var auth to a real
+    tenant. The export should produce a real CSV file at the requested
+    path.
+  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
+    bounds (no inline `T00:00:00Z` for these flags — the CLI treats them
+    as whole-day boundaries) and select the single-file CSV shape with
+    `--file-format csv`.
+  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked tenant export with bounded window, --output-file, and --file-format csv"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)(?=.*--file-format\s+csv\b)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Export produced ./audit-window.csv"
+    path: "./audit-window.csv"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Export is a well-formed CSV: header carries the documented PascalCase columns and every data row matches the header width (a header-only file is acceptable for a quiet tenant)"
+    command: |
+      python3 -c "
+      import csv, sys
+      REQUIRED = ['Id','CreatedOn','OrganizationId','ActorId','EventType','EventSource','EventTarget']
+      with open('./audit-window.csv', newline='', encoding='utf-8-sig') as f:
+          rows = list(csv.reader(f))
+      assert rows, 'CSV is empty — no header row'
+      header = rows[0]
+      missing = [c for c in REQUIRED if c not in header]
+      assert not missing, f'header missing required columns: {missing}; header={header}'
+      for i, r in enumerate(rows[1:], 1):
+          assert len(r) == len(header), f'row {i} has {len(r)} cols, header has {len(header)}'
+      print(f'OK: header has {len(header)} columns, {len(rows) - 1} data rows')
+      "
+    timeout: 60
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 10
+  max_turns: 40
+  turn_timeout: 600

--- a/tests/tasks/uipath-admin/audit_org_export_csv_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_csv_smoke.yaml
@@ -1,0 +1,48 @@
+task_id: skill-admin-audit-org-export-csv-smoke
+description: >
+  Skill-guided evaluation: agent uses the uipath-admin skill to run
+  `export` with `--file-format csv` at ORG scope (not tenant). Mirrors
+  the tenant CSV smoke. Org-scope exports cover admin events
+  (memberships, license, tenant lifecycle) that don't live under any
+  single tenant — picking the wrong scope returns the wrong data
+  silently.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, mode:operate, audit, export, scope-org]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  An admin needs a single CSV of all ORGANIZATION-level audit events
+  (memberships, license changes, tenant lifecycle) from yesterday to
+  open in Excel for compliance review. Write the CSV to
+  ./audit-org-yesterday.csv in the current working directory.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked `uip admin audit org export` (org scope) with --from-date, --to-date, --output-file, AND --file-format csv"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)(?=.*--file-format\s+csv\b)'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent's CSV export targeted the requested ./audit-org-yesterday.csv path"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b.*--output-file\s+\.?/?audit-org-yesterday\.csv'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Documents the new `uip admin audit <org|tenant> export --file-format <zip|csv>` option in the `uipath-admin` skill and adds matching coder-eval tests.

The CLI change is **UiPath/cli#2438** (layered on the unified-audit onboarding #1372): `zip` (default) writes one JSON file per UTC day inside a ZIP; `csv` merges every event into a single RFC 4180 CSV.

## Skill docs (3 files)

- **SKILL.md** — frontmatter description, the Audit export bullet, and Critical Rule 30 now cover ZIP (default) vs CSV and when to pick each (match the `--output-file` extension).
- **references/audit-commands.md** — new `--file-format <zip|csv>` flag row, a CSV example, the output `Data` shape gains `Events` (csv only), and CSV implementation notes (merge, column order, numeric `Status`, JSON-stringified `ClientInfo`, formula-injection neutralization, atomic abort).
- **references/audit-workflow-guide.md** — Investigation 3 gains a CSV export + verify branch; the JSON-vs-CSV gotcha and output-etiquette example updated.

## Tests (3 new, mirroring the existing ZIP tasks)

| File | Tier | Asserts |
|---|---|---|
| `audit_export_csv_smoke.yaml` | smoke | tenant export emits `--file-format csv` + required flags → `.csv` path |
| `audit_org_export_csv_smoke.yaml` | smoke | org-scope CSV variant |
| `audit_export_csv_verify_e2e.yaml` | e2e (real-artifact) | produces a real CSV; validates header columns + row/column width |

The 3 existing ZIP tasks are unchanged (they still exercise the default path).

## Passing-run claim

Both CSV **smoke** tasks pass under `experiments/default.yaml` (coder-eval, `claude-sonnet-4-6`, tempdir):

- `skill-admin-audit-export-csv-smoke` — SUCCESS, 2/2 criteria, score 1.000
- `skill-admin-audit-org-export-csv-smoke` — SUCCESS, 2/2 criteria, score 1.000

The agent (guided by the updated skill) emitted:

```
uip admin audit tenant export --from-date … --to-date … --file-format csv --output-file ./audit-yesterday.csv --output json
uip admin audit org    export --from-date … --to-date … --file-format csv --output-file ./audit-org-yesterday.csv --output json
```

`/lint-task`: 0 Critical/High/Medium (1 advisory Low — the e2e prompt names the format flag, justified by its artifact-correctness purpose). CLI-verb reachability: clean.

## Not run here

`audit_export_csv_verify_e2e` needs a real authenticated tenant **and** the published `@uipath/cli` carrying `--file-format` (#2438). It is gated exactly like the existing ZIP verify e2e (#1372) and will run on the e2e/nightly cadence once those land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
