### PR TITLE
fix: skills to support trigger activities (#ENGCE-58624)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -65,6 +65,20 @@ Each entry is one input field the user supplies when configuring the trigger (e.
 
 > **Source of truth:** `parameters[]` is populated for every connector. `flow registry get`'s `eventParameters.fields` derives from `triggers describe`'s `events.<operation>.required`/`.optional`, which several connectors do not emit. Full field semantics: [/uipath:uipath-platform — triggers.md — `parameters[]`](../../../../../../uipath-platform/references/integration-service/triggers.md#parameters--canonical-event-parameter-input-fields).
 
+**1b-2. Resolve the object name and fetch field metadata** — **mandatory** for every trigger node.
+
+> **MUST READ before this step:** [/uipath:uipath-platform — triggers.md](../../../../../../uipath-platform/references/integration-service/triggers.md). Single source of truth for fetching trigger parameters and fields — object name resolution, describe call, source-of-truth contract.
+
+1. Resolve `<objectName>` from the Step 1b `triggers objects` response per [/uipath:uipath-platform — triggers.md — Object Name Resolution](../../../../../../uipath-platform/references/integration-service/triggers.md#object-name-resolution). If the object name is not recognizable from the user's prompt, **ask the user** — present candidates by `displayName`. Do NOT guess.
+2. Fetch field metadata:
+
+```bash
+uip is triggers describe "<connector-key>" "<OPERATION>" "<objectName>" \
+  --connection-id "<id>" --output json
+```
+
+> **Source of truth for node configuration:** event-parameter inputs come from `triggers objects` → `parameters[]` (Step 1b); field metadata comes from `triggers describe` (this step). Follow these two responses exclusively — do not invent parameters or fields.
+
 ### Step 1c — Select the final connection
 
 **If `byoaConnection: true`** — the Step 1a connection is not usable. Follow the BYOA selection workflow in [/uipath:uipath-platform — connections.md — For BYOA Connections](../../../../../../uipath-platform/references/integration-service/connections.md#for-byoa-connections-webhook-triggers) (filter with `--byoa`, `--refresh` retry, stop-and-ask if none exist).
@@ -178,6 +192,8 @@ Each trigger type has a different output schema — field names like `.text`, `.
 Follow the [CLI: Replace manual trigger with connector trigger](../../editing-operations-cli.md#replace-manual-trigger-with-connector-trigger) procedure. The CLI handles edge cleanup, orphaned definition removal, and `variables.nodes` regeneration automatically. Note the generated node ID from the `node add` response — you need it for Step 6.
 
 ### Step 6 — Configure the trigger node
+
+> **MUST READ before `node configure`:** [/uipath:uipath-platform — triggers.md](../../../../../../uipath-platform/references/integration-service/triggers.md). The parameters fetched there (`triggers objects` → `parameters[]`, Step 1b) and fields (`triggers describe`, Step 1b-2) are the source of truth for everything in `--detail`. If you have not run both calls, go back to Step 1b.
 
 **Read the `--detail` field table below before calling `node configure`.** The fields and types are strict — unknown keys or wrong types cause validation errors. Do not guess field names from other node types (e.g., activity nodes use `method`/`endpoint`/`bodyParameters`; triggers use `eventMode`/`eventParameters`/`filter`).
 
@@ -400,9 +416,9 @@ uip maestro flow node remove <PROJECT>.flow start --output json       # remove m
 uip maestro flow node add <PROJECT>.flow <trigger-node-type> --label "<LABEL>" --position 200,144 --output json
 uip maestro flow node configure <PROJECT>.flow <nodeId> --detail '<TRIGGER_DETAIL_JSON>' --output json
 
-# Trigger object metadata (MANDATORY — Step 1b)
-uip is triggers objects "<connector-key>" "<operation>" --connection-id "<id>" --output json
-uip is triggers describe "<connector-key>" "<operation>" "<objectName>" --connection-id "<id>" --output json
+# Trigger object metadata (MANDATORY — Steps 1b and 1b-2)
+uip is triggers objects "<connector-key>" "<operation>" --connection-id "<id>" --output json   # Step 1b: objects + parameters[]
+uip is triggers describe "<connector-key>" "<operation>" "<objectName>" --connection-id "<id>" --output json  # Step 1b-2: fields
 
 # Connections — see /uipath:uipath-platform — connections.md for selection rules (Native, BYOA, --refresh)
 uip is connections list "<connector-key>" --all-folders --output json         # discover connections (--all-folders is mandatory)

--- a/skills/uipath-platform/references/integration-service/triggers.md
+++ b/skills/uipath-platform/references/integration-service/triggers.md
@@ -11,6 +11,7 @@ Triggers are event-based activities that fire when something happens in an exter
 - [List Trigger Activities](#list-trigger-activities)
 - [Trigger Objects](#trigger-objects)
   - [`parameters[]` — canonical event-parameter input fields](#parameters--canonical-event-parameter-input-fields)
+- [Object Name Resolution](#object-name-resolution)
 - [Trigger Metadata (Describe)](#trigger-metadata-describe)
 - [CRUD vs Non-CRUD Triggers](#crud-vs-non-crud-triggers)
 - [Response Fields](#response-fields)
@@ -24,11 +25,13 @@ Triggers are event-based activities that fire when something happens in an exter
 
 ```
 [ ] 1. List trigger activities  →  pick one  →  note its **Operation**
-[ ] 2. If Operation is CREATED/UPDATED/DELETED  →  get objects  →  pick one
-[ ] 3. Get metadata (fields) for the chosen object + operation
+[ ] 2. If Operation is CREATED/UPDATED/DELETED  →  get objects  →  resolve object name (ask user if unclear)
+[ ] 3. Describe the resolved object + operation  →  field metadata
 ```
 
 **Decision point at step 2**: CREATED, UPDATED, and DELETED operations require an intermediate "objects" step. For other trigger operations, skip to step 3 using the activity's **ObjectName**.
+
+> **Source of truth:** Event-parameter inputs come from `triggers objects` → `parameters[]`. Field metadata comes from `triggers describe`. Configure trigger nodes exclusively from these two responses — do not invent parameters or fields, and do not substitute metadata from other commands.
 
 ---
 
@@ -60,19 +63,32 @@ uip is triggers objects "<connector-key>" "<OPERATION>" \
 
 ---
 
+## Object Name Resolution
+
+`triggers describe` requires an exact object name. Resolve it from the `triggers objects` response (`Data[].Name`):
+
+1. Match the user's intent against each object's `Name` / `DisplayName` (case-insensitive).
+2. Exactly one match → use its `Name` verbatim.
+3. No match or ambiguous → **ask the user** — present candidate objects by `displayName`. Do NOT guess or fabricate an object name; `triggers describe` with a wrong name returns empty or wrong field metadata.
+
+For non-CRUD operations there is no objects step — use the trigger activity's **ObjectName** field directly.
+
+---
+
 ## Trigger Metadata (Describe)
 
 Get field metadata for a trigger object:
 
 ```bash
-uip is triggers describe "<connector-key>" "<OPERATION>" "<object-name>" --output json
-
-# With connection (includes custom fields):
 uip is triggers describe "<connector-key>" "<OPERATION>" "<object-name>" \
   --connection-id "<id>" --output json
 ```
 
 Returns field definitions with names, types, and descriptions. Always requests `allFields=true` from the API.
+
+- `<object-name>` comes from [Object Name Resolution](#object-name-resolution) above
+- Always pass `--connection-id` — without it, results omit custom/connection-specific fields
+- The returned fields are the **source of truth** for the trigger's field metadata. Use them verbatim — do not guess field names
 
 ---
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generate_schema.yaml
@@ -4,7 +4,7 @@ description: >
   "Create Issue" connector node so that customFieldsRequestDetails captures
   the parent values (project key + issue type id) that drive the schema
   fetch, and bodyParameters carries the required fields.summary value.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, ipe]
+tags: [uipath-platform, integration, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, ipe]
 
 run_limits:
   expected_turns: 39

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -34,6 +34,8 @@ initial_prompt: |
   Step 3 for resolving the `parentFolderId` reference field against the bound
   connection. Do not reuse any folder ID you may have seen before.
 
+  Use the connection in Shared/uipath-maestro-flow folder.
+
 success_criteria:
   # ── Structural: flow builds and validates ──────────────────────────────
   - type: run_command
@@ -53,6 +55,17 @@ success_criteria:
     pass_threshold: 1.0
 
   # ── Regression: reference-ID resolution (PR #348) ──────────────────────
+  - type: command_executed
+    description: "Agent queried trigger objects for the connector's EMAIL_RECEIVED operation (connector-trigger Step 1b, mandatory)"
+    tool_name: "Bash"
+    # `[\s\S]` matches across newlines — agents often split `uip` commands with
+    # backslash line-continuation, which `.*` would miss. Quotes around the
+    # connector key / operation are optional, so match bare tokens.
+    command_pattern: 'uip\s+is\s+triggers\s+objects[\s\S]+?uipath-microsoft-outlook365[\s\S]+?EMAIL_RECEIVED'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent resolved MailFolder against the current --connection-id (PR #348 regression)"
     tool_name: "Bash"


### PR DESCRIPTION
## Why

Agents configuring connector trigger nodes guessed event parameters and field names instead of fetching them, producing invalid `--detail` payloads. Skills lacked a mandatory metadata-fetch step and a source-of-truth contract for trigger configuration (#ENGCE-58624).

## Changes

### Skill docs

**`uipath-maestro-flow` — connector-trigger/impl.md**
- New mandatory **Step 1b-2**: resolve `<objectName>` from the `triggers objects` response, then fetch field metadata with `uip is triggers describe ... --connection-id`. Ask the user when the object name is ambiguous — never guess.
- New MUST READ gate before Step 6 (`node configure`): `--detail` must come exclusively from `triggers objects` → `parameters[]` (Step 1b) + `triggers describe` (Step 1b-2). Not run both → go back to Step 1b.
- Command cheat-sheet annotated with which step each `triggers` call belongs to.

**`uipath-platform` — integration-service/triggers.md**
- New **Object Name Resolution** section: match user intent against `Data[].Name`/`DisplayName`; exactly one match → use verbatim; ambiguous/no match → ask user. Non-CRUD operations use the activity's **ObjectName** directly.
- Source-of-truth contract added to the workflow checklist: event-parameter inputs from `triggers objects` → `parameters[]`, field metadata from `triggers describe` — configure nodes from these two responses only.
- `triggers describe` now documented with `--connection-id` always (without it, custom/connection-specific fields are omitted).

### Tests

- `single_node/outlook_trigger_inbox`: new weight-1.5 `command_executed` criterion asserting the agent ran `uip is triggers objects ... uipath-microsoft-outlook365 ... EMAIL_RECEIVED` (Step 1b regression guard); prompt pins the connection to `Shared/uipath-maestro-flow`.
- `connector_features/generate_schema.yaml`: skill tag corrected `uipath-maestro-flow` → `uipath-platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Test Results

`outlook_trigger_inbox` ran 10 times in parallel: **9/10 passed**.
