### PR TITLE
feat(uipath-admin): audit export as a folder of day-wise .json files (was ZIP)

### DIFF
--- a/skills/uipath-admin/SKILL.md
+++ b/skills/uipath-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-admin
-description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, ZIP or single-CSV exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
+description: "UiPath Admin via `uip admin` — Identity Server (users, groups, robot accounts, external OAuth2 apps, secrets), Authorization (custom roles, role assignments, permission catalog, effective-access via check-access PDP), OMS (org read/update, tenant lifecycle, service provisioning, regions, async operation polling), IP Restriction (allowlist, enforcement switch, bypass rules, lockout safety), Audit (event sources, paginated queries, day-wise-JSON-folder or single-CSV exports — login history, compliance dumps, who-did-what-when-where on a resource). For Orchestrator-specific roles/permissions/folders/jobs→uipath-platform. For RPA workflows→uipath-rpa."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -49,9 +49,9 @@ Administrative operations on UiPath via `uip admin` — Identity Server, Authori
 
 Activate on both **explicit audit requests** and **natural-language investigation intent** — users rarely say "audit events" by name.
 
-- **Explicit** — `uip admin audit` commands; list sources / targets / types; query, filter, paginate, or export events; CSV/ZIP dump of audit history for a window.
+- **Explicit** — `uip admin audit` commands; list sources / targets / types; query, filter, paginate, or export events; CSV or per-day-JSON dump of audit history for a window.
 - **Query audit events** — list event sources, filter events by source / target / type / user / status / time window at org or tenant scope
-- **Export audit events** — chunked download from the long-term store (one call per UTC day, atomic abort on any chunk failure) as a ZIP of day-wise JSON files (default) or a single merged CSV via `--file-format csv`
+- **Export audit events** — chunked download from the long-term store (one call per UTC day, atomic abort on any chunk failure) as a folder of day-wise JSON files (default) or a single merged CSV via `--file-format csv`
 - **Membership / license phrasings** — "who joined / left the organization", "who was made an admin", "license changes", "cross-tenant audit"
 - **Sign-in / authentication phrasings** — "failed/successful logins", "login history for user X", "who's been signing in"
 - **Tenant-activity phrasings** — "what happened on tenant X", "asset/queue/folder edits", "queue items processed", "job failures", "Action Center task changes", "Apps / AgentHub / Document Understanding / Integration Service / Test Manager activity"
@@ -107,7 +107,7 @@ Each rule is the agent contract. Per-area detail is in the linked reference file
 27. **Bound the time window, ISO 8601 in UTC.** Don't call `audit <scope> events` without `--from-date` and `--to-date` on a noisy tenant. Accepted formats: date-only (`2026-04-01`) or with time (`2026-04-01T14:30:00Z`). **`--to-date` is inclusive of the exact instant** — to capture a full final day, pass the start of the next day or `T23:59:59.999Z`.
 28. **`--tenant-id` is silently ignored on `org`-scoped audit commands.** If you find yourself reaching for it on `audit org events`, switch to `audit tenant` instead.
 29. **On 401 from audit, do NOT retry.** The token is missing the `Audit.Read` scope; tell the user to `uip logout && uip login`.
-30. **`audit <scope> export` writes a ZIP (default) or a single merged CSV from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are all required; dates per Rule 27. **`--file-format <zip|csv>`** selects the shape: `zip` (default) is one JSON file per UTC day; `csv` merges every event into one CSV — pick `csv` when the user wants a flat spreadsheet/Excel-friendly dump and `zip` for archival or per-day JSON. Match the `--output-file` extension to the format (`.zip` / `.csv`). **Never overwrite a path the user did not explicitly approve** — surface the resolved `--output-file` and confirm before running.
+30. **`audit <scope> export` writes a folder of day-wise JSON files (default) or a single merged CSV from the long-term store.** `--from-date`, `--to-date`, and `--output-file` are all required; dates per Rule 27. **`--file-format <json|csv>`** selects the shape: `json` (default) writes one `<YYYY-MM-DD>.json` file per UTC day into the `--output-file` **folder**; `csv` merges every event into one CSV file — pick `csv` when the user wants a flat spreadsheet/Excel-friendly dump and `json` for per-day files. For `json` give `--output-file` a folder path (no extension); for `csv` give it a `.csv` file path. **Never overwrite a path the user did not explicitly approve** — surface the resolved `--output-file` and confirm before running.
 
 ### IP Restriction
 

--- a/skills/uipath-admin/references/audit-commands.md
+++ b/skills/uipath-admin/references/audit-commands.md
@@ -26,7 +26,7 @@ uip admin audit
 |---|---|
 | `audit <scope> sources` | array of `AuditEventSourceDto` |
 | `audit <scope> events` | object `{auditEvents, next, previous}` |
-| `audit <scope> export` | object `{Path, Bytes, Format, Days, NonEmptyDays}` (+ `Events` when `--file-format csv`) |
+| `audit <scope> export` | object `{Path, Format, Bytes, Days, NonEmptyDays}` (+ `Files` for `json`, + `Events` for `--file-format csv`) |
 
 `events` is the one verb that legitimately returns an object — pagination cursors live alongside the rows. Full shape detail per verb in the sections below.
 
@@ -138,14 +138,14 @@ uip admin audit tenant events --from-date 2026-04-22T00:00:00Z --to-date 2026-04
 
 ## uip admin audit `<scope>` export
 
