### PR TITLE
DISCUSSION: rewrite uipath-agents coder-eval prompts in customer voice (6 worst offenders)

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
@@ -12,15 +12,13 @@ run_limits:
   max_turns: 60
 
 initial_prompt: |
-  Build a UiPath coded agent named `greeter` using `uip codedagent new`.
-  The agent takes a name and returns "Hello, <name>!". No LLM — purely
-  deterministic Python.
+  Build a small UiPath coded agent named `greeter` that takes a name and
+  returns "Hello, <name>!" — no LLM, just deterministic Python.
 
-  Once the agent runs locally, scaffold a custom evaluator using
-  `uip codedagent add evaluator` that checks the agent execution time is
-  under 500ms. Register it with `uip codedagent register evaluator`, wire
-  it into an eval set with at least 2 test cases, and run it with
-  `uip codedagent eval main <eval-set> --no-report --output-file eval-results.json`.
+  Once it runs locally, I want a custom evaluation that fails the agent
+  whenever a run takes longer than 500ms. Give it at least two test cases,
+  run the evaluation locally (no Studio Web reporting), and save the
+  results to `eval-results.json`.
 
   Do NOT publish, upload, or deploy. Do NOT call `uip login`. Complete
   the entire task end-to-end in a single pass.

--- a/tests/tasks/uipath-agents/coded/file_attachment_input/file_attachment_input.yaml
+++ b/tests/tasks/uipath-agents/coded/file_attachment_input/file_attachment_input.yaml
@@ -11,19 +11,16 @@ run_limits:
   expected_turns: 33
 
 initial_prompt: |
-  1. Create a 'test.txt' file at cwd with 'This is the file content' as content.
-  2. Build a UiPath coded agent named `attachment-agent` that accepts it as input and outputs its name and content.
+  I want a UiPath coded agent named `attachment-agent` that takes a file
+  someone attaches when they run it and returns the file's name and its
+  text contents.
 
-  Use the coded function shape with Pydantic models. In `main.py`, define
-  `class Input(BaseModel)` with an `attachment: Attachment` field imported
-  from `uipath.platform.attachments`. Do not use dataclasses for the Input
-  model: `uip codedagent init` must recognize the `Attachment` type and emit
-  `x-uipath-resource-kind: JobAttachment` in `entry-points.json`.
+  To try it out locally, first create a file `test.txt` in the current
+  directory containing `This is the file content`, then run the agent
+  against that file so I can see it works.
 
-  For local testing, branch on `UiPathConfig.job_key`; when it is `None`, read
-  bytes from the `UIPATH_LOCAL_ATTACHMENT` file path and pass a placeholder
-  attachment object to `uip codedagent run`.
-  Then run it locally.
+  Do NOT publish, upload, or deploy. Do NOT pause between planning and
+  implementation. Complete end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
@@ -19,31 +19,16 @@ sandbox:
       path: ../_fixtures/SimpleCodedAgent
 
 initial_prompt: |
-  I have a coded LangGraph agent in graph.py. I tried to add a user-prompt-
-  attacks guardrail but I'm not sure I placed it right. First add the snippet
-  below to graph.py exactly as-is (do not modify it yet) — it puts a
-  @guardrail decorator above @tool def lookup_account_info using
-  UserPromptAttacksValidator and BlockAction at GuardrailExecutionStage.PRE:
+  I have a coded LangGraph agent in graph.py for customer support. I tried
+  to protect it from prompt-injection / adversarial inputs by adding a
+  user-prompt-attacks guardrail, and I put it on the `lookup_account_info`
+  tool — but it doesn't seem to be doing anything and I'm not sure I wired
+  it up correctly.
 
-      @guardrail(
-          validator=UserPromptAttacksValidator(),
-          action=BlockAction(reason="Adversarial input detected."),
-          name="Block prompt attacks",
-          stage=GuardrailExecutionStage.PRE,
-      )
-      @tool
-      def lookup_account_info(customer_id: str) -> str:
-          ...
-
-  Add the necessary imports for it. Then fetch the guardrail catalog with
-  `uip agent guardrails catalog`, the definitions with
-  `uip agent guardrails list`, and the SDK docs from
-  https://uipath.github.io/uipath-python/core/guardrails/ and
-  https://uipath.github.io/uipath-python/langchain/guardrails/ . Run a
-  validation pass against the snippet — `user_prompt_attacks` is LLM-scope
-  only, so decorating a `@tool` is wrong. Fix it by moving the @guardrail
-  above the existing create_llm() factory function instead, and remove it
-  from above @tool def lookup_account_info. Make sure graph.py still parses.
+  Can you work out whether it's set up right for this kind of guardrail,
+  and fix it if it isn't? Check what the guardrail catalog and the UiPath
+  Python SDK docs say about where this guardrail is allowed to run. Make
+  sure graph.py still parses when you're done.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or
   feedback. Do NOT pause between planning and implementation. Complete the

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -20,30 +20,17 @@ sandbox:
       path: fixtures
 
 initial_prompt: |
