### PR TITLE
docs(uipath-rpa): decouple timeout guidance from shell tool defaults [PILOT-5634]

### DIFF
--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -68,7 +68,7 @@ To create a project, see [environment-setup.md](environment-setup.md); `--target
 
 `uip rpa` connects to one of two Studio flavors behind the same IPC contract:
 
-- **Headless Studio (Helm) — default.** Ships as a NuGet package and auto-launches on first use. **No Studio Desktop install needed.** First call on a cold NuGet cache may sit near-silent for 30–90 s while `dotnet restore` runs — raise `--timeout` to ≥ 180 for that call.
+- **Headless Studio (Helm) — default.** Ships as a NuGet package and auto-launches on first use. **No Studio Desktop install needed.** First call on a cold NuGet cache may sit near-silent for 30–90 s while `dotnet restore` runs — the default shell timeout covers this; raise `timeoutSeconds` only behind a slow feed.
 - **Studio Desktop.** The interactive UI. Used automatically only by verbs with **UI side effects** — those that open a window or highlight something in the designer (discover them via `--help`; they don't work headless). For such a verb, ensure Desktop is up first (`uip rpa studio start --project-dir "<PROJECT_DIR>"`), then run it. Force Desktop for any command with `UIPATH_RPA_TOOL_USE_STUDIO=1` (not recommended for the standard authoring loop).
 
 `--studio-dir` is consulted **only when Studio Desktop is in use**; headless ignores it. When Desktop auto-detection fails, resolution falls back to `UIPATH_STUDIO_DIR`, then the default install path, then a dev build output. Errors like `"does not have interop support"` / `"Requires Studio 26.2+"` mean the detected Desktop is too old — tell the user to update it; this affects only the Desktop-only verbs.
@@ -146,7 +146,7 @@ Rules:
 
 `uip rpa analyzer-rules list` reports the Workflow Analyzer rules **enabled** for the project — the best-practice rules `validate` and `build` enforce. Reports rules, not violations. Each rule returns `severity` (`error`/`warning`/`info`), rule ID, scope, title, and (when available) `recommendation` and `docs` URL. Prefix convention: `ST-*` = built-in Studio rule, `MA-*` = package-shipped rule.
 
-> **Performance:** the unscoped call enumerates every rule across every package and can take a minute or more. If the default 60 s shell timeout fires, narrow with `--scope` (`Activity`, `Workflow`, `Project`, or `Coded Workflow`) — scoped calls return in seconds. See `--help` for accepted scope values.
+> **Performance:** the unscoped call enumerates every rule across every package and can take a minute or more. Narrow with `--scope` (`Activity`, `Workflow`, `Project`, or `Coded Workflow`) — scoped calls return in seconds. See `--help` for accepted scope values.
 
 ---
 
@@ -194,7 +194,7 @@ Diagnose by error category, apply the recovery, retry **once** — do not loop t
 | Error pattern | Cause | Recovery |
 |---------------|-------|----------|
 | `connection refused`, `EPIPE`, `pipe not found` | Studio IPC unavailable. Headless: NuGet restore failed or process exited. Desktop: not running. | Re-run — headless relaunches automatically. If persistent, raise `--timeout` and check Helm restore output for NuGet errors. Run `uip rpa studio start` only for Desktop-only verbs or when `UIPATH_RPA_TOOL_USE_STUDIO=1`. |
-| `timeout`, `ETIMEDOUT` | Cold Helm NuGet restore (30–90 s) or long operation. | Raise timeout: `uip rpa --timeout 600 <command>`. For `validate`, also try `--skip-validation`. |
+| `timeout`, `ETIMEDOUT` | Cold Helm NuGet restore (30–90 s) or long operation. | Raise both limits together: shell `timeoutSeconds` toward its documented max, and `uip rpa --timeout <timeoutSeconds − 30> <command>` — the shell timeout must exceed `--timeout` by ≥ 30 s or the shell kills the CLI before it can cancel cleanly. For `validate`, also try `--skip-validation`. |
 | `not authenticated`, `401`, `403` | Auth required for cloud features. | `uip login`, then retry. |
 | `package not found`, `version not available` | Wrong package ID or version. | Verify via `uip rpa activities find`; omit `version` to auto-resolve latest. |
 | `project not found`, `no project open` | Wrong `--project-dir` or project not open. | Verify the path points at the `project.json` folder. |

--- a/skills/uipath-rpa/references/environment-setup.md
+++ b/skills/uipath-rpa/references/environment-setup.md
@@ -14,7 +14,7 @@ For these two, see [§ Edge case: requiring Studio Desktop](#edge-case-requiring
 
 > **Coded UI automation caveat.** One non-interactive task also needs Studio Desktop: regenerating `ObjectRepository.cs` — the `Descriptors.*` class consumed by coded `uiAutomation.*` workflows. `uip rpa build` alone does NOT produce it; Studio Desktop reconciles the coded workflow against the Object Repository to generate it. A headless flow can author and validate coded UIA, but populating `Descriptors.*` requires a Studio Desktop pass. See [ui-automation-guide.md](ui-automation-guide.md) § Finding Descriptors.
 
-> **First call is slow.** On a cold NuGet cache, the very first `uip rpa` invocation triggers a silent `dotnet restore` of the headless Studio package and may sit near-silent for 30–90 seconds (longer behind a slow feed). A heartbeat line every 15s confirms it's still working. Bump the per-call timeout to ≥ 180s for the first invocation.
+> **First call is slow.** On a cold NuGet cache, the very first `uip rpa` invocation triggers a silent `dotnet restore` of the headless Studio package and may sit near-silent for 30–90 seconds (longer behind a slow feed). A heartbeat line every 15s confirms it's still working. The default shell timeout covers this; bump `timeoutSeconds` only behind a slow feed.
 
 ## Step 0.1: Establish Project Root
 


### PR DESCRIPTION
## Issue

[PILOT-5634](https://uipath.atlassian.net/browse/PILOT-5634)

## Summary

- Drop restated shell-timeout values (60 s / 180 s) from `cli-reference.md` and `environment-setup.md` — the shell tool schema documents its own default/max, so the skill no longer carries numbers that drift
- Timeout recovery now pairs the two limits: raise shell `timeoutSeconds` toward its documented max and pass `uip rpa --timeout <timeoutSeconds − 30>` so the CLI cancels cleanly before the shell kills it

Pairs with UiPath/Autopilot#3587 (raised shell tool defaults/max and transport RPC deadlines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-5634]: https://uipath.atlassian.net/browse/PILOT-5634?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