### PR TITLE
fix(tests): close prompt-gap in traces_e2e task

### DIFF
--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -15,7 +15,7 @@ run_limits:
 initial_prompt: |
   Use the `uipath-platform` skill.
 
-  Verify that the published agent at process key `$TRACES_SMOKE_PROCESS_KEY` produces LLM trace spans. Save the raw spans output to spans.json.
+  Start a new job for the published agent at process key `$TRACES_SMOKE_PROCESS_KEY` and wait for it to finish. Then verify the run produced LLM trace spans and save the raw spans output to spans.json.
 
   Use `--output json` on all uip commands.
 


### PR DESCRIPTION
## Motivation

The `skill-platform-traces-e2e` task fails intermittently because its prompt never tells the agent to start a job or wait for completion — leaving the graded start+wait path to chance. The 2026-06-11 run passed 1.00 by guessing the intent; the 2026-06-12 run read existing traces instead and scored 0.83 FAILURE on the `--wait-for-completion` criterion. This makes the prompt deterministic so the e2e grades reliably.

## Summary

- Rewrote the `initial_prompt` in `tests/tasks/uipath-platform/traces/traces_e2e.yaml` to explicitly instruct the agent to **start a new job and wait for it to finish** before fetching spans, matching the task's own `description` intent.
- Kept the prompt behavioral (no `--wait-for-completion` literal) per the repo rule that prompts must not enumerate CLI flags — the `uipath-platform` skill already teaches that flag (`references/orchestrator/run-jobs.md`).
- Left the success criteria unchanged; they correctly encode the e2e intent and are now reachable.

## Tests performed

**Verified passing in CI.** Dispatched `run-coder-eval.yml` on this branch (`fix/traces-e2e-prompt-gap`), which runs the e2e against the real tenant (`experiments/nightly.yaml`, `TRACES_SMOKE_PROCESS_KEY` injected):

- ▶️ Run: https://github.com/UiPath/skills/actions/runs/27441381592
- Result: **`skill-platform-traces-e2e: SUCCESS` — 1/1 PASS**, **weighted score 1.000**, all **5/5** criteria scored 1.00 — including the previously-failing *"Agent started the job with --wait-for-completion"*.

`Run coder-eval` step log:

```
[skill-platform-traces-e2e] evaluation.checker: Criterion 'command_executed' score: 1.00   (x3)
[skill-platform-traces-e2e] evaluation.checker: Criterion 'file_exists' score: 1.00
[docker:skill-platform-traces-e2e] OK: 3 span(s) returned
[skill-platform-traces-e2e] evaluation.checker: Criterion 'run_command' score: 1.00
[skill-platform-traces-e2e] orchestrator: Success criteria: 5/5 passed, weighted score: 1.000
[skill-platform-traces-e2e] orchestrator: Task finished: status=SUCCESS duration=119.3s iterations=1
Run complete: /tmp/runs
Results: 1/1 succeeded
```

**Flakiness this fixes.** The same task on the pre-fix prompt scored **0.83 FAILURE** — the agent read existing traces instead of starting a job, so `--wait-for-completion` never matched:

- https://coder-evalboard.uipath-dev.com/runs/2026-06-12_04-03-10/skill-platform-traces-e2e

## Test plan

- [x] Re-run `skill-platform-traces-e2e` via coder-eval and confirm the `--wait-for-completion` criterion passes
- [x] Confirm overall score returns to 1.00 (5/5 criteria)
- [ ] `/lint-task tests/tasks/uipath-platform/traces/traces_e2e.yaml` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
