### PR TITLE
feat(uipath-agents): document llm_as_judge built-in guardrail [AL-469]

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
@@ -177,11 +177,13 @@ Run `uip agent guardrails list --output json` (from Step 0) and find the matchin
 | CLI field | What to check |
 |-----------|---------------|
 | `Required: true` | Parameter must be present in `validatorParameters` |
-| `Type` | Must match `$parameterType` — `"enum-list"`, `"map-enum"`, or `"number"` |
-| `Options` | For `enum-list`: every value must be in this list; array must be non-empty |
+| `Type` | Must match `$parameterType` — `"enum-list"`, `"map-enum"`, `"number"`, `"enum"`, `"text"`, or `"text-list"` |
+| `Options` | For `enum-list` and `enum`: every value must be in this list; array must be non-empty. **Exception:** `llm_as_judge` ships `Options: []` for `model` on the wire — discovery happens out-of-band. Use the same flow as the agent's `settings.model`: run `uip agent model list --output json` and pick per [../../model-selection-guide.md](../../model-selection-guide.md). The Gateway rejects any model not authorized for the `llm-as-judge-validator` feature at runtime. |
 | `KeySource` | For `map-enum`: keys must **exactly** match the values of the `Options`-sourced parameter named by `KeySource` — no extra, no missing keys |
 | `Min` / `Max` | For `number` and `map-enum`: values must fall within this range |
 | `Step` | For `number` and `map-enum`: values must be multiples of Step (e.g. Step=2, Min=0, Max=6 → valid values are 0, 2, 4, 6) |
+| `MaxLength` | For `text` and `text-list`: each string value must not exceed this length |
+| `MaxItems` | For `text-list`: array length must not exceed this |
 
 Check that every parameter object has a `$parameterType` discriminator. Missing discriminators cause schema validation failures.
 

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Guardrails are safeguards that inspect agent inputs and outputs for policy violations (PII, harmful content, prompt injection, intellectual property, custom rules). They are configured at the **agent.json root level** as a `guardrails` array.
+Guardrails are safeguards that inspect agent inputs and outputs for policy violations (PII, harmful content, prompt injection, intellectual property, LLM-as-judge natural-language rules, custom rules). They are configured at the **agent.json root level** as a `guardrails` array.
 
 Two types exist:
 - **`custom`** — deterministic rules you define (word matching, number comparison, boolean checks, universal triggers)
-- **`builtInValidator`** — UiPath Guardrails API validators (PII detection, harmful content, prompt injection, IP protection, user prompt attacks)
+- **`builtInValidator`** — UiPath Guardrails API validators (PII detection, harmful content, prompt injection, IP protection, user prompt attacks, LLM-as-judge)
 
 > **Autonomous agents:** All guardrails are configured at the `agent.json` root `guardrails` array. **Conversational agents:** see § Conversational Support below — the runtime-effective location is each tool's `resources/<Tool>/resource.json` → `guardrail.policies[]`.
 
@@ -574,7 +574,10 @@ Built-in validators call the UiPath Guardrails API. They have a `validatorType` 
 |-------------------|---------|-------------|
 | `"enum-list"` | Array parameters (e.g., `entities`, `harmfulContentEntities`, `ipEntities`) | string[] |
 | `"map-enum"` | Threshold maps (e.g., `entityThresholds`, `harmfulContentEntityThresholds`) | object (keys = entity names, values = numbers) |
-| `"number"` | Scalar numbers (e.g., `threshold` for prompt injection) | number |
+| `"number"` | Scalar numbers (e.g., `threshold` for prompt injection / llm_as_judge) | number |
+| `"enum"` | Single-select string from a fixed list (e.g., `model` for llm_as_judge) | string |
+| `"text"` | Free-form single string (e.g., `guardrailText` for llm_as_judge) | string |
+| `"text-list"` | Array of free-form strings (e.g., `positiveExamples`, `negativeExamples` for llm_as_judge) | string[] |
 
 ### Validators Quick Reference
 
@@ -587,6 +590,9 @@ Built-in validators call the UiPath Guardrails API. They have a `validatorType` 
 | `harmful_content` | Agent, Llm, Tool | **Tool only** | Pre + Post | Block, Log, Escalate |
 | `intellectual_property` | Llm, Agent | **Not usable** (no Tool scope) | Post only | Block, Log, Escalate |
 | `user_prompt_attacks` | Llm | **Not usable** (no Tool scope) | Pre only | Block, Log, Escalate |
