### PR TITLE
test(uipath-platform): fix consumables-summary command_pattern (--mode summary is default) [PLT-103133]

### DIFF
--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -18,9 +18,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform licenses consumables get --mode summary` with --output json"
+    description: "Agent ran `uip platform licenses consumables get` for a summary report (summary is the default --mode) with --output json"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+summary.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders)).*--output\s+json'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -2,8 +2,8 @@ task_id: skill-platform-licensing-consumables-summary
 description: >
   Smoke test: agent uses the uipath-platform skill to fetch a consumables
   summary report (default mode). Verifies the agent calls `uip platform
-  licenses consumables get --mode summary --output json`. CLI auth failure
-  is expected offline.
+  licenses consumables get --output json` (summary is the default `--mode`,
+  so the flag is optional). CLI auth failure is expected offline.
 tags: [uipath-platform, smoke, licensing, consumables]
 
 initial_prompt: |

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -24,3 +24,9 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
+
+  - type: skill_triggered
+    description: "Agent invoked the uipath-platform skill"
+    skill_name: "uipath-platform"
+    expected_skill: "uipath-platform"
+    weight: 1.0

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -51,9 +51,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran consumables get --mode summary"
+    description: "Agent ran consumables get for a summary (summary is the default --mode)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+summary.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders)).*--output\s+json'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Follow-up to #1387. On evalboard run `2026-06-16_04-04-06`, two licensing tasks failed for the **same single reason** — a too-strict `command_pattern`, not an environment or skill problem:

- `skill-platform-licensing-consumables-summary` → **FAILURE, score 0.000**
- `skill-platform-licensing-read-e2e` → **0.935** (every other criterion passed: users/groups commands, `file_exists`, the `licensing_check.py` validator with `Result: "Success"`, and `llm_judge` — only the consumables criterion scored 0)

### Root cause

Both asserted:
```
command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+summary.*--output\s+json'
```
This requires a literal `--mode summary`. But `summary` is the CLI's **default** mode, and the skill documents the summary call as `uip platform licenses consumables get --output json` (no `--mode`) — see `consumables-report.md:41`. So the agent ran exactly that, and the regex matched **0/1**.

Confirmed against the actual agent command in the run:
> `uip platform licenses consumables get --output json 2>&1`

### Fix

```
command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders)).*--output\s+json'
```

Matches the summary call whether the default is implicit or `--mode summary` is explicit (any flag order), while excluding `--mode daily|folders` via negative lookahead — those modes are covered by the dedicated `consumables_daily` / `consumables_folders` tasks.

Applied to both `consumables_summary.yaml` and the consumables step of `licensing_read_e2e.yaml`.

## Validation

- Both YAMLs parse.
- Regex verified against the real agent command (matches) and against `--mode daily` / `--mode folders` invocations (correctly excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Passing run

With the fixed pattern, the **Run skill smoke tests** check on this PR re-ran `skill-platform-licensing-consumables-summary` and it **passed**: `status=SUCCESS, score=1.000, 1/1 criteria` ([job](https://github.com/UiPath/skills/actions/runs/27616783489/job/81654643346)). The `read-e2e` task is `tier:e2e` (not selected by the smoke gate); its only failing criterion on run `2026-06-16_04-04-06` was this same consumables pattern, which the identical fix resolves.
