### PR TITLE
feat: align plugin/marketplace version with the @uipath/skills npm scheme (PILOT-5516)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uipath",
       "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
-      "version": "0.0.36",
+      "version": "1.197.0",
       "author": {
         "name": "UiPath"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "0.0.36",
+  "version": "1.197.0",
   "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "0.0.36",
+  "version": "1.197.0",
   "description": "UiPath skills for building, validating, deploying, and operating automations and agents from Codex.",
   "author": {
     "name": "UiPath"

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -44,34 +44,23 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Bump version in plugin.json and marketplace.json
+      - uses: actions/setup-node@v4
+        if: steps.check.outputs.exists != 'true'
+        with:
+          node-version: "22.x"
+
+      - name: Bump plugin version (shared major.minor, daily patch counter)
         id: bump
         if: steps.check.outputs.exists != 'true'
         run: |
-          PLUGIN=".claude-plugin/plugin.json"
-          MARKETPLACE=".claude-plugin/marketplace.json"
-
-          # Plugin version shares major.minor with package.json (the npm
-          # package / CLI line); the patch is an independent daily counter.
-          # When the package minor advances, the counter resets to 0.
-          # See docs/RELEASE.md.
-          PKG_LINE=$(jq -r '.version | split(".") | "\(.[0]).\(.[1])"' package.json)
-          VERSION=$(jq -r '.version' "$PLUGIN")
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-
-          if [ "$MAJOR.$MINOR" = "$PKG_LINE" ]; then
-            NEW_VERSION="$PKG_LINE.$((PATCH + 1))"
-          else
-            NEW_VERSION="$PKG_LINE.0"
-          fi
-
-          # Update plugin.json
-          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN" > tmp.json && mv tmp.json "$PLUGIN"
-
-          # Update marketplace.json (version is inside plugins[0])
-          jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' "$MARKETPLACE" > tmp.json && mv tmp.json "$MARKETPLACE"
-
-          echo "old_version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Single source of the bump rule: `sync-version.mjs --bump-patch`
+          # advances the plugin/marketplace/Codex patch (resetting onto
+          # package.json's minor line if it has moved on). The rule lives only
+          # in the script — not duplicated in jq here. See docs/RELEASE.md.
+          OLD_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          node scripts/sync-version.mjs --bump-patch
+          NEW_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          echo "old_version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
@@ -88,6 +77,7 @@ jobs:
             Updated files:
             - `.claude-plugin/plugin.json`
             - `.claude-plugin/marketplace.json`
+            - `.codex-plugin/plugin.json`
           branch: "auto/version-bump-${{ steps.bump.outputs.new_version }}"
           base: main
           assignees: ${{ github.event.inputs.assignees || 'gabrielavaduva,RaduAna-Maria'}}

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -51,10 +51,19 @@ jobs:
           PLUGIN=".claude-plugin/plugin.json"
           MARKETPLACE=".claude-plugin/marketplace.json"
 
-          # Read current version from plugin.json
+          # Plugin version shares major.minor with package.json (the npm
+          # package / CLI line); the patch is an independent daily counter.
+          # When the package minor advances, the counter resets to 0.
+          # See docs/RELEASE.md.
+          PKG_LINE=$(jq -r '.version | split(".") | "\(.[0]).\(.[1])"' package.json)
           VERSION=$(jq -r '.version' "$PLUGIN")
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+          if [ "$MAJOR.$MINOR" = "$PKG_LINE" ]; then
+            NEW_VERSION="$PKG_LINE.$((PATCH + 1))"
+          else
+            NEW_VERSION="$PKG_LINE.0"
+          fi
 
           # Update plugin.json
           jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN" > tmp.json && mv tmp.json "$PLUGIN"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,8 +9,9 @@ The whole skills repo is published as an npm package, **`@uipath/skills`**, vers
 | File | Field | Purpose |
 |------|-------|---------|
 | `version-manifest.json` | `skillsVersion`, `targetCli` | CLI↔skills pairing record |
-| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) |
+| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) — the canonical plugin version |
 | `.claude-plugin/marketplace.json` | `plugins[0].version` | Always equals `plugin.json` `version` |
+| `.codex-plugin/plugin.json` | `version` | Codex plugin version — always equals `plugin.json` `version` |
 
 ### One `major.minor`, three patch counters
 
@@ -20,9 +21,9 @@ All channels share `major.minor` (the CLI-compatibility signal); the **patch div
 |---------|---------|---------------|
 | npm `latest` | `M.N.<release>` | per stable release — what the CLI pins |
 | npm `alpha` | `M.N.<release>-alpha.<date>.<run>` | per alpha dispatch |
