### PR TITLE
feat(hooks): emit plugin-usage telemetry to App Insights on PostToolUse

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -8,15 +8,14 @@ stream (see [Correlation](#correlation)).
 
 ## Enabling / disabling
 
-Telemetry sends **only** when both are true:
-
 | Env var | Effect |
 |---------|--------|
-| `UIPATH_TELEMETRY_ENABLED` | Opt-in switch. Send only when set to exactly `1`. Unset or `0` → no send. |
+| `UIPATH_TELEMETRY_DISABLED` | Opt-out switch. Set to `1` or `true` to disable. Same variable and semantics as the `uip` CLI, so disabling CLI telemetry disables this hook too. |
 | `UIPATH_TELEMETRY_CONNECTION_STRING` | App Insights connection string (`InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/`). Without it there is nothing to send to. `APPLICATIONINSIGHTS_CONNECTION_STRING` is read as a fallback. |
 
-Default (neither set) is silent no-op. To turn off after enabling, set
-`UIPATH_TELEMETRY_ENABLED=0` or unset it.
+Telemetry is attempted by default, but **only transmits when a connection
+string is configured** — there is no built-in default endpoint. To turn it off
+explicitly, set `UIPATH_TELEMETRY_DISABLED=1` (or `true`).
 
 ## What triggers an event
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -64,22 +64,24 @@ sends becomes an event property.
 |-------|---------|-------|
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
-| `sessionId` | `b3f1...` | Claude Code `session_id` — session correlation key |
+| `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
+| `userId` | `9eeb311fc6d5fa03` | **SHA-256 of `cwd`** (first 16 hex) — stable, anonymous per-workspace id. Distinct from the CLI-stamped `CloudUserId` |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
-| `fileExt` | `.flow` | File-tool calls only |
+| `fileExtension` | `.flow` | File-tool calls only |
 | `environment` | `alpha` / `staging` / `prod` / `other` / `unknown` | From `uip login status` `BaseUrl`, cached 1h |
 | `baseUrl` | `https://cloud.uipath.com` | Cloud base URL only |
 | `outcome` | `ok` / `failure` / `interrupted` | From `tool_response`, not output content |
 | `permissionMode` | `bypassPermissions` | |
-| `effortLevel` | `high` | When present in payload |
-| `os` | `Linux`, `Darwin`, `MINGW64_NT-...` | |
-| `pluginVersion` | `1.197.0` | `skillsVersion` from `version-manifest.json` |
+| `effortLevel` | `high` | From the payload's `effort.level`, when present (`low` / `medium` / `high` / `xhigh` / `max`) |
+| `operatingSystem` | `Linux`, `Darwin`, `MINGW64_NT-...` | From `uname -s` |
+| `skillsVersion` | `1.196.0` | `skillsVersion` from `version-manifest.json` |
 | `cliVersion` | `1.197.0-beta...` | From `uip --version` |
 | `durationMs` | `1234` | Tool-call wall-clock from the payload's `duration_ms`. JSON **number**; the CLI stringifies it for App Insights, so latency queries use `toreal(tostring(durationMs))`. `null` when absent → dropped |
 
-`pluginVersion` is designed to track `cliVersion`; both are sent so drift is
-visible in queries.
+`skillsVersion` tracks the CLI version (`version-manifest.json` `targetCli`) and
+is sent alongside `cliVersion` so drift is visible in queries. It is **not** the
+`.claude-plugin/plugin.json` plugin package version.
 
 ### Added by the CLI
 
@@ -89,7 +91,7 @@ sends them, and a `source` value sent by the hook would be overridden:
 | Field | Notes |
 |-------|-------|
 | `source` | Always `skills-plugin` |
-| `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity |
+| `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity — distinct from the hook's anonymous `userId` |
 | CLI app version | The `uip` CLI's own version |
 
 ## Privacy
@@ -97,14 +99,17 @@ sends them, and a `source` value sent by the hook would be overridden:
 Skills telemetry rides the CLI's telemetry tracker, so each event is
 **associated with the signed-in UiPath identity** — `CloudUserId`,
 `CloudTenantId`, `CloudOrganizationId`, plus the CLI app version, all stamped by
-the CLI. It is **not** anonymous.
+the CLI. It is **not** anonymous. The hook also sends a `userId` that is a
+SHA-256 hash of the working directory — a stable, anonymous **per-workspace**
+id, separate from the authenticated `CloudUserId`.
 
 What the hook **never** sends:
 
 - File contents, `stdout`, `stderr` — only `outcome` and `durationMs`.
 - Full command lines — only the derived `uip` subcommand verb.
 - File paths — only the extension / known filename.
-- The `cwd` / project path, and `transcript_path` — neither is collected.
+- Raw `cwd` / project path — only its SHA-256 hash (`userId`). `transcript_path`
+  is never collected.
 
 All fields the hook derives are low-cardinality. Nothing is sent unless
 explicitly opted in with `UIPATH_TELEMETRY_DISABLED=0`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -109,12 +109,10 @@ aggregations over events sharing `ai.session.id`:
 
 ## Reliability & performance
 
-- **Non-blocking:** for an attributable call the hook declares itself async
-  (prints `{"async": true, "asyncTimeout": 10000}` before any slow work), so
-  Claude Code stops waiting and lets it finish in the background. It also POSTs
-  in a detached subshell with a 4s cap and always exits 0 — it never delays or
-  fails a tool call. Opted-out and non-UiPath calls exit synchronously in
-  milliseconds, so only real emissions spawn a background task.
+- **Non-blocking:** the hook is registered as an async hook in `hooks.json`
+  (`"async": true`), so Claude Code runs it in the background and never waits
+  for it. It also POSTs in a detached subshell with a 4s cap and always exits
+  0 — it never delays or fails a tool call.
 - **Best-effort delivery:** an event is dropped on network failure (no local
   retry queue). Telemetry is for aggregate trends, not exact accounting.
 - **Environment cost:** `uip login status` (~0.5s) runs at most once per hour;

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -109,8 +109,12 @@ aggregations over events sharing `ai.session.id`:
 
 ## Reliability & performance
 
-- **Non-blocking:** the hook POSTs in a detached subshell with a 4s cap and
-  always exits 0 — it never delays or fails a tool call.
+- **Non-blocking:** for an attributable call the hook declares itself async
+  (prints `{"async": true, "asyncTimeout": 10000}` before any slow work), so
+  Claude Code stops waiting and lets it finish in the background. It also POSTs
+  in a detached subshell with a 4s cap and always exits 0 — it never delays or
+  fails a tool call. Opted-out and non-UiPath calls exit synchronously in
+  milliseconds, so only real emissions spawn a background task.
 - **Best-effort delivery:** an event is dropped on network failure (no local
   retry queue). Telemetry is for aggregate trends, not exact accounting.
 - **Environment cost:** `uip login status` (~0.5s) runs at most once per hour;

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,0 +1,108 @@
+# UiPath Skills Plugin Telemetry
+
+Opt-in, privacy-preserving usage telemetry for the UiPath skills plugin. Off by
+default. One `PostToolUse` hook (`hooks/send-telemetry.sh`) emits a single event
+per relevant tool call to Azure Application Insights. No local state file, no
+session daemon — session-level metrics are computed at query time from the event
+stream (see [Correlation](#correlation)).
+
+## Enabling / disabling
+
+Telemetry sends **only** when both are true:
+
+| Env var | Effect |
+|---------|--------|
+| `UIPATH_TELEMETRY_ENABLED` | Opt-in switch. Send only when set to exactly `1`. Unset or `0` → no send. |
+| `UIPATH_TELEMETRY_CONNECTION_STRING` | App Insights connection string (`InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/`). Without it there is nothing to send to. `APPLICATIONINSIGHTS_CONNECTION_STRING` is read as a fallback. |
+
+Default (neither set) is silent no-op. To turn off after enabling, set
+`UIPATH_TELEMETRY_ENABLED=0` or unset it.
+
+## What triggers an event
+
+The hook fires on every tool call but emits only for calls attributable to this
+plugin; everything else exits silently. A call qualifies when:
+
+| Tool | Qualifies when |
+|------|----------------|
+| `Skill` | skill name starts with `uipath:` / `uipath-` |
+| `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
+| `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
+
+## What is collected
+
+Each event is an App Insights `customEvent` named `ToolUse`.
+
+### Properties (dimensions)
+
+| Field | Example | Notes |
+|-------|---------|-------|
+| `toolName` | `Skill`, `Bash` | Claude Code tool |
+| `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
+| `skillName` | `uipath:uipath-platform` | `Skill` calls only |
+| `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
+| `fileExt` | `.flow` | File-tool calls only |
+| `environment` | `alpha` / `staging` / `prod` / `other` / `unknown` | From `uip login status` `BaseUrl`, cached 1h |
+| `baseUrl` | `https://cloud.uipath.com` | Cloud base URL only |
+| `outcome` | `ok` / `failure` / `interrupted` | From `tool_response`, not output content |
+| `permissionMode` | `bypassPermissions` | |
+| `effortLevel` | `high` | When present in payload |
+| `os` | `Linux`, `Darwin`, `MINGW64_NT-...` | |
+| `pluginVersion` | `1.197.0` | `skillsVersion` from `version-manifest.json` |
+| `cliVersion` | `1.197.0-beta...` | From `uip --version` |
+
+`pluginVersion` is designed to track `cliVersion`; both are sent so drift is
+visible in queries.
+
+### Measurements (metrics)
+
+| Field | Notes |
+|-------|-------|
+| `durationMs` | Tool-call wall-clock from the payload's `duration_ms` |
+
+### Tags (envelope)
+
+| Tag | Value |
+|-----|-------|
+| `ai.cloud.role` | `uipath-skills-plugin` |
+| `ai.cloud.roleInstance` | resolved environment |
+| `ai.session.id` | Claude Code `session_id` |
+| `ai.user.id` | **SHA-256 of `cwd`** (stable anonymous workspace id) |
+| `ai.application.ver` | `pluginVersion` |
+
+## Privacy
+
+What **never** leaves the machine:
+
+- Raw `cwd` / project path — only a SHA-256 hash (`ai.user.id`).
+- `transcript_path`.
+- Full command lines — only the derived `uip` subcommand verb.
+- File contents, `stdout`, `stderr` — only `outcome` and `durationMs`.
+- File paths — only the extension / known filename.
+
+All emitted fields are low-cardinality and PII-free. Nothing is sent unless
+explicitly opted in.
+
+## Correlation
+
+Session-level metrics need no local state file — they are query-time
+aggregations over events sharing `ai.session.id`:
+
+| Metric | Query shape |
+|--------|-------------|
+| Tool calls per session | `count() by session_id` |
+| Session duration | `max(timestamp) - min(timestamp) by session_id` |
+| Time-to-first-skill | first `Skill` event − first event, per session |
+| Retries | repeated `uipSubcommand` flipping `failure → ok`, ordered by `timestamp` then `toolUseId` |
+
+## Reliability & performance
+
+- **Non-blocking:** the hook POSTs in a detached subshell with a 4s cap and
+  always exits 0 — it never delays or fails a tool call.
+- **Best-effort delivery:** an event is dropped on network failure (no local
+  retry queue). Telemetry is for aggregate trends, not exact accounting.
+- **Environment cost:** `uip login status` (~0.5s) runs at most once per hour;
+  the result is cached in a per-user, `chmod 700` directory and parsed as data,
+  never sourced.
+- **Cross-platform:** pure POSIX `bash` + `grep`/`sed`/`awk`, no `jq`
+  dependency (macOS, Linux, Windows Git Bash).

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,8 +65,7 @@ sends becomes an event property.
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
 | `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
-| `agentId` | `agt_77` | Subagent id; present only when the call ran inside a spawned subagent (empty = main session) |
-| `agentType` | `Explore` | Subagent name (`Explore` / `Plan` / custom); empty = main session |
+| `modelId` | `opus` / `sonnet` | Model family — best-effort from the payload's `model` id, mapped to a short name (`opus` / `sonnet` / `haiku` / `fable`). Empty if the payload carries no model id |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
 | `fileExtension` | `.flow` | File-tool calls only |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -30,6 +30,7 @@ plugin; everything else exits silently. A call qualifies when:
 | Tool | Qualifies when |
 |------|----------------|
 | `Skill` | skill name starts with `uipath:` / `uipath-` |
+| `Agent` | `subagent_type` is a UiPath agent (`uipath:` / `uipath-`) or a Claude built-in (`general-purpose`, `Explore`, `Plan`, `claude`, `claude-code-guide`, `statusline-setup`, `fork`) — **not** other plugins' (`<plugin>:<name>`) or user-defined custom agents |
 | `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
 | `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,6 +65,9 @@ sends becomes an event property.
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
 | `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
+| `subagentModel` | `claude-sonnet-4-6` | From `tool_response.resolvedModel` — model resolved for a spawned subagent. Empty when absent |
+| `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type on an Agent-tool call. Empty when absent |
+| `agentType` | `Explore` | From the top-level `agent_type` — type of the running subagent. Empty in the main session |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
 | `fileExtension` | `.flow` | File-tool calls only |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,7 +65,8 @@ sends becomes an event property.
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
 | `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
-| `userId` | `9eeb311fc6d5fa03` | **SHA-256 of `cwd`** (first 16 hex) — stable, anonymous per-workspace id. Distinct from the CLI-stamped `CloudUserId` |
+| `agentId` | `agt_77` | Subagent id; present only when the call ran inside a spawned subagent (empty = main session) |
+| `agentType` | `Explore` | Subagent name (`Explore` / `Plan` / custom); empty = main session |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
 | `fileExtension` | `.flow` | File-tool calls only |
@@ -74,14 +75,13 @@ sends becomes an event property.
 | `outcome` | `ok` / `failure` / `interrupted` | From `tool_response`, not output content |
 | `permissionMode` | `bypassPermissions` | |
 | `effortLevel` | `high` | From the payload's `effort.level`, when present (`low` / `medium` / `high` / `xhigh` / `max`) |
-| `operatingSystem` | `Linux`, `Darwin`, `MINGW64_NT-...` | From `uname -s` |
 | `skillsVersion` | `1.196.0` | `skillsVersion` from `version-manifest.json` |
-| `cliVersion` | `1.197.0-beta...` | From `uip --version` |
 | `durationMs` | `1234` | Tool-call wall-clock from the payload's `duration_ms`. JSON **number**; the CLI stringifies it for App Insights, so latency queries use `toreal(tostring(durationMs))`. `null` when absent → dropped |
 
-`skillsVersion` tracks the CLI version (`version-manifest.json` `targetCli`) and
-is sent alongside `cliVersion` so drift is visible in queries. It is **not** the
-`.claude-plugin/plugin.json` plugin package version.
+`skillsVersion` tracks the CLI version (`version-manifest.json` `targetCli`); it
+is **not** the `.claude-plugin/plugin.json` plugin package version. The hook no
+longer sends `cliVersion` or `operatingSystem` — the CLI tracker already records
+its own version as `application_Version` and the OS / client context by default.
 
 ### Added by the CLI
 
@@ -91,25 +91,23 @@ sends them, and a `source` value sent by the hook would be overridden:
 | Field | Notes |
 |-------|-------|
 | `source` | Always `skills-plugin` |
-| `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity — distinct from the hook's anonymous `userId` |
-| CLI app version | The `uip` CLI's own version |
+| `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity |
+| `application_Version` | The `uip` CLI's own version (replaces the hook's former `cliVersion`) |
+| OS / client context | Recorded by the tracker by default (replaces the hook's former `operatingSystem`) |
 
 ## Privacy
 
 Skills telemetry rides the CLI's telemetry tracker, so each event is
 **associated with the signed-in UiPath identity** — `CloudUserId`,
 `CloudTenantId`, `CloudOrganizationId`, plus the CLI app version, all stamped by
-the CLI. It is **not** anonymous. The hook also sends a `userId` that is a
-SHA-256 hash of the working directory — a stable, anonymous **per-workspace**
-id, separate from the authenticated `CloudUserId`.
+the CLI. It is **not** anonymous.
 
 What the hook **never** sends:
 
 - File contents, `stdout`, `stderr` — only `outcome` and `durationMs`.
 - Full command lines — only the derived `uip` subcommand verb.
 - File paths — only the extension / known filename.
-- Raw `cwd` / project path — only its SHA-256 hash (`userId`). `transcript_path`
-  is never collected.
+- The `cwd` / project path and `transcript_path` — neither is collected.
 
 All fields the hook derives are low-cardinality. Nothing is sent unless
 explicitly opted in with `UIPATH_TELEMETRY_DISABLED=0`.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -40,7 +40,13 @@ plugin; everything else exits silently. A call qualifies when:
    the call is attributable to this plugin (table above).
 2. For a qualifying call it derives a small set of low-cardinality fields,
    sanitizes each value (charset + 120-char cap), and resolves the UiPath
-   environment from `uip login status` (cached 1h).
+   environment from `uip login status` (cached 1h). Field extraction is
+   **region-scoped**: a single string-aware `awk` pass walks the payload once,
+   tracking brace/string depth, and pulls each field only from the region it
+   lives in — envelope (top-level keys), `tool_input`, `tool_response`, or
+   `effort`. Free-form customer content embedded in a string (a prompt, a
+   command line, `stdout`) can never false-match an envelope field (see
+   [Region scoping](#region-scoping)).
 3. It pipes one flat `key:value` JSON object to `uip track` on stdin, in a
    detached subshell, then exits 0.
 4. `uip track` ([UiPath/cli#2600](https://github.com/UiPath/cli/pull/2600))
@@ -63,20 +69,21 @@ sends becomes an event property.
 
 | Field | Example | Notes |
 |-------|---------|-------|
-| `toolName` | `Skill`, `Bash` | Claude Code tool |
+| `schemaVersion` | `1` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas |
+| `toolName` | `Skill`, `Bash` | Claude Code tool. From the top-level `tool_name` |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
 | `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
-| `subagentModel` | `claude-sonnet-4-6` | From `tool_response.resolvedModel` — model resolved for a spawned subagent. Empty when absent |
-| `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type on an Agent-tool call. Empty when absent |
-| `agentType` | `Explore` | From the top-level `agent_type` — type of the running subagent. Empty in the main session |
-| `skillName` | `uipath:uipath-platform` | `Skill` calls only |
-| `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
-| `fileExtension` | `.flow` | File-tool calls only |
+| `subagentModel` | `opus` | From `tool_response.resolvedModel`, normalized to a family — `opus` / `sonnet` / `haiku` / `fable` (`other` if unrecognized). The context-window marker is dropped (`claude-opus-4-8[1m]` → `opus`). Set on an Agent-**spawn** event; empty otherwise |
+| `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type. Set on an Agent-**spawn** event; empty otherwise |
+| `agentType` | `Explore` | From the top-level `agent_type` — type of the subagent the call runs **inside**. Empty on a main-loop call |
+| `skillName` | `uipath:uipath-platform` | From `tool_input.skill`. `Skill` calls only |
+| `uipSubcommand` | `solution publish` | First 1–2 verbs derived from `tool_input.command` — never the full command line, never `stdout` |
+| `fileExtension` | `.flow` | Derived from `tool_input.file_path`. File-tool calls only |
 | `environment` | `alpha` / `staging` / `prod` / `other` / `unknown` | From `uip login status` `BaseUrl`, cached 1h |
 | `baseUrl` | `https://cloud.uipath.com` | Cloud base URL only |
-| `outcome` | `ok` / `failure` / `interrupted` | From `tool_response`, not output content |
-| `permissionMode` | `bypassPermissions` | |
-| `effortLevel` | `high` | From the payload's `effort.level`, when present (`low` / `medium` / `high` / `xhigh` / `max`) |
+| `outcome` | `ok` / `failure` / `interrupted` / `unknown` | From the `tool_response` region **only**, never output content — see [Outcome semantics](#outcome-semantics) |
+| `permissionMode` | `bypassPermissions` | From the top-level `permission_mode` |
+| `effortLevel` | `high` | From the top-level `effort.level`, when present (`low` / `medium` / `high` / `xhigh` / `max`) |
 | `skillsVersion` | `1.196.0` | `skillsVersion` from `version-manifest.json` |
 | `durationMs` | `1234` | Tool-call wall-clock from the payload's `duration_ms`. JSON **number**; the CLI stringifies it for App Insights, so latency queries use `toreal(tostring(durationMs))`. `null` when absent → dropped |
 
@@ -84,6 +91,56 @@ sends becomes an event property.
 is **not** the `.claude-plugin/plugin.json` plugin package version. The hook no
 longer sends `cliVersion` or `operatingSystem` — the CLI tracker already records
 its own version as `application_Version` and the OS / client context by default.
+
+### Region scoping
+
+The payload embeds free-form customer content — prompts, command lines,
+`stdout` / `stderr`, file contents. A grep over the **whole** payload
+mis-extracts fields when that content happens to contain JSON-shaped text: a
+`stdout` with `"success":false`, an Agent prompt naming `uip solution publish`
+or `.flow"`, a log line with `"resolvedModel":"x"`. To prevent this, a single
+string-aware `awk` pass walks the payload once, tracks brace/string nesting
+depth (honoring `\"` and `\\` escapes), and emits each field **only** from the
+region where it actually lives:
+
+| Region | Fields |
+|--------|--------|
+| Envelope (top-level keys) | `toolName`, `toolUseId`, `sessionId`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType` |
+| `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` |
+| `tool_response` | `outcome` (`interrupted` / `success`), `subagentModel` (`resolvedModel`) |
+
+Content nested inside a JSON string, or at the wrong depth, can never satisfy a
+top-level match — so `stdout` / prompt text cannot corrupt a field or cause
+over-attribution. The relevance gate is scoped the same way (the `uip` command
+is matched against `tool_input.command`, file extensions against
+`tool_input.file_path`).
+
+### Outcome semantics
+
+`outcome` is computed from the `tool_response` region **only** — output content
+never flips it:
+
+| Value | Condition |
+|-------|-----------|
+| `interrupted` | top-level `tool_response.interrupted == true` (takes precedence) |
+| `failure` | top-level `tool_response.success == false` |
+| `ok` | `tool_response` present with no failure signal — the default for tools that report no status (`Read`, `Edit`, `Write`, `Glob`, most MCP) |
+| `unknown` | no `tool_response` in the payload at all |
+
+A `tool_response` that is a JSON **string** or **array** (some MCP tools) yields
+`ok` — it is present but exposes no `success` / `interrupted` field.
+
+### Subagent fields — distinct meanings
+
+The three subagent fields describe two different viewpoints and are independent:
+
+- **`subagentType` + `subagentModel`** describe an Agent-**spawn** event — i.e.
+  `toolName == Agent`, the **parent's** view of the child it launched
+  (`tool_input.subagent_type` and the resolved `tool_response.resolvedModel`).
+- **`agentType`** is set on calls made **inside** a subagent — the **child's**
+  own view, from the top-level `agent_type`.
+
+All three are empty on a plain main-loop tool call.
 
 ### Added by the CLI
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -65,7 +65,6 @@ sends becomes an event property.
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
 | `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
-| `modelId` | `opus` / `sonnet` | Model family — best-effort from the payload's `model` id, mapped to a short name (`opus` / `sonnet` / `haiku` / `fable`). Empty if the payload carries no model id |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
 | `fileExtension` | `.flow` | File-tool calls only |

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -83,6 +83,18 @@ What **never** leaves the machine:
 All emitted fields are low-cardinality and PII-free. Nothing is sent unless
 explicitly opted in.
 
+## Missing fields
+
+Every field above is **always emitted**, even when the source value is absent
+from the payload, so query schemas stay stable:
+
+- **Properties** fall back to an empty string `""` — never JSON `null`, because
+  App Insights drops null-valued properties (which would make the field
+  disappear from the event).
+- The **`durationMs` measurement** falls back to JSON `null` when absent, so a
+  missing value is recorded as "no data" rather than `0` (which would skew
+  latency aggregations).
+
 ## Correlation
 
 Session-level metrics need no local state file — they are query-time

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -27,7 +27,7 @@ plugin; everything else exits silently. A call qualifies when:
 |------|----------------|
 | `Skill` | skill name starts with `uipath:` / `uipath-` |
 | `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
-| `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
+| `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
 
 ## What is collected
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,22 +1,26 @@
 # UiPath Skills Plugin Telemetry
 
-Opt-in, privacy-preserving usage telemetry for the UiPath skills plugin. Off by
-default. One `PostToolUse` hook (`hooks/send-telemetry.sh`) emits a single event
-per relevant tool call to Azure Application Insights. No local state file, no
-session daemon — session-level metrics are computed at query time from the event
-stream (see [Correlation](#correlation)).
+Opt-in usage telemetry for the UiPath skills plugin. Off by default. One
+`PostToolUse` hook (`hooks/send-telemetry.sh`) hands a single flat JSON object
+per relevant tool call to the hidden `uip track` CLI command, which forwards it
+through the CLI's own telemetry tracker as one `uip.skills.tool-use`
+Application Insights event. No local state file, no session daemon —
+session-level metrics are computed at query time from the event stream (see
+[Correlation](#correlation)).
 
 ## Enabling / disabling
 
-Telemetry is **opt-in / off by default**. It sends only when both are true:
+Telemetry is **opt-in / off by default**. The hook and `uip track` share one
+gate:
 
 | Env var | Effect |
 |---------|--------|
 | `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Send **only** when explicitly set to `0`. Unset (default) or `1` → no send. |
-| `UIPATH_TELEMETRY_CONNECTION_STRING` | App Insights connection string (`InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/`). Without it there is nothing to send to. `APPLICATIONINSIGHTS_CONNECTION_STRING` is read as a fallback. |
 
 Default (var unset) is a silent no-op. To opt in, set
-`UIPATH_TELEMETRY_DISABLED=0` and configure a connection string.
+`UIPATH_TELEMETRY_DISABLED=0` on a machine signed in to UiPath (`uip login`).
+The CLI owns the Application Insights connection — there is **no** connection
+string to configure on the skills side.
 
 ## What triggers an event
 
@@ -29,16 +33,38 @@ plugin; everything else exits silently. A call qualifies when:
 | `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
 | `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
 
+## How it works
+
+1. The `PostToolUse` hook fires on every tool call and exits silently unless
+   the call is attributable to this plugin (table above).
+2. For a qualifying call it derives a small set of low-cardinality fields,
+   sanitizes each value (charset + 120-char cap), and resolves the UiPath
+   environment from `uip login status` (cached 1h).
+3. It pipes one flat `key:value` JSON object to `uip track` on stdin, in a
+   detached subshell, then exits 0.
+4. `uip track` ([UiPath/cli#2600](https://github.com/UiPath/cli/pull/2600))
+   reads that object, hard-codes the event name `uip.skills.tool-use`, stamps a
+   `source: "skills-plugin"` dimension, attaches the authenticated UiPath cloud
+   identity and the CLI app version, and forwards it through the CLI's
+   telemetry tracker. Every key becomes an event property; non-scalar values
+   (objects / arrays / `null`) are dropped.
+
+The hook builds **no** App Insights envelope and makes **no** direct HTTP POST.
+Transport, the connection, the event name, the `source` dimension, and identity
+all belong to the CLI.
+
 ## What is collected
 
-Each event is an App Insights `customEvent` named `ToolUse`.
+Each event is the App Insights event `uip.skills.tool-use`. Every key the hook
+sends becomes an event property.
 
-### Properties (dimensions)
+### Properties sent by the hook
 
 | Field | Example | Notes |
 |-------|---------|-------|
 | `toolName` | `Skill`, `Bash` | Claude Code tool |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
+| `sessionId` | `b3f1...` | Claude Code `session_id` — session correlation key |
 | `skillName` | `uipath:uipath-platform` | `Skill` calls only |
 | `uipSubcommand` | `solution publish` | Derived first 1–2 verbs of a `uip` command — never the full command line |
 | `fileExt` | `.flow` | File-tool calls only |
@@ -50,60 +76,59 @@ Each event is an App Insights `customEvent` named `ToolUse`.
 | `os` | `Linux`, `Darwin`, `MINGW64_NT-...` | |
 | `pluginVersion` | `1.197.0` | `skillsVersion` from `version-manifest.json` |
 | `cliVersion` | `1.197.0-beta...` | From `uip --version` |
+| `durationMs` | `1234` | Tool-call wall-clock from the payload's `duration_ms`. JSON **number**; the CLI stringifies it for App Insights, so latency queries use `toreal(tostring(durationMs))`. `null` when absent → dropped |
 
 `pluginVersion` is designed to track `cliVersion`; both are sent so drift is
 visible in queries.
 
-### Measurements (metrics)
+### Added by the CLI
+
+The CLI stamps these on every `uip.skills.tool-use` event — the hook never
+sends them, and a `source` value sent by the hook would be overridden:
 
 | Field | Notes |
 |-------|-------|
-| `durationMs` | Tool-call wall-clock from the payload's `duration_ms` |
-
-### Tags (envelope)
-
-| Tag | Value |
-|-----|-------|
-| `ai.cloud.role` | `uipath-skills-plugin` |
-| `ai.cloud.roleInstance` | resolved environment |
-| `ai.session.id` | Claude Code `session_id` |
-| `ai.user.id` | **SHA-256 of `cwd`** (stable anonymous workspace id) |
-| `ai.application.ver` | `pluginVersion` |
+| `source` | Always `skills-plugin` |
+| `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity |
+| CLI app version | The `uip` CLI's own version |
 
 ## Privacy
 
-What **never** leaves the machine:
+Skills telemetry rides the CLI's telemetry tracker, so each event is
+**associated with the signed-in UiPath identity** — `CloudUserId`,
+`CloudTenantId`, `CloudOrganizationId`, plus the CLI app version, all stamped by
+the CLI. It is **not** anonymous.
 
-- Raw `cwd` / project path — only a SHA-256 hash (`ai.user.id`).
-- `transcript_path`.
-- Full command lines — only the derived `uip` subcommand verb.
+What the hook **never** sends:
+
 - File contents, `stdout`, `stderr` — only `outcome` and `durationMs`.
+- Full command lines — only the derived `uip` subcommand verb.
 - File paths — only the extension / known filename.
+- The `cwd` / project path, and `transcript_path` — neither is collected.
 
-All emitted fields are low-cardinality and PII-free. Nothing is sent unless
-explicitly opted in.
+All fields the hook derives are low-cardinality. Nothing is sent unless
+explicitly opted in with `UIPATH_TELEMETRY_DISABLED=0`.
 
 ## Missing fields
 
-Every field above is **always emitted**, even when the source value is absent
-from the payload, so query schemas stay stable:
+Every property above is **always sent** by the hook, even when the source value
+is absent from the payload, so query schemas stay stable:
 
-- **Properties** fall back to an empty string `""` — never JSON `null`, because
-  App Insights drops null-valued properties (which would make the field
-  disappear from the event).
-- The **`durationMs` measurement** falls back to JSON `null` when absent, so a
-  missing value is recorded as "no data" rather than `0` (which would skew
-  latency aggregations).
+- **String properties** fall back to an empty string `""` — a scalar the CLI
+  keeps (it drops only objects, arrays, and `null`).
+- **`durationMs`** falls back to JSON `null` when absent; the CLI drops `null`
+  values, so a missing duration records as "no data" rather than `0` (which
+  would skew latency aggregations).
 
 ## Correlation
 
 Session-level metrics need no local state file — they are query-time
-aggregations over events sharing `ai.session.id`:
+aggregations over events sharing `sessionId`:
 
 | Metric | Query shape |
 |--------|-------------|
-| Tool calls per session | `count() by session_id` |
-| Session duration | `max(timestamp) - min(timestamp) by session_id` |
+| Tool calls per session | `count() by sessionId` |
+| Session duration | `max(timestamp) - min(timestamp) by sessionId` |
 | Time-to-first-skill | first `Skill` event − first event, per session |
 | Retries | repeated `uipSubcommand` flipping `failure → ok`, ordered by `timestamp` then `toolUseId` |
 
@@ -111,12 +136,14 @@ aggregations over events sharing `ai.session.id`:
 
 - **Non-blocking:** the hook is registered as an async hook in `hooks.json`
   (`"async": true`), so Claude Code runs it in the background and never waits
-  for it. It also POSTs in a detached subshell with a 4s cap and always exits
-  0 — it never delays or fails a tool call.
-- **Best-effort delivery:** an event is dropped on network failure (no local
-  retry queue). Telemetry is for aggregate trends, not exact accounting.
+  for it. It pipes to `uip track` in a detached subshell and always exits 0 —
+  it never delays or fails a tool call. `uip track` is itself never-fail (always
+  exits 0, emits nothing when telemetry is off or on any error).
+- **Best-effort delivery:** an event is dropped on failure (no local retry
+  queue). Telemetry is for aggregate trends, not exact accounting.
 - **Environment cost:** `uip login status` (~0.5s) runs at most once per hour;
   the result is cached in a per-user, `chmod 700` directory and parsed as data,
   never sourced.
 - **Cross-platform:** pure POSIX `bash` + `grep`/`sed`/`awk`, no `jq`
-  dependency (macOS, Linux, Windows Git Bash).
+  dependency (macOS, Linux, Windows Git Bash). Requires the `uip` CLI on `PATH`
+  — the plugin's `SessionStart` hook ensures it is installed.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -8,14 +8,15 @@ stream (see [Correlation](#correlation)).
 
 ## Enabling / disabling
 
+Telemetry is **opt-in / off by default**. It sends only when both are true:
+
 | Env var | Effect |
 |---------|--------|
-| `UIPATH_TELEMETRY_DISABLED` | Opt-out switch. Set to `1` or `true` to disable. Same variable and semantics as the `uip` CLI, so disabling CLI telemetry disables this hook too. |
+| `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Send **only** when explicitly set to `0`. Unset (default) or `1` → no send. |
 | `UIPATH_TELEMETRY_CONNECTION_STRING` | App Insights connection string (`InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/`). Without it there is nothing to send to. `APPLICATIONINSIGHTS_CONNECTION_STRING` is read as a fallback. |
 
-Telemetry is attempted by default, but **only transmits when a connection
-string is configured** — there is no built-in default endpoint. To turn it off
-explicitly, set `UIPATH_TELEMETRY_DISABLED=1` (or `true`).
+Default (var unset) is a silent no-op. To opt in, set
+`UIPATH_TELEMETRY_DISABLED=0` and configure a connection string.
 
 ## What triggers an event
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -18,6 +18,18 @@
           }
         ]
       }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -26,7 +26,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
-            "timeout": 5
+            "timeout": 10
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -26,7 +26,8 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
-            "timeout": 10
+            "async": true,
+            "timeout": 5
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -26,8 +26,7 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
-            "async": true,
-            "timeout": 5
+            "async": true
           }
         ]
       }

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+# PostToolUse telemetry hook for the UiPath skills plugin.
+#
+# Reads the hook JSON payload from stdin, decides whether the tool call is
+# attributable to THIS plugin (skill gate), resolves the UiPath environment
+# (alpha / staging / prod), and emits one customEvent to Azure Application
+# Insights. Calls from other plugins or bare Claude Code are dropped.
+#
+# Non-blocking by contract: always exits 0, swallows every error, and POSTs in
+# a detached subshell so it never delays the observed tool call.
+# Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
+#
+# Configuration (env only — nothing is sent unless the connection string is set):
+#   UIPATH_TELEMETRY_CONNECTION_STRING   App Insights connection string
+#       (InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/)
+#   APPLICATIONINSIGHTS_CONNECTION_STRING  Fallback if the above is unset.
+#   UIPATH_TELEMETRY_DISABLE=1           Hard off-switch.
+
+set +e
+
+[ "${UIPATH_TELEMETRY_DISABLE:-}" = "1" ] && exit 0
+
+conn="${UIPATH_TELEMETRY_CONNECTION_STRING:-${APPLICATIONINSIGHTS_CONNECTION_STRING:-}}"
+[ -z "$conn" ] && exit 0   # not configured -> no-op
+
+payload="$(cat)"
+
+# --- field helpers ---------------------------------------------------------
+json_str() { # $1 = key; prints first JSON string value for that key
+  printf '%s' "$payload" \
+    | grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
+
+event="$(json_str hook_event_name)"
+tool="$(json_str tool_name)"
+[ "$event" = "PostToolUse" ] || exit 0
+
+# --- UiPath relevance gate -------------------------------------------------
+# No "active plugin" field exists in the payload, so attribute per-call from
+# concrete signals in tool_input. Anything that doesn't match -> exit 0.
+skill="$(json_str skill)"
+file_path="$(json_str file_path)"
+
+is_uipath=0
+case "$tool" in
+  Skill)
+    case "$skill" in uipath:*|uipath-*) is_uipath=1 ;; esac
+    ;;
+  Bash|PowerShell)
+    printf '%s' "$payload" \
+      | grep -Eq '(^|[\\"[:space:];|&(])(uip|rpa-tool)[[:space:]]|\$UIP\b' && is_uipath=1
+    ;;
+  Edit|Write|Read|Glob|Grep)
+    printf '%s' "$payload" \
+      | grep -Eiq '\.(flow|xaml|uipx|bpmn)"|/(agent|caseplan|project|app\.config|action-schema)\.json"' && is_uipath=1
+    ;;
+esac
+[ "$is_uipath" = "1" ] || exit 0
+
+# --- environment resolution (cached; `uip login status` is ~0.5s) ----------
+# Resolve once per TTL and reuse, so only one tool call per hour pays the cost.
+cache_dir="${TMPDIR:-/tmp}/uipath-telemetry"
+mkdir -p "$cache_dir" 2>/dev/null
+cache="$cache_dir/env.cache"
+ttl=3600
+now="$(date +%s 2>/dev/null || echo 0)"
+
+env_name="unknown"; base_url=""; cli_ver=""; _ts=0
+[ -f "$cache" ] && . "$cache" 2>/dev/null
+
+if [ -z "${_ts:-}" ] || [ "$(( now - ${_ts:-0} ))" -ge "$ttl" ]; then
+  status_json="$(uip login status --output json 2>/dev/null)"
+  base_url="$(printf '%s' "$status_json" \
+    | grep -oE '"BaseUrl"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+  cli_ver="$(uip --version 2>/dev/null | awk 'NR==1{print $1}')"
+  case "$base_url" in
+    *alpha.uipath.com*)   env_name="alpha" ;;
+    *staging.uipath.com*) env_name="staging" ;;
+    *cloud.uipath.com*)   env_name="prod" ;;
+    "")                   env_name="unknown" ;;
+    *)                    env_name="other" ;;
+  esac
+  {
+    echo "_ts=$now"
+    echo "env_name=$env_name"
+    echo "base_url=$base_url"
+    echo "cli_ver=$cli_ver"
+  } > "$cache" 2>/dev/null
+fi
+
+# --- derived, low-cardinality, PII-free fields -----------------------------
+skill_name=""; uip_subcommand=""; file_ext=""
+case "$tool" in
+  Skill)
+    skill_name="$skill"
+    ;;
+  Bash|PowerShell)
+    # e.g. "solution publish" from "uip solution publish --output json"
+    uip_subcommand="$(printf '%s' "$payload" \
+      | grep -oE '(uip|\$UIP)[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)?' \
+      | head -1 | sed -E 's/^(uip|\$UIP)[[:space:]]+//')"
+    ;;
+  Edit|Write|Read|Glob|Grep)
+    file_ext="$(printf '%s' "$file_path" | grep -oE '\.[A-Za-z0-9]+$' | head -1)"
+    case "$file_path" in
+      *agent.json)    file_ext="agent.json" ;;
+      *caseplan.json) file_ext="caseplan.json" ;;
+    esac
+    ;;
+esac
+
+# Outcome from tool_response (no stdout/stderr content leaves the machine).
+outcome="ok"
+printf '%s' "$payload" | grep -q '"interrupted"[[:space:]]*:[[:space:]]*true'  && outcome="interrupted"
+printf '%s' "$payload" | grep -q '"success"[[:space:]]*:[[:space:]]*false'     && outcome="failure"
+
+duration_ms="$(printf '%s' "$payload" | grep -oE '"duration_ms"[[:space:]]*:[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$')"
+[ -z "$duration_ms" ] && duration_ms=0
+
+session_id="$(json_str session_id)"
+permission_mode="$(json_str permission_mode)"
+effort_level="$(printf '%s' "$payload" \
+  | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
+os_name="$(uname -s 2>/dev/null)"
+
+# cwd contains the OS username -> never send raw. Hash to a stable anon id.
+cwd="$(json_str cwd)"
+hash_of() {
+  if   command -v sha256sum >/dev/null 2>&1; then printf '%s' "$1" | sha256sum    | cut -c1-16
+  elif command -v shasum    >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | cut -c1-16
+  else printf '%s' "$1" | cksum | tr -d ' '; fi
+}
+workspace_id="$(hash_of "$cwd")"
+
+# Sanitize free-ish text to keep the hand-built JSON valid and bounded.
+san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
+tool="$(san "$tool")"
+skill_name="$(san "$skill_name")"
+uip_subcommand="$(san "$uip_subcommand")"
+file_ext="$(san "$file_ext")"
+env_name="$(san "$env_name")"
+base_url="$(san "$base_url")"
+outcome="$(san "$outcome")"
+permission_mode="$(san "$permission_mode")"
+effort_level="$(san "$effort_level")"
+cli_ver="$(san "$cli_ver")"
+os_name="$(san "$os_name")"
+
+# --- emit to Application Insights ------------------------------------------
+ikey="$(printf '%s' "$conn" | grep -oE 'InstrumentationKey=[^;]+' | head -1 | cut -d= -f2)"
+endpoint="$(printf '%s' "$conn" | grep -oE 'IngestionEndpoint=[^;]+' | head -1 | cut -d= -f2)"
+[ -z "$endpoint" ] && endpoint="https://dc.services.visualstudio.com"
+endpoint="${endpoint%/}"
+[ -z "$ikey" ] && exit 0
+
+ts_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null)"
+
+body="$(cat <<JSON
+{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$cli_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","cliVersion":"$cli_ver"},"measurements":{"durationMs":$duration_ms}}}}
+JSON
+)"
+
+# Detached subshell ( cmd & ) survives this hook's exit so the agent never waits.
+( curl -sS -m 4 -X POST "$endpoint/v2/track" \
+    -H "Content-Type: application/json" \
+    --data "$body" >/dev/null 2>&1 & )
+
+exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -60,16 +60,29 @@ esac
 
 # --- environment resolution (cached; `uip login status` is ~0.5s) ----------
 # Resolve once per TTL and reuse, so only one tool call per hour pays the cost.
