### PR TITLE
feat(mcp-servers): gate IS activities and platform-mcp to alpha/staging only

### DIFF
--- a/assets/cli-versions.json
+++ b/assets/cli-versions.json
@@ -1,6 +1,6 @@
 {
-  "schemaVersion": 1,
-  "generated_at": "2026-06-02T00:00:00Z",
+  "schemaVersion": 2,
+  "generated_at": "2026-06-11T00:00:00Z",
   "environments": {
     "alpha": {
       "cliVersion": "1.2"
@@ -9,7 +9,10 @@
       "cliVersion": "1.1"
     },
     "cloud": {
-      "cliVersion": "0.1"
+      "cliVersion": "0.1",
+      "excludedSkillFeatures": {
+        "uipath-mcp-servers": ["is-activity", "platform-mcp"]
+      }
     }
   }
 }

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -84,6 +84,10 @@
     },
     "uipath-mcp-servers": {
       "status": "in-development",
+      "featureGates": {
+        "is-activity": { "environments": ["alpha", "staging"] },
+        "platform-mcp": { "environments": ["alpha", "staging"] }
+      },
       "confluence": { "page_id": null, "url": null },
       "last_synced": null
     },


### PR DESCRIPTION
## Summary

- Adds `excludedSkillFeatures` to the `cloud` (prod) entry in `assets/cli-versions.json` (schemaVersion bumped to 2) — `is-activity` and `platform-mcp` features of `uipath-mcp-servers` are excluded from production
- Adds `featureGates` to the `uipath-mcp-servers` entry in `assets/skill-status.json` — declares that both features are scoped to `["alpha", "staging"]` environments only

## Why

IS activities tools (the `is-activity` tool kind on `uipath`-type MCP servers) and the `platform` MCP server type are not yet production-ready. Following the CLI Versioning & Environment Mapping proposal, `cli-versions.json` is the single source of truth for environment-specific feature exclusions.

## Test plan

- [ ] Verify `cli-versions.json` `schemaVersion` is `2` and `cloud.excludedSkillFeatures` lists `is-activity` and `platform-mcp`
- [ ] Verify `skill-status.json` `uipath-mcp-servers.featureGates` has both features scoped to `["alpha", "staging"]`
- [ ] Confirm no other skill entries or SKILL.md files were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)