### PR TITLE
test(uipath-troubleshoot): move top-level run-limit keys into run_limits block

### DIFF
--- a/tests/tasks/uipath-troubleshoot/excel-rr-concurrent-jobs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-concurrent-jobs/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-file-deleted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-file-deleted/task.yaml
@@ -16,9 +16,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-host-evidence/task.yaml
@@ -16,9 +16,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 50
-turn_timeout: 5400
+run_limits:
+  task_timeout: 5400
+  max_turns: 50
+  turn_timeout: 5400
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-nre-label/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-nre-namedrange/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 50
-turn_timeout: 5400
+run_limits:
+  task_timeout: 5400
+  max_turns: 50
+  turn_timeout: 5400
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-nre-opaque/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-nre-opaque/task.yaml
@@ -20,9 +20,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 50
-turn_timeout: 5400
+run_limits:
+  task_timeout: 5400
+  max_turns: 50
+  turn_timeout: 5400
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-orphan-process/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-relative-path/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-sheet-bytes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-sheet-bytes/task.yaml
@@ -17,9 +17,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 7200
-max_turns: 50
-turn_timeout: 5400
+run_limits:
+  task_timeout: 7200
+  max_turns: 50
+  turn_timeout: 5400
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-sheet-case/task.yaml
@@ -16,9 +16,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-sheet-typo/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-rr-unmapped-drive/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 50
-turn_timeout: 5400
+run_limits:
+  task_timeout: 5400
+  max_turns: 50
+  turn_timeout: 5400
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-wc-formula-semicolons/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 50
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 50
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-wc-loop-thrash/task.yaml
@@ -21,9 +21,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 50
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 50
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/excel-wc-scope-conflict/task.yaml
@@ -18,9 +18,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 50
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 50
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-code-file/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-com-interop/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-method-name/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-params/task.yaml
@@ -12,9 +12,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/invokevba-trust-access/task.yaml
@@ -11,9 +11,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-active-filters/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-file-locked/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-formula-cells/task.yaml
@@ -17,9 +17,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-invalid-range/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-not-installed/task.yaml
@@ -12,9 +12,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/lookuprange-null-reference/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 5400
-max_turns: 60
-turn_timeout: 3600
+run_limits:
+  task_timeout: 5400
+  max_turns: 60
+  turn_timeout: 3600
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 40
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 40
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-operator-ui/task.yaml
@@ -13,9 +13,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/rpa-job-killed-by-watchdog-account/task.yaml
@@ -15,9 +15,10 @@ agent:
   type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
-task_timeout: 4500
-max_turns: 30
-turn_timeout: 3600
+run_limits:
+  task_timeout: 4500
+  max_turns: 30
+  turn_timeout: 3600
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
@
Migrates 29 `uipath-troubleshoot` task YAMLs from the deprecated top-level `task_timeout` / `max_turns` / `turn_timeout` placement into the canonical `run_limits:` block (per `tests/tasks/uipath-troubleshoot/CLAUDE.md`, the location after the `c/2026-05-12-unify-run-limits` migration).

Top-level placement still works via a grace shim but is deprecated. Values are preserved exactly — config-location-only, no behavior change. All 29 files validated as parseable YAML; indented sub-agent `max_turns` caps left untouched.
@