-cache_dir="${TMPDIR:-/tmp}/uipath-telemetry"
-mkdir -p "$cache_dir" 2>/dev/null
+# Per-user, owner-only cache dir (NOT world-writable /tmp), so another local
+# user can't pre-create the file. chmod is a no-op on Windows but harmless.
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/uipath-telemetry"
+mkdir -p "$cache_dir" 2>/dev/null && chmod 700 "$cache_dir" 2>/dev/null
 cache="$cache_dir/env.cache"
 ttl=3600
 now="$(date +%s 2>/dev/null || echo 0)"
 
+# Parse the cache as DATA into whitelisted variables — never `source` it, so a
+# tampered cache can't execute arbitrary shell in this hook's context.
+cache_val() { # $1 = key; emits value stripped to a safe charset
+  grep -E "^$1=" "$cache" 2>/dev/null | head -1 | cut -d= -f2- | tr -cd 'A-Za-z0-9:._/-'
+}
 env_name="unknown"; base_url=""; cli_ver=""; _ts=0
-[ -f "$cache" ] && . "$cache" 2>/dev/null
+if [ -f "$cache" ]; then
+  _ts="$(cache_val _ts)"
+  env_name="$(cache_val env_name)"
+  base_url="$(cache_val base_url)"
+  cli_ver="$(cache_val cli_ver)"
+  case "$_ts" in *[!0-9]*|"") _ts=0 ;; esac   # non-numeric -> treat as stale
+fi
 
