### PR TITLE
test(activation): admin + ixp datasets, solution expanded to 50, adversarial negatives (T5)

### DIFF
--- a/tests/tasks/activation/README.md
+++ b/tests/tasks/activation/README.md
@@ -10,7 +10,7 @@ plus a confusion matrix.
 |------|---------|
 | `<skill>.jsonl` | Positives for that skill — every prompt should fire that skill. `expected_skill` is injected per file by `activation.yaml`. |
 | `negative.jsonl` | Shared negatives — prompts that should fire **no** skill (small talk, unrelated dev tasks, adjacent UiPath products, other workflow tools). |
-| `activation.yaml` | coder-eval task config. Uses `dataset.paths` to merge all skill jsonls + `negative.jsonl`, and stacks 20 `skill_triggered` criteria — one per skill — each computing its own confusion matrix from the same agent traces. |
+| `activation.yaml` | coder-eval task config. Uses `dataset.paths` to merge all skill jsonls + `negative.jsonl`, and stacks 19 `skill_triggered` criteria — one per skill — each computing its own confusion matrix from the same agent traces. |
 
 The `expected_skill` field on each row is the row's true label (the skill it should fire, or `""` for negatives). Each criterion compares its own `skill_name` to `expected_skill`: `expected="yes"` iff they match. So for skill X:
 - `<X>.jsonl` rows are positives.
@@ -34,7 +34,7 @@ uv run --project /path/to/coder_eval coder-eval run \
   --backend bedrock --sample 20 -j 4
 ```
 
-Reports land in `tmp/<run-id>/`. The suite gate fails per criterion on `recall.yes < 0.70`. Class imbalance (~50 yes / ~900 no per skill) makes accuracy and recall.no trivially high; recall.yes is the only meaningful gate.
+Reports land in `tmp/<run-id>/`. The suite gate fails per criterion on `recall.yes < 0.70`. Class imbalance (~50 yes / ~1070 no per skill) makes accuracy and recall.no trivially high; recall.yes is the only meaningful gate.
 
 ## Adding a new skill
 
@@ -44,7 +44,7 @@ Reports land in `tmp/<run-id>/`. The suite gate fails per criterion on `recall.y
 
 ## Cost
 
-On Sonnet 4.6 via Bedrock, ~$0.05–$0.10 per row. The dataset is ~950 rows total. The agent runs ONCE per row regardless of criteria count, and the 20 stacked criteria are pure-Python evaluation against the same trace, so the full benchmark across all 20 skills costs **~$50–95**. Use `--sample N` for cheaper iteration (note: `--sample` slices first-N, which biases toward the first-listed paths; useful for smoke runs, not for metrics).
+On Sonnet 4.6 via Bedrock, ~$0.05–$0.10 per row. The dataset is ~1,120 rows total. The agent runs ONCE per row regardless of criteria count, and the 19 stacked criteria are pure-Python evaluation against the same trace, so the full benchmark across all 19 skills costs **~$55–110**. Use `--sample N` for cheaper iteration (note: `--sample` slices first-N, which biases toward the first-listed paths; useful for smoke runs, not for metrics).
 
 ## Provenance
 
@@ -59,3 +59,11 @@ file just stops at the highest count quality could sustain.
 Covers most skills in the repo. Brand-new skills (especially Preview-tagged
 ones whose CLI surface is still in flux) may be added on a delay so prompt
 curation doesn't chase a moving target.
+
+2026-06: added `uipath-admin` (50) and `uipath-ixp` (50) after their CLI
+surfaces and descriptions stabilized; expanded `uipath-solution` 11 → 50;
+appended adversarial negatives adjacent to all three (Azure AD / Okta identity
+admin, AWS IAM, Office 365 audit, Google Document AI / Textract / pdfplumber
+extraction, docker/npm deploys). `negative-045` was rephrased from a UiPath
+Document Understanding prompt (now a true `uipath-ixp` positive) to
+Communications Mining, which stays out of every skill's scope.

