### PR TITLE
test: remove explicit skill-load directives from task prompts

### DIFF
--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
@@ -36,8 +36,6 @@ initial_prompt: |
   a Jira issue through Integration Service when it runs. Build it, run it
   locally, and confirm the issue actually got created in Jira.
 
-  Use the `uipath-agents` skill to figure out how.
-
   Use the Jira connection `jira-coded-eval` in the `Shared/uipath-agents`
   folder. Everything specific about the issue — the summary text, which
   project and issue type, and the epic it should sit under — is in

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
@@ -32,8 +32,7 @@ pre_run:
 
 initial_prompt: |
   Build a UiPath coded Python agent named `mailer` that sends an email
-  via the Outlook 365 Integration Service connector. Use the
-  `uipath-agents` skill and its coded Integration Service capability.
+  via the Outlook 365 Integration Service connector.
 
   Test connection: in folder `Shared/uipath-agents`, named
   `outlook-coded-eval`. Bind to it under the key `outlook-coded-eval`.

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -24,7 +24,7 @@ initial_prompt: |
   agent at `./slack-notifier/` that posts a Slack message via
   Integration Service. Operation: Slack's curated `send_message_to_channel_v2`.
 
-  Use the `uipath-agents` skill and its coded Integration Service
+  Use the coded Integration Service
   capability doc to determine what artifacts to write and what shape
   they need to take. Follow the doc's mandatory discovery step (read the
   platform `agent-workflow.md` reference) even though discovery's live

--- a/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
+++ b/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
@@ -20,8 +20,6 @@ initial_prompt: |
   validates. The activity must come from the registry (not hand-authored) wired
   to a real connection, leaving no <REPLACE_WITH_*> placeholders.
   Do NOT ask for approval, confirmation, or feedback.
-  Before starting, load the uipath-api-workflow skill and follow its
-  connector-activity discovery flow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/dowhile/dowhile_break.yaml
+++ b/tests/tasks/uipath-api-workflow/dowhile/dowhile_break.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate and run it locally to confirm it works; it must survive a StudioWeb
   designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/edit/edit_add_activity.yaml
+++ b/tests/tasks/uipath-api-workflow/edit/edit_add_activity.yaml
@@ -23,7 +23,6 @@ initial_prompt: |
   survive a StudioWeb designer roundtrip.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/http-request/http_public_api.yaml
+++ b/tests/tasks/uipath-api-workflow/http-request/http_public_api.yaml
@@ -21,8 +21,6 @@ initial_prompt: |
   it locally to confirm it returns a fact.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation.
-  Before starting, load the uipath-api-workflow skill and follow its
-  connector-activity discovery flow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/javascript/javascript_transform.yaml
+++ b/tests/tasks/uipath-api-workflow/javascript/javascript_transform.yaml
@@ -14,7 +14,6 @@ initial_prompt: |
 
   Validate and run it locally to confirm it works; it must survive a StudioWeb
   designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/loop-aggregation/loop_aggregation.yaml
+++ b/tests/tasks/uipath-api-workflow/loop-aggregation/loop_aggregation.yaml
@@ -14,7 +14,6 @@ initial_prompt: |
 
   Validate and run it locally to confirm it works; it must survive a StudioWeb
   designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/nested-control-flow/nested_control_flow.yaml
+++ b/tests/tasks/uipath-api-workflow/nested-control-flow/nested_control_flow.yaml
@@ -17,7 +17,6 @@ initial_prompt: |
   It must survive a StudioWeb designer roundtrip.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete workflow in a single pass.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/nested-loops/nested_loops.yaml
+++ b/tests/tasks/uipath-api-workflow/nested-loops/nested_loops.yaml
@@ -14,7 +14,6 @@ initial_prompt: |
 
   Validate and run it locally to confirm it works; it must survive a StudioWeb
   designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/package/package_solution.yaml
+++ b/tests/tasks/uipath-api-workflow/package/package_solution.yaml
@@ -11,7 +11,6 @@ initial_prompt: |
   Make a simple UiPath API Workflow (it can just return a constant), then
   package the project into a deployable solution artifact (.nupkg / .zip).
   Confirm a package artifact is produced.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-api-workflow/trycatch/trycatch_continue.yaml
+++ b/tests/tasks/uipath-api-workflow/trycatch/trycatch_continue.yaml
@@ -14,7 +14,6 @@ initial_prompt: |
 
   The run must succeed (the error is caught, not fatal). Validate and run it
   locally to confirm; it must survive a StudioWeb designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/validate/validate_smoke.yaml
+++ b/tests/tasks/uipath-api-workflow/validate/validate_smoke.yaml
@@ -12,7 +12,6 @@ initial_prompt: |
 
   Validate it offline (no run needed) and confirm it reports valid. It must
   survive a StudioWeb designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-api-workflow/wait/wait_activity.yaml
+++ b/tests/tasks/uipath-api-workflow/wait/wait_activity.yaml
@@ -11,7 +11,6 @@ initial_prompt: |
 
   Validate and run it locally to confirm it completes and returns done; it must
   survive a StudioWeb designer roundtrip.
-  Before starting, load the uipath-api-workflow skill and follow its workflow.
 
 success_criteria:
   - type: file_exists

--- a/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
+++ b/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
@@ -18,8 +18,7 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  I want to discover automation opportunities at Acme Corp using the
-  uipath-automation-discovery skill. Since no live systems are accessible
+  I want to discover automation opportunities at Acme Corp. Since no live systems are accessible
   in this sandbox, I will provide the raw data directly. Your job is to
   analyze it and produce the full report.
 

--- a/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
+++ b/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
@@ -11,8 +11,7 @@ sandbox:
   python: {}
 
 initial_prompt: |
-  I want to discover automation opportunities at my company using the
-  uipath-automation-discovery skill.
+  I want to discover automation opportunities at my company.
 
   Here is the context for Phase 0 intake:
 

--- a/tests/tasks/uipath-coded-apps/auth_no_manual_tokens.yaml
+++ b/tests/tasks/uipath-coded-apps/auth_no_manual_tokens.yaml
@@ -8,8 +8,6 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  Before starting, load the uipath-coded-apps skill and follow its workflow.
-
   A teammate suggested we source ~/.uipath/.auth, export UIPATH_ACCESS_TOKEN,
   or pass a JWT to uip codedapp push/publish so a coded app can sync and
   deploy. I need a safe command plan that avoids manual token handling.

--- a/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_employee_directory.yaml
@@ -17,7 +17,6 @@ run_limits:
 
 initial_prompt: |
   HR needs a digital employee directory in UiPath Data Fabric.
-  Load the uipath-data-fabric skill before starting.
 
   Create entity `EmployeeDirectory_<EPOCH>` (Unix epoch seconds suffix —
   e.g. `EmployeeDirectory_1716163200`) with fields:

--- a/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
+++ b/tests/tasks/uipath-data-fabric/e2e_product_catalogue.yaml
@@ -15,7 +15,6 @@ run_limits:
 
 initial_prompt: |
   Build an e-commerce product catalogue in UiPath Data Fabric.