-if [ -z "${_ts:-}" ] || [ "$(( now - ${_ts:-0} ))" -ge "$ttl" ]; then
+if [ "$(( now - _ts ))" -ge "$ttl" ]; then
   status_json="$(uip login status --output json 2>/dev/null)"
   base_url="$(printf '%s' "$status_json" \
     | grep -oE '"BaseUrl"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -52,11 +52,21 @@ tool="$(json_str tool_name)"
 # concrete signals in tool_input. Anything that doesn't match -> exit 0.
 skill="$(json_str skill)"
 file_path="$(json_str file_path)"
+subagent_type="$(json_str subagent_type)"
 
 is_uipath=0
 case "$tool" in
   Skill)
     case "$skill" in uipath:*|uipath-*) is_uipath=1 ;; esac
+    ;;
+  Agent)
+    # Track subagent spawns only for UiPath agents or Claude's built-in agent
+    # types — NOT custom agents from other plugins (`<plugin>:<name>`) or
+    # user-defined ones.
+    case "$subagent_type" in
+      uipath:*|uipath-*) is_uipath=1 ;;
+      general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork) is_uipath=1 ;;
+    esac
     ;;
   Bash|PowerShell)
     printf '%s' "$payload" \
@@ -158,12 +168,12 @@ effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 
-# Subagent fields, extracted by key name (empty when the payload omits them):
+# Subagent fields (empty when the payload omits them). subagent_type is read
+# above in the relevance gate; here we add the model and the running-agent type:
 #   tool_response.resolvedModel -> subagentModel (model resolved for the spawn)
-#   tool_input.subagent_type    -> subagentType  (requested subagent type)
+#   tool_input.subagent_type    -> subagentType  (read in the gate above)
 #   agent_type (top-level)      -> agentType     (type of the running subagent)
 subagent_model="$(json_str resolvedModel)"
-subagent_type="$(json_str subagent_type)"
 agent_type="$(json_str agent_type)"
 
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -10,18 +10,20 @@
 # a detached subshell so it never delays the observed tool call.
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
-# Configuration (env only — nothing is sent unless the connection string is set):
+# Configuration (env only):
+#   UIPATH_TELEMETRY_ENABLED             Opt-in switch. Telemetry is OFF unless
+#                                        this is exactly "1". Unset or "0" -> no send.
 #   UIPATH_TELEMETRY_CONNECTION_STRING   App Insights connection string
 #       (InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/)
 #   APPLICATIONINSIGHTS_CONNECTION_STRING  Fallback if the above is unset.
-#   UIPATH_TELEMETRY_DISABLE=1           Hard off-switch.
 
 set +e
 
-[ "${UIPATH_TELEMETRY_DISABLE:-}" = "1" ] && exit 0
+# Opt-in: send only when explicitly enabled (default off).
+[ "${UIPATH_TELEMETRY_ENABLED:-0}" = "1" ] || exit 0
 
 conn="${UIPATH_TELEMETRY_CONNECTION_STRING:-${APPLICATIONINSIGHTS_CONNECTION_STRING:-}}"
-[ -z "$conn" ] && exit 0   # not configured -> no-op
+[ -z "$conn" ] && exit 0   # enabled but no endpoint configured -> nothing to send to
 
 payload="$(cat)"
 
@@ -132,7 +134,14 @@ duration_ms="$(printf '%s' "$payload" | grep -oE '"duration_ms"[[:space:]]*:[[:s
 [ -z "$duration_ms" ] && duration_ms=0
 
 session_id="$(json_str session_id)"
+tool_use_id="$(json_str tool_use_id)"   # unique per call: correlation key + ordering tiebreaker
 permission_mode="$(json_str permission_mode)"
+
+# Plugin (skills) version — designed to track the CLI version, so send both and
+# let drift surface in queries. Read from the plugin manifest, NOT git.
+plugin_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
+  "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
+  | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
@@ -159,6 +168,8 @@ outcome="$(san "$outcome")"
 permission_mode="$(san "$permission_mode")"
 effort_level="$(san "$effort_level")"
 cli_ver="$(san "$cli_ver")"
+plugin_ver="$(san "$plugin_ver")"
+tool_use_id="$(san "$tool_use_id")"
 os_name="$(san "$os_name")"
 
 # --- emit to Application Insights ------------------------------------------