--- a/tests/tasks/activation/activation.yaml
+++ b/tests/tasks/activation/activation.yaml
@@ -9,6 +9,7 @@ tags: [activation, classification]
 
 dataset:
   paths:
+    - uipath-admin.jsonl
     - uipath-agents.jsonl
     - uipath-coded-apps.jsonl
     - uipath-data-fabric.jsonl
@@ -16,6 +17,7 @@ dataset:
     - uipath-feedback.jsonl
     - uipath-governance.jsonl
     - uipath-human-in-the-loop.jsonl
+    - uipath-ixp.jsonl
     - uipath-maestro-bpmn.jsonl
     - uipath-maestro-case.jsonl
     - uipath-maestro-flow.jsonl
@@ -30,8 +32,8 @@ dataset:
 
 initial_prompt: "${row.prompt}"
 
-# 17 skill_triggered criteria — one per skill. Each derives expected internally
-# from `expected_skill == skill_name`. Heavy class imbalance (~50 yes / ~900 no
+# 19 skill_triggered criteria — one per skill. Each derives expected internally
+# from `expected_skill == skill_name`. Heavy class imbalance (~50 yes / ~1070 no
 # per skill) means recall.yes is the meaningful gate; recall.no is trivially high.
 success_criteria:
   - type: skill_triggered
@@ -117,5 +119,15 @@ success_criteria:
   - type: skill_triggered
     description: "uipath-test activation"
     skill_name: uipath-test
+    expected_skill: "${row.expected_skill}"
+    suite_thresholds: {recall.yes: 0.70}
+  - type: skill_triggered
+    description: "uipath-admin activation"
+    skill_name: uipath-admin
+    expected_skill: "${row.expected_skill}"
+    suite_thresholds: {recall.yes: 0.70}
+  - type: skill_triggered
+    description: "uipath-ixp activation"
+    skill_name: uipath-ixp
     expected_skill: "${row.expected_skill}"
     suite_thresholds: {recall.yes: 0.70}

--- a/tests/tasks/activation/negative.jsonl
+++ b/tests/tasks/activation/negative.jsonl
@@ -42,9 +42,21 @@
 {"id": "negative-042", "prompt": "Create a Camunda BPMN process", "expected_skill": ""}
 {"id": "negative-043", "prompt": "Design a Process Maker workflow", "expected_skill": ""}
 {"id": "negative-044", "prompt": "Set up UiPath AI Center to deploy my fraud detection ML model", "expected_skill": ""}
-{"id": "negative-045", "prompt": "Configure UiPath Document Understanding to extract invoice line items from scanned PDFs", "expected_skill": ""}
+{"id": "negative-045", "prompt": "Set up UiPath Communications Mining to triage our support emails", "expected_skill": ""}
 {"id": "negative-046", "prompt": "Build a UiPath Insights dashboard to visualize bot performance over the last quarter", "expected_skill": ""}
 {"id": "negative-047", "prompt": "Migrate my Automation Anywhere bots to a new environment", "expected_skill": ""}
 {"id": "negative-048", "prompt": "Refactor my Blue Prism object to use a work queue instead of a collection", "expected_skill": ""}
 {"id": "negative-049", "prompt": "Train a sklearn random forest classifier on my customer churn dataset", "expected_skill": ""}
 {"id": "negative-050", "prompt": "Set up Kubernetes ingress with cert-manager and Let's Encrypt", "expected_skill": ""}