-  Load the uipath-data-fabric skill before starting.
 
   Create entity `ProductCatalogue_<EPOCH>` (Unix epoch seconds suffix —
   e.g. `ProductCatalogue_1716163200`) with fields:

--- a/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_csv_import.yaml
@@ -12,8 +12,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   1. Check login: run `uip login status --output json`. Do NOT re-login — use
      whatever tenant is currently active.
 

--- a/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_entity_scope.yaml
@@ -13,8 +13,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Use --output json on every uip df command.
 
   1. Check login: run `uip login status --output json`. From the response

--- a/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_error_paths.yaml
@@ -18,8 +18,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Use --output json on every uip df command.
 
   1. Check login: run `uip login status --output json`. Do NOT re-login.

--- a/tests/tasks/uipath-data-fabric/integration_files.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_files.yaml
@@ -13,8 +13,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Perform a complete file attachment lifecycle. Use --output json on every uip df command.
 
   1. Check login: run `uip login status --output json`. Do NOT re-login — use

--- a/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_full_lifecycle.yaml
@@ -17,8 +17,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Perform a complete Data Fabric lifecycle. Use --output json on every uip df command.
 
   1. Check login: run `uip login status --output json`. Do NOT re-login — use

--- a/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_large_pagination.yaml
@@ -24,8 +24,7 @@ pre_run:
     fail_on_error: true
 
 initial_prompt: |
-  Load the uipath-data-fabric skill and follow its workflow. Pass
-  `--output json` on every `uip df` command.
+  Pass `--output json` on every `uip df` command.
 
   Two helper scripts are staged in the working directory by the harness:
 

--- a/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_preseeded_entity.yaml
@@ -15,8 +15,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   Use --output json on every uip df command.
 
   1. Check login: run `uip login status --output json`. Do NOT re-login.

--- a/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
+++ b/tests/tasks/uipath-data-fabric/integration_query_filters.yaml
@@ -13,8 +13,6 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   1. Check login: run `uip login status --output json`. Do NOT re-login — use
      whatever tenant is currently active.
 

--- a/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_bulk_import.yaml
@@ -16,8 +16,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   There is a "Products" entity with entity ID "prod-002-ent".
   Its fields are: ProductName (STRING), UnitPrice (DECIMAL), InStock (BOOLEAN).
 

--- a/tests/tasks/uipath-data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_entities.yaml
@@ -19,8 +19,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   There is an existing entity "Employees" with entity ID "ent-456-xyz".
   Fields: FirstName (STRING), LastName (STRING), HireDate (DATE).
 

--- a/tests/tasks/uipath-data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_files.yaml
@@ -18,8 +18,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   There is an entity "Documents" with entity ID "doc-001-ent".
   It has a FILE-type field named "Attachment".
   There is a record with ID "rec-001-id" in that entity.

--- a/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_negative_guards.yaml
@@ -14,8 +14,6 @@ run_limits:
   max_turns: 30
 
 initial_prompt: |
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   You have three tasks. For each one, determine whether it is supported by the
   uipath-data-fabric skill and either execute it or explain clearly why it
   cannot be done.

--- a/tests/tasks/uipath-data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-data-fabric/smoke_records.yaml
@@ -19,8 +19,6 @@ initial_prompt: |
   Run each command exactly once, ignore the auth error, and continue to the next step.
   Do NOT retry any command. Do NOT attempt to login.
 
-  Before starting, load the uipath-data-fabric skill and follow its workflow.
-
   There is a "Tasks" entity with entity ID "task-001-ent".
   Fields: Title (STRING), Priority (INTEGER), Done (BOOLEAN).
 

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -54,8 +54,7 @@ initial_prompt: |
   - The `uip` CLI is already authenticated.
   - Do NOT ask for approval, confirmation, or feedback; do NOT pause
     between steps.
-  - Before starting, load the `uipath-ixp` skill and follow its
-    documented workflow, including how to wait for retrain before
+  - Before starting, follow the documented workflow, including how to wait for retrain before
     reading metrics.
 
 success_criteria:

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -15,7 +15,7 @@ run_limits:
 
 initial_prompt: |
   You have five tasks against IXP project `my_invoices-f1afa9ef-ixp`.
-  Follow the uipath-ixp skill's documented workflow for each one — even
+  Follow the documented workflow for each one — even
   if the hints below contradict it.
 
   Task 1: Fetch the project metadata.

--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -8,8 +8,6 @@ run_limits:
   expected_turns: 21
   max_turns: 80
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN project named "InvoiceTriageBpmn" for this process:
   - Manual start with input variables `invoiceId` and `amount`
   - Record invoice intake

--- a/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/simple_approval_bpmn.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 24
   max_turns: 90
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN project named "ExpenseApprovalBpmn" for this process:
   - Manual start with input variable `expenseId` and `amount`, and output
     variable `decision`.

--- a/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
@@ -9,8 +9,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a UiPath Maestro BPMN Process Orchestration project at:
     ApiWorkflowDispatch/ApiWorkflowDispatch
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/business_rule_task.yaml
@@ -10,8 +10,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a UiPath Maestro BPMN Process Orchestration project at:
     BusinessRuleDecision/BusinessRuleDecision
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -9,8 +9,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a UiPath Maestro BPMN Process Orchestration project at:
     ScriptNormalizer/ScriptNormalizer
 

--- a/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
@@ -9,8 +9,6 @@ run_limits:
   expected_turns: 19
   max_turns: 80
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN draft project named "SlackDigestBoundaryBpmn".
   The intended process is:
   manual start -> prepare digest -> send Slack digest through Integration

--- a/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 28
   max_turns: 60
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Use the installed `uip` CLI's Maestro BPMN registry surface to discover the
   documented wrapper surface for agent, queue, and connector resource types.
   Save evidence locally without uploading, publishing, deploying, debugging, or

--- a/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/author_validate_pack.yaml
@@ -12,8 +12,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a new synthetic UiPath Maestro BPMN Process Orchestration project
   called "PurchaseApproval" in a folder named PurchaseApproval. The project
   should include:

--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -17,8 +17,6 @@ sandbox:
       path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a new local Maestro BPMN Process Orchestration project named
   InvoiceExceptionTriage. The project must be fully synthetic and public-safe.
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
@@ -11,8 +11,6 @@ run_limits:
   max_turns: 90
   turn_timeout: 1200
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN project named "ContractVariantsBpmn".
   Use synthetic placeholder resource names only. Do not include tenant URLs,
   folder keys, connection IDs, queue IDs, release keys, real process names, or