-  Hand-author (do NOT scaffold via the CLI) a UiPath coded Python
-  agent at `./slack-notifier/` that posts a Slack message via
-  Integration Service. Operation: Slack's curated `send_message_to_channel_v2`.
+  I want a UiPath coded Python agent at `./slack-notifier/` that posts a
+  message to a Slack channel through Integration Service. It takes a
+  `channel` and a `message` and returns `ok` (bool). Use the Slack
+  `send_message_to_channel_v2` operation, and bind it to our Slack
+  connection under the key `slack-notifier`.
 
-  Use the `uipath-agents` skill and its coded Integration Service
-  capability doc to determine what artifacts to write and what shape
-  they need to take. Follow the doc's mandatory discovery step (read the
-  platform `agent-workflow.md` reference) even though discovery's live
-  `uip is resources describe` call is pre-recorded for you here.
-
-  The describe output for this operation is provided at
-  `./slack_send_message_describe.json` (staged in your cwd). Treat it as
-  the live `uip is resources describe --output json` result and map it to
-  your `ActivityMetadata` literal per the capability doc's mapping table.
-  Do NOT invent field names from worked examples; derive them from the
-  provided describe JSON.
-
-  No live tenant: do not run `uip codedagent init` / `run`. For the
-  required `__uipath/uipath.json` resourceOverwrite, use placeholder values
-  per the capability doc's local-run binding recipe (a real run would source
-  them from `uip is connections list`).
-
-  Agent input: `channel` (str), `message` (str). Output: `ok` (bool).
-  Bind to the connection under the key `slack-notifier`.
+  I don't have a live tenant here, so don't run the agent — just build it
+  so it's ready to run. To save you a round-trip, I've staged a sample of
+  what that connector operation's `describe` output looks like at
+  `./slack_send_message_describe.json`; use that to get the operation's
+  fields right rather than guessing them.
 
   Do NOT pause between planning and implementation. Do NOT ask for
   approval. Complete in a single pass.

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -14,19 +14,13 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "FraudTriageAgent" that accepts a required
-  `transaction` (object) and returns a `verdict` (string). When the
-  agent is uncertain, it must escalate to a human reviewer via an
-  EXISTING EXTERNAL ActionCenter app named "FraudEscalation" that
-  is already deployed to the Orchestrator "Shared" folder (not inside
-  this solution). Model this as an escalation resource on the agent.
-  The solution should be named "FraudSol".
-
-  When writing the escalation resource.json, set `isEnabled` to true so
-  the escalation is active for the agent. Set `properties.folderPath`
-  to the literal string "Shared" (the live Orchestrator folder where
-  FraudEscalation is deployed) — never use placeholder values
-  like "solution_folder".
+  Create a UiPath low-code agent "FraudTriageAgent" that takes a
+  `transaction` (object) and returns a `verdict` (string). When it isn't
+  confident, it should hand the case off to a human reviewer using our
+  existing "FraudEscalation" review app — that app is already deployed in
+  Orchestrator's "Shared" folder, outside this solution. Make sure the
+  escalation is actually active for the agent. The solution should be
+  named "FraudSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
@@ -12,29 +12,25 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "MemorySol" containing a single low-code
-  agent "SupportMemoryAgent". The agent accepts a required
-  `userQuestion` string and returns an `answer` string.
+  Create a UiPath solution "MemorySol" with a single low-code agent
+  "SupportMemoryAgent" that takes a required `userQuestion` string and
+  returns an `answer` string.
 
-  Attach the existing UiPath memory space named
-  "UiPathAgentsSupportMemory" from the Orchestrator folder
-  "Shared/uipath-agents" as an agent memory feature named
-  `SupportRecall`. Enable dynamic few-shot retrieval with hybrid
-  search, threshold 0.25, result count 5, and field weighting
-  `userQuestion=1`.
+  I want the agent to get better over time by drawing on past support
+  cases. Connect it to our existing UiPath memory space
+  "UiPathAgentsSupportMemory" (in the Orchestrator folder
+  "Shared/uipath-agents") as a memory feature called `SupportRecall`, and
+  set it up for dynamic few-shot recall: hybrid search, a 0.25 similarity
+  threshold, up to 5 results, weighting matches on `userQuestion`.
 
-  Add one seed memory item to `SupportRecall`: key
-  `refund-policy-tone`, value `Use empathetic wording and cite the
-  remembered support precedent when a refund case resembles a prior
-  escalation.`, memory type `episodic`, feedback ID
+  Seed `SupportRecall` with one example so I can see it working — an
+  episodic memory with key `refund-policy-tone`, value `Use empathetic
+  wording and cite the remembered support precedent when a refund case
+  resembles a prior escalation.`, feedback ID
   `d640fe25-3c05-4f2e-bd8d-42bdb20704c1`, and metadata
   `{"source":"seed","scenario":"support"}`.
 
-  Use the full low-code memory CLI workflow for memory features:
-  discover the memory space before attaching it and refresh solution
-  resources after migration, even though the memory name and folder
-  are provided. Do not hand-create memory feature JSON. Do NOT
-  publish, upload, or deploy. Do NOT ask for approval, confirmation,
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation,
   or feedback. Do NOT pause between planning and implementation.
   Complete the entire task end-to-end in a single pass.
 


### PR DESCRIPTION
## 🗣️ DISCUSSION — not a merge-ready change

I've been reviewing the `tests/tasks/uipath-agents` prompts from the angle of: **do they actually test whether a coding agent can use the `uipath-agents` skill and succeed?** An eval prompt only tests that if it reads like something a real customer/developer would write and leaves the agent to discover the *how* from the skill. A chunk of the current prompts instead hand over the exact commands, the answer, or the artifact shapes — so an agent can pass by transcription without ever exercising the skill.

Full write-up with the per-task ratings of all 106 prompts (24 High / 64 Medium / 18 Low, plus a 14-prompt "pasted-file seeding" category) is here:
📄 **[Coder-Eval Task Review (Confluence, CA space)](https://uipath.atlassian.net/wiki/spaces/CA/pages/90805731553)**

**This PR is a conversation starter, not a request to merge.** It rewrites **6 of the worst offenders** into a customer/developer voice so we have concrete diffs to react to. I deliberately left every `success_criteria` block **unchanged** — the whole bet is that a capable agent + the skill should still satisfy the existing checks from a natural prompt. If it can't, that tells us something about the skill, not the prompt.

Would love the owners' and test-writers' read on whether these go too far, not far enough, or break reproducibility.

### What changed (prompt text only)

| Task | What the prompt was leaking | What the rewrite removes |
|---|---|---|
| `coded/file_attachment_input` | import paths, `Input` model shape, `x-uipath-resource-kind` emission, `UiPathConfig.job_key` branching | all of it — now just "takes an attached file, returns its name + contents; try it locally" |
| `coded/eval_custom_evaluator` | exact `add evaluator` → `register evaluator` → `eval --no-report --output-file` sequence | the command sequence; keeps the 500ms goal, ≥2 cases, `eval-results.json` |
| `coded/guardrails/validate` | **states the answer** ("user_prompt_attacks is LLM-scope only, move it above `create_llm()`") | the answer; keeps the symptom + "check the catalog & SDK docs" nudge |
| `coded/is_smoke` | "use the `uipath-agents` skill", "read `agent-workflow.md`", "map to your `ActivityMetadata` literal per the mapping table" | the insider doc/skill references; keeps no-tenant + staged `describe.json` |
| `lowcode/memory_space` | "use the full memory CLI workflow", "discover before attaching", "refresh after migration", "don't hand-create JSON" | the procedure; keeps the concrete config + the seed item the checker needs |
| `lowcode/external_escalation` | "set `isEnabled` true", "`properties.folderPath` literal", "never use `solution_folder`" | the `resource.json` key dictation; keeps "active escalation to FraudEscalation in Shared" |

### ⚠️ Three of these also need a fixture/design decision (the real discussion)

These rewrites expose where a prompt was carrying the answer *to make the test reproducible* — removing the text isn't enough on its own:

- **`coded/guardrails/validate`** — today the prompt tells the agent to paste a known-misconfigured decorator *and* states the fix, which is how the failure is made reproducible. My rewrite assumes the misconfigured guardrail is **seeded in the `SimpleCodedAgent` fixture** instead, so the prompt can stay naive ("I put it on the tool, it's not working"). I did **not** touch the fixture in this PR — that's the decision I'd want owners to make.
- **`coded/is_smoke`** — two criteria check that the agent loaded the `uipath-agents` skill and `Read` `agent-workflow.md`. The rewrite relies on the **skill auto-triggering** and instructing those reads, rather than the prompt naming them. If skill routing isn't reliable enough for that, this prompt can't be fully de-insidered.
- **`lowcode/memory_space`** — same shape: the criteria already enforce the CLI workflow (`memory add`, `item add`, `resources refresh`, no hand-authored JSON). The rewrite leans on the skill to drive that instead of the prompt dictating it.

### Open questions for owners & test-writers

1. **Persona:** should these read as a *non-technical customer*, or a *developer who knows UiPath but not the CLI*? That line decides how much of the 64 "Medium" set (lifecycle jargon like `scaffold → init → run`, `sync bindings`) is acceptable.
2. **Reproducibility vs. realism:** for diagnose/fix tasks, are we OK moving seeded state into fixtures so prompts can stay naive?
3. **Skill-routing confidence:** are we comfortable relying on the skill to pull in references (`agent-workflow.md`) and command workflows, rather than naming them in the prompt?
4. Want me to extend the same treatment to the rest of the **High** set (and the 14 pasted-file seeds → on-disk fixtures) in follow-up PRs?

cc owners of `/tests/tasks/uipath-agents/` and the relevant sub-areas:
- Core: @UiPath/team-coded-agents @AlexandruCGhimisi @andreibalas-uipath @al3xanndru @andreitava-uip
- Guardrails: @apetraru-uipath @valentinabojan @ctiliescuuipath
- Context grounding (for the broader review, not these 6): @gcuip @JeremyReist2 @cfauchere @CalebMartinUiPath @jordan-uipath @eteodorovici @pateljay43 @swathiJayav

🤖 Generated with [Claude Code](https://claude.com/claude-code)
