### PR TITLE
docs(commands): cross-cutting capability analysis (Context Grounding) + scorecard wiring

### DIFF
--- a/.claude/commands/generate-confluence-scorecard.md
+++ b/.claude/commands/generate-confluence-scorecard.md
@@ -16,7 +16,7 @@ Build a Coding-Agents Scorecard Confluence page from two data sources and the ca
 
 **Output:** A new Confluence page in space **CA** under the org scorecard, titled `Coding Agents Scorecard — Eval Scores & Test Pass/Fail (run <run-date>)`. Returns the page URL.
 
-> This command **creates** a page (never overwrites the org scorecard). The numbers it fills are **derived only** — Build/Operate/Diagnose eval scores and Tests Pass/Fail come from the run; Test Coverage comes from the coverage source. It leaves Product-Coverage / Exhaustive / FDE-Golden columns blank (not derivable here).
+> This command **creates** (or, on a re-run, **updates**) a child page under the org scorecard — never overwrites the org scorecard itself. It reproduces **both** of the org card's product tables (Product Level Scorecard + Product Capability Enumeration) and fills only **derived** cells: Build/Operate/Diagnose eval scores + Tests Pass/Fail + per-tier Skills Smoke / Integration+E2E come from the run; Test Coverage / Skill Coverage come from the coverage source. It leaves Product-Coverage, CLI-* columns, Exhaustive, FDE-Golden, and Peer-Sign-off blank (not derivable here; CLI values are carried verbatim from the org card).
 
 ---
 
@@ -30,7 +30,9 @@ Build a Coding-Agents Scorecard Confluence page from two data sources and the ca
 
 Confirm these still resolve with `getConfluenceSpaces`/`getConfluencePage` before publishing.
 
-**Stale parent.** The org scorecard is re-created weekly, so the hard-coded parent id (`90748321845`) may 404. If `getConfluencePage` on it fails: search the CA space for the most recent page whose title starts with `Coding Agents Scorecard` (`searchConfluenceUsingCql`: `space=CA AND title ~ "Coding Agents Scorecard*"`, newest first), use that as parent, and tell the user which parent you picked. If none found, create the page at the space root and flag it.
+**Stale parent — always resolve the NEWEST dated scorecard, don't just trust the hard-coded id.** The org scorecard is re-created weekly. The hard-coded id is only a hint; a *stale-but-still-live* card (e.g. last week's) resolves fine via `getConfluencePage` and will NOT 404, so a 404-only check silently publishes the new child under an outdated parent. Instead, **always** run `searchConfluenceUsingCql` (`space=CA AND title ~ "Coding Agents Scorecard*" AND type=page`, newest first) and pick the most recent dated card (parse the `MM/DD/YYYY` in the title; the newest date wins, not merely the newest `lastModified`). Use that as the parent and tell the user which one you picked and its date. Only fall back to the hard-coded id if the search returns nothing; if that also 404s, create at the space root and flag it. The `--parent <pageId>` override always wins over this search.
+
+Pick the matching org-card revision as your **column/row template too** (Phase 3): the scorecard's product list and the second "Product Capability Enumeration" table drift week to week (rows added/removed, e.g. Agent Hub). Read the parent you selected, not a cached layout.
 
 **Auth / access.** If the Atlassian tools are unavailable or the CA space is not accessible, stop and report — do not write the page anywhere else.
 
@@ -57,10 +59,20 @@ tr = [t for t in tr if t.get('variant_id') == TARGET]
 
 DIAG = {'diagnose','troubleshoot'}        # both merge into the Troubleshoot column
 STD  = ['build','operate','diagnose']     # the three scorecard eval columns
-def new(): return {'pass':0,'total':0,'scores':[],'mode':defaultdict(list)}
+TIERS = ['smoke','integration','e2e']     # for the org card's 2nd table (Skills Smoke vs Int+E2E)
+def new(): return {'pass':0,'total':0,'scores':[],'mode':defaultdict(list),
+                   'tier':{ti:[0,0] for ti in TIERS+['none']}}   # tier -> [pass,total]
+def tier_of(t):
+    tags = t.get('tags') or []
+    for ti in TIERS:
+        if ti in tags: return ti
+    return 'none'                          # untiered run tasks — counted in total, not in either tier
 def add(b, t, ws):                         # fold one task_result into a bucket
     b['total'] += 1
-    if t.get('status') == 'SUCCESS': b['pass'] += 1
+    ok = t.get('status') == 'SUCCESS'
+    if ok: b['pass'] += 1
+    ti = tier_of(t); b['tier'][ti][1] += 1
+    if ok: b['tier'][ti][0] += 1
     if ws is not None:
         b['scores'].append(ws)             # None scores excluded consistently
         for tag in (t.get('tags') or []):
@@ -90,11 +102,20 @@ def cells(b):                              # per-COLUMN fallback (not per-skill)
         out[col] = (f"{pct(xs)} (n={len(xs)})" if xs                 # real mode-tagged mean
                     else (f"{mean}*" if mean is not None else None)) # else overall-mean fallback (*)
     return mean, out
+def tcell(pd): return f"{pd[0]}/{pd[1]}" if pd[1] else "—"   # [pass,total] -> "p/t" or "—"
+def tiers(b):                              # Skills Smoke vs combined Integration+E2E (2nd table)
+    sm = b['tier']['smoke']
+    ie = [b['tier']['integration'][0]+b['tier']['e2e'][0],
+          b['tier']['integration'][1]+b['tier']['e2e'][1]]
+    nn = b['tier']['none']
+    return tcell(sm), tcell(ie), (f" (+{tcell(nn)} untiered)" if nn[1] else "")
 def line(name, b):
     mean, c = cells(b)
     extra = {k: f"{pct(v)} (n={len(v)})" for k,v in b['mode'].items() if k not in STD}
+    sm, ie, unt = tiers(b)
     print(f"{name:32} {b['pass']}/{b['total']:<4} mean={mean}  "
-          f"build={c['build']}  operate={c['operate']}  troubleshoot={c['diagnose']}"
+          f"build={c['build']}  operate={c['operate']}  troubleshoot={c['diagnose']}  "
+          f"SMOKE={sm} INT+E2E={ie}{unt}"
           + (f"  NON-SCORECARD-MODES={extra}" if extra else ''))
 
 print('=== PER SKILL ===')