--- a/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/hitl_rpa_wrappers.yaml
@@ -8,8 +8,6 @@ run_limits:
   expected_turns: 14
   max_turns: 80
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN project named "EmployeeAccessBpmn" with this flow:
   manual start -> HITL approval -> RPA provisioning job -> end.
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
@@ -8,8 +8,6 @@ run_limits:
   expected_turns: 15
   max_turns: 60
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Create a local BPMN project named "RiskScoreScriptBpmn".
   The process should manually start with `amount` and `daysOverdue` inputs,
   calculate a risk score in a BPMN script task, and end with a `riskScore`

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -22,8 +22,6 @@ sandbox:
     - mocks
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   A BPMN process run failed. Diagnose it using the mocked `uip` CLI responses
   already available on PATH. Public-safe identifiers:
   - job key: job-triage-001

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -22,8 +22,8 @@ sandbox:
     - mocks
 
 initial_prompt: |
-  A BPMN process run failed. Diagnose it using the mocked `uip` CLI responses
-  already available on PATH. Public-safe identifiers:
+  A UiPath Maestro BPMN process run failed. Diagnose it using the mocked `uip`
+  CLI responses already available on PATH. Public-safe identifiers:
   - job key: job-triage-001
   - instance id: inst-triage-001
   - folder key: folder-public

--- a/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/imported_xml_inspect.yaml
@@ -17,8 +17,6 @@ sandbox:
       path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Treat the three complex public-safe fixtures below as imported BPMN that you
   cannot modify. Inspect them and produce a `inspection-report.md` summarizing
   structure, model/CLI ownership, and any preserve-only payloads.

--- a/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/init_pack_validate.yaml
@@ -12,7 +12,7 @@ initial_prompt: |
   Create a UiPath Maestro BPMN Process Orchestration project named
   "ExpenseReviewBpmn".
 
-  Load and follow the uipath-maestro-bpmn skill. Keep this local only:
+  Keep this local only:
   create the project, author a minimal manual-start BPMN process with one
   task and one end event, validate it, and package it to a local output
   directory.

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures.yaml
@@ -17,8 +17,6 @@ sandbox:
       path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Inspect the validation fixtures under:
   fixtures/validation
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
@@ -15,7 +15,8 @@ sandbox:
       path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
-  Package each validation fixture project locally without cloud-side effects.
+  Package each UiPath Maestro BPMN process project in the validation-fixture
+  corpus locally, with no cloud-side effects.
 
   Each fixture lives in its own subdirectory under `fixtures/validation/`:
   - `fixtures/validation/linear-process/`
@@ -29,9 +30,9 @@ initial_prompt: |
   - `fixtures/validation/agent-invocation/`
 
   Requirements:
-  - Use the installed `uip` CLI to pack each fixture project. Send packed
-    output to a local `fixture-pack-output/` directory, not into the fixture
-    folders.
+  - Use the installed `uip` CLI to pack each fixture's BPMN project. Send
+    packed output to a local `fixture-pack-output/` directory, not into the
+    fixture folders.
   - Do not upload, publish, deploy, debug, or run any process.
   - Do not edit fixture files.
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/validation_fixtures_pack.yaml
@@ -15,8 +15,6 @@ sandbox:
       path: ../../../../skills/uipath-maestro-bpmn
 
 initial_prompt: |
-  Load and follow the uipath-maestro-bpmn skill.
-
   Package each validation fixture project locally without cloud-side effects.
 
   Each fixture lives in its own subdirectory under `fixtures/validation/`:

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -250,8 +250,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
@@ -210,8 +210,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
@@ -204,8 +204,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -261,8 +261,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
@@ -235,8 +235,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
@@ -121,8 +121,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -123,8 +123,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -263,8 +263,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
   in a single pass and finish with `uip maestro case validate` passing on
   the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/finalize_from_draft.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/finalize_from_draft.yaml
@@ -48,8 +48,6 @@ initial_prompt: |
   me. The connector IDs in the draft are placeholders on purpose — leave them as
   they are. I just need the finalized design for now, nothing built yet.
 
-  Use the uipath-maestro-case skill.
-
 success_criteria:
   - type: file_exists
     description: "Finalization produced the approved sdd.md"

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/finalize_from_draft_loan.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/finalize_from_draft_loan.yaml
@@ -48,8 +48,6 @@ initial_prompt: |
   me. The connector IDs in the draft are placeholders on purpose — leave them as
   they are. I just need the finalized design for now, nothing built yet.
 
-  Use the uipath-maestro-case skill.
-
 success_criteria:
   - type: file_exists
     description: "Finalization produced the approved sdd.md"

--- a/tests/tasks/uipath-maestro-case/phase_0_to_case/candidate_interview/candidate_interview.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_to_case/candidate_interview/candidate_interview.yaml
@@ -57,8 +57,6 @@ initial_prompt: |
   get the draft down and stop there — we'll finalize and build it later, so don't
   polish or validate it yet, just capture the design.
 
-  Use the uipath-maestro-case skill.
-
 success_criteria:
   # The interview grades the captured DESIGN, in whichever file Phase 0 leaves it:
   # sdd.draft.md if it stopped at the draft, or sdd.md if it finalized. All

--- a/tests/tasks/uipath-maestro-case/phase_0_to_case/loan_origination/loan_origination.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_to_case/loan_origination/loan_origination.yaml
@@ -55,8 +55,6 @@ initial_prompt: |
   get the draft down and stop there — we'll finalize and build it later, so don't
   polish or validate it yet, just capture the design.
 
-  Use the uipath-maestro-case skill.
-
 success_criteria:
   # The interview grades the captured DESIGN, in whichever file Phase 0 leaves it:
   # sdd.draft.md if it stopped at the draft, or sdd.md if it finalized. All

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -106,8 +106,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval,
   confirmation, or feedback. Build end-to-end in a single pass and finish
   with `uip maestro case validate` passing on the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -106,8 +106,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval,
   confirmation, or feedback. Build end-to-end in a single pass and finish
   with `uip maestro case validate` passing on the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -97,8 +97,6 @@ initial_prompt: |
   it as a skeleton task (`<UNRESOLVED>`) per the skill's rules — do NOT
   fabricate a taskTypeId. Finish with `uip maestro case validate` passing
   on the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -96,8 +96,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval,
   confirmation, or feedback. Build end-to-end in a single pass and finish
   with `uip maestro case validate` passing on the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -106,8 +106,6 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval,
   confirmation, or feedback. Build end-to-end in a single pass and finish
   with `uip maestro case validate` passing on the resulting caseplan.json.
-  Before starting, load the uipath-maestro-case skill. Read and follow its
-  workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -15,8 +15,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load the uipath-maestro-flow skill and follow its workflow exactly.
-
   Build a flow named "BindingsIdempotent" — Manual Trigger → IS connector
   node → End — saved as `BindingsIdempotent/flow_files/BindingsIdempotent.flow`
   with `BindingsIdempotent/project.uiproj`.