+| `llm_as_judge` | Agent, Llm, Tool | **Tool only** | Pre + Post | Block, Log, Escalate |
+
+> **`llm_as_judge` — picking the `model` parameter value.** Unlike other validators, `uip agent guardrails list` returns `Parameters[].Options: []` for `model` — there is no enum to choose from in the guardrails-list output. The judge model is sourced from the **same place as the agent's `settings.model`**: run `uip agent model list --output json`, pick per [../../model-selection-guide.md](../../model-selection-guide.md), and copy the chosen entry's `Name` field verbatim into the `enum` parameter's `value`. Example: if `uip agent model list` returns an entry `{ "Name": "anthropic.claude-sonnet-4-6", ... }`, write `{ "$parameterType": "enum", "id": "model", "value": "anthropic.claude-sonnet-4-6" }`. The LLM Gateway rejects any model name that is not authorized for the `llm-as-judge-validator` feature at runtime, so verify the model appears in the live list before authoring — do not invent names or copy from this skill's examples without verification.
 
 Run `uip agent guardrails list --output json` to get the authoritative list. Only use validators where `Status` is `"Available"`. Use the output to populate `validatorType`, `selector.scopes`, and `validatorParameters` fields. **For conversational agents, intersect `AllowedScopes` with `["Tool"]` — if `"Tool"` is not in the validator's `AllowedScopes`, the validator cannot be used in a conversational agent.**
 **How to map `uip agent guardrails list` output to guardrail JSON:**
@@ -947,6 +953,59 @@ Redacts specific fields from a tool's output instead of blocking or logging. Use
 }
 ```
 
+### Example 11: LLM-as-Judge — Natural-Language Rule on Agent Output
+
+Use when a policy is best expressed in plain English and no fixed validator covers it (brand-voice, domain-specific compliance, off-topic drift). A product-configured judge model decides whether the payload complies. Optional positive/negative examples calibrate the verdict; `threshold` is the harmful-content-style 0/2/4/6 scale (lower = stricter; default `2`).
+
+```json
+{
+  "$guardrailType": "builtInValidator",
+  "id": "9a8b7c6d-5e4f-3210-9876-543210fedcba",
+  "name": "Block off-topic agent responses",
+  "description": "Rejects agent responses that drift off the support topic.",
+  "validatorType": "llm_as_judge",
+  "validatorParameters": [
+    {
+      "$parameterType": "text",
+      "id": "guardrailText",
+      "value": "The response must stay on the topic of customer support for our software product. Reject responses about politics, religion, competitors, or unrelated topics."
+    },
+    {
+      "$parameterType": "enum",
+      "id": "model",
+      "value": "anthropic.claude-haiku-4-5-20251001-v1:0"
+    },
+    {
+      "$parameterType": "text-list",
+      "id": "positiveExamples",
+      "value": [
+        "Our software supports SSO via SAML 2.0. Here is the setup guide…"
+      ]
+    },
+    {
+      "$parameterType": "text-list",
+      "id": "negativeExamples",
+      "value": [
+        "Honestly, you should try Competitor X — they handle this better."
+      ]
+    },
+    {
+      "$parameterType": "number",
+      "id": "threshold",
+      "value": 2
+    }
+  ],
+  "action": {
+    "$actionType": "block",
+    "reason": "Response violates the on-topic policy."
+  },
+  "enabledForEvals": true,
+  "selector": {
+    "scopes": ["Agent"]
+  }
+}
+```
+
 ## agent.json with Guardrails
 
 Add the `guardrails` array at the agent.json root level alongside `settings`, `messages`, etc.:
@@ -1005,6 +1064,9 @@ Add the `guardrails` array at the agent.json root level alongside `settings`, `m
 19. **Do not attempt OR logic within a single guardrail** — all rules and all fields within a guardrail are combined with AND. OR is not supported. To achieve OR behavior, create separate guardrails — one per condition branch.
 20. **Do not generate guardrails targeting unsupported tool types** — `matchNames` can only reference tools of supported types: agent, process, activity, builtInTool, ixpTool, or Integration Service connector. Do not generate guardrails with `matchNames` targeting other tool types.
 21. **Do not omit `matchNames` to target "all tools"** — always explicitly list every tool resource name in `matchNames`. Read the agent's `resources/` directory first. If the agent has no tool resources, do not add the guardrail.
