### PR TITLE
fix(uipath-agents): make low-code coder-eval prompts fit for purpose

### DIFF
--- a/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/built-in-tools.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/built-in-tools.md
@@ -15,6 +15,7 @@ For process tools (RPA / agent / API / agentic), see [../process/process.md](../
 2. **`properties.toolType` is the discriminator** — fixed per built-in, kebab-lowercase. Copy from the per-tool walkthrough; do not invent.
 3. **No solution-level files.** Built-in tools need no `uip solution resources refresh`. Validate the agent and bundle.
 4. **Input/output schemas are fixed.** Do not edit them. Each tool's walkthrough lists the canonical schema.
+5. **Inline agents need the flow node too.** When the built-in tool is on an *inline* agent (embedded in a flow), authoring the `resource.json` is **not enough** — also wire a `uipath.agent.resource.tool.builtin.<toolType>` flow node to the autonomous node's `tool` handle. Fetch the node manifest with `uip maestro flow registry get` and hand the node + edge authoring to the `uipath-maestro-flow` skill (Critical Rule 16). Without the flow node the tool is never reachable at runtime. See [../inline-in-flow/inline-in-flow.md](../inline-in-flow/inline-in-flow.md).
 
 ## Resource Shape
 

--- a/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
@@ -11,7 +11,7 @@ The only channel type currently supported end-to-end by `uip solution resources 
 
 **Key pattern:** the skill writes only the agent-level `resources/{EscalationName}/resource.json`. `uip solution resources refresh` emits an App binding into `bindings_v2.json` and then hand-writes the four solution-level files (`app/workflow Action/`, `appVersion/`, `package/`, `process/webApp/`) plus two `debug_overwrites.json` entries (`kind: "app"`, `kind: "process"`) automatically. No manual solution-level authoring is required for `actionCenter` channels.
 
-**Inline agents (escalation inside a flow):** authoring the escalation `resource.json` is **not enough** — an inline agent's escalation must also be wired as a `uipath.agent.resource.escalation` flow node connected to the autonomous node's `escalation` handle. Do the full discovery below (including `uip solution resources list --kind App`), author the resource, fetch the node manifest with `uip maestro flow registry get <…>uipath.agent.resource.escalation<…>`, then hand the node + edge authoring to the `uipath-maestro-flow` skill (Critical Rule 16). Without the flow node the escalation is never reachable at runtime. See [../inline-in-flow/inline-in-flow.md](../inline-in-flow/inline-in-flow.md).
+**Inline agents (escalation inside a flow):** still run the full discovery below (including `uip solution resources list --kind App`) and author the `resource.json` the same way — then **also** wire a `uipath.agent.resource.escalation` flow node (see Step 6b). Without the node the escalation is never reached at runtime.
 
 ## Discovery
 
@@ -222,6 +222,10 @@ The fourth file (`process/webApp/...`) backs the app resource's `dependencies[1]
 **File:** `<AGENT_NAME>/resources/<EscalationName>/resource.json`
 
 Use the full shape from § Agent-Level Resource Shape above. Generate fresh UUIDs for the top-level `id` AND the channel `id` — do not reuse.
+
+### Step 6b — Inline agents only: wire the escalation flow node
+
+**Skip if the agent is standalone.** If the escalation is on an **inline** agent (embedded in a flow), the `resource.json` alone is never reached at runtime — you MUST also add a `uipath.agent.resource.escalation` flow node connected to the autonomous node's `escalation` handle. Fetch its manifest with `uip maestro flow registry get <…uipath.agent.resource.escalation…> --output json`, then hand the node + edge authoring to the `uipath-maestro-flow` skill (Critical Rule 16 — this skill does not author `.flow` graphs directly). Run Step 7's refresh/validate with `--inline-in-flow` plus `--bindings-target <FlowProjectDir>/bindings_v2.json`. See [../inline-in-flow/inline-in-flow.md](../inline-in-flow/inline-in-flow.md).
 
 ### Step 7 — Refresh, validate, and refresh solution resources
 

--- a/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/escalation/escalation.md
@@ -11,6 +11,8 @@ The only channel type currently supported end-to-end by `uip solution resources 
 
 **Key pattern:** the skill writes only the agent-level `resources/{EscalationName}/resource.json`. `uip solution resources refresh` emits an App binding into `bindings_v2.json` and then hand-writes the four solution-level files (`app/workflow Action/`, `appVersion/`, `package/`, `process/webApp/`) plus two `debug_overwrites.json` entries (`kind: "app"`, `kind: "process"`) automatically. No manual solution-level authoring is required for `actionCenter` channels.
 
+**Inline agents (escalation inside a flow):** authoring the escalation `resource.json` is **not enough** — an inline agent's escalation must also be wired as a `uipath.agent.resource.escalation` flow node connected to the autonomous node's `escalation` handle. Do the full discovery below (including `uip solution resources list --kind App`), author the resource, fetch the node manifest with `uip maestro flow registry get <…>uipath.agent.resource.escalation<…>`, then hand the node + edge authoring to the `uipath-maestro-flow` skill (Critical Rule 16). Without the flow node the escalation is never reachable at runtime. See [../inline-in-flow/inline-in-flow.md](../inline-in-flow/inline-in-flow.md).
+
 ## Discovery
 
 ### Step 1 — Scaffold solution and agent (if not already done)
@@ -133,7 +135,7 @@ Escalations hand off agent control to a human via a channel. Generate fresh UUID
   "storageBucketName": null,                        // only used when escalationType = 1
   "properties": {},
   "governanceProperties": { "isEscalatedAtRuntime": false },
-  "isEnabled": true,
+  "isEnabled": true,                                // REQUIRED — must be true, or the escalation is inactive (not defaulted; always set it explicitly)
   "channels": [
     {
       "id": "<uuid-v4>",                            // channel id — generate a new one per channel
@@ -255,6 +257,7 @@ uip solution upload ./dist/<SOLUTION_NAME>.uis --output json
 See [../../critical-rules.md](../../critical-rules.md) Critical Rules. Escalation-specific gotchas:
 
 - `properties.folderName` MUST be the literal `Folder` from `uip solution resources list --kind App` (e.g., `"Shared/Approvals"`). `uip agent refresh` translates it to `folderPath` in the App binding inside `bindings_v2.json`. Do NOT use `"solution_folder"` — escalation apps are always external. See [../../critical-rules.md](../../critical-rules.md) Rule 11 and Anti-pattern 18.
+- `isEnabled` MUST be `true` — it is not defaulted. An escalation written without it (or with `null`) is inactive and fails validation.
 - `recipients` array MUST have at least one entry. Empty uploads but routes nowhere.
 - For `type: 3` (email) recipients, do NOT set `displayName`.
 - Generate fresh UUIDs for the top-level `id` AND each channel `id`.

--- a/tests/tasks/uipath-agents/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-agents/_shared/cleanup_solutions.py
@@ -78,7 +78,7 @@ def main() -> int:
             continue
 
         r = subprocess.run(
-            ["uip", "solution", "delete", sid, "--output", "json"],
+            ["uip", "solution", "delete", sid, "--yes", "--output", "json"],
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/smoke_trigger.yaml
@@ -10,11 +10,10 @@ run_limits:
   expected_turns: 5
 
 initial_prompt: |
-  I'm building a low-code agent in Studio Web Agent Builder (`agent.json`
-  with `"type": "lowCode"`). I want it to take a CSV upload and add two
-  new LLM-filled columns: a category and a confidence label. Tell me
-  which skill applies and which built-in tool I need to enable. Do NOT
-  scaffold any files.
+  I'm building a low-code agent in Studio Web Agent Builder. I want it to take a
+  CSV upload and add two new LLM-filled columns: a category and a confidence
+  label. How would I do this in UiPath, and which built-in tool would handle it?
+  Don't scaffold any files — just point me in the right direction.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
@@ -69,12 +69,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "DocAnalystAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/context_index/check_context_index.py
+++ b/tests/tasks/uipath-agents/lowcode/context_index/check_context_index.py
@@ -2,11 +2,12 @@
 """Context (semantic index) resource check.
 
 Validates:
-  1. resources/UiPathAgentsProductKnowledge/resource.json declares a context
-     resource of type "index":
+  1. A context resource under resources/<folder> (located by type; the folder
+     name is the agent's choice) declares:
        - $resourceType == "context"
        - contextType == "index"
-       - name == indexName == "UiPathAgentsProductKnowledge"
+       - name == its folder name (convention: the folder matches `name`)
+       - indexName == "UiPathAgentsProductKnowledge" (the deployed index)
        - folderPath == "Shared/uipath-agents" (the deployed Orchestrator folder)
   2. settings.retrievalMode is one of the documented values:
      "semantic" | "structured" | "deepRAG" | "batchTransform".
@@ -28,7 +29,7 @@ from pathlib import Path
 ROOT = Path(os.getcwd()) / "KnowledgeSol" / "ProductSupportAgent"
 AGENT = ROOT / "agent.json"
 ENTRY = ROOT / "entry-points.json"
-RESOURCE = ROOT / "resources" / "UiPathAgentsProductKnowledge" / "resource.json"
+RESOURCES = ROOT / "resources"
 BINDINGS = ROOT / "bindings_v2.json"
 
 EXPECTED_INDEX_NAME = "UiPathAgentsProductKnowledge"
@@ -46,7 +47,27 @@ def load(path: Path) -> dict:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
 
 
-def assert_context_resource(resource: dict) -> None:
+def find_context_resource() -> tuple[str, dict]:
+    """Locate the context resource by type. The resource folder name is the
+    agent's choice (convention: it matches the resource's `name` field) — it is
+    NOT pinned to the index name; the index identity lives in `indexName`."""
+    if not RESOURCES.is_dir():
+        sys.exit(f"FAIL: {RESOURCES} does not exist — no context resource authored")
+    for path in sorted(RESOURCES.rglob("resource.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("$resourceType") == "context" and data.get("contextType") == "index":
+            print(f"OK: found context resource at {path.relative_to(ROOT.parent)}")
+            return path.parent.name, data
+    sys.exit(
+        f'FAIL: no context resource ($resourceType=="context", contextType=="index") '
+        f"found under {RESOURCES}"
+    )
+
+
+def assert_context_resource(folder_name: str, resource: dict) -> None:
     rtype = resource.get("$resourceType")
     if rtype != "context":
         sys.exit(f'FAIL: resource.json $resourceType should be "context", got {rtype!r}')
@@ -54,10 +75,10 @@ def assert_context_resource(resource: dict) -> None:
     if ctype != "index":
         sys.exit(f'FAIL: resource.json contextType should be "index", got {ctype!r}')
     name = resource.get("name")
-    if name != EXPECTED_INDEX_NAME:
+    if name != folder_name:
         sys.exit(
-            f'FAIL: resource.json name should be {EXPECTED_INDEX_NAME!r} '
-            f"(matching the deployed index), got {name!r}"
+            f"FAIL: resource.json name {name!r} must match its folder name {folder_name!r} "
+            "(convention: the resource folder matches the resource's `name`)"
         )
     index_name = resource.get("indexName")
     if index_name != EXPECTED_INDEX_NAME:
@@ -73,7 +94,7 @@ def assert_context_resource(resource: dict) -> None:
         )
     print(
         f'OK: resource.json is $resourceType="context", contextType="index", '
-        f"name=indexName={EXPECTED_INDEX_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
+        f"name=folder={resource.get('name')!r}, indexName={EXPECTED_INDEX_NAME!r}, folderPath={EXPECTED_FOLDER_PATH!r}"
     )
 
 
@@ -191,10 +212,10 @@ def assert_bindings_index(bindings: dict) -> None:
 def main() -> None:
     agent = load(AGENT)
     entry = load(ENTRY)
-    resource = load(RESOURCE)
+    folder_name, resource = find_context_resource()
     bindings = load(BINDINGS)
 
-    assert_context_resource(resource)
+    assert_context_resource(folder_name, resource)
     assert_retrieval_mode(resource)
     in_schema, out_schema = assert_schema_sync(agent, entry)
     assert_input_shape(in_schema)

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -106,13 +106,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "UiPathAgentsProductKnowledge context resource.json was created"
-    path: "KnowledgeSol/ProductSupportAgent/resources/UiPathAgentsProductKnowledge/resource.json"
-    weight: 2.5
-    pass_threshold: 1.0
-
-
   - type: run_command
     description: "Context resource shape, retrievalMode, and schema sync"
     command: "python3 $TASK_DIR/check_context_index.py"

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -13,16 +13,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "ProductSupportAgent" that accepts a required
-  `question` (string) and returns a string `answer`. It must ground its
-  answers in the existing semantic index named
-  "UiPathAgentsProductKnowledge" that is already deployed in the tenant.
-  The solution should be named "KnowledgeSol".
-
-  Use the real folder, index name, and backing storage bucket from
-  the tenant — do not hard-code or guess these values. Name the
-  agent's context resource `UiPathAgentsProductKnowledge` (matching
-  the index).
+  Create a UiPath low-code agent "ProductSupportAgent" that answers a user's
+  `question` (string) and returns an `answer` (string). It should base its
+  answers on our existing "UiPathAgentsProductKnowledge" knowledge index —
+  which is already set up in our tenant — instead of answering from general
+  knowledge. The solution should be named "KnowledgeSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -98,12 +93,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ProductSupportAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/debug/debug.yaml
+++ b/tests/tasks/uipath-agents/lowcode/debug/debug.yaml
@@ -23,17 +23,16 @@ initial_prompt: |
 
   Do NOT publish or deploy. Do NOT ask for approval, confirmation, or feedback.
   Do NOT pause between planning and implementation. Complete the entire task
-  end-to-end in a single pass. Before starting, load the uipath-agents skill and
-  follow its low-code debug workflow exactly.
+  end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed
-    description: "Agent loaded the uipath-agents skill"
+    description: "Advisory: agent auto-loaded the uipath-agents skill (informational, non-gating)"
     tool_name: "Skill"
     command_pattern: "uipath-agents"
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   # `uip agent debug` exits non-zero unless the run reaches State:Successful, so
   # require_success asserts the agent's own debug finished Successful. The two

--- a/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/smoke_trigger.yaml
@@ -10,11 +10,10 @@ run_limits:
   expected_turns: 5
 
 initial_prompt: |
-  I'm building a low-code agent in Studio Web Agent Builder
-  (`agent.json` with `"type": "lowCode"`). It receives multiple PDF
-  attachments and must synthesize a single answer with citations. Tell
-  me which skill applies and which built-in tool I need to enable. Do
-  NOT scaffold any files.
+  I'm building a low-code agent in Studio Web Agent Builder. It receives several
+  PDF attachments and must produce a single answer with citations drawn from
+  them. How would I do this in UiPath, and which built-in tool would handle it?
+  Don't scaffold any files — just point me in the right direction.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -98,12 +98,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "DisputeAnalystAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -15,13 +15,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a low-code agent "GreeterAgent" that accepts a required
-  `name` (string) and returns a `greeting` (string). Refresh and
-  validate it. The solution should be named "GreetSol".
+  Create a low-code agent "GreeterAgent" that takes a required `name` (string)
+  and returns a `greeting` (string). The solution should be named "GreetSol".
 
-  Then EDIT the agent to also accept a required `language` (string)
-  input and make the user message template include both inputs.
-  Refresh and validate again.
+  Then update the agent so it also takes a required `language` (string), and
+  have its greeting to the user use both the name and the language.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -45,12 +43,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "GreeterAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
@@ -19,15 +19,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "OutreachAgent" that accepts a required
-  `subject` (string) and returns a string `content`. It must compose
-  the content by delegating to an agent named "EmailDrafter" that is
-  already deployed in the tenant — not by drafting the email itself.
-  The solution should be named "OutreachSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the wrapper's tool resource
-  `EmailDrafter` (matching the deployed agent).
+  Create a UiPath low-code agent "OutreachAgent" that takes a required
+  `subject` (string) and returns a string `content`. OutreachAgent shouldn't
+  write the email itself — the draft should come from our existing
+  "EmailDrafter" agent, which is already deployed in our tenant. The solution
+  should be named "OutreachSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -103,12 +99,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "OutreachAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -18,15 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "WeatherAgent" that accepts a required
-  `location` (string) and returns a number `temperature`. It must
-  compute the temperature using an API workflow named "WeatherAPI"
-  that is already deployed in the tenant — not by reasoning about the
-  answer itself. The solution should be named "WeatherSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `WeatherAPI` (matching the process).
+  Create a UiPath low-code agent "WeatherAgent" that takes a required
+  `location` (string) and returns a number `temperature`. WeatherAgent
+  shouldn't figure out the temperature itself — the value should come from our
+  existing "WeatherAPI" workflow, which is already deployed in our tenant. The
+  solution should be named "WeatherSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -102,12 +98,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "WeatherAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -14,19 +14,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "FraudTriageAgent" that accepts a required
-  `transaction` (object) and returns a `verdict` (string). When the
-  agent is uncertain, it must escalate to a human reviewer via an
-  EXISTING EXTERNAL ActionCenter app named "FraudEscalation" that
-  is already deployed to the Orchestrator "Shared" folder (not inside
-  this solution). Model this as an escalation resource on the agent.
-  The solution should be named "FraudSol".
-
-  When writing the escalation resource.json, set `isEnabled` to true so
-  the escalation is active for the agent. Set `properties.folderPath`
-  to the literal string "Shared" (the live Orchestrator folder where
-  FraudEscalation is deployed) — never use placeholder values
-  like "solution_folder".
+  Create a UiPath low-code agent "FraudTriageAgent" that reviews a
+  `transaction` (object) and returns a `verdict` (string). When it isn't
+  confident, it should escalate the case to a human reviewer through our
+  existing "FraudEscalation" Action Center app, which is already running in
+  Orchestrator (it isn't part of this solution). The solution should be named
+  "FraudSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -78,12 +71,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "FraudTriageAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -18,16 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "ProcurementAgent" that accepts a required
-  `productId` (number) and returns a boolean `status`. It must
-  determine the status by delegating to an Agentic process named
-  "ProcurementProcess" that is already deployed in the tenant — not by
-  reasoning about the answer itself. The solution should be named
-  "ProcurementSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `ProcurementProcess` (matching the deployed process).
+  Create a UiPath low-code agent "ProcurementAgent" that takes a required
+  `productId` (number) and returns a boolean `status`. ProcurementAgent
+  shouldn't decide the status itself — it should come from our existing
+  "ProcurementProcess" agentic process, which is already deployed in our
+  tenant. The solution should be named "ProcurementSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -103,12 +98,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ProcurementAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -18,15 +18,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "FibonacciAgent" that accepts a required
-  `index` (number) and returns a number `value`. It must compute the
-  value using a process named "FibonacciRPA" that is already deployed
-  in the tenant — not by reasoning about the answer itself. The
-  solution should be named "FibonacciSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `FibonacciRPA` (matching the process).
+  Create a UiPath low-code agent "FibonacciAgent" that takes a required
+  `index` (number) and returns a number `value`. FibonacciAgent shouldn't
+  compute the value itself — it should come from our existing "FibonacciRPA"
+  process, which is already deployed in our tenant. The solution should be
+  named "FibonacciSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -102,12 +98,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "FibonacciAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/agent.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/agent.json
@@ -1,0 +1,133 @@
+{
+  "version": "1.1.0",
+  "settings": {
+    "model": "anthropic.claude-opus-4-6-v1",
+    "maxTokens": 16384,
+    "temperature": 0,
+    "engine": "basic-v2",
+    "maxIterations": 15,
+    "mode": "standard"
+  },
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "topic": {
+        "type": "string",
+        "description": "The topic or question to research on the web"
+      },
+      "slackChannel": {
+        "type": "string",
+        "description": "Slack channel ID or name where the briefing will be posted"
+      },
+      "jiraProject": {
+        "type": "string",
+        "description": "Jira project key where a tracking issue will be created (e.g. DEMO)"
+      }
+    },
+    "required": [
+      "topic",
+      "slackChannel",
+      "jiraProject"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "slackMessageTimestamp": {
+        "type": "string",
+        "description": "Timestamp of the posted Slack message"
+      },
+      "jiraIssueKey": {
+        "type": "string",
+        "description": "Key of the created Jira tracking issue (e.g. DEMO-42)"
+      },
+      "sourcesCount": {
+        "type": "integer",
+        "description": "Total number of sources found (web search results + summary citations)"
+      }
+    }
+  },
+  "metadata": {
+    "storageVersion": "50.0.0",
+    "isConversational": false,
+    "showProjectCreationExperience": false,
+    "targetRuntime": "pythonAgent"
+  },
+  "type": "lowCode",
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a Web Research Briefing Agent. Execute exactly these 5 tool calls in order — one call each, no repeats:\n\nSTEP 1 — Web Search (call ONCE):\n  Call Web Search with the research topic as the query and num=10.\n  From the response, count how many items are in the `results` array. Call this value SEARCH_COUNT.\n  Do NOT call Web Search again after this step.\n\nSTEP 2 — Web Summary (call ONCE):\n  Call Web Summary with the same research topic.\n  From the response, count how many items are in the `citations` array. Call this value CITATIONS_COUNT.\n  Do NOT call Web Summary again after this step.\n\nSTEP 3 — Count Sources (call ONCE):\n  Call Count Sources with a=SEARCH_COUNT and b=CITATIONS_COUNT.\n  The response gives TOTAL_SOURCES = a + b.\n\nSTEP 4 — Send Slack Message (call ONCE):\n  Call Send message to channel with the channel from the input and a message containing:\n  - Bold header with the research topic\n  - The AI-generated summary from Web Summary\n  - Numbered list of top search results (title + URL) from Web Search\n  - \"Total sources: TOTAL_SOURCES\"\n  Save the timestamp from the response as SLACK_TS.\n\nSTEP 5 — Create Jira Issue (call ONCE):\n  Call Create Issue with a nested 'fields' object:\n  { \"fields\": { \"project\": { \"key\": \"<the jiraProject input value>\" }, \"issuetype\": { \"id\": \"3\" }, \"summary\": \"Research briefing: <topic>\" } }\n  The issuetype id must be the string \"3\" (not a number).\n  Save the issue key from the response as JIRA_KEY.\n\nAfter completing all 5 steps, return: slackMessageTimestamp=SLACK_TS, jiraIssueKey=JIRA_KEY, sourcesCount=TOTAL_SOURCES.",
+      "contentTokens": [
+        {
+          "type": "simpleText",
+          "rawString": "You are a Web Research Briefing Agent. Execute exactly these 5 tool calls in order — one call each, no repeats:\n\nSTEP 1 — Web Search (call ONCE):\n  Call Web Search with the research topic as the query and num=10.\n  From the response, count how many items are in the `results` array. Call this value SEARCH_COUNT.\n  Do NOT call Web Search again after this step.\n\nSTEP 2 — Web Summary (call ONCE):\n  Call Web Summary with the same research topic.\n  From the response, count how many items are in the `citations` array. Call this value CITATIONS_COUNT.\n  Do NOT call Web Summary again after this step.\n\nSTEP 3 — Count Sources (call ONCE):\n  Call Count Sources with a=SEARCH_COUNT and b=CITATIONS_COUNT.\n  The response gives TOTAL_SOURCES = a + b.\n\nSTEP 4 — Send Slack Message (call ONCE):\n  Call Send message to channel with the channel from the input and a message containing:\n  - Bold header with the research topic\n  - The AI-generated summary from Web Summary\n  - Numbered list of top search results (title + URL) from Web Search\n  - \"Total sources: TOTAL_SOURCES\"\n  Save the timestamp from the response as SLACK_TS.\n\nSTEP 5 — Create Jira Issue (call ONCE):\n  Call Create Issue with a nested 'fields' object:\n  { \"fields\": { \"project\": { \"key\": \"<the jiraProject input value>\" }, \"issuetype\": { \"id\": \"3\" }, \"summary\": \"Research briefing: <topic>\" } }\n  The issuetype id must be the string \"3\" (not a number).\n  Save the issue key from the response as JIRA_KEY.\n\nAfter completing all 5 steps, return: slackMessageTimestamp=SLACK_TS, jiraIssueKey=JIRA_KEY, sourcesCount=TOTAL_SOURCES."
+        }
+      ]
+    },
+    {
+      "role": "user",
+      "content": "Research the following topic and post a briefing:\n\nTopic: {{input.topic}}\nSlack channel: {{input.slackChannel}}\nJira project: {{input.jiraProject}}",
+      "contentTokens": [
+        {
+          "type": "simpleText",
+          "rawString": "Research the following topic and post a briefing:\n\nTopic: "
+        },
+        {
+          "type": "variable",
+          "rawString": "input.topic"
+        },
+        {
+          "type": "simpleText",
+          "rawString": "\nSlack channel: "
+        },
+        {
+          "type": "variable",
+          "rawString": "input.slackChannel"
+        },
+        {
+          "type": "simpleText",
+          "rawString": "\nJira project: "
+        },
+        {
+          "type": "variable",
+          "rawString": "input.jiraProject"
+        }
+      ]
+    }
+  ],
+  "guardrails": [
+    {
+      "$guardrailType": "builtInValidator",
+      "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+      "name": "Harmful content guardrail",
+      "description": "Blocks harmful content in agent outputs",
+      "validatorType": "harmful_content",
+      "validatorParameters": [
+        {
+          "$parameterType": "enum-list",
+          "id": "harmfulContentEntities",
+          "value": ["Hate", "SelfHarm"]
+        },
+        {
+          "$parameterType": "map-enum",
+          "id": "harmfulContentEntityThresholds",
+          "value": {
+            "Hate": 2,
+            "SelfHarm": 2,
+            "Sexual": 2
+          }
+        }
+      ],
+      "action": {
+        "$actionType": "block",
+        "reason": "Harmful content detected."
+      },
+      "enabledForEvals": true,
+      "selector": {
+        "scopes": ["Agent"]
+      }
+    }
+  ],
+  "projectId": "d01190b7-425e-4733-acd6-be5f23d49a74"
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/bindings_v2.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/bindings_v2.json
@@ -1,0 +1,72 @@
+{
+  "version": "2.0",
+  "resources": [
+    {
+      "resource": "process",
+      "key": "A_Plus_B",
+      "value": {
+        "name": {
+          "defaultValue": "A_Plus_B",
+          "isExpression": false,
+          "displayName": "Process name"
+        }
+      },
+      "metadata": {
+        "subType": "process",
+        "bindingsVersion": "2.2",
+        "solutionsSupport": "true"
+      }
+    },
+    {
+      "resource": "connection",
+      "key": "3d8b2ad9-ec99-429c-a993-6c6f3f238d1c",
+      "value": {
+        "connectionId": {
+          "defaultValue": "3d8b2ad9-ec99-429c-a993-6c6f3f238d1c",
+          "isExpression": false,
+          "displayName": "Connection ID"
+        }
+      },
+      "metadata": {
+        "connector": "uipath-atlassian-jira",
+        "useConnectionService": "true",
+        "bindingsVersion": "2.2",
+        "solutionsSupport": "true"
+      }
+    },
+    {
+      "resource": "connection",
+      "key": "a9174bb6-e808-4330-b182-c8578bc100b1",
+      "value": {
+        "connectionId": {
+          "defaultValue": "a9174bb6-e808-4330-b182-c8578bc100b1",
+          "isExpression": false,
+          "displayName": "Connection ID"
+        }
+      },
+      "metadata": {
+        "connector": "uipath-salesforce-slack",
+        "useConnectionService": "true",
+        "bindingsVersion": "2.2",
+        "solutionsSupport": "true"
+      }
+    },
+    {
+      "resource": "connection",
+      "key": "d2e61ee5-6008-4162-8f54-eba948bbd5a0",
+      "value": {
+        "connectionId": {
+          "defaultValue": "d2e61ee5-6008-4162-8f54-eba948bbd5a0",
+          "isExpression": false,
+          "displayName": "Connection ID"
+        }
+      },
+      "metadata": {
+        "connector": "uipath-uipath-airdk",
+        "useConnectionService": "true",
+        "bindingsVersion": "2.2",
+        "solutionsSupport": "true"
+      }
+    }
+  ]
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/entry-points.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/entry-points.json
@@ -1,0 +1,46 @@
+{
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+        {
+            "filePath": "/content/agent.json",
+            "uniqueId": "8689053e-f34d-4936-abfd-6a8edf85b068",
+            "type": "agent",
+            "input": {
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": "The topic or question to research on the web"
+                    },
+                    "slackChannel": {
+                        "type": "string",
+                        "description": "Slack channel ID or name where the briefing will be posted"
+                    },
+                    "jiraProject": {
+                        "type": "string",
+                        "description": "Jira project key where a tracking issue will be created (e.g. DEMO)"
+                    }
+                },
+                "required": ["topic", "slackChannel", "jiraProject"]
+            },
+            "output": {
+                "type": "object",
+                "properties": {
+                    "slackMessageTimestamp": {
+                        "type": "string",
+                        "description": "Timestamp of the posted Slack message"
+                    },
+                    "jiraIssueKey": {
+                        "type": "string",
+                        "description": "Key of the created Jira tracking issue (e.g. DEMO-42)"
+                    },
+                    "sourcesCount": {
+                        "type": "integer",
+                        "description": "Total number of sources found (web search results + summary citations)"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/project.uiproj
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/project.uiproj
@@ -1,0 +1,6 @@
+{
+  "ProjectType": "Agent",
+  "Name": "WebResearchBriefingAgent",
+  "Description": null,
+  "MainFile": null
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/CountSources/resource.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/CountSources/resource.json
@@ -1,0 +1,43 @@
+{
+  "$resourceType": "tool",
+  "id": "3b37ac83-8e45-4f41-86ca-5b11b345dc04",
+  "type": "process",
+  "location": "external",
+  "name": "Count Sources",
+  "description": "Adds two integers together. Use this to count the total number of sources by summing the number of web search results and the number of web summary citations.",
+  "isEnabled": true,
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "a": {
+        "type": "integer",
+        "description": "First number (e.g. count of web search results)"
+      },
+      "b": {
+        "type": "integer",
+        "description": "Second number (e.g. count of web summary citations)"
+      }
+    },
+    "required": [
+      "a",
+      "b"
+    ]
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "sum": {
+        "type": "integer",
+        "description": "Total count (a + b)"
+      }
+    }
+  },
+  "settings": {},
+  "properties": {
+    "processName": "A_Plus_B",
+    "folderPath": "solution_folder",
+    "exampleCalls": []
+  },
+  "referenceKey": "3a53b879-c1f7-4041-ac33-cdb2ad2207eb",
+  "argumentProperties": {}
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/CreateJiraIssue/resource.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/CreateJiraIssue/resource.json
@@ -1,0 +1,139 @@
+{
+  "$resourceType": "tool",
+  "id": "95557466-99ca-4d30-b068-0f5152729710",
+  "type": "integration",
+  "location": "external",
+  "name": "Create Issue",
+  "description": "Create a Jira Task issue. Pass a nested 'fields' object containing: project.key (the Jira project key string), issuetype.id (always the string '3'), and summary (the issue title string).",
+  "isEnabled": true,
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "fields": {
+        "type": "object",
+        "title": "Fields",
+        "description": "Jira issue fields. Must contain: project.key, issuetype.id (always '3'), and summary.",
+        "properties": {
+          "project": {
+            "type": "object",
+            "properties": {
+              "key": {
+                "type": "string",
+                "description": "The Jira project key"
+              }
+            },
+            "required": [
+              "key"
+            ]
+          },
+          "issuetype": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Issue type ID. Always use '3' for Task.",
+                "enum": [
+                  "3"
+                ]
+              }
+            },
+            "required": [
+              "id"
+            ]
+          },
+          "summary": {
+            "type": "string",
+            "description": "The title/summary of the Jira issue"
+          }
+        },
+        "required": [
+          "project",
+          "issuetype",
+          "summary"
+        ]
+      }
+    },
+    "required": [
+      "fields"
+    ]
+  },
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "id": {
+        "title": "Issue ID",
+        "type": "string",
+        "description": "The ID of the issue"
+      },
+      "key": {
+        "title": "Issue key",
+        "type": "string",
+        "description": "The key of the issue"
+      },
+      "fields.issuetype.name": {
+        "title": "Issue type",
+        "type": "string",
+        "description": "The type of the created issue"
+      }
+    }
+  },
+  "iconUrl": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-atlassian-jira/image",
+  "settings": {},
+  "isPreview": false,
+  "properties": {
+    "toolPath": "/curated_create_issue",
+    "objectName": "curated_create_issue",
+    "toolDisplayName": "Create Issue",
+    "toolDescription": "Create a Jira Task issue. Pass a nested 'fields' object containing: project.key (the Jira project key string), issuetype.id (always the string '3'), and summary (the issue title string).",
+    "method": "POST",
+    "bodyStructure": {
+      "contentType": "json"
+    },
+    "connection": {
+      "id": "3d8b2ad9-ec99-429c-a993-6c6f3f238d1c",
+      "name": "andrei.petraru@uipath.com-uipath",
+      "elementInstanceId": 0,
+      "apiBaseUri": "",
+      "state": "enabled",
+      "isDefault": false,
+      "connector": {
+        "key": "uipath-atlassian-jira",
+        "name": "Jira",
+        "image": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-atlassian-jira/image",
+        "enabled": true
+      },
+      "folder": {
+        "key": "11451fd1-a693-44b9-b38d-5bc1a891dff0",
+        "path": "11451fd1-a693-44b9-b38d-5bc1a891dff0"
+      },
+      "solutionProperties": {
+        "resourceKey": "3d8b2ad9-ec99-429c-a993-6c6f3f238d1c"
+      }
+    },
+    "parameters": [
+      {
+        "name": "fields",
+        "displayName": "Fields",
+        "type": "object",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Jira issue fields (project.key, issuetype.id, summary)",
+        "position": "primary",
+        "sortOrder": 1,
+        "required": true,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      }
+    ]
+  },
+  "guardrail": {
+    "policies": []
+  },
+  "argumentProperties": {}
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/SendSlackMessage/resource.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/SendSlackMessage/resource.json
@@ -1,0 +1,253 @@
+{
+  "$resourceType": "tool",
+  "id": "62d07fbe-9d5a-415d-83cc-6fc711f17d90",
+  "type": "integration",
+  "location": "external",
+  "name": "Send message to channel",
+  "description": "Send a message to a Slack channel.",
+  "isEnabled": true,
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "channel": {
+        "type": "string",
+        "title": "Channel name/ID",
+        "description": "Channel name/ID"
+      },
+      "messageToSend": {
+        "type": "string",
+        "title": "Message",
+        "description": "This is the main text that people will see in the message. It's also used for notifications and in places where rich formatting isn't supported."
+      },
+      "username": {
+        "type": "string",
+        "title": "Bot name",
+        "description": "Bot name"
+      },
+      "mrkdwn": {
+        "type": "boolean",
+        "title": "Mrkdwn"
+      },
+      "unfurl_links": {
+        "type": "boolean",
+        "title": "Unfurl links",
+        "description": "Whether to display the preview of the links mentioned in the text message?"
+      },
+      "link_names": {
+        "type": "boolean",
+        "title": "Link names",
+        "description": "Whether to link and mention all the user groups automatically if the respective names are mentioned in the text message?"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "channel",
+      "messageToSend"
+    ]
+  },
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "ok": {
+        "title": "Ok",
+        "type": "boolean"
+      },
+      "channel": {
+        "title": "Channel name/ID",
+        "type": "string",
+        "description": "Channel name/ID"
+      },
+      "ts": {
+        "title": "Message timestamp",
+        "type": "string",
+        "description": "The ID (timestamp) of the message sent"
+      },
+      "message.text": {
+        "title": "Message text",
+        "type": "string"
+      }
+    }
+  },
+  "iconUrl": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-salesforce-slack/image",
+  "settings": {},
+  "isPreview": false,
+  "properties": {
+    "toolPath": "/send_message_to_channel_v2",
+    "objectName": "send_message_to_channel_v2",
+    "toolDisplayName": "Send message to channel",
+    "toolDescription": "Send a message to a Slack channel.",
+    "method": "POST",
+    "bodyStructure": {
+      "contentType": "json"
+    },
+    "connection": {
+      "id": "a9174bb6-e808-4330-b182-c8578bc100b1",
+      "name": "andrei.petraru",
+      "elementInstanceId": 0,
+      "apiBaseUri": "",
+      "state": "enabled",
+      "isDefault": false,
+      "connector": {
+        "key": "uipath-salesforce-slack",
+        "name": "Slack",
+        "image": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-salesforce-slack/image",
+        "enabled": true
+      },
+      "folder": {
+        "key": "11451fd1-a693-44b9-b38d-5bc1a891dff0",
+        "path": "11451fd1-a693-44b9-b38d-5bc1a891dff0"
+      },
+      "solutionProperties": {
+        "resourceKey": "a9174bb6-e808-4330-b182-c8578bc100b1"
+      }
+    },
+    "parameters": [
+      {
+        "name": "send_as",
+        "displayName": "Send as",
+        "type": "string",
+        "fieldLocation": "query",
+        "value": "bot",
+        "description": "Whether to send the message as the App bot i.e. using Bot token or yourself i.e. using User token?",
+        "position": "primary",
+        "sortOrder": 1,
+        "required": true,
+        "fieldVariant": "static",
+        "isCascading": false,
+        "dynamic": false,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": true,
+        "dynamicBehavior": [],
+        "reference": {
+          "objectName": "available_tokens",
+          "lookupNames": [
+            "name",
+            "value"
+          ],
+          "lookupValue": "value",
+          "path": "/available_tokens"
+        }
+      },
+      {
+        "name": "channel",
+        "displayName": "Channel name/ID",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Channel name/ID",
+        "position": "primary",
+        "sortOrder": 2,
+        "required": true,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": true,
+        "dynamicBehavior": [],
+        "reference": {
+          "objectName": "curated_channels?types=public_channel,private_channel",
+          "lookupNames": [
+            "name",
+            "id"
+          ],
+          "lookupValue": "id",
+          "path": "/curated_channels?fields=id,name"
+        }
+      },
+      {
+        "name": "messageToSend",
+        "displayName": "Message",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "This is the main text that people will see in the message. It's also used for notifications and in places where rich formatting isn't supported.",
+        "position": "primary",
+        "sortOrder": 3,
+        "required": true,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "username",
+        "displayName": "Bot name",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Bot name",
+        "position": "secondary",
+        "sortOrder": 4,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "mrkdwn",
+        "displayName": "Mrkdwn",
+        "type": "boolean",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "",
+        "position": "secondary",
+        "sortOrder": 5,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "unfurl_links",
+        "displayName": "Unfurl links",
+        "type": "boolean",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Whether to display the preview of the links mentioned in the text message?",
+        "position": "secondary",
+        "sortOrder": 6,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "link_names",
+        "displayName": "Link names",
+        "type": "boolean",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Whether to link and mention all the user groups automatically if the respective names are mentioned in the text message?",
+        "position": "secondary",
+        "sortOrder": 7,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      }
+    ]
+  },
+  "guardrail": {
+    "policies": []
+  }
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/WebSearch/resource.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/WebSearch/resource.json
@@ -1,0 +1,250 @@
+{
+  "$resourceType": "tool",
+  "id": "fd6d08f4-3833-4438-b55a-70f189b1c168",
+  "type": "integration",
+  "location": "external",
+  "name": "Web Search",
+  "description": "Web search executes a search of the public domain using a natural language search query. The search results are available in the output. Web search offers near-real time search results, but certain time sensitive data like stock prices or weather will not consistently be current. There could be a few days lag. Be sure to pass in date/time and/or location as arguments in the query if required.",
+  "isEnabled": true,
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "provider": {
+        "type": "string",
+        "title": "Search Engine",
+        "description": "The search engine to use",
+        "enum": [
+          "GoogleCustomSearch"
+        ],
+        "oneOf": [
+          {
+            "const": "GoogleCustomSearch",
+            "title": "GoogleCustomSearch"
+          }
+        ]
+      },
+      "query": {
+        "type": "string",
+        "title": "Search",
+        "description": "The natural language query to search the web for"
+      },
+      "num": {
+        "type": "integer",
+        "title": "Number of results",
+        "description": "The number of results. Default to 10."
+      },
+      "start": {
+        "type": "integer",
+        "title": "Start",
+        "description": "First result index (pagination)."
+      },
+      "siteSearch": {
+        "type": "string",
+        "title": "Site Search",
+        "description": "Restrict or exclude results for a domain."
+      },
+      "siteSearchFilter": {
+        "type": "string",
+        "title": "Site Search Filter",
+        "description": "Either \"i\" (include) or \"e\" (exclude)."
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "provider",
+      "query"
+    ]
+  },
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "formattedResults": {
+        "title": "FormattedResults",
+        "type": "string",
+        "description": "The search results string containing title, URL, and snippet"
+      },
+      "results[*]": {
+        "title": "Result title",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/results[*]"
+        }
+      }
+    },
+    "definitions": {
+      "results[*]": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "title": "Result title",
+            "type": "string",
+            "description": "The title of a search result item."
+          },
+          "snippet": {
+            "title": "Result snippet",
+            "type": "string",
+            "description": "A brief summary or excerpt of a search result item."
+          },
+          "url": {
+            "title": "Result url",
+            "type": "string",
+            "description": "The web address of the search result."
+          }
+        }
+      }
+    }
+  },
+  "iconUrl": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-uipath-airdk/image",
+  "settings": {},
+  "isPreview": false,
+  "properties": {
+    "toolPath": "/v2/webSearch",
+    "objectName": "v2::webSearch",
+    "toolDisplayName": "Web Search",
+    "toolDescription": "Web search executes a search of the public domain using a natural language search query. The search results are available in the output. Web search offers near-real time search results, but certain time sensitive data like stock prices or weather will not consistently be current. There could be a few days lag. Be sure to pass in date/time and/or location as arguments in the query if required.",
+    "method": "POST",
+    "bodyStructure": {
+      "contentType": "json"
+    },
+    "connection": {
+      "id": "d2e61ee5-6008-4162-8f54-eba948bbd5a0",
+      "name": "UiPath GenAI Activities",
+      "elementInstanceId": 0,
+      "apiBaseUri": "",
+      "state": "enabled",
+      "isDefault": false,
+      "connector": {
+        "key": "uipath-uipath-airdk",
+        "name": "UiPath GenAI Activities",
+        "image": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-uipath-airdk/image",
+        "enabled": true
+      },
+      "folder": {
+        "key": "284cd393-c966-4d00-84e6-8dadc432534f",
+        "path": "284cd393-c966-4d00-84e6-8dadc432534f"
+      },
+      "solutionProperties": {
+        "resourceKey": "d2e61ee5-6008-4162-8f54-eba948bbd5a0"
+      }
+    },
+    "parameters": [
+      {
+        "name": "provider",
+        "displayName": "Search Engine",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "GoogleCustomSearch",
+        "description": "The search engine to use",
+        "position": "primary",
+        "sortOrder": 1,
+        "required": true,
+        "fieldVariant": "static",
+        "isCascading": false,
+        "dynamic": false,
+        "enumValues": [
+          {
+            "name": "GoogleCustomSearch",
+            "value": "GoogleCustomSearch"
+          }
+        ],
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "query",
+        "displayName": "Search",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "The natural language query to search the web for",
+        "position": "primary",
+        "sortOrder": 2,
+        "required": true,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "num",
+        "displayName": "Number of results",
+        "type": "integer",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "The number of results. Default to 10.",
+        "position": "secondary",
+        "sortOrder": 3,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "start",
+        "displayName": "Start",
+        "type": "integer",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "First result index (pagination).",
+        "position": "secondary",
+        "sortOrder": 4,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "siteSearch",
+        "displayName": "Site Search",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Restrict or exclude results for a domain.",
+        "position": "secondary",
+        "sortOrder": 5,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "siteSearchFilter",
+        "displayName": "Site Search Filter",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "Either \"i\" (include) or \"e\" (exclude).",
+        "position": "secondary",
+        "sortOrder": 6,
+        "required": false,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      }
+    ]
+  },
+  "guardrail": {
+    "policies": []
+  }
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/WebSummary/resource.json
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingAgent/resources/WebSummary/resource.json
@@ -1,0 +1,142 @@
+{
+  "$resourceType": "tool",
+  "id": "dd86582a-758b-421e-a313-63baaa80288b",
+  "type": "integration",
+  "location": "external",
+  "name": "Web Summary",
+  "description": "Web summary executes a web search and returns an AI-generated summary of the results along with citation URLs.",
+  "isEnabled": true,
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "query": {
+        "type": "string",
+        "title": "Search",
+        "description": "The natural language query to search the web for"
+      },
+      "provider": {
+        "type": "string",
+        "title": "Search Engine",
+        "description": "The search engine to use.",
+        "enum": [
+          "Perplexity"
+        ],
+        "oneOf": [
+          {
+            "const": "Perplexity",
+            "title": "Perplexity"
+          }
+        ]
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+      "query",
+      "provider"
+    ]
+  },
+  "outputSchema": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "response": {
+        "title": "Search Summary",
+        "type": "string",
+        "description": "The summary of the web search results."
+      },
+      "citations[*]": {
+        "title": "Citations",
+        "type": "array",
+        "items": {
+          "$ref": "#/definitions/citations[*]"
+        }
+      }
+    },
+    "definitions": {
+      "citations[*]": {
+        "type": "string",
+        "description": "URLs used to generate the search results"
+      }
+    }
+  },
+  "iconUrl": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-uipath-airdk/image",
+  "settings": {},
+  "isPreview": false,
+  "properties": {
+    "toolPath": "/v1/webSummary",
+    "objectName": "v1::webSummary",
+    "toolDisplayName": "Web Summary",
+    "toolDescription": "Web summary executes a web search and returns an AI-generated summary of the results along with citation URLs.",
+    "method": "POST",
+    "bodyStructure": {
+      "contentType": "json"
+    },
+    "connection": {
+      "id": "d2e61ee5-6008-4162-8f54-eba948bbd5a0",
+      "name": "UiPath GenAI Activities",
+      "elementInstanceId": 0,
+      "apiBaseUri": "",
+      "state": "enabled",
+      "isDefault": false,
+      "connector": {
+        "key": "uipath-uipath-airdk",
+        "name": "UiPath GenAI Activities",
+        "image": "https://alpha.uipath.com/elements_/scaleunit_/3854d037-4ab5-4881-909b-968c433f6d88/v3/element/elements/uipath-uipath-airdk/image",
+        "enabled": true
+      },
+      "folder": {
+        "key": "284cd393-c966-4d00-84e6-8dadc432534f",
+        "path": "284cd393-c966-4d00-84e6-8dadc432534f"
+      },
+      "solutionProperties": {
+        "resourceKey": "d2e61ee5-6008-4162-8f54-eba948bbd5a0"
+      }
+    },
+    "parameters": [
+      {
+        "name": "query",
+        "displayName": "Search",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "{{prompt}}",
+        "description": "The natural language query to search the web for",
+        "position": "primary",
+        "sortOrder": 1,
+        "required": true,
+        "fieldVariant": "dynamic",
+        "isCascading": false,
+        "dynamic": true,
+        "enumValues": null,
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      },
+      {
+        "name": "provider",
+        "displayName": "Search Engine",
+        "type": "string",
+        "fieldLocation": "body",
+        "value": "Perplexity",
+        "description": "The search engine to use.",
+        "position": "primary",
+        "sortOrder": 2,
+        "required": true,
+        "fieldVariant": "static",
+        "isCascading": false,
+        "dynamic": false,
+        "enumValues": [
+          {
+            "name": "Perplexity",
+            "value": "Perplexity"
+          }
+        ],
+        "loadReferenceOptionsByDefault": null,
+        "dynamicBehavior": [],
+        "reference": null
+      }
+    ]
+  },
+  "guardrail": {
+    "policies": []
+  }
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingSolution.uipx
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/_fixtures/WebResearchBriefingSolutionMisconfigured/WebResearchBriefingSolution/WebResearchBriefingSolution.uipx
@@ -1,0 +1,12 @@
+{
+    "DocVersion": "1.0.0",
+    "StudioMinVersion": "2025.10.0",
+    "SolutionId": "11492cbe-4060-4b3a-5dc2-08dea85408fc",
+    "Projects": [
+        {
+            "Type": "Agent",
+            "ProjectRelativePath": "WebResearchBriefingAgent/project.uiproj",
+            "Id": "db439402-bc30-444e-83e3-b9795f9cdf1b"
+        }
+    ]
+}

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -7,11 +7,10 @@ description: >
   $selectorType, $actionType), PascalCase scope values, and a unique UUID.
 tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
 initial_prompt: |
-  Create a UiPath low-code agent "SafeAgent" that answers user questions. Add
-  a custom guardrail that blocks the word "CONFIDENTIAL" from appearing
-  in any agent or LLM output. The guardrail should use a word rule with
-  the "contains" operator and a block action with the reason "Forbidden
-  term detected." The solution should be named "GuardSol".
+  Create a UiPath low-code agent "SafeAgent" that answers user questions. Add a
+  guardrail that blocks any agent or LLM output containing the word
+  "CONFIDENTIAL", with the message "Forbidden term detected." The solution
+  should be named "GuardSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -63,12 +62,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "SafeAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -61,12 +61,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "DiscoverAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -19,12 +19,11 @@ agent:
 
 initial_prompt: |
   Create a UiPath low-code agent "ComplianceAgent" for handling user requests
-  about financial data. Add a guardrail that detects PII — specifically
-  email addresses and phone numbers — and instead of blocking, escalates
-  violations to a human reviewer via the deployed Action Center app whose
-  name contains "Guardrail.Escalation.Action.App" (match it even if the
-  deployed name carries a prefix or a version suffix such as ".2"),
-  notifying reviewer@example.com. The solution should be named "EscalateSol".
+  about financial data. Add a guardrail that watches for PII — email addresses
+  and phone numbers — and, instead of blocking, escalates flagged cases to a
+  human reviewer (notify reviewer@example.com) using our deployed
+  "Guardrail.Escalation.Action.App" Action Center app. The solution should be
+  named "EscalateSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -100,12 +99,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ComplianceAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
@@ -9,28 +9,10 @@ description: >
 tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "ReviewAgent" that handles compliance review
-  requests. Add a built-in PII detection guardrail that escalates
-  violations to a human reviewer instead of blocking. The solution
-  should be named "ValidationSol".
-
-  Guardrail requirements:
-  - validatorType: pii_detection
-  - Detect Email entities, threshold 0.5
-  - Scope: Agent level
-  - Action: use $actionType "escalate"
-  - Escalation app name: "EscalationWorksApp"
-  - Recipient email: reviewer@example.com (type 3)
-
-  Use path-based commands from the working directory (no cd required):
-    uip solution init "ValidationSol" --output json
-    uip agent init "ValidationSol/ReviewAgent" --output json
-    uip agent refresh "ValidationSol/ReviewAgent" --output json
-    uip agent guardrails list --output json
-    uip solution resources list --kind App --source remote --output json
-
-  You MUST validate the app's action schema before using it in the
-  escalate action. If the app does not have the required schema,
-  report the error and do NOT write the guardrail.
+  requests. Add a guardrail that watches for personal data (email addresses)
+  and, instead of blocking, escalates flagged cases to a human reviewer using
+  our "EscalationWorksApp" Action Center app. The solution should be named
+  "ValidationSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -8,13 +8,10 @@ description: >
   PascalCase scope values.
 tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
 initial_prompt: |
-  Create a UiPath low-code agent "PiiSafeAgent" that answers user questions
-  about their accounts. Add a built-in PII detection guardrail that
-  blocks Email and PhoneNumber entities in agent-level output. Use a
-  block action with reason "PII detected in output." The solution
-  should be named "PiiGuardSol".
-
-  Include entity thresholds of 0.5 for both Email and PhoneNumber.
+  Create a UiPath low-code agent "PiiSafeAgent" that answers user questions about
+  their accounts. Add a guardrail that blocks email addresses and phone numbers
+  in the agent's output — use a 0.5 threshold for each — with the message "PII
+  detected in output." The solution should be named "PiiGuardSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -66,12 +63,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "PiiSafeAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -7,10 +7,10 @@ description: >
   for the threshold parameter, and does not add it to PostExecution stage.
 tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
 initial_prompt: |
-  Create a UiPath low-code agent "InjSafeAgent" that answers user questions.
-  Add a built-in prompt injection detection guardrail with a threshold
-  of 0.5. Use a block action with reason "Prompt injection detected."
-  The solution should be named "InjGuardSol".
+  Create a UiPath low-code agent "InjSafeAgent" that answers user questions. Add
+  a guardrail that catches prompt-injection attempts (use a 0.5 threshold) and
+  blocks them with the message "Prompt injection detected." The solution should
+  be named "InjGuardSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -62,12 +62,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "InjSafeAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
@@ -1,9 +1,7 @@
 task_id: skill-agent-guardrail-validate
 description: >
-  Guardrail validation: a pre-built Web Research Briefing Agent is seeded with no guardrails.
-  Add a deliberately misconfigured harmful_content guardrail (harmfulContentEntityThresholds
-  has an extra key "Sexual" not in harmfulContentEntities), then use the skill to validate
-  and fix all issues. Verifies that the catalog is fetched, the misconfiguration is detected
+  Guardrail validation: a pre-built Web Research Briefing Agent is pre-seeded with a deliberately misconfigured harmful_content guardrail (harmfulContentEntityThresholds
+  has an extra key "Sexual" not in harmfulContentEntities). The agent must detect and fix it. Verifies that the catalog is fetched, the misconfiguration is detected
   and corrected, and the agent validates successfully after the fix.
 tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
 max_iterations: 1
@@ -11,61 +9,34 @@ max_iterations: 1
 sandbox:
   template_sources:
     - type: template_dir
-      path: ../_fixtures/WebResearchBriefingSolution
+      path: ../_fixtures/WebResearchBriefingSolutionMisconfigured
 
 initial_prompt: |
-  I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent.
-  I tried to add a harmful content guardrail but I'm not sure I got the configuration
-  right. Can you add the following guardrail exactly as-is (don't modify it yet), then
-  then fetch the guardrail catalog with `uip agent guardrails catalog` and the definitions
-  with `uip agent guardrails list`, run a validation, and fix any issues you find?
+  I added a harmful-content guardrail to my web research agent at
+  WebResearchBriefingSolution/WebResearchBriefingAgent, but I'm not sure I got
+  the configuration right — validation keeps complaining. Can you figure out
+  what's wrong with it and fix it so the agent validates cleanly?
 
-  {
-    "$guardrailType": "builtInValidator",
-    "id": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
-    "name": "Harmful content guardrail",
-    "description": "Blocks harmful content in agent outputs",
-    "validatorType": "harmful_content",
-    "validatorParameters": [
-      {
-        "$parameterType": "enum-list",
-        "id": "harmfulContentEntities",
-        "value": ["Hate", "SelfHarm"]
-      },
-      {
-        "$parameterType": "map-enum",
-        "id": "harmfulContentEntityThresholds",
-        "value": {
-          "Hate": 2,
-          "SelfHarm": 2,
-          "Sexual": 2
-        }
-      }
-    ],
-    "action": { "$actionType": "block", "reason": "Harmful content detected." },
-    "enabledForEvals": true,
-    "selector": { "scopes": ["Agent"] }
-  }
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
   implementation. Complete the entire task end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed
-    description: "Agent fetched the guardrail catalog"
+    description: "Advisory: agent fetched the guardrail catalog (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent fetched the guardrails list"
+    description: "Advisory: agent fetched the guardrails list (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+list'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
     description: "Agent refreshed the project to regenerate derived files"

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -15,11 +15,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "DocsFlow" that uses an inline low-code agent
-  to help users understand uploaded documents. Enable the built-in
-  "Analyze Files" tool on the inline agent so it can analyze PDF and
-  image attachments, and wire that tool in the flow. The solution
-  should be named "DocsFlowSol".
+  Create a UiPath Flow project "DocsFlow" that uses an inline low-code agent to
+  help users understand uploaded documents. Enable the built-in "Analyze Files"
+  tool on the inline agent so it can analyze PDF and image attachments. The
+  solution should be named "DocsFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -95,12 +94,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -15,16 +15,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "KnowledgeFlow" with an inline low-code agent
-  that accepts a required `question` (string) and returns a string
-  `answer`. It must ground its answers in the existing semantic index
-  named "UiPathAgentsProductKnowledge" that is already deployed in the
-  tenant (indexes always live outside the solution). The solution
-  should be named "KnowledgeFlowSol".
-
-  Use the real folder and index name from the tenant — do not
-  hard-code or guess these values. Name the agent's context resource
-  `UiPathAgentsProductKnowledge` (matching the index).
+  Create a UiPath Flow project "KnowledgeFlow" that runs an inline low-code
+  agent which answers a user's `question` (string) and returns an `answer`
+  (string). It should base its answers on our existing
+  "UiPathAgentsProductKnowledge" knowledge index — which is already set up in
+  our tenant — instead of answering from general knowledge. Wire it into the
+  flow. The solution should be named "KnowledgeFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -116,12 +112,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -15,16 +15,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "OutreachFlow" with an inline low-code agent
-  that accepts a required `subject` (string) and returns a string
-  `content`. It must compose the content by delegating to an agent
-  named "EmailDrafter" that is already deployed in the tenant — not by
-  drafting the email itself. The solution should be named
-  "OutreachFlowSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `EmailDrafter` (matching the deployed agent).
+  Create a UiPath Flow project "OutreachFlow" that runs an inline low-code
+  agent which takes a required `subject` (string) and returns a string
+  `content`. The agent shouldn't write the email itself — the draft should
+  come from our existing "EmailDrafter" agent, which is already deployed in our
+  tenant. Wire it into the flow. The solution should be named "OutreachFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -116,12 +111,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -14,16 +14,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "WeatherFlow" with an inline low-code agent
-  that accepts a required `location` (string) and returns a number
-  `temperature`. It must compute the temperature using an API workflow
-  named "WeatherAPI" that is already deployed in the tenant — not by
-  reasoning about the answer itself. The solution should be named
+  Create a UiPath Flow project "WeatherFlow" that runs an inline low-code agent
+  which takes a required `location` (string) and returns a number
+  `temperature`. The agent shouldn't figure out the temperature itself — the
+  value should come from our existing "WeatherAPI" workflow, which is already
+  deployed in our tenant. Wire it into the flow. The solution should be named
   "WeatherFlowSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `WeatherAPI` (matching the process).
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -115,12 +111,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -16,12 +16,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "FraudFlow" that uses an inline low-code agent
-  to triage transactions and escalate uncertain cases to an EXISTING
-  EXTERNAL ActionCenter app named "FraudEscalation" already
-  deployed to the Orchestrator "Shared" folder (not inside this
-  solution). Wire the escalation as a resource on the inline agent.
-  The solution should be named "FraudFlowSol".
+  Create a UiPath Flow project "FraudFlow" that runs an inline low-code agent
+  which triages transactions and, when it isn't confident, escalates the case to
+  a human reviewer through our existing "FraudEscalation" Action Center app —
+  it's already running in Orchestrator, not part of this solution. Wire that
+  into the flow. The solution should be named "FraudFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -53,12 +52,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent searched the flow registry for the escalation node manifest"
+    description: "Advisory: agent searched the flow registry for the escalation node (informational, non-gating — the escalation node key is fixed, so the agent may fetch it directly)"
     tool_name: "Bash"
     command_pattern: 'uip\s+maestro\s+flow\s+registry\s+search\b'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
     description: "Agent fetched the escalation node manifest from the flow registry"
@@ -105,12 +104,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -15,12 +15,16 @@ run_limits:
   expected_turns: 66
   turn_timeout: 1200
 
+# An agent left to itself often models "escalate to a human" as a human-in-the-loop
+# flow node — fine in general, but this task specifically exercises the agent
+# Escalation capability, so the prompt asks for it explicitly.
 initial_prompt: |
   Create a UiPath Flow project "FraudFlow" that runs an inline low-code agent
   which triages transactions and, when it isn't confident, escalates the case to
   a human reviewer through our existing "FraudEscalation" Action Center app —
-  it's already running in Orchestrator, not part of this solution. Wire that
-  into the flow. The solution should be named "FraudFlowSol".
+  it's already running in Orchestrator, not part of this solution. Set this up
+  using the agent's Escalation capability, wired into the flow — not a standalone human-in-the-loop node. The
+  solution should be named "FraudFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -15,16 +15,12 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "ProcurementFlow" with an inline low-code agent
-  that accepts a required `productId` (number) and returns a boolean
-  `status`. It must determine the status by delegating to an Agentic
-  process named "ProcurementProcess" that is already deployed in the
-  tenant — not by reasoning about the answer itself. The solution
-  should be named "ProcurementFlowSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `ProcurementProcess` (matching the deployed process).
+  Create a UiPath Flow project "ProcurementFlow" that runs an inline low-code
+  agent which takes a required `productId` (number) and returns a boolean
+  `status`. The agent shouldn't decide the status itself — it should come from
+  our existing "ProcurementProcess" agentic process, which is already deployed
+  in our tenant. Wire it into the flow. The solution should be named
+  "ProcurementFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -116,12 +112,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -14,16 +14,11 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "FibonacciFlow" with an inline low-code agent
-  that accepts a required `index` (number) and returns a number
-  `value`. It must compute the value using a process named
-  "FibonacciRPA" that is already deployed in the tenant — not by
-  reasoning about the answer itself. The solution should be named
-  "FibonacciFlowSol".
-
-  Use the real folder and process name from the tenant — do not
-  hard-code or guess these values. Name the agent's tool resource
-  `FibonacciRPA` (matching the process).
+  Create a UiPath Flow project "FibonacciFlow" that runs an inline low-code
+  agent which takes a required `index` (number) and returns a number `value`.
+  The agent shouldn't compute the value itself — it should come from our
+  existing "FibonacciRPA" process, which is already deployed in our tenant.
+  Wire it into the flow. The solution should be named "FibonacciFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -115,12 +110,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
@@ -69,12 +69,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -19,16 +19,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "ResearchFlow" that uses an inline low-code
-  agent to search the web using the "WebSearch" activity from the
-  UiPath GenAI Activities Integration Service connector (connector key
-  `uipath-uipath-airdk`). Wire the Integration Service activity as a
-  tool on the inline agent via the flow canvas, update the agent
-  bindings, and refresh the solution so the connection resource is
-  provisioned. Validate the inline agent. The solution should be named
-  "ResearchFlowSol".
-
-  Do NOT invoke the connector at runtime.
+  Create a UiPath Flow project "ResearchFlow" that runs an inline low-code
+  agent which can look things up on the web. Give the agent a tool so it can
+  run web searches on demand, and wire it into the flow. The solution should be
+  named "ResearchFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -96,12 +90,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -8,17 +8,18 @@ description: >
   the documented sparse shape, and that a `uipath.agent.resource.mcp.*`
   flow node is wired to the autonomous agent node's `tool` handle.
 tags: [uipath-agents, e2e-blocked, mode:build, low-code, inline-flow]
+skip: true
+# Skipped for now — wiring an inline MCP server tool into the flow is not yet
+# reliable on the run tenant. Re-enable once the inline MCP flow-node path works.
 
 run_limits:
   expected_turns: 77
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project "DevToolsFlow" that uses an inline low-code
-  agent connecting to an MCP server named "GitHubMcp" exposing
-  GitHub-related tools. Declare the MCP server as a resource on the
-  inline agent and wire it into the flow. The solution should be named
-  "DevToolsFlowSol".
+  Create a UiPath Flow project "DevToolsFlow" that runs an inline low-code agent
+  connected to our "GitHubMcp" MCP server so it can use that server's GitHub
+  tools. Wire it into the flow. The solution should be named "DevToolsFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -70,12 +71,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
@@ -46,12 +46,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent discovered the memory space with uip solution resources list --kind MemorySpace"
+    description: "Advisory: agent discovered the memory space with uip solution resources list --kind MemorySpace (informational, non-gating — the memory name + folder are given in the prompt)"
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+resources\s+list\b.*--kind\s+MemorySpace'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
     description: "Agent attached the memory space to the inline agent using uip agent memory add"
@@ -70,9 +70,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent refreshed the inline agent with --bindings-target"
+    description: "Agent refreshed the inline agent with --inline-in-flow (binding propagation to the parent flow is verified by the run_command; --bindings-target is auto-detected, so it isn't required explicitly)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+refresh\b(?=.*--inline-in-flow)(?=.*--bindings-target\s+\S*bindings_v2\.json)'
+    command_pattern: 'uip\s+agent\s+refresh\s+.*--inline-in-flow'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
@@ -13,25 +13,16 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "MemoryFlowSol" containing a flow project
-  "MemoryFlow" with an inline low-code agent. The agent accepts a
-  required `userQuestion` string and returns an `answer` string.
+  Create a UiPath solution "MemoryFlowSol" with a flow project "MemoryFlow"
+  that runs an inline low-code agent. The agent takes a required
+  `userQuestion` (string) and returns an `answer` (string).
 
-  Attach the existing UiPath memory space named
-  "UiPathAgentsSupportMemory" from the Orchestrator folder
-  "Shared/uipath-agents" as an inline agent memory feature named
-  `SupportRecall`. Enable dynamic few-shot retrieval with hybrid
-  search, threshold 0.25, result count 5, and field weighting
-  `userQuestion=1`.
-
-  Use the full low-code memory CLI workflow for memory features:
-  discover the memory space before attaching it and refresh solution
-  resources after migration, even though the memory name and folder
-  are provided. Memory spaces must live under the inline agent's
-  `features/` directory, not under `resources/`. After the flow graph
-  edits are complete, run inline validation and inline migration with
-  a bindings target so the memorySpace binding is propagated into the
-  parent flow project's `bindings_v2.json`.
+  The agent should get better over time by recalling past support cases. Give
+  it a memory called "SupportRecall" backed by our existing
+  "UiPathAgentsSupportMemory" memory space, which lives in our
+  "Shared/uipath-agents" Orchestrator folder. When the agent answers, it
+  should use hybrid search over the `userQuestion` field to pull back the 5
+  closest past cases, with a similarity threshold of 0.25.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -87,20 +78,20 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent refreshed solution resources after memory binding propagation"
+    description: "Advisory: agent refreshed solution resources (informational, non-gating — inline binding propagation happens via uip agent refresh --bindings-target, not solution resources refresh)"
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+resources\s+refresh'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_not_executed
     description: "Agent must not hand-author memory feature JSON with shell redirection"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -23,14 +23,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath Flow project named "OrchestratorFlow" inside the
-  existing "OrchestratorFlowSol" solution (in the current directory). The
-  flow must use an inline low-code agent that delegates to the existing
-  "ToolAgent" agent already in that solution — wire ToolAgent in as a tool
-  the inline agent can call.
-
-  Reuse ToolAgent as-is — do NOT re-create it, and do NOT re-initialize
-  the solution.
+  Create a new UiPath Flow project named "OrchestratorFlow" inside the existing
+  "OrchestratorFlowSol" solution (in the current directory). Its inline low-code
+  agent should get its work done by handing off to the existing "ToolAgent"
+  that's already in the solution, rather than doing it itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -146,12 +142,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -22,14 +22,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath Flow project named "ShippingFlow" inside the
-  existing "ShippingFlowSol" solution (in the current directory). The
-  flow must use an inline low-code agent that delegates to the existing
-  "CalculateShippingRate" API workflow already in that solution — wire
-  CalculateShippingRate in as a tool the inline agent can call.
-
-  Reuse CalculateShippingRate as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath Flow project named "ShippingFlow" inside the existing
+  "ShippingFlowSol" solution (in the current directory). Its inline low-code
+  agent should get shipping rates from the existing "CalculateShippingRate" API
+  workflow that's already in the solution, rather than working them out itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -115,12 +111,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -20,12 +20,16 @@ pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/_fixtures/ReviewFlowSol ."
     timeout: 10
 
+# An agent left to itself often models "escalate to a human" as a human-in-the-loop
+# flow node — fine in general, but this task specifically exercises the agent
+# Escalation capability, so the prompt asks for it explicitly.
 initial_prompt: |
   Create a new UiPath Flow project named "ReviewFlow" inside the existing
   "ReviewFlowSol" solution (in the current directory). The flow must use
-  an inline low-code agent to moderate user content and escalate
-  uncertain cases to a human reviewer via a UiPath ActionCenter app
-  provisioned inside this same solution.
+  an inline low-code agent to moderate user content and escalate uncertain
+  cases to a human reviewer via a UiPath Action Center app in this same
+  solution. Set this up using the agent's Escalation capability, wired into the flow — not a standalone
+  human-in-the-loop node.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -25,11 +25,7 @@ initial_prompt: |
   "ReviewFlowSol" solution (in the current directory). The flow must use
   an inline low-code agent to moderate user content and escalate
   uncertain cases to a human reviewer via a UiPath ActionCenter app
-  provisioned inside this same solution. Wire the escalation as a
-  resource on the inline agent.
-
-  Reuse the existing solution structure — do NOT re-create
-  "ModerationAgent", and do NOT re-initialize the solution.
+  provisioned inside this same solution.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -92,12 +88,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -23,14 +23,11 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath Flow project named "OnboardingFlow" inside the
-  existing "OnboardingFlowSol" solution (in the current directory). The
-  flow must use an inline low-code agent that delegates to the existing
-  "EmployeeOnboarding" Agentic process already in that solution — wire
-  EmployeeOnboarding in as a tool the inline agent can call.
-
-  Reuse EmployeeOnboarding as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath Flow project named "OnboardingFlow" inside the existing
+  "OnboardingFlowSol" solution (in the current directory). Its inline low-code
+  agent should carry out onboarding by handing off to the existing
+  "EmployeeOnboarding" agentic process that's already in the solution, rather
+  than doing it itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -125,12 +122,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -22,14 +22,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath Flow project named "PayrollFlow" inside the
-  existing "PayrollFlowSol" solution (in the current directory). The
-  flow must use an inline low-code agent that delegates to the existing
-  "CalculatePay" RPA process already in that solution — wire CalculatePay
-  in as a tool the inline agent can call.
-
-  Reuse CalculatePay as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath Flow project named "PayrollFlow" inside the existing
+  "PayrollFlowSol" solution (in the current directory). Its inline low-code
+  agent should compute pay using the existing "CalculatePay" RPA process that's
+  already in the solution, rather than working it out itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -115,12 +111,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "Flow file was created"

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -17,15 +17,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "ResearchAgent" that can search the web using
-  the "WebSearch" activity from the UiPath GenAI Activities Integration
-  Service connector (connector key `uipath-uipath-airdk`). Expose the
-  activity to the agent as an Integration Service tool. Update the
-  agent's bindings and refresh the solution so the connection resource
-  is provisioned. Validate the agent project. The solution should be
-  named "ResearchSol".
-
-  Do NOT invoke the connector at runtime.
+  Create a UiPath low-code agent "ResearchAgent" that can look things up on the
+  web. Give it a tool so it can run web searches on demand. The solution should
+  be named "ResearchSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -93,12 +87,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ResearchAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/check_mcp_server_tool.py
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/check_mcp_server_tool.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """MCP server resource check.
 
-Validates resources/orchestrator/resource.json declares the UiPath
-Orchestrator MCP server reference in the authoritative shape
+Validates that an MCP server resource for the UiPath Orchestrator MCP server is
+authored under DevAssistantAgent/resources/ in the authoritative shape
 (agents-storage-schemas `mcpStorageSchemaV16`):
   - $resourceType == "mcp"  (not "tool" — MCP is a distinct resource type)
-  - name == "orchestrator"  (the resource is named after the MCP server itself,
-    matching its folder; the job-subset lives in availableTools, not the name)
+  - name is a non-empty string. The resource name is the agent's choice (the
+    job-subset lives in availableTools, not the name), so it is NOT pinned to a
+    specific value — we locate the resource by $resourceType, not by folder name.
   - description is a non-empty string
   - id is a UUID-shaped non-empty string (agent-local id)
   - slug is a non-empty string (the AgentHub server slug)
@@ -26,16 +27,25 @@ import sys
 from pathlib import Path
 
 ROOT = Path(os.getcwd()) / "DevToolsSol" / "DevAssistantAgent"
-RESOURCE = ROOT / "resources" / "orchestrator" / "resource.json"
+RESOURCES = ROOT / "resources"
 
 
-def load(path: Path) -> dict:
-    if not path.is_file():
-        sys.exit(f"FAIL: Missing {path}")
-    try:
-        return json.loads(path.read_text())
-    except json.JSONDecodeError as e:
-        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+def find_mcp_resource() -> dict:
+    if not RESOURCES.is_dir():
+        sys.exit(
+            f"FAIL: {RESOURCES} does not exist — the agent authored no MCP resource"
+        )
+    for path in sorted(RESOURCES.rglob("resource.json")):
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if data.get("$resourceType") == "mcp":
+            print(f"OK: found MCP resource at {path.relative_to(ROOT.parent)}")
+            return data
+    sys.exit(
+        f'FAIL: no MCP resource ($resourceType=="mcp") found under {RESOURCES}'
+    )
 
 
 def require_nonempty_str(resource: dict, field: str) -> str:
@@ -51,13 +61,8 @@ def assert_mcp_resource(resource: dict) -> None:
         sys.exit(
             f'FAIL: $resourceType should be "mcp" (distinct from "tool"), got {rtype!r}'
         )
-    name = resource.get("name")
-    if name != "orchestrator":
-        sys.exit(
-            f'FAIL: MCP resource name should be "orchestrator" (named after the '
-            f"MCP server itself, matching its folder), got {name!r}"
-        )
 
+    name = require_nonempty_str(resource, "name")
     require_nonempty_str(resource, "description")
     require_nonempty_str(resource, "slug")
     require_nonempty_str(resource, "folderPath")
@@ -89,14 +94,14 @@ def assert_mcp_resource(resource: dict) -> None:
             )
 
     print(
-        f'OK: resource.json is $resourceType="mcp", name="orchestrator", id={rid}, '
+        f'OK: resource.json is $resourceType="mcp", name={name!r}, id={rid}, '
         f'slug={resource.get("slug")!r}, folderPath={resource.get("folderPath")!r}, '
-        f'resourceKey present, availableTools list present ({len(tools)} selected)'
+        f"resourceKey present, availableTools list present ({len(tools)} selected)"
     )
 
 
 def main() -> None:
-    resource = load(RESOURCE)
+    resource = find_mcp_resource()
     assert_mcp_resource(resource)
 
 

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
@@ -13,11 +13,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "DevAssistantAgent" that connects to the
-  UiPath Orchestrator MCP server to manage Orchestrator jobs (start, list,
-  inspect, stop, restart). Declare the MCP server as a resource on the agent,
-  naming the resource after the server itself ("orchestrator"), and select the
-  job-related tools. The solution should be named "DevToolsSol".
+  Create a UiPath low-code agent "DevAssistantAgent" that can manage Orchestrator
+  jobs — start, list, inspect, stop, restart — through our UiPath Orchestrator
+  MCP server. Connect the agent to that server and give it the job-related
+  tools. The solution should be named "DevToolsSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -69,23 +68,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "DevAssistantAgent/agent.json was created"
     path: "DevToolsSol/DevAssistantAgent/agent.json"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "orchestrator MCP resource.json was created (named after the server)"
-    path: "DevToolsSol/DevAssistantAgent/resources/orchestrator/resource.json"
-    weight: 2.5
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-agents/lowcode/memory_space/check_memory_space.py
+++ b/tests/tasks/uipath-agents/lowcode/memory_space/check_memory_space.py
@@ -4,9 +4,11 @@
 Validates:
   1. features/SupportRecall/feature.json declares a CLI-managed
      memorySpace feature for the expected tenant memory space and folder.
-  2. Dynamic few-shot retrieval uses the requested settings and weights
-     the `userQuestion` input field.
-  3. The requested episodic seed item and JSON metadata are present.
+  2. Dynamic few-shot retrieval uses the requested hybrid search, result
+     count, and similarity threshold, weighting the `userQuestion` field.
+  3. A starter memory item was seeded (matched loosely by content — the
+     prompt describes the example in plain language, so ids/metadata/memory
+     type are left to the agent and not asserted).
   4. agent.json schemas stay synchronized with entry-points.json.
   5. bindings_v2.json contains a generated memorySpace binding with
      the expected name and folderPath.
@@ -27,12 +29,6 @@ BUILDER = ROOT / ".agent-builder" / "agent.json"
 EXPECTED_FEATURE_NAME = "SupportRecall"
 EXPECTED_MEMORY_SPACE = "UiPathAgentsSupportMemory"
 EXPECTED_FOLDER_PATH = "Shared/uipath-agents"
-EXPECTED_ITEM_KEY = "refund-policy-tone"
-EXPECTED_FEEDBACK_ID = "d640fe25-3c05-4f2e-bd8d-42bdb20704c1"
-EXPECTED_ITEM_VALUE = (
-    "Use empathetic wording and cite the remembered support precedent "
-    "when a refund case resembles a prior escalation."
-)
 
 
 def load(path: Path) -> dict:
@@ -135,22 +131,15 @@ def assert_dynamic_few_shot(feature: dict) -> None:
 
 def assert_seed_item(feature: dict) -> None:
     items = feature.get("items")
-    if not isinstance(items, list):
-        sys.exit(f"FAIL: feature items must be a list, got {items!r}")
-    matches = [i for i in items if isinstance(i, dict) and i.get("key") == EXPECTED_ITEM_KEY]
-    if len(matches) != 1:
-        sys.exit(f"FAIL: expected exactly one item keyed {EXPECTED_ITEM_KEY!r}, got {len(matches)}")
-    item = matches[0]
-    if item.get("value") != EXPECTED_ITEM_VALUE:
-        sys.exit(f"FAIL: seed item value mismatch: {item.get('value')!r}")
-    if item.get("memoryType") not in (0, "episodic"):
-        sys.exit(f"FAIL: seed item memoryType should be episodic/0, got {item.get('memoryType')!r}")
-    if item.get("feedbackId") != EXPECTED_FEEDBACK_ID:
-        sys.exit(f"FAIL: seed item feedbackId should be {EXPECTED_FEEDBACK_ID!r}, got {item.get('feedbackId')!r}")
-    metadata = item.get("metadata")
-    if metadata != {"source": "seed", "scenario": "support"}:
-        sys.exit(f"FAIL: seed item metadata mismatch: {metadata!r}")
-    print("OK: episodic seed item, feedbackId, and metadata are present")
+    if not isinstance(items, list) or not items:
+        sys.exit(f"FAIL: feature must contain at least one seeded item, got {items!r}")
+    values = [i.get("value", "") for i in items if isinstance(i, dict)]
+    # The prompt describes the starter example in plain language ("a refund
+    # case that looks like a past escalation"); match on that gist rather than
+    # an exact string, and don't assert key/feedbackId/memoryType/metadata.
+    if not any(isinstance(v, str) and "refund" in v.lower() for v in values):
+        sys.exit(f"FAIL: expected a seeded item about the refund example, got {values!r}")
+    print("OK: a starter memory item about the refund example is present")
 
 
 def assert_memory_binding(bindings: dict) -> None:

--- a/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
@@ -1,10 +1,11 @@
 task_id: skill-agent-memory-space
 description: >
   End-to-end test: scaffold a standalone low-code agent that attaches
-  an existing UiPath Memory Space with `uip agent memory` and seeds an
-  episodic memory item. Verifies the CLI-managed
+  an existing UiPath Memory Space with `uip agent memory` and seeds a
+  starter memory item. Verifies the CLI-managed
   features/{FeatureName}/feature.json convention, dynamic few-shot
-  settings, seed item metadata, and generated memorySpace binding.
+  settings (result count + similarity threshold), the seeded item, and
+  the generated memorySpace binding.
 tags: [uipath-agents, e2e, mode:build, low-code, lifecycle:generate]
 
 run_limits:
@@ -12,31 +13,24 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath solution "MemorySol" containing a single low-code
-  agent "SupportMemoryAgent". The agent accepts a required
-  `userQuestion` string and returns an `answer` string.
+  Create a UiPath solution "MemorySol" with a single low-code agent
+  "SupportMemoryAgent". It takes a required `userQuestion` (string) and
+  returns an `answer` (string).
 
-  Attach the existing UiPath memory space named
-  "UiPathAgentsSupportMemory" from the Orchestrator folder
-  "Shared/uipath-agents" as an agent memory feature named
-  `SupportRecall`. Enable dynamic few-shot retrieval with hybrid
-  search, threshold 0.25, result count 5, and field weighting
-  `userQuestion=1`.
+  The agent should get better over time by recalling past support cases. Give
+  it a memory called "SupportRecall" backed by our existing
+  "UiPathAgentsSupportMemory" memory space, which lives in our
+  "Shared/uipath-agents" Orchestrator folder. When the agent answers, it
+  should use hybrid search over the `userQuestion` field to pull back the 5
+  closest past cases, with a similarity threshold of 0.25.
 
-  Add one seed memory item to `SupportRecall`: key
-  `refund-policy-tone`, value `Use empathetic wording and cite the
-  remembered support precedent when a refund case resembles a prior
-  escalation.`, memory type `episodic`, feedback ID
-  `d640fe25-3c05-4f2e-bd8d-42bdb20704c1`, and metadata
-  `{"source":"seed","scenario":"support"}`.
+  Seed SupportRecall with one starter example so it has something to recall
+  from the start: when a new refund case looks like a past escalation, the
+  agent should use empathetic wording and point back to the earlier case.
 
-  Use the full low-code memory CLI workflow for memory features:
-  discover the memory space before attaching it and refresh solution
-  resources after migration, even though the memory name and folder
-  are provided. Do not hand-create memory feature JSON. Do NOT
-  publish, upload, or deploy. Do NOT ask for approval, confirmation,
-  or feedback. Do NOT pause between planning and implementation.
-  Complete the entire task end-to-end in a single pass.
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation,
+  or feedback. Do NOT pause between planning and implementation. Complete the
+  entire task end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed
@@ -72,9 +66,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent seeded the episodic memory item using uip agent memory item add"
+    description: "Agent seeded a starter memory item using uip agent memory item add"
     tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+memory\s+item\s+add\s+SupportRecall\s+refund-policy-tone\b(?=.*--memory-type\s+episodic)(?=.*--feedback-id\s+d640fe25-3c05-4f2e-bd8d-42bdb20704c1)'
+    command_pattern: 'uip\s+agent\s+memory\s+item\s+add\s+SupportRecall\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -104,12 +98,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_not_executed
     description: "Agent must not hand-author memory feature JSON with shell redirection"
@@ -154,7 +148,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Memory feature shape, seed item, schema sync, and memorySpace binding"
+    description: "Memory feature shape, dynamic few-shot settings, seeded item, schema sync, and memorySpace binding"
     command: "python3 $TASK_DIR/check_memory_space.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -92,12 +92,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ResolutionDrafterAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -39,12 +39,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Schema sync, prompt-matching schemas, and user message inlines {{input.userQuery}}"

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
@@ -21,13 +21,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath low-code agent named "ParentAgent" inside the
-  existing "OrchestratorSol" solution (in the current directory), and wire
-  the existing "ToolAgent" agent already in that solution in as a tool that
-  ParentAgent can call.
-
-  Reuse ToolAgent as-is — do NOT re-create it, and do NOT re-initialize
-  the solution.
+  Create a new UiPath low-code agent named "ParentAgent" inside the existing
+  "OrchestratorSol" solution (in the current directory). ParentAgent should get
+  its work done by handing off to the existing "ToolAgent" that's already in
+  the solution, rather than doing it itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -111,12 +108,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ParentAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -19,13 +19,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath low-code agent named "ShippingAgent" inside the
-  existing "ShippingSol" solution (in the current directory), and wire
-  the existing "CalculateShippingRate" API workflow already in that
-  solution in as a tool that ShippingAgent can call.
-
-  Reuse CalculateShippingRate as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath low-code agent named "ShippingAgent" inside the existing
+  "ShippingSol" solution (in the current directory). ShippingAgent should get
+  shipping rates from the existing "CalculateShippingRate" API workflow that's
+  already in the solution, rather than working them out itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -105,12 +102,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "ShippingAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -20,14 +20,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Add a "HumanReview" escalation resource to the existing "ModerationAgent"
-  agent inside the existing "ReviewSol" solution (in the current directory).
-  When the agent is uncertain, it must be able to escalate to a human
-  reviewer via UiPath ActionCenter. Set `isEnabled` to true so the
-  escalation is active for the agent.
-
-  Reuse ModerationAgent as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Add a "HumanReview" escalation to the existing "ModerationAgent" agent inside
+  the existing "ReviewSol" solution (in the current directory). When the agent
+  is uncertain, it should be able to escalate to a human reviewer via UiPath
+  Action Center.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -81,12 +77,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "HumanReview escalation resource.json was created"

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -19,13 +19,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath low-code agent named "OnboardingAgent" inside the
-  existing "OnboardingSol" solution (in the current directory), and wire
-  the existing "EmployeeOnboarding" Agentic process already in that
-  solution in as a tool that OnboardingAgent can call.
-
-  Reuse EmployeeOnboarding as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath low-code agent named "OnboardingAgent" inside the existing
+  "OnboardingSol" solution (in the current directory). OnboardingAgent should
+  carry out onboarding by handing off to the existing "EmployeeOnboarding"
+  agentic process that's already in the solution, rather than doing it itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -110,12 +107,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "OnboardingAgent/agent.json was created"

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
@@ -18,13 +18,10 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  Create a new UiPath low-code agent named "PayrollAgent" inside the
-  existing "PayrollSol" solution (in the current directory), and wire
-  the existing "CalculatePay" RPA process already in that solution in
-  as a tool that PayrollAgent can call.
-
-  Reuse CalculatePay as-is — do NOT re-create it, and do NOT
-  re-initialize the solution.
+  Create a new UiPath low-code agent named "PayrollAgent" inside the existing
+  "PayrollSol" solution (in the current directory). PayrollAgent should compute
+  pay using the existing "CalculatePay" RPA process that's already in the
+  solution, rather than working it out itself.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and
@@ -100,12 +97,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: file_exists
     description: "PayrollAgent/agent.json was created"


### PR DESCRIPTION
Rewrites the low-code `uipath-agents` coder-eval task prompts to read like real customer/developer requests instead of spoon-feeding `uip` commands, JSON keys, and internal names — so passing the eval means the agent used the skill, not transcribed the prompt (per the [Confluence review](https://uipath.atlassian.net/wiki/spaces/CA/pages/90805731553)).

- 39 task prompts rewritten to customer voice. Config a user would actually supply (thresholds, resource names, I/O schemas) is kept **and** asserted; internals the user wouldn't know (folders discovery resolves, JSON keys, connector keys) are removed.
- Graders: `--output json` made advisory (non-gating); a few redundant process checks relaxed where the outcome already covers them. Outcome checks unchanged; original weights kept.
- `guardrails/validate`: the misconfigured guardrail is pre-staged in a fixture instead of pasted into the prompt.
- Skill docs: teach inline agents to also wire the escalation / built-in-tool flow node, and make escalation `isEnabled` a required field.
- `inline_mcp_server_tool` skipped (inline agent MCP tool support not yet finalized in flow); 
- `cleanup_solutions.py` now passes `--yes` to the delete.

Runs:

Run with all touched tests: https://github.com/UiPath/skills/actions/runs/27544228401 31/38
Run with remaining tests fixed: https://github.com/UiPath/skills/actions/runs/27598319746 7/7