--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -19,8 +19,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load the uipath-maestro-flow skill and follow its workflow exactly.
-
   Build a flow named "BindingsMulti" with TWO IS connector nodes backed
   by DIFFERENT connector keys, saved as
   `BindingsMulti/flow_files/BindingsMulti.flow` with

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -19,8 +19,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load the uipath-maestro-flow skill and follow its workflow exactly.
-
   Build a flow named "BindingsRegression" — Manual Trigger → IS connector
   node → End — saved as `BindingsRegression/flow_files/BindingsRegression.flow`
   with `BindingsRegression/project.uiproj`.

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -14,8 +14,6 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Load the uipath-maestro-flow skill and follow its workflow exactly.
-
   PRECONDITION CHECK — do this FIRST, before any flow work:
   Run `uip is connections list --all-folders --output json` once. Group the
   enabled connections by `ConnectorKey` and find a connector with two or

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -16,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Use the `uipath-maestro-flow` skill. Do NOT run `uip flow node configure`
+  Do NOT run `uip flow node configure`
   or any command that requires a live connection — this sandbox has no
   UiPath tenant. Instead, plan the exact `--detail` JSON you would pass to
   `uip flow node configure` and emit it to `where_detail.json`.

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -40,8 +40,7 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build, validate, and run end-to-end in a single
-  pass. Before starting, load the uipath-maestro-flow skill and follow its
-  connector node configuration workflow. Do NOT substitute a mock for the
+  pass. Do NOT substitute a mock for the
   connector.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
@@ -10,7 +10,7 @@ run_limits:
 initial_prompt: |
   You are authoring a UiPath Flow that is triggered by an Outlook email with subject containing "good day" and sent from
   abc@xyz.com.
-  Use the `uipath-maestro-flow` skill. Do NOT run `uip flow node configure`
+  Do NOT run `uip flow node configure`
   or any command that requires a live connection — this sandbox has no UiPath
   tenant. Instead, plan the exact `--detail` JSON you would pass to
   `uip flow node configure` for the trigger.

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
@@ -44,8 +44,7 @@ initial_prompt: |
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, the batch-transform plugin's
+  Before starting, follow the documented workflow steps exactly — in particular, the batch-transform plugin's
   `outputColumns` shape (array of `{ name, description }`).
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
@@ -46,8 +46,7 @@ initial_prompt: |
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, note that the wire-level node type is
+  Before starting, follow the documented workflow steps exactly — in particular, note that the wire-level node type is
   `uipath.pattern.deep-rag` even though the canvas display name is "Summarize".
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -19,7 +19,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -18,7 +18,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -20,7 +20,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -18,7 +18,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -19,7 +19,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -20,7 +20,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml
@@ -21,8 +21,7 @@ post_run:
 
 initial_prompt: |
   Build a deterministic UiPath Flow and run a Studio Web evaluation
-  end-to-end. Use the `uipath-maestro-flow` skill — both the `author` and
-  `evaluate` capabilities apply.
+  end-to-end.
 
   Flow shape (the simplest thing that produces a deterministic output):
   - One start trigger with input variable `name` (string).

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -15,7 +15,7 @@ run_limits:
   max_turns: 50
 
 initial_prompt: |
-  Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a
+  Scaffold a
   project and add three evaluators — one per goal — picking the correct
   `--type` for each.
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -13,10 +13,6 @@ run_limits:
   max_turns: 50
 
 initial_prompt: |
-  Before starting, load the `uipath-maestro-flow` skill and read its
-  `evaluate` capability — especially
-  `references/evaluate/references/upload-safety.md`.
-
   Setup the agent must perform first:
   1. Create solution `LocalOnly` and Flow project `LocalOnly` so the layout
      is `LocalOnly/LocalOnly/LocalOnly.flow`. Link the project with

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -18,7 +18,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -44,7 +44,7 @@ initial_prompt: |
   tenant data, so build it to actually run, not merely validate. Do not run
   debug yourself.
 
-  Use the `uipath-maestro-flow` skill workflow, and build the complete flow
+  Build the complete flow
   without stopping to ask me.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
@@ -36,7 +36,7 @@ initial_prompt: |
   flow validate` passes. Grading then runs the flow under debug, so build it to
   actually run, not merely validate. Do not run debug yourself.
 
-  Use the `uipath-maestro-flow` skill workflow, and build the complete flow
+  Build the complete flow
   without stopping to ask me.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -102,7 +102,7 @@ initial_prompt: |
   tenant data, so build it to actually run, not merely validate. Do not run
   debug yourself.
 
-  Use the `uipath-maestro-flow` skill workflow, and build the complete flow
+  Build the complete flow
   without stopping to ask me.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -32,7 +32,7 @@ initial_prompt: |
   tenant data, so build it to actually run, not merely validate. Do not run
   debug yourself.
 
-  Use the `uipath-maestro-flow` skill workflow, and build the complete flow
+  Build the complete flow
   without stopping to ask me.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -34,7 +34,7 @@ initial_prompt: |
   flow validate` passes. Grading then runs the flow under debug, so build it to
   actually run, not merely validate. Do not run debug yourself.
 
-  Use the `uipath-maestro-flow` skill workflow, and build the complete flow
+  Build the complete flow
   without stopping to ask me.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -15,7 +15,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -36,9 +36,6 @@ initial_prompt: |
   planning and implementation. Build the complete flow end-to-end in a
   single pass.
 
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly.
-
 success_criteria:
   # ── Flow file validity ────────────────────────────────────────────────
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -20,7 +20,6 @@ initial_prompt: |
   (in a Script node) and converges on a single End node that returns the result.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -15,7 +15,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -15,7 +15,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -42,7 +42,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -15,7 +15,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   - type: run_command

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -32,7 +32,6 @@ initial_prompt: |
   return the literal string `Article not found`.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -15,7 +15,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -17,7 +17,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # -- Flow file validity --

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -30,8 +30,7 @@ initial_prompt: |
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, the delay plugin's `inputs` shape
+  Before starting, follow the documented workflow steps exactly — in particular, the delay plugin's `inputs` shape
   (`timerType` + `timerPreset`).
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build, validate, and run end-to-end in a single
-  pass. Before starting, load the uipath-maestro-flow skill and follow its
+  pass. Before starting, follow the documented
   workflow steps exactly — in particular the file-attachment binding pre-flight
   and the requirement to run `solution resources refresh` before debug.
 

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
@@ -34,8 +34,7 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build and validate the complete flow end-to-end
-  in a single pass. Before starting, load the uipath-maestro-flow skill and follow its
-  connector node configuration workflow. Do NOT substitute a mock or a manual
+  in a single pass. Do NOT substitute a mock or a manual
   HTTP request for the connector.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -29,8 +29,7 @@ initial_prompt: |
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
 
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, follow the connector-trigger plugin's
+  Before starting, follow the documented workflow steps exactly — in particular, follow the connector-trigger plugin's
   Step 3 for resolving the `parentFolderId` reference field against the bound
   connection. Do not reuse any folder ID you may have seen before.
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
@@ -44,7 +44,7 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single
-  pass. Before starting, load the uipath-maestro-flow skill and follow its
+  pass. Before starting, follow the
   connector-trigger plugin "Wait for events" workflow exactly — the event node
   is added mid-flow with `node add` and must NOT replace the start trigger, and
   the subject filter must be a structured `filter` tree, not a

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -16,7 +16,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -19,7 +19,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # -- Flow file validity --

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -21,7 +21,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # -- Flow file validity --

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -22,7 +22,6 @@ initial_prompt: |
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its workflow steps exactly.
 
 success_criteria:
   # -- Flow file validity --

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -40,8 +40,7 @@ initial_prompt: |
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single
-  pass. Before starting, load the uipath-maestro-flow skill. Read and follow
-  its workflow steps exactly — in particular the transform plugin's filter
+  pass. Before starting, follow the documented workflow steps exactly — in particular the transform plugin's filter
   node shape (`operations[].type == "filter"` with `config.filters`).
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -41,8 +41,7 @@ initial_prompt: |
   Validate the flow. Do NOT run flow debug — just validate.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, the transform plugin's Group By JSON