+22. **Do not use `llm_as_judge` when a fixed validator already covers the rule** — fixed validators (`pii_detection`, `harmful_content`, `prompt_injection`, `user_prompt_attacks`, `intellectual_property`) are deterministic, cheaper, and lower-latency. Use `llm_as_judge` as the catch-all for policies the fixed validators do not express (brand voice, domain-specific compliance, off-topic drift) — not as a replacement.
+23. **Do not invent `model` values for `llm_as_judge`** — the catalog ships an empty `Options` list because discovery happens out-of-band. Use the same flow as `settings.model` for the agent: run `uip agent model list --output json` and pick per [../../model-selection-guide.md](../../model-selection-guide.md), then pass the discovered `Name` as the `enum` parameter's `value`. The Gateway rejects models that are not authorized for the `llm-as-judge-validator` feature at runtime, so verify the chosen model appears in the tenant's model list before authoring.
+24. **Do not put secrets, credentials, or untrusted user input into `guardrailText`, `positiveExamples`, or `negativeExamples`** — those strings are sent verbatim to the judge model as part of the prompt. Treat the rule and examples as policy content the customer authors, never as a pass-through for tenant data.
 
 ## Walkthrough
 

--- a/tests/tasks/uipath-agents/lowcode/guardrails/llm_as_judge/check_llm_as_judge.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/llm_as_judge/check_llm_as_judge.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""LLM-as-judge built-in validator guardrail check.
+
+Validates that the agent authored a builtInValidator guardrail for
+llm_as_judge in agent.json with correct structure:
+
+  - guardrails array exists and is non-empty
+  - At least one guardrail has $guardrailType == "builtInValidator"
+  - That guardrail has validatorType == "llm_as_judge"
+  - validatorParameters contains a text parameter with id "guardrailText"
+    whose value is a non-empty string
+  - validatorParameters contains an enum parameter with id "model"
+    whose value is a non-empty string
+  - If threshold present, it uses the discrete 0/2/4/6 scale (number)
+  - If positive/negative examples present, they use the text-list type
+  - action.$actionType == "block"
+  - selector.scopes uses PascalCase values
+  - id is UUID-shaped
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "OnTopicGuardSol" / "OnTopicAgent"
+AGENT = ROOT / "agent.json"
+
+VALID_SCOPES = {"Agent", "Llm", "Tool"}
+VALID_THRESHOLDS = {0, 2, 4, 6}
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def find_param(params: list, param_id: str) -> dict | None:
+    for p in params:
+        if isinstance(p, dict) and p.get("id") == param_id:
+            return p
+    return None
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    judges = [
+        g for g in guardrails
+        if g.get("$guardrailType") == "builtInValidator"
+        and g.get("validatorType") == "llm_as_judge"
+    ]
+    if not judges:
+        types = [
+            (g.get("$guardrailType"), g.get("validatorType"))
+            for g in guardrails
+        ]
+        sys.exit(
+            f"FAIL: no guardrail with $guardrailType == \"builtInValidator\" "
+            f"and validatorType == \"llm_as_judge\". Got: {types}"
+        )
+    g = judges[0]
+    print('OK: found builtInValidator guardrail with validatorType == "llm_as_judge"')
+
+    gid = g.get("id")
+    if not isinstance(gid, str) or "-" not in gid:
+        sys.exit(f"FAIL: guardrail id missing or malformed: {gid!r}")
+    print(f"OK: guardrail id is UUID-shaped: {gid}")
+
+    action = g.get("action")
+    if not isinstance(action, dict):
+        sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
+    if action.get("$actionType") != "block":
+        sys.exit(
+            f'FAIL: guardrail.action.$actionType must be "block", '
+            f"got {action.get('$actionType')!r}"
+        )
+    print('OK: action.$actionType == "block"')
+
+    selector = g.get("selector")
+    if not isinstance(selector, dict):
+        sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
+    scopes = selector.get("scopes")
+    if not isinstance(scopes, list) or len(scopes) == 0:
+        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+    invalid = [s for s in scopes if s not in VALID_SCOPES]
+    if invalid:
+        sys.exit(
+            f"FAIL: guardrail.selector.scopes contains invalid values {invalid}. "
+            f"Valid PascalCase values: {sorted(VALID_SCOPES)}"
+        )
+    print(f"OK: selector.scopes = {scopes} (all PascalCase)")
+
+    params = g.get("validatorParameters")
+    if not isinstance(params, list):
+        sys.exit(f"FAIL: validatorParameters must be an array, got {params!r}")
+
+    text_param = find_param(params, "guardrailText")
+    if text_param is None:
+        ids = [p.get("id") for p in params if isinstance(p, dict)]
+        sys.exit(
+            f'FAIL: validatorParameters missing required parameter id "guardrailText". '
+            f"Got ids: {ids}"
+        )
+    if text_param.get("$parameterType") != "text":
+        sys.exit(
+            f'FAIL: guardrailText parameter.$parameterType must be "text", '
+            f"got {text_param.get('$parameterType')!r}"
+        )
+    text_value = text_param.get("value")
+    if not isinstance(text_value, str) or not text_value.strip():
+        sys.exit(f"FAIL: guardrailText parameter.value must be a non-empty string, got {text_value!r}")
+    print(f"OK: guardrailText (text) is non-empty ({len(text_value)} chars)")
+
+    model_param = find_param(params, "model")
+    if model_param is None:
+        ids = [p.get("id") for p in params if isinstance(p, dict)]
+        sys.exit(
+            f'FAIL: validatorParameters missing required parameter id "model". '
+            f"Got ids: {ids}"
+        )
+    if model_param.get("$parameterType") != "enum":
+        sys.exit(
+            f'FAIL: model parameter.$parameterType must be "enum", '
+            f"got {model_param.get('$parameterType')!r}"
+        )
+    model_value = model_param.get("value")
+    if not isinstance(model_value, str) or not model_value.strip():
+        sys.exit(f"FAIL: model parameter.value must be a non-empty string, got {model_value!r}")
+    print(f"OK: model (enum) = {model_value}")
+
+    threshold_param = find_param(params, "threshold")
+    if threshold_param is not None:
+        if threshold_param.get("$parameterType") != "number":
+            sys.exit(
+                f'FAIL: threshold parameter.$parameterType must be "number", '
+                f"got {threshold_param.get('$parameterType')!r}"
+            )
+        threshold_value = threshold_param.get("value")
+        if threshold_value not in VALID_THRESHOLDS:
+            sys.exit(
+                f"FAIL: threshold parameter.value must be one of {sorted(VALID_THRESHOLDS)} "
+                f"(discrete 0/2/4/6 scale, Step=2, Min=0, Max=6). Got {threshold_value!r}"
+            )
+        print(f"OK: threshold (number) = {threshold_value}")
+
+    for examples_id in ("positiveExamples", "negativeExamples"):
+        ex_param = find_param(params, examples_id)
+        if ex_param is None:
+            continue
+        if ex_param.get("$parameterType") != "text-list":
+            sys.exit(
+                f'FAIL: {examples_id} parameter.$parameterType must be "text-list", '
+                f"got {ex_param.get('$parameterType')!r}"
+            )
+        ex_value = ex_param.get("value")
+        if not isinstance(ex_value, list):
+            sys.exit(f"FAIL: {examples_id} parameter.value must be an array, got {ex_value!r}")
+        if len(ex_value) > 2:
+            sys.exit(
+                f"FAIL: {examples_id} parameter.value exceeds MaxItems=2 "
+                f"(got {len(ex_value)} items)"
+            )
+        print(f"OK: {examples_id} (text-list) has {len(ex_value)} items")
+
+    print("OK: llm_as_judge builtInValidator guardrail is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/llm_as_judge/llm_as_judge.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/llm_as_judge/llm_as_judge.yaml
@@ -1,0 +1,103 @@
+task_id: skill-agent-guardrail-llm-as-judge
+description: >
+  Built-in LLM-as-judge guardrail. End-to-end test: scaffold a standalone
+  low-code agent and add a builtInValidator guardrail for llm_as_judge
+  with a natural-language policy on agent output. Verifies correct
+  $guardrailType, validatorType, the new parameter types (text, enum,
+  text-list, number), PascalCase scope values, and the discrete 0/2/4/6
+  threshold scale.
+tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+initial_prompt: |
+  Create a UiPath low-code agent "OnTopicAgent" that answers customer
+  support questions about our software product. Add a built-in
+  llm_as_judge guardrail that blocks agent responses drifting off the
+  support topic (politics, religion, competitors, unrelated topics).
+  Apply the guardrail at the Agent scope on output. Use a block action
+  with reason "Response violates the on-topic policy." The solution
+  should be named "OnTopicGuardSol".
+
+  Use a strict threshold of 2. Pick the judge model the same way you
+  would pick the agent's settings.model — discover available models
+  with uip agent model list and select a current GA reasoning model.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the solution with uip solution init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scaffolded the agent project with uip agent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Project is registered in the parent solution .uipx"
+    path: "OnTopicGuardSol/OnTopicGuardSol.uipx"
+    assertions:
+      - expression: "length(Projects)"
+        operator: "gte"
+        expected: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered judge models via uip agent model list (same flow as settings.model)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+model\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on uip commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "OnTopicAgent/agent.json was created"
+    path: "OnTopicGuardSol/OnTopicAgent/agent.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "llm_as_judge guardrail shape (builtInValidator, validatorType, parameter types, threshold scale)"
+    command: "python3 $TASK_DIR/check_llm_as_judge.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 15
+  max_turns: 30
+  turn_timeout: 1200


### PR DESCRIPTION
## Summary

Updates the **uipath-agents** skill to support the new `llm_as_judge` built-in validator added by [UiPath/Agents#5465](https://github.com/UiPath/Agents/pull/5465). Implements [AL-469](https://uipath.atlassian.net/browse/AL-469).

The backend ships:
- A new `ValidatorType.LlmAsJudge` (wire name `llm_as_judge`)
- Three new polymorphic parameter primitives: `enum`, `text`, `text-list`
- Customer-visible params: `guardrailText` (text), `model` (enum — discovered out-of-band via the same flow as the agent's `settings.model`), `positiveExamples` / `negativeExamples` (text-list), `threshold` (number, discrete 0/2/4/6 scale)

## Changes

### `skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md`
- Added 3 new parameter types (`enum`, `text`, `text-list`) to the Parameter Types table
- Added `llm_as_judge` to the Validators Quick Reference (Agent/Llm/Tool, Pre + Post)
- **New positive note** directly under the Validators Quick Reference explaining the `model` mapping in concrete terms: run `uip agent model list --output json` → pick per `model-selection-guide.md` → copy the `Name` field verbatim into `{ "$parameterType": "enum", "id": "model", "value": "<Name>" }`. Includes a worked `anthropic.claude-sonnet-4-6` example
- New **Example 11** — full `llm_as_judge` guardrail with all 5 parameters
- 3 new anti-patterns: don't substitute `llm_as_judge` for fixed validators; don't invent `model` values (use the discovery flow); don't put secrets/untrusted input into `guardrailText` or examples

### `skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md`
- Extended the Correctness Check `Type` row with the 3 new parameter types
- Documented the `Options: []` exception for `llm_as_judge` `model`
- Added generic `MaxLength` / `MaxItems` rows for `text` and `text-list`

### `tests/tasks/uipath-agents/lowcode/guardrails/llm_as_judge/`
- New e2e build task mirroring the `pii_detection` pattern
- `check_llm_as_judge.py` asserts validator discriminators, `text`/`enum`/`text-list` parameter shapes, the discrete 0/2/4/6 threshold scale, and `MaxItems ≤ 2` on examples
- Task prompt and a dedicated `command_executed` criterion steer the agent to discover the judge model via `uip agent model list` (same flow as `settings.model`)

## Notes

- The PR description on UiPath/Agents#5465 called the wire name `llm_judge` and threshold a 0–1 float with default `0.5`. The actual merged code uses `llm_as_judge` and the discrete 0/2/4/6 scale (aligned with `harmful_content`). The skill docs match what was merged.
- The coded-agents guardrails reference (`skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md`) defers to `WebFetch` of the live UiPath Python SDK docs, so no edit is needed there.

## Test plan
- [x] `validate-skill-descriptions.sh` clean
- [x] `check-skill-status.py` OK (22 skills, manifest valid)
- [x] `check-cli-verbs.py` clean on changed files (0 High, 0 Medium)
- [x] New test YAML parses; `check_llm_as_judge.py` passes `ast.parse`
- [ ] Run the new task with `coder-eval` once the `EnableGuardrailLlmAsJudge` feature flag is enabled in the test tenant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AL-469]: https://uipath.atlassian.net/browse/AL-469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