### PR TITLE
docs(uipath-solution): document --author and --description pack flags

### DIFF
--- a/skills/uipath-api-workflow/references/cli-reference.md
+++ b/skills/uipath-api-workflow/references/cli-reference.md
@@ -432,6 +432,8 @@ uip solution pack <solutionPath> <outputPath> \
 | `<outputPath>` | yes | Output directory for the `.zip`. The file lands as `<outputPath>/<name>_<version>.zip` — underscore, not a dot. |
 | `-n, --name <name>` | no | Package name. Defaults to solution folder name. |
 | `-v, --version <version>` | no | Package version. Default `1.0.0`. |
+| `--author <author>` | no | Package author. Default `UiPath`. |
+| `--description <text>` | no | Package description. Default `Created by UiPath`. |
 | `--login-validity <minutes>` | no | Min minutes before token refresh. Default `10`. |
 
 ### What the API workflow packager does

--- a/skills/uipath-coded-apps/references/commands-reference.md
+++ b/skills/uipath-coded-apps/references/commands-reference.md
@@ -110,8 +110,8 @@ uip codedapp pack <dist> [options]
 | `-n, --name <name>` | Package name | Prompted interactively |
 | `-v, --version <version>` | Package version | `1.0.0` |
 | `-o, --output <dir>` | Output directory for `.nupkg` | `./.uipath` |
-| `-a, --author <author>` | Package author | `UiPath Developer` |
-| `--description <desc>` | Package description | Prompted |
+| `--author <author>` | Package author | `UiPath Developer` |
+| `--description <text>` | Package description | Prompted |
 | `--main-file <file>` | Main entry file | `index.html` |
 | `--content-type <type>` | Content type: `webapp`, `library`, `process` | `webapp` |
 | `--dry-run` | Preview packaging without creating the file | `false` |

--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -122,6 +122,8 @@ uip maestro case pack <project-path> <output-path> --output json
 | `<output-path>` | **(required)** Output directory for the `.nupkg` |
 | `-n, --name <name>` | Package name (default: project folder name) |
 | `-v, --version <version>` | Package version (default: `1.0.0`) |
+| `--author <author>` | Package author (default: `UiPath`) |
+| `--description <text>` | Package description (default: `Created by UiPath`) |
 
 > **Not the deploy path.** `uip solution publish` accepts a solution `.zip`, not a project `.nupkg`, and `uip solution pack` already produces the project `.nupkg` internally. Phase 7 uses `uip solution pack` — see below.
 

--- a/skills/uipath-solution/references/pack-and-deploy.md
+++ b/skills/uipath-solution/references/pack-and-deploy.md
@@ -67,6 +67,8 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
 | `--nuget-sources-config-path <path>` | Local `NuGet.config` that sets the package sources used for resolution | -- |
+| `--author <author>` | Set the package author | `UiPath` |
+| `--description <text>` | Set the package description | `Created by UiPath` |
 
 The output is a `.zip` file named `<name>_<version>.zip` — **underscore between name and version, not a dot** — written under `<output-path>/` (e.g., `MySolution_2.0.0.zip`). Don't guess the filename: read it from the command's `Data.Packages` field, or list `<output-path>/`. Run `solution resources refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
 


### PR DESCRIPTION
## What

Documents the `--author` and `--description` pack flags across the skill references:

- `uipath-solution/references/pack-and-deploy.md` — added to the `uip solution pack` options table
- `uipath-api-workflow/references/cli-reference.md` — added to the `uip solution pack` flag table
- `uipath-maestro-case/references/case-commands.md` — added to the `uip maestro case pack` flag table
- `uipath-coded-apps/references/commands-reference.md` — fixed `-a, --author` to `--author` (the short flag never existed)

## Why

- UiPath/cli#2489 adds `--author`/`--description` to `uip solution pack` (defaults `UiPath` / `Created by UiPath` when not set).
- UiPath/cli#2491 moves them into the shared pack-metadata helper so all pack commands accept them (solution, flow, maestro bpmn, case, api-workflow, codedapp). It also removes `--package-author`/`--package-description` from `api-workflow pack` — no skill reference used those names, so no removal needed here.

Depends on both CLI PRs — should merge after they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)