### PR TITLE
docs: add rpa-tool object-repository read commands to CLI reference

### DIFF
--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -174,12 +174,13 @@ Read the project's UI **Object Repository** — the saved hierarchy of applicati
 
   | Parameter | Required | Description |
   |-----------|----------|-------------|
-  | `--library-paths` | yes | Absolute path(s) to the library `.nupkg` file(s) to read. Repeatable, one path per occurrence. |
+  | `--library-paths` | yes | Absolute path(s) to the library `.nupkg` file(s) to read. Pass a single flag with the paths **comma-separated** (e.g. `"a.nupkg,b.nupkg"`) — it is not a repeatable flag. Avoid paths containing commas. |
 
   ```bash
+  # multiple libraries: one --library-paths flag, comma-separated
   uip rpa object-repository get-library \
     --project-dir "<PROJECT_DIR>" \
-    --library-paths "C:\libs\Acme.UiLib.1.2.0.nupkg" \
+    --library-paths "C:\libs\Acme.UiLib.1.2.0.nupkg,C:\libs\Other.UiLib.2.0.0.nupkg" \
     --output json
   ```
 

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -160,6 +160,33 @@ Rules:
 
 ---
 
+## object-repository
+
+Read the project's UI **Object Repository** — the saved hierarchy of applications, screens, and elements (selectors/targets) that UI Automation activities bind to. Two read commands cover the project's own entries and those exposed by referenced libraries; both require an open project.
+
+- **Project Object Repository** — `uip rpa object-repository get` returns the project's *own* Object Repository as a JSON tree of applications → screens → elements. Entries inherited from referenced libraries are **excluded** (use the library command below for those). Takes no arguments beyond the standard `--project-dir`.
+
+  ```bash
+  uip rpa object-repository get --project-dir "<PROJECT_DIR>" --output json
+  ```
+
+- **Library Object Repository** — `uip rpa object-repository get-library` reads the Object Repository out of one or more library `.nupkg` files and returns the applications, screens, and elements grouped by library. Pass the absolute path(s) to the library packages; packages without an Object Repository are omitted from the result.
+
+  | Parameter | Required | Description |
+  |-----------|----------|-------------|
+  | `--library-paths` | yes | Absolute path(s) to the library `.nupkg` file(s) to read. Repeatable, one path per occurrence. |
+
+  ```bash
+  uip rpa object-repository get-library \
+    --project-dir "<PROJECT_DIR>" \
+    --library-paths "C:\libs\Acme.UiLib.1.2.0.nupkg" \
+    --output json
+  ```
+
+Read the project repository before authoring UI Automation activities to discover existing screens/elements to reuse instead of re-indicating them; read the library repository to discover targets a referenced UI library already exposes. Confirm the live verb names and flags with `uip rpa object-repository --help`.
+
+---
+
 ## Commands -- Data Fabric Entities
 
 UiPath Data Fabric entities live in the Orchestrator tenant's Data Service. To use them in an RPA project — as typed arguments (`UiPath.DataService.Activities`, test-data bindings) or any generated entity type — they must first be **installed** into the project, which writes a manifest under `.entities/` and compiles a strongly-typed assembly.
@@ -210,7 +237,7 @@ Diagnose by error category, apply the recovery, retry **once** — do not loop t
 |--------|-----|
 | **Explore project files** | `Glob` `**/*.xaml` |
 | **Search XAML content** | `Grep` regex across `.xaml` |
-| **Explore Object Repository** | `Glob` `**/*` under `{PROJECT_DIR}/.objects/` + `Read` metadata |
+| **Explore Object Repository** | `uip rpa object-repository get` for the project's apps/screens/elements as JSON, `uip rpa object-repository get-library` for a referenced library's (see [object-repository](#object-repository)); or `Glob` `**/*` under `{PROJECT_DIR}/.objects/` + `Read` metadata for raw files |
 | **Get JIT type definitions** | `Read` `{PROJECT_DIR}/.project/JitCustomTypesSchema.json` |
 | **Activity docs** | See [Installed package activity documentation](#installed-package-activity-documentation) above |
 | **Inspect a NuGet package's API** | `uip rpa packages inspect` — see [coded/inspect-package-guide.md](coded/inspect-package-guide.md) |

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -358,6 +358,8 @@ Read `<PROJECT_DIR>/.local/.codedworkflows/ObjectRepository.cs`. This file conta
 >
 > A pure-CLI flow with no Studio Desktop attached will not produce `ObjectRepository.cs`. Plan for a Studio Desktop step in any workflow that depends on `Descriptors.*`.
 
+When `ObjectRepository.cs` is missing or stale (see above), enumerate the project's registered apps/screens/elements as JSON with `uip rpa object-repository get` ([cli-reference.md § object-repository](cli-reference.md#object-repository)) — it reads the saved Object Repository without a Studio Desktop regen. Use it to confirm a screen/element exists before authoring; the strongly-typed `Descriptors.<App>.<Screen>.<Element>` reference still comes from `ObjectRepository.cs`.
+
 **Important:** Add the ObjectRepository using statement:
 ```csharp
 using <ProjectNamespace>.ObjectRepository;
@@ -366,6 +368,8 @@ using <ProjectNamespace>.ObjectRepository;
 #### Step 2 — Check UILibrary NuGet packages
 
 Look in `project.json` → `dependencies` for packages matching `*.UILibrary`, `*.ObjectRepository`, `*.Descriptors`, or `*.UIAutomation`. Inspect with `uip rpa packages inspect`.
+
+To list the apps/screens/elements a library actually exposes — not just its assembly API — read its Object Repository directly with `uip rpa object-repository get-library` ([cli-reference.md § object-repository](cli-reference.md#object-repository)), pointing at the library `.nupkg` path(s).
 
 For UILibrary packages, use the **package** namespace, not the project namespace:
 ```csharp


### PR DESCRIPTION
## Summary

Documents two new `rpa-tool` commands (added in UiPath/Studio PR #28085) in the uipath-rpa skill CLI reference:

- **`get-object-repository`** — reads the Object Repository of the currently open Studio **project** (its own apps/screens/elements as a JSON tree, excluding library-inherited entries).
- **`get-library-object-repository`** — reads the Object Repository exposed by one or more **library** `.nupkg` files, grouped by library. Requires `libraryPaths`.

## Changes

- `skills/uipath-rpa/references/cli-reference.md`:
  - New `## object-repository` section documenting both commands with parameters and usage examples, matching the existing per-verb section style.
  - Updated the "Explore Object Repository" row in the RPA discovery-tools table to point at the new CLI commands instead of only reading raw `.objects/` files.

## Notes

- Command/verb names were derived from Studio's `tool-names.ts` and `docs/commands.md`. The exact `uip rpa` verb spelling is documented with a `--help` pointer per this reference's "CLI is the source of truth" convention — worth confirming against a built CLI before relying on it.

## Related PR
https://github.com/UiPath/Studio/pull/28085

🤖 Generated with [Claude Code](https://claude.com/claude-code)