### PR TITLE
test(uipath-maestro-flow): bump turn_timeout for skill-flow-eval-run-e2e to 1800s

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -13,6 +13,7 @@ tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute, feature:eval]
 
 run_limits:
   max_turns: 90
+  turn_timeout: 1800
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"


### PR DESCRIPTION
## Summary
- The `skill-flow-eval-run-e2e` task times out under the experiment-default 900s `turn_timeout`.
- A diagnostic run (`task.json`) shows the agent spent ~7m on setup, then launched `uip maestro flow eval run start --wait --timeout 600` and was killed ~8m into that wait when the 900s wall-clock budget elapsed (`duration_ms=0, status=unknown` on the final command).
- The prompt itself budgets ≥12m of post-upload work (`--wait --timeout 600` + up to 5 × ~30s status polls + results fetch), which alone exceeds the 900s turn budget with zero slack for scaffolding.

## Change
Override `run_limits.turn_timeout` to **1800s** at the task level. Precedent: [`tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml`](https://github.com/UiPath/skills/blob/main/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml) (also 1800s); several other e2e HITL tasks use 1200s. 1800s leaves comfortable margin for slow Studio Web responses.

## Test plan
- [ ] Trigger the eval workflow on this branch scoped to `skill-flow-eval-run-e2e` and confirm the run completes (Completed or Failed) instead of timing out mid-`--wait`.
- [ ] Confirm aggregate score is 1.0 on the deterministic Hello-Alice data point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)