-Export the long-term audit store covering `[--from-date, --to-date]` — as a ZIP of day-wise JSON files (default) or a single merged CSV.
+Export the long-term audit store covering `[--from-date, --to-date]` — as a folder of day-wise JSON files (default) or a single merged CSV.
 
 ```bash
-# Default — ZIP of one JSON file per UTC day
+# Default (json) — a folder with one JSON file per UTC day
 uip admin audit tenant export \
   --from-date 2026-01-01 \
   --to-date 2026-02-01 \
-  --output-file ./audit-jan.zip \
+  --output-file ./audit-jan \
   --output json
 
 # Single merged CSV of every event
@@ -161,32 +161,33 @@ uip admin audit tenant export \
 
 | Flag | Required | Description |
 |---|---|---|
-| `--output-file <path>` | **yes** | Where to write the export. Parent dir is created if missing; existing file is overwritten. Resolved to absolute internally. Match the extension to `--file-format` (`.zip` / `.csv`). |
+| `--output-file <path>` | **yes** | Where to write the export. For `json` this is a **folder** (created if missing) that receives one JSON file per UTC day; for `csv` it is the output `.csv` file path. Existing files are overwritten; resolved to absolute internally. |
 | `--from-date <iso>` | **yes** | Start of time interval. Both bounds are required by Commander before any HTTP call. |
 | `--to-date <iso>` | **yes** | End of time interval. |
-| `--file-format <zip\|csv>` | no | Output shape. `zip` (default) = one JSON file per UTC day inside a ZIP. `csv` = every event merged into a single RFC 4180 CSV under a shared header. Invalid values fail before any HTTP call with `Invalid --file-format '<v>'. Use 'zip' or 'csv'.` |
+| `--file-format <json\|csv>` | no | Output shape. `json` (default) = a folder holding one `<YYYY-MM-DD>.json` file per UTC day. `csv` = every event merged into a single RFC 4180 CSV under a shared header. Invalid values fail before any HTTP call with `Invalid --file-format '<v>'. Use 'json' or 'csv'.` |
 | `--login-validity <minutes>` | no | Token-refresh hint. |
 | `--tenant-id <guid>` | no | **Tenant scope only.** Override the active tenant. |
 
 **Output `Code`:** `AuditOrgExport` / `AuditTenantExport`.
 
-**Output `Data`:** `Format` echoes the chosen `--file-format`. The CSV path adds `Events` (total rows written, excluding the header); the ZIP path omits it.
+**Output `Data`:** `Format` echoes the chosen `--file-format`. The `json` path reports `Files` (number of day-wise files written) and `Path` is the output **folder**; the `csv` path reports `Events` (total rows, excluding the header) and `Path` is the CSV file.
 
 ```json
-// --file-format zip (default)
+// --file-format json (default) — Path is the output folder
 {
-  "Path": "C:\\absolute\\path\\to\\audit-jan.zip",
+  "Path": "C:\\absolute\\path\\to\\audit-jan",
+  "Format": "json",
+  "Files": 27,
   "Bytes": 1841,
-  "Format": "zip",
   "Days": 31,
   "NonEmptyDays": 27
 }
 
