### PR TITLE
feat(uipath-planner): Office document pipeline — docx PDD ingestion + SDD-to-Word scripts

### DIFF
--- a/skills/uipath-planner/SKILL.md
+++ b/skills/uipath-planner/SKILL.md
@@ -155,6 +155,13 @@ High-level view of what each specialist owns. **Do not describe internal flows o
 | [Coded App Template](assets/templates/coded-app-sdd-template.md) | SDD template for Coded Apps (web) |
 | [API Workflow Template](assets/templates/api-workflow-sdd-template.md) | SDD template for API Workflows |
 
+### Scripts (Phase D)
+
+| Script | Purpose |
+|------|---------|
+| `scripts/docx-extract.sh` | .docx PDD → UTF-8 markdown + extracted screenshots (pandoc). Run at Phase D Step 1 when a Word PDD renders garbled — never drive Word via COM. |
+| `scripts/sdd-to-docx.sh` | Generated SDD markdown → styled .docx, optional corporate `--reference-doc`. Run at Phase D Step 2.5 only when the user asks for Word output. |
+
 ### Lanes A & B — Planning
 
 | File | Purpose |

--- a/skills/uipath-planner/references/pdd-analysis-guide.md
+++ b/skills/uipath-planner/references/pdd-analysis-guide.md
@@ -7,7 +7,7 @@ How to extract structured information from Process Design Documents in any forma
 | Format | How to Read | Notes |
 |---|---|---|
 | PDF | Use the Read tool with `pages` parameter. Read in chunks of up to 20 pages. | Screenshots are visible as images — see "Handling Screenshots" below. |
-| Word (.docx) | Read the file directly. | Tables may render differently — verify structure. |
+| Word (.docx) | Read the file directly. If it renders garbled, convert with `scripts/docx-extract.sh` (see sdd-generation-guide.md Step 1) and read the markdown + extracted media instead. | Tables may render differently — verify structure. |
 | Markdown | Read the file directly. | Easiest format — structure is already parseable. |
 | Pasted text | Process from the conversation context. | Ask the user to paste section by section if the PDD is large. |
 

--- a/skills/uipath-planner/references/pdd-analysis-guide.md
+++ b/skills/uipath-planner/references/pdd-analysis-guide.md
@@ -7,7 +7,7 @@ How to extract structured information from Process Design Documents in any forma
 | Format | How to Read | Notes |
 |---|---|---|
 | PDF | Use the Read tool with `pages` parameter. Read in chunks of up to 20 pages. | Screenshots are visible as images — see "Handling Screenshots" below. |
-| Word (.docx) | Read the file directly. If it renders garbled, convert with `scripts/docx-extract.sh` (see sdd-generation-guide.md Step 1) and read the markdown + extracted media instead. | Tables may render differently — verify structure. |
+| Word (.docx) | Do NOT Read directly — convert first with `scripts/docx-extract.sh` (see sdd-generation-guide.md Step 1), then read the markdown + extracted media. | Complex tables may extract as raw HTML `<table>` blocks — parse them; verify structure. |
 | Markdown | Read the file directly. | Easiest format — structure is already parseable. |
 | Pasted text | Process from the conversation context. | Ask the user to paste section by section if the PDD is large. |
 
@@ -20,6 +20,7 @@ When you encounter screenshots in the PDD:
 3. **Do NOT extract** selectors, XPath, CSS, coordinates, colors, or visual layout details — these are determined at development time, not from static images.
 4. **Reference** the screenshot content in the relevant process step's "Remarks" field if useful.
 5. **DO extract concrete data values** shown in the screenshot — sample IDs, names, dates, expected outputs, error messages. These are oracles for the test strategy, not selectors. See "Extract Canonical Examples" below.
+6. **Unreadable media formats (.emf, .wmf):** the Read tool cannot render these (common in Word-extracted media). Do not guess their content — ask the user for a PNG export of the figure, or mark every extraction that depended on it as `[SME REVIEW]` naming the file.
 
 ## Extract Canonical Examples
 