+{"id": "negative-051", "prompt": "Add jane@contoso.com to the Marketing group in Azure AD", "expected_skill": ""}
+{"id": "negative-052", "prompt": "Create an AWS IAM role with S3 read-only access for my Lambda", "expected_skill": ""}
+{"id": "negative-053", "prompt": "Rotate the client secret on my Azure AD app registration", "expected_skill": ""}
+{"id": "negative-054", "prompt": "Parse this PDF and extract the invoice total in Python with pdfplumber", "expected_skill": ""}
+{"id": "negative-055", "prompt": "Use Google Document AI to process my receipts", "expected_skill": ""}
+{"id": "negative-056", "prompt": "Build an AWS Textract pipeline for form extraction", "expected_skill": ""}
+{"id": "negative-057", "prompt": "Deploy my Docker container to Kubernetes", "expected_skill": ""}
+{"id": "negative-058", "prompt": "Publish my package to the npm registry", "expected_skill": ""}
+{"id": "negative-059", "prompt": "Set up Okta group-based access for our internal apps", "expected_skill": ""}
+{"id": "negative-060", "prompt": "Export the Office 365 audit log for the security team", "expected_skill": ""}
+{"id": "negative-061", "prompt": "Block sign-ins from outside our corporate IP range using Azure AD conditional access", "expected_skill": ""}
+{"id": "negative-062", "prompt": "Label images for my YOLO object detection training set", "expected_skill": ""}