-// --file-format csv
+// --file-format csv — Path is the CSV file
 {
   "Path": "C:\\absolute\\path\\to\\audit-jan.csv",
-  "Bytes": 98765,
   "Format": "csv",
+  "Bytes": 98765,
   "Days": 31,
   "NonEmptyDays": 27,
   "Events": 1234
@@ -196,10 +197,10 @@ uip admin audit tenant export \
 **Implementation notes (worth knowing for diagnostic conversations):**
 
 - Both formats share the same fetch: the CLI issues **one HTTP call per UTC day** inside `[from, to]` and aggregates the per-day responses. Mirrors the `audit-dowload-from-longterm-store.sh` pattern in the AuditService repo.
-- **ZIP (default):** per-day entries land at the **root of the output ZIP** named `<YYYY-MM-DD>.txt` (no folder prefix). Each `.txt` is a JSON array of events with PascalCase keys (`Id`, `CreatedOn`, `EventType`, …).
+- **JSON (default):** one file per UTC day is written into the `--output-file` **folder**, named `<YYYY-MM-DD>.json` (nested-ZIP entries from the server are flattened to `<inner>_<outer>.json`; same-name collisions get an iso-day suffix). The server names the per-day payloads `.txt`; the CLI writes them with a `.json` extension since each is a JSON array of events with PascalCase keys (`Id`, `CreatedOn`, `EventType`, …). Entry names are validated as safe basenames and confirmed to resolve inside the folder before any write (no path traversal / Zip-Slip).
 - **CSV:** the same per-day JSON arrays are parsed and merged into **one** RFC 4180 CSV (CRLF line endings, header row first). Columns follow the long-term-store field order — `Id, CreatedOn, OrganizationId, TenantId, ActorId, ActorName, ActorEmail, ActorDetails, EventType, EventSource, EventTarget, EventDetails, Status, ClientInfo` — with any extra server fields appended (union across events) so no data is dropped. `Status` is the numeric enum (`0`=Success, `1`=Failure); nested objects (e.g. `ClientInfo`) are JSON-stringified into the cell. String cells beginning with `= + - @` (or TAB/CR) are prefixed with a single quote to neutralize spreadsheet formula injection.
-- On any single-day HTTP failure (or, for CSV, a day whose payload is not valid JSON), **no file is written** and the error message identifies which day failed. Earlier successful chunks are not preserved (atomic export).
-- `Days` reports the total number of UTC days requested; `NonEmptyDays` reports how many actually had data. A long export with `NonEmptyDays: 0` means the window was entirely idle, not that the export failed. For CSV, `Events: 0` yields a header-only file.
+- On any single-day HTTP failure (or, for CSV, a day whose payload is not valid JSON), **nothing is written** — for `json` the output folder isn't even created — and the error message identifies which day failed. Earlier successful chunks are not preserved (atomic export).
+- `Days` reports the total number of UTC days requested; `NonEmptyDays` reports how many actually had data. A long export with `NonEmptyDays: 0` means the window was entirely idle, not that the export failed. For `json`, `Files` counts the day-wise files written; for `csv`, `Events: 0` yields a header-only file.
 
 ---
 
@@ -209,7 +210,7 @@ These appear on every command (not just audit) — set at the program level by t
 
 | Flag | Description |
 |---|---|
-| `--output <table\|json\|yaml\|plain>` | Format of the success/failure envelope on stdout. Defaults to `json`. The export file body (ZIP or CSV) is unaffected — `--output` only controls the metadata envelope, NOT `--file-format`. |
+| `--output <table\|json\|yaml\|plain>` | Format of the success/failure envelope on stdout. Defaults to `json`. The exported files (the per-day JSON folder, or the CSV) are unaffected — `--output` only controls the metadata envelope, NOT `--file-format`. |
 | `--output-filter <jmespath>` | JMESPath query applied to the envelope before printing. Useful for `events`/`sources`. Less useful for `export` (envelope is small). |
 | `--log-level <debug\|info\|warn\|error>` | Logger threshold. Logs go to stderr. |
 | `--log-file <path>` | Redirect logs from stderr to a file. |

--- a/skills/uipath-admin/references/audit-workflow-guide.md
+++ b/skills/uipath-admin/references/audit-workflow-guide.md
@@ -172,9 +172,9 @@ For each event:
 
 ## Investigation 3 — "Give me an audit dump for January"
 
-**User asks:** "Export everything for compliance for Q4." / "I need the full audit log for January for the security review." / "Pull last month's events for tenant X as a ZIP."
+**User asks:** "Export everything for compliance for Q4." / "I need the full audit log for January for the security review." / "Pull last month's events for tenant X as JSON files."
 
-**Approach:** `export` straight to a file. Default is a ZIP of day-wise JSON files; add `--file-format csv` for a single merged CSV when the user wants a flat, spreadsheet/Excel-friendly dump. No need to query `events` first unless the user wants a preview. Match the `--output-file` extension to the format (`.zip` / `.csv`).
+**Approach:** `export` straight to disk. Default (`json`) writes a **folder** of day-wise JSON files; add `--file-format csv` for a single merged CSV when the user wants a flat, spreadsheet/Excel-friendly dump. No need to query `events` first unless the user wants a preview. Give `--output-file` a folder path (no extension) for `json`, or a `.csv` path for `csv`.
 
 ### Step 1 — Confirm scope and window
 
@@ -183,11 +183,11 @@ If the user is ambiguous about scope, ask once. For compliance reviews, **both**
 ### Step 2 — Export
 
 ```bash
-# Tenant scope — most events (default ZIP of day-wise JSON files)
+# Tenant scope — most events (default json: a folder of day-wise JSON files)
 uip admin audit tenant export \
   --from-date 2026-01-01 \
   --to-date   2026-02-01 \
-  --output-file ./audit-tenant-2026-01.zip \
+  --output-file ./audit-tenant-2026-01 \
   --output json
 
 # Tenant scope as a single merged CSV (flat, Excel-friendly)
@@ -202,31 +202,31 @@ uip admin audit tenant export \
 uip admin audit org export \
   --from-date 2026-01-01 \
   --to-date   2026-02-01 \
-  --output-file ./audit-org-2026-01.zip \
+  --output-file ./audit-org-2026-01 \
   --output json
 ```
 
-The CLI issues one HTTP call per UTC day under the hood. ZIP aggregates the daily responses into a flat ZIP; CSV parses the same daily JSON and merges every event into one CSV. `Days` and `NonEmptyDays` in the result tell you how many calendar days had data; for CSV, `Events` reports the total row count.
+The CLI issues one HTTP call per UTC day under the hood. `json` writes one JSON file per UTC day into the output folder; `csv` parses the same daily JSON and merges every event into one CSV. `Days` and `NonEmptyDays` in the result tell you how many calendar days had data; `json` reports `Files` (files written) and `csv` reports `Events` (total rows).
 
 ### Step 3 — Verify the export
 
-**ZIP** — list the per-day entries:
+**JSON (default)** — list the folder's per-day files:
 
 ```bash
-unzip -l ./audit-tenant-2026-01.zip
+ls ./audit-tenant-2026-01
 ```
 
-Typical layout (one entry per UTC day with events):
+Typical layout (one file per UTC day with events):
 
 ```
-audit-tenant-2026-01.zip
-├── 2026-01-01.txt
-├── 2026-01-02.txt
+audit-tenant-2026-01/
+├── 2026-01-01.json
+├── 2026-01-02.json
 ├── ...
-└── 2026-01-31.txt
+└── 2026-01-31.json
 ```
 
-Each `.txt` is a JSON array of audit events with **PascalCase** keys (`Id`, `CreatedOn`, `OrganizationId`, `ActorId`, `ActorName`, `EventType`, …) — different from the camelCase shape returned by the live `events` endpoint. Note this in the user's hand-off if they're going to feed the dump into other tooling.
+Each `.json` file is a JSON array of audit events with **PascalCase** keys (`Id`, `CreatedOn`, `OrganizationId`, `ActorId`, `ActorName`, `EventType`, …) — different from the camelCase shape returned by the live `events` endpoint. Note this in the user's hand-off if they're going to feed the dump into other tooling.
 
 **CSV** — inspect the header and row count:
 
@@ -235,12 +235,12 @@ head -1 ./audit-tenant-2026-01.csv          # shared header (PascalCase columns)
 python3 -c "import csv; print(sum(1 for _ in csv.reader(open('./audit-tenant-2026-01.csv'))) - 1, 'rows')"
 ```
 
-One header row, then every event across all days as a data row (same PascalCase column names as the ZIP's JSON keys). The row count should match `Events` in the result envelope.
+One header row, then every event across all days as a data row (same PascalCase column names as the JSON files' keys). The row count should match `Events` in the result envelope.
 
 Edge cases the CLI handles automatically — surface in your hand-off only if they appear:
 
-- **Nested ZIPs**: when a single day's response is itself a ZIP-of-ZIPs, inner files are renamed `<inner>_<outer>.txt` rather than collapsed.
-- **Same-name collisions**: duplicate basenames across days get an `_<YYYY-MM-DD>` suffix (and `_<YYYY-MM-DD>_2`, `_3`, … if needed) to keep entries unique.
+- **Nested ZIPs**: when a single day's server response is itself a ZIP-of-ZIPs, inner files are flattened into the folder as `<inner>_<outer>.json` rather than collapsed.
+- **Same-name collisions**: duplicate basenames across days get an `_<YYYY-MM-DD>` suffix (and `_<YYYY-MM-DD>_2`, `_3`, … if needed) to keep filenames unique.
 
 ### Step 4 — Hand off
 
@@ -291,7 +291,7 @@ If the user wants more depth on any one event type, drill in with Investigation 
 |---|---|
 | "who" / "did" + a verb on a resource | **1** — Who did X to Y |
 | "logged in" / "login" / "authenticated" / a user's email | **2** — Login history |
-| "export" / "dump" / "ZIP" / "CSV" / a date range | **3** — Date-range dump |
+| "export" / "dump" / "JSON" / "CSV" / a date range | **3** — Date-range dump |
 | "overview" / "what's happening" / "recent activity" / "audit summary" | **4** — Overview |
 
 Two or more signals? Run them in sequence and stitch the results in the final report. Don't make the user re-ask.
@@ -301,14 +301,14 @@ Two or more signals? Run them in sequence and stitch the results in the final re
 - **`tenant` events without an active tenant fail loudly.** If `uip login` has no tenant selected, every tenant-scoped command throws. Either re-`uip login` and pick a tenant, or pass `--tenant-id <guid>` on every call.
 - **`events` cursor pagination is chronologically reversed from intuition.** `next` = newer (often null), `previous` = older (the typical "load more"). The CLI tool follows `previous` automatically when you bump `--limit > 200` — don't re-implement this in the agent.
 - **Date-only ISO strings are interpreted as UTC midnight.** `--from-date 2026-01-01` means `2026-01-01T00:00:00Z`. To capture the full final day in `--to-date`, use `2026-02-01` (exclusive next day) or `2026-01-31T23:59:59.999Z`.
-- **Export format depends on `--file-format`.** The default `zip` holds one **JSON** file per UTC day (not CSV) with **PascalCase** keys; `--file-format csv` produces a single merged **CSV** whose header uses those same PascalCase field names. Both differ from the camelCase live `events` endpoint — don't paste an export into a parser expecting the live shape. In the CSV, `Status` is numeric (`0`/`1`) and `ClientInfo` is a JSON-stringified cell.
+- **Export format depends on `--file-format`.** The default `json` writes one **JSON** file per UTC day (named `<YYYY-MM-DD>.json`) into the `--output-file` **folder**, with **PascalCase** keys; `--file-format csv` produces a single merged **CSV** whose header uses those same PascalCase field names. Both differ from the camelCase live `events` endpoint — don't paste an export into a parser expecting the live shape. In the CSV, `Status` is numeric (`0`/`1`) and `ClientInfo` is a JSON-stringified cell.
 - **Org sources and tenant sources are different sets.** Don't reuse a GUID from `org sources` in a `tenant events` query — the filter will silently match nothing.
 
 ## Output Etiquette — after an audit query or export
 
 After every `events` or `export` call, surface the following before waiting for the user's next-step choice. Do not chain mutations.
 
-1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days`, `Wrote 123,456 bytes to /path/to/audit.zip (3 days, 2 non-empty)`, or for CSV `Wrote 98,765 bytes to /path/to/audit.csv (1,234 events across 3 days, 2 non-empty)`.
+1. **Operation & result** — e.g. `Found 47 audit events on tenant T in the last 7 days`, `Wrote 27 JSON files (123,456 bytes) to /path/to/audit-jan/ (31 days, 27 non-empty)`, or for CSV `Wrote 98,765 bytes to /path/to/audit.csv (1,234 events across 31 days, 27 non-empty)`.
 2. **Scope used** (`org` or `tenant`) and any `--tenant-id` override.
 3. **Time window** — explicit ISO bounds, even if they came from a relative phrase ("last 7 days").
 4. **Filters applied** — sources, types, users, status.

--- a/tests/tasks/uipath-admin/audit_export_basic_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_export_basic_smoke.yaml
@@ -15,9 +15,9 @@ run_limits:
   expected_turns: 5
 
 initial_prompt: |
-  An admin needs a ZIP of all tenant audit events from yesterday for
-  archival. Write the ZIP to ./audit-yesterday.zip in the current
-  working directory.
+  An admin needs all tenant audit events from yesterday exported as
+  day-wise JSON files for archival. Write them to the ./audit-yesterday
+  folder in the current working directory.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
@@ -38,9 +38,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent's export targeted the requested ./audit-yesterday.zip path"
+    description: "Agent's export targeted the requested ./audit-yesterday folder (json default; no .zip/.csv extension)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b.*--output-file\s+\.?/?audit-yesterday\.zip'
+    # Match the audit-yesterday folder path; the negative lookahead rejects a .zip/.csv
+    # file (the retired ZIP shape) so this confirms the json-folder default is used.
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b.*--output-file\s+\S*audit-yesterday(?![\w.])'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
@@ -7,11 +7,11 @@ description: >
   (c) every data row has the same column count as the header.
 
   This is the CSV counterpart to `audit_export_verify_e2e.yaml` (which
-  validates the default ZIP). The underlying long-term-store data is the
-  same; this task asserts the CSV-specific serialization is correct
-  (single merged file, shared header, aligned rows). The format-agnostic
-  "export IDs are a subset of live events" fidelity check is already
-  covered by the ZIP verify task and is not duplicated here.
+  validates the default json folder). The underlying long-term-store data
+  is the same; this task asserts the CSV-specific serialization is correct
+  (single merged file, shared header, aligned rows). The per-day file
+  structure is already covered by the json folder verify task and is not
+  duplicated here.
 
   Whole-day granularity note: `uip admin audit ... export` issues one
   HTTP call per UTC day inside [--from-date, --to-date]. For CSV those
