### PR TITLE
test(uipath-test): accept equivalent CLI cmds in 2 evals [TMHUB-32103]

### DIFF
--- a/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
+++ b/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
@@ -73,9 +73,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent retrieved execution history (`executions list --project-key` + `--output json`)"
+    description: "Agent retrieved execution history — either `executions list --project-key` or the per-test-case `testcases list-result-history --project-key` (both with `--output json`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+executions\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+executions\s+list\s+.*--output\s+json.*--project-key|uip\s+tm\s+testcases\s+list-result-history\s+.*--project-key.*--output\s+json|uip\s+tm\s+testcases\s+list-result-history\s+.*--output\s+json.*--project-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
+++ b/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
@@ -49,9 +49,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete list command: `uip tm requirements list --project-key HEALTH --labels eval-export --output json`"
+    description: "List HEALTH requirements carrying the eval-export label, server-side — either `uip tm requirements list --project-key HEALTH --labels eval-export --output json` or the equivalent `uip tm objectlabel list --project-key HEALTH --object-type Requirement --filter eval-export --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--labels\s+["\x27]?eval-export)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+list\s'
+    command_pattern: '(?:(?=.*--project-key\s+HEALTH)(?=.*--labels\s+["\x27]?eval-export)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+list\s)|(?:(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+Requirement)(?=.*(?:--filter|--labels)\s+["\x27]?eval-export)(?=.*--output\s+json)uip\s+tm\s+objectlabel\s+list\b)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
Relaxes two command_executed criteria so an equally valid, skill-documented CLI command validates the same intent (testcases list-result-history ∥ executions list; objectlabel list --filter ∥ requirements list --labels). Validated via coder_eval's CommandExecutedChecker against recorded agent commands — both criteria 1.00. Jira: https://uipath.atlassian.net/browse/TMHUB-32103