### PR TITLE
fix(uipath-automation-discovery): add required mode:build tag to test tasks

### DIFF
--- a/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
+++ b/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   the full discovery workflow (intake through report) for a fictional company
   with pre-seeded data. Tests the complete Phases 0-4 loop and validates
   the output report structure, tier classification, and evidence quality.
-tags: [uipath-automation-discovery, e2e, lifecycle:generate]
+tags: [uipath-automation-discovery, e2e, mode:build, lifecycle:generate]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
+++ b/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
@@ -4,7 +4,7 @@ description: >
   Phase 0 (intake) for a fictional company. Tests that the skill triggers
   correctly and the agent follows the structured intake workflow — gathering
   company context, tool inventory, org structure, and scope agreement.
-tags: [uipath-automation-discovery, smoke, lifecycle:discover]
+tags: [uipath-automation-discovery, smoke, mode:build, lifecycle:discover]
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## What

Adds the required `mode:build` tag to both `uipath-automation-discovery` test tasks:

- `tests/tasks/uipath-automation-discovery/smoke_intake.yaml`
- `tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml`

## Why

Follow-up to #1332, which merged without this fix. Both task YAMLs were missing the required `mode:*` tag — flagged by all three reviewers on #1332 as the one genuine blocker.

`tests/README.md` Tag Taxonomy and `.claude/rules/test-writing.md` Must-Do #1 require all four tag classes: `skill` + `tier` + `mode:*` + `lifecycle:*`. Both tasks carried skill/tier/lifecycle but no `mode:*`, so they were invisible to mode-sliced `make`/coverage/evalboard queries (e.g. `make tags TAGS="mode:build"`).

`mode:build` is correct for both: each task produces a deliverable (discovery report / `report.json`).

## Change

```
- tags: [uipath-automation-discovery, smoke, lifecycle:discover]
+ tags: [uipath-automation-discovery, smoke, mode:build, lifecycle:discover]

- tags: [uipath-automation-discovery, e2e, lifecycle:generate]
+ tags: [uipath-automation-discovery, e2e, mode:build, lifecycle:generate]
```

> Note: skill-status manifest registration (as `preview`) and the `> **Preview**` callout removal were handled separately on `main` via #1396, so this PR is scoped to the tag fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)