--- a/skills/uipath-planner/references/sdd-generation-guide.md
+++ b/skills/uipath-planner/references/sdd-generation-guide.md
@@ -71,13 +71,13 @@ These tasks track SDD generation. Implementation tasks are owned by Lane A (task
    - **10-50 pages:** read the ToC first, then read sections in priority order (overview → steps → exceptions → applications → credentials).
    - **Over 50 pages:** read ToC, then read high-priority sections (overview, process steps, exceptions) first, extract as you go, then read remaining sections.
 3. For pasted text over 3000 words, ask the user to paste in sections.
-4. **Docx handling:** if the .docx file renders as raw XML or binary content, do NOT attempt to extract data from garbled output. Convert it first:
+4. **Docx handling:** .docx is a binary format — do NOT Read it directly or attempt to extract data from garbled output. Convert first. Run from the directory where the markdown should land (output defaults to the current working directory):
 
    ```bash
-   bash <SKILL_DIR>/scripts/docx-extract.sh "<PDD_PATH>.docx"
+   bash <SKILL_DIR>/scripts/docx-extract.sh "<PDD_FILE_PATH>"
    ```
 
-   `<SKILL_DIR>` is the folder containing this skill's SKILL.md. The script produces a UTF-8 markdown file plus a `-media/` folder with embedded screenshots — Read both (screenshots feed the canonical-example extraction). If the script reports pandoc missing, relay its install command to the user; only if the user cannot install pandoc, fall back to: "Please export the Word document as PDF or paste the content directly." Never drive Word via COM automation.
+   `<SKILL_DIR>` is the folder containing this skill's SKILL.md; `<PDD_FILE_PATH>` is the full path to the .docx. The script produces a UTF-8 markdown file plus a `-media/` folder with embedded screenshots — Read both (screenshots feed the canonical-example extraction). Complex multi-paragraph tables may come out as raw HTML `<table>` blocks — parse them, they carry the same data. If the script reports pandoc missing, relay its install command to the user; only if the user cannot install pandoc, fall back to: "Please export the Word document as PDF or paste the content directly." Never drive Word via COM automation.
 5. **Error cases:** if the document cannot be read (corrupt PDF, password-protected, unsupported format), tell the user and ask them to provide it in a different format. If the document does not appear to be a PDD (no process steps, no application details, no exception handling), tell the user and stop.
 6. **Language handling:** if the PDD is not in English, use `AskUserQuestion` with the numbered-choice format:
 

--- a/skills/uipath-planner/references/sdd-generation-guide.md
+++ b/skills/uipath-planner/references/sdd-generation-guide.md
@@ -71,7 +71,13 @@ These tasks track SDD generation. Implementation tasks are owned by Lane A (task
    - **10-50 pages:** read the ToC first, then read sections in priority order (overview → steps → exceptions → applications → credentials).
    - **Over 50 pages:** read ToC, then read high-priority sections (overview, process steps, exceptions) first, extract as you go, then read remaining sections.
 3. For pasted text over 3000 words, ask the user to paste in sections.
-4. **Docx handling:** if the .docx file renders as raw XML or binary content, tell the user: "The Word document could not be parsed as readable text. Please export it as PDF or paste the content directly." Do not attempt to extract data from garbled output.
+4. **Docx handling:** if the .docx file renders as raw XML or binary content, do NOT attempt to extract data from garbled output. Convert it first:
+
+   ```bash
+   bash <SKILL_DIR>/scripts/docx-extract.sh "<PDD_PATH>.docx"
+   ```
+
+   `<SKILL_DIR>` is the folder containing this skill's SKILL.md. The script produces a UTF-8 markdown file plus a `-media/` folder with embedded screenshots — Read both (screenshots feed the canonical-example extraction). If the script reports pandoc missing, relay its install command to the user; only if the user cannot install pandoc, fall back to: "Please export the Word document as PDF or paste the content directly." Never drive Word via COM automation.
 5. **Error cases:** if the document cannot be read (corrupt PDF, password-protected, unsupported format), tell the user and ask them to provide it in a different format. If the document does not appear to be a PDD (no process steps, no application details, no exception handling), tell the user and stop.
 6. **Language handling:** if the PDD is not in English, use `AskUserQuestion` with the numbered-choice format:
 
@@ -436,6 +442,20 @@ This step runs in BOTH Autonomous and Interactive modes — it is a hard blocker
 
 **Next:** Phase D is complete. Proceed into Lane A (task derivation) with this SDD path — Lane A derives the task list and emits live `TaskCreate` calls.
 ```
+
+### Step 2.5: Word (.docx) Delivery — only when requested
+
+When the user asks for a Word deliverable (client-facing SDD, "official template", ".docx"), convert the written SDD — do not author Word content by hand and never drive Word via COM automation:
+
+```bash
+bash <SKILL_DIR>/scripts/sdd-to-docx.sh "<SDD_PATH>.md"
+```
+
+- **Corporate styling:** if the user has an official SDD Word template, pass it as a style reference — `--reference-doc "<TEMPLATE_PATH>.docx"`. The output picks up its fonts, heading styles, and margins. Section *structure* still follows this skill's markdown SDD; mapping content into a different section skeleton is a manual step — say so.
+- **Mermaid diagrams** stay as code blocks in the .docx (the script warns). Offer the user the choice: leave as-is, or render externally and insert manually.
+- If the script reports pandoc missing, relay its install command. Do not fall back to COM, HTML-to-doc tricks, or hand-built XML.
+
+Skip this step entirely when the user did not ask for Word output.
 
 ### Step 3: Proceed to Lane A (Task Derivation)
 

--- a/skills/uipath-planner/scripts/docx-extract.sh
+++ b/skills/uipath-planner/scripts/docx-extract.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Extract a .docx document (typically a PDD) to GitHub-flavored Markdown.
+# UTF-8 safe, preserves tables as pipe tables, extracts embedded images
+# (screenshots) to a media folder so the agent can Read them.
+#
+# Usage: docx-extract.sh <input.docx> [output.md]
+#   output.md defaults to <input-basename>.md in the current directory
+#   embedded media lands in <output-basename>-media/
+#
+# Exit codes: 0 success · 1 usage error · 2 pandoc missing · 3 conversion failed
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  echo "Usage: docx-extract.sh <input.docx> [output.md]"
+  echo "Converts a .docx to GitHub-flavored Markdown via pandoc."
+  echo "Embedded images are extracted to <output-basename>-media/."
+  [ $# -lt 1 ] && exit 1 || exit 0
+fi
+
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "ERROR: pandoc is not installed." >&2
+  echo "Install it, then re-run:" >&2
+  echo "  Windows: winget install JohnMacFarlane.Pandoc" >&2
+  echo "  macOS:   brew install pandoc" >&2
+  echo "  Linux:   sudo apt-get install pandoc" >&2
+  exit 2
+fi
+
+input="$1"
+if [ ! -f "$input" ]; then
+  echo "ERROR: input file not found: $input" >&2
+  exit 1
+fi
+
+base="$(basename "$input")"
+output="${2:-${base%.*}.md}"
+media_dir="${output%.md}-media"
+
+if ! pandoc "$input" -f docx -t gfm --wrap=none --extract-media="$media_dir" -o "$output"; then
+  echo "ERROR: pandoc conversion failed for $input" >&2
+  exit 3
+fi
+
+echo "Markdown: $output"
+if [ -d "$media_dir" ]; then
+  echo "Media:    $media_dir/ ($(find "$media_dir" -type f | wc -l | tr -d ' ') file(s))"
+else
+  echo "Media:    none embedded"
+fi

--- a/skills/uipath-planner/scripts/docx-extract.sh
+++ b/skills/uipath-planner/scripts/docx-extract.sh
@@ -44,6 +44,11 @@ fi
 echo "Markdown: $output"
 if [ -d "$media_dir" ]; then
   echo "Media:    $media_dir/ ($(find "$media_dir" -type f | wc -l | tr -d ' ') file(s))"
+  unreadable="$(find "$media_dir" -type f \( -iname '*.emf' -o -iname '*.wmf' \) | tr '\n' ' ')"
+  if [ -n "${unreadable% }" ]; then
+    echo "WARNING: EMF/WMF media cannot be rendered by the Read tool: $unreadable" >&2
+    echo "Ask the user for PNG exports of those figures, or mark dependent extractions [SME REVIEW]." >&2
+  fi
 else
   echo "Media:    none embedded"
 fi

--- a/skills/uipath-planner/scripts/sdd-to-docx.sh
+++ b/skills/uipath-planner/scripts/sdd-to-docx.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Convert a generated SDD markdown file to a styled Word document.
+# Optionally takes a corporate .docx as a style reference (--reference-doc)
+# so the output picks up the customer's fonts, heading styles, and margins
+# without committing any template binary to this repo.
+#
+# Usage: sdd-to-docx.sh <sdd.md> [output.docx] [--reference-doc <template.docx>]
+#   output.docx defaults to <input-basename>.docx in the current directory
+#
+# Known limitation: mermaid code blocks are NOT rendered — they appear as
+# code in the document. Render them separately (e.g. mermaid-cli) and replace
+# manually if the deliverable needs diagram images.
+#
+# Exit codes: 0 success · 1 usage error · 2 pandoc missing · 3 conversion failed
+set -euo pipefail
+
+if [ $# -lt 1 ] || [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+  echo "Usage: sdd-to-docx.sh <sdd.md> [output.docx] [--reference-doc <template.docx>]"
+  echo "Converts an SDD markdown file to .docx via pandoc, with table of contents."
+  echo "--reference-doc applies the styles of an existing Word document."
+  [ $# -lt 1 ] && exit 1 || exit 0
+fi
+
+if ! command -v pandoc >/dev/null 2>&1; then
+  echo "ERROR: pandoc is not installed." >&2
+  echo "Install it, then re-run:" >&2
+  echo "  Windows: winget install JohnMacFarlane.Pandoc" >&2
+  echo "  macOS:   brew install pandoc" >&2
+  echo "  Linux:   sudo apt-get install pandoc" >&2
+  exit 2
+fi
+
+input="$1"
+shift
+if [ ! -f "$input" ]; then
+  echo "ERROR: input file not found: $input" >&2
+  exit 1
+fi
+
+base="$(basename "$input")"
+output="${base%.*}.docx"
+reference=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --reference-doc)
+      [ $# -ge 2 ] || { echo "ERROR: --reference-doc needs a path" >&2; exit 1; }
+      reference="$2"
+      shift 2
+      ;;
+    *)
+      output="$1"
+      shift
+      ;;
+  esac
+done
+
+args=("$input" -f gfm -t docx --toc --toc-depth=2 -o "$output")
+if [ -n "$reference" ]; then
+  if [ ! -f "$reference" ]; then
+    echo "ERROR: reference doc not found: $reference" >&2
+    exit 1
+  fi
+  args+=("--reference-doc=$reference")
+fi
+
+if ! pandoc "${args[@]}"; then
+  echo "ERROR: pandoc conversion failed for $input" >&2
+  exit 3
+fi
+
+echo "Word document: $output"
+if grep -q '```mermaid' "$input"; then
+  echo "NOTE: the SDD contains mermaid diagrams — they are embedded as code" >&2
+  echo "blocks, not rendered images. Render separately if the deliverable" >&2
+  echo "needs visuals." >&2
+fi


### PR DESCRIPTION
@
## Summary

Adds an Office-document pipeline to the planner so it can **ingest `.docx` PDDs** and **emit the SDD as a Word document**, not just markdown.

**Stacked on #1441** (`feat/planner/constraint-awareness`). Review/merge **after** #1441 — once #1441 merges, this PR auto-retargets to `main` and the diff narrows to just these commits.

## Changes
- `scripts/docx-extract.sh` — extract text from a `.docx` PDD for Phase D ingestion.
- `scripts/sdd-to-docx.sh` — render the generated SDD markdown to a Word `.docx`.
- `sdd-generation-guide.md` / `pdd-analysis-guide.md` / SKILL.md — wire the scripts into the Phase D flow.
- docx ingestion fixes from an AS-persona validation run.

## Commits
- `feat(uipath-planner): Office document pipeline — docx PDD ingestion + SDD-to-Word scripts`
- `fix(uipath-planner): docx ingestion fixes from AS-persona validation run`

## Scope
5 files under `skills/uipath-planner/` — 2 new scripts + 3 guide/SKILL wiring edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@