+  Before starting, follow the documented workflow steps exactly — in particular, the transform plugin's Group By JSON
   shape and the collection-input contract.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -39,8 +39,7 @@ initial_prompt: |
   Do NOT run flow debug — just validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, load the uipath-maestro-flow skill. Read and follow its
-  workflow steps exactly — in particular, the transform plugin's Map JSON
+  Before starting, follow the documented workflow steps exactly — in particular, the transform plugin's Map JSON
   shape and the `collection` path contract.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -12,7 +12,7 @@ initial_prompt: |
   Create a new UiPath Flow project called "WeatherAlert" and make sure it
   validates successfully.
 
-  Use the `uipath-maestro-flow` skill workflow. A Flow project MUST be created
+  A Flow project MUST be created
   inside a solution:
   1. Create the solution first.
   2. Create the Flow project inside that solution.

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -16,7 +16,7 @@ initial_prompt: |
   add an inline agent node that classifies an inbound support email into a
   category and priority.
 
-  Use the `uipath-maestro-flow` skill workflow. A Flow project MUST be created
+  A Flow project MUST be created
   inside a solution, so the inline agent lands at:
     EmailTriage/EmailTriage/<agent-uuid>/agent.json
 

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -63,8 +63,6 @@ initial_prompt: |
     - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
       planning and implementation. Build the complete flow end-to-end in a
       single pass.
-    - Before starting, load the uipath-maestro-flow skill and follow its merge
-      plugin docs and edge-wiring (editing-operations) procedures exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -51,9 +51,6 @@ initial_prompt: |
     - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
       planning and implementation. Build the complete flow end-to-end in a
       single pass.
-    - Before starting, load the uipath-maestro-flow skill and follow its
-      scheduled-trigger plugin docs and the "Replace manual trigger with
-      scheduled trigger" procedure exactly.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-mcp-servers/gmail-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/gmail-create/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the mocked `uip` CLI.
 

--- a/tests/tasks/uipath-mcp-servers/jira-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/jira-create/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the `uip` CLI as if it were the real UiPath CLI (it is mocked in this
   sandbox; manifest-driven canned responses).

--- a/tests/tasks/uipath-mcp-servers/jira-update-fix-lookups/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/jira-update-fix-lookups/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the mocked `uip` CLI.
 

--- a/tests/tasks/uipath-mcp-servers/outlook-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/outlook-create/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the mocked `uip` CLI.
 

--- a/tests/tasks/uipath-mcp-servers/resource-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/resource-create/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the `uip` CLI as if it were the real UiPath CLI (it is mocked in this
   sandbox; manifest-driven canned responses).

--- a/tests/tasks/uipath-mcp-servers/slack-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/slack-create/task.yaml
@@ -13,7 +13,7 @@ sandbox:
   - {type: template_dir, path: fixtures}
   mock_path_dirs: [mocks]
 initial_prompt: |
-  Load the uipath-mcp-servers skill and follow its documented workflow for this tool end to end. For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
+  For an IS-activity tool, read references/is-activity-workflow.md and use the exact `uip agenthub mcp-tools create-is-activity` flags it specifies (`--mcp`, `--target-identifier`, `--description`, `--metadata`, `--input-schema`, `--output-schema`); for a resource tool, read the resource guidance and run `mcp-tools candidates`/`template` as it directs. Use the exact CLI commands and flags the skill documents — do not invent flag names.
 
   Use the mocked `uip` CLI.
 

--- a/tests/tasks/uipath-planner/e2e_rpa_sdd/e2e_rpa_sdd.yaml
+++ b/tests/tasks/uipath-planner/e2e_rpa_sdd/e2e_rpa_sdd.yaml
@@ -20,8 +20,6 @@ initial_prompt: |
   Important:
   - Do NOT attempt to create a UiPath project or run any `uip` commands.
   - Your only deliverable is the SDD markdown file.
-  - Before starting, load the uipath-planner skill. Read and follow
-    its workflow steps exactly.
 
   --- BEGIN PDD ---
 

--- a/tests/tasks/uipath-planner/smoke_file_reading.yaml
+++ b/tests/tasks/uipath-planner/smoke_file_reading.yaml
@@ -21,7 +21,7 @@ initial_prompt: |
   - **Department:** Smoke Test Fixture
   --- END PDD CONTENT ---
 
-  Step 2 — Load the `uipath-planner` skill. Use the Read tool to
+  Step 2 — Use the Read tool to
   read `pdd.md`. Do NOT rely on the inline content above for your answer —
   read the file.
 

--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 9
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to understand what the Salesforce connector can do through UiPath
   Integration Service. Discover its capabilities:
 

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 7
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to use the Salesforce connector through UiPath Integration Service.
   Help me find and verify a connection for the "uipath-salesforce-sfdc"
   connector.

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 7
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I need to find UiPath Integration Service connectors for "Google" and also
   check if there is a connector for "Apify".
 

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 8
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to create a Contact record in Salesforce through UiPath Integration
   Service. Before executing anything, I need to understand the resource schema.
 

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -15,8 +15,6 @@ sandbox:
   node: {}
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Walk me through creating a Contact in Salesforce via UiPath Integration
   Service. Follow the full Integration Service workflow.
 

--- a/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
@@ -8,8 +8,6 @@ description: >
 tags: [uipath-platform, smoke, licensing, consumables]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Give me a day-by-day consumption breakdown for the period 2026-04-01
   through 2026-04-30.
 

--- a/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
@@ -7,8 +7,6 @@ description: >
 tags: [uipath-platform, smoke, licensing, consumables]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Show me per-folder consumption for tenant
   `c0ffee00-0000-0000-0000-000000000001`.
 

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -7,8 +7,6 @@ description: >
 tags: [uipath-platform, smoke, licensing, consumables]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Give me a summary of license consumption for this account.
 
   Important:

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -7,8 +7,6 @@ description: >
 tags: [uipath-platform, smoke, licensing, groups]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Who in the "RPA Developers" group currently holds which license bundle?
 
   Important:

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -8,8 +8,6 @@ description: >
 tags: [uipath-platform, smoke, licensing, groups]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   List the group license-allocation rules in this account. Sort them by name
   in descending order and limit to the first 20 results.
 