@@ -32,7 +32,8 @@ tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 initial_prompt: |
   Export tenant audit events for the 3-day window from 5 days ago
   through 2 days ago (UTC, whole days) to ./audit-window.csv in the
-  current working directory, as a single merged CSV (not a ZIP).
+  current working directory, as a single merged CSV (not the default
+  per-day JSON folder).
   Resolve the dates with `date -u -d '5 days ago' +%Y-%m-%d` and
   `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the run
   date.

--- a/tests/tasks/uipath-admin/audit_export_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_e2e.yaml
@@ -2,9 +2,9 @@ task_id: skill-admin-audit-export-e2e
 description: >
   End-to-end skill-guided evaluation: agent uses the uipath-admin skill
   to drive a complete investigation — discover sources, query events
-  in a window, then export the same window to a ZIP. Validates the
-  full sources → events → export chain plus the export's required
-  --from-date / --to-date / --output-file flags.
+  in a window, then export the same window as day-wise JSON files.
+  Validates the full sources → events → export chain plus the export's
+  required --from-date / --to-date / --output-file flags.
 
   Platform note: commands fail with auth errors in this environment.
   E2e tests still validate the CLI invocation surface — the agent must
@@ -19,9 +19,9 @@ initial_prompt: |
     1. See what audit event sources are visible (so they know what's
        being captured).
     2. Get a quick preview of the most recent events for context.
-    3. Get the entire 7-day window as a ZIP for offline review.
+    3. Get the entire 7-day window as day-wise JSON files for offline review.
 
-  Output the ZIP to ./audit-last-7d.zip in the current working
+  Output them to the ./audit-last-7d folder in the current working
   directory.
 
   Do NOT ask for approval, confirmation, or feedback.
@@ -60,11 +60,11 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  # 4. export written to the requested path
+  # 4. export written to the requested folder (json default; no .zip/.csv extension)
   - type: command_executed
-    description: "Agent's export targeted ./audit-last-7d.zip"
+    description: "Agent's export targeted the ./audit-last-7d folder"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b.*--output-file\s+\S*audit-last-7d\.zip'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b.*--output-file\s+\S*audit-last-7d(?![\w.])'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
@@ -1,10 +1,10 @@
 task_id: skill-admin-audit-export-verify-e2e
 description: >
-  End-to-end test (artifact verification tier): agent drives
-  `uip admin audit tenant export` to produce a real ZIP, then verifies
-  (a) the ZIP exists, (b) it contains at least one daily .txt file,
-  (c) the event IDs inside the export are a subset of what the live
-  `events` API returns for the same whole-day window.
+  End-to-end test (artifact verification tier): agent drives the default
+  `uip admin audit tenant export` (json) to produce a real folder of
+  day-wise JSON files, then verifies (a) the output folder exists, and
+  (b) each per-day file is a JSON array whose events use the documented
+  PascalCase schema.
 
   Unlike the command-construction e2e (`audit_export_e2e.yaml`), this
   task asserts real artifact correctness against the test tenant
@@ -12,85 +12,78 @@ description: >
   + UIPATH_CLI_ORG/TENANT_*).
 
   Whole-day granularity note: `uip admin audit ... export` issues one
-  HTTP call per UTC day inside [--from-date, --to-date] and produces
-  one .txt per day. The `events` API takes timestamp-precise bounds,
-  so to compare the same window the events query must use
-  `T00:00:00Z` / `T23:59:59.999Z` boundaries that bracket the export's
-  per-day files.
+  HTTP call per UTC day inside [--from-date, --to-date] and writes one
+  <YYYY-MM-DD>.json JSON file per day into the output folder.
 
   LTS lag note: the export reads from the long-term store, which lags
-  the live `events` endpoint. We pin the comparison window to dates at
-  least 48h in the past so LTS has caught up. Assertion direction is
-  "export IDs ⊆ events IDs" — events is the more complete set.
+  the live `events` endpoint. We pin the window to dates at least 48h in
+  the past so LTS has caught up.
 
-  Blocker: this task requires `uip admin audit` to exist in the
-  published `@uipath/cli` (UiPath/cli#1372 must ship + publish first).
-  Until then it will fail at the export step with `unknown command
-  'audit'`.
+  Blocker: this task requires the json-folder export behavior in the
+  published `@uipath/cli` (UiPath/cli#2534 must ship + publish, on top of
+  #1372 which adds `uip admin audit`). Until then the default export
+  still emits the older single-file shape and the folder assertions fail.
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
 initial_prompt: |
   Export tenant audit events for the 3-day window from 5 days ago
-  through 2 days ago (UTC, whole days) to ./audit-window.zip in the
-  current working directory. Resolve the dates with
-  `date -u -d '5 days ago' +%Y-%m-%d` and `date -u -d '2 days ago' +%Y-%m-%d`
-  so the window slides with the run date.
+  through 2 days ago (UTC, whole days) as day-wise JSON files into the
+  ./audit-window folder in the current working directory. Resolve the
+  dates with `date -u -d '5 days ago' +%Y-%m-%d` and
+  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the run
+  date.
 
   Important:
-  - The `uip` CLI is available and connected via env-var auth to a
-    real tenant. The export should produce a real ZIP file at the
+  - The `uip` CLI is available and connected via env-var auth to a real
+    tenant. The export should produce a real folder of JSON files at the
     requested path.
   - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
-    bounds (no inline `T00:00:00Z` for these flags — the CLI treats
-    them as whole-day boundaries).
-  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer so
-    the export is comparable against the live events endpoint.
+    bounds (no inline `T00:00:00Z` for these flags — the CLI treats them
+    as whole-day boundaries). json is the default format; `--output-file`
+    is the destination folder.
+  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked tenant export with bounded window + --output-file"
+    description: "Agent invoked tenant export with bounded window + --output-file folder"
     tool_name: "Bash"
     command_pattern: 'uip\s+admin\s+audit\s+tenant\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Export produced ./audit-window.zip"
-    path: "./audit-window.zip"
+  - type: run_command
+    description: "Export produced the ./audit-window folder (a directory, not a file)"
+    command: |
+      python3 -c "
+      import os, sys
+      assert os.path.isdir('./audit-window'), './audit-window is not a directory'
+      names = os.listdir('./audit-window')
+      print(f'OK: output folder exists with {len(names)} file(s)')
+      "
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Export is a valid ZIP (zero or more .txt entries — an empty zip is acceptable for a quiet tenant)"
+    description: "Folder contains well-formed events: each per-day .json file is a JSON array; events use the documented PascalCase schema (empty window acceptable for a quiet tenant)"
     command: |
       python3 -c "
-      import sys, zipfile
-      assert zipfile.is_zipfile('./audit-window.zip'), 'not a valid zip'
-      names = zipfile.ZipFile('./audit-window.zip').namelist()
-      print(f'OK: {len(names)} entries')
-      "
-    timeout: 10
-    expected_exit_code: 0
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "Export contains well-formed events: each per-day file is a JSON array; events use the documented PascalCase schema"
-    command: |
-      python3 -c "
-      import json, sys, zipfile
+      import json, os, sys
       REQUIRED = ['Id','CreatedOn','OrganizationId','ActorId','EventType','EventSource','EventTarget']
-      z = zipfile.ZipFile('./audit-window.zip')
-      txt_files = [n for n in z.namelist() if n.endswith('.txt')]
-      if not txt_files:
+      d = './audit-window'
+      assert os.path.isdir(d), f'{d} is not a directory'
+      day_files = [f for f in os.listdir(d) if f.endswith('.json')]
+      if not day_files:
           print('OK: export window is empty (no per-day files) — structural assertion trivially holds')
           sys.exit(0)
       sample = None
       total = 0
-      for name in txt_files:
-          data = json.loads(z.read(name))
+      for name in day_files:
+          with open(os.path.join(d, name), encoding='utf-8-sig') as fh:
+              data = json.load(fh)
           assert isinstance(data, list), f'{name} is not a JSON array'
           total += len(data)
           if sample is None and data:
@@ -100,7 +93,7 @@ success_criteria:
           sys.exit(0)
       missing = [k for k in REQUIRED if k not in sample]
       assert not missing, f'sample event missing PascalCase keys: {missing}; sample={sample}'
-      print(f'OK: validated structure across {len(txt_files)} per-day files, total events={total}')
+      print(f'OK: validated structure across {len(day_files)} per-day files, total events={total}')
       "
     timeout: 60
     expected_exit_code: 0

--- a/tests/tasks/uipath-admin/audit_org_export_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_smoke.yaml
@@ -15,10 +15,10 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  An admin needs a ZIP of all ORGANIZATION-level audit events
-  (memberships, license changes, tenant lifecycle) from yesterday for
-  compliance archival. Write the ZIP to ./audit-org-yesterday.zip in
-  the current working directory.
+  An admin needs all ORGANIZATION-level audit events (memberships,
+  license changes, tenant lifecycle) from yesterday exported as day-wise
+  JSON files for compliance archival. Write them to the
+  ./audit-org-yesterday folder in the current working directory.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
@@ -39,9 +39,11 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent's export targeted the requested ./audit-org-yesterday.zip path"
+    description: "Agent's export targeted the requested ./audit-org-yesterday folder (json default; no .zip/.csv extension)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b.*--output-file\s+\.?/?audit-org-yesterday\.zip'
+    # Match the audit-org-yesterday folder path; the negative lookahead rejects a .zip/.csv
+    # file (the retired ZIP shape) so this confirms the json-folder default is used.
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b.*--output-file\s+\S*audit-org-yesterday(?![\w.])'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
@@ -1,10 +1,10 @@
 task_id: skill-admin-audit-org-export-verify-e2e
 description: >
-  End-to-end test (artifact verification tier): agent drives
-  `uip admin audit org export` to produce a real ZIP, then verifies
-  (a) the ZIP exists, (b) it contains at least one daily .txt file,
-  (c) the event IDs inside the export are a subset of what the live
-  `events` API returns for the same whole-day window.
+  End-to-end test (artifact verification tier): agent drives the default
+  `uip admin audit org export` (json) to produce a real folder of
+  day-wise JSON files, then verifies (a) the output folder exists, and
+  (b) each per-day file is a JSON array whose events use the documented
+  PascalCase schema.
 
   Sibling to `audit_export_verify_e2e.yaml` — same verification logic,
   but exercises the `org` scope (admin events: memberships, license,
@@ -15,44 +15,41 @@ description: >
   path specifically.
 
   Whole-day granularity note: `uip admin audit ... export` issues one
-  HTTP call per UTC day inside [--from-date, --to-date] and produces
-  one .txt per day. The `events` API takes timestamp-precise bounds,
-  so to compare the same window the events query must use
-  `T00:00:00Z` / `T23:59:59.999Z` boundaries that bracket the export's
-  per-day files.
+  HTTP call per UTC day inside [--from-date, --to-date] and writes one
+  <YYYY-MM-DD>.json JSON file per day into the output folder.
 
   LTS lag note: the export reads from the long-term store, which lags
-  the live `events` endpoint. We pin the comparison window to dates at
-  least 48h in the past so LTS has caught up. Assertion direction is
-  "export IDs ⊆ events IDs" — events is the more complete set.
+  the live `events` endpoint. We pin the window to dates at least 48h in
+  the past so LTS has caught up.
 
   Org-scope volume note: organization-level audit events (memberships,
   license, tenant lifecycle) are typically sparser than tenant events.
   An empty or near-empty result on a quiet test org is a real outcome
-  and should not fail the test — the assertion is *correctness* of the
-  subset relationship, not a minimum event count.
+  and should not fail the test — the assertion is structural correctness
+  of the per-day JSON files, not a minimum event count.
 
-  Blocker: this task requires `uip admin audit` to exist in the
-  published `@uipath/cli` (UiPath/cli#1372 must ship + publish first).
-  Until then it will fail at the export step with `unknown command
-  'audit'`.
+  Blocker: this task requires the json-folder export behavior in the
+  published `@uipath/cli` (UiPath/cli#2534 must ship + publish, on top of
+  #1372 which adds `uip admin audit`). Until then the default export
+  still emits the older single-file shape and the folder assertions fail.
 tags: [uipath-admin, e2e, mode:operate, audit, export, scope-org, real-artifact]
 
 initial_prompt: |
   Export ORGANIZATION-level audit events (memberships, license changes,
-  tenant lifecycle) for the single UTC day **2 days ago** to
-  ./audit-org-window.zip in the current working directory. Resolve the
-  date with `date -u -d '2 days ago' +%Y-%m-%d` so the window slides
-  with the run date — use the same value for both `--from-date` and
-  `--to-date`.
+  tenant lifecycle) for the single UTC day **2 days ago** as day-wise
+  JSON files into the ./audit-org-window folder in the current working
+  directory. Resolve the date with `date -u -d '2 days ago' +%Y-%m-%d`
+  so the window slides with the run date — use the same value for both
+  `--from-date` and `--to-date`.
 
   Important:
   - The `uip` CLI is available and connected via env-var auth to a
-    real tenant. The export should produce a real ZIP file at the
-    requested path.
+    real tenant. The export should produce a real folder of JSON files
+    at the requested path.
   - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
     bounds (no inline `T00:00:00Z` for these flags — the CLI treats
-    them as whole-day boundaries).
+    them as whole-day boundaries). json is the default format;
+    `--output-file` is the destination folder.
   - The 2-days-ago boundary preserves the >48h LTS-lag buffer.
   - This is ORG scope, not tenant. Do NOT pass `--tenant-id` (org
     silently ignores it).
@@ -60,48 +57,44 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip admin audit org export` (org scope) with bounded window + --output-file"
+    description: "Agent invoked `uip admin audit org export` (org scope) with bounded window + --output-file folder"
     tool_name: "Bash"
     command_pattern: 'uip\s+admin\s+audit\s+org\s+export\b(?=.*--from-date\s+\S+)(?=.*--to-date\s+\S+)(?=.*--output-file\s+\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Export produced ./audit-org-window.zip"
