### PR TITLE
feat: release/latest stable ref for the marketplace + daily bump retarget (PILOT-5544)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uipath",
       "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
-      "version": "0.0.36",
+      "version": "1.197.0",
       "author": {
         "name": "UiPath"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "0.0.36",
+  "version": "1.197.0",
   "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "0.0.36",
+  "version": "1.197.0",
   "description": "UiPath skills for building, validating, deploying, and operating automations and agents from Codex.",
   "author": {
     "name": "UiPath"

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -44,34 +44,23 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Bump version in plugin.json and marketplace.json
+      - uses: actions/setup-node@v4
+        if: steps.check.outputs.exists != 'true'
+        with:
+          node-version: "22.x"
+
+      - name: Bump plugin version (shared major.minor, daily patch counter)
         id: bump
         if: steps.check.outputs.exists != 'true'
         run: |
-          PLUGIN=".claude-plugin/plugin.json"
-          MARKETPLACE=".claude-plugin/marketplace.json"
-
-          # Plugin version shares major.minor with package.json (the npm
-          # package / CLI line); the patch is an independent daily counter.
-          # When the package minor advances, the counter resets to 0.
-          # See docs/RELEASE.md.
-          PKG_LINE=$(jq -r '.version | split(".") | "\(.[0]).\(.[1])"' package.json)
-          VERSION=$(jq -r '.version' "$PLUGIN")
-          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-
-          if [ "$MAJOR.$MINOR" = "$PKG_LINE" ]; then
-            NEW_VERSION="$PKG_LINE.$((PATCH + 1))"
-          else
-            NEW_VERSION="$PKG_LINE.0"
-          fi
-
-          # Update plugin.json
-          jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN" > tmp.json && mv tmp.json "$PLUGIN"
-
-          # Update marketplace.json (version is inside plugins[0])
-          jq --arg v "$NEW_VERSION" '.plugins[0].version = $v' "$MARKETPLACE" > tmp.json && mv tmp.json "$MARKETPLACE"
-
-          echo "old_version=$VERSION" >> "$GITHUB_OUTPUT"
+          # Single source of the bump rule: `sync-version.mjs --bump-patch`
+          # advances the plugin/marketplace/Codex patch (resetting onto
+          # package.json's minor line if it has moved on). The rule lives only
+          # in the script — not duplicated in jq here. See docs/RELEASE.md.
+          OLD_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          node scripts/sync-version.mjs --bump-patch
+          NEW_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          echo "old_version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
@@ -88,6 +77,7 @@ jobs:
             Updated files:
             - `.claude-plugin/plugin.json`
             - `.claude-plugin/marketplace.json`
+            - `.codex-plugin/plugin.json`
           branch: "auto/version-bump-${{ steps.bump.outputs.new_version }}"
           base: main
           assignees: ${{ github.event.inputs.assignees || 'gabrielavaduva,RaduAna-Maria'}}

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -51,10 +51,19 @@ jobs:
           PLUGIN=".claude-plugin/plugin.json"
           MARKETPLACE=".claude-plugin/marketplace.json"
 
-          # Read current version from plugin.json
+          # Plugin version shares major.minor with package.json (the npm
+          # package / CLI line); the patch is an independent daily counter.
+          # When the package minor advances, the counter resets to 0.
+          # See docs/RELEASE.md.
+          PKG_LINE=$(jq -r '.version | split(".") | "\(.[0]).\(.[1])"' package.json)
           VERSION=$(jq -r '.version' "$PLUGIN")
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          NEW_VERSION="$MAJOR.$MINOR.$((PATCH + 1))"
+
+          if [ "$MAJOR.$MINOR" = "$PKG_LINE" ]; then
+            NEW_VERSION="$PKG_LINE.$((PATCH + 1))"
+          else
+            NEW_VERSION="$PKG_LINE.0"
+          fi
 
           # Update plugin.json
           jq --arg v "$NEW_VERSION" '.version = $v' "$PLUGIN" > tmp.json && mv tmp.json "$PLUGIN"

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -1,12 +1,25 @@
 name: Daily Version Bump
 
+# Bumps the plugin version (Claude Code plugin.json + marketplace.json + Codex
+# plugin.json) on the current release line. The marketplace tracks
+# `release/latest`, and plugin auto-update fires when the `version` field on
+# that ref changes — so the bump commits directly to the durable release branch
+# (`release/v<minor>`) and fast-forwards `release/latest` to it. `main` gets NO
+# daily bumps: its plugin version is pinned at `M.N.0` once per sprint by the
+# release cut. See docs/RELEASE.md ("Marketplace channel").
+
 on:
   schedule:
     - cron: '0 7 * * *' # every day at 07:00 UTC
   workflow_dispatch:
     inputs:
+      legacy_main_bump:
+        description: 'Transition-only: bump via PR to main instead of the release line (delete after one sprint)'
+        type: boolean
+        required: false
+        default: false
       assignees:
-        description: 'Comma-separated GitHub usernames to assign to the PR'
+        description: 'Comma-separated GitHub usernames to assign to the legacy PR'
         required: false
         default: ''
 
@@ -14,8 +27,113 @@ permissions:
   contents: write
   pull-requests: write
 
+# Shared with the sprint release cut so a daily bump never races the Sunday
+# branch advance.
+concurrency:
+  group: release-line-updates
+  cancel-in-progress: false
+
 jobs:
-  bump-version:
+  bump-release-line:
+    if: github.event_name == 'schedule' || github.event.inputs.legacy_main_bump != 'true'
+    runs-on: ubuntu-latest
+    env:
+      # Shared constant for the bump-commit subject. The skip-guard matches on
+      # it and the commit step writes it — both read this one value so they
+      # can't silently desync. (A hand-edited message that no longer matches
+      # the guard would resume forcing identical-content plugin re-downloads,
+      # with no failure to alert anyone.)
+      BUMP_COMMIT_PREFIX: "chore: bump plugin version to"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+
+      - name: Resolve release/latest
+        id: resolve
+        run: |
+          if ! git ls-remote --exit-code --heads origin release/latest > /dev/null; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Skipped: release/latest does not exist yet"
+              echo ""
+              echo "Create the release line first (see docs/RELEASE.md, Marketplace channel)."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          echo "exists=true" >> "$GITHUB_OUTPUT"
+          git fetch origin release/latest
+          git checkout --detach FETCH_HEAD
+
+      - name: Skip if nothing landed since the last bump
+        id: guard
+        if: steps.resolve.outputs.exists == 'true'
+        run: |
+          SUBJECT=$(git log -1 --format=%s)
+          if [[ "$SUBJECT" == "$BUMP_COMMIT_PREFIX"* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Skipped: no new content on the release line"
+              echo ""
+              echo "HEAD is already a bump commit (\`$SUBJECT\`). Bumping again would force a plugin re-download for identical content."
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump plugin version (shared major.minor, daily patch counter)
+        id: bump
+        if: steps.resolve.outputs.exists == 'true' && steps.guard.outputs.skip != 'true'
+        run: |
+          # Single source of the bump rule: `sync-version.mjs --bump-patch`
+          # advances the plugin/marketplace/Codex patch (resetting onto
+          # package.json's minor line if it has moved on). The rule lives only
+          # in the script — not duplicated in jq here. See docs/RELEASE.md.
+          PKG_LINE=$(node -p "require('./package.json').version.split('.').slice(0,2).join('.')")
+          OLD_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          node scripts/sync-version.mjs --bump-patch
+          NEW_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
+          echo "old_version=$OLD_VERSION" >> "$GITHUB_OUTPUT"
+          echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_branch=release/v$PKG_LINE" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push to the release line
+        if: steps.resolve.outputs.exists == 'true' && steps.guard.outputs.skip != 'true'
+        run: |
+          BRANCH="${{ steps.bump.outputs.release_branch }}"
+
+          # Invariant: release/latest HEAD belongs to the durable branch for
+          # the current minor. If that branch is missing, the release line is
+          # broken — fail loudly instead of inventing a branch.
+          if ! git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
+            echo "::error::release/latest is at $(git rev-parse --short HEAD) but $BRANCH does not exist on origin."
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
+          git commit -m "$BUMP_COMMIT_PREFIX ${{ steps.bump.outputs.new_version }}"
+          # --atomic: both refs update or neither does. Without it a transient
+          # failure on the second refspec could leave release/v<minor> ahead of
+          # release/latest, breaking the "they're always equal" invariant the
+          # next run assumes.
+          git push --atomic origin "HEAD:$BRANCH" "HEAD:release/latest"
+
+          {
+            echo "## Plugin version bumped"
+            echo ""
+            echo "\`${{ steps.bump.outputs.old_version }}\` → \`${{ steps.bump.outputs.new_version }}\` on \`$BRANCH\` (+ \`release/latest\`)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Transition-only fallback: the pre-release-line flow (PR to main). Kept for
+  # one sprint after the marketplace cutover to release/latest; delete after.
+  legacy-main-bump:
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.legacy_main_bump == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -53,10 +171,6 @@ jobs:
         id: bump
         if: steps.check.outputs.exists != 'true'
         run: |
-          # Single source of the bump rule: `sync-version.mjs --bump-patch`
-          # advances the plugin/marketplace/Codex patch (resetting onto
-          # package.json's minor line if it has moved on). The rule lives only
-          # in the script — not duplicated in jq here. See docs/RELEASE.md.
           OLD_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
           node scripts/sync-version.mjs --bump-patch
           NEW_VERSION=$(node -p "require('./.claude-plugin/plugin.json').version")
@@ -70,7 +184,7 @@ jobs:
           commit-message: "chore: bump version to ${{ steps.bump.outputs.new_version }}"
           title: "chore: bump version from ${{ steps.bump.outputs.old_version }} to ${{ steps.bump.outputs.new_version }}"
           body: |
-            Automated daily version bump.
+            Automated daily version bump (legacy main flow).
 
             `${{ steps.bump.outputs.old_version }}` → `${{ steps.bump.outputs.new_version }}`
 

--- a/.github/workflows/daily-version-bump.yml
+++ b/.github/workflows/daily-version-bump.yml
@@ -44,6 +44,12 @@ jobs:
       # the guard would resume forcing identical-content plugin re-downloads,
       # with no failure to alert anyone.)
       BUMP_COMMIT_PREFIX: "chore: bump plugin version to"
+      # The sprint cut (sprint-release-cut.yml) commits "chore(release): cut
+      # <line> line" and ALREADY sets the plugin version + moves release/latest,
+      # so the morning-after bump would be a version-only change over identical
+      # skills content — a redundant plugin re-download. Treat the cut commit as
+      # a "no new content" state too. Keep in sync with the cut commit subject.
+      CUT_COMMIT_PREFIX: "chore(release): cut"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,12 +80,12 @@ jobs:
         if: steps.resolve.outputs.exists == 'true'
         run: |
           SUBJECT=$(git log -1 --format=%s)
-          if [[ "$SUBJECT" == "$BUMP_COMMIT_PREFIX"* ]]; then
+          if [[ "$SUBJECT" == "$BUMP_COMMIT_PREFIX"* || "$SUBJECT" == "$CUT_COMMIT_PREFIX"* ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             {
               echo "## Skipped: no new content on the release line"
               echo ""
-              echo "HEAD is already a bump commit (\`$SUBJECT\`). Bumping again would force a plugin re-download for identical content."
+              echo "HEAD is a version-only commit (\`$SUBJECT\`) — a bump or the sprint cut, which already set the version and moved release/latest. Bumping again would force a plugin re-download for identical content."
             } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -133,6 +133,12 @@ This repository works as a **Claude Code plugin**. Install skills via `uip skill
 
 > **Avoid manual plugin installation** (e.g., `claude plugin marketplace add` / `claude plugin install`). Manually installed plugins must be updated manually, and you may miss skill updates and fixes.
 
+If you must add the marketplace manually, pin the release line — never bare `UiPath/skills` (that tracks `main`, which gets no plugin version bumps and will not auto-update):
+
+```text
+/plugin marketplace add UiPath/skills@release/latest
+```
+
 If you've already installed manually, uninstall and re-install via `uip skills install` to switch to automatic updates.
 
 #### Reduce permission prompts

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -9,8 +9,9 @@ The whole skills repo is published as an npm package, **`@uipath/skills`**, vers
 | File | Field | Purpose |
 |------|-------|---------|
 | `version-manifest.json` | `skillsVersion`, `targetCli` | CLI↔skills pairing record |
-| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) |
+| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) — the canonical plugin version |
 | `.claude-plugin/marketplace.json` | `plugins[0].version` | Always equals `plugin.json` `version` |
+| `.codex-plugin/plugin.json` | `version` | Codex plugin version — always equals `plugin.json` `version` |
 
 ### One `major.minor`, three patch counters
 
@@ -20,9 +21,9 @@ All channels share `major.minor` (the CLI-compatibility signal); the **patch div
 |---------|---------|---------------|
 | npm `latest` | `M.N.<release>` | per stable release — what the CLI pins |
 | npm `alpha` | `M.N.<release>-alpha.<date>.<run>` | per alpha dispatch |
-| plugin / `marketplace.json` | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code plugin auto-update |
+| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code / Codex plugin auto-update |
 
-`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin/marketplace version to `M.N.0`; if they match, the daily counter is left untouched. The marketplace version must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line.
+`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin version to `M.N.0` (and **refuses to downgrade** if `package.json`'s minor is below the plugin's); if they match, `--bump-patch` advances the daily counter, otherwise the patch is left untouched. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. The bump rule lives only in `sync-version.mjs` (`daily-version-bump.yml` calls `--bump-patch` rather than reimplementing it).
 
 Run after any version change:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,13 +4,25 @@ The whole skills repo is published as an npm package, **`@uipath/skills`**, vers
 
 ## Version model
 
-`package.json` `version` is the **single source of truth** for the npm package. `scripts/sync-version.mjs` derives this manifest from it (do not edit by hand):
+`package.json` `version` is the **single source of truth** for the npm package. `scripts/sync-version.mjs` derives these manifests from it (do not edit by hand):
 
 | File | Field | Purpose |
 |------|-------|---------|
 | `version-manifest.json` | `skillsVersion`, `targetCli` | CLI↔skills pairing record |
+| `.claude-plugin/plugin.json` | `version` | Claude Code plugin version (shared `major.minor`, independent patch) |
+| `.claude-plugin/marketplace.json` | `plugins[0].version` | Always equals `plugin.json` `version` |
 
-> **Not yet unified:** `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` stay on their own version track (bumped daily by `daily-version-bump.yml`) until the alignment task lands. Unifying them under this scheme is tracked separately — see the linked Jira task in PR #1283.
+### One `major.minor`, three patch counters
+
+All channels share `major.minor` (the CLI-compatibility signal); the **patch diverges deliberately per channel**:
+
+| Channel | Version | Patch cadence |
+|---------|---------|---------------|
+| npm `latest` | `M.N.<release>` | per stable release — what the CLI pins |
+| npm `alpha` | `M.N.<release>-alpha.<date>.<run>` | per alpha dispatch |
+| plugin / `marketplace.json` | `M.N.<daily-counter>` | daily (`daily-version-bump.yml`) — drives Claude Code plugin auto-update |
+
+`sync-version.mjs` enforces the shared line: if the plugin `major.minor` differs from `package.json`, it resets the plugin/marketplace version to `M.N.0`; if they match, the daily counter is left untouched. The marketplace version must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line.
 
 Run after any version change:
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -36,7 +36,7 @@ npm run version:check     # CI guard — non-zero exit if drifted
 
 The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.197.x` → skills `1.197.x`). `version-manifest.json.targetCli` records the matching line as `^MAJOR.MINOR.0`. The CLI pins this line, so it never pulls a skills package from a different minor.
 
-> **Today the CLI clones `main` directly** (`packages/cli/src/commands/skills/contentStore.ts` → `REPO_URL` / `ZIP_URL`). That is the mismatch source: any CLI version gets whatever is on `main` at install time. Switching that consumption path to install the pinned `@uipath/skills` version is the **CLI-side change** that closes the loop — tracked as a decision below, not yet done.
+> **The CLI resolves `@uipath/skills` from npm, matched to its own minor line.** `uip skills install` lists the published versions and picks the one matching the CLI's `MAJOR.MINOR` (`packages/cli/src/commands/skills/contentStore.ts` → `fetchMatchingSkillsPackageInfo` / `pickMatchingSkillsVersion`, registry `registry.npmjs.org`), then fetches that tarball into the content store. So a given CLI release always resolves a compatible skills package and the loop this section describes is closed — for the `uip skills install` **content** path. The Claude Code / Codex plugin marketplace is a **separate** channel (a git ref, not the npm package) and is what the daily plugin-version bump serves.
 
 ## Publishing tracks (`.github/workflows/publish.yml`)
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -57,6 +57,37 @@ Both tracks are **manually triggered** — there is no auto-publish on push to `
 | `publish-alpha` | GitHub Packages (`npm.pkg.github.com`) | built-in `GITHUB_TOKEN` |
 | `publish-release` | npmjs (`registry.npmjs.org`) | **OIDC trusted publishing** (no token) + signed `--provenance` |
 
+## Marketplace channel (`release/latest`)
+
+The Claude Code marketplace tracks the **latest release branch**, not `main`. Release branches are named per sprint (`release/v1.195` → `release/v1.196`), and a marketplace `ref` is a fixed string — so the marketplace points permanently at the stable ref **`release/latest`**, which always equals the HEAD of the newest `release/v<minor>` branch.
+
+Who moves what:
+
+| Ref | Moved by | How |
+|-----|----------|-----|
+| `release/v<minor>` | `daily-version-bump.yml` | daily plugin-version bump commit (skipped when nothing landed since the last bump) |
+| `release/latest` | `daily-version-bump.yml` | fast-forward to the same commit |
+| `release/latest` | sprint release cut (Sunday automation) | **forced ref update** to the new `release/v<minor>` (the new branch does not contain the old line's daily-bump commits; `release/latest` is a pointer, never a base for work) |
+
+`main` gets **no daily plugin bumps** — its plugin version is pinned at `M.N.0` per sprint. Plugin auto-update fires off the `version` field on the tracked ref, so daily bumps land only on the release line. Plugin version monotonicity holds across the sprint handoff (`1.197.0 > 1.196.k`).
+
+Manual marketplace add (when not using `uip skills install`) must pin the ref:
+
+```text
+/plugin marketplace add UiPath/skills@release/latest
+```
+
+> **Warning:** installs added as bare `UiPath/skills` track `main` and will never see a version bump again — they silently freeze. Re-add with `@release/latest`.
+
+### One-time setup for a new line (or first rollout)
+
+```bash
+git push origin main:refs/heads/release/v<minor>
+git push origin main:refs/heads/release/latest
+```
+
+Branch-protection requirements (repo settings): `release/v*` and `release/latest` must allow direct push by the Actions identity, and `release/latest` must additionally allow **force push** (for the sprint handoff).
+
 ## Cutting a stable release
 
 1. Bump `package.json` to the target version (match the CLI minor line), run `npm run version:sync`, merge.

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -8,23 +8,31 @@
  *   - version-manifest.json        .skillsVersion + .targetCli
  *   - .claude-plugin/plugin.json   .version (major.minor only — see below)
  *   - .claude-plugin/marketplace.json  .plugins[0].version (== plugin.json)
+ *   - .codex-plugin/plugin.json    .version (== plugin.json — Codex channel)
  *
  * `targetCli` is derived as the matching @uipath/cli minor line
  * (`^MAJOR.MINOR.0`). A skills release tracks the CLI minor line it ships
  * with, so a given CLI release resolves to a compatible skills package and
  * the two never mismatch.
  *
- * Plugin/marketplace versions share `major.minor` with package.json but the
- * patch is an independent daily counter (bumped by daily-version-bump.yml to
- * drive Claude Code plugin auto-update). Rule enforced here:
+ * The plugin manifests share `major.minor` with package.json but the patch is
+ * an independent daily counter (advanced by --bump-patch from
+ * daily-version-bump.yml to drive plugin auto-update). `.claude-plugin/plugin.json`
+ * is the canonical plugin version; the marketplace and Codex manifests mirror
+ * it. Rule enforced here:
  *   - plugin major.minor != package.json major.minor -> reset to `M.N.0`
- *   - plugin major.minor == package.json major.minor -> patch left untouched
- *   - marketplace .plugins[0].version must always equal plugin.json .version
+ *     (errors out if package.json minor is BELOW the plugin minor — plugin
+ *      auto-update never downgrades, so a lower version would freeze users)
+ *   - plugin major.minor == package.json major.minor -> --bump-patch advances
+ *     the patch by 1; without it the patch is left untouched
+ *   - marketplace .plugins[0].version and .codex-plugin/plugin.json .version
+ *     must always equal .claude-plugin/plugin.json .version
  * See docs/RELEASE.md.
  *
  * Usage:
- *   node scripts/sync-version.mjs           # rewrite derived manifests
- *   node scripts/sync-version.mjs --check    # exit 1 if any are out of sync
+ *   node scripts/sync-version.mjs               # rewrite derived manifests
+ *   node scripts/sync-version.mjs --bump-patch  # also advance the plugin daily-counter patch
+ *   node scripts/sync-version.mjs --check       # exit 1 if any are out of sync
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
@@ -33,12 +41,14 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
 const CHECK = process.argv.includes("--check");
+const BUMP_PATCH = process.argv.includes("--bump-patch");
 
 const PATHS = {
   pkg: join(ROOT, "package.json"),
   manifest: join(ROOT, "version-manifest.json"),
   plugin: join(ROOT, ".claude-plugin", "plugin.json"),
   marketplace: join(ROOT, ".claude-plugin", "marketplace.json"),
+  codexPlugin: join(ROOT, ".codex-plugin", "plugin.json"),
 };
 
 function readJson(p) {
@@ -62,6 +72,15 @@ function minorLine(version) {
   return `${major}.${minor}`;
 }
 
+/** Compare two `M.N` lines numerically. Returns -1, 0, or 1. */
+function compareMinorLine(a, b) {
+  const [am, an] = a.split(".").map(Number);
+  const [bm, bn] = b.split(".").map(Number);
+  if (am !== bm) return am < bm ? -1 : 1;
+  if (an !== bn) return an < bn ? -1 : 1;
+  return 0;
+}
+
 const version = readJson(PATHS.pkg).version;
 const targetCli = cliLine(version);
 
@@ -79,19 +98,40 @@ if (manifest.skillsVersion !== version || manifest.targetCli !== targetCli) {
   writes.push(() => writeJson(PATHS.manifest, manifest));
 }
 
-// .claude-plugin/plugin.json — shared major.minor, independent patch counter.
+// .claude-plugin/plugin.json — canonical plugin version: shared major.minor
+// with package.json, independent daily-counter patch.
 const plugin = readJson(PATHS.plugin);
 let pluginVersion = plugin.version;
 if (minorLine(pluginVersion) !== minorLine(version)) {
-  const next = `${minorLine(version)}.0`;
-  drift.push(`.claude-plugin/plugin.json: ${pluginVersion} -> ${next}`);
-  pluginVersion = next;
-  plugin.version = next;
+  // Reset the patch counter onto package.json's minor line — but never
+  // downgrade. Plugin auto-update doesn't go backwards, so resetting to a
+  // lower minor (a bad manual edit / revert in package.json) would freeze
+  // users on a version they can never leave. Fail loudly instead.
+  if (compareMinorLine(minorLine(version), minorLine(pluginVersion)) < 0) {
+    console.error(
+      `✗ package.json minor (${minorLine(version)}) is below the plugin minor ` +
+        `(${minorLine(pluginVersion)}). Refusing to downgrade .claude-plugin/plugin.json.`,
+    );
+    process.exit(1);
+  }
+  pluginVersion = `${minorLine(version)}.0`;
+} else if (BUMP_PATCH && !CHECK) {
+  const patch = Number(pluginVersion.split(".")[2]);
+  pluginVersion = `${minorLine(version)}.${patch + 1}`;
+}
+
+if (plugin.version !== pluginVersion) {
+  drift.push(`.claude-plugin/plugin.json: ${plugin.version} -> ${pluginVersion}`);
+  plugin.version = pluginVersion;
   writes.push(() => writeJson(PATHS.plugin, plugin));
 }
 
 // .claude-plugin/marketplace.json — must equal plugin.json exactly.
 const marketplace = readJson(PATHS.marketplace);
+if (!Array.isArray(marketplace.plugins) || marketplace.plugins.length === 0) {
+  console.error("✗ .claude-plugin/marketplace.json has no plugins[] entry to sync.");
+  process.exit(1);
+}
 if (marketplace.plugins[0].version !== pluginVersion) {
   drift.push(
     `.claude-plugin/marketplace.json: ${marketplace.plugins[0].version} -> ${pluginVersion}`,
@@ -100,20 +140,36 @@ if (marketplace.plugins[0].version !== pluginVersion) {
   writes.push(() => writeJson(PATHS.marketplace, marketplace));
 }
 
+// .codex-plugin/plugin.json — Codex distribution channel; must equal plugin.json.
+const codexPlugin = readJson(PATHS.codexPlugin);
+if (codexPlugin.version !== pluginVersion) {
+  drift.push(
+    `.codex-plugin/plugin.json: ${codexPlugin.version} -> ${pluginVersion}`,
+  );
+  codexPlugin.version = pluginVersion;
+  writes.push(() => writeJson(PATHS.codexPlugin, codexPlugin));
+}
+
 if (CHECK) {
   if (drift.length > 0) {
     console.error("✗ Version drift detected (run `npm run version:sync`):");
     for (const d of drift) console.error(`  - ${d}`);
     process.exit(1);
   }
-  console.log(`✓ All manifests in sync at ${version} (targetCli ${targetCli}).`);
+  console.log(
+    `✓ All manifests in sync (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}).`,
+  );
   process.exit(0);
 }
 
 if (writes.length === 0) {
-  console.log(`✓ Already in sync at ${version} (targetCli ${targetCli}).`);
+  console.log(
+    `✓ Already in sync (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}).`,
+  );
 } else {
   for (const w of writes) w();
-  console.log(`✓ Synced ${writes.length} manifest(s) to ${version} (targetCli ${targetCli}):`);
+  console.log(
+    `✓ Synced ${writes.length} manifest(s) (package ${version}, plugin ${pluginVersion}, targetCli ${targetCli}):`,
+  );
   for (const d of drift) console.log(`  - ${d}`);
 }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -5,16 +5,21 @@
  *
  * `package.json` `version` is authoritative. This script propagates it to:
  *
- *   - version-manifest.json   .skillsVersion + .targetCli
+ *   - version-manifest.json        .skillsVersion + .targetCli
+ *   - .claude-plugin/plugin.json   .version (major.minor only — see below)
+ *   - .claude-plugin/marketplace.json  .plugins[0].version (== plugin.json)
  *
  * `targetCli` is derived as the matching @uipath/cli minor line
  * (`^MAJOR.MINOR.0`). A skills release tracks the CLI minor line it ships
  * with, so a given CLI release resolves to a compatible skills package and
  * the two never mismatch.
  *
- * Note: `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`
- * are deliberately NOT managed here yet — they stay on their own version
- * track (bumped by daily-version-bump.yml) until the alignment task lands.
+ * Plugin/marketplace versions share `major.minor` with package.json but the
+ * patch is an independent daily counter (bumped by daily-version-bump.yml to
+ * drive Claude Code plugin auto-update). Rule enforced here:
+ *   - plugin major.minor != package.json major.minor -> reset to `M.N.0`
+ *   - plugin major.minor == package.json major.minor -> patch left untouched
+ *   - marketplace .plugins[0].version must always equal plugin.json .version
  * See docs/RELEASE.md.
  *
  * Usage:
@@ -32,6 +37,8 @@ const CHECK = process.argv.includes("--check");
 const PATHS = {
   pkg: join(ROOT, "package.json"),
   manifest: join(ROOT, "version-manifest.json"),
+  plugin: join(ROOT, ".claude-plugin", "plugin.json"),
+  marketplace: join(ROOT, ".claude-plugin", "marketplace.json"),
 };
 
 function readJson(p) {
@@ -49,6 +56,12 @@ function cliLine(version) {
   return `^${major}.${minor}.0`;
 }
 
+/** `1.196.4` -> `1.196`. */
+function minorLine(version) {
+  const [major, minor] = version.split(".");
+  return `${major}.${minor}`;
+}
+
 const version = readJson(PATHS.pkg).version;
 const targetCli = cliLine(version);
 
@@ -64,6 +77,27 @@ if (manifest.skillsVersion !== version || manifest.targetCli !== targetCli) {
   manifest.skillsVersion = version;
   manifest.targetCli = targetCli;
   writes.push(() => writeJson(PATHS.manifest, manifest));
+}
+
+// .claude-plugin/plugin.json — shared major.minor, independent patch counter.
+const plugin = readJson(PATHS.plugin);
+let pluginVersion = plugin.version;
+if (minorLine(pluginVersion) !== minorLine(version)) {
+  const next = `${minorLine(version)}.0`;
+  drift.push(`.claude-plugin/plugin.json: ${pluginVersion} -> ${next}`);
+  pluginVersion = next;
+  plugin.version = next;
+  writes.push(() => writeJson(PATHS.plugin, plugin));
+}
+
+// .claude-plugin/marketplace.json — must equal plugin.json exactly.
+const marketplace = readJson(PATHS.marketplace);
+if (marketplace.plugins[0].version !== pluginVersion) {
+  drift.push(
+    `.claude-plugin/marketplace.json: ${marketplace.plugins[0].version} -> ${pluginVersion}`,
+  );
+  marketplace.plugins[0].version = pluginVersion;
+  writes.push(() => writeJson(PATHS.marketplace, marketplace));
 }
 
 if (CHECK) {


### PR DESCRIPTION
## What

Implements **PILOT-5544**: the stable ref the Claude Code marketplace points at permanently — `release/latest`, always equal to the HEAD of the newest `release/v<minor>` branch — and retargets the daily plugin-version bump to the release line.

> **Stacked on #1450** (PILOT-5516) — the bump logic relies on the shared `major.minor` scheme. Merge #1450 first; this PR's base is `feat/plugin-version-alignment` and should auto-retarget to `main`.

## Design

Plugin auto-update fires off the `version` field on the **tracked ref**. Once the marketplace tracks `release/latest`, daily bumps to `main` would never reach plugin users — so the daily bump now:

1. Checks out `release/latest` (graceful skip + step-summary note while the ref doesn't exist yet — protects the scheduled run between this PR merging and the branches being created)
2. **Skip-guard:** if HEAD is already a bump commit, nothing landed since the last bump → skip (no forced plugin re-downloads for identical content)
3. Bumps plugin + marketplace + Codex via `sync-version.mjs --bump-patch` (PR #1450 logic: shared `major.minor`, daily patch counter, single source of the rule)
4. Pushes **atomically** to `release/v<minor>` and fast-forwards `release/latest`

`main` gets **no** daily bumps — its plugin version stays pinned at `M.N.0` per sprint. A shared `concurrency` group (`release-line-updates`) prevents racing the Sunday sprint cut (PILOT-5518, #1452). The legacy PR-to-main flow is kept behind a `workflow_dispatch` boolean (`legacy_main_bump`) for one transition sprint, then delete.

## Review feedback addressed (@RaduAna-Maria)

- **Atomic dual push** — `git push --atomic` so `release/v<minor>` and `release/latest` both update or neither does (no out-of-sync invariant break on a partial failure).
- **Skip-guard no longer string-coupled** — the bump-commit subject now lives in one job-level `BUMP_COMMIT_PREFIX` env constant that both the guard and the commit step read, so they can't silently desync.
- **Consolidation carried in** — both bump jobs call `sync-version.mjs --bump-patch` instead of reimplementing the rule in jq (and so pick up the Codex manifest automatically).
- **Setup-version refs corrected** to the live `1.197` line (below).

## Operational steps after merge (one-time)

```bash
git push origin main:refs/heads/release/v1.197
git push origin main:refs/heads/release/latest
```

(Cut from post-#1450 `main`, which is on the `1.197` line, NOT from `release/v1.195` — that line predates the 1.197.x plugin scheme and its content is a sprint old.)

**Repo settings:** allow Actions push on `release/v*` and `release/latest`, plus **force push** on `release/latest` (sprint handoff is a forced ref update — the new branch doesn't contain the old line's daily-bump commits).

**Migration caveat:** existing manual installs added as bare `UiPath/skills` track `main` and will silently freeze once bumps leave main. Docs now instruct `/plugin marketplace add UiPath/skills@release/latest`; announce the re-add to existing users.

## Verification

- `npx js-yaml .github/workflows/daily-version-bump.yml` — parses clean
- After branch creation: dispatch **Daily Version Bump** → one commit on `release/v1.197`, `release/latest` at the same SHA, plugin/marketplace/Codex bumped to `1.197.1`; re-dispatch same day → skipped via guard

## Related

- PILOT-5518 (Sunday sprint-cut automation that advances `release/latest`) lands in #1452.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