@@ -171,7 +182,7 @@ endpoint="${endpoint%/}"
 ts_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null)"
 
 body="$(cat <<JSON
-{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$cli_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","cliVersion":"$cli_ver"},"measurements":{"durationMs":$duration_ms}}}}
+{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$plugin_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","toolUseId":"$tool_use_id","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","pluginVersion":"$plugin_ver","cliVersion":"$cli_ver"},"measurements":{"durationMs":$duration_ms}}}}
 JSON
 )"
 

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -158,12 +158,21 @@ effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 
-# Subagent context — present only when the tool call ran inside a spawned
-# subagent (absent in the main session, so empty = main loop). agentType is the
-# subagent name (Explore / Plan / custom). The model id is NOT in the
-# PostToolUse payload, so it cannot be sent from the hook.
-agent_id="$(json_str agent_id)"
-agent_type="$(json_str agent_type)"
+# modelId — best-effort from the payload, mapped to a short family name
+# (opus / sonnet / haiku / fable). Prefer an explicit `model` field; else scan
+# for a `claude-<family>` id token anywhere in the payload. `model` is not a
+# documented PostToolUse field, so this is empty unless the payload carries it.
+model_raw="$(json_str model)"
+[ -z "$model_raw" ] && model_raw="$(printf '%s' "$payload" \
+  | grep -oE 'claude-(opus|sonnet|haiku|fable)[a-z0-9._-]*' | head -1)"
+case "$model_raw" in
+  *opus*)   model_id="opus" ;;
+  *sonnet*) model_id="sonnet" ;;
+  *haiku*)  model_id="haiku" ;;
+  *fable*)  model_id="fable" ;;
+  "")       model_id="" ;;
+  *)        model_id="$model_raw" ;;
+esac
 
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
 # sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
@@ -181,8 +190,7 @@ effort_level="$(san "$effort_level")"
 skills_ver="$(san "$skills_ver")"
 tool_use_id="$(san "$tool_use_id")"
 session_id="$(san "$session_id")"
-agent_id="$(san "$agent_id")"
-agent_type="$(san "$agent_type")"
+model_id="$(san "$model_id")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
 # Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
@@ -195,7 +203,7 @@ agent_type="$(san "$agent_type")"
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"agentId\":\"$agent_id\",\"agentType\":\"$agent_type\",\"durationMs\":$dur_json}" \
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"modelId\":\"$model_id\",\"durationMs\":$dur_json}" \
     | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -14,35 +14,32 @@
 # gates on opt-in; value sanitization stays the hook's responsibility because
 # the CLI and skills ship co-versioned.
 #
-# REGION-SCOPED EXTRACTION (why the awk pass exists): the payload embeds
-# free-form customer content (prompts, command lines, stdout/stderr, file
-# contents). A naive grep over the whole payload mis-extracts fields when that
-# content happens to contain `"success":false`, `uip solution publish`,
-# `.flow"`, `"resolvedModel":"..."`, etc. So a single string-aware awk pass
-# walks the JSON once, tracks brace/string depth, and emits each field ONLY
-# from the region it actually lives in:
-#   ENVELOPE (top-level keys, depth 1) -> tool_name, tool_use_id, session_id,
-#     permission_mode, duration_ms, agent_type, hook_event_name
-#   tool_input  (depth 2) -> skill, command, file_path, subagent_type
-#   tool_response (depth 2) -> interrupted, success, resolvedModel
-#   effort      (depth 2) -> level
-# Nested content (depth >= 2 inside the wrong region, or anything inside a JSON
-# string) can never false-match an envelope field. Only derived, low-
-# cardinality, PII-free values ever leave the machine.
+# REGION-SCOPED EXTRACTION (see extract_fields): the payload embeds free-form
+# customer content (prompts, command lines, stdout/stderr, file contents). A
+# naive grep over the whole payload mis-extracts fields when that content
+# contains JSON-shaped text (`"success":false`, `uip solution publish`,
+# `.flow"`, `"resolvedModel":"..."`). So a single string-aware awk pass walks
+# the JSON once and pulls each field ONLY from the region it lives in:
+#   ENVELOPE (top-level)  -> toolName, toolUseId, sessionId, permissionMode,
+#                            durationMs, effortLevel (effort.level), agentType
+#   tool_input            -> skillName, uipSubcommand (command), fileExtension
+#                            (file_path), subagentType
+#   tool_response         -> outcome (interrupted/success), subagentModel
+#                            (resolvedModel)
+# Only derived, low-cardinality, PII-free values ever leave the machine.
 #
 # Non-blocking by contract: registered as an async hook in hooks.json
 # ("async": true), so Claude Code runs it in the background and never waits for
 # it. Always exits 0, swallows every error, and pipes to `uip track` in a
-# detached subshell. It never delays or fails the observed tool call.
-# Cross-platform (macOS, Linux, Windows via Git Bash / MSYS). Pure bash +
-# grep/sed/awk — no jq, node, or python.
+# detached subshell. Cross-platform (macOS, Linux, Windows via Git Bash /
+# MSYS). Pure bash + grep/sed/awk — no jq, node, or python.
 #
-# Configuration (env only):
+# Structure: pure helpers + side-effecting procedures (below), driven by main()
+# (bottom). Configuration is env only:
 #   UIPATH_TELEMETRY_DISABLED   Gate. Reuses the uip CLI's variable name.
-#                               Send ONLY when explicitly set to "0".
-#                               Unset (default) or "1" -> do not send.
-#                               Privacy-first default-off; absent is treated
-#                               as disabled.
+#                               Send ONLY when explicitly set to "0". Unset
+#                               (default) or "1" -> do not send. Privacy-first
+#                               default-off; absent is treated as disabled.
 
 set +e
 
@@ -50,193 +47,200 @@ set +e
 # Insights can segment events emitted with older/churned schemas.
 SCHEMA_VERSION=1
 
-# Send only when telemetry is explicitly NOT disabled (=0). Unset defaults to
-# "1" (disabled), so nothing is sent unless the user opts in with =0. `uip
-# track` enforces the same gate on its side; we short-circuit here too.
-[ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
+# --- extraction ------------------------------------------------------------
 
-payload="$(cat)"
-
-# --- single-pass, region-scoped field extraction --------------------------
-# One string-aware walk over the payload. Emits `key<TAB>value` lines for the
-# fields we want, each pulled from its correct region (see header). String
-# values are emitted raw (escapes left as-is); they are single-line because
-# valid JSON escapes control chars, so a real TAB never appears inside a value.
-# Large, uninteresting value strings (stdout, file contents, prompts) are
-# scanned but never buffered, so this stays O(n) without the awk O(n^2)
-# string-concat trap.
-fields="$(printf '%s' "$payload" | awk '
-  function interesting(k, d, c) {
-    if (d == 1)
-      return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
-              k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
-              k=="hook_event_name")
-    if (d == 2 && c == "input")
-      return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type")
-    if (d == 2 && c == "response")
-      return (k=="interrupted"||k=="success"||k=="resolvedModel")
-    if (d == 2 && c == "effort")
-      return (k=="level")
-    return 0
-  }
-  { buf = buf $0 "\n" }
-  END {
-    n = length(buf)
-    depth = 0; instr = 0; esc = 0
-    pend = 0; pkey = ""; pdepth = 0       # pending value after a key + colon
-    ctx = ""                              # region at depth 2: input/response/effort/other
-    laststr = ""                          # last closed string (candidate key)
-    cur = ""; buffering = 0; isval = 0
-    i = 1
-    while (i <= n) {
-      c = substr(buf, i, 1)
-      if (instr) {
-        if (esc)          { if (buffering) cur = cur c; esc = 0; i++; continue }
-        if (c == "\\")    { if (buffering) cur = cur c; esc = 1; i++; continue }
-        if (c == "\"") {
-          instr = 0
-          if (isval) {
-            if (buffering) print pkey "\t" cur
-            pend = 0; isval = 0
-          } else {
-            laststr = cur
-          }
-          cur = ""; buffering = 0; i++; continue
-        }
-        if (buffering) cur = cur c
-        i++; continue
-      }
-      if (c == "\"") {
-        instr = 1; cur = ""
-        if (pend) { isval = 1; buffering = interesting(pkey, pdepth, ctx) }
-        else      { isval = 0; buffering = 1 }   # key strings are small
-        i++; continue
-      }
-      if (c == ":") {
-        pkey = laststr; pdepth = depth; pend = 1
-        if (depth == 1 && laststr == "tool_response") print "tool_response_seen\t1"
-        i++; continue
-      }
-      if (c == "{") {
-        if (pend) {
-          if (pdepth == 1) {
-            if (pkey == "tool_input")        ctx = "input"
-            else if (pkey == "tool_response") ctx = "response"
-            else if (pkey == "effort")        ctx = "effort"
-            else                              ctx = "other"
-          }
-          pend = 0
-        }
-        depth++; i++; continue
-      }
-      if (c == "[") {
-        if (pend) { if (pdepth == 1) ctx = "other"; pend = 0 }
-        depth++; i++; continue
-      }
-      if (c == "}" || c == "]") {
-        depth--; if (depth <= 1) ctx = ""; pend = 0; i++; continue
-      }
-      if (c == ",")  { pend = 0; i++; continue }
-      if (c == " " || c == "\t" || c == "\n" || c == "\r") { i++; continue }
-      if (pend) {                               # literal value: number/true/false/null
-        lit = ""
-        while (i <= n) {
-          c = substr(buf, i, 1)
-          if (c==","||c=="}"||c=="]"||c==" "||c=="\t"||c=="\n"||c=="\r") break
-          lit = lit c; i++
-        }
-        if (interesting(pkey, pdepth, ctx)) print pkey "\t" lit
-        pend = 0; continue                      # leave delimiter for the main loop
-      }
-      i++
+# extract_fields: one string-aware awk pass over the payload (stdin). Prints
+# `key<TAB>value` lines, each field pulled ONLY from its region (see header),
+# so embedded customer content can never false-match a top-level field. String
+# values are emitted raw (escapes left as-is) and single-line (valid JSON
+# escapes control chars, so a real TAB never appears inside a value). Large,
+# uninteresting value strings (stdout, file contents, prompts) are scanned but
+# never buffered, so this stays O(n) without the awk O(n^2) string-concat trap.
+extract_fields() {
+  awk '
+    function interesting(k, d, c) {
+      if (d == 1)
+        return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
+                k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
+                k=="hook_event_name")
+      if (d == 2 && c == "input")
+        return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type")
+      if (d == 2 && c == "response")
+        return (k=="interrupted"||k=="success"||k=="resolvedModel")
+      if (d == 2 && c == "effort")
+        return (k=="level")
+      return 0
     }
-  }
-')"
-
-# --- parse the emitted key<TAB>value lines into shell variables ------------
-event=""; tool=""; tool_use_id=""; session_id=""; permission_mode=""
-duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
-subagent_type=""; interrupted=""; success=""; resolved_model=""
-effort_level=""; response_seen=""
-while IFS="$(printf '\t')" read -r k v; do
-  case "$k" in
-    hook_event_name)    event="$v" ;;
-    tool_name)          tool="$v" ;;
-    tool_use_id)        tool_use_id="$v" ;;
-    session_id)         session_id="$v" ;;
-    permission_mode)    permission_mode="$v" ;;
-    duration_ms)        duration_ms="$v" ;;
-    agent_type)         agent_type="$v" ;;
-    skill)              skill="$v" ;;
-    command)            command="$v" ;;
-    file_path)          file_path="$v" ;;
-    subagent_type)      subagent_type="$v" ;;
-    interrupted)        interrupted="$v" ;;
-    success)            success="$v" ;;
-    resolvedModel)      resolved_model="$v" ;;
-    level)              effort_level="$v" ;;
-    tool_response_seen) response_seen="1" ;;
-  esac
-done <<EOF
-$fields
-EOF
-
-[ "$event" = "PostToolUse" ] || exit 0
-
-# --- UiPath relevance gate (scoped to tool_input, never to content) --------
-# No "active plugin" field exists in the payload, so attribute per-call from
-# concrete signals in tool_input. Anything that doesn't match -> exit 0. The
-# command / file_path tested here come from tool_input only, so stdout or
-# prompt content can never cause over-attribution.
-is_uipath=0
-case "$tool" in
-  Skill)
-    case "$skill" in uipath:*|uipath-*) is_uipath=1 ;; esac
-    ;;
-  Agent)
-    # Track subagent spawns only for UiPath agents or Claude's built-in agent
-    # types — NOT custom agents from other plugins (`<plugin>:<name>`) or
-    # user-defined ones.
-    case "$subagent_type" in
-      uipath:*|uipath-*) is_uipath=1 ;;
-      general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork) is_uipath=1 ;;
-    esac
-    ;;
-  Bash|PowerShell)
-    printf '%s' "$command" \
-      | grep -Eq '(^|[\\"[:space:];|&(])(uip|rpa-tool)[[:space:]]|\$UIP\b' && is_uipath=1
-    ;;
-  Edit|Write|Read|Glob|Grep)
-    printf '%s' "$file_path" \
-      | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)$|(^|[/\\])(agent|caseplan|project|app\.config|action-schema)\.json$' && is_uipath=1
-    ;;
-esac
-[ "$is_uipath" = "1" ] || exit 0
-
-# --- environment resolution (cached; `uip login status` is ~0.5s) ----------
-# Resolve once per TTL and reuse, so only one tool call per hour pays the cost.
-# Per-user, owner-only cache dir (NOT world-writable /tmp), so another local
-# user can't pre-create the file. chmod is a no-op on Windows but harmless.
-cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/uipath-telemetry"
-mkdir -p "$cache_dir" 2>/dev/null && chmod 700 "$cache_dir" 2>/dev/null
-cache="$cache_dir/env.cache"
-ttl=3600
-now="$(date +%s 2>/dev/null || echo 0)"
-
-# Parse the cache as DATA into whitelisted variables — never `source` it, so a
-# tampered cache can't execute arbitrary shell in this hook's context.
-cache_val() { # $1 = key; emits value stripped to a safe charset
-  grep -E "^$1=" "$cache" 2>/dev/null | head -1 | cut -d= -f2- | tr -cd 'A-Za-z0-9:._/-'
+    { buf = buf $0 "\n" }
+    END {
+      n = length(buf)
+      depth = 0; instr = 0; esc = 0
+      pend = 0; pkey = ""; pdepth = 0       # pending value after a key + colon
+      ctx = ""                              # region at depth 2: input/response/effort/other
+      laststr = ""                          # last closed string (candidate key)
+      cur = ""; buffering = 0; isval = 0
+      i = 1
+      while (i <= n) {
+        c = substr(buf, i, 1)
+        if (instr) {
+          if (esc)          { if (buffering) cur = cur c; esc = 0; i++; continue }
+          if (c == "\\")    { if (buffering) cur = cur c; esc = 1; i++; continue }
+          if (c == "\"") {
+            instr = 0
+            if (isval) {
+              if (buffering) print pkey "\t" cur
+              pend = 0; isval = 0
+            } else {
+              laststr = cur
+            }
+            cur = ""; buffering = 0; i++; continue
+          }
+          if (buffering) cur = cur c
+          i++; continue
+        }
+        if (c == "\"") {
+          instr = 1; cur = ""
+          if (pend) { isval = 1; buffering = interesting(pkey, pdepth, ctx) }
+          else      { isval = 0; buffering = 1 }   # key strings are small
+          i++; continue
+        }
+        if (c == ":") {
+          pkey = laststr; pdepth = depth; pend = 1
+          if (depth == 1 && laststr == "tool_response") print "tool_response_seen\t1"
+          i++; continue
+        }
+        if (c == "{") {
+          if (pend) {
+            if (pdepth == 1) {
+              if (pkey == "tool_input")        ctx = "input"
+              else if (pkey == "tool_response") ctx = "response"
+              else if (pkey == "effort")        ctx = "effort"
+              else                              ctx = "other"
+            }
+            pend = 0
+          }
+          depth++; i++; continue
+        }
+        if (c == "[") {
+          if (pend) { if (pdepth == 1) ctx = "other"; pend = 0 }
+          depth++; i++; continue
+        }
+        if (c == "}" || c == "]") {
+          depth--; if (depth <= 1) ctx = ""; pend = 0; i++; continue
+        }
+        if (c == ",")  { pend = 0; i++; continue }
+        if (c == " " || c == "\t" || c == "\n" || c == "\r") { i++; continue }
+        if (pend) {                               # literal value: number/true/false/null
+          lit = ""
+          while (i <= n) {
+            c = substr(buf, i, 1)
+            if (c==","||c=="}"||c=="]"||c==" "||c=="\t"||c=="\n"||c=="\r") break
+            lit = lit c; i++
+          }
+          if (interesting(pkey, pdepth, ctx)) print pkey "\t" lit
+          pend = 0; continue                      # leave delimiter for the main loop
+        }
+        i++
+      }
+    }
+  '
 }
