### PR TITLE
docs(solution): document uip solution restore command

### DIFF
--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -82,7 +82,7 @@ Manage assets, queues, triggers, buckets, libraries, and webhooks — a subset o
 
 ## Solution (`uip solution`)
 
-`uip solution` (init/new, project add|remove|import, resource list|refresh|get|add|remove|edit, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
+`uip solution` (init/new, project add|remove|import, resource list|refresh|get|add|remove|edit, restore, pack, publish, deploy run|status|list|activate|uninstall, deploy config get|set|link|unlink, upload, download, packages list|delete|download) is owned by [`uipath-solution`](/uipath:uipath-solution). Load that skill for any `.uipx` lifecycle work.
 
 ---
 

--- a/skills/uipath-solution/SKILL.md
+++ b/skills/uipath-solution/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-solution
-description: "Always invoke for `.uipx` files. UiPath Solution lifecycle via the `uip solution` CLI: init/pack/publish/deploy/activate/upload, project add|import|remove, resource refresh|add|remove|edit. Also DIAGNOSE solution-lifecycle failures: pack/publish/deploy/activate errors, stale or missing bindings, unimported/unset/unresolved resources, deploy error codes (e.g. `[1009] Invalid argument 'Value'`), publish name+version/processKey collisions, and `uip solution` 'unknown command' after the new→init rename. Bundles multiple automation projects (RPA/Flow/Case/Agents/API Workflows) into one deployable `.uipx`. For PDD→SDD design (sdd.md/pdd.md) & multi-skill task derivation→uipath-planner. For non-solution Orchestrator/IS/resources/auth/traces→uipath-platform. For .xaml/.cs→uipath-rpa. For .flow→uipath-maestro-flow. For .bpmn→uipath-maestro-bpmn. For agent.json and .py agents→uipath-agents. For coded-app deploy→uipath-coded-apps."
+description: "Always invoke for `.uipx` files. UiPath Solution lifecycle via the `uip solution` CLI: init/restore/pack/publish/deploy/activate/upload, project add|import|remove, resource refresh|add|remove|edit. Also DIAGNOSE solution-lifecycle failures: pack/publish/deploy/activate errors, stale or missing bindings, unimported/unset/unresolved resources, deploy error codes (e.g. `[1009] Invalid argument 'Value'`), publish name+version/processKey collisions, and `uip solution` 'unknown command' after the new→init rename. Bundles multiple automation projects (RPA/Flow/Case/Agents/API Workflows) into one deployable `.uipx`. For PDD→SDD design (sdd.md/pdd.md) & multi-skill task derivation→uipath-planner. For non-solution Orchestrator/IS/resources/auth/traces→uipath-platform. For .xaml/.cs→uipath-rpa. For .flow→uipath-maestro-flow. For .bpmn→uipath-maestro-bpmn. For agent.json and .py agents→uipath-agents. For coded-app deploy→uipath-coded-apps."
 when_to_use: "User mentions .uipx / 'uip solution' / 'pack the solution' / 'publish the solution' / 'deploy the solution' / 'activate' / multi-project / Solution scope / Solution Folder. Fires for 'create a new solution', 'add project/resource to solution', 'add a queue/asset/bucket/connection to the solution', 'import a cloud queue/asset', 'edit/remove a resource', 'change a queue/asset field', 'set an asset value in the solution'. Also fires to DIAGNOSE solution problems: 'why did my solution pack/publish/deploy fail', 'pack ships stale/old bindings', 'my resource edit didn't take effect', 'refresh imported 0 bindings', deploy fails '[1009] Invalid argument Value', publish 'name+version / processKey collision', 'uip solution new: unknown command', 'coded app missing from the .uipx / not packed'. (Solution build-time/CLI faults belong here; faulted Orchestrator JOBS at runtime → uipath-troubleshoot.) Load BEFORE editing .uipx or running uip solution commands. For PDD→SDD design→uipath-planner; for an 'architect then deploy' two-phase request, run uipath-planner first, then return here to pack/deploy."
 ---
 
@@ -62,12 +62,15 @@ The typical lifecycle for a UiPath Solution:
 ```
 1. init / project add  → Create solution, register projects (.uipx + resources/solution_folder/)
 2. resource refresh    → Sync bundled artefacts and debug overwrites with cloud state
-3. pack                → Produce deployable .zip package
-4. login               → uip login (if not already authenticated)
-5. publish             → Upload packed solution to UiPath
-6. deploy run          → Promote to Orchestrator (auto-activates by default)
-7. (optional) activate → Use --skip-activate on deploy, then activate explicitly
+3. (optional) restore  → Resolve NuGet deps in place (incl. authenticated Orchestrator feeds); login first
+4. pack                → Produce deployable .zip package
+5. login               → uip login (if not already authenticated)
+6. publish             → Upload packed solution to UiPath
+7. deploy run          → Promote to Orchestrator (auto-activates by default)
+8. (optional) activate → Use --skip-activate on deploy, then activate explicitly
 ```
+
+> **`restore` is an optimization, not a requirement.** `pack` restores dependencies internally, so a separate `restore` step is only useful when you want deps resolved up front — most often in CI (`login → restore → pack`) to fail fast on a missing feed before the heavier pack runs. `restore` takes a `<solutionPath>` only (solution dir with a `.uipx`, or a `.uis` file), resolves deps in place, and does **not** produce a package. It needs an authenticated session to reach private Orchestrator feeds, so run `uip login` before it.
 
 > **Coded apps in the project list deploy in parallel, not through `uip solution`.** Coded-app projects (Coded Web Apps and Coded Action Apps) have no `project.uiproj` / `project.json` and are NOT registered via `uip solution project add`. For each coded-app project in the unified list, run `uip codedapp publish` / `uip codedapp deploy` independently — the rest of the solution still goes through steps 1-7 above. See `uipath-coded-apps` for the coded-app lifecycle.
 
@@ -85,7 +88,7 @@ This skill is the terminal step of an SDD-driven build: after `uipath-planner` p
 |------|---------|
 | [Solution Overview](references/solution-overview.md) | What a Solution is, `.uipx` manifest, file structure, lifecycle diagram, command tree |
 | [Develop a Solution](references/develop-solution.md) | `uip solution init / project add / import / remove / resource refresh / resource add / resource remove / resource edit`; field-tested gotchas |
-| [Pack and Deploy](references/pack-and-deploy.md) | `pack / publish / deploy run`, deploy configs, CI/CD pipeline patterns |
+| [Pack and Deploy](references/pack-and-deploy.md) | `restore / pack / publish / deploy run`, deploy configs, CI/CD pipeline patterns |
 | [Activate and Manage](references/activate-and-manage.md) | `deploy activate / status / uninstall`, environment management |
 | [Scenarios Index](references/scenarios.md) | Failure modes and edge cases — manual edits, shared resources, virtual resources, name collisions |
 

--- a/skills/uipath-solution/references/pack-and-deploy.md
+++ b/skills/uipath-solution/references/pack-and-deploy.md
@@ -20,7 +20,8 @@ Pack a solution into a deployable package, publish to the feed, and deploy to Or
 
 ```mermaid
 graph LR
-    A[solution pack] --> B[solution publish]
+    R["(optional)<br/>solution restore"] --> A[solution pack]
+    A --> B[solution publish]
     B --> C[deploy config get]
     C --> D[config set / link]
     D --> E["deploy run<br/>(auto-activate by default)"]
@@ -31,6 +32,21 @@ graph LR
 ```
 
 ---
+
+## Step 0 (Optional): Restore Dependencies
+
+Resolve NuGet dependencies for every project in the solution, in place, using the authenticated session:
+
+```bash
+uip solution restore ./MySolution --output json
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `<solutionPath>` | Solution directory (containing a `.uipx`) or a `.uis` file (required) | -- |
+| `--login-validity <minutes>` | Minimum minutes left on the access token before the CLI refreshes it before restore starts | 10 |
+
+`restore` resolves dependencies on disk and does **not** produce a package. It needs an authenticated session (`uip login`) to reach private Orchestrator feeds. `pack` already restores internally, so this step is an **optimization, not a requirement** — its value is in CI, where running `login → restore → pack` fails fast on a missing or unreachable feed before the heavier pack step runs. Skip it for a plain local pack.
 
 ## Step 1: Pack the Solution
 
@@ -245,6 +261,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: npm install -g @uipath/cli
       - run: uip login --client-id "${{ secrets.UIPATH_CLIENT_ID }}" --client-secret "${{ secrets.UIPATH_CLIENT_SECRET }}" --tenant "${{ secrets.UIPATH_TENANT }}" --output json
+      - run: uip solution restore ./MySolution --output json   # optional: fail fast on a missing feed before pack
       - run: uip solution pack ./MySolution ./output --version "1.0.${{ github.run_number }}" --output json
       - run: uip solution publish ./output/MySolution.*.zip --output json
       - run: uip solution deploy run -n "MySolution-${{ github.run_number }}" --package-name "MySolution" --package-version "1.0.${{ github.run_number }}" --folder-name "MySolution" --config-file deploy-config.json --output json

--- a/skills/uipath-solution/references/solution-overview.md
+++ b/skills/uipath-solution/references/solution-overview.md
@@ -75,6 +75,7 @@ uip solution
   │                                        (pre-rename CLIs expose this as `new`; see SKILL.md "CLI Surface Probe")
   ├── delete <solution-id>                Delete a solution from Studio Web
   ├── upload <path>                       Upload solution to Studio Web
+  ├── restore <solution>                  Resolve NuGet deps in place before pack (needs login; no package produced)
   ├── pack <solution> <output>            Pack into a deployable .zip package
   ├── publish <package>                   Upload packed solution to UiPath
   ├── project


### PR DESCRIPTION
Adds the new `uip solution restore` verb to the uipath-solution skill and related command references. Restore resolves NuGet deps in place (incl. authenticated Orchestrator feeds) before pack; pack restores internally so it's an optimization, not a requirement (main use: CI login → restore → pack to fail fast on a missing feed).

Tracks the CLI change in UiPath/cli#2467 (`feat(solution-tool): add uip solution restore command`).

## Changes
- **uipath-solution SKILL.md** — add restore to the verb list, lifecycle workflow (optional step 3), Pack-and-Deploy nav row; note that restore is an optimization, not a requirement.
- **pack-and-deploy.md** — new "Step 0 (Optional): Restore Dependencies" with option table, restore node in the flow diagram, restore line in the CI/CD example.
- **solution-overview.md** — add restore to the command tree.
- **uipath-platform uip-commands.md** — add restore to the solution surface enumeration.
- **assets/uip-catalog-snapshot.json** — add the `solution restore` verb so /audit-verbs and the skill-verb checker recognize it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)