### PR TITLE
fix(uipath-troubleshoot): drop brittle version-mismatch exclude in healing-agent-no-license task

### DIFF
--- a/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
@@ -65,13 +65,13 @@ success_criteria:
       - "Allowed.AgentService"
       - "LicensedFeatures"
     # Excludes target false-positive conclusions that should NEVER appear as
-    # the chosen root cause. "pool exhausted" / "Test Heals" are intentionally
-    # NOT excluded — they appear legitimately in `to_eliminate` when the agent
-    # discriminates cause #1 from causes #7 / Test-Heals branch.
+    # the chosen root cause. "pool exhausted" / "Test Heals" / "version mismatch"
+    # are intentionally NOT excluded — they appear legitimately in `to_eliminate`
+    # when the agent discriminates cause #1 from causes #7 / Test-Heals /
+    # package-version-mismatch branches (a flat substring scan cannot tell a
+    # chosen root cause from a correctly eliminated one).
     excludes:
-      - "Attended StudioPro is not HA-eligible"
       - "package corruption"
-      - "version mismatch"
     weight: 1.0
 
   - type: command_executed


### PR DESCRIPTION
## What
Prune two brittle/fabricated phrases from the `excludes` list of the `hypotheses.json` `file_contains` criterion in the `healing-agent-no-license` faithful-replay task:

- `"version mismatch"` — caused the nightly failure (below).
- `"Attended StudioPro is not HA-eligible"` — fabricated never-correct conclusion that contradicts the playbook.

## Why — `"version mismatch"`
In nightly run `2026-06-16_04-04-06` the task was marked **FAILURE** at **0.986** despite a correct diagnosis (`llm_judge` = 1.0, all `command_executed` = 1.0, `skill_triggered` = 1.0). The only failing criterion was this `file_contains` (0.83 < 0.90 threshold): the agent's `hypotheses.json` contained `"version mismatch"` — but only inside `"package-version mismatch"`, in eliminating reasoning where the agent *correctly ruled that cause out*. `file_contains` excludes is a flat whole-file substring scan; it cannot distinguish a forbidden *conclusion* from a correctly *eliminated* alternative. The author already exempted `"pool exhausted"` / `"Test Heals"` for this exact reason — `"version mismatch"` was simply missed.

## Why — `"Attended StudioPro is not HA-eligible"`
Not from any playbook — a grep across `skills/` and `tests/tasks/` finds it only in this task. It's the **opposite** of what `healing-agent-no-license.md` states: runtime type (Attended/Unattended, `RuntimeType`) does **not** gate HA eligibility — only the tenant entitlement and the release `ProcessType` do (playbook lines 39, 50, 62). So it's a fabricated trap phrase already covered by the weight-3.0 `llm_judge`.

Remaining exclude: `"package corruption"` (also fabricated; left in place for now). The weight-3.0 `llm_judge` remains the real guard against a wrong diagnosis, so real coverage is unchanged.

## Validation
Run Coder Eval [#27604997077](https://github.com/UiPath/skills/actions/runs/27604997077) → **SUCCESS**, `1/1 PASS` (validated the `"version mismatch"` removal; the `"Attended StudioPro"` removal strictly shrinks the never-matching exclude set and cannot change the result).