### PR TITLE
fix(maestro-flow/e2e): accept outcome-completed in devcon check script

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -113,7 +113,11 @@ def main() -> None:
             "or =js:$vars.<node>.output.<field>"
         )
 
-    if not any(e.get("sourceNodeId") == hitl_id and e.get("sourcePort") == "completed" for e in edges):
+    if not any(
+        e.get("sourceNodeId") == hitl_id
+        and e.get("sourcePort") in ("completed", "outcome-completed")
+        for e in edges
+    ):
         fail("HITL completed handle must be wired")
 
     scripts = [


### PR DESCRIPTION
## Summary

HITL v1.1 nodes wire `sourcePort: "outcome-completed"` instead of `"completed"`. The devcon check script was doing an exact `== "completed"` match, so any agent using a v1.1 HITL node would fail the completed-handle check even when the edge was correctly wired.

Verified against the actual failing flow from run `2026-06-15_04-04-11` — script now outputs `OK`.

Same root cause as the `'"completed"'` → `'completed'` fix in PR #1360, just in the Python checker rather than a YAML `file_contains` criterion.

## Test plan
- [ ] Devcon expense approval passes on next nightly run

🤖 Generated with [Claude Code](https://claude.com/claude-code)