-    path: "./audit-org-window.zip"
+  - type: run_command
+    description: "Org export produced the ./audit-org-window folder (a directory, not a file)"
+    command: |
+      python3 -c "
+      import os, sys
+      assert os.path.isdir('./audit-org-window'), './audit-org-window is not a directory'
+      names = os.listdir('./audit-org-window')
+      print(f'OK: output folder exists with {len(names)} file(s)')
+      "
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Org export is a valid ZIP (zero or more .txt entries — an empty zip is acceptable for a quiet org)"
+    description: "Org folder contains well-formed events: each per-day .json file is a JSON array; events use the documented PascalCase schema (empty window acceptable for a quiet org)"
     command: |
       python3 -c "
-      import zipfile
-      assert zipfile.is_zipfile('./audit-org-window.zip'), 'not a valid zip'
-      names = zipfile.ZipFile('./audit-org-window.zip').namelist()
-      print(f'OK: {len(names)} entries')
-      "
-    timeout: 10
-    expected_exit_code: 0
-    weight: 2.5
-    pass_threshold: 1.0
-
-  - type: run_command
-    description: "Org export contains well-formed events: each per-day file is a JSON array; events use the documented PascalCase schema"
-    command: |
-      python3 -c "
-      import json, sys, zipfile
+      import json, os, sys
       REQUIRED = ['Id','CreatedOn','OrganizationId','ActorId','EventType','EventSource','EventTarget']
