### PR TITLE
fix(uipath-troubleshoot): rename stale 'or processes edit' mock to canonical 'update'

### DIFF
--- a/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/fixtures/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/fixtures/mocks/responses/manifest.json
@@ -11,8 +11,8 @@
       "file": "or-jobs-help-2-1-uip-or-processes-help.json"
     },
     {
-      "match": "or processes edit --help",
-      "file": "or-processes-edit-help.json"
+      "match": "or processes update --help",
+      "file": "or-processes-update-help.json"
     },
     {
       "match": "or jobs start --help",

--- a/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/fixtures/mocks/responses/or-processes-update-help.json
+++ b/tests/tasks/uipath-troubleshoot/rpa-selector-healing-disabled/fixtures/mocks/responses/or-processes-update-help.json
@@ -2,9 +2,9 @@
   "Result": "Success",
   "Code": "Help",
   "Data": {
-    "Command": "edit",
-    "Description": "Edit process settings by key (GUID). No folder needed — resolves cross-folder. Only provided fields are updated (PATCH). Use 'processes get' to see current values.",
-    "Usage": "uip or processes edit [options] <process-key>",
+    "Command": "update",
+    "Description": "Update process settings by key (GUID). No folder needed — resolves cross-folder. Only provided fields are updated (PATCH). Use 'processes get' to see current values.",
+    "Usage": "uip or processes update [options] <process-key>",
     "Arguments": [
       {
         "Name": "process-key",
@@ -93,9 +93,9 @@
     "Examples": [
       {
         "Description": "Change a process description",
-        "Command": "uip or processes edit c3d4e5f6-0000-0000-0000-000000000001 --description \"Monthly invoice batch\"",
+        "Command": "uip or processes update c3d4e5f6-0000-0000-0000-000000000001 --description \"Monthly invoice batch\"",
         "Output": {
-          "Code": "ProcessEdited",
+          "Code": "ProcessUpdated",
           "Data": {
             "Key": "c3d4e5f6-0000-0000-0000-000000000001",
             "Name": "InvoiceProcessing",


### PR DESCRIPTION
## Problem

The shared smoke task `skill-troubleshoot-smoke-manifest-commands` (a `pre_run` gate with `fail_on_error: true`) walks **every** troubleshoot scenario's manifest and validates each mocked `uip` command against the installed CLI. It aborts the task with `status=ERROR` on the first command the CLI no longer enumerates.

It is currently failing repo-wide on a single rule:

```
[BAD] or processes edit [--help]  -- 'edit' is not a subcommand of 'uip or processes'
      rpa-selector-healing-disabled: rule 2
```

The CLI renamed `or processes edit` → `or processes update` (`edit` kept only as a legacy alias that `--help` no longer enumerates — confirmed in `orchestrator-tool/src/commands/processes.ts`: `.command("update").alias("edit")`, and in the regenerated catalog for build `1.197.0-alpha.20260615.7527`). CI installs `@uipath/cli@latest` (the alpha line), so its `or processes` listing has `update`, not `edit`. Local stable `1.196.0` still shows `edit`, which is why the verifier passes locally but fails in CI.

## Impact

Because the gate walks all manifests, this one stale rule fails the **Run skill smoke tests** required check on **every open `uipath-troubleshoot` PR** (#1463 #1462 #1461 #1420 #1419 #1418 #1417 #1359 #1358 #1357 #1356). A re-run does not help — it is deterministic. Fixing it here on `main` unblocks all of them.

## Fix

In `rpa-selector-healing-disabled`'s manifest, rename the mock rule `or processes edit --help` → `or processes update --help` (canonical name), rename its canned response file, and update the response's `Command`/`Usage`/`Description`/example to match. No other scenario references the removed verb.

The fix is verified by this PR's own smoke check (which runs the alpha CLI).