### PR TITLE
fix(hitl/e2e): increase e2e_01 turn_timeout 1200s → 2400s

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -13,7 +13,7 @@ tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write
 run_limits:
   expected_turns: 19
   max_turns: 60
-  turn_timeout: 1200
+  turn_timeout: 2400
 
 initial_prompt: |
   Build a UiPath Flow named "InvoiceApproval" that extracts invoice data


### PR DESCRIPTION
## Summary

Agent builds a complete 11-node flow (SharePoint fetch, loop over invoices, HITL review with 7 fields, decision, SAP post, rejection log, error handler) and reads 16 reference files for the connector/loop/HITL plugins it needs. All of that fit inside ~1180s — the agent was killed during the final `uip maestro flow validate` call at turn 23. The built flow was correct and complete.

Increasing from 1200s to 2400s (recommendation from the run's automated analysis).

## Test plan
- [ ] e2e_01 passes on next nightly run with the extended budget

🤖 Generated with [Claude Code](https://claude.com/claude-code)