--- a/tests/tasks/activation/uipath-admin.jsonl
+++ b/tests/tasks/activation/uipath-admin.jsonl
@@ -1,0 +1,50 @@
+{"id": "uipath-admin-001", "prompt": "Invite jane@acme.com to our UiPath organization and add her to the Administrators group", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-002", "prompt": "List all identity users in our UiPath organization", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-003", "prompt": "uip admin users invite --email new.hire@acme.com --output json", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-004", "prompt": "Delete the user mark.old@acme.com from our organization directory", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-005", "prompt": "Create a group called Finance-Devs and add alice@acme.com and bob@acme.com as members", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-006", "prompt": "Remove bob@acme.com from the Citizen Developers group", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-007", "prompt": "uip admin groups members add 1a2b3c4d --user-ids 9f8e7d6c", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-008", "prompt": "Create a robot account identity for our unattended payroll automation", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-009", "prompt": "uip admin robot-accounts create --name svc-finance-bot --output json", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-010", "prompt": "Register an external OAuth2 application with the OR.Folders application scope", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-011", "prompt": "Generate a new client secret for our CI/CD external app", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-012", "prompt": "The external app secret was only shown once and I lost it — issue a new one", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-013", "prompt": "List the OAuth2 scopes I can grant to an external application", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-014", "prompt": "Create three new groups for the RPA CoE and set their initial members", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-015", "prompt": "Offboard a departing employee: remove them from every group, then delete their identity user", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-016", "prompt": "Create a custom role at Tenant scope from my actions.json permission list", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-017", "prompt": "uip admin authorization roles create --scope Tenant --name \"ReadOnlyOps\" --file ./actions.json", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-018", "prompt": "Assign the AuditViewer custom role to the ComplianceTeam group at organization scope", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-019", "prompt": "roles assignments create failed because the role's owner service doesn't match the scope path", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-020", "prompt": "Show me the permission definitions catalog across all services", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-021", "prompt": "Run a check-access to see what alice@acme.com can effectively do at Tenant scope", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-022", "prompt": "uip admin authorization check-access alice@acme.com --scope Tenant --output json", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-023", "prompt": "What can the robot account svc-bot actually do? Compute its effective access", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-024", "prompt": "Show our UiPath organization's settings", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-025", "prompt": "Update our organization's display name", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-026", "prompt": "Create a new tenant called staging in the Europe region", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-027", "prompt": "uip admin tenants create --name staging --region europe --output json", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-028", "prompt": "Disable the qa tenant in our organization", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-029", "prompt": "Re-enable the finance-dev tenant that was disabled last month", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-030", "prompt": "Soft-delete the old sandbox tenant", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-031", "prompt": "Which regions can I provision a new tenant in?", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-032", "prompt": "List which services are provisioned on the staging tenant and which are still available to add", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-033", "prompt": "tenants services remove reported Success but the service is still listed on the tenant", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-034", "prompt": "Add IP range 10.8.0.0/16 to the organization's IP allowlist", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-035", "prompt": "Enable IP-restriction enforcement for the org — verify my IP is covered first", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-036", "prompt": "uip admin ip-restriction enforcement enable --confirm", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-037", "prompt": "Add a bypass rule so webhook callbacks are exempt from IP restriction", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-038", "prompt": "I locked myself out of the org with an IP restriction rule — how do I recover access?", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-039", "prompt": "Our new contractor should only reach the platform from the office VPN range — set that up", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-040", "prompt": "What's my public IP as seen by UiPath? I want to check it before enabling IP restriction", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-041", "prompt": "Export the org audit log for Q1 as a ZIP for the compliance team", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-042", "prompt": "uip admin audit export --from-date 2026-01-01 --to-date 2026-03-31 --output-file q1-audit.zip", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-043", "prompt": "uip admin audit org events --from-date 2026-06-01 --to-date 2026-06-07 --limit 500", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-044", "prompt": "Show failed logins for dana@acme.com this month", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-045", "prompt": "Which users logged in last week from outside the office network?", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-046", "prompt": "Who was made an organization admin in the last 30 days?", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-047", "prompt": "Which users joined or left the organization this quarter?", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-048", "prompt": "Did anyone delete the Vendors group recently? Pull the relevant audit events", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-049", "prompt": "The auditors need a who-did-what-when dump for the whole organization covering Q4", "expected_skill": "uipath-admin"}
+{"id": "uipath-admin-050", "prompt": "uip admin audit org events returns 401 even though I'm logged in", "expected_skill": "uipath-admin"}

--- a/tests/tasks/activation/uipath-ixp.jsonl
+++ b/tests/tasks/activation/uipath-ixp.jsonl
@@ -1,0 +1,50 @@
+{"id": "uipath-ixp-001", "prompt": "Create a new IXP project from these 20 invoice PDFs", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-002", "prompt": "Upload this batch of contracts to my IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-003", "prompt": "uip ixp projects list --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-004", "prompt": "Import this taxonomy file into a new Document Understanding extraction project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-005", "prompt": "Review the predictions on the newly uploaded documents and confirm the correct fields", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-006", "prompt": "Confirm the valid fields on document 42 in the invoices IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-007", "prompt": "The total_amount field keeps extracting the subtotal instead — fix the extraction", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-008", "prompt": "Improve the field instructions so invoice_date stops grabbing the due date", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-009", "prompt": "Update the extraction prompt for the vendor_name field", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-010", "prompt": "uip ixp fields update-prompts my_invoices-f1afa9ef-ixp --updates \"$(cat field_updates.json)\"", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-011", "prompt": "Publish the current model version of my IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-012", "prompt": "uip ixp projects publish my_invoices-f1afa9ef-ixp --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-013", "prompt": "List the trained model versions for my extraction project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-014", "prompt": "Roll back the IXP project to model version 3", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-015", "prompt": "What's the per-field F1 on my IXP project?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-016", "prompt": "Show extraction metrics for the invoices project — which fields score lowest?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-017", "prompt": "uip ixp projects get-metrics my_invoices-f1afa9ef-ixp --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-018", "prompt": "Add a field group called line_items to my IXP taxonomy", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-019", "prompt": "Rename the field invoice_no to invoice_number in my extraction project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-020", "prompt": "Add a money data type for the currency fields in the IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-021", "prompt": "Delete document 7c2a from my IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-022", "prompt": "uip ixp documents upload my_contracts-9b1d2c3e-ixp ./contract_041.pdf --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-023", "prompt": "po_number genuinely doesn't appear on these documents and IXP predicted nothing — record it as missing", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-024", "prompt": "Unconfirm the fields I wrongly confirmed on document 15", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-025", "prompt": "uip ixp labellings confirm my_invoices-f1afa9ef-ixp 42 --fields total_amount,invoice_date --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-026", "prompt": "Suggest a taxonomy from these 8 sample documents", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-027", "prompt": "Set the overall extraction instructions for the whole IXP project", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-028", "prompt": "uip ixp projects update-prompt my_receipts-2c4d6e8f-ixp --prompt \"Extract line-level values only\"", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-029", "prompt": "Describe my IXP project — live model version, taxonomy, field groups", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-030", "prompt": "What did the taxonomy look like when model version 4 was published?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-031", "prompt": "uip ixp deployments get-taxonomy my_invoices-f1afa9ef-ixp --version 4", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-032", "prompt": "Which documents in the project still have unconfirmed predictions?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-033", "prompt": "Run the prompt-improvement loop on the receipts project until F1 stops improving", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-034", "prompt": "The OCR garbled the invoice number (MSIÓÓÓ601020 instead of MSI0601020) — apply a correction while confirming", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-035", "prompt": "Metrics didn't change after my prompt update — did the retrain finish?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-036", "prompt": "ModelVersion in my IXP project isn't advancing after labelling — check the retrain status", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-037", "prompt": "The IXP CLI rejects my project Title — should I be using the Name slug instead?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-038", "prompt": "uip ixp projects configure-model my_invoices-f1afa9ef-ixp --output json", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-039", "prompt": "uip ixp groups add my_invoices-f1afa9ef-ixp --name line_items --instructions \"One row per line item\" --fields '[{\"name\":\"description\"}]'", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-040", "prompt": "uip ixp data-types add my_invoices-f1afa9ef-ixp --name due_date --kind date --instructions \"Payment due date\"", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-041", "prompt": "Compare extraction scores before and after the last prompt update", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-042", "prompt": "Which fields in my document-extraction model have precision below 0.8?", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-043", "prompt": "Vendor invoices come in three layouts and the extractor confuses them — tighten the field prompts", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-044", "prompt": "Label the remaining 30 documents in the IXP project — confirm only the correct predictions", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-045", "prompt": "Delete the abandoned IXP project and its trained models", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-046", "prompt": "Change the quantity field's type from text to number in the extraction taxonomy", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-047", "prompt": "The amount field found the right spot on the page but the text is OCR-mangled — correct it", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-048", "prompt": "Publish the model version and tag it as live", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-049", "prompt": "labellings confirm was a no-op for a field with a stale annotation — mark it missing instead", "expected_skill": "uipath-ixp"}
+{"id": "uipath-ixp-050", "prompt": "I have a folder of utility bills — set up an IXP extraction project end to end: upload, review predictions, publish", "expected_skill": "uipath-ixp"}

--- a/tests/tasks/activation/uipath-solution.jsonl
+++ b/tests/tasks/activation/uipath-solution.jsonl
@@ -9,3 +9,42 @@
 {"id": "uipath-solution-009", "prompt": "Upgrade my solution to the latest published version in the Shared folder", "expected_skill": "uipath-solution"}
 {"id": "uipath-solution-010", "prompt": "List solution packages in the tenant feed and filter by name", "expected_skill": "uipath-solution"}
 {"id": "uipath-solution-011", "prompt": "Deploy my solution to production Orchestrator with a deployment pipeline and approval gates", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-012", "prompt": "uip solution init MyAutomationSuite", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-013", "prompt": "Initialize a new solution and register my two RPA projects in it", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-014", "prompt": "Add the InvoiceProcessor project to my solution", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-015", "prompt": "uip solution project add ./agents/triage-agent", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-016", "prompt": "Import an existing cloud project into the solution manifest", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-017", "prompt": "Remove the deprecated project from the solution and let the CLI clean up resources/solution_folder", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-018", "prompt": "Add a queue resource to the solution", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-019", "prompt": "Add an asset to the solution so it ships with the package", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-020", "prompt": "Add a storage bucket resource to the solution manifest", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-021", "prompt": "Add an Integration Service connection resource to my solution", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-022", "prompt": "Import the TransactionQueue from the cloud tenant into the solution's resources", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-023", "prompt": "Edit the queue resource in the solution to bump its max retries field", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-024", "prompt": "Set the asset value in the solution before packing", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-025", "prompt": "Remove the unused bucket resource from the solution", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-026", "prompt": "Refresh the solution resources so the bundled artefacts match cloud state", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-027", "prompt": "My .uipx and resources/solution_folder disagree on the project set — reconcile them", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-028", "prompt": "Open this .uipx and tell me which projects are registered in it", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-029", "prompt": "uip solution pack --output json", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-030", "prompt": "Pack the solution and publish it to the tenant feed", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-031", "prompt": "uip solution deploy run -c prod --parent-folder-path Shared --output json", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-032", "prompt": "Deploy the solution with --skip-activate, then activate it explicitly", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-033", "prompt": "Activate the staged solution deployment in the Finance folder", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-034", "prompt": "Check the deploy status of my solution", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-035", "prompt": "uip solution deploy status --output json", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-036", "prompt": "Upgrade the deployed solution to version 2.1.0", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-037", "prompt": "Uninstall the solution deployment from the staging folder", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-038", "prompt": "Roll back the solution deployment to the previous published version", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-039", "prompt": "Promote the same .uipx from dev to staging to prod using deploy configs", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-040", "prompt": "List the resources registered in my solution and verify the imported queue is there", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-041", "prompt": "Bundle my RPA process, Maestro flow, and agent project into one solution package", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-042", "prompt": "Push the solution to Studio Web with uip solution upload for browser debugging", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-043", "prompt": "uip solution project import ./crm-flow", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-044", "prompt": "Pack failed with stale bindings — do I need to run resources refresh first?", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-045", "prompt": "deploy run says 'unknown flag --parent-folder-path' — am I on the pre-rename CLI?", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-046", "prompt": "uip solution project remove ./legacy-process", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-047", "prompt": "List the solution's deployments and their activation state", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-048", "prompt": "Create a multi-project solution for our order-to-cash automations and pack it", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-049", "prompt": "Add my API workflow project to the solution and re-pack the .uipx", "expected_skill": "uipath-solution"}
+{"id": "uipath-solution-050", "prompt": "I hand-edited resources/solution_folder and now pack is broken — restore a consistent state", "expected_skill": "uipath-solution"}


### PR DESCRIPTION
## Summary

Tranche 5, stacked on #1459 (T4). Closes the activation-eval coverage gaps the audit found: uipath-admin and uipath-ixp had no datasets (the activation gate silently skipped them), uipath-solution had 11 prompts — too small for a reliable recall signal.

## Changes

| File | Before | After |
|---|---|---|
| uipath-admin.jsonl | — | 50 prompts |
| uipath-ixp.jsonl | — | 50 prompts |
| uipath-solution.jsonl | 11 | 50 (original rows untouched) |
| negative.jsonl | 50 | 62 (+12 adversarial: Azure AD, AWS IAM, Document AI, docker, npm publish) |
| Total dataset | 969 rows | 1,120 rows |
| activation.yaml | 18 paths / 17 criteria | 20 paths / 19 criteria |

Style matches the existing sets: ~60% natural asks, ~20% raw CLI fragments, ~10% error/symptom phrasing, ~10% indirect-but-unambiguous. Every row was disambiguated against the confusable siblings' descriptions (admin↔platform, admin↔troubleshoot, ixp↔maestro-flow, solution↔platform/planner) — rationale per cluster in the commit message.

One judgment call to review: `negative-045` ("Configure UiPath Document Understanding to extract invoice line items…") became a true ixp positive the moment ixp joined the eval — keeping it as a negative would penalize every correct ixp activation. Rephrased to Communications Mining (explicitly out of ixp's scope per its SKILL.md).

## What this PR deliberately does NOT do

`tests/scripts/activation_gate.py` baselines are untouched — baselines for admin/ixp/solution must come from a real eval run (`coder-eval run tests/tasks/activation/activation.yaml -e tests/experiments/activation.yaml`), not be invented. After this merges, a fresh full activation run (~$55–110 per the README estimate) establishes them and measures the T1 description rewrites (ixp/test/review/agents) against the old baselines (review 20%, agents 55%).

## Validation

- All four JSONL files parse (json.loads per line), ids sequential, zero duplicate prompts within and across files
- activation.yaml criterion blocks byte-match the existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)