### PR TITLE
feat: exclude in-development skills from stable releases — maturity gate (PILOT-5542)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -98,6 +98,20 @@ jobs:
           npm install -g npm@latest
           echo "npm $(npm --version) / node $(node --version)"
 
+      # Maturity gate (stable track only — alpha ships everything): drop
+      # in-development skills from the tarball. Uncommitted working-tree
+      # mutation, same pattern as the alpha version stamp. The pruned list
+      # lands in the step summary so an exclusion is never silent.
+      - name: Exclude in-development skills (maturity gate)
+        run: |
+          node scripts/prune-dev-skills.mjs | tee -a "$GITHUB_STEP_SUMMARY"
+
+      # The packaged README must not advertise skills absent from the tarball.
+      # prune-dev-skills.mjs already rewrote the manifest; regenerate the
+      # generated status table from it (stdlib-only script, runner python3).
+      - name: Regenerate README status table for the pruned package
+        run: python3 scripts/check-skill-status.py --write-readme
+
       # No auth token and no setup-node registry-url — a token would make npm
       # use token auth and bypass OIDC. We only pin the scoped package to
       # npmjs; credentials come from the OIDC exchange. `--provenance` attaches

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -35,6 +35,18 @@ The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.196.x` → skills 
 
 Both tracks are **manually triggered** — there is no auto-publish on push to `main`. Alpha is dispatched on demand; stable runs when a GitHub Release is published. `npm install @uipath/skills` (no tag) always resolves to the last stable npmjs release — alphas live only under the `alpha` tag on GitHub Packages.
 
+### Maturity gate (stable track only)
+
+The stable publish excludes skills marked `in-development` in `assets/skill-status.json`. Before `npm publish`, the `publish-release` job runs `scripts/prune-dev-skills.mjs`: it deletes those `skills/<name>/` dirs from the working tree (uncommitted — same pattern as the alpha version stamp), rewrites the shipped manifest to stay bijective with the shipped dirs, and regenerates the README status table. The pruned list is written to the workflow step summary — an exclusion is never silent.
+
+| Channel | In-development skills |
+|---------|----------------------|
+| npm `latest` (stable) | **excluded** |
+| npm `alpha` | included |
+| Claude Code plugin (git) | included |
+
+Dry-run locally with `node scripts/prune-dev-skills.mjs --list`. To ship a skill in the next stable release, set its status to `preview` or `stable` in the manifest (and regenerate the README table).
+
 ### Registry routing
 
 `@uipath/skills` is a **scoped** package, so the publish target is set via the **scoped registry** (`@uipath:registry=<url>`) — not a `--registry` flag (which only sets the *unscoped* default and is ignored for scoped packages). There is **no committed `.npmrc` and no `publishConfig.registry`**: a static scoped-registry line would override the per-job target (and break `npm install` for anyone cloning this public repo).

--- a/scripts/prune-dev-skills.mjs
+++ b/scripts/prune-dev-skills.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+/**
+ * Maturity gate for stable releases (PILOT-5542).
+ *
+ * Removes every skill marked `in-development` in assets/skill-status.json
+ * from the working tree so it never ships in the stable npm tarball, and
+ * rewrites the manifest to drop the pruned entries (the shipped manifest
+ * stays bijective with the shipped skills/ dirs).
+ *
+ * Run ONLY in the publish-release job of publish.yml, before `npm publish` —
+ * an uncommitted working-tree mutation, exactly like the alpha version stamp.
+ * The alpha track and the git-based Claude Code plugin channel are NOT gated:
+ * they ship everything. See docs/RELEASE.md.
+ *
+ * Usage:
+ *   node scripts/prune-dev-skills.mjs           # delete + rewrite manifest
+ *   node scripts/prune-dev-skills.mjs --list    # report only, change nothing
+ *
+ * Exits non-zero if a manifest entry has no matching skills/<name>/ dir
+ * (manifest drift — fix assets/skill-status.json before publishing).
+ */
+
+import { existsSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const MANIFEST = join(ROOT, "assets", "skill-status.json");
+const LIST_ONLY = process.argv.includes("--list");
+
+const manifest = JSON.parse(readFileSync(MANIFEST, "utf-8"));
+const entries = manifest.skills ?? {};
+
+const pruned = [];
+const missing = [];
+
+for (const name of Object.keys(entries).sort()) {
+  if (entries[name].status !== "in-development") continue;
+  const dir = join(ROOT, "skills", name);
+  if (!existsSync(dir)) {
+    missing.push(name);
+    continue;
+  }
+  pruned.push(name);
+}
+
+if (missing.length > 0) {
+  console.error(
+    `✗ Manifest drift: ${missing.length} in-development entr(y/ies) have no skills/<name>/ dir:`,
+  );
+  for (const name of missing) console.error(`  - ${name}`);
+  console.error("Fix assets/skill-status.json before publishing.");
+  process.exit(1);
+}
+
+if (pruned.length === 0) {
+  console.log("✓ No in-development skills — nothing to prune.");
+  process.exit(0);
+}
+
+if (LIST_ONLY) {
+  console.log(`Would prune ${pruned.length} in-development skill(s) (dry run):`);
+  for (const name of pruned) console.log(`  - skills/${name}`);
+  process.exit(0);
+}
+
+for (const name of pruned) {
+  rmSync(join(ROOT, "skills", name), { recursive: true });
+  delete entries[name];
+}
+writeFileSync(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`);
+
+console.log(
+  `✓ Pruned ${pruned.length} in-development skill(s) from the stable package:`,
+);
+for (const name of pruned) console.log(`  - skills/${name}`);
+console.log(
+  `${Object.keys(entries).length} skill(s) remain (stable/preview). Manifest rewritten.`,
+);


### PR DESCRIPTION
## What

Implements **PILOT-5542**: the stable npmjs publish no longer ships skills marked `in-development` in `assets/skill-status.json`. WIP skills keep landing on `main` for iteration without reaching `@uipath/skills@latest` users.

Independent of the version-alignment stack (#1450/#1451/#1452) — based directly on `main`.

## Scope decision

| Channel | In-development skills |
|---------|----------------------|
| npm `latest` (stable) | **excluded** |
| npm `alpha` | included (power-user/testing channel) |
| Claude Code plugin (git) | included — git-based, never sees the pruned tree |

## How

- New `scripts/prune-dev-skills.mjs`, run in `publish-release` **before** `npm publish` as an **uncommitted working-tree mutation** (same pattern as the alpha version stamp):
  - deletes every `in-development` `skills/<name>/` dir
  - rewrites `assets/skill-status.json` to drop pruned entries — the shipped manifest stays bijective with shipped dirs
  - prints a sorted, deterministic report, `tee`'d into the **step summary** — an exclusion is never silent
  - `--list` flag for local dry-runs; exits non-zero on manifest drift (entry without a dir)
- `publish.yml` then regenerates the README status table (`check-skill-status.py --write-readme`, stdlib-only) so the npmjs page doesn't advertise absent skills.
- `docs/RELEASE.md` documents the gate and the per-channel matrix.

## Verification (run locally)

```
node scripts/prune-dev-skills.mjs --list   # 12 skills listed
node scripts/prune-dev-skills.mjs          # pruned, manifest rewritten, 10 remain
python3 scripts/check-skill-status.py --write-readme
npm pack --dry-run                         # 1029 files, ZERO skills/<in-dev>/ paths,
                                           # exactly the 10 stable/preview skills ship
git checkout -- skills assets README.md    # restore
```

## Notes for reviewers

- Today 12 of 22 skills are `in-development` (incl. `uipath-maestro-flow`, `uipath-agents`, `uipath-maestro-bpmn`) — the stable package is substantially smaller than alpha. If any of those are actually meant to ship, flip their manifest status; this PR makes the manifest authoritative for the stable tarball.
- Several surviving skills' frontmatter `→` redirects point at pruned skills (e.g. `uipath-rpa` → `uipath-agents`). Harmless — a redirect to an absent skill simply doesn't activate — but consumers installing only the stable package won't have the redirect target.
- First real release: review the "Exclude in-development skills" step summary to confirm the pruned list matches expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