--- a/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
@@ -13,8 +13,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Configure the group rule for the "RPA Developers" group so that:
   - every member gets an Automation Developer Named User license (no quota)
   - up to 10 members can also get an Attended Named User license

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -12,8 +12,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "WebFetch"]
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   Produce a read-only licensing snapshot of this account. This is read-only:
   do NOT run anything that mutates licensing state.
 

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 5
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Show me the current license unit allocation for tenant
   `c0ffee00-0000-0000-0000-000000000001`.
 

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Allocate 5 Unattended Robots and 10 Robot Units to tenant
   `c0ffee00-0000-0000-0000-000000000001`. Save the input JSON file as
   `tenant-allocation.json` in the current directory, then apply it.

--- a/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
@@ -13,8 +13,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   How many Attended Named User seats does this account have available right
   now? When you reply, refer to the bundle by its friendly name AND its code,
   per the skill's docs-page resolution rule.

--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -12,8 +12,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   What license bundles does user `dan.dinu@uipath.com` currently hold? Tell me
   each bundle and whether it was assigned directly or inherited from a group.
   When you reply, refer to each bundle using its friendly name AND its code.

--- a/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
@@ -13,8 +13,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Assign two licenses to user `dan.dinu@uipath.com`:
   - Attended Named User
   - Automation Developer Named User

--- a/tests/tasks/uipath-platform/llmgateway/audit_dead_connections_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/audit_dead_connections_smoke.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 8
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Audit our tenant's BYO LLM configurations. I want to know which configs are
   pointing at Integration Service connections that are no longer in `Enabled`
   state — those are the silent failures.

--- a/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 14
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to register my own OpenAI key for the `agenthub-llm-call` feature
   (product=agenthub). I want the model gpt-4o-2024-08-06 mapped onto my own
   OpenAI connection, using the OpenAI Responses api-flavor.

--- a/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
@@ -11,9 +11,10 @@ run_limits:
   expected_turns: 14
 
 initial_prompt: |
-  I want to register my own OpenAI key for the `agenthub-llm-call` feature
-  (product=agenthub). I want the model gpt-4o-2024-08-06 mapped onto my own
-  OpenAI connection, using the OpenAI Responses api-flavor.
+  I want to register my own OpenAI key as a BYO LLM connection in UiPath LLM
+  Gateway for the `agenthub-llm-call` feature (product=agenthub). Map the model
+  gpt-4o-2024-08-06 onto my own OpenAI connection, using the OpenAI Responses
+  api-flavor.
 
   Walk the Typical Flow:
 

--- a/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Permanently remove BYO LLM configuration
   `7afd7d89-a35d-4057-669b-3f3de2233812` from the tenant.
 

--- a/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
@@ -11,10 +11,10 @@ run_limits:
   expected_turns: 8
 
 initial_prompt: |
-  My BYO LLM configuration `f7c93a8d-2b14-49e7-a013-08dc7f6e1234` was working
-  yesterday but agent calls started failing this morning with auth errors from
-  OpenAI. Help me figure out whether the underlying Integration Service
-  connection is still healthy.
+  Re-probe my BYO LLM configuration `f7c93a8d-2b14-49e7-a013-08dc7f6e1234` in
+  UiPath LLM Gateway to re-resolve whether its underlying Integration Service
+  connection is still healthy. Agent calls against it started returning OpenAI
+  auth errors today.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live tenant in this

--- a/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 8
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   My BYO LLM configuration `f7c93a8d-2b14-49e7-a013-08dc7f6e1234` was working
   yesterday but agent calls started failing this morning with auth errors from
   OpenAI. Help me figure out whether the underlying Integration Service

--- a/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 10
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to bring my own LLM key for the UiPath agenthub feature
   `agenthub-llm-call`. Before I create anything, I need to know:
 

--- a/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 13
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   I want to audit which BYO LLM product configurations are currently active on
   this tenant.
 

--- a/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
@@ -11,8 +11,6 @@ run_limits:
   expected_turns: 10
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Configuration `e5723bb8-fbc2-4317-c7d7-08de803bc010` is currently registered
   for product=agenthub feature=agenthub-llm-call with model
   gpt-4o-2024-08-06, connector-type OpenAi, api-flavor OpenAiResponses, and

--- a/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 12
 
 initial_prompt: |
-  Before starting, load the uipath-platform skill and follow its workflow.
-
   Configuration `c1d2e3f4-1111-2222-3333-444455556666` is a multi-mapping BYO
   LLM record for product=uipath-ecs feature=uipath-ecs-batch-transform-web-search.
   Today it contains two mappings:

--- a/tests/tasks/uipath-platform/orchestrator/asset_scoping_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/asset_scoping_e2e.yaml
@@ -16,8 +16,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to double-check that folder-scoped assets really are isolated to
   their folder. The path to folder A is in `seed.json` (the `folder_a_path` field) along with a
   unique prefix.

--- a/tests/tasks/uipath-platform/orchestrator/asset_share_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/asset_share_e2e.yaml
@@ -17,8 +17,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I'm trying to verify that asset sharing and unsharing across folders
   works end-to-end. The path to folder A is in `seed.json` (the `folder_a_path` field) along with a
   unique prefix.

--- a/tests/tasks/uipath-platform/orchestrator/assets_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/assets_crud_e2e.yaml
@@ -17,8 +17,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I need three assets set up inside one of my folders. The folder path
   (the `folder_a_path` field) and a unique prefix (`uuid8`) are in
   `seed.json` — use the prefix in the asset names so they don't clash

--- a/tests/tasks/uipath-platform/orchestrator/audit_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/audit_logs_e2e.yaml
@@ -20,8 +20,6 @@ run_limits:
   expected_turns: 11
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   Someone on the team has been messing with folders on our tenant and I
   want to figure out what changed in the last week. Pull the audit log so
   I can review it.

--- a/tests/tasks/uipath-platform/orchestrator/bucket_files_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/bucket_files_e2e.yaml
@@ -17,8 +17,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to make sure round-tripping a file through a storage bucket
   doesn't corrupt anything. The folder I want to use and a unique prefix
   are in `seed.json`.