-      z = zipfile.ZipFile('./audit-org-window.zip')
-      txt_files = [n for n in z.namelist() if n.endswith('.txt')]
-      if not txt_files:
+      d = './audit-org-window'
+      assert os.path.isdir(d), f'{d} is not a directory'
+      day_files = [f for f in os.listdir(d) if f.endswith('.json')]
+      if not day_files:
           print('OK: org export window is empty (no per-day files) — structural assertion trivially holds')
           sys.exit(0)
       sample = None
       total = 0
-      for name in txt_files:
-          data = json.loads(z.read(name))
+      for name in day_files:
+          with open(os.path.join(d, name), encoding='utf-8-sig') as fh:
+              data = json.load(fh)
           assert isinstance(data, list), f'{name} is not a JSON array'
           total += len(data)
           if sample is None and data:
@@ -111,7 +104,7 @@ success_criteria:
           sys.exit(0)
       missing = [k for k in REQUIRED if k not in sample]
       assert not missing, f'sample event missing PascalCase keys: {missing}; sample={sample}'
-      print(f'OK: validated structure across {len(txt_files)} per-day files, total events={total}')
+      print(f'OK: validated structure across {len(day_files)} per-day files, total events={total}')
       "
     timeout: 60
     expected_exit_code: 0


### PR DESCRIPTION
> **Related PR:** CLI implementation in **UiPath/cli#2534**. This PR updates the `uipath-admin` skill + tests to match; merge/publish cli#2534 first (the real-artifact e2e tasks are gated on it).
> Coder Eval passing for modified tests - https://github.com/UiPath/skills/actions/runs/27639770709

## What

Updates the `uipath-admin` skill (docs + coder-eval tests) for the audit-export change in **UiPath/cli#2534**: `uip admin audit <scope> export --file-format <json|csv>` (default `json`) now writes a **folder of day-wise `<YYYY-MM-DD>.json` files** into `--output-file` instead of a single ZIP. `csv` (single merged CSV) is unchanged.

This supersedes the ZIP behavior that the merged #1399 documented.

## Docs (3)
- **SKILL.md** — frontmatter description, the Audit export bullet, and Rule 30 now describe the json-folder default (`--file-format json|csv`, folder output, per-day `.json` files).
- **references/audit-commands.md** — export section rewritten: `--file-format <json\|csv>`, `--output-file` is a folder for json, `Data` gains `Files`, implementation notes (per-day `.json` files, nested-ZIP flattening, the path-traversal/Zip-Slip guard), and the `--output` cross-cutting note.
- **references/audit-workflow-guide.md** — Investigation 3 export + verify step (folder of `.json` files), the format gotcha, the picker table, and output etiquette.

## Tests
- The 5 ZIP tasks → json folder: smoke tasks now assert a **folder** output path with a `.zip`/`.csv`-rejecting negative lookahead; the verify-e2e tasks validate a **directory** of `<date>.json` arrays with the documented PascalCase schema. The CSV verify-e2e description was updated (no behavior change). The 2 CSV smoke + 1 CSV verify tasks are otherwise unchanged.

## Validation (coder-eval, `experiments/default.yaml`, claude-sonnet-4-6)
Command-construction tasks **pass 3/3**, agent emitting folder-path exports:
- `skill-admin-audit-export-basic-smoke` — SUCCESS 2/2 → `… export … --output-file ./audit-yesterday --output json`
- `skill-admin-audit-org-export-smoke` — SUCCESS 2/2 → `… org export … --output-file ./audit-org-yesterday --output json`
- `skill-admin-audit-export-e2e` — SUCCESS 4/4 (sources → events → export folder)

CLI-verb check clean; all audit task YAMLs parse.

## Gated
The real-artifact `verify-e2e` tasks (tenant + org) require a live tenant **and** the json-folder behavior in published `@uipath/cli` (cli#2534). Documented in each task's blocker note; they run on the e2e/nightly cadence once #2534 ships — not on this PR's smoke gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

