### PR TITLE
test(uipath-maestro-flow): match ixp project-selection NodeType by model prefix (RE-12460)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -111,11 +111,11 @@ success_criteria:
       case "$(pwd)" in
         *aviation*)
           model='aviation-investigation-final-report-demo-a42b1d4d-ixp'
-          nt='uipath\.ixp\.aviation-investigation-final-report-demo-a42b1d4d-ixp\.shared-aviation-investigation-final-report-demo-a42b1d4d-ixp'
+          nt='uipath\.ixp\.aviation-investigation-final-report-demo-a42b1d4d-ixp\.'
           ;;
         *birth*)
           model='birth_certificates_oob-6252526a-ixp'
-          nt='uipath\.ixp\.birth-certificates-oob-6252526a-ixp\.shared-birth-certificates-oob-6252526a-ixp'
+          nt='uipath\.ixp\.birth-certificates-oob-6252526a-ixp\.'
           ;;
         *)
           echo "Unknown row in pwd: $(pwd)" >&2


### PR DESCRIPTION
## Why

`e2e_02_project_selection` (aviation, birth-certificate) fails in nightly: the strict
check requires NodeType `uipath.ixp.<model>.shared-<model>`, but flow-core emits
`…<model>.undefined-<folderKey>` (flow-workbench #1920 — fix stranded on flow-core
`develop`/`0.4.x`; the CLI bundles the `0.2.x` line). The agent picks the right model —
exact `modelName` matches; only the CLI-generated classifier suffix is wrong. RE-12460.

## Fix

Match the NodeType by model **prefix** (`uipath.ixp.<model>.`) and keep the exact
`modelName` pin, instead of the full `.shared-<model>` suffix. The criterion description
already says "NodeType prefix" — this restores that intent and decouples the test from a
CLI-side, agent-uncontrolled field. No revert needed once #1920 ships.

## Evidence

Replayed the strict criterion against the captured 06-11 nightly flows — both rows
**FAIL → PASS** with the prefix match, `modelName` pin still enforced. Stays strong:
wrong-model or mock fallback still fail (modelName + model-prefixed NodeType + the
separate real-`uipath.ixp.*` / no-`core.logic.mock` criteria).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
