### PR TITLE
chore: refresh uip CLI catalog (1.196.0-alpha.20260610.7478)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-06-11T05:38:56Z",
+  "generated_at": "2026-06-12T05:38:07Z",
   "cli_version": "1.196.0-alpha.20260610.7478",
   "verbs": [
     "admin",
@@ -146,6 +146,7 @@
     "agent context add",
     "agent context list",
     "agent context remove",
+    "agent debug",
     "agent deploy",
     "agent escalation",
     "agent escalation add",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.196.0-alpha.20260610.7478`. The catalog has 1221 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.