### PR TITLE
feat(uipath-feedback): capture installed skills/plugin version (PILOT-5541)

### DIFF
--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -65,6 +65,13 @@ From login status, extract only: `tenantName`, `organizationName`, `baseUrl`. St
 
 From tools list, extract tool `name` and `version` from each row.
 
+**Capture installed skills version.** Read `skillsVersion` from `version-manifest.json` — it ships next to the skills. Check in order, stop at first hit:
+
+1. `$CLAUDE_PLUGIN_ROOT/version-manifest.json` (Claude Code plugin install)
+2. `version-manifest.json` two levels up from this skill's own directory (CLI-copied install)
+
+When found via the plugin root, also read `version` from `$CLAUDE_PLUGIN_ROOT/.claude-plugin/plugin.json` (the daily plugin build). If neither file exists, report `unknown`. Never guess the version and never derive it from `uip --version` (that is the CLI version, captured separately).
+
 #### 2c. Capture skill-specific troubleshooting
 
 | Skill context | What to capture | Limits |
@@ -181,6 +188,8 @@ Build the `--description` content:
 ## Environment
 - Skill context: {detected skill name}
 - uip version: {version}
+- Skills version: {skillsVersion from version-manifest.json, or "unknown"}
+- Plugin version: {plugin.json version -- omit this line when not installed as a plugin}
 - CLI tools: {name version, name version, ...}
 - OS: {os info}
 - Tenant: {tenant} ({org})
@@ -227,6 +236,8 @@ ExpressionError: Invalid expression at unknown location — currentItem is not d
 ## Environment
 - Skill context: Flow
 - uip version: 0.1.20
+- Skills version: 1.196.0
+- Plugin version: 1.196.4
 - CLI tools: docsai-tool 0.1.12
 - OS: Windows 11 Enterprise 10.0.26100
 - Tenant: demo (aro)


### PR DESCRIPTION
## What

Implements **PILOT-5541**: every feedback submission records the installed **skills version** (and plugin version where relevant), so reported issues trace back to the exact `@uipath/skills` release the user was on.

Independent of the other release-model PRs — based directly on `main`.

## Changes (`skills/uipath-feedback/SKILL.md`)

- **Step 2b (Capture environment)** — new capture instruction with a bounded location cascade for `version-manifest.json` (the file ships in the package next to the skills):
  1. `$CLAUDE_PLUGIN_ROOT/version-manifest.json` (Claude Code plugin install) — also reads `plugin.json` version (the daily plugin build identity, disambiguates "npm line 1.196.0" from "plugin build 1.196.7")
  2. Two levels up from the skill's own directory (CLI-copied install for Codex/Cursor/Copilot/Gemini)
  3. Fallback: `unknown` — never hardcoded, never derived from `uip --version` (that's the CLI version, captured separately)
- **`## Environment` template + worked example** gain:
  ```
  - Skills version: {skillsVersion, or "unknown"}
  - Plugin version: {omit when not installed as a plugin}
  ```

## Known limitation (flagged, out of scope)

Until the CLI installs the pinned `@uipath/skills` package instead of copying skill files ([PILOT-5545]), CLI-channel installs may not have `version-manifest.json` alongside the skills — those sessions report `unknown`. The cascade + fallback makes this safe to ship first; the value lights up automatically once PILOT-5545 lands.

## Verification

- `python3 scripts/check-skill-status.py` → OK, 22 skills, manifest valid
- `hooks/validate-skill-descriptions.sh` → exit 0 (frontmatter untouched)
- No eval fixtures assert the Environment template (`tests/tasks/` checked — only activation jsonl and unrelated platform traces tasks reference feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-5545]: https://uipath.atlassian.net/browse/PILOT-5545?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