@@ -111,7 +132,9 @@ if nonstd:   print('NON-SCORECARD mode values seen (surface, never drop/fold):',
 if unmapped: print('UNMAPPED task_ids (no tests/tasks/<skill>/ in path):', unmapped)
 ```
 
-Record per skill: **Tests Pass/Fail** (`pass/total`), **mean score %**, per-mode % for `build`/`operate`/`diagnose` (each with its `(n=…)` tagged-task count), plus any `NON-SCORECARD-MODES`. The script also prints the **`uipath-platform` sub-dir breakdown** (Phase 3 platform split), the **status-code counts** (ERROR vs FAILURE vs MAX_TURNS_EXHAUSTED — use for the failures note in Phase 4), the **overall mean weighted score**, and any `NON-SCORECARD` mode values / `UNMAPPED` task_ids. Headline numbers come from this script (`run_n`, `succ`, overall mean) — **recompute for the scored variant**, do not copy `d['tasks_run']`/`experiment.md` blindly (those count all variants).
+Record per skill: **Tests Pass/Fail** (`pass/total`), **mean score %**, per-mode % for `build`/`operate`/`diagnose` (each with its `(n=…)` tagged-task count), the **per-tier split** (`SMOKE=` and combined `INT+E2E=` pass/total, plus any `untiered` remainder — feeds the org card's 2nd table, see Phase 4 §3b), plus any `NON-SCORECARD-MODES`. The script also prints the **`uipath-platform` sub-dir breakdown** (Phase 3 platform split — note `tiers()` works on `psub` buckets too, so each platform sub-product has its own Smoke/Int+E2E split), the **status-code counts** (ERROR vs FAILURE vs MAX_TURNS_EXHAUSTED — use for the failures note in Phase 4), the **overall mean weighted score**, and any `NON-SCORECARD` mode values / `UNMAPPED` task_ids. Headline numbers come from this script (`run_n`, `succ`, overall mean) — **recompute for the scored variant**, do not copy `d['tasks_run']`/`experiment.md` blindly (those count all variants).
+
+> **Untiered tasks.** `tier_of()` returns `none` for run tasks carrying no `smoke`/`integration`/`e2e` tag. They count in the product total but in neither tier column, so Smoke + Int+E2E will not always sum to the total — surface the `(+p/t untiered)` remainder rather than silently dropping it (it also flags tag-hygiene gaps in the source repo).
 
 **Critical nuances:**
 1. **Mode tags are sparse — fall back PER COLUMN, not per skill.** Only mode-tagged tasks feed Build/Operate/Troubleshoot. For **each** of the three columns independently: if the skill has ≥1 task tagged for that mode, show that mode's mean; otherwise fill the cell with the skill's **overall mean** marked `*` (footnote: "overall mean — no `mode:<x>` tasks"). Consequences: a skill with zero mode tags shows `mean*` in all three (the original all-or-nothing case); a skill tagged only `build` shows its real Build % and `mean*` for Operate/Troubleshoot — never leave those two blank, which would falsely read as "no signal" when the skill ran many untagged tasks. The script's `cells()` does this; the `(n=…)` count rides on every non-fallback cell. Keep the `(n=…)` counts **only in the Source Data table** (not the Product scorecard, whose columns must match the org card exactly) so reviewers can see how thin a column is — e.g. a `build 0 (n=1)` is one bad task, not a systemic failure.
@@ -125,6 +148,8 @@ Record per skill: **Tests Pass/Fail** (`pass/total`), **mean score %**, per-mode
 ## Phase 2 — Parse the coverage source
 
 **Prefer the structured sidecar.** If `tests/reports/coverage.json` exists (written by `/test-coverage all`), read it instead of scraping markdown — `skills.<name>.overall_pct` is the Test Coverage value, `planned` flags planned skills, and you also get `top_untested`, per-dimension counts, and contributions for free. This is the stable contract; fall back to parsing `SUMMARY.md` only when the JSON is absent (older runs). If both exist but disagree, trust `coverage.json` and note the staleness (regenerate with `/test-coverage all`).
+
+**Cross-cutting capability entries → a product row.** A coverage.json entry with `"cross_cutting": true` (e.g. `uipath-context-grounding`) is the Test-Coverage / Skill-Coverage source for the **standalone product row it maps to** — currently `uipath-context-grounding` → **ECS / Context Grounding** (see Phase 3 mapping). For that row use the entry's `overall_pct` as **Skill Coverage / Test Coverage** (instead of `—`), and its `mode_coverage` / `mode_floor` for the per-mode read. Its tasks are tag-selected and **also counted under the host skills** (`host_skills`), so the row's Tests Pass/Fail are **cross-cutting, non-additive** (footnote ⁷) — never add them into the run totals or the host-skill rows. If no cross-cutting entry exists yet (older coverage.json), the ECS row stays `—` and you re-select the `tag` from the run for its pass/fail (Phase 1).
 
 Read the coverage source (default `tests/reports/SUMMARY.md`). For each skill take the **Overall** % from the Overview table — this is the **Test Coverage vs Skills** value (coverage of taught capabilities by tests; **not** a pass-rate). Planned-but-missing skills are `0% (planned)`.
 
@@ -166,7 +191,7 @@ Do not edit this embedded table on the fly; report drift so a human updates the 
 | API Workflow | `uipath-api-workflow` | +api-workflow-tool tasks in agents |
 | Coded Apps | `uipath-coded-apps` | skill exists, 0 tests |
 | Orchestrator | `uipath-platform/orchestrator` + `uipath-platform/resources` | |
-| ECS / Context Grounding | none dedicated | exercised in agents (context_index/deeprag) |
+| ECS / Context Grounding | `uipath-context-grounding` (cross-cutting coverage entry) | no dedicated dir; tag `context-grounding` selects tasks in agents (deeprag/batch_transform) + flow. Skill Coverage from the `cross_cutting` coverage.json entry (`overall_pct`); pass/fail non-additive ⁷ |
 | Test Manager | `uipath-test` | |
 | Solutions | `uipath-solution` | +~many agent tasks publish via `uip solution` (cross-cutting only) |
 | Governance | `uipath-governance` | |
@@ -198,7 +223,13 @@ Produce these sections, in this order:
 
 1. **Source + caveat panels** — `panel-info` with run id/path, variant scored, tasks run/passed/success-rate/overall-mean score, generated date. `panel-warning` listing column semantics: Tests Pass/Fail = run outcomes; Test Coverage = SUMMARY "Overall"; Eval `*` = **per-column** overall-mean fallback (no `mode:<x>` tasks for that column); non-scorecard mode tags (e.g. `inspect`, `edit-validate`) excluded from the three columns; platform rows (³) carry per-sub-product eval/pass-fail but the platform-wide coverage; run is a snapshot whose task counts may differ from the current repo; Product-Coverage/Exhaustive/FDE blank.
 2. **Gap-to-target headline** (`panel-note`, near the top) — state run success-rate vs the `--target` bar (default 95%): e.g. `78.8% vs 95% target → 16.2pp gap; ≈ N more passing tasks needed` where `N = ceil(target/100 × run_n) − succ`. List the products **below bar** (pass-rate < target), worst first, so the page answers the org's own stated question. If success-rate ≥ target, say so plainly.
-3. **Product Level Scorecard** — reproduce the org scorecard's product table **columns exactly** (Product/Capability, Build/Operate/Troubleshoot Product Coverage, Test Coverage vs Skills, Build/Operate/Diagnose Eval %, Tests Pass/Fail, Exhaustive, FDE Golden). Fill only: Test Coverage, the three Eval %, Tests Pass/Fail. Leave the rest blank. **Do not put `(n=…)` here** — these columns must match the org card. Footnotes: platform sub-product split + platform-wide coverage (³), rpa-shared (²), per-column overall-mean fallback (*), non-scorecard mode tags (†).
+3. **Reproduce BOTH org-card tables — the scorecard has TWO product tables, fill the derivable cells in each.** The org card carries a *Product Level Scorecard* table AND a second *Product Capability Enumeration* table; reproduce both with their columns and rows **exactly as they appear on the parent revision you selected** (Stale-parent step — row sets drift, e.g. Agent Hub was added). Fill only what this run derives; leave everything else blank or carry the org card's value verbatim:
+
+   **3a. Product Level Scorecard** (first table) — columns: Product/Capability, Build/Operate/Troubleshoot Product Coverage, Test Coverage vs Skills, Build/Operate/Diagnose Eval %, Tests Pass/Fail, Exhaustive, FDE Golden. **Fill:** Test Coverage, the three Eval %, Tests Pass/Fail. **Leave blank:** Product Coverage ×3, Exhaustive, FDE Golden. **Do not put `(n=…)` here** — these columns must match the org card.
+
+   **3b. Product Capability Enumeration** (second table) — columns: Product/Capability, Product Capability Enumeration, CLI Coverage, **Skill Coverage**, CLI Smoke Tests, CLI Int and E2E Tests, CLI Test Coverage%, **Skills Smoke Tests (No.)**, **Skills Integration and E2E Tests (No.)**, Exhaustive Scenarios, Test Peer Sign-off. **Fill (the three Skills columns are the whole point of this table):** `Skill Coverage` = coverage.json Overall % per product (same value as 3a's Test Coverage, color-banded); `Skills Smoke Tests` and `Skills Integration and E2E Tests` = the per-tier `pass/total` from Phase 1's `tiers()` (combine integration+e2e; append the `(+p/t untiered)` remainder where present). **CLI columns are NOT derivable from a skills run** — carry the org card's existing CLI values verbatim (note: the org card's "CLI Smoke Tests" column is populated with coverage *percentages*, not pass/total — copy as-is, do not reinterpret) and leave CLI Coverage / CLI Int+E2E / CLI Test Coverage% / Product Capability Enumeration / Exhaustive Scenarios / Test Peer Sign-off blank. Color the Skills cells with the pass-rate bands.
+
+   Footnotes (both tables): platform sub-product split + platform-wide coverage (³), rpa-shared / under-RPA (²), per-column overall-mean fallback (*), non-scorecard mode tags (†), duplicate org-card row (⁴), skip-thinned denominator (⁵), planned/not-yet-built skill — e.g. Agent Hub (⁶), cross-cutting capability — tag-selected, already counted in host skills, non-additive — e.g. ECS / Context Grounding from `uipath-context-grounding` (⁷).
 4. **Coverage × Eval risk reads** — the analytical payoff of merging the two sources. For each product with both a coverage % and a pass-rate, classify into a quadrant (thresholds: coverage ≥ 50% = "tested", pass-rate ≥ `--target` = "passing"):
 
    | Coverage | Pass-rate | Quadrant | Read |
@@ -218,12 +249,13 @@ Keep prose terse (repo token-optimization rules). Use `—` for not-applicable, 
 
 ## Phase 5 — Publish
 
-1. Verify target with `getConfluenceSpaces keys=CA` (spaceId) and `getConfluencePage` on the parent (apply the Stale-parent fallback above if it 404s).
+1. Verify target with `getConfluenceSpaces keys=CA` (spaceId) and resolve the parent via the **Stale-parent** step above (always pick the newest dated card, not just on 404).
 2. **Duplicate-title check.** A page titled `… (run <run-date>)` may already exist from a prior run of this command (re-runs are common). Search CA for that exact title first. If found, ask the user: **update** the existing page (`updateConfluencePage` — safe, it's our child page, not the org scorecard), **create a new one** with a ` (v2)`/timestamp suffix, or **abort**. Default to update. Never blindly create a second page with an identical title.
 3. `createConfluencePage` (or `updateConfluencePage` per step 2) with `cloudId`, `spaceId`, `parentId`, `contentFormat: html`, `status: current` (or `draft` if `--draft`), title `Coding Agents Scorecard — Eval Scores & Test Pass/Fail (run <run-date>)`.
-4. **HTML rejection.** `createConfluencePage` rejects invalid ADF nesting (block elements inside inline, headings in table cells, etc.) with a descriptive error. On rejection, fix the offending markup and retry — do not fall back to markdown (it loses panels/footnotes). Common cause: stray block tags inside `<td>`.
-5. **Round-trip verification.** A successful create response does NOT guarantee the body rendered intact — HTML→ADF conversion can silently drop or merge cells/panels. Re-fetch the page (`getConfluencePage`, `contentFormat: html`) and assert: the Product Level Scorecard table has the expected **row count** (one header + one per org product row, e.g. 29 data rows) and **11 columns**; the Source Data and Product→Test tables are present with their expected row counts; and the panels survived (info/note/warning macros present). If a table was mangled, fix the markup and `updateConfluencePage` — do not leave a corrupted page live. Report the assertion result.
-6. Return the `webui` URL. Summarize what was filled, what was left blank, the gap-to-target and risk-read findings, and any drift/mismatch/skip notes surfaced in Phases 1–3.
+   - **Body is large (~30–45 KB). `createConfluencePage` echoes the full body back in its response, which can exceed the tool-result token cap.** That is not a failure — the page is still created. Recover the `id`/`webui` by grepping the persisted tool-result file for `"id"`/`"webui"` rather than re-creating. On any **`updateConfluencePage`**, always pass **`includeBody: false`** so the response stays small.
+4. **HTML rejection.** `createConfluencePage` rejects invalid ADF nesting (block elements inside inline, headings in table cells, etc.) with a descriptive error. On rejection, fix the offending markup and retry — do not fall back to markdown (it loses panels/footnotes). Common cause: stray block tags inside `<td>`. Build the body programmatically (a small Python script that emits the HTML to a file, then read it) rather than hand-writing 29×11 cells — far fewer nesting/escaping mistakes, and trivial to regenerate when a row set changes.
+5. **Round-trip verification.** A successful create/update response does NOT guarantee the body rendered intact — HTML→ADF conversion can silently drop or merge cells/panels. Re-fetch the page (`getConfluencePage`, `contentFormat: html`) and assert: the **Product Level Scorecard** table has the expected **row count** (one per org product row) and **11 columns**; the **Product Capability Enumeration** table (Phase 4 §3b) is present with its 11 columns and the same product rows, and its Skills columns are populated; the Source Data and Product→Test tables are present with their expected row counts; and the panels survived (info/note/warning macros present). If a table was mangled, fix the markup and `updateConfluencePage` (`includeBody: false`) — do not leave a corrupted page live. Report the assertion result.
+6. Return the `webui` URL. Summarize what was filled, what was left blank, the gap-to-target and risk-read findings, the parent you selected (with its date), and any drift/mismatch/skip notes surfaced in Phases 1–3.
 
 ---
 
@@ -283,15 +315,21 @@ Exclude the generic `uip … --output json` sentinel pattern (unattributable). N
 | Skipped tasks (`skip: true`) | Denominator = run tasks; authored = run + skipped (this snapshot), not current dir count; note authored vs run | 1 |
 | Run task counts differ from current repo | Expected (run is a snapshot); note divergence, don't reconcile to dir counts | 1 |
 | `tests/reports/coverage.json` present | Prefer it over scraping `SUMMARY.md` (stable contract; gives top_untested + contributions too) | 2 |
+| `cross_cutting` coverage.json entry (e.g. `uipath-context-grounding`) | Maps to its standalone product row (ECS); Skill Coverage = its `overall_pct`; pass/fail non-additive (⁷, already in host skills). Older coverage.json without it → ECS stays `—`, re-select by `tag` | 2,3 |
 | `SUMMARY.md` has multiple `\| uipath- \|` tables | Only when no `coverage.json`: parse the `## Overview` table only (header has `Overall`); naive parse double-counts | 2 |
 | Coverage cell has `~` / `(planned)` decoration | Strip bold only; keep `~` and `(planned)` verbatim | 2 |
 | `tests/reports/` missing | Run `/test-coverage all` first (it creates the folder) | 2 |
 | Coverage stale vs run date | Warn; offer regenerate | 2 |
 | Skill in run, absent from coverage | Coverage `—` (not `0%`); warn | 2 |
 | Skill in coverage, absent from run | Eval/pass `—`/`not in run` | 2 |
-| Org scorecard adds/removes a product row | Reconcile vs embedded map; emit/flag, don't drop | 3 |
+| Org scorecard adds/removes a product row (e.g. Agent Hub) | Reconcile vs the parent revision you selected; emit/flag, don't drop. Planned skill with no folder → Skill Coverage `0% (planned)`, Skills tiers `not in run` | 3 |
 | New skill folder maps to no product row | Surface in Source Data; tell user | 3 |
-| `uipath-platform` sub-product eval/pass-fail | Split from the run's `psub` breakdown by default (orchestrator+resources summed); coverage stays platform-wide unless `uipath-platform.md` splits it | 3 |
+| `uipath-platform` sub-product eval/pass-fail | Split from the run's `psub` breakdown by default (orchestrator+resources summed); coverage stays platform-wide unless `uipath-platform.md` splits it. `tiers()` also runs per sub-dir for the 2nd table | 3 |
+| Org card has TWO product tables | Reproduce both (Phase 4 §3a + §3b); the 2nd ("Product Capability Enumeration") is where Skill Coverage / Skills Smoke / Skills Int+E2E go | 3,4 |
+| 2nd table's CLI columns | Not derivable from a skills run — carry org-card values verbatim (its "CLI Smoke Tests" column holds coverage %, not pass/total); leave CLI Coverage/Int+E2E/Test-Cov% blank | 4 |
+| Untiered run tasks (no smoke/integration/e2e tag) | Counted in product total, in neither tier column; surface `(+p/t untiered)` remainder, don't drop | 1,4 |
+| Stale-but-live parent (resolves, doesn't 404) | Don't trust the hard-coded id — always search newest dated `Coding Agents Scorecard*` and prefer it | 5 |
+| `createConfluencePage` response too large (body echoed) | Page IS created; grep persisted tool-result for `id`/`webui`. Use `includeBody:false` on updates | 5 |
 | Parent page 404 (weekly rotation) | Fallback: newest `Coding Agents Scorecard*` in CA | 5 |
 | Page with same title already exists | Ask: update (default) / new-with-suffix / abort | 5 |
 | `createConfluencePage` rejects HTML | Fix ADF nesting and retry; don't downgrade to markdown | 5 |
@@ -312,3 +350,6 @@ Exclude the generic `uip … --output json` sentinel pattern (unattributable). N
 - **Don't double-count variants.** Score exactly one variant; an A/B run has N task_results per task.
 - **Don't create duplicate pages.** Same-title page exists → update it (default) or suffix the new one; never leave two identical-title pages.
 - **Don't force unmapped skills into a product row.** Aux/connector skills with no product row belong only in the Source Data table.
+- **Don't reproduce only the first product table.** The org card has two (Product Level Scorecard + Product Capability Enumeration); the second is where Skill Coverage / Skills Smoke / Skills Int+E2E live — omitting it drops the columns the platform team reads for the skills side.
+- **Don't reinterpret the org card's CLI columns.** They're not yours to compute from a skills run — carry them verbatim (its "CLI Smoke Tests" column holds coverage %, not pass/total) and leave the rest of the CLI columns blank.
+- **Don't trust the hard-coded parent id when a newer dated card exists.** A stale-but-live parent resolves without a 404; always search for and prefer the newest dated `Coding Agents Scorecard*`.

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -15,13 +15,23 @@ Analyze what a skill teaches vs what its tests verify. Produce a gap analysis wi
 ## Phase 1 — Discovery
 
 1. Resolve target skill(s):
-   - Single name → `skills/<name>/`. If `skills/<name>/` does NOT exist but `<name>` is in the **Planned Skills Registry** below, treat it as a planned skill (use the planned-skill template in Phase 5).
-   - Empty/all → union of (a) glob `skills/uipath-*/` and (b) every entry in the **Planned Skills Registry** below whose folder does not yet exist. Planned-but-missing skills MUST appear in the per-skill report set and the summary roll-up so they remain visible at 0% until they ship.
-2. For each existing skill, check for `tests/tasks/<skill-name>/`.
-3. Find `*.yaml` test files recursively under each test directory. Exclude `_shared/`.
+   - Single name → `skills/<name>/`. If `skills/<name>/` does NOT exist but `<name>` is in the **Planned Skills Registry** below, treat it as a planned skill (use the planned-skill template in Phase 5). If `<name>` is in the **Cross-Cutting Capability Registry** below, treat it as a cross-cutting capability (see that section).
+   - Empty/all → union of (a) glob `skills/uipath-*/`, (b) every entry in the **Planned Skills Registry** whose folder does not yet exist, and (c) every entry in the **Cross-Cutting Capability Registry**. Planned-but-missing skills MUST appear in the per-skill report set and roll-up at 0% until they ship; cross-cutting capabilities MUST appear as their own report + roll-up row (flagged cross-cutting, see §4f and §5).
+2. For a normal skill, check for `tests/tasks/<skill-name>/`. For a cross-cutting capability, there is **no dedicated dir** — discover its tests by **tag** (step 3).
+3. Find `*.yaml` test files. Normal skill: recursively under `tests/tasks/<skill-name>/`, exclude `_shared/`. Cross-cutting capability: `grep -rl '<tag>' tests/tasks --include='*.yaml' | grep -v _shared` across the **whole** `tests/tasks/` tree (its tasks live inside other skills' dirs).
 4. Find `check_*.py` scripts recursively. Exclude `_shared/test_*.py` (unit tests for shared helpers).
 
 For multi-skill runs, use parallel Explore agents — one per skill — to read skill + test content simultaneously. Skip Phase 2 entirely for planned-but-missing skills (no SKILL.md to read).
+
+### Cross-Cutting Capability Registry
+
+Some capabilities are taught and tested across **multiple** skills with no folder of their own, yet are first-class products on the org scorecard (e.g. ECS / Context Grounding). Analyze each as its own unit: a dedicated `references/` doc is the capability inventory source, and its tests are selected by **tag** (they physically live inside other skills' `tests/tasks/` dirs). Because those tasks are **also** counted under their host skills, a cross-cutting unit is an **additive overlay, not a partition** — flag it and **exclude it from the repo-wide Totals sums** (Phase 5) so tasks/components are not double-counted.
+
+| Capability (report key) | Tag | Inventory source(s) | Host skills | Scorecard row |
+|---|---|---|---|---|
+| `uipath-context-grounding` | `context-grounding` | `skills/uipath-agents/references/context-grounding-patterns.md` (decision logic) + `skills/uipath-agents/references/coded/capabilities/context-grounding.md` + `.../lowcode/capabilities/context/context.md` + the BatchTransform/DeepRAG `planning.md` files those link to | `uipath-agents`, `uipath-maestro-flow` | ECS (uip context-grounding) |
+
+Add a row when a capability (a) is documented in a shared `references/` doc, (b) is exercised by tasks tagged with a single stable tag that span ≥2 skill dirs, and (c) maps to a standalone scorecard product row. Remove it only if the capability gets its own `skills/uipath-<name>/` folder (then it becomes a normal skill).
 
 ### Planned Skills Registry
 
@@ -56,8 +66,9 @@ Components are the specific, testable units the skill teaches. What counts as a 
 | Solution design + planning (`uipath-planner`) | PDD → SDD design (Phase D: PDD analysis, architecture review, SDD generation, product/scope selection, SDD templates) plus multi-skill task derivation (Lane A/B). Found in the Critical Rules, Entry Guard, Phase D, lane summaries, and Reference Navigation sections. |
 | Agent development (`uipath-agents`) | Lifecycle stages (Auth, Setup, Build, Bindings, Run, Deploy), framework types (LangGraph, LlamaIndex, etc.). Found in "Lifecycle Stages" section. |
 | Coded apps (`uipath-coded-apps`) | Pipeline stages (Push, Pull, Pack, Publish, Deploy), app configuration concepts. Found in lifecycle and "Ship It" sections. |
+| Cross-cutting capability (`uipath-context-grounding`) | The **modes × surfaces** matrix from the inventory doc: BatchTransform (coded, low-code), DeepRAG (coded, low-code), Index search (coded, low-code) — 6 components from `context-grounding-patterns.md` §The Three Modes + §Surface Selection. Found in the registered inventory source(s), NOT a SKILL.md. |
 
-Group components by category. For skills with `references/plugins/` subdirectories (like `uipath-maestro-flow`), each plugin directory is one component — use the planning.md to understand what it covers.
+Group components by category. For skills with `references/plugins/` subdirectories (like `uipath-maestro-flow`), each plugin directory is one component — use the planning.md to understand what it covers. **Cross-cutting capability:** there is no SKILL.md — read the registered inventory source doc(s) instead. Components = the capability's modes/surfaces matrix; critical rules = its invariants (e.g. `context-grounding-patterns.md` §Cross-Surface Invariants is 6 numbered rules; the file-type routing rule — CSV→BatchTransform, PDF/TXT→DeepRAG — is a 7th). Workflow steps usually N/A (Steps weight redistributes to Components/Rules).
 
 ### 2b. Identify workflow steps
 
@@ -99,6 +110,61 @@ Determine what environment each skill requires to be testable. Use the same phra
 
 Tag each skill with its dependencies. This informs which tests are feasible to write and run in CI.
 
+### 2f. Classify each capability by mode (Coding Agents Scorecard)
+
+Label every component, workflow step, and critical rule with the mode(s) it serves. Multi-label allowed — a `validate` step is both `build` and `diagnose`.
+
+- **build** — creating, designing, editing, deploying (init, scaffold, pack, edit, validate-during-build, deploy)
+- **operate** — running, triggering, managing live instances/connectors/integrations (run, trigger, invoke, manage connections)
+- **diagnose** — investigating faults, inspecting traces, debugging (get-errors, logs, trace inspect, debug)
+
+These labels define each mode's denominator in Phase 4f-mode. Most build-heavy skills come out build-dominant — expected. A skill that clearly teaches an `operate` or `diagnose` surface but has zero capabilities labeled that mode is itself a finding (surface it in the gaps).
+
+**Labeling subtlety — `validate` and `list`/`get` are mode-dependent.** A capability's mode follows the *intent the skill teaches*, not the verb:
+- `validate` / `build` run on a **fresh artifact during authoring** → `build`. The same command run on a **pre-broken artifact to surface and fix errors** (the autonomous validate→read-errors→fix loop) → also `diagnose`. Tag both; a build-only test does NOT cover the diagnose loop.
+- `list` / `get` / `status` as a **happy-path step** → the mode of the step it serves. The same read used to **triage a fault** ("list jobs `--state Faulted`", "get incidents before deciding") → `diagnose`.
+- `run` / `invoke` / `deploy` of a **deployed, live artifact** → `operate`, even when the build skill owns the command.
+
+#### 2f-i. Operate & diagnose surface checklist (apply to EVERY skill)
+
+Build coverage is almost always the strong mode; `operate` and `diagnose` are where real gaps hide and where a skill's SKILL.md mentions a surface that no test touches. The archetypes below recur across ≥2 skills. For each skill, walk both lists: if the SKILL.md / references teach the surface (even in a reference, not just the main body), it is a labeled capability for that mode — and if no test exercises it, it is a `None` that feeds the Phase 4f-mode denominator and the Phase 4i mode gap. Cite the specific archetype in the gap title (e.g. "Missing `operate` coverage in uipath-rpa — run/invoke + deploy-activate untested").
+
+**Operate archetypes — does any test exercise…**
+
+| # | Archetype | Surface pattern (skill-agnostic) |
+|---|---|---|
+| O1 | **Run / invoke a deployed artifact** | start a job/process/agent/flow/test-case by key → returns execution id (`jobs start`, `tm testcases run`, `flow debug`, `api-workflow run`, `codedagent deploy`+invoke) |
+| O2 | **Deploy + activate as separate steps** | `deploy run` then stand-alone `deploy activate` / `deploy status` poll (esp. after `--skip-activate`); `deploy config link/unlink`; `deploy uninstall` |
+| O3 | **File sync push / pull** | `codedagent`/`codedapp push` + `pull` roundtrip; `solution upload` to Studio Web / workspace |
+| O4 | **Instance lifecycle** | pause / resume / cancel / retry a *running* instance (`maestro flow|case instance …`, BPMN job lifecycle beyond start+stop, `jobs stop`+retry) |
+| O5 | **Queue operations** | add items, requeue / review failed items, set deadline / SLA on a live queue |
+| O6 | **Trigger create + fire (non-cron)** | create a **queue** or **API** trigger and verify it fires — not just time-based cron |
+| O7 | **Connection create + test** | create an IS OAuth connection (`is connections create <key>`) + `ping`/test on a live tenant |
+| O8 | **Enable / disable a live resource** | toggle tenant service, webhook, IP-restriction enforcement, or BYO-LLM config on/off and verify state change |
+| O9 | **Publish / register a live version** | publish IXP model version, BYO-LLM config, or `packages upload` so it becomes the live version |
+| O10 | **License / seat assignment** | assign user/group license bundles, set tenant allocation, read consumables |
+| O11 | **Eval run + poll + fetch results** | start a Studio Web eval against a deployed flow/agent, poll to done, fetch scored results |
+
+**Diagnose archetypes — does any test exercise…**
+
+| # | Archetype | Surface pattern (skill-agnostic) |
+|---|---|---|
+| D1 | **Validate → read errors → fix loop on a PRE-BROKEN artifact** | feed a deliberately broken file, assert the agent reads structured errors and fixes the root cause, then re-validates clean (NOT happy-path validate) |
+| D2 | **Incident / fault read on a failed runtime instance** | `instance incidents` / `instance variables` / job faults after a failed run, without rerunning |
+| D3 | **Job / execution log retrieval** | `jobs logs <id> --output json`, `tm executions get` / step-log drill-down on a faulted run |
+| D4 | **Trace / span inspection** | `traces spans get <trace-id>` as a standalone diagnostic (LLM/tool calls, token counts), not a build/operate side effect |
+| D5 | **Audit query filtered for triage** | `audit … events --status Failure` / by user / by time window to answer "who did X / what changed" |
+| D6 | **Effective-access / authorization check** | folder-scoped `authorization check-access <user>`, `deployed-policy get --user-id` — "why can't user X do Y" |
+| D7 | **Connectivity / health check** | BYO-LLM `--force-refresh` / reprobe, `is connections list --all-folders`, dead-connection audit |
+| D8 | **Failure-mode / error-code classification** | match an error code / exception (e.g. `MST-9107`, `CS0103`, exit codes) to a known catalog and recommend the fix branch |
+| D9 | **Model / metric quality inspection** | `get-metrics` + `list-models`, per-field F1 / precision / recall to explain bad extraction |
+| D10 | **Schema / contract-drift detection** | out-of-sync `bindings_v2.json`, `entry-points` drift, camelCase/naming mismatch surfaced by validate |
+| D11 | **Read-only discovery for triage** | `login status`, `list --state Faulted`, `get` before mutating — inspecting state to scope a fault |
+
+**Two recurring meta-findings to always check (emit as gaps when present):**
+- **Tag-drift on operate/diagnose:** a skill's only operate/diagnose tests are tagged `mode:build` (or carry no `mode:*` at all) — fires the Phase 4f-mode tag cross-check. Common on catalog skills (`uipath-tasks`, `uipath-data-fabric`, `uipath-ixp`) where every task inherited `mode:build`.
+- **Surface-without-test:** SKILL.md/references document an operate/diagnose command (e.g. `maestro case instance`, `rpa debug start`, `solution deploy activate`) that has zero covering tests — the most common source of `operate`/`diagnose` `None`s.
+
 ## Phase 3 — Extract test coverage
 
 ### 3a. Parse each test YAML
@@ -113,7 +179,7 @@ tags            — array carrying values from the Tag Taxonomy dimensions
                   [skill, tier, mode:X, shape:X, node:..., resource, connector, windows, feature:...]
                     skill      — uipath-<name>                                (required, flat)
                     tier       — smoke | integration | e2e                    (required, flat)
-                    mode       — mode:{build|operate|troubleshoot}                (required)
+                    mode       — mode:{build|operate|diagnose}                  (required; see Phase 2f for mode definitions)
                     shape      — shape:{single-node|multi-node}              (flow-building tests)
                     node       — node:{decision|switch|subflow|terminate|loop|transform|hitl} (0..n)
                     resource   — flat boolean marker (present iff task uses a resource node) (0..1)
@@ -225,12 +291,34 @@ Weights reflect what tests actually catch:
 | Command-catalog skills (e.g. `uipath-platform`, `uipath-servo`, `uipath-test`, `uipath-feedback`, `uipath-data-fabric`) | Rules, Path, Steps (often) | Comp 100% (or Comp 65% / Steps 35% if the skill has explicit workflow steps) |
 | Planning skills (e.g. `uipath-planner`) | Components (often), Rules (sometimes), Path | Steps 70% / Rules 30% (or Steps 100% if no rules section) |
 | Agent-orchestration skills (e.g. `uipath-troubleshoot`) | Path, sometimes Components | Components 55% (sub-agents + phases) / Steps 30% / Rules 15% |
+| Cross-cutting capability (e.g. `uipath-context-grounding`) | Path, Steps (usually) | Comp 70% (modes×surfaces) / Rules 30% (invariants) |
 
 Formula: `overall = sum(applicable_weight_i * dimension_pct_i) / sum(applicable_weight_i)`
 
 **Per-dimension contribution.** Define `renorm_weight_i = applicable_weight_i / sum(applicable_weight_i)` (so the renormalized weights sum to 1) and `contribution_i = renorm_weight_i * dimension_pct_i`. By construction `sum(contribution_i) = overall`. Render this decomposition in each per-skill report's **Score Contribution** table (see the with-tests template) so the headline number is traceable to the dimensions that earned or forfeited it. Also report `lost_i = renorm_weight_i*100 − contribution_i` — the largest `lost_i` is the highest-leverage dimension to test next, and should align with that skill's top-ranked gaps.
 
 For skills with **no tests**: overall = 0% (skip the Score Contribution table — every dimension contributes 0).
+
+### 4f-mode. Per-mode coverage (scored slices, reported beside Overall)
+
+Report a coverage score for **each** Coding Agents Scorecard mode (`build`, `operate`, `diagnose`) alongside the Overall. Mode is orthogonal to the scored dimensions — do NOT add it as a weighted dimension (that double-counts against Workflow steps; see Phase 4h). Instead **re-slice the same capability inventory by the Phase 2f mode labels** and re-run the Phase 4f weighted formula per slice:
+
+1. For mode `m`, take only the components / workflow steps / critical rules labeled `m`.
+2. Compute each dimension's direct-only coverage within that slice; renormalize the applicable weights over the dimensions present in the slice (same N/A handling as Phase 4f).
+3. `mode_pct(m)` = that weighted number.
+
+Cases:
+- Mode has labeled capabilities, zero covering tests → **0%**.
+- Mode has no labeled capabilities in this skill → **N/A** (e.g. a pure-build catalog skill with no diagnose surface). N/A modes do not fire the Phase 4i mode gap.
+- Overall (Phase 4f) is unchanged — it is **NOT** the mean of the three modes (slices differ in size). Report both; they will not match, by design.
+
+**Tag cross-check.** A capability counts toward `mode_pct(m)` from its Phase 2f label, regardless of which test covers it. But if a mode-`m` capability is covered *only* by tests not tagged `mode:m`, the test's mode tag is wrong — emit a consistency flag (name the test). This keeps the coverage slices aligned with the `mode:*` tags that `/generate-confluence-scorecard` slices eval by, so per-mode coverage and per-mode eval pair correctly.
+
+**Mode-balanced & mode-floor headlines (report beside the capability Overall).** The capability Overall is build-dominated by construction — the inventory is mostly build capabilities, so a skill can read "healthy" (e.g. 79%) while `operate`/`diagnose` sit near 0%, because those modes are a small slice of each dimension's denominator. To make that blindness legible without changing the Overall, compute and report two derived figures from the per-mode slices:
+- **Mode-balanced** = arithmetic mean of `mode_pct(m)` over the modes that are **not N/A** (i.e. modes the skill actually has a surface for). A skill with `diagnose` N/A averages only `build` + `operate`.
+- **Mode-floor** = `min` of `mode_pct(m)` over the not-N/A modes — the worst-covered real mode. This is the single number that exposes a 0% mode.
+
+Report both beside the Overall in the per-skill Summary, the SUMMARY Overview, and `coverage.json` (`mode_balanced`, `mode_floor`). They are **descriptive, not a new weighted score** — the Overall is still the Phase 4f capability number. Rule of thumb for readers: a high Overall with a low Mode-floor = build-solid but mode-blind; that gap is the action item, and the Phase 4i mode gap already names which archetype to test. Skills with no tests → `0`/`0`; planned skills → `—`.
 
 ### 4g. Test-density troubleshooting (sidecar, not scored)
 
@@ -245,7 +333,7 @@ Report these alongside the Summary table to flag structural fragility that a hig
 
 For each skill that has at least one test, compute which values from the Tag Taxonomy are exercised. Report the variable dimensions (the `skill` dimension is trivially covered and `tier` is already reported in the Summary table):
 
-- **Mode** — tick each of `mode:build`, `mode:operate`, `mode:diagnose` if any test carries that tag. All three are expected eventually for most skills; missing modes surface as gaps.
+- **Mode** — now a **scored slice** (Phase 4f-mode), not a sidecar tick. Report it in the Per-Mode Coverage table, not here.
 - **Shape** — tick each of `shape:single-node`, `shape:multi-node` (applies to flow-building skills only).
 - **Node** — list values present under `node:*` for skills where that axis applies.
 - **Resource / Connector / Windows** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`, `windows`) for skills where they apply.
@@ -260,7 +348,8 @@ Run these checks and emit findings into the "Coverage Gaps — Priority Ranked" 
 | Signal | Condition | Priority | Gap title template |
 |---|---|---|---|
 | **Edit-scenario gap** | The skill teaches an edit workflow (it documents modifying an existing artifact — common for `uipath-maestro-flow`, `uipath-rpa`, `uipath-agents`) but no test exercises that scenario (no task under `tests/tasks/<skill>/edit/` and no `initial_prompt` describes modifying an existing artifact). | **High** | "Editing existing `<artifact>`" |
-| **Mode gap** | The skill has tests but does not exercise all three modes (`mode:build`, `mode:operate`, `mode:diagnose`) where they're plausibly applicable. Catalog skills may legitimately stop at `mode:operate`; flag for the writer to confirm. | **Medium** | "Missing `<mode>` coverage" |
+| **Mode gap** | A mode with a non-trivial labeled capability surface (Phase 2f) is below threshold coverage (Phase 4f-mode). N/A modes (no surface) do not fire — a catalog skill with no `diagnose` surface is not penalized. **Name the specific Phase 2f-i archetype(s) untested** (e.g. O4 instance lifecycle, D1 validate→fix loop). | **High** if a mode with a real surface sits at 0%; **Medium** otherwise | "Missing `<mode>` coverage — `<archetype>` untested" |
+| **Mode tag-drift** | A skill's operate/diagnose capability is covered *only* by tests tagged `mode:build` or carrying no `mode:*` (Phase 4f-mode cross-check / Phase 2f-i meta-finding). | **Medium** | "Re-tag `<test>` as `mode:<operate\|diagnose>`" |
 | **Negative-test gap** | The skill's SKILL.md lists ≥3 anti-patterns and zero tests assert on any of them. | **High** | "Negative tests for anti-patterns" |
 | **Tier gap** | The skill has tests but is missing a tier (smoke-only, integration-only, or e2e-only). | **High** (if smoke or e2e is missing — those are the minimum bar), **Medium** (integration missing) | "Missing `<tier>` tier" |
 
@@ -290,6 +379,8 @@ Create `tests/reports/` if needed.
       "paths": {"covered": 3, "total": 3, "pct": 100},
       "weights": {"components": 45, "workflow": 25, "rules": 15, "paths": 15},
       "contribution": {"components": 12.6, "workflow": 16.8, "rules": 3.2, "paths": 15.0},
+      "mode_coverage": {"build": {"pct": 31, "covered": 8, "total": 26}, "operate": {"pct": 0, "covered": 0, "total": 4}, "diagnose": null},
+      "mode_balanced": 16, "mode_floor": 0,
       "top_untested": ["triggers 0/3", "IS connectors 0/2", "run/publish 2/8"],
       "infra": "Requires Windows + Studio"
     },
@@ -298,7 +389,27 @@ Create `tests/reports/` if needed.
 }
 ```
 
-Use `null` for N/A dimensions (e.g. `"rules": null` for a catalog skill, `"paths": null` for single-path). The `contribution` values must match the per-skill Score Contribution tables and sum to `overall_pct`. Single-skill runs may write/refresh just that skill's entry; do not blank the others.
+Use `null` for N/A dimensions (e.g. `"rules": null` for a catalog skill, `"paths": null` for single-path). The `contribution` values must match the per-skill Score Contribution tables and sum to `overall_pct`. `mode_coverage` carries one object per mode (`{pct, covered, total}`) or `null` for a mode with no capability surface (Phase 4f-mode) — this is the per-mode coverage `/generate-confluence-scorecard` pairs with its per-mode eval. `mode_balanced` (mean of non-N/A mode pcts) and `mode_floor` (min of non-N/A mode pcts) are the descriptive headlines from Phase 4f-mode — integers, or omitted/`null` for planned skills. Single-skill runs may write/refresh just that skill's entry; do not blank the others.
+
+**Cross-cutting capability entries** carry the same shape plus `"cross_cutting": true`, `"tag": "<tag>"`, and `"host_skills": [...]` so consumers (e.g. `/generate-confluence-scorecard`'s ECS row) can read them and know NOT to add their tests/components into repo-wide totals:
+```json
+"uipath-context-grounding": {
+  "overall_pct": 0, "cross_cutting": true, "tag": "context-grounding",
+  "host_skills": ["uipath-agents", "uipath-maestro-flow"],
+  "tests": {"smoke": 0, "integration": 0, "e2e": 0},
+  "components": {"direct": 0, "direct_indirect": 0, "total": 6, "direct_pct": 0},
+  "rules": {"covered": 0, "total": 7, "pct": 0}, "workflow": null, "paths": null,
+  "weights": {"components": 70, "rules": 30}, "contribution": {"components": 0, "rules": 0},
+  "top_untested": [...], "infra": "Local-only (validate); cloud auth for index/run"
+}
+```
+(Fill the real numbers — components from the modes×surfaces matrix, tests by tag, etc. Coverage shape is **Components + Rules** with Path and usually Workflow N/A, so renormalize to ~Comp 70% / Rules 30% per Phase 4f. A cross-cutting entry also carries `mode_coverage`/`mode_balanced`/`mode_floor` like any skill — context-grounding is build-dominant, so its operate/diagnose slices are typically N/A and Mode-floor ≈ the build slice.)
+
+**Roll-up reconciliation (run AFTER all reports + SUMMARY + coverage.json are written, before reporting done).** The three artifacts are produced separately — in `all` mode often by parallel sub-agents — so they can drift. `coverage.json` is the contract `/generate-confluence-scorecard` consumes, so a mismatch silently corrupts the scorecard. Verify and fix before finishing:
+1. **coverage.json ↔ per-skill report.** For each skill, `overall_pct`, the tier counts, and the dimension %s in `coverage.json` equal the headline figures in `tests/reports/<skill>.md`. 
+2. **coverage.json ↔ SUMMARY Overview.** Every skill row in `SUMMARY.md`'s Overview table matches its `coverage.json` entry (Overall %, tests, top-untested buckets).
+3. **Roster completeness.** The set of keys in `coverage.json` == existing `skills/uipath-*/` folders ∪ planned-registry entries ∪ cross-cutting-registry entries; no skill missing, none stale. Planned-but-missing skills are `{"overall_pct":0,"planned":true}`; cross-cutting entries carry `"cross_cutting":true`. The repo-wide **Totals** in SUMMARY must **exclude** `cross_cutting` entries (their tests/components are already counted in the host skills) — verify the Totals math sums only normal skills.
+4. **Cross-agent sanity (parallel `all` runs).** Spot-check that independent sub-agents applied the weights consistently for same-shape skills (e.g. all catalog skills use Comp 65/Steps 35 or Comp 100); reconcile any outlier interpretation. A quick `python3 -c "import json; ..."` over `coverage.json` is the cheapest way to run checks 1–3.
 
 **Output rules:**
 
@@ -306,7 +417,8 @@ Use `null` for N/A dimensions (e.g. `"rules": null` for a catalog skill, `"paths
 |---|---|
 | Single skill (e.g. `uipath-maestro-flow`) | `tests/reports/<skill-name>.md` only. |
 | Single planned skill (folder missing, name in registry) | `tests/reports/<skill-name>.md` using the **planned-skill template** below. |
-| `all` (or empty) | One per-skill report **and** the roll-up: `tests/reports/<skill-name>.md` for every existing skill, `tests/reports/<skill-name>.md` for every planned-but-missing skill (planned template), `tests/reports/SUMMARY.md`, **and** `tests/reports/coverage.json` (the machine-readable sidecar). |
+| `all` (or empty) | One per-skill report **and** the roll-up: `tests/reports/<skill-name>.md` for every existing skill, `tests/reports/<skill-name>.md` for every planned-but-missing skill (planned template), `tests/reports/<capability>.md` for every cross-cutting registry entry (with-tests template, sourced from its inventory doc + tag-selected tasks), `tests/reports/SUMMARY.md`, **and** `tests/reports/coverage.json`. |
+| Single cross-cutting capability (e.g. `uipath-context-grounding`) | `tests/reports/<capability>.md` (with-tests template); refresh just its `coverage.json` entry. |
 | User-specified custom path | Use that path instead. |
 
 Overwrite any existing report at the same path. The summary file name is `SUMMARY.md` (uppercase), matching the directory structure documented in `tests/README.md`.
@@ -318,6 +430,7 @@ Choose the per-skill template by state:
 | Folder exists, has ≥1 test | **Per-Skill (with tests)** |
 | Folder exists, zero tests | **Per-Skill (no tests)** |
 | Folder does NOT exist, name in Planned Skills Registry | **Per-Skill (planned, not yet created)** |
+| Cross-cutting registry entry | **Per-Skill (with tests)** if tag matches ≥1 task, else (no tests). Header it "Cross-cutting capability" and add a note: tests are tag-selected and counted under host skills (non-additive); coverage source is the inventory doc, not a SKILL.md. |
 
 ---
 
@@ -345,6 +458,8 @@ Use this template when the skill has at least one test task.
 | Workflow steps covered | X / Y (Z%) |
 | Critical rules covered (direct) | X / Y (Z%) *or* N/A (no Critical Rules section) |
 | Path coverage | X / Y (Z%) *or* N/A (single-path skill) |
+| Per-mode coverage (B/O/D) | 31% / 0% / N/A *(scored slices — see Per-Mode Coverage; reported beside Overall, not folded in)* |
+| Mode-balanced / floor | 16% / 0% *(mean & min of non-N/A mode slices — exposes mode blindness the Overall dilutes; descriptive, not scored)* |
 | **Estimated overall coverage** | **Z%** (weights: Comp W1% / Steps W2% / Rules W3% / Path W4% — renormalized over applicable dimensions) |
 
 Anti-patterns are inventoried in the Anti-Patterns section below but are **not** part of the overall score (see Phase 4e).
@@ -415,6 +530,18 @@ Applicable only when the skill documents ≥2 implementation paths. Otherwise wr
 | Coded (C#) | Yes | skill-rpa-coded-test-case |
 | XAML | No | — |
 
+### Per-Mode Coverage (scored slices)
+
+Re-slices the capability inventory by the Phase 2f mode labels and re-runs the weighted formula per slice (Phase 4f-mode). Reported beside — never folded into — the Overall. `N/A` = the skill has no capability surface for that mode.
+
+| Mode | Capabilities (covered/total) | Coverage % | Covering tests |
+|------|------------------------------|-----------|----------------|
+| `build` | 8/26 | 31% | skill-flow-calculator, skill-flow-init-validate, … |
+| `operate` | 0/4 | 0% | — |
+| `diagnose` | — | N/A | — |
+
+⚠ *tag mismatch:* emit a bullet when a capability's only covering test carries the wrong `mode:*` tag (Phase 4f-mode cross-check) — name the test and the expected mode.
+
 ### Anti-Patterns (X/Y covered — troubleshooting only, NOT in overall score)
 
 | # | Anti-Pattern | Covered | Test(s) | Notes |
@@ -425,13 +552,7 @@ Applicable only when the skill documents ≥2 implementation paths. Otherwise wr
 
 Sidecar troubleshooting — see Phase 4h. Not part of the weighted overall score.
 
-**Mode**
-
-| Value | Tests | Status |
-|---|---|---|
-| `mode:build` | skill-flow-calculator, skill-flow-init-validate, skill-flow-add-node, … | ✓ |
-| `mode:operate` | — | ✗ |
-| `mode:diagnose` | — | ✗ |
+**Mode** — scored separately in the **Per-Mode Coverage** section above; not repeated as a sidecar tick.
 
 **Shape** (flow-building tests only)
 
@@ -590,16 +711,17 @@ Produce this whenever more than one skill is analyzed (including `all` mode).
 
 ## Overview
 
-| Skill | Tests | Components (direct) | Workflow | Rules | Paths | Overall | Tests/Comp (med) | Top untested buckets | Infra |
-|-------|-------|---------------------|----------|-------|-------|---------|------------------|----------------------|-------|
-| uipath-maestro-flow | 49 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 1/2 (50%) | 33% | 2 | control-flow 5/7, queue 0/2, resource 0/3 | Requires cloud auth |
-| uipath-rpa | 2 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 1/2 (50%) | 8% | 0 | triggers 0/3, IS connectors 0/2, run/publish 2/8 | Requires Windows + Studio |
-| uipath-platform | 5 | 2/12 (17%) | N/A | N/A | N/A | 17% | 0 | orchestrator-admin 7/15, jobs-adv 0/4 | Requires cloud auth |
-| uipath-document-understanding | 0 | — / — (0%) | — | — | — | **0%** (planned) | — | — (planned) | Skill folder not yet created |
+| Skill | Tests | Components (direct) | Workflow | Rules | Paths | Overall | Mode B/O/D | Bal/Floor | Tests/Comp (med) | Top untested buckets | Infra |
+|-------|-------|---------------------|----------|-------|-------|---------|------------|-----------|------------------|----------------------|-------|
+| uipath-maestro-flow | 49 | 6/24 (25%) | 6/9 (67%) | 1/16 (6%) | 1/2 (50%) | 33% | 33/0/— | 17/0 | 2 | control-flow 5/7, queue 0/2, resource 0/3 | Requires cloud auth |
+| uipath-rpa | 2 | 0/39 (0%) | 0/8 (0%) | 0/21 (0%) | 1/2 (50%) | 8% | 8/0/— | 4/0 | 0 | triggers 0/3, IS connectors 0/2, run/publish 2/8 | Requires Windows + Studio |
+| uipath-platform | 5 | 2/12 (17%) | N/A | N/A | N/A | 17% | 17/17/— | 17/17 | 0 | orchestrator-admin 7/15, jobs-adv 0/4 | Requires cloud auth |
+| uipath-document-understanding | 0 | — / — (0%) | — | — | — | **0%** (planned) | — | — | — | — (planned) | Skill folder not yet created |
+| uipath-context-grounding ⁺ | 10 | 4/6 (67%) | N/A | 3/7 (43%) | N/A | 60% | 67/—/— | 67/67 | — | index-search 0/2, low-code DeepRAG 1/2 | Cross-cutting (agents+flow); local validate / cloud run |
 
-Overall is weighted and renormalized across applicable dimensions (see Phase 4e). N/A cells mean the skill is missing that dimension (e.g. no Critical Rules section, single-path skill, catalog skill with no workflow steps) — weights redistribute proportionally. Planned-but-missing skills (no `skills/<name>/` folder yet) are scored at 0% and tagged "(planned)" in the Overall column; they appear in the same table — do not split them out, so the gap is impossible to overlook. **Top untested buckets** (Phase 4a) names the 2–3 largest `None` groups dragging each skill's score, so a reader can see *why* the coverage number is low without opening the per-skill report; full detail lives in each report's Untested Features section.
+Overall is weighted and renormalized across applicable dimensions (see Phase 4e). N/A cells mean the skill is missing that dimension (e.g. no Critical Rules section, single-path skill, catalog skill with no workflow steps) — weights redistribute proportionally. Planned-but-missing skills (no `skills/<name>/` folder yet) are scored at 0% and tagged "(planned)" in the Overall column; they appear in the same table — do not split them out, so the gap is impossible to overlook. **Cross-cutting capabilities** (⁺, e.g. `uipath-context-grounding`) appear as their own row but are **additive overlays** — their tests/components are already counted in the host skills, so they are EXCLUDED from the Totals line below. **Mode B/O/D** is the compact per-mode coverage (`build`/`operate`/`diagnose`, Phase 4f-mode) — `—` marks an N/A mode (no capability surface); these are scored beside Overall, never folded into it. **Bal/Floor** is Mode-balanced (mean of non-N/A mode slices) / Mode-floor (min of them, Phase 4f-mode): a high Overall with a low Floor flags a build-solid but mode-blind skill. **Top untested buckets** (Phase 4a) names the 2–3 largest `None` groups dragging each skill's score; full detail lives in each report's Untested Features section.
 
-**Totals:** N tests across M skills (P planned, not yet authored). X components inventoried, Y directly tested (Z%). A workflow steps, B covered. C critical rules, D directly tested. E multi-path skills, F with full path coverage. Anti-patterns are inventoried per skill but intentionally excluded from the overall score.
+**Totals (normal skills only — excludes planned stubs and cross-cutting ⁺ overlays to avoid double-counting):** N tests across M skills (P planned, not yet authored; Q cross-cutting capabilities reported separately). X components inventoried, Y directly tested (Z%). A workflow steps, B covered. C critical rules, D directly tested. E multi-path skills, F with full path coverage. Anti-patterns are inventoried per skill but intentionally excluded from the overall score.
 
 ## Planned Skills (folder not yet created)
 


### PR DESCRIPTION
## What

Teaches `/test-coverage` and `/generate-confluence-scorecard` to treat **cross-cutting capabilities** — surfaces that have no `skills/<name>/` folder but are taught in a shared reference and tested by a single tag across multiple skills — as first-class analyzed units. First entry: **Context Grounding** (the org scorecard's **ECS** row). Documentation-only change to two agent-facing command files; no skill, test, or hook behavior changes.

> **Supersedes #1364.** This branch carries #1364's operate/diagnose archetype lens + mode-balanced/floor scoring, consolidated into `test-coverage.md` alongside the new cross-cutting work. Please close #1364 in favor of this PR. Original mode-coverage work credited to @uipreliga.

## Why

Context Grounding is a standalone product on the Coding-Agents Scorecard (ECS), but it has **no skill folder** — it's taught inside `uipath-agents` (`context-grounding-patterns.md`) and exercised by 10 tasks tagged `context-grounding` that live under `uipath-agents` and `uipath-maestro-flow`. Before this change:
- `/test-coverage` folded those tasks into their host skills, so ECS had **no coverage number of its own**.
- `/generate-confluence-scorecard` left the ECS row's Skill Coverage blank (`—`), reading as "untested" when it's really "tested, hidden inside agents/flow".

The result was a real capability (60% covered, but **diagnose mode 0%**) that was invisible from every headline.

## Changes

### `test-coverage.md`
- **Cross-Cutting Capability Registry** (Phase 1): capabilities discovered by **tag** (`grep` across the whole `tests/tasks/` tree), not by directory. Registered: `uipath-context-grounding` (tag `context-grounding`, sourced from `context-grounding-patterns.md` + the coded/low-code capability refs, host skills `uipath-agents` + `uipath-maestro-flow`, scorecard row ECS).
- Component model = the **modes × surfaces** matrix (BatchTransform / DeepRAG / Index-search × coded / low-code); rules = the Cross-Surface Invariants. Shape **Comp 70% / Rules 30%**.
- `coverage.json` gains `cross_cutting` / `tag` / `host_skills` (+ `mode_coverage` / `mode_balanced` / `mode_floor`). Cross-cutting entries are **additive overlays EXCLUDED from repo-wide Totals** (their tasks are already counted in the host skills).
- Roll-up reconciliation step + SUMMARY row/Totals handling.
- **Consolidates #1364:** operate/diagnose archetype checklist (O1–O11, D1–D11) and Mode-balanced / Mode-floor headlines.

### `generate-confluence-scorecard.md` (consumer side)
- **Reads `cross_cutting` coverage.json entries** and maps them to their product row (`uipath-context-grounding` → ECS): Skill Coverage from `overall_pct`, pass/fail **non-additive** (footnote ⁷).
- Reproduces **both** org product tables, incl. the *Product Capability Enumeration* table with the **Skills Smoke / Integration+E2E** split.
- Always resolves the **newest dated** org scorecard as parent (not just on 404 — a stale-but-live card was silently winning).
- Publish ergonomics: `includeBody:false` on update, large create-response handling.

## Scope / risk

Documentation-only, two command files (+202 / −39). `tests/reports/` outputs are gitignored, so they're not in this PR. No skill / test / hook behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)