### PR TITLE
fix(codedagent): simplify inputs with variables

### DIFF
--- a/skills/uipath-agents/references/coded/embedding-in-flows.md
+++ b/skills/uipath-agents/references/coded/embedding-in-flows.md
@@ -98,38 +98,6 @@ Without `--local`, `registry list`/`get` query the tenant registry (Orchestrator
 
 ## Wiring the Agent's Inputs
 
-The agent node carries one entry under `inputs.<fieldName>` for every property declared in the agent's `entry-points.json` input schema (the Pydantic `Input` model). `uip maestro flow node add` seeds each entry with an empty string; you replace that placeholder with one of two forms.
+For inputs that reference flow variables, use `{ "type": "literal", "expression": "{{ $vars.X }}", "fieldType": "string" }` — NOT `=js:...` expressions. `=js:` ships as a literal string to the agent activity and fails at runtime with `Cannot find name '<identifier>'`.
 
-> **Do NOT use `=js:` for these fields.** Agent input slots are bound by the agent activity, not evaluated by Jint. Wrapping the value in `=js:` ships the literal string `=js:...` to the agent and the runtime fails with `Cannot find name '<identifier>'`. The same rule applies to inputs on most action nodes — `=js:` is reserved for the few fields explicitly documented to take expressions (decision `expression`, variable updates, end-node output `source`, IS connector `bodyParameters` — see [variables-and-expressions.md](../../../uipath-maestro-flow/references/shared/variables-and-expressions.md)).
-
-### Allowed forms
-
-| Form | Example | Use when |
-|---|---|---|
-| Literal value | `"file_path": "shared/inputs/report.txt"` | The value is known at design time and never varies. |
-| `$vars.<flowVarId>` reference | `"file_path": "$vars.file_path"` | The value comes from a flow-level `globals[]` input (`direction: "in"` or `"inout"`). |
-| `$vars.<nodeId>.output.<field>` reference | `"file_path": "$vars.uploadDoc.output.path"` | The value comes from an upstream node's output. |
-
-The `$vars.…` strings are pattern-matched by the agent activity at runtime and resolved against the flow's variable scope. They are NOT JavaScript expressions — only the bare reference form works (no arithmetic, no method calls, no template literals).
-
-### Wiring the agent's output back out
-
-This direction *does* use `=js:` — output mappings and variable updates go through Jint. On an End node, map each `direction: "out"` global from the agent's output:
-
-```json
-"outputs": {
-  "summary": { "source": "=js:$vars.<agentNodeId>.output.summary" }
-}
-```
-
-Or, with a `variableUpdate` against an `inout` global:
-
-```json
-"variableUpdates": {
-  "<agentNodeId>": [
-    { "variableId": "summary", "expression": "=js:$vars.<agentNodeId>.output.summary" }
-  ]
-}
-```
-
-See [variables-and-expressions.md § Variable Updates](../../../uipath-maestro-flow/references/shared/variables-and-expressions.md#variable-updates-variableupdates) for the full rules around `=js:` contexts.
+Input-only rule. Mapping the agent's output back to a flow-level global on an End node DOES use `=js:` — see [variables-and-expressions.md § Variable Updates](../../../uipath-maestro-flow/references/shared/variables-and-expressions.md#variable-updates-variableupdates).

--- a/skills/uipath-agents/references/coded/flow-integration.md
+++ b/skills/uipath-agents/references/coded/flow-integration.md
@@ -9,7 +9,7 @@ Coded agents in flows use the `uipath.core.agent.{key}` node with `Orchestrator.
 The coded agent lives as a sibling folder inside the same solution as the flow. The flow references it with `section: "In this solution"`; the runtime resolves the node via the Studio Web projects API.
 
 - **Agent-side scaffolding:** [embedding-in-flows.md](embedding-in-flows.md)
-- **Wiring the agent's inputs (literal vs. `$vars.<id>` — and why `=js:` is wrong for these slots):** [embedding-in-flows.md § Wiring the Agent's Inputs](embedding-in-flows.md#wiring-the-agents-inputs)
+- **Wiring the agent's inputs:** [embedding-in-flows.md § Wiring the Agent's Inputs](embedding-in-flows.md#wiring-the-agents-inputs)
 - **Flow node JSON shape + top-level `bindings[]` + `definitions[]` entry:** [agent/impl.md § In-solution variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--in-solution-variant)
 
 The node-type's `{key}` is the local `resource.key` minted by `uip solution project add` (written to `resources/solution_folder/process/agent/<name>.json`) and surfaced by `uip maestro flow registry list --local`.

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -294,11 +294,11 @@ Execute the following in order, end-to-end, in one pass — do not pause for con
 
 7. **Wire the agent node into the `.flow` file.** Edit `<FlowName>.flow` directly:
    - Add a `uipath.core.agent.<resourceKey>` node to `nodes[]` with one `inputs.<field>` entry per property in the agent's input schema (see step 6's `Data.Node.inputDefinition`) and `model.section: "In this solution"`.
-   - Each input field takes either a **literal value** (`"file_path": "/path/to/file.txt"`) or a **bare `$vars.<flowVarId>` reference** (`"file_path": "$vars.file_path"` to read a flow-level global, or `"$vars.<upstreamNodeId>.output.<field>"` to chain from another node's output). **Never wrap agent input values in `=js:`** — those fields are bound by the agent activity, not evaluated by Jint, and an `=js:…` value ships as a literal string and fails at runtime with `Cannot find name '<identifier>'`. See [embedding-in-flows.md § Wiring the Agent's Inputs](embedding-in-flows.md#wiring-the-agents-inputs).
+   - For input field values, see [embedding-in-flows.md § Wiring the Agent's Inputs](embedding-in-flows.md#wiring-the-agents-inputs).
    - Add the definition from step 6 to `definitions[]`.
    - Add a top-level `bindings[]` entry for the agent (no duplicates per `(resourceKey, propertyAttribute)`).
    - Add edges from upstream nodes to the agent's input port and from its output port downstream.
-   - To surface the agent's output as a flow-level result, declare an `out` global and map it on the End node with `"source": "=js:$vars.<agentNodeId>.output.<field>"` (this direction *does* use `=js:` — only the agent's *input* slots do not). See [embedding-in-flows.md § Wiring the agent's output back out](embedding-in-flows.md#wiring-the-agents-output-back-out).
+   - To surface the agent's output as a flow-level result, declare an `out` global and map it on the End node with `"source": "=js:$vars.<agentNodeId>.output.<field>"` (outputs DO use `=js:`; only inputs do not).
 
    See [embedding-in-flows.md](embedding-in-flows.md) for the directory layout and [flow-integration.md § Pattern 1](flow-integration.md#pattern-1-in-solution-coded-agent) for the JSON shape.
 


### PR DESCRIPTION
## Description

Instruct coding agents how to properly pass inputs that are simple variable refs to coded agent nodes in a Flow. Basically this simplifies the fix from https://github.com/UiPath/skills/pull/1335