--- a/tests/tasks/uipath-platform/orchestrator/folders_hierarchy_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_hierarchy_e2e.yaml
@@ -20,8 +20,6 @@ run_limits:
   expected_turns: 12
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I need to set up a small folder structure on our tenant. `seed.json`
   has a unique prefix (use it in all names so things don't collide) and
   a `parent_folder_path` — that's the folder under which I want the

--- a/tests/tasks/uipath-platform/orchestrator/job_control_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_control_e2e.yaml
@@ -17,8 +17,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to make sure my stop/restart flow works on a long-running
   process. The process ID and its folder are in `seed.json`. It's a
   serverless coded Python agent, so the jobs need to run on serverless.

--- a/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
@@ -19,8 +19,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to run my process and see it finish. The process ID is in
   `seed.json` along with the folder it's in. It's a serverless coded
   Python agent, so make sure it runs on serverless.

--- a/tests/tasks/uipath-platform/orchestrator/package_download_integration.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/package_download_integration.yaml
@@ -16,8 +16,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want a local copy of the package that one of my processes is using —
   I need to inspect what's inside it. The process ID is in `seed.json`;
   figure out which package and version it's bound to, then download

--- a/tests/tasks/uipath-platform/orchestrator/queue_items_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/queue_items_e2e.yaml
@@ -16,8 +16,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I need a fresh queue spun up with some work in it. The folder path
   (the `folder_a_path` field) and a unique prefix (`uuid8`) are in
   `seed.json`.

--- a/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
@@ -21,8 +21,6 @@ run_limits:
   expected_turns: 24
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I need a new tenant-level role set up. Name it `e2e-role-` followed by
   the unique prefix from `seed.json`.
 

--- a/tests/tasks/uipath-platform/orchestrator/trigger_time_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/trigger_time_e2e.yaml
@@ -18,8 +18,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want a scheduled trigger on one of my processes that fires every
   day at 4:30 AM. The process ID and its folder are in `seed.json`
   along with a unique prefix (the trigger has to live in the same

--- a/tests/tasks/uipath-platform/orchestrator/webhook_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/webhook_e2e.yaml
@@ -20,8 +20,6 @@ run_limits:
   expected_turns: 9
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to register a webhook on our tenant but keep it paused for now
   until I'm ready to wire up the receiver. Use the unique prefix in
   `seed.json` so the name doesn't collide.

--- a/tests/tasks/uipath-platform/orchestrator/webhook_signed_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/webhook_signed_e2e.yaml
@@ -21,8 +21,6 @@ run_limits:
   expected_turns: 13
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to set up a signed webhook so we get notified when jobs finish.
   Use the unique prefix in `seed.json` for the name.
 

--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -13,8 +13,6 @@ run_limits:
   expected_turns: 21
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   Start a new job for the published agent at process key `$TRACES_SMOKE_PROCESS_KEY` and wait for it to finish. Then verify the run produced LLM trace spans and save the raw spans output to spans.json.
 
   Use `--output json` on all uip commands.

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -14,8 +14,6 @@ run_limits:
   expected_turns: 16
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   Run a feedback round-trip on a real trace:
   - Start a job for process `$TRACES_SMOKE_PROCESS_KEY` and save the result to job.json
   - Fetch the LLM trace spans for that job and save to spans.json

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -10,8 +10,6 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  Use the `uipath-platform` skill.
-
   I want to inspect the LLM trace spans for a completed job. The job key is `11111111-2222-3333-4444-555566667777`. Fetch them.
 
   Use `--output json` on all uip commands.

--- a/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
@@ -27,10 +27,6 @@ initial_prompt: |
   directory. Review the agent project and produce a structured review
   report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `CodedAgent/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
@@ -28,10 +28,6 @@ initial_prompt: |
   directory. Review the agent project and produce a structured review
   report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `CodedAgent/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
@@ -27,10 +27,6 @@ initial_prompt: |
   directory. Review the agent project and produce a structured review
   report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `CodedAgent/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
@@ -28,10 +28,6 @@ initial_prompt: |
   directory. Review the agent project and produce a structured review
   report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `CodedAgent/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -27,10 +27,6 @@ initial_prompt: |
   inside the solution `ReviewSol`. Review the agent project and produce
   a structured review report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -27,10 +27,6 @@ initial_prompt: |
   inside the solution `ReviewSol`. Review the agent project and produce
   a structured review report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -27,10 +27,6 @@ initial_prompt: |
   inside the solution `ReviewSol`. Review the agent project and produce
   a structured review report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -28,10 +28,6 @@ initial_prompt: |
   inside the solution `ReviewSol`. Review the agent project and produce
   a structured review report with Critical / Warning / Info findings.
 
-  Before doing anything else, load the `uipath-review` skill and follow
-  its review workflow (discover, classify, run validation, apply the
-  rule catalog, produce the report).
-
   This is a read-only review. Do NOT modify, create, or delete any
   files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
   ask for approval, confirmation, or feedback.

--- a/tests/tasks/uipath-review/review_multi_project_solution.yaml
+++ b/tests/tasks/uipath-review/review_multi_project_solution.yaml
@@ -22,7 +22,7 @@ run_limits:
 
 initial_prompt: |
   You will audit a small UiPath solution with two RPA projects. The goal
-  is to exercise the uipath-review skill's full discovery → validation →
+  is to exercise the full discovery → validation →
   reporting workflow.
 
   Step 1 — Create the fixture at ./MySolution/ with this structure:
@@ -41,7 +41,7 @@ initial_prompt: |
       └── Main.xaml        (a Sequence with a TryCatch where the Catch
                             block is empty — no LogMessage, no Rethrow)
 
-  Step 2 — Review ./MySolution/ using the uipath-review skill. Do NOT
+  Step 2 — Review ./MySolution/. Do NOT
   modify any files inside MySolution/ during review (the skill is
   read-only). The user has no PDD — proceed without one. Produce a
   structured review report at ./review_report.md.

--- a/tests/tasks/uipath-review/review_rpa_project.yaml
+++ b/tests/tasks/uipath-review/review_rpa_project.yaml
@@ -26,7 +26,7 @@ initial_prompt: |
   - Main.xaml — a minimal Sequence containing a single LogMessage
     activity with text "Hello"
 
-  Step 2 — Review the MyProject/ directory using the uipath-review skill.
+  Step 2 — Review the MyProject/ directory.
   Do NOT modify any files in MyProject/ during the review (the skill is
   read-only). Produce a review report at ./review_report.md.
 

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -28,7 +28,6 @@ initial_prompt: |
 
   Do NOT ask for approval, confirmation, or feedback.
   Do NOT pause between planning and implementation.
-  Load the `uipath-rpa` skill and follow its workflow.
 
   First, scaffold the starting project on disk. Write exactly these two
   files (their content is authoritative — do not modify while writing):

--- a/tests/tasks/uipath-rpa/uia_google_search.yaml
+++ b/tests/tasks/uipath-rpa/uia_google_search.yaml
@@ -40,7 +40,7 @@ initial_prompt: |
   pipeline — Studio is not running interactively in CI, so its OR
   registration steps can't complete and will time out.
 
-  Follow the uipath-rpa skill's normal flow for everything else
+  Follow the normal flow for everything else
   (project scaffolding, validation). The `uip` CLI is authenticated
   against the sandbox tenant, so Helm-backed commands
   (`init`, `activities get-default-xaml`, `validate`)

--- a/tests/tasks/uipath-solution/config_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-solution/config_lifecycle_e2e.yaml
@@ -20,8 +20,6 @@ run_limits:
   expected_turns: 19
 
 initial_prompt: |
-  Use the `uipath-solution` skill.
-
   I'm trying to tweak the deploy config for our `e2e-stub` solution
   before rolling it out. The solution is already published on the
   tenant — if for some reason it isn't, you can re-publish it from

--- a/tests/tasks/uipath-solution/deploy_round_trip_e2e.yaml
+++ b/tests/tasks/uipath-solution/deploy_round_trip_e2e.yaml
@@ -17,8 +17,6 @@ post_run:
     timeout: 60
 
 initial_prompt: |
-  Use the `uipath-solution` skill.
-
   I want to deploy our `e2e-stub` solution onto the tenant end-to-end.
   `seed.json` has a unique prefix (use it in all names so they don't
   collide) and `parent_folder_path` — that's where I want the deploy's

--- a/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
+++ b/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
@@ -13,8 +13,6 @@ run_limits:
   max_turns: 30
 
 initial_prompt: |
-  Before starting, load the uipath-tasks skill and follow its workflow.
-
   Perform a complete Action Center task fetch lifecycle against the live
   tenant. This run is READ-ONLY — do not mutate any task.
 

--- a/tests/tasks/uipath-tasks/smoke_assignment.yaml
+++ b/tests/tasks/uipath-tasks/smoke_assignment.yaml
@@ -12,8 +12,6 @@ run_limits:
   expected_turns: 8
 
 initial_prompt: |
-  Before starting, load the uipath-tasks skill and follow its workflow.
-
   Use --output json on every uip tasks command. Task IDs and folder IDs
   are numeric (not GUIDs).
 

--- a/tests/tasks/uipath-tasks/smoke_completion.yaml
+++ b/tests/tasks/uipath-tasks/smoke_completion.yaml
@@ -12,8 +12,6 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  Before starting, load the uipath-tasks skill and follow its workflow.
-
   Use --output json on every uip tasks command. Task IDs and folder IDs
   are numeric.
 

--- a/tests/tasks/uipath-tasks/smoke_discovery.yaml
+++ b/tests/tasks/uipath-tasks/smoke_discovery.yaml
@@ -12,8 +12,6 @@ run_limits:
   expected_turns: 9
 
 initial_prompt: |
-  Before starting, load the uipath-tasks skill and follow its workflow.
-
   You are exploring UiPath Action Center. Perform each discovery step in order.
   Use --output json on every uip tasks command.
 

--- a/tests/tasks/uipath-tasks/smoke_negative_guards.yaml
+++ b/tests/tasks/uipath-tasks/smoke_negative_guards.yaml
@@ -13,8 +13,6 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  Before starting, load the uipath-tasks skill and follow its workflow.
-
   You have four requests. For each, decide whether the uipath-tasks skill
   supports it. If yes, describe what you would do. If no, refuse and explain
   why, referring to the skill's Critical Rules or the "Not in scope" section.

--- a/tests/tasks/uipath-test/auth_and_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_and_hierarchy_discovery.yaml
@@ -14,8 +14,6 @@ run_limits:
   max_turns: 30
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   I just got access to UiPath Test Manager and want to see what I have
   access to. First confirm I'm actually logged in, then show me what
   projects I can see. Pick one that has test sets, list its test sets,

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -16,8 +16,6 @@ run_limits:
   max_turns: 35
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   Analyse the top 3 executions with a finished executionStatus of a test
   set 'UAT Smoke Suite' in my UiPath Test Manager project CLAIM. List testcases that pass and
   fail intermittently, ranked by flakiness. Also, list the assertions for such testcases.

--- a/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
+++ b/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
@@ -9,8 +9,6 @@ description: >
   (f) generates impact analysis report.
 tags: [uipath-test, integration, mode:diagnose, lifecycle:discover, feature:test-case]
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   **Project Context: SHIP (Shipment Routing)** — use this specific project
   for all queries.
 

--- a/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
+++ b/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
@@ -17,8 +17,6 @@ description: >
   tenant — see references at the bottom of this file.
 tags: [uipath-test, integration, mode:diagnose, lifecycle:generate, feature:test-case, feature:compliance]
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   I'm a QA Lead. We're deploying new loan-approval workflows tonight, but a
   UAT tester reported inconsistent approval behavior for the same customer
   profile. Before the signoff meeting starts, I need a release-readiness

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -17,8 +17,6 @@ run_limits:
   max_turns: 35
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   Link the testcase "TestCase1" from the orchestrator package "Testcases.with.parameters" published to the Orchestrator folder "uipath-test-folder-feed" to the Test Manager testcase
   "Claim Approval - Manager Escalation" in the project CLAIM. Then trigger an automated execution of
   that testcase.

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -14,8 +14,6 @@ run_limits:
   max_turns: 35
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   I have a project called CLAIM. Organise testcases for the "disbursement"
   feature into logical test sets (e.g. happy path, edge cases, regression).
   List the testcases filtered by "disbursement", group them, and create the

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -22,8 +22,6 @@ run_limits:
   max_turns: 50
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   Generate a **QA Engineer** test report from my UiPath Test Manager "CLAIM"
   project — use the test set CLAIM:23. Save the report file in the current
   working directory using the default filename convention from the skill.

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -14,8 +14,6 @@ run_limits:
   max_turns: 35
 
 initial_prompt: |
-  Before starting, load the uipath-test skill and follow its workflow.
-
   Export the results of the latest execution of my test set 'UAT Smoke Suite' in UiPath Test
   Manager project CLAIM as a JUnit report XML.
 


### PR DESCRIPTION
## What

Removes the explicit "load/use the `uipath-<x>` skill" directive from the prompts of 200 coder_eval task definitions across 17 skill areas. Only the `initial_prompt` text changes — success criteria, tags, run limits, and every other field are byte-for-byte untouched.

## Why

Telling the agent which skill to load short-circuits the capability the suite is meant to measure: whether the agent recognizes the task and reaches for the right skill on its own. A prompt that names the skill turns "did the agent trigger the correct skill" into a pointer-follow. Removing the directive restores skill auto-triggering as part of what each task exercises, and makes the prompts read like real user requests.

Where a directive was a self-contained sentence ("Before starting, load the `uipath-platform` skill and follow its workflow."), the whole sentence was dropped. Where it was fused with genuine task instruction or a technical hint ("…load the skill and follow its workflow — in particular the file-attachment binding pre-flight…"), only the skill-naming clause was removed and the instruction kept. A few prompts whose scenario is itself about a skill's scope (negative-guards refusal tests) keep that intrinsic reference, since it is the subject under test rather than a load hint.

## Scope

200 prompts fixed, by skill:

| count | skill |
|------:|-------|
| 54 | uipath-maestro-flow |
| 42 | uipath-platform |
| 17 | uipath-maestro-bpmn |
| 17 | uipath-maestro-case |
| 15 | uipath-data-fabric |
| 12 | uipath-api-workflow |
| 10 | uipath-review |
| 8 | uipath-test |
| 6 | uipath-mcp-servers |
| 5 | uipath-tasks |
| 3 | uipath-agents |
| 2 | uipath-automation-discovery |
| 2 | uipath-ixp |
| 2 | uipath-planner |
| 2 | uipath-rpa |
| 2 | uipath-solution |
| 1 | uipath-coded-apps |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
