### PR TITLE
fix(uipath-troubleshoot): harden getasset-activity-silent-failure (presentation-graded judge + log breadcrumb)

### DIFF
--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/fixtures/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/fixtures/mocks/responses/manifest.json
@@ -35,6 +35,14 @@
       "file": "or-jobs-logs-7d2e5f3c-level-error-output-json.json"
     },
     {
+      "match": "or jobs logs \"7d2e5f3c-1a6b-4e9f-8c4d-3e2f1a0b9c8d\" --output json",
+      "file": "or-jobs-logs-7d2e5f3c-output-json.json"
+    },
+    {
+      "match": "or jobs logs 7d2e5f3c-1a6b-4e9f-8c4d-3e2f1a0b9c8d --output json",
+      "file": "or-jobs-logs-7d2e5f3c-output-json.json"
+    },
+    {
       "match": "or assets list --folder-key 5a8c4d3e-9f2b-4a6c-8e1f-2b3c4d5e6f7a --output json",
       "file": "or-assets-list-folder-key-5a8c4d3e-output-json.json"
     },

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/fixtures/mocks/responses/or-jobs-logs-7d2e5f3c-output-json.json
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/fixtures/mocks/responses/or-jobs-logs-7d2e5f3c-output-json.json
@@ -1,0 +1,41 @@
+{
+  "Result": "Success",
+  "Code": "JobLogs",
+  "Data": [
+    {
+      "Level": "Info",
+      "TimeStamp": "2026-05-13T18:02:11.804Z",
+      "Message": "AssetSilentFailure execution started"
+    },
+    {
+      "Level": "Trace",
+      "TimeStamp": "2026-05-13T18:02:12.118Z",
+      "Message": "Get Credential: execution started"
+    },
+    {
+      "Level": "Trace",
+      "TimeStamp": "2026-05-13T18:02:12.221Z",
+      "Message": "Get Credential: execution ended (no exception)"
+    },
+    {
+      "Level": "Trace",
+      "TimeStamp": "2026-05-13T18:02:12.244Z",
+      "Message": "Log Message: execution started"
+    },
+    {
+      "Level": "Error",
+      "TimeStamp": "2026-05-13T18:02:12.299Z",
+      "Message": "Log Message: Object reference not set to an instance of an object.\r\nin Main.xaml\r\n    at LogMessage \"Log Message\"\r\n    at Sequence \"Main Sequence\"\r\n    at Main \"Main\"\r\n"
+    },
+    {
+      "Level": "Error",
+      "TimeStamp": "2026-05-13T18:02:12.310Z",
+      "Message": "System.NullReferenceException: Object reference not set to an instance of an object.\r\n   at GlobalVariablesNamespace.GlobalVariablesNamespace.Container_DesignedProcess.LambdaValue1(ActivityContext context)\r\n   at System.Activities.CodeActivity`1.InternalExecuteInResolutionContextUntyped(CodeActivityContext context)\r\n   at System.Activities.Runtime.ActivityExecutor.ExecuteActivityWorkItem.ExecuteBody(ActivityExecutor executor, BookmarkManager bookmarkManager, Location resultLocation)"
+    },
+    {
+      "Level": "Info",
+      "TimeStamp": "2026-05-13T18:02:12.341Z",
+      "Message": "AssetSilentFailure execution ended"
+    }
+  ]
+}

--- a/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/getasset-activity-silent-failure/task.yaml
@@ -57,9 +57,6 @@ success_criteria:
     include_reference: true
     include_agent_output: true
     include_tool_calls: true
-    files:
-      - .local/investigations/state.json
-      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome. The Reference solution attached to this prompt
@@ -84,15 +81,14 @@ success_criteria:
               version with the documented Ctrl+K output-binding bug.
 
         Evidence sources (in priority order):
-          1. state.json's `matched_playbooks` -- the
-             get-asset-activity-bug-silent-failure playbook should
-             appear (absolute or relative path).
+          1. The agent's final response -- it should name the
+             get-asset-activity-bug-silent-failure playbook.
           2. The agent's tool-call summary -- a Read on the playbook
              file under references/activity-packages/system-activities/
              playbooks/ AND a Read on `project.json` (the
              package-version anchor).
-          3. state.json's `scope.domain` -- should include the
-             system-activities or activity-packages domain.
+        Grade only what the agent presented (final response + tool
+        calls); do NOT inspect internal investigation state.
 
         Acceptable / non-penalized: the agent may also Read neighboring
         get-asset-* playbooks (not-found, folder-scope-mismatch,
@@ -139,17 +135,16 @@ success_criteria:
         same either way: upgrade the package.
 
         Evidence sources (in priority order):
-          1. state.json -- `requirements.package_version` (22.10.5),
-             `requirements.downstream_error`, `triage_summary`,
-             scope/domain.
-          2. hypotheses.json -- a hypothesis (need not be flagged
-             `is_root_cause: true`) should name BOTH the package
-             version 22.10.x AND the silent-failure pattern
+          1. The agent's final response -- it should name BOTH the
+             package version 22.10.x AND the silent-failure pattern
              (Get Credential ran but produced no error AND null
-             output). The agent may legitimately leave the
-             root-cause flag conservative if they cannot verify
-             the Ctrl+K trigger from static XAML.
-          3. The agent's last text response.
+             output), and recommend the upgrade fix. The agent may
+             legitimately hedge about the exact Ctrl+K trigger, which
+             cannot be confirmed from static XAML.
+          2. The agent's tool-call summary and any evidence it cites
+             from the job logs / project.json / Main.xaml.
+        Grade only what the agent presented; do NOT inspect internal
+        investigation state.
 
       SCORING RUBRIC (single score reflecting both dimensions):
 


### PR DESCRIPTION
## What

Quality hardening for the `getasset-activity-silent-failure` scenario. Two changes:

1. **Judge → presentation-graded.** Removed the `files: [.local/investigations/state.json, hypotheses.json]` injection and rewrote the DIMENSION A/B evidence sources to grade the agent's **final response + tool calls**, dropping the internal-state fields (`matched_playbooks`, `scope.domain`, `requirements.package_version`, `hypotheses.json`). Per `tests/tasks/uipath-troubleshoot/CLAUDE.md`, judges must grade presentation, not `.local/investigations/` bookkeeping. Scoring tiers and the thoughtful Ctrl+K calibration note are unchanged.
2. **Evidence breadcrumb.** Added a full `or-jobs-logs` fixture (+ manifest rules) that makes the silent-failure chain explicit — `Get Credential: execution ended (no exception)` immediately followed by the downstream `Log Message` NullReferenceException — so the backward trace (downstream NRE → Get Credential produced null output without erroring → `UiPath.System.Activities 22.10.x` package bug) is reliably reachable for weaker runs.

## Important context: the eval-board red was NOT this scenario

The board failures for this task (`2026-06-10` and `2026-06-11` nightlies) were a **transient Bedrock 503 on the `llm_judge` check**:
```
Error during check: RuntimeError: Bedrock invoke failed: 503 {"message":"Bedrock is unable to process your request."}
```
That's a Gateway/Bedrock infra error during the judge call, not a scenario defect — the scenario scores **1.0 locally**. This hardening is **independent quality cleanup**; it does not (and cannot) change that infra failure mode. The board reds just need a re-run against a healthy Bedrock. The systemic fix is harness-side: retry the judge's Bedrock call on transient 5xx instead of erroring the criterion.

## Validation

Local `coder-eval` (experiment `default.yaml`, claude-sonnet-4-6, LLM-Gateway proxy, 2026-06-11):
- 1 replicate **SUCCESS, weighted_score 1.0** (`skill_triggered` 1.0 + `llm_judge` 1.0) — judge confirmed the agent matched the playbook, named `22.10.5`, and recommended the upgrade.
- A second replicate hit the **3600s `turn_timeout`** (a runtime flake under parallel `-j 2` load, not a content/judge issue). An earlier standalone run also scored 1.0.

## Scope

Fix only — touches `task.yaml`, the manifest, and adds one log fixture. No playbook change. Standalone fix PR against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
