### PR TITLE
chore(release): bump skills to 1.197.0

### DIFF
--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,7 +21,7 @@ npm run version:check     # CI guard — non-zero exit if drifted
 
 ### Why lockstep with the CLI
 
-The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.196.x` → skills `1.196.x`). `version-manifest.json.targetCli` records the matching line as `^MAJOR.MINOR.0`. The CLI pins this line, so it never pulls a skills package from a different minor.
+The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.197.x` → skills `1.197.x`). `version-manifest.json.targetCli` records the matching line as `^MAJOR.MINOR.0`. The CLI pins this line, so it never pulls a skills package from a different minor.
 
 > **Today the CLI clones `main` directly** (`packages/cli/src/commands/skills/contentStore.ts` → `REPO_URL` / `ZIP_URL`). That is the mismatch source: any CLI version gets whatever is on `main` at install time. Switching that consumption path to install the pinned `@uipath/skills` version is the **CLI-side change** that closes the loop — tracked as a decision below, not yet done.
 
@@ -53,6 +53,6 @@ Both tracks are **manually triggered** — there is no auto-publish on push to `
 
 - [x] **npmjs Trusted Publishing** — configure a GitHub Actions trusted publisher on the `@uipath/skills` package (npmjs → package → Settings → Trusted Publisher): repository `UiPath/skills`, workflow `publish.yml`. No `NPM_TOKEN` secret is used — the `publish-release` job authenticates via OIDC (`id-token: write`). Do **not** set `NODE_AUTH_TOKEN`; a token makes npm bypass OIDC and (with 2FA) fail `EOTP`.
 - [x] Package name/scope confirmed: **`@uipath/skills`** (published).
-- [x] Seed version confirmed: **`1.196.0`** (current CLI minor line). Automating the ongoing CLI↔skills lockstep is tracked in PILOT-5518.
+- [x] Seed version confirmed: **`1.197.0`** (current CLI minor line). Automating the ongoing CLI↔skills lockstep is tracked in PILOT-5518.
 
 > The alpha track also needs no secret — `publish-alpha` uses the built-in `GITHUB_TOKEN` with `packages: write`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/skills",
-  "version": "1.196.0",
+  "version": "1.197.0",
   "description": "UiPath agent skills for Claude Code, Codex, Cursor, Copilot, Gemini and OpenCode — RPA, UI automation, UI testing, coded agents/apps/workflows, and troubleshooting. Distributed as the UiPath Claude Code plugin.",
   "author": {
     "name": "UiPath"

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -43,7 +43,7 @@ function writeJson(p, obj) {
   writeFileSync(p, `${JSON.stringify(obj, null, 2)}\n`);
 }
 
-/** `1.196.4` -> `^1.196.0` (the matching CLI minor line). */
+/** `1.197.4` -> `^1.197.0` (the matching CLI minor line). */
 function cliLine(version) {
   const [major, minor] = version.split(".");
   return `^${major}.${minor}.0`;

--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "skillsVersion": "1.196.0",
-  "targetCli": "^1.196.0"
+  "skillsVersion": "1.197.0",
+  "targetCli": "^1.197.0"
 }


### PR DESCRIPTION
## What

Advance `main` to the next CLI minor line, **`1.197.0`**, after cutting [`release/v1.196`](https://github.com/UiPath/skills/tree/release/v1.196) to freeze the `1.196.x` line.

Mirrors the prior `release/v1.195` cut — same four files:

- `package.json` → `1.197.0`
- `version-manifest.json` → `skillsVersion 1.197.0`, `targetCli ^1.197.0` (re-synced via `npm run version:sync`)
- `scripts/sync-version.mjs` → doc-comment example bumped to `1.197.x`
- `docs/RELEASE.md` → lockstep example + seed version → `1.197`

`npm run version:check` passes (manifests in sync at `1.197.0`).

## Release branch

`release/v1.196` is pushed and freezes the `1.196.0` line for backports/patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)