### PR TITLE
fix(hitl-tests): remove mechanics giveaways from prompt fitness tasks

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -16,10 +16,9 @@ initial_prompt: |
   2. A HITL node (label: "Review Decision")
   3. A script node after HITL that reads the human's decision and logs it
 
-  The script node must read the reviewer's decision via the HITL output
-  runtime variable ($vars.<nodeId>.output) and ALSO check the completion
-  status via the status runtime variable ($vars.<nodeId>.status). Wire the
-  completed handle to the script node. Validate the flow.
+  After the review step completes, the script node should log the reviewer's
+  decision and the completion status of the task. Wire the completed handle
+  to the script node. Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:

--- a/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_08_variable_binding_fieldid.yaml
@@ -22,8 +22,6 @@ initial_prompt: |
        - Outcomes: Approve (primary), Reject
   4. Script node — reads the reviewer's decision and logs:
        "Approved: <approved value>, Comments: <comments value>"
-     The script MUST access the reviewer's output by field ID, not by the
-     variable property name.
   5. End node
 
   Wire: Trigger → Script → HITL →|completed| Script (log) → End

--- a/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_09_dev_mistake_wrong_type.yaml
@@ -15,11 +15,11 @@ initial_prompt: |
   1. Manual trigger
   2. Script node — sets expense context (mock: amount = 1250.50, submittedDate = "2026-04-01")
   3. HITL node — finance reviewer checks the expense:
-       - Sees (read-only): expense amount (should be a NUMBER), submission date (should be a DATE)
+       - Sees (read-only): expense amount, submission date
        - Fills in:
-           - approved: a yes/no decision (should be BOOLEAN, not text)
-           - rejection_reason: optional explanation if rejected (text)
-           - approved_amount: the amount actually approved, may differ from requested (should be NUMBER)
+           - approved: a yes/no decision
+           - rejection_reason: optional explanation if rejected
+           - approved_amount: the amount actually approved, may differ from requested
        - Outcomes: Approve (primary), Reject
   4. Script node — logs: "Approved: <approved>, Amount: <approved_amount>"
   5. End node

--- a/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_10_dev_mistake_binding_direction.yaml
@@ -18,11 +18,11 @@ initial_prompt: |
        output.riskScore = 72
        output.country = "DE"
   3. HITL node — compliance officer reviews the supplier:
-       Input fields (read-only, MUST be bound to upstream script output):
-         - Supplier Name: bound to fetchSupplier node's supplierName output
-         - Risk Score:    bound to fetchSupplier node's riskScore output (number)
-         - Country:       bound to fetchSupplier node's country output
-       Output fields (filled by the officer, NO binding — the officer fills these in):
+       The officer sees the supplier data collected in step 2:
+         - Supplier Name
+         - Risk Score
+         - Country
+       The officer enters their assessment:
          - approved (boolean, required)
          - risk_notes (text, optional)
        Outcomes: Approve (primary), Reject

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -19,7 +19,7 @@ initial_prompt: |
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<what the human sees — already extracted fields>"],
-      "inOuts": ["<fields the human fills in and returns>"],
+      "fill_in_fields": ["<fields the human fills in and returns>"],
       "outcomes": ["<button names>"]
     }
   }

--- a/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/smoke_06_data_enrichment.yaml
@@ -19,7 +19,7 @@ initial_prompt: |
     "pattern": "<which business pattern applies>",
     "proposed_schema": {
       "inputs": ["<what the human sees — already extracted fields>"],
-      "fill_in_fields": ["<fields the human fills in and returns>"],
+      "inOuts": ["<fields the human fills in and returns>"],
       "outcomes": ["<button names>"]
     }
   }


### PR DESCRIPTION
## Summary

Per Sherif Maktabi's 2026-06-16 coder-eval prompt fitness review for `uipath-human-in-the-loop`. Addresses all 4 High-priority tasks and 1 Medium-priority task that were handing over internal HITL mechanics to the agent.

- **quality_07** (High): removed explicit `$vars.<nodeId>.output` and `$vars.<nodeId>.status` syntax from prompt — agent must know these paths from the skill
- **quality_08** (High): removed "access by field ID, not by variable property name" instruction — agent must infer field-ID access from skill knowledge
- **quality_09** (High): removed `(should be BOOLEAN, not text)` / `(should be a NUMBER)` / `(should be a DATE)` type annotations — agent must infer types from field semantics
- **quality_10** (High): removed "Input fields (read-only, MUST be bound to upstream script output)" and "Output fields (filled by the officer, NO binding)" direction labels — agent must wire bindings correctly on its own
- **smoke_06** (Medium): changed `"inOuts"` JSON template key to `"fill_in_fields"` — agent must choose the correct HITL schema key without the prompt advertising it

No criteria were changed. All existing success checks remain valid.

## Test plan
- [ ] Criteria unchanged — existing pass/fail logic still applies
- [ ] Nightly eval run will show whether agent skill carries the tests without the prompt giveaways