-| plugin / `marketplace.json` | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code plugin auto-update |
+| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code / Codex plugin auto-update |
 
-`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin/marketplace version to `M.N.0`; if they match, the daily counter is left untouched. The marketplace version must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line.
+`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin version to `M.N.0` (and **refuses to downgrade** if `package.json`'s minor is below the plugin's); if they match, `--bump-patch` advances the daily counter, otherwise the patch is left untouched. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. The bump rule lives only in `sync-version.mjs` (`daily-version-bump.yml` calls `--bump-patch` rather than reimplementing it).
 
 Run after any version change:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,13 +4,25 @@ The whole skills repo is published as an npm package, **`@uipath/skills`**, vers
 
 ## Version model
 
-`package.json` `version` is the **single source of truth** for the npm package. `scripts/sync-version.mjs` derives this manifest from it (do not edit by hand):
+`package.json` `version` is the **single source of truth** for the npm package. `scripts/sync-version.mjs` derives these manifests from it (do not edit by hand):
 
 | File | Field | Purpose |
 |------|-------|---------|
 | `version-manifest.json` | `skillsVersion`, `targetCli` | CLI↔skills pairing record |
+| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) |
+| `.claude-plugin/marketplace.json` | `plugins[0].version` | Always equals `plugin.json` `version` |
 
-> **Not yet unified:** `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` stay on their own version track (bumped daily by `daily-version-bump.yml`) until the alignment task lands. Unifying them under this scheme is tracked separately — see the linked Jira task in PR #1283.
+### One `major.minor`, three patch counters
+
+All channels share `major.minor` (the CLI-compatibility signal); the **patch diverges deliberately per channel**:
+
+| Channel | Version | Patch cadence |
+|---------|---------|---------------|
+| npm `latest` | `M.N.<release>` | per stable release — what the CLI pins |
+| npm `alpha` | `M.N.<release>-alpha.<date>.<run>` | per alpha dispatch |
+| plugin / `marketplace.json` | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code plugin auto-update |
+
+`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin/marketplace version to `M.N.0`; if they match, the daily counter is left untouched. The marketplace version must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line.
 
 Run after any version change:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -36,7 +36,7 @@ npm run version:check     # CI guard — non-zero exit if drifted
 
 The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.197.x` → skills `1.197.x`). `version-manifest.json.targetCli` records the matching line as `^MAJOR.MINOR.0`. The CLI pins this line, so it never pulls a skills package from a different minor.
 
-> **Today the CLI clones `main` directly** (`packages/cli/src/commands/skills/contentStore.ts` → `REPO_URL` / `ZIP_URL`). That is the mismatch source: any CLI version gets whatever is on `main` at install time. Switching that consumption path to install the pinned `@uipath/skills` version is the **CLI-side change** that closes the loop — tracked as a decision below, not yet done.
+> **The CLI resolves `@uipath/skills` from npm, matched to its own minor line.** `uip skills install` lists the published versions and picks the one matching the CLI's `MAJOR.MINOR` (`packages/cli/src/commands/skills/contentStore.ts` → `fetchMatchingSkillsPackageInfo` / `pickMatchingSkillsVersion`, registry `registry.npmjs.org`), then fetches that tarball into the content store. So a given CLI release always resolves a compatible skills package and the loop this section describes is closed — for the `uip skills install` **content** path. The Claude Code / Codex plugin marketplace is a **separate** channel (a git ref, not the npm package) and is what the daily plugin-version bump serves.
 
 ## Publishing tracks (`.github/workflows/publish.yml`)
 

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -8,23 +8,31 @@
  *   - version-manifest.json        .skillsVersion + .targetCli
  *   - .claude-plugin/plugin.json   .version (major.minor only — see below)
  *   - .claude-plugin/marketplace.json  .plugins[0].version (== plugin.json)
+ *   - .codex-plugin/plugin.json    .version (== plugin.json — Codex channel)
  *
  * `targetCli` is derived as the matching @uipath/cli minor line
  * (`^MAJOR.MINOR.0`). A skills release tracks the CLI minor line it ships
  * with, so a given CLI release resolves to a compatible skills package and
  * the two never mismatch.
  *
- * Plugin/marketplace versions share `major.minor` with package.json but the
- * patch is an independent daily counter (bumped by daily-version-bump.yml to
- * drive Claude Code plugin auto-update). Rule enforced here:
+ * The plugin manifests share `major.minor` with package.json but the patch is
+ * an independent daily counter (advanced by --bump-patch from
+ * daily-version-bump.yml to drive plugin auto-update). `.claude-plugin/plugin.json`
+ * is the canonical plugin version; the marketplace and Codex manifests mirror
+ * it. Rule enforced here:
  *   - plugin major.minor != package.json major.minor -> reset to `M.N.0`
- *   - plugin major.minor == package.json major.minor -> patch left untouched
- *   - marketplace .plugins[0].version must always equal plugin.json .version
+ *     (errors out if package.json minor is BELOW the plugin minor — plugin
+ *      auto-update never downgrades, so a lower version would freeze users)
+ *   - plugin major.minor == package.json major.minor -> --bump-patch advances
+ *     the patch by 1; without it the patch is left untouched
+ *   - marketplace .plugins[0].version and .codex-plugin/plugin.json .version
+ *     must always equal .claude-plugin/plugin.json .version
  * See docs/RELEASE.md.
  *
  * Usage:
- *   node scripts/sync-version.mjs           # rewrite derived manifests
- *   node scripts/sync-version.mjs --check    # exit 1 if any are out of sync
+ *   node scripts/sync-version.mjs               # rewrite derived manifests
+ *   node scripts/sync-version.mjs --bump-patch  # also advance the plugin daily-counter patch
+ *   node scripts/sync-version.mjs --check       # exit 1 if any are out of sync
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -33,12 +41,14 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CHECK = process.argv.includes("--check");
+const BUMP_PATCH = process.argv.includes("--bump-patch");
 
 const PATHS = {
   pkg: join(ROOT, "package.json"),
   manifest: join(ROOT, "version-manifest.json"),
   plugin: join(ROOT, ".claude-plugin", "plugin.json"),
   marketplace: join(ROOT, ".claude-plugin", "marketplace.json"),
+  codexPlugin: join(ROOT, ".codex-plugin", "plugin.json"),
 };
 
 function readJson(p) {
@@ -62,6 +72,15 @@ function minorLine(version) {
   return `${major}.${minor}`;
 }
 
+/** Compare two `M.N` lines numerically. Returns -1, 0, or 1. */
+function compareMinorLine(a, b) {
+  const [am, an] = a.split(".").map(Number);
+  const [bm, bn] = b.split(".").map(Number);
+  if (am !== bm) return am < bm ? -1 : 1;
+  if (an !== bn) return an < bn ? -1 : 1;
+  return 0;
+}
+
 const version = readJson(PATHS.pkg).version;
 const targetCli = cliLine(version);
 
@@ -79,19 +98,40 @@ if (manifest.skillsVersion !== version || manifest.targetCli !== targetCli) {
   writes.push(() => writeJson(PATHS.manifest, manifest));
 }
 
-// .claude-plugin/plugin.json — shared major.minor, independent patch counter.
+// .claude-plugin/plugin.json — canonical plugin version: shared major.minor
+// with package.json, independent daily-counter patch.
 const plugin = readJson(PATHS.plugin);
 let pluginVersion = plugin.version;
 if (minorLine(pluginVersion) !== minorLine(version)) {
-  const next = `${minorLine(version)}.0`;
-  drift.push(`.claude-plugin/plugin.json: ${pluginVersion} -> ${next}`);
-  pluginVersion = next;
-  plugin.version = next;
+  // Reset the patch counter onto package.json's minor line — but never
+  // downgrade. Plugin auto-update doesn't go backwards, so resetting to a
+  // lower minor (a bad manual edit / revert in package.json) would freeze
+  // users on a version they can never leave. Fail loudly instead.
+  if (compareMinorLine(minorLine(version), minorLine(pluginVersion)) < 0) {
+    console.error(
+      `✗ package.json minor (${minorLine(version)}) is below the plugin minor ` +
+        `(${minorLine(pluginVersion)}). Refusing to downgrade .claude-plugin/plugin.json.`,
+    );
+    process.exit(1);
+  }
+  pluginVersion = `${minorLine(version)}.0`;
+} else if (BUMP_PATCH && !CHECK) {
+  const patch = Number(pluginVersion.split(".")[2]);
+  pluginVersion = `${minorLine(version)}.${patch + 1}`;
+}
+
+if (plugin.version !== pluginVersion) {
+  drift.push(`.claude-plugin/plugin.json: ${plugin.version} -> ${pluginVersion}`);
+  plugin.version = pluginVersion;
   writes.push(() => writeJson(PATHS.plugin, plugin));
 }
 
 // .claude-plugin/marketplace.json — must equal plugin.json exactly.
 const marketplace = readJson(PATHS.marketplace);
+if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+  console.error("✗ .claude-plugin/marketplace.json has no plugins[] entry to sync.");
+  process.exit(1);
+}
 if (marketplace.plugins[0].version !== pluginVersion) {
   drift.push(
     `.claude-plugin/marketplace.json: ${marketplace.plugins[0].version} -> ${pluginVersion}`,
@@ -100,20 +140,36 @@ if (marketplace.plugins[0].version !== pluginVersion) {
   writes.push(() => writeJson(PATHS.marketplace, marketplace));
 }
 
+// .codex-plugin/plugin.json — Codex distribution channel; must equal plugin.json.
+const codexPlugin = readJson(PATHS.codexPlugin);
+if (codexPlugin.version !== pluginVersion) {
+  drift.push(
+    `.codex-plugin/plugin.json: ${codexPlugin.version} -> ${pluginVersion}`,
+  );
+  codexPlugin.version = pluginVersion;
+  writes.push(() => writeJson(PATHS.codexPlugin, codexPlugin));
+}
+
 if (CHECK) {
   if (drift.length > 0) {
     console.error("✗ Version drift detected (run `npm run version:sync`):");
     for (const d of drift) console.error(`  - ${d}`);
     process.exit(1);
   }
-  console.log(`✓ All manifests in sync at ${version} (targetCli ${targetCli}).`);
+  console.log(
+    `✓ All manifests in sync (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}).`,
+  );
   process.exit(0);
 }
 
 if (writes.length === 0) {
-  console.log(`✓ Already in sync at ${version} (targetCli ${targetCli}).`);
+  console.log(
+    `✓ Already in sync (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}).`,
+  );
 } else {
   for (const w of writes) w();
-  console.log(`✓ Synced ${writes.length} manifest(s) to ${version} (targetCli ${targetCli}):`);
+  console.log(
+    `✓ Synced ${writes.length} manifest(s) (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}):`,
+  );
   for (const d of drift) console.log(`  - ${d}`);
 }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -5,16 +5,21 @@
  *
  * `package.json` `version` is authoritative. This script propagates it to:
  *
- *   - version-manifest.json   .skillsVersion + .targetCli
+ *   - version-manifest.json        .skillsVersion + .targetCli
+ *   - .claude-plugin/plugin.json   .version (major.minor only — see below)
+ *   - .claude-plugin/marketplace.json  .plugins[0].version (== plugin.json)
  *
  * `targetCli` is derived as the matching @uipath/cli minor line
  * (`^MAJOR.MINOR.0`). A skills release tracks the CLI minor line it ships
  * with, so a given CLI release resolves to a compatible skills package and
  * the two never mismatch.
  *
- * Note: `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- * are deliberately NOT managed here yet — they stay on their own version
- * track (bumped by daily-version-bump.yml) until the alignment task lands.
+ * Plugin/marketplace versions share `major.minor` with package.json but the
+ * patch is an independent daily counter (bumped by daily-version-bump.yml to
+ * drive Claude Code plugin auto-update). Rule enforced here:
+ *   - plugin major.minor != package.json major.minor -> reset to `M.N.0`
+ *   - plugin major.minor == package.json major.minor -> patch left untouched
+ *   - marketplace .plugins[0].version must always equal plugin.json .version
  * See docs/RELEASE.md.
  *
  * Usage:
@@ -32,6 +37,8 @@ const CHECK = process.argv.includes("--check");
 const PATHS = {
   pkg: join(ROOT, "package.json"),
   manifest: join(ROOT, "version-manifest.json"),
+  plugin: join(ROOT, ".claude-plugin", "plugin.json"),
+  marketplace: join(ROOT, ".claude-plugin", "marketplace.json"),
 };
 
 function readJson(p) {
@@ -49,6 +56,12 @@ function cliLine(version) {
   return `^${major}.${minor}.0`;
 }
 
+/** `1.196.4` -> `1.196`. */
+function minorLine(version) {
+  const [major, minor] = version.split(".");
+  return `${major}.${minor}`;
+}
+
 const version = readJson(PATHS.pkg).version;
 const targetCli = cliLine(version);
 
@@ -64,6 +77,27 @@ if (manifest.skillsVersion !== version || manifest.targetCli !== targetCli) {
   manifest.skillsVersion = version;
   manifest.targetCli = targetCli;
   writes.push(() => writeJson(PATHS.manifest, manifest));
+}
+
+// .claude-plugin/plugin.json — shared major.minor, independent patch counter.
+const plugin = readJson(PATHS.plugin);
+let pluginVersion = plugin.version;
+if (minorLine(pluginVersion) !== minorLine(version)) {
+  const next = `${minorLine(version)}.0`;
+  drift.push(`.claude-plugin/plugin.json: ${pluginVersion} -> ${next}`);
+  pluginVersion = next;
+  plugin.version = next;
+  writes.push(() => writeJson(PATHS.plugin, plugin));
+}
+
+// .claude-plugin/marketplace.json — must equal plugin.json exactly.
+const marketplace = readJson(PATHS.marketplace);
+if (marketplace.plugins[0].version !== pluginVersion) {
+  drift.push(
+    `.claude-plugin/marketplace.json: ${marketplace.plugins[0].version} -> ${pluginVersion}`,
+  );
+  marketplace.plugins[0].version = pluginVersion;
+  writes.push(() => writeJson(PATHS.marketplace, marketplace));
 }
 
 if (CHECK) {


### PR DESCRIPTION
## What

Implements **PILOT-5516**: cuts `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `.codex-plugin/plugin.json` over from their isolated `0.0.x` track to the `@uipath/skills` version scheme — shared `major.minor` with `package.json` (the CLI-compatibility line), patch as an independent daily counter.

Per the packaging & release model doc: keep `major.minor` in sync across channels, let the patch diverge deliberately per channel.

## Changes

- **One-time cutover:** plugin + marketplace + Codex plugin version `0.0.36` → `1.197.0`
- **`scripts/sync-version.mjs`** now manages all three plugin manifests via one rule:
  - plugin `major.minor` ≠ `package.json` → reset to `M.N.0` (minor advance resets the daily counter), **refusing to downgrade** if `package.json`'s minor is below the plugin's
  - `major.minor` matches → `--bump-patch` advances the patch, otherwise it is left untouched (same script is valid on `main` and on release branches)
  - `marketplace.plugins[0].version` and `.codex-plugin/plugin.json` `version` must hard-equal `plugin.json` `version`
  - guards an empty `marketplace.plugins[]` array
  - `--check` (already wired into `publish.yml` guard) fails on any violation
- **`daily-version-bump.yml`** now calls `sync-version.mjs --bump-patch` instead of reimplementing the bump rule in jq — the rule lives in exactly one place and covers all three manifests (incl. Codex) automatically
- **`docs/RELEASE.md`**: documents the Codex manifest and the single-source bump rule

## Review feedback addressed (@RaduAna-Maria)

- **Codex plugin included** in the sync (inline comments on `marketplace.json`, `daily-version-bump.yml`, `docs/RELEASE.md`).
- **Bump rule consolidated** into `sync-version.mjs --bump-patch` (the suggested follow-up) — no longer duplicated in jq.
- **Downgrade guard** added (the unconditional-reset finding).
- **Empty-`plugins[]` guard** added (nit).
- **`--check`/`--sync` messages** now report the plugin version too (nit).

## Notes for reviewers / ops

- The `0.0.36 → 1.197.0` jump fires plugin auto-update for current users once merged (an upgrade, monotonic — no downgrade-detection issue).
- **Before/at merge:** if a stale open `auto/version-bump-*` PR exists, close it and delete its branch — its `0.0.x` numbering is obsolete and the dedupe check would skip the first run of the new scheme. (None open at time of writing.)
- Jira note: PILOT-5516 shows Merged/Done but the repo did not contain the implementation — this PR is it; the ticket should be re-pointed at this PR.
- Follow-ups land separately: `release/latest` stable ref (PILOT-5544, #1451), Sunday sprint-cut automation (PILOT-5518, #1452).

## Verification

- `npm run version:sync` → brings `.codex-plugin/plugin.json` to `1.197.0`; second run reports already in sync (idempotent)
- `npm run version:check` → exit 0 (`All manifests in sync (package 1.197.0, plugin 1.197.0, …)`)
- `node scripts/sync-version.mjs --bump-patch` → advances all three manifests `1.197.0 → 1.197.1`
- Negative test: plugin minor above package minor → script exits 1 (`Refusing to downgrade`)
- After merge: dispatch **Daily Version Bump** → PR should show `1.197.0 → 1.197.1` touching all three manifests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