-env_name="unknown"; base_url=""; _ts=0
-if [ -f "$cache" ]; then
-  _ts="$(cache_val _ts)"
-  env_name="$(cache_val env_name)"
-  base_url="$(cache_val base_url)"
-  case "$_ts" in *[!0-9]*|"") _ts=0 ;; esac   # non-numeric -> treat as stale
-fi
 
-if [ "$(( now - _ts ))" -ge "$ttl" ]; then
+# read_fields: parse extract_fields output ($1) into the field globals. The
+# while loop runs in the current shell (here-doc, not a pipe), so the
+# assignments persist.
+read_fields() {
+  event=""; tool=""; tool_use_id=""; session_id=""; permission_mode=""
+  duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
+  subagent_type=""; interrupted=""; success=""; resolved_model=""
+  effort_level=""; response_seen=""
+  local k v
+  while IFS="$(printf '\t')" read -r k v; do
+    case "$k" in
+      hook_event_name)    event="$v" ;;
+      tool_name)          tool="$v" ;;
+      tool_use_id)        tool_use_id="$v" ;;
+      session_id)         session_id="$v" ;;
+      permission_mode)    permission_mode="$v" ;;
+      duration_ms)        duration_ms="$v" ;;
+      agent_type)         agent_type="$v" ;;
+      skill)              skill="$v" ;;
+      command)            command="$v" ;;
+      file_path)          file_path="$v" ;;
+      subagent_type)      subagent_type="$v" ;;
+      interrupted)        interrupted="$v" ;;
+      success)            success="$v" ;;
+      resolvedModel)      resolved_model="$v" ;;
+      level)              effort_level="$v" ;;
+      tool_response_seen) response_seen="1" ;;
+    esac
+  done <<EOF
+$1
+EOF
+}
+
+# --- relevance gate --------------------------------------------------------
+
+# is_uipath_call: 0 if this call is attributable to the plugin, else 1. No
+# "active plugin" field exists, so attribute per-call from tool_input signals
+# only (command / file_path), so stdout or prompt content can never
+# over-attribute.
+is_uipath_call() {
+  case "$tool" in
+    Skill)
+      case "$skill" in uipath:*|uipath-*) return 0 ;; esac
+      ;;
+    Agent)
+      # UiPath agents or Claude's built-in agent types only — NOT custom agents
+      # from other plugins (`<plugin>:<name>`) or user-defined ones.
+      case "$subagent_type" in
+        uipath:*|uipath-*) return 0 ;;
+        general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork) return 0 ;;
+      esac
+      ;;
+    Bash|PowerShell)
+      printf '%s' "$command" \
+        | grep -Eq '(^|[\\"[:space:];|&(])(uip|rpa-tool)[[:space:]]|\$UIP\b' && return 0
+      ;;
+    Edit|Write|Read|Glob|Grep)
+      printf '%s' "$file_path" \
+        | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)$|(^|[/\\])(agent|caseplan|project|app\.config|action-schema)\.json$' && return 0
+      ;;
+  esac
+  return 1
+}
+
+# --- environment resolution ------------------------------------------------
+
+# cache_val <file> <key>: emit a cached value stripped to a safe charset. Parses
+# the cache as DATA — never `source` it, so a tampered cache can't execute
+# arbitrary shell in this hook's context.
+cache_val() {
+  grep -E "^$2=" "$1" 2>/dev/null | head -1 | cut -d= -f2- | tr -cd 'A-Za-z0-9:._/-'
+}
+
+# resolve_environment: set env_name + base_url from `uip login status` (~0.5s),
+# cached per-user for 1h so only one tool call per hour pays the cost. The cache
+# dir is per-user, owner-only (NOT world-writable /tmp), so another local user
+# can't pre-create the file. chmod is a no-op on Windows but harmless.
+resolve_environment() {
+  local cache_dir cache ttl now _ts status_json
+  cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/uipath-telemetry"
+  mkdir -p "$cache_dir" 2>/dev/null && chmod 700 "$cache_dir" 2>/dev/null
+  cache="$cache_dir/env.cache"
+  ttl=3600
+  now="$(date +%s 2>/dev/null || echo 0)"
+
+  env_name="unknown"; base_url=""; _ts=0
+  if [ -f "$cache" ]; then
+    _ts="$(cache_val "$cache" _ts)"
+    env_name="$(cache_val "$cache" env_name)"
+    base_url="$(cache_val "$cache" base_url)"
+    case "$_ts" in *[!0-9]*|"") _ts=0 ;; esac   # non-numeric -> treat as stale
+  fi
+
+  [ "$(( now - _ts ))" -ge "$ttl" ] || return 0
+
   status_json="$(uip login status --output json 2>/dev/null)"
   base_url="$(printf '%s' "$status_json" \
     | grep -oE '"BaseUrl"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
@@ -252,103 +256,84 @@ if [ "$(( now - _ts ))" -ge "$ttl" ]; then
     echo "env_name=$env_name"
     echo "base_url=$base_url"
   } > "$cache" 2>/dev/null
-fi
+}
 
-# --- derived, low-cardinality fields ---------------------------------------
-skill_name=""; uip_subcommand=""; file_ext=""
-case "$tool" in
-  Skill)
-    skill_name="$skill"
-    ;;
-  Bash|PowerShell)
-    # e.g. "solution publish" from "uip solution publish --output json".
-    # Derived from tool_input.command only, so stdout content can't leak in.
-    uip_subcommand="$(printf '%s' "$command" \
-      | grep -oE '(uip|\$UIP)[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)?' \
-      | head -1 | sed -E 's/^(uip|\$UIP)[[:space:]]+//')"
-    ;;
-  Edit|Write|Read|Glob|Grep)
-    file_ext="$(printf '%s' "$file_path" | grep -oE '\.[A-Za-z0-9]+$' | head -1)"
-    case "$file_path" in
-      *agent.json)    file_ext="agent.json" ;;
-      *caseplan.json) file_ext="caseplan.json" ;;
-    esac
-    ;;
-esac
+# --- field derivation ------------------------------------------------------
 
-# Outcome from the tool_response region ONLY — content never flips it.
-#   interrupted == true -> interrupted
+# derive_fields: set skill_name, uip_subcommand, file_ext from the parsed
+# tool_input values (so stdout content can't leak in).
+derive_fields() {
+  skill_name=""; uip_subcommand=""; file_ext=""
+  case "$tool" in
+    Skill)
+      skill_name="$skill"
+      ;;
+    Bash|PowerShell)
+      # e.g. "solution publish" from "uip solution publish --output json".
+      uip_subcommand="$(printf '%s' "$command" \
+        | grep -oE '(uip|\$UIP)[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)?' \
+        | head -1 | sed -E 's/^(uip|\$UIP)[[:space:]]+//')"
+      ;;
+    Edit|Write|Read|Glob|Grep)
+      file_ext="$(printf '%s' "$file_path" | grep -oE '\.[A-Za-z0-9]+$' | head -1)"
+      case "$file_path" in
+        *agent.json)    file_ext="agent.json" ;;
+        *caseplan.json) file_ext="caseplan.json" ;;
+      esac
+      ;;
+  esac
+}
+
+# compute_outcome: print outcome from the tool_response region ONLY — content
+# never flips it.
+#   interrupted == true -> interrupted (takes precedence)
 #   success     == false -> failure
 #   tool_response present, no failure signal -> ok (Read/Edit/Write/most MCP)
 #   no tool_response at all -> unknown
-if [ "$interrupted" = "true" ]; then
-  outcome="interrupted"
-elif [ "$success" = "false" ]; then
-  outcome="failure"
-elif [ -n "$response_seen" ]; then
-  outcome="ok"
-else
-  outcome="unknown"
-fi
+compute_outcome() {
+  if   [ "$interrupted" = "true" ];  then printf 'interrupted'
+  elif [ "$success" = "false" ];     then printf 'failure'
+  elif [ -n "$response_seen" ];      then printf 'ok'
+  else                                    printf 'unknown'
+  fi
+}
 
-# durationMs is a JSON number. Emit JSON null (not 0) when absent, so a missing
-# value doesn't skew latency aggregations. The CLI drops a null-valued property,
-# so a missing duration simply records as "no data". Stays unquoted.
-case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
+# model_family <resolvedModel>: print the low-cardinality family and drop the
+# context-window marker (e.g. claude-opus-4-8[1m] -> opus). Empty when absent
+# (plain main-loop call); `other` for an unrecognized family.
+model_family() {
+  case "$1" in
+    "")       printf '' ;;
+    *opus*)   printf 'opus' ;;
+    *sonnet*) printf 'sonnet' ;;
+    *haiku*)  printf 'haiku' ;;
+    *fable*)  printf 'fable' ;;
+    *)        printf 'other' ;;
+  esac
+}
 
-# Normalize the resolved subagent model to a low-cardinality family and drop
-# the context-window marker (e.g. `claude-opus-4-8[1m]` -> `opus`). Empty when
-# absent (plain main-loop call); `other` for an unrecognized family.
-case "$resolved_model" in
-  "")        subagent_model="" ;;
-  *opus*)    subagent_model="opus" ;;
-  *sonnet*)  subagent_model="sonnet" ;;
-  *haiku*)   subagent_model="haiku" ;;
-  *fable*)   subagent_model="fable" ;;
-  *)         subagent_model="other" ;;
-esac
+# read_skills_version: skills/CLI co-version from version-manifest.json (NOT
+# git, NOT the plugin package version). The CLI's own app version already rides
+# the tracker as application_Version, so no separate cliVersion is sent.
+read_skills_version() {
+  grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
+}
 
-# Skills version — tracks the CLI version (version-manifest.json `targetCli`).
-# The CLI's own app version already rides the tracker as `application_Version`,
-# so we no longer send a separate cliVersion. Read from the manifest, NOT git.
-# This is the skills/CLI co-version, NOT the .claude-plugin/plugin.json package
-# version.
-skills_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
-  "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
-  | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-
-# Sanitize free-ish text to keep the assembled JSON valid and bounded. Strips
-# anything outside a safe charset (so no quotes / backslashes / control chars /
-# pipes survive) and caps length. Value sanitization is the hook's job (CLI and
-# skills ship co-versioned); the CLI then namespaces, stamps identity, forwards.
+# san: sanitize free-ish text to keep the assembled JSON valid and bounded.
+# Strips anything outside a safe charset (so no quotes / backslashes / control
+# chars / pipes survive) and caps length.
 san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
-tool="$(san "$tool")"
-skill_name="$(san "$skill_name")"
-uip_subcommand="$(san "$uip_subcommand")"
-file_ext="$(san "$file_ext")"
-env_name="$(san "$env_name")"
-base_url="$(san "$base_url")"
-outcome="$(san "$outcome")"
-permission_mode="$(san "$permission_mode")"
-effort_level="$(san "$effort_level")"
-skills_ver="$(san "$skills_ver")"
-tool_use_id="$(san "$tool_use_id")"
-session_id="$(san "$session_id")"
-subagent_model="$(san "$subagent_model")"
-subagent_type="$(san "$subagent_type")"
-agent_type="$(san "$agent_type")"
 
-# --- hand off to the CLI telemetry tracker ---------------------------------
-# Canonical field set, defined ONCE and assembled by iteration (fixed order,
-# every key always emitted). Each row is `name|type|value`: type `s` -> JSON
-# string, `n` -> JSON number/literal. Values are already sanitized, so `|`
-# cannot appear inside one (san maps it to `_`); durationMs/schemaVersion are
-# numeric/literal. The CLI hard-codes the event name (uip.skills.tool-use),
-# stamps source: "skills-plugin", attaches the authenticated cloud identity +
-# CLI app version, and owns transport + flush. The CLI drops any non-scalar
-# value (so a null durationMs simply disappears). Send no `event` key, no
-# envelope, and no `source` (the CLI overrides it).
-fields_spec="schemaVersion|n|$SCHEMA_VERSION
+# build_event_json: assemble the canonical, ordered, flat JSON from the
+# (already sanitized) field globals + dur_json + SCHEMA_VERSION. The key set is
+# defined ONCE here and assembled by iteration (fixed order, every key always
+# emitted). Each row is `name|type|value`: `s` -> JSON string, `n` -> JSON
+# number/literal. Sanitized values cannot contain `|` (san maps it to `_`).
+build_event_json() {
+  local spec json sep fkey ftyp fval
+  spec="schemaVersion|n|$SCHEMA_VERSION
 toolName|s|$tool
 skillName|s|$skill_name
 uipSubcommand|s|$uip_subcommand
@@ -365,23 +350,72 @@ subagentModel|s|$subagent_model
 subagentType|s|$subagent_type
 agentType|s|$agent_type
 durationMs|n|$dur_json"
-
-json="{"; sep=""
-while IFS='|' read -r fkey ftyp fval; do
-  [ -n "$fkey" ] || continue
-  case "$ftyp" in
-    n) json="$json$sep\"$fkey\":$fval" ;;
-    *) json="$json$sep\"$fkey\":\"$fval\"" ;;
-  esac
-  sep=","
-done <<EOF
-$fields_spec
+  json="{"; sep=""
+  while IFS='|' read -r fkey ftyp fval; do
+    [ -n "$fkey" ] || continue
+    case "$ftyp" in
+      n) json="$json$sep\"$fkey\":$fval" ;;
+      *) json="$json$sep\"$fkey\":\"$fval\"" ;;
+    esac
+    sep=","
+  done <<EOF
+$spec
 EOF
-json="$json}"
+  printf '%s}' "$json"
+}
 
-# Detached subshell ( cmd & ) survives this hook's exit so the agent never
-# waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
-# telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "$json" | uip track >/dev/null 2>&1 & )
+# --- main ------------------------------------------------------------------
+main() {
+  # Send only when telemetry is explicitly NOT disabled (=0). `uip track`
+  # enforces the same gate on its side; we short-circuit here too.
+  [ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
 
-exit 0
+  payload="$(cat)"
+  read_fields "$(printf '%s' "$payload" | extract_fields)"
+
+  [ "$event" = "PostToolUse" ] || exit 0
+  is_uipath_call || exit 0
+
+  resolve_environment
+  derive_fields
+
+  outcome="$(compute_outcome)"
+  # durationMs is a JSON number. Emit JSON null (not 0) when absent, so a missing
+  # value doesn't skew latency aggregations. The CLI drops a null-valued
+  # property, so a missing duration records as "no data". Stays unquoted.
+  case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
+  subagent_model="$(model_family "$resolved_model")"
+  skills_ver="$(read_skills_version)"
+
+  # Sanitize every string field before assembly.
+  tool="$(san "$tool")"
+  skill_name="$(san "$skill_name")"
+  uip_subcommand="$(san "$uip_subcommand")"
+  file_ext="$(san "$file_ext")"
+  env_name="$(san "$env_name")"
+  base_url="$(san "$base_url")"
+  outcome="$(san "$outcome")"
+  permission_mode="$(san "$permission_mode")"
+  effort_level="$(san "$effort_level")"
+  skills_ver="$(san "$skills_ver")"
+  tool_use_id="$(san "$tool_use_id")"
+  session_id="$(san "$session_id")"
+  subagent_model="$(san "$subagent_model")"
+  subagent_type="$(san "$subagent_type")"
+  agent_type="$(san "$agent_type")"
+
+  # Hand off to the CLI telemetry tracker. The CLI hard-codes the event name
+  # (uip.skills.tool-use), stamps source: "skills-plugin", attaches the
+  # authenticated cloud identity + CLI app version, and owns transport + flush;
+  # it drops any non-scalar value (so a null durationMs disappears). Send no
+  # `event` key, no envelope, and no `source` (the CLI overrides it).
+  #
+  # Detached subshell ( cmd & ) survives this hook's exit so the agent never
+  # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
+  # telemetry is off); piping to it is harmless even if the CLI is absent.
+  ( printf '%s' "$(build_event_json)" | uip track >/dev/null 2>&1 & )
+
+  exit 0
+}
+
+main

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -14,11 +14,28 @@
 # gates on opt-in; value sanitization stays the hook's responsibility because
 # the CLI and skills ship co-versioned.
 #
+# REGION-SCOPED EXTRACTION (why the awk pass exists): the payload embeds
+# free-form customer content (prompts, command lines, stdout/stderr, file
+# contents). A naive grep over the whole payload mis-extracts fields when that
+# content happens to contain `"success":false`, `uip solution publish`,
+# `.flow"`, `"resolvedModel":"..."`, etc. So a single string-aware awk pass
+# walks the JSON once, tracks brace/string depth, and emits each field ONLY
+# from the region it actually lives in:
+#   ENVELOPE (top-level keys, depth 1) -> tool_name, tool_use_id, session_id,
+#     permission_mode, duration_ms, agent_type, hook_event_name
+#   tool_input  (depth 2) -> skill, command, file_path, subagent_type
+#   tool_response (depth 2) -> interrupted, success, resolvedModel
+#   effort      (depth 2) -> level
+# Nested content (depth >= 2 inside the wrong region, or anything inside a JSON
+# string) can never false-match an envelope field. Only derived, low-
+# cardinality, PII-free values ever leave the machine.
+#
 # Non-blocking by contract: registered as an async hook in hooks.json
 # ("async": true), so Claude Code runs it in the background and never waits for
 # it. Always exits 0, swallows every error, and pipes to `uip track` in a
 # detached subshell. It never delays or fails the observed tool call.
-# Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
+# Cross-platform (macOS, Linux, Windows via Git Bash / MSYS). Pure bash +
+# grep/sed/awk — no jq, node, or python.
 #
 # Configuration (env only):
 #   UIPATH_TELEMETRY_DISABLED   Gate. Reuses the uip CLI's variable name.
@@ -29,6 +46,10 @@
 
 set +e
 
+# schemaVersion of the emitted event. Bump on ANY change to the key set so App
+# Insights can segment events emitted with older/churned schemas.
+SCHEMA_VERSION=1
+
 # Send only when telemetry is explicitly NOT disabled (=0). Unset defaults to
 # "1" (disabled), so nothing is sent unless the user opts in with =0. `uip
 # track` enforces the same gate on its side; we short-circuit here too.
@@ -36,24 +57,137 @@ set +e
 
 payload="$(cat)"
 
-# --- field helpers ---------------------------------------------------------
-json_str() { # $1 = key; prints first JSON string value for that key
-  printf '%s' "$payload" \
-    | grep -oE "\"$1\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" \
-    | head -1 | sed 's/.*"\([^"]*\)"$/\1/'
-}
+# --- single-pass, region-scoped field extraction --------------------------
+# One string-aware walk over the payload. Emits `key<TAB>value` lines for the
+# fields we want, each pulled from its correct region (see header). String
+# values are emitted raw (escapes left as-is); they are single-line because
+# valid JSON escapes control chars, so a real TAB never appears inside a value.
+# Large, uninteresting value strings (stdout, file contents, prompts) are
+# scanned but never buffered, so this stays O(n) without the awk O(n^2)
+# string-concat trap.
+fields="$(printf '%s' "$payload" | awk '
+  function interesting(k, d, c) {
+    if (d == 1)
+      return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
+              k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
+              k=="hook_event_name")
+    if (d == 2 && c == "input")
+      return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type")
+    if (d == 2 && c == "response")
+      return (k=="interrupted"||k=="success"||k=="resolvedModel")
+    if (d == 2 && c == "effort")
+      return (k=="level")
+    return 0
+  }
+  { buf = buf $0 "\n" }
+  END {
+    n = length(buf)
+    depth = 0; instr = 0; esc = 0
+    pend = 0; pkey = ""; pdepth = 0       # pending value after a key + colon
+    ctx = ""                              # region at depth 2: input/response/effort/other
+    laststr = ""                          # last closed string (candidate key)
+    cur = ""; buffering = 0; isval = 0
+    i = 1
+    while (i <= n) {
+      c = substr(buf, i, 1)
+      if (instr) {
+        if (esc)          { if (buffering) cur = cur c; esc = 0; i++; continue }
+        if (c == "\\")    { if (buffering) cur = cur c; esc = 1; i++; continue }
+        if (c == "\"") {
+          instr = 0
+          if (isval) {
+            if (buffering) print pkey "\t" cur
+            pend = 0; isval = 0
+          } else {
+            laststr = cur
+          }
+          cur = ""; buffering = 0; i++; continue
+        }
+        if (buffering) cur = cur c
+        i++; continue
+      }
+      if (c == "\"") {
+        instr = 1; cur = ""
+        if (pend) { isval = 1; buffering = interesting(pkey, pdepth, ctx) }
+        else      { isval = 0; buffering = 1 }   # key strings are small
+        i++; continue
+      }
+      if (c == ":") {
+        pkey = laststr; pdepth = depth; pend = 1
+        if (depth == 1 && laststr == "tool_response") print "tool_response_seen\t1"
+        i++; continue
+      }
+      if (c == "{") {
+        if (pend) {
+          if (pdepth == 1) {
+            if (pkey == "tool_input")        ctx = "input"
+            else if (pkey == "tool_response") ctx = "response"
+            else if (pkey == "effort")        ctx = "effort"
+            else                              ctx = "other"
+          }
+          pend = 0
+        }
+        depth++; i++; continue
+      }
+      if (c == "[") {
+        if (pend) { if (pdepth == 1) ctx = "other"; pend = 0 }
+        depth++; i++; continue
+      }
+      if (c == "}" || c == "]") {
+        depth--; if (depth <= 1) ctx = ""; pend = 0; i++; continue
+      }
+      if (c == ",")  { pend = 0; i++; continue }
+      if (c == " " || c == "\t" || c == "\n" || c == "\r") { i++; continue }
+      if (pend) {                               # literal value: number/true/false/null
+        lit = ""
+        while (i <= n) {
+          c = substr(buf, i, 1)
+          if (c==","||c=="}"||c=="]"||c==" "||c=="\t"||c=="\n"||c=="\r") break
+          lit = lit c; i++
+        }
+        if (interesting(pkey, pdepth, ctx)) print pkey "\t" lit
+        pend = 0; continue                      # leave delimiter for the main loop
+      }
+      i++
+    }
+  }
+')"
 
-event="$(json_str hook_event_name)"
-tool="$(json_str tool_name)"
+# --- parse the emitted key<TAB>value lines into shell variables ------------
+event=""; tool=""; tool_use_id=""; session_id=""; permission_mode=""
+duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
+subagent_type=""; interrupted=""; success=""; resolved_model=""
+effort_level=""; response_seen=""
+while IFS="$(printf '\t')" read -r k v; do
+  case "$k" in
+    hook_event_name)    event="$v" ;;
+    tool_name)          tool="$v" ;;
+    tool_use_id)        tool_use_id="$v" ;;
+    session_id)         session_id="$v" ;;
+    permission_mode)    permission_mode="$v" ;;
+    duration_ms)        duration_ms="$v" ;;
+    agent_type)         agent_type="$v" ;;
+    skill)              skill="$v" ;;
+    command)            command="$v" ;;
+    file_path)          file_path="$v" ;;
+    subagent_type)      subagent_type="$v" ;;
+    interrupted)        interrupted="$v" ;;
+    success)            success="$v" ;;
+    resolvedModel)      resolved_model="$v" ;;
+    level)              effort_level="$v" ;;
+    tool_response_seen) response_seen="1" ;;
+  esac
+done <<EOF
+$fields
+EOF
+
 [ "$event" = "PostToolUse" ] || exit 0
 
-# --- UiPath relevance gate -------------------------------------------------
+# --- UiPath relevance gate (scoped to tool_input, never to content) --------
 # No "active plugin" field exists in the payload, so attribute per-call from
-# concrete signals in tool_input. Anything that doesn't match -> exit 0.
-skill="$(json_str skill)"
-file_path="$(json_str file_path)"
-subagent_type="$(json_str subagent_type)"
-
+# concrete signals in tool_input. Anything that doesn't match -> exit 0. The
+# command / file_path tested here come from tool_input only, so stdout or
+# prompt content can never cause over-attribution.
 is_uipath=0
 case "$tool" in
   Skill)
@@ -69,12 +203,12 @@ case "$tool" in
     esac
     ;;
   Bash|PowerShell)
-    printf '%s' "$payload" \
+    printf '%s' "$command" \
       | grep -Eq '(^|[\\"[:space:];|&(])(uip|rpa-tool)[[:space:]]|\$UIP\b' && is_uipath=1
     ;;
   Edit|Write|Read|Glob|Grep)
-    printf '%s' "$payload" \
-      | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)"|/(agent|caseplan|project|app\.config|action-schema)\.json"' && is_uipath=1
+    printf '%s' "$file_path" \
+      | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)$|(^|[/\\])(agent|caseplan|project|app\.config|action-schema)\.json$' && is_uipath=1
     ;;
 esac
 [ "$is_uipath" = "1" ] || exit 0
@@ -127,8 +261,9 @@ case "$tool" in
     skill_name="$skill"
     ;;
   Bash|PowerShell)
-    # e.g. "solution publish" from "uip solution publish --output json"
-    uip_subcommand="$(printf '%s' "$payload" \
+    # e.g. "solution publish" from "uip solution publish --output json".
+    # Derived from tool_input.command only, so stdout content can't leak in.
+    uip_subcommand="$(printf '%s' "$command" \
       | grep -oE '(uip|\$UIP)[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)?' \
       | head -1 | sed -E 's/^(uip|\$UIP)[[:space:]]+//')"
     ;;
@@ -141,20 +276,37 @@ case "$tool" in
     ;;
 esac
 
-# Outcome from tool_response (no stdout/stderr content leaves the machine).
-outcome="ok"
-printf '%s' "$payload" | grep -q '"interrupted"[[:space:]]*:[[:space:]]*true'  && outcome="interrupted"
-printf '%s' "$payload" | grep -q '"success"[[:space:]]*:[[:space:]]*false'     && outcome="failure"
+# Outcome from the tool_response region ONLY — content never flips it.
+#   interrupted == true -> interrupted
+#   success     == false -> failure
+#   tool_response present, no failure signal -> ok (Read/Edit/Write/most MCP)
+#   no tool_response at all -> unknown
+if [ "$interrupted" = "true" ]; then
+  outcome="interrupted"
+elif [ "$success" = "false" ]; then
+  outcome="failure"
+elif [ -n "$response_seen" ]; then
+  outcome="ok"
+else
+  outcome="unknown"
+fi
 
-duration_ms="$(printf '%s' "$payload" | grep -oE '"duration_ms"[[:space:]]*:[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$')"
-# durationMs is sent as a JSON number. Emit JSON null (not 0) when absent, so a
-# missing value doesn't skew latency aggregations. The CLI drops a null-valued
-# property, so a missing duration simply records as "no data". Stays unquoted.
+# durationMs is a JSON number. Emit JSON null (not 0) when absent, so a missing
+# value doesn't skew latency aggregations. The CLI drops a null-valued property,
+# so a missing duration simply records as "no data". Stays unquoted.
 case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
 
-session_id="$(json_str session_id)"
-tool_use_id="$(json_str tool_use_id)"   # unique per call: correlation key + ordering tiebreaker
-permission_mode="$(json_str permission_mode)"
+# Normalize the resolved subagent model to a low-cardinality family and drop
+# the context-window marker (e.g. `claude-opus-4-8[1m]` -> `opus`). Empty when
+# absent (plain main-loop call); `other` for an unrecognized family.
+case "$resolved_model" in
+  "")        subagent_model="" ;;
+  *opus*)    subagent_model="opus" ;;
+  *sonnet*)  subagent_model="sonnet" ;;
+  *haiku*)   subagent_model="haiku" ;;
+  *fable*)   subagent_model="fable" ;;
+  *)         subagent_model="other" ;;
+esac
 
 # Skills version — tracks the CLI version (version-manifest.json `targetCli`).
 # The CLI's own app version already rides the tracker as `application_Version`,
@@ -164,21 +316,11 @@ permission_mode="$(json_str permission_mode)"
 skills_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
   "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
   | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-effort_level="$(printf '%s' "$payload" \
-  | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
-  | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 
-# Subagent fields (empty when the payload omits them). subagent_type is read
-# above in the relevance gate; here we add the model and the running-agent type:
-#   tool_response.resolvedModel -> subagentModel (model resolved for the spawn)
-#   tool_input.subagent_type    -> subagentType  (read in the gate above)
-#   agent_type (top-level)      -> agentType     (type of the running subagent)
-subagent_model="$(json_str resolvedModel)"
-agent_type="$(json_str agent_type)"
-
-# Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
-# sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
-# then namespaces, stamps identity, and forwards.
+# Sanitize free-ish text to keep the assembled JSON valid and bounded. Strips
+# anything outside a safe charset (so no quotes / backslashes / control chars /
+# pipes survive) and caps length. Value sanitization is the hook's job (CLI and
+# skills ship co-versioned); the CLI then namespaces, stamps identity, forwards.
 san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
 tool="$(san "$tool")"
 skill_name="$(san "$skill_name")"
@@ -197,17 +339,49 @@ subagent_type="$(san "$subagent_type")"
 agent_type="$(san "$agent_type")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
-# Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
-# codes the event name (uip.skills.tool-use), stamps source: "skills-plugin",
-# attaches the authenticated cloud identity + CLI app version, and owns
-# transport + flush. Every scalar key below becomes an event property; the CLI
-# drops any non-scalar value (so a null durationMs simply disappears). Send no
-# `event` key, no envelope, and no `source` (the CLI overrides it).
-#
+# Canonical field set, defined ONCE and assembled by iteration (fixed order,
+# every key always emitted). Each row is `name|type|value`: type `s` -> JSON
+# string, `n` -> JSON number/literal. Values are already sanitized, so `|`
+# cannot appear inside one (san maps it to `_`); durationMs/schemaVersion are
+# numeric/literal. The CLI hard-codes the event name (uip.skills.tool-use),
+# stamps source: "skills-plugin", attaches the authenticated cloud identity +
+# CLI app version, and owns transport + flush. The CLI drops any non-scalar
+# value (so a null durationMs simply disappears). Send no `event` key, no
+# envelope, and no `source` (the CLI overrides it).
+fields_spec="schemaVersion|n|$SCHEMA_VERSION
+toolName|s|$tool
+skillName|s|$skill_name
+uipSubcommand|s|$uip_subcommand
+fileExtension|s|$file_ext
+environment|s|$env_name
+baseUrl|s|$base_url
+outcome|s|$outcome
+permissionMode|s|$permission_mode
+effortLevel|s|$effort_level
+skillsVersion|s|$skills_ver
+toolUseId|s|$tool_use_id
+sessionId|s|$session_id
+subagentModel|s|$subagent_model
+subagentType|s|$subagent_type
+agentType|s|$agent_type
+durationMs|n|$dur_json"
+
+json="{"; sep=""
+while IFS='|' read -r fkey ftyp fval; do
+  [ -n "$fkey" ] || continue
+  case "$ftyp" in
+    n) json="$json$sep\"$fkey\":$fval" ;;
+    *) json="$json$sep\"$fkey\":\"$fval\"" ;;
+  esac
+  sep=","
+done <<EOF
+$fields_spec
+EOF
+json="$json}"
+
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"subagentModel\":\"$subagent_model\",\"subagentType\":\"$subagent_type\",\"agentType\":\"$agent_type\",\"durationMs\":$dur_json}" \
-    | uip track >/dev/null 2>&1 & )
+( printf '%s' "$json" | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -59,7 +59,7 @@ case "$tool" in
     ;;
   Edit|Write|Read|Glob|Grep)
     printf '%s' "$payload" \
-      | grep -Eiq '\.(flow|xaml|uipx|bpmn)"|/(agent|caseplan|project|app\.config|action-schema)\.json"' && is_uipath=1
+      | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)"|/(agent|caseplan|project|app\.config|action-schema)\.json"' && is_uipath=1
     ;;
 esac
 [ "$is_uipath" = "1" ] || exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -149,15 +149,28 @@ session_id="$(json_str session_id)"
 tool_use_id="$(json_str tool_use_id)"   # unique per call: correlation key + ordering tiebreaker
 permission_mode="$(json_str permission_mode)"
 
-# Plugin (skills) version — designed to track the CLI version, so send both and
-# let drift surface in queries. Read from the plugin manifest, NOT git.
-plugin_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
+# Skills version — tracks the CLI version (version-manifest.json `targetCli`),
+# so send it alongside cliVersion and let drift surface in queries. Read from
+# the manifest, NOT git. This is the skills/CLI co-version, NOT the
+# .claude-plugin/plugin.json package version.
+skills_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
   "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
   | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 os_name="$(uname -s 2>/dev/null)"
+
+# cwd embeds the OS username -> never send raw. Hash to a stable, anonymous
+# workspace id. This is the agent's working directory, distinct from the cloud
+# identity (CloudUserId) the CLI stamps; it segments telemetry by workspace.
+cwd="$(json_str cwd)"
+hash_of() {
+  if   command -v sha256sum >/dev/null 2>&1; then printf '%s' "$1" | sha256sum    | cut -c1-16
+  elif command -v shasum    >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | cut -c1-16
+  else printf '%s' "$1" | cksum | tr -d ' '; fi
+}
+if [ -n "$cwd" ]; then user_id="$(hash_of "$cwd")"; else user_id=""; fi
 
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
 # sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
@@ -173,10 +186,11 @@ outcome="$(san "$outcome")"
 permission_mode="$(san "$permission_mode")"
 effort_level="$(san "$effort_level")"
 cli_ver="$(san "$cli_ver")"
-plugin_ver="$(san "$plugin_ver")"
+skills_ver="$(san "$skills_ver")"
 tool_use_id="$(san "$tool_use_id")"
 session_id="$(san "$session_id")"
 os_name="$(san "$os_name")"
+user_id="$(san "$user_id")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
 # Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
@@ -189,7 +203,7 @@ os_name="$(san "$os_name")"
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExt\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"os\":\"$os_name\",\"pluginVersion\":\"$plugin_ver\",\"cliVersion\":\"$cli_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"durationMs\":$dur_json}" \
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"operatingSystem\":\"$os_name\",\"skillsVersion\":\"$skills_ver\",\"cliVersion\":\"$cli_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"userId\":\"$user_id\",\"durationMs\":$dur_json}" \
     | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -158,22 +158,6 @@ effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 
-# modelId — best-effort from the payload, mapped to a short family name
-# (opus / sonnet / haiku / fable). Prefer an explicit `model` field; else scan
-# for a `claude-<family>` id token anywhere in the payload. `model` is not a
-# documented PostToolUse field, so this is empty unless the payload carries it.
-model_raw="$(json_str model)"
-[ -z "$model_raw" ] && model_raw="$(printf '%s' "$payload" \
-  | grep -oE 'claude-(opus|sonnet|haiku|fable)[a-z0-9._-]*' | head -1)"
-case "$model_raw" in
-  *opus*)   model_id="opus" ;;
-  *sonnet*) model_id="sonnet" ;;
-  *haiku*)  model_id="haiku" ;;
-  *fable*)  model_id="fable" ;;
-  "")       model_id="" ;;
-  *)        model_id="$model_raw" ;;
-esac
-
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
 # sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
 # then namespaces, stamps identity, and forwards.
@@ -190,7 +174,6 @@ effort_level="$(san "$effort_level")"
 skills_ver="$(san "$skills_ver")"
 tool_use_id="$(san "$tool_use_id")"
 session_id="$(san "$session_id")"
-model_id="$(san "$model_id")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
 # Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
@@ -203,7 +186,7 @@ model_id="$(san "$model_id")"
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"modelId\":\"$model_id\",\"durationMs\":$dur_json}" \
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"durationMs\":$dur_json}" \
     | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -84,12 +84,11 @@ now="$(date +%s 2>/dev/null || echo 0)"
 cache_val() { # $1 = key; emits value stripped to a safe charset
   grep -E "^$1=" "$cache" 2>/dev/null | head -1 | cut -d= -f2- | tr -cd 'A-Za-z0-9:._/-'
 }
-env_name="unknown"; base_url=""; cli_ver=""; _ts=0
+env_name="unknown"; base_url=""; _ts=0
 if [ -f "$cache" ]; then
   _ts="$(cache_val _ts)"
   env_name="$(cache_val env_name)"
   base_url="$(cache_val base_url)"
-  cli_ver="$(cache_val cli_ver)"
   case "$_ts" in *[!0-9]*|"") _ts=0 ;; esac   # non-numeric -> treat as stale
 fi
 
@@ -97,7 +96,6 @@ if [ "$(( now - _ts ))" -ge "$ttl" ]; then
   status_json="$(uip login status --output json 2>/dev/null)"
   base_url="$(printf '%s' "$status_json" \
     | grep -oE '"BaseUrl"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-  cli_ver="$(uip --version 2>/dev/null | awk 'NR==1{print $1}')"
   case "$base_url" in
     *alpha.uipath.com*)   env_name="alpha" ;;
     *staging.uipath.com*) env_name="staging" ;;
@@ -109,7 +107,6 @@ if [ "$(( now - _ts ))" -ge "$ttl" ]; then
     echo "_ts=$now"
     echo "env_name=$env_name"
     echo "base_url=$base_url"
-    echo "cli_ver=$cli_ver"
   } > "$cache" 2>/dev/null
 fi
 
@@ -149,28 +146,24 @@ session_id="$(json_str session_id)"
 tool_use_id="$(json_str tool_use_id)"   # unique per call: correlation key + ordering tiebreaker
 permission_mode="$(json_str permission_mode)"
 
-# Skills version — tracks the CLI version (version-manifest.json `targetCli`),
-# so send it alongside cliVersion and let drift surface in queries. Read from
-# the manifest, NOT git. This is the skills/CLI co-version, NOT the
-# .claude-plugin/plugin.json package version.
+# Skills version — tracks the CLI version (version-manifest.json `targetCli`).
+# The CLI's own app version already rides the tracker as `application_Version`,
+# so we no longer send a separate cliVersion. Read from the manifest, NOT git.
+# This is the skills/CLI co-version, NOT the .claude-plugin/plugin.json package
+# version.
 skills_ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
   "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
   | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-os_name="$(uname -s 2>/dev/null)"
 
-# cwd embeds the OS username -> never send raw. Hash to a stable, anonymous
-# workspace id. This is the agent's working directory, distinct from the cloud
-# identity (CloudUserId) the CLI stamps; it segments telemetry by workspace.
-cwd="$(json_str cwd)"
-hash_of() {
-  if   command -v sha256sum >/dev/null 2>&1; then printf '%s' "$1" | sha256sum    | cut -c1-16
-  elif command -v shasum    >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | cut -c1-16
-  else printf '%s' "$1" | cksum | tr -d ' '; fi
-}
-if [ -n "$cwd" ]; then user_id="$(hash_of "$cwd")"; else user_id=""; fi
+# Subagent context — present only when the tool call ran inside a spawned
+# subagent (absent in the main session, so empty = main loop). agentType is the
+# subagent name (Explore / Plan / custom). The model id is NOT in the
+# PostToolUse payload, so it cannot be sent from the hook.
+agent_id="$(json_str agent_id)"
+agent_type="$(json_str agent_type)"
 
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
 # sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
@@ -185,12 +178,11 @@ base_url="$(san "$base_url")"
 outcome="$(san "$outcome")"
 permission_mode="$(san "$permission_mode")"
 effort_level="$(san "$effort_level")"
-cli_ver="$(san "$cli_ver")"
 skills_ver="$(san "$skills_ver")"
 tool_use_id="$(san "$tool_use_id")"
 session_id="$(san "$session_id")"
-os_name="$(san "$os_name")"
-user_id="$(san "$user_id")"
+agent_id="$(san "$agent_id")"
+agent_type="$(san "$agent_type")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
 # Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
@@ -203,7 +195,7 @@ user_id="$(san "$user_id")"
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"operatingSystem\":\"$os_name\",\"skillsVersion\":\"$skills_ver\",\"cliVersion\":\"$cli_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"userId\":\"$user_id\",\"durationMs\":$dur_json}" \
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"agentId\":\"$agent_id\",\"agentType\":\"$agent_type\",\"durationMs\":$dur_json}" \
     | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -6,8 +6,10 @@
 # (alpha / staging / prod), and emits one customEvent to Azure Application
 # Insights. Calls from other plugins or bare Claude Code are dropped.
 #
-# Non-blocking by contract: always exits 0, swallows every error, and POSTs in
-# a detached subshell so it never delays the observed tool call.
+# Non-blocking by contract: for an attributable call it declares itself an
+# async hook (prints {"async":true,...} so Claude Code stops waiting and lets
+# the rest run in the background), always exits 0, and swallows every error.
+# It never delays or fails the observed tool call.
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
 # Configuration (env only):
@@ -63,6 +65,16 @@ case "$tool" in
     ;;
 esac
 [ "$is_uipath" = "1" ] || exit 0
+
+# --- go async: fire-and-forget ---------------------------------------------
+# This call is attributable to the plugin, so we'll resolve the environment
+# (a ~0.5s `uip login status` at most once/hour) and POST to App Insights.
+# Declare the hook async BEFORE that work so Claude Code reads this line, stops
+# waiting, and lets the remainder finish in the background (bounded by
+# asyncTimeout, in MILLISECONDS). Everything above — opted-out and
+# non-attributable calls — already exited synchronously in milliseconds, so
+# only real emissions ever spawn a background task.
+printf '{"async": true, "asyncTimeout": 10000}\n'
 
 # --- environment resolution (cached; `uip login status` is ~0.5s) ----------
 # Resolve once per TTL and reuse, so only one tool call per hour pays the cost.
@@ -196,7 +208,9 @@ body="$(cat <<JSON
 JSON
 )"
 
-# Detached subshell ( cmd & ) survives this hook's exit so the agent never waits.
+# The hook already went async above, so the agent has moved on. The detached
+# subshell ( cmd & ) is the flush-safety net: it keeps the POST non-blocking
+# even if bash buffers the async directive, and lets this process exit at once.
 ( curl -sS -m 4 -X POST "$endpoint/v2/track" \
     -H "Content-Type: application/json" \
     --data "$body" >/dev/null 2>&1 & )

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -11,20 +11,20 @@
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
 # Configuration (env only):
-#   UIPATH_TELEMETRY_DISABLED            Opt-out switch, SAME var + semantics as the
-#                                        uip CLI (packages/common/src/telemetry/
-#                                        telemetry-init.ts): "1" or "true" disables.
-#                                        A user who silenced CLI telemetry silences
-#                                        this hook too. Unset -> telemetry attempted.
+#   UIPATH_TELEMETRY_DISABLED            Gate. Reuses the uip CLI's variable name.
+#                                        Send ONLY when explicitly set to "0".
+#                                        Unset (default) or "1" -> do not send.
+#                                        Privacy-first default-off; absent is
+#                                        treated as disabled.
 #   UIPATH_TELEMETRY_CONNECTION_STRING   App Insights connection string
 #       (InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/)
 #   APPLICATIONINSIGHTS_CONNECTION_STRING  Fallback if the above is unset.
 
 set +e
 
-# Opt-out, mirroring the uip CLI: "1" or "true" disables. Default is enabled,
-# but nothing transmits unless a connection string is also configured (below).
-case "${UIPATH_TELEMETRY_DISABLED:-}" in 1|true) exit 0 ;; esac
+# Send only when telemetry is explicitly NOT disabled (=0). Unset defaults to
+# "1" (disabled), so nothing is sent unless the user opts in with =0.
+[ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
 
 conn="${UIPATH_TELEMETRY_CONNECTION_STRING:-${APPLICATIONINSIGHTS_CONNECTION_STRING:-}}"
 [ -z "$conn" ] && exit 0   # no endpoint configured -> nothing to send to

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -11,19 +11,23 @@
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
 # Configuration (env only):
-#   UIPATH_TELEMETRY_ENABLED             Opt-in switch. Telemetry is OFF unless
-#                                        this is exactly "1". Unset or "0" -> no send.
+#   UIPATH_TELEMETRY_DISABLED            Opt-out switch, SAME var + semantics as the
+#                                        uip CLI (packages/common/src/telemetry/
+#                                        telemetry-init.ts): "1" or "true" disables.
+#                                        A user who silenced CLI telemetry silences
+#                                        this hook too. Unset -> telemetry attempted.
 #   UIPATH_TELEMETRY_CONNECTION_STRING   App Insights connection string
 #       (InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/)
 #   APPLICATIONINSIGHTS_CONNECTION_STRING  Fallback if the above is unset.
 
 set +e
 
-# Opt-in: send only when explicitly enabled (default off).
-[ "${UIPATH_TELEMETRY_ENABLED:-0}" = "1" ] || exit 0
+# Opt-out, mirroring the uip CLI: "1" or "true" disables. Default is enabled,
+# but nothing transmits unless a connection string is also configured (below).
+case "${UIPATH_TELEMETRY_DISABLED:-}" in 1|true) exit 0 ;; esac
 
 conn="${UIPATH_TELEMETRY_CONNECTION_STRING:-${APPLICATIONINSIGHTS_CONNECTION_STRING:-}}"
-[ -z "$conn" ] && exit 0   # enabled but no endpoint configured -> nothing to send to
+[ -z "$conn" ] && exit 0   # no endpoint configured -> nothing to send to
 
 payload="$(cat)"
 

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -6,9 +6,9 @@
 # (alpha / staging / prod), and emits one customEvent to Azure Application
 # Insights. Calls from other plugins or bare Claude Code are dropped.
 #
-# Non-blocking by contract: for an attributable call it declares itself an
-# async hook (prints {"async":true,...} so Claude Code stops waiting and lets
-# the rest run in the background), always exits 0, and swallows every error.
+# Non-blocking by contract: registered as an async hook in hooks.json
+# ("async": true), so Claude Code runs it in the background and never waits for
+# it. Always exits 0, swallows every error, and POSTs in a detached subshell.
 # It never delays or fails the observed tool call.
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
@@ -65,16 +65,6 @@ case "$tool" in
     ;;
 esac
 [ "$is_uipath" = "1" ] || exit 0
-
-# --- go async: fire-and-forget ---------------------------------------------
-# This call is attributable to the plugin, so we'll resolve the environment
-# (a ~0.5s `uip login status` at most once/hour) and POST to App Insights.
-# Declare the hook async BEFORE that work so Claude Code reads this line, stops
-# waiting, and lets the remainder finish in the background (bounded by
-# asyncTimeout, in MILLISECONDS). Everything above — opted-out and
-# non-attributable calls — already exited synchronously in milliseconds, so
-# only real emissions ever spawn a background task.
-printf '{"async": true, "asyncTimeout": 10000}\n'
 
 # --- environment resolution (cached; `uip login status` is ~0.5s) ----------
 # Resolve once per TTL and reuse, so only one tool call per hour pays the cost.
@@ -208,9 +198,7 @@ body="$(cat <<JSON
 JSON
 )"
 
-# The hook already went async above, so the agent has moved on. The detached
-# subshell ( cmd & ) is the flush-safety net: it keeps the POST non-blocking
-# even if bash buffers the async directive, and lets this process exit at once.
+# Detached subshell ( cmd & ) survives this hook's exit so the agent never waits.
 ( curl -sS -m 4 -X POST "$endpoint/v2/track" \
     -H "Content-Type: application/json" \
     --data "$body" >/dev/null 2>&1 & )

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -3,33 +3,36 @@
 #
 # Reads the hook JSON payload from stdin, decides whether the tool call is
 # attributable to THIS plugin (skill gate), resolves the UiPath environment
-# (alpha / staging / prod), and emits one customEvent to Azure Application
-# Insights. Calls from other plugins or bare Claude Code are dropped.
+# (alpha / staging / prod), and pipes one flat JSON object to `uip track`,
+# which forwards it through the CLI's own telemetry tracker as a single
+# uip.skills.tool-use Application Insights event. Calls from other plugins or
+# bare Claude Code are dropped.
+#
+# The CLI (see UiPath/cli#2600) owns transport, the App Insights connection,
+# the event name, the authenticated cloud identity, and the `source:
+# "skills-plugin"` dimension. This hook only derives + sanitizes fields and
+# gates on opt-in; value sanitization stays the hook's responsibility because
+# the CLI and skills ship co-versioned.
 #
 # Non-blocking by contract: registered as an async hook in hooks.json
 # ("async": true), so Claude Code runs it in the background and never waits for
-# it. Always exits 0, swallows every error, and POSTs in a detached subshell.
-# It never delays or fails the observed tool call.
+# it. Always exits 0, swallows every error, and pipes to `uip track` in a
+# detached subshell. It never delays or fails the observed tool call.
 # Cross-platform (macOS, Linux, Windows via Git Bash / MSYS).
 #
 # Configuration (env only):
-#   UIPATH_TELEMETRY_DISABLED            Gate. Reuses the uip CLI's variable name.
-#                                        Send ONLY when explicitly set to "0".
-#                                        Unset (default) or "1" -> do not send.
-#                                        Privacy-first default-off; absent is
-#                                        treated as disabled.
-#   UIPATH_TELEMETRY_CONNECTION_STRING   App Insights connection string
-#       (InstrumentationKey=...;IngestionEndpoint=https://<region>.in.applicationinsights.azure.com/)
-#   APPLICATIONINSIGHTS_CONNECTION_STRING  Fallback if the above is unset.
+#   UIPATH_TELEMETRY_DISABLED   Gate. Reuses the uip CLI's variable name.
+#                               Send ONLY when explicitly set to "0".
+#                               Unset (default) or "1" -> do not send.
+#                               Privacy-first default-off; absent is treated
+#                               as disabled.
 
 set +e
 
 # Send only when telemetry is explicitly NOT disabled (=0). Unset defaults to
-# "1" (disabled), so nothing is sent unless the user opts in with =0.
+# "1" (disabled), so nothing is sent unless the user opts in with =0. `uip
+# track` enforces the same gate on its side; we short-circuit here too.
 [ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
-
-conn="${UIPATH_TELEMETRY_CONNECTION_STRING:-${APPLICATIONINSIGHTS_CONNECTION_STRING:-}}"
-[ -z "$conn" ] && exit 0   # no endpoint configured -> nothing to send to
 
 payload="$(cat)"
 
@@ -110,7 +113,7 @@ if [ "$(( now - _ts ))" -ge "$ttl" ]; then
   } > "$cache" 2>/dev/null
 fi
 
-# --- derived, low-cardinality, PII-free fields -----------------------------
+# --- derived, low-cardinality fields ---------------------------------------
 skill_name=""; uip_subcommand=""; file_ext=""
 case "$tool" in
   Skill)
@@ -137,8 +140,9 @@ printf '%s' "$payload" | grep -q '"interrupted"[[:space:]]*:[[:space:]]*true'  &
 printf '%s' "$payload" | grep -q '"success"[[:space:]]*:[[:space:]]*false'     && outcome="failure"
 
 duration_ms="$(printf '%s' "$payload" | grep -oE '"duration_ms"[[:space:]]*:[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$')"
-# Measurement fallback: emit JSON null (not 0) when absent, so a missing value
-# doesn't skew latency aggregations. Must stay unquoted in the JSON.
+# durationMs is sent as a JSON number. Emit JSON null (not 0) when absent, so a
+# missing value doesn't skew latency aggregations. The CLI drops a null-valued
+# property, so a missing duration simply records as "no data". Stays unquoted.
 case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
 
 session_id="$(json_str session_id)"
@@ -155,16 +159,9 @@ effort_level="$(printf '%s' "$payload" \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 os_name="$(uname -s 2>/dev/null)"
 
-# cwd contains the OS username -> never send raw. Hash to a stable anon id.
-cwd="$(json_str cwd)"
-hash_of() {
-  if   command -v sha256sum >/dev/null 2>&1; then printf '%s' "$1" | sha256sum    | cut -c1-16
-  elif command -v shasum    >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | cut -c1-16
-  else printf '%s' "$1" | cksum | tr -d ' '; fi
-}
-if [ -n "$cwd" ]; then workspace_id="$(hash_of "$cwd")"; else workspace_id=""; fi
-
-# Sanitize free-ish text to keep the hand-built JSON valid and bounded.
+# Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
+# sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
+# then namespaces, stamps identity, and forwards.
 san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
 tool="$(san "$tool")"
 skill_name="$(san "$skill_name")"
@@ -178,29 +175,21 @@ effort_level="$(san "$effort_level")"
 cli_ver="$(san "$cli_ver")"
 plugin_ver="$(san "$plugin_ver")"
 tool_use_id="$(san "$tool_use_id")"
+session_id="$(san "$session_id")"
 os_name="$(san "$os_name")"
 
-# --- emit to Application Insights ------------------------------------------
-ikey="$(printf '%s' "$conn" | grep -oE 'InstrumentationKey=[^;]+' | head -1 | cut -d= -f2)"
-endpoint="$(printf '%s' "$conn" | grep -oE 'IngestionEndpoint=[^;]+' | head -1 | cut -d= -f2)"
-[ -z "$endpoint" ] && endpoint="https://dc.services.visualstudio.com"
-endpoint="${endpoint%/}"
-[ -z "$ikey" ] && exit 0
-
-ts_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null)"
-
-# Field-fallback contract: every key below is always emitted. Properties whose
-# payload source was missing carry an empty string "" (NOT JSON null — App
-# Insights drops null-valued properties, which would make the field vanish).
-# The lone measurement carries JSON null when absent (see $dur_json above).
-body="$(cat <<JSON
-{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$plugin_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","toolUseId":"$tool_use_id","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","pluginVersion":"$plugin_ver","cliVersion":"$cli_ver"},"measurements":{"durationMs":$dur_json}}}}
-JSON
-)"
-
-# Detached subshell ( cmd & ) survives this hook's exit so the agent never waits.
-( curl -sS -m 4 -X POST "$endpoint/v2/track" \
-    -H "Content-Type: application/json" \
-    --data "$body" >/dev/null 2>&1 & )
+# --- hand off to the CLI telemetry tracker ---------------------------------
+# Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
+# codes the event name (uip.skills.tool-use), stamps source: "skills-plugin",
+# attaches the authenticated cloud identity + CLI app version, and owns
+# transport + flush. Every scalar key below becomes an event property; the CLI
+# drops any non-scalar value (so a null durationMs simply disappears). Send no
+# `event` key, no envelope, and no `source` (the CLI overrides it).
+#
+# Detached subshell ( cmd & ) survives this hook's exit so the agent never
+# waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
+# telemetry is off); piping to it is harmless even if the CLI is absent.
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExt\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"os\":\"$os_name\",\"pluginVersion\":\"$plugin_ver\",\"cliVersion\":\"$cli_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"durationMs\":$dur_json}" \
+    | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -158,6 +158,14 @@ effort_level="$(printf '%s' "$payload" \
   | grep -oE '"effort"[[:space:]]*:[[:space:]]*\{[^}]*"level"[[:space:]]*:[[:space:]]*"[^"]*"' \
   | grep -oE '"level"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
 
+# Subagent fields, extracted by key name (empty when the payload omits them):
+#   tool_response.resolvedModel -> subagentModel (model resolved for the spawn)
+#   tool_input.subagent_type    -> subagentType  (requested subagent type)
+#   agent_type (top-level)      -> agentType     (type of the running subagent)
+subagent_model="$(json_str resolvedModel)"
+subagent_type="$(json_str subagent_type)"
+agent_type="$(json_str agent_type)"
+
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded. Value
 # sanitization is the hook's job (CLI and skills ship co-versioned); the CLI
 # then namespaces, stamps identity, and forwards.
@@ -174,6 +182,9 @@ effort_level="$(san "$effort_level")"
 skills_ver="$(san "$skills_ver")"
 tool_use_id="$(san "$tool_use_id")"
 session_id="$(san "$session_id")"
+subagent_model="$(san "$subagent_model")"
+subagent_type="$(san "$subagent_type")"
+agent_type="$(san "$agent_type")"
 
 # --- hand off to the CLI telemetry tracker ---------------------------------
 # Build a flat key:value JSON object and pipe it to `uip track`. The CLI hard-
@@ -186,7 +197,7 @@ session_id="$(san "$session_id")"
 # Detached subshell ( cmd & ) survives this hook's exit so the agent never
 # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
 # telemetry is off); piping to it is harmless even if the CLI is absent.
-( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"durationMs\":$dur_json}" \
+( printf '%s' "{\"toolName\":\"$tool\",\"skillName\":\"$skill_name\",\"uipSubcommand\":\"$uip_subcommand\",\"fileExtension\":\"$file_ext\",\"environment\":\"$env_name\",\"baseUrl\":\"$base_url\",\"outcome\":\"$outcome\",\"permissionMode\":\"$permission_mode\",\"effortLevel\":\"$effort_level\",\"skillsVersion\":\"$skills_ver\",\"toolUseId\":\"$tool_use_id\",\"sessionId\":\"$session_id\",\"subagentModel\":\"$subagent_model\",\"subagentType\":\"$subagent_type\",\"agentType\":\"$agent_type\",\"durationMs\":$dur_json}" \
     | uip track >/dev/null 2>&1 & )
 
 exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -131,7 +131,9 @@ printf '%s' "$payload" | grep -q '"interrupted"[[:space:]]*:[[:space:]]*true'  &
 printf '%s' "$payload" | grep -q '"success"[[:space:]]*:[[:space:]]*false'     && outcome="failure"
 
 duration_ms="$(printf '%s' "$payload" | grep -oE '"duration_ms"[[:space:]]*:[[:space:]]*[0-9]+' | head -1 | grep -oE '[0-9]+$')"
-[ -z "$duration_ms" ] && duration_ms=0
+# Measurement fallback: emit JSON null (not 0) when absent, so a missing value
+# doesn't skew latency aggregations. Must stay unquoted in the JSON.
+case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
 
 session_id="$(json_str session_id)"
 tool_use_id="$(json_str tool_use_id)"   # unique per call: correlation key + ordering tiebreaker
@@ -154,7 +156,7 @@ hash_of() {
   elif command -v shasum    >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | cut -c1-16
   else printf '%s' "$1" | cksum | tr -d ' '; fi
 }
-workspace_id="$(hash_of "$cwd")"
+if [ -n "$cwd" ]; then workspace_id="$(hash_of "$cwd")"; else workspace_id=""; fi
 
 # Sanitize free-ish text to keep the hand-built JSON valid and bounded.
 san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
@@ -181,8 +183,12 @@ endpoint="${endpoint%/}"
 
 ts_iso="$(date -u +%Y-%m-%dT%H:%M:%S.000Z 2>/dev/null)"
 
+# Field-fallback contract: every key below is always emitted. Properties whose
+# payload source was missing carry an empty string "" (NOT JSON null — App
+# Insights drops null-valued properties, which would make the field vanish).
+# The lone measurement carries JSON null when absent (see $dur_json above).
 body="$(cat <<JSON
-{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$plugin_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","toolUseId":"$tool_use_id","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","pluginVersion":"$plugin_ver","cliVersion":"$cli_ver"},"measurements":{"durationMs":$duration_ms}}}}
+{"name":"Microsoft.ApplicationInsights.Event","time":"$ts_iso","iKey":"$ikey","tags":{"ai.cloud.role":"uipath-skills-plugin","ai.cloud.roleInstance":"$env_name","ai.session.id":"$session_id","ai.user.id":"$workspace_id","ai.application.ver":"$plugin_ver"},"data":{"baseType":"EventData","baseData":{"ver":2,"name":"ToolUse","properties":{"toolName":"$tool","toolUseId":"$tool_use_id","skillName":"$skill_name","uipSubcommand":"$uip_subcommand","fileExt":"$file_ext","environment":"$env_name","baseUrl":"$base_url","outcome":"$outcome","permissionMode":"$permission_mode","effortLevel":"$effort_level","os":"$os_name","pluginVersion":"$plugin_ver","cliVersion":"$cli_ver"},"measurements":{"durationMs":$dur_json}}}}
 JSON
 )"
 


### PR DESCRIPTION
## What

Adds a `PostToolUse` hook (`hooks/send-telemetry.sh`) that emits one
`uip.skills.tool-use` Application Insights event per UiPath-attributable tool
call by piping a flat JSON object to the hidden `uip track` CLI command. Adds
`TELEMETRY.md` documenting the schema, privacy model, and opt-in gate. Wires the
hook into `hooks/hooks.json` as an async `PostToolUse` hook.

## Why

Understand how the plugin is used in the field — which skills fire, which `uip`
CLI verbs run, success/latency, and on which environment (alpha/staging/prod) —
without shipping file contents, full command lines, file paths, cwd, or
transcripts.

## How it works

1. **Opt-in / off by default.** Gated on `UIPATH_TELEMETRY_DISABLED=0` (reuses
   the `uip` CLI's own telemetry gate variable). Unset (default) or `1` → silent
   no-op.
2. **Relevance gate.** Fires on every tool call; emits only for plugin-
   attributable calls — `Skill` (`uipath:`/`uipath-`), `Bash`/`PowerShell`
   invoking `uip`/`rpa-tool`, `Agent` of a UiPath or Claude built-in type, and
   file tools on `.cs`/`.flow`/`.xaml`/`.uipx`/`.bpmn`/`agent.json`/
   `caseplan.json`/`project.json`/`app.config.json`/`action-schema.json`.
   Attribution comes from `tool_input` only.
3. **Region-scoped extraction.** A single string-aware `awk` pass walks the
   payload once and pulls each field only from its region (envelope /
   `tool_input` / `tool_response` / `effort`), so embedded customer content
   (prompts, stdout, file contents) can never false-match a field.
4. **Environment resolution.** Maps `uip login status` → `BaseUrl` to
   `alpha`/`staging`/`prod`/`other`/`unknown`, cached 1h in a per-user
   `chmod 700` dir, parsed as data (never sourced).
5. **Hands off to the CLI.** Pipes one flat JSON object to `uip track` on stdin
   in a detached subshell. The CLI owns transport, the App Insights connection,
   the event name (`uip.skills.tool-use`), the `source: "skills-plugin"`
   dimension, and stamps the authenticated cloud identity + CLI version.

## Privacy

**Not anonymous.** Events ride the CLI's telemetry tracker, so each is
associated with the signed-in UiPath identity (`CloudUserId` / `CloudTenantId` /
`CloudOrganizationId`, stamped by the CLI). The hook itself never sends file
contents, stdout/stderr, full command lines, file paths, `cwd`, or
`transcript_path` — only derived, low-cardinality fields (tool name, skill name,
derived `uip` subcommand verb, file extension, environment, outcome,
`durationMs`, etc.). Nothing is sent unless explicitly opted in with
`UIPATH_TELEMETRY_DISABLED=0`. Full schema in `TELEMETRY.md`.

## Non-blocking by contract

Async hook (`"async": true`) + always `exit 0` + detached subshell → never
delays or fails a tool call. Pure bash + grep/sed/awk, no `jq` dependency,
cross-platform (macOS / Linux / Windows Git Bash).

## Dependency

Requires `uip track` ([UiPath/cli#2600](https://github.com/UiPath/cli/pull/2600))
in the released CLI to actually emit; harmless no-op if the command is absent.

## Testing

Validated against the gate matrix with a stubbed `uip track`:

| Case | Result |
|------|--------|
| `Skill` uipath:uipath-platform | emit, skillName set ✓ |
| `Bash` echo hello | dropped ✓ |
| `Bash` uip solution publish | emit, uipSubcommand=`solution publish` ✓ |
| `Edit` README.md | dropped ✓ |
| `Edit` proc.flow | emit, fileExtension=`.flow` ✓ |
| `Bash` interrupted | emit, outcome=`interrupted` ✓ |

All emitted event bodies parse as valid JSON and gate correctly on
`UIPATH_TELEMETRY_DISABLED`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
