### PR TITLE
feat(uipath-maestro-bpmn): bundle offline BPMN validator at full 19-rule parity

### DIFF
--- a/skills/uipath-maestro-bpmn/references/author/references/validation.md
+++ b/skills/uipath-maestro-bpmn/references/author/references/validation.md
@@ -51,8 +51,24 @@ uip maestro bpmn validate ProjectName/ProjectName.bpmn --output json
 ```
 
 Only validate a project directory if the installed CLI explicitly supports that
-shape. If the installed CLI does not expose validation, run an explicit XML
-parse command against the BPMN source, for example:
+shape. If the installed CLI does not expose validation, or when you want full
+19-rule semantic parity with the PO.Frontend canvas validator, run the bundled
+offline validator that ships with this skill against the BPMN source:
+
+```bash
+node validator/validate-bpmn.mjs ProjectName/ProjectName.bpmn
+```
+
+It parses the BPMN with the UiPath extension descriptor, runs all 19
+PO.Frontend semantic rules plus a Maestro variable-existence check, prints
+`VALID` and exits `0` when there are no blocking errors, and exits non-zero
+(listing each rule code and message) otherwise. WARNING-severity findings are
+printed but do not gate. See [validator/README.md](../../../validator/README.md)
+for the full rule list and the documented RequiredFields parity caveat. Run
+`npm install` once in the `validator/` directory before first use.
+
+If neither the CLI validator nor the bundled validator is available, run an
+explicit XML parse command against the BPMN source, for example:
 
 ```bash
 python3 -c "import xml.etree.ElementTree as ET; ET.parse('ProjectName/ProjectName.bpmn')"

--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -22,8 +22,77 @@ node validate-bpmn.mjs <bpmn-file> [resources]
   unauthenticated CLI is reported as a NOTE, never a hard failure.
 
 ```bash
-npm test   # rule-coverage harness: asserts every rule fires on a crafted invalid
+npm test   # runs all three suites below; green = no drift from the frontend
 ```
+
+## Test suites (`test/`)
+
+`npm test` runs three layers and asserts all 28 rule codes are exercised:
+
+1. **Crafted-invalid XML coverage** (`run-tests.mjs`): for each rule, a minimal
+   BPMN that should trip exactly that rule's code, plus a check that valid twins
+   don't. Proves the full parse → model → rules pipeline end-to-end.
+2. **Ported PO.Frontend rule tests** (`test/ported-rule-tests.mjs`): a 1:1
+   translation of every `PO.Frontend/src/services/validation/bpmn/rules/*.test.ts`
+   case (162 assertions). Each case carries a `// FE:` comment naming the
+   originating frontend test and runs the same synthetic Node/Edge/CanvasState
+   graph through **our** rule engine. This is the primary drift detector: if our
+   port disagrees with a frontend test's expectation, this suite fails.
+3. **Integration over real `.bpmn` files** (`test/integration.test.mjs`): every
+   file in `test/fixtures/` is a real, externally-validated artifact (backend
+   BpmnParser/Worker/Athena/V2-E2E TestData, and PO.Frontend editor mocks),
+   bundled so the suite is self-contained in CI. `fixtures/known-good/` must
+   produce **zero** ERROR-severity findings; `fixtures/expected-findings/` assert
+   the exact ERROR codes the frontend would also raise (each verified by reading
+   the file). Set `MAESTRO_BPMN_TESTDATA` / `MAESTRO_BPMN_FRONTEND_MOCKS` to also
+   sweep a live corpus during development.
+
+## Drift log (hand-port vs. PO.Frontend source of truth)
+
+Surfaced by running the frontend's own test inputs and real `.bpmn` corpora
+through this port. Each was either **fixed to match the frontend** or
+**justified and documented**.
+
+1. **Empty `<conditionExpression/>` crash — FIXED.** Legacy `model:`-namespace
+   files (and any empty condition element) parse to a moddle object with no
+   `.body`; `model.mjs` fell back to the moddle object itself, crashing the
+   string-based rules (`expression.startsWith is not a function`). Now an empty
+   condition element is treated as "no condition" (frontend behavior).
+2. **`FakeJoinRule` over-firing — FIXED (match frontend behavior).** The frontend
+   rule matches only the **literal** abstract types `"bpmn:Activity"` /
+   `"bpmn:Event"`. On the real canvas every node carries its **concrete** `$type`
+   (`bpmn:Task`, `bpmn:EndEvent`, …; `bpmn-from-xml.ts` sets `type: $type`), so
+   the rule is **dormant on exported BPMN** — its own source has a `TODO` noting
+   it must be rewritten to walk the inherited-type chain. An earlier hand-port
+   fired `FAKE_JOIN` on concrete activities/events, producing false positives on
+   many valid real files. The port now applies the frontend's exact predicate, so
+   it is faithful (same inputs → same outputs). The rule's logic is proven in the
+   ported suite (which feeds literal abstract types, like the frontend test); it
+   is intentionally not triggerable via real XML.
+3. **`validateRequiredFields(null)` crash — FIXED.** The frontend rule guards
+   `if (!nodes || !edges) return []`; the port now guards null inputs too.
+4. **`VARIABLE_DOES_NOT_EXIST` false positives on node-output variables — FIXED.**
+   A node's `<uipath:output var="x">` **declares** variable `x` (frontend
+   `mapNodeOutputsToVariables`: `id: v.var`), available to downstream nodes/edges.
+   `collectKnownVariableIds` only gathered declared `uipath:variables` blocks, so
+   a gateway condition reading a variable written by an upstream script/task
+   output false-positived. Now node outputs' `var`/`name`/`canonicalId` are
+   included in the known-id set. Also fixed: script-task IO lives under
+   `uipath:Mapping` (same shape as `uipath:Activity`/`Event`), which the model now
+   recognizes.
+
+### Justified, intentional divergences (documented, not bugs)
+
+- **`FAKE_JOIN` dormant on real BPMN** (see #2): faithful to the frontend, which
+  cannot fire it on concrete-typed canvas nodes.
+- **`RequiredFields` is a conservative subset** offline (see the parity note
+  below): flags present-but-empty required fields, not absent ones.
+- **`VARIABLE_DOES_NOT_EXIST` is the existence half** of the frontend's variable
+  validation. The frontend additionally emits a *separate* `VARIABLE_NOT_SET`
+  WARNING for variables that exist but aren't reachable in flow order; this port
+  intentionally implements only the existence check (declared/produced anywhere),
+  which is why some backend parser fixtures with genuinely dangling `vars.*`
+  references are listed as expected-findings — the frontend would flag them too.
 
 ## Architecture (Phase 1 → Phase 2)
 

--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -1,0 +1,86 @@
+# Maestro BPMN Validator (bundled, offline)
+
+A dependency-light, offline semantic validator for UiPath Maestro BPMN XML. It
+parses the BPMN with `bpmn-moddle` using the UiPath extension descriptor (the
+same `getModdle()` + `fromXML()` pattern as PO.Frontend), reconstructs the
+PO.Frontend `Node[] / Edge[] / CanvasState` model from the parse tree, and runs
+**all 19** PO.Frontend validation rules plus a Maestro-original
+variable-existence check and an optional connection-liveness ping.
+
+## Usage
+
+```bash
+npm install
+node validate-bpmn.mjs <bpmn-file> [resources]
+```
+
+- Prints `VALID` and exits `0` when there are no ERROR-severity findings.
+- Otherwise lists every finding (rule code + message) and exits `1`.
+- WARNING-severity findings are printed but do not gate.
+- `resources` (optional): a numeric folder id (or comma-separated release names)
+  for the connection-liveness ping via the `uip` CLI. Best-effort; a missing or
+  unauthenticated CLI is reported as a NOTE, never a hard failure.
+
+```bash
+npm test   # rule-coverage harness: asserts every rule fires on a crafted invalid
+```
+
+## Architecture (Phase 1 → Phase 2)
+
+| File | Role |
+| --- | --- |
+| `rules.mjs` | **Self-contained rule engine** — the swap target. In Phase 2 this single module is replaced by the published npm package with no behavior change. |
+| `model.mjs` | Integration glue: reconstructs the frontend model from the moddle tree; bundles registry metadata. |
+| `validate-bpmn.mjs` | CLI entry: parse → build model → run rules → gate. |
+| `bpmn-spec.json` | Bundled maestro-sdk registry, consumed offline for RequiredFields. |
+| `uipath-moddle.v1.json` | Verbatim UiPath moddle descriptor from PO.Frontend. |
+
+## 19-rule coverage
+
+Each rule is a faithful port of the PO.Frontend rule of the same name. Source
+column shows where the rule's truth comes from offline.
+
+| # | Rule (PO.Frontend) | Source | Codes emitted |
+| --- | --- | --- | --- |
+| 1 | ConditionalFlow | XML graph | `MISSING_CONDITION_EXPRESSION` |
+| 2 | Connection | XML graph | `INVALID_CONNECTION`, `INVALID_CONNECTION_TYPE` |
+| 3 | DuplicateErrorEventSubprocess | XML graph + `bpmn:Error` objects | `MULTIPLE_CATCH_ALL_ERROR_EVENT_SUBPROCESS`, `DUPLICATE_ERROR_EVENT_SUBPROCESS` |
+| 4 | EmptyStartEventDefinitionInSubProcess | XML graph | `START_EVENT_WITH_DEFINITION_IN_SUBPROCESS`, `START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS`, `INVALID_EVENT_DEFINITION_IN_EVENT_SUBPROCESS` |
+| 5 | ErrorBoundaryEvent | XML graph + `bpmn:Error` objects | `ERROR_BOUNDARY_EVENT_EMPTY_ERROR_REF`, `ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE`, `MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK`, `DUPLICATE_ERROR_BOUNDARY_EVENT_ON_TASK` |
+| 6 | ErrorEndEvent | XML graph | `ERROR_END_EVENT_MISSING_EXCEPTION` |
+| 7 | FakeJoin | XML graph | `FAKE_JOIN` |
+| 8 | MessageFlowObjectsPool | XML graph (pools) | `SAME_POOL_MESSAGE_FLOW` |
+| 9 | MissingResource | XML extension (`serviceType` + bindings) | `MISSING_RESOURCE` (WARNING) |
+| 10 | MissingRootVariable | XML extension (variables + outputs) | `MISSING_ROOT_VARIABLE` (WARNING) |
+| 11 | NoAssignments | Pure check on expressions | `ASSIGNMENT_NOT_ALLOWED` (WARNING) |
+| 12 | RequiredFields | **Registry metadata** (`bpmn-spec.json`) | `EMPTY_REQUIRED_FIELD` |
+| 13 | SequenceFlowPoolCrossing | XML graph (pools) | `CROSSING_POOL_BOUNDARY` |
+| 14 | SequenceFlowSubProcessCrossing | XML graph | `CROSSING_SUBPROCESS_BOUNDARY` |
+| 15 | SingleBlankStartEvent | XML graph | `MULTIPLE_BLANK_START_EVENTS` |
+| 16 | SingleStartEventInEventSubProcess | XML graph | `MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS` |
+| 17 | SuperfluousGateway | XML graph | `SUPERFLUOUS_GATEWAY` |
+| 18 | TaskTimer | Pure check (range) | `TASK_TIMER_OUT_OF_RANGE` (WARNING) |
+| 19 | TimerDuration | Pure check (ISO 8601) | `TIMER_DURATION_INVALID`, `TIMER_DURATION_WEEK_UNSUPPORTED` (WARNING) |
+| + | Variable existence (Maestro-original) | XML extension + declared variables | `VARIABLE_DOES_NOT_EXIST` |
+
+## RequiredFields parity note (honest scope)
+
+The PO.Frontend `RequiredFields` rule fires when `field.required && isNilOrEmpty(field.value)`.
+On the canvas, `field.required` is attached to each *live* node field by
+actions-service-enriched node data, where the field name already matches.
+
+Offline we recover `required` from the bundled registry (`bpmn-spec.json`), but
+the registry's required-field **names** are canonical designer names that do
+**not** always match the names a field is serialized under in exported BPMN
+(e.g. registry `url` vs serialized `path`; registry `name` vs serialized
+`messageName`). The registry also does not carry a name-alias map.
+
+Therefore this port flags a required field only when a serialized field whose
+name matches a registry-required name is **present but empty** — the genuine
+"user left a required field blank" case, and a true subset of the canvas
+behavior. Required fields that are entirely **absent** from the serialized data
+are not flagged, because offline their absence is ambiguous (bound elsewhere,
+serialized under a different canonical name, or supplied by design-time
+enrichment that exported BPMN does not carry). This is the one rule that cannot
+reach full byte-for-byte parity offline; it is intentionally conservative to
+avoid false positives on valid processes.

--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -4,8 +4,9 @@ A dependency-light, offline semantic validator for UiPath Maestro BPMN XML. It
 parses the BPMN with `bpmn-moddle` using the UiPath extension descriptor (the
 same `getModdle()` + `fromXML()` pattern as PO.Frontend), reconstructs the
 PO.Frontend `Node[] / Edge[] / CanvasState` model from the parse tree, and runs
-**all 19** PO.Frontend validation rules plus a Maestro-original
-variable-existence check and an optional connection-liveness ping.
+**all 19** PO.Frontend validation rules plus the variable-validation checks
+(`VARIABLE_DOES_NOT_EXIST`, including element-local `result.X`, and the
+flow-order `VARIABLE_NOT_SET` warning) and an optional connection-liveness ping.
 
 ## Usage
 
@@ -27,14 +28,15 @@ npm test   # runs all three suites below; green = no drift from the frontend
 
 ## Test suites (`test/`)
 
-`npm test` runs three layers and asserts all 28 rule codes are exercised:
+`npm test` runs three layers and asserts all 29 rule codes are exercised:
 
 1. **Crafted-invalid XML coverage** (`run-tests.mjs`): for each rule, a minimal
    BPMN that should trip exactly that rule's code, plus a check that valid twins
    don't. Proves the full parse → model → rules pipeline end-to-end.
 2. **Ported PO.Frontend rule tests** (`test/ported-rule-tests.mjs`): a 1:1
    translation of every `PO.Frontend/src/services/validation/bpmn/rules/*.test.ts`
-   case (162 assertions). Each case carries a `// FE:` comment naming the
+   case plus the variable-validation cases from `VariableUtil.test.ts`
+   (173 assertions). Each case carries a `// FE:` comment naming the
    originating frontend test and runs the same synthetic Node/Edge/CanvasState
    graph through **our** rule engine. This is the primary drift detector: if our
    port disagrees with a frontend test's expectation, this suite fails.
@@ -47,52 +49,99 @@ npm test   # runs all three suites below; green = no drift from the frontend
    the file). Set `MAESTRO_BPMN_TESTDATA` / `MAESTRO_BPMN_FRONTEND_MOCKS` to also
    sweep a live corpus during development.
 
-## Drift log (hand-port vs. PO.Frontend source of truth)
+## Parity status
 
-Surfaced by running the frontend's own test inputs and real `.bpmn` corpora
-through this port. Each was either **fixed to match the frontend** or
-**justified and documented**.
+**Full parity with the PO.Frontend rule engine is now reached for every rule
+except two clearly-bounded residuals (below).** Each rule is a faithful port of
+the frontend rule of the same name: same inputs → same outputs, verified by the
+1:1 ported test suite (frontend test inputs) and the real-`.bpmn` integration
+corpus (zero ERROR findings on 31 known-good files; exact ERROR-code match on 28
+expected-findings files).
 
-1. **Empty `<conditionExpression/>` crash — FIXED.** Legacy `model:`-namespace
-   files (and any empty condition element) parse to a moddle object with no
-   `.body`; `model.mjs` fell back to the moddle object itself, crashing the
-   string-based rules (`expression.startsWith is not a function`). Now an empty
-   condition element is treated as "no condition" (frontend behavior).
-2. **`FakeJoinRule` over-firing — FIXED (match frontend behavior).** The frontend
-   rule matches only the **literal** abstract types `"bpmn:Activity"` /
-   `"bpmn:Event"`. On the real canvas every node carries its **concrete** `$type`
-   (`bpmn:Task`, `bpmn:EndEvent`, …; `bpmn-from-xml.ts` sets `type: $type`), so
-   the rule is **dormant on exported BPMN** — its own source has a `TODO` noting
-   it must be rewritten to walk the inherited-type chain. An earlier hand-port
-   fired `FAKE_JOIN` on concrete activities/events, producing false positives on
-   many valid real files. The port now applies the frontend's exact predicate, so
-   it is faithful (same inputs → same outputs). The rule's logic is proven in the
-   ported suite (which feeds literal abstract types, like the frontend test); it
-   is intentionally not triggerable via real XML.
-3. **`validateRequiredFields(null)` crash — FIXED.** The frontend rule guards
-   `if (!nodes || !edges) return []`; the port now guards null inputs too.
-4. **`VARIABLE_DOES_NOT_EXIST` false positives on node-output variables — FIXED.**
-   A node's `<uipath:output var="x">` **declares** variable `x` (frontend
-   `mapNodeOutputsToVariables`: `id: v.var`), available to downstream nodes/edges.
-   `collectKnownVariableIds` only gathered declared `uipath:variables` blocks, so
-   a gateway condition reading a variable written by an upstream script/task
-   output false-positived. Now node outputs' `var`/`name`/`canonicalId` are
-   included in the known-id set. Also fixed: script-task IO lives under
-   `uipath:Mapping` (same shape as `uipath:Activity`/`Event`), which the model now
-   recognizes.
+### Closed gaps (now at parity)
 
-### Justified, intentional divergences (documented, not bugs)
+1. **`RequiredFields` flags ABSENT required fields, not only present-but-empty.**
+   Frontend `RequiredFieldsRule.ts:24-27` + `ValidateRequiredFieldsInData.ts:15-16`
+   fire on `field.required && isNilOrEmpty(field.value)`. On canvas every field a
+   serviceType declares is present in node data, so an *unbound* required field is
+   present-with-empty-value. In exported BPMN that field is simply absent. The
+   model (`model.mjs`) attaches the serviceType's full registry required-field name
+   set (`bpmn-spec.json`, 128 `required` entries) as `uipath.requiredFieldNames`,
+   and the rule now treats an absent required name exactly as the frontend treats
+   an unbound field. Present-but-empty still fires too, in the frontend's
+   context → inputs → outputs order, one finding per node.
+2. **`VARIABLE_NOT_SET` (WARNING) is now implemented.** Port of the flow-order
+   reachability half of `VariableUtil.validateVariablesInExpression`
+   (`VariableUtil.ts:758-866`), built on the pure topology helpers
+   `getSourceEdgeMappings` (`:121-130`), `mapNodeOutputsToVariables` (`:539-579`),
+   `getVariablesForSubProcess` (`:495-525`), `getAvailableVariablesFromSourceNodes`
+   (`:303-389`, backward BFS over sequence-flow edges + boundary re-parenting +
+   subprocess scope), and `getAvailableVariablesForElement` (`:401-481`, parent
+   chain + event-subprocess shared scope + subprocess EndEvent exposure). A
+   *declared* variable referenced where no flow path reaches its producer fires
+   `VARIABLE_NOT_SET` (WARNING, non-gating). **Skipped entirely for Case
+   Management** (`VariableUtil.ts:826-828`). Root variables are globally available
+   and never warn.
+3. **`result.X` existence is now validated element-locally.** Frontend puts an
+   unresolved `result.X` in the non-existing set (`VariableUtil.ts:263`) and a
+   `result.X` is valid only if `X` names one of the *referencing element's own*
+   outputs (`isResultVariableValidForElement`, `:166-178`). The port previously
+   skipped all `result.` refs unconditionally; it now resolves `result.X` against
+   the element's own output identifiers and fires `VARIABLE_DOES_NOT_EXIST` for an
+   invalid one (edge conditions have no own outputs, so every `result.X` on an
+   edge is invalid, matching the frontend).
+4. **`ConnectionRule` unknown-type fallback now returns `false`.** Frontend
+   `canNodeTypesBeConnected` (`BPMNTypesUtils.ts:51-82`) returns **false** when no
+   rule matches the source type, yielding `INVALID_CONNECTION_TYPE` (WARNING). The
+   port previously returned `true` for unknown source types; it now matches the
+   frontend. The abstract-type inheritance the frontend additionally walks is
+   already folded into our concrete allow-map (every concrete activity/event type
+   has an explicit entry), so an unknown source type genuinely has no rule. The
+   ported `ConnectionRule` test was un-doctored to the frontend's actual input
+   (source `"output"` → target `"input"`, both unknown) per `ConnectionRule.test.ts:33-43`.
+5. **Custom-output accessor gating aligned to the frontend.** Both the existence
+   check and `VARIABLE_NOT_SET` now collect a custom output's `source` only when
+   `getAccessorFromType(type) === "source"`, and `body` only when the accessor is
+   `body` (`VariableUtil.ts:952-968`).
 
-- **`FAKE_JOIN` dormant on real BPMN** (see #2): faithful to the frontend, which
-  cannot fire it on concrete-typed canvas nodes.
-- **`RequiredFields` is a conservative subset** offline (see the parity note
-  below): flags present-but-empty required fields, not absent ones.
-- **`VARIABLE_DOES_NOT_EXIST` is the existence half** of the frontend's variable
-  validation. The frontend additionally emits a *separate* `VARIABLE_NOT_SET`
-  WARNING for variables that exist but aren't reachable in flow order; this port
-  intentionally implements only the existence check (declared/produced anywhere),
-  which is why some backend parser fixtures with genuinely dangling `vars.*`
-  references are listed as expected-findings — the frontend would flag them too.
+### Earlier fixes (already at parity before this round)
+
+6. **Empty `<conditionExpression/>` crash — FIXED.** An empty condition element
+   parses to a moddle object with no `.body`; the model now treats it as "no
+   condition" (frontend behavior) instead of crashing the string-based rules.
+7. **`FakeJoinRule` over-firing — FIXED (match frontend behavior).** See the
+   residual note below.
+8. **`validateRequiredFields(null)` crash — FIXED.** Matches the frontend's
+   `if (!nodes || !edges) return []` guard.
+9. **`VARIABLE_DOES_NOT_EXIST` false positives on node-output variables — FIXED.**
+   A node's `<uipath:output var="x">` declares variable `x`
+   (`mapNodeOutputsToVariables`: `id: v.var`); these are now in the known-id set,
+   and script-task IO under `uipath:Mapping` is recognized.
+
+## Genuine residuals (the only two)
+
+These are the **only** places this port is not byte-for-byte identical to the
+frontend, and both are bounded and justified — not drift.
+
+- **Dynamic IS-connector required-ness needs `registry get` enrichment (shared
+  with the frontend).** For Integration-Service connector activity types whose
+  required fields are NOT in the static `bpmn-spec.json` registry — their
+  required-ness only materializes after a live `registry get` enrichment — the
+  model has no `requiredFieldNames`, so `RequiredFields` stays conservative
+  (only present-but-empty fires; absence cannot be judged). **The frontend has
+  the identical limitation:** it also needs that enrichment to learn the field is
+  required. For every serviceType present in the static registry, absent-required
+  detection is at full parity.
+- **`FAKE_JOIN` is dormant on real/exported BPMN (faithful to the frontend).**
+  The frontend `FakeJoinRule` matches only the **literal** abstract types
+  `"bpmn:Activity"` / `"bpmn:Event"`, but the canvas assigns every node its
+  **concrete** `$type` (`bpmn:Task`, `bpmn:EndEvent`, …; `bpmn-from-xml.ts` sets
+  `type: $type`). The rule therefore never fires on exported BPMN — its own
+  source carries a `TODO` admitting it must be rewritten to walk the inherited-
+  type chain, which it does not yet do. The port applies the frontend's exact
+  predicate, so it is faithful (same inputs → same outputs); its logic is proven
+  in the ported suite (which feeds literal abstract types, like the frontend
+  test) and is intentionally not triggerable via real XML.
 
 ## Architecture (Phase 1 → Phase 2)
 
@@ -104,7 +153,7 @@ through this port. Each was either **fixed to match the frontend** or
 | `bpmn-spec.json` | Bundled maestro-sdk registry, consumed offline for RequiredFields. |
 | `uipath-moddle.v1.json` | Verbatim UiPath moddle descriptor from PO.Frontend. |
 
-## 19-rule coverage
+## Rule coverage
 
 Each rule is a faithful port of the PO.Frontend rule of the same name. Source
 column shows where the rule's truth comes from offline.
@@ -130,26 +179,29 @@ column shows where the rule's truth comes from offline.
 | 17 | SuperfluousGateway | XML graph | `SUPERFLUOUS_GATEWAY` |
 | 18 | TaskTimer | Pure check (range) | `TASK_TIMER_OUT_OF_RANGE` (WARNING) |
 | 19 | TimerDuration | Pure check (ISO 8601) | `TIMER_DURATION_INVALID`, `TIMER_DURATION_WEEK_UNSUPPORTED` (WARNING) |
-| + | Variable existence (Maestro-original) | XML extension + declared variables | `VARIABLE_DOES_NOT_EXIST` |
+| + | Variable existence (incl. element-local `result.X`) | XML extension + declared variables | `VARIABLE_DOES_NOT_EXIST` |
+| + | Variable-not-set (flow-order reachability) | XML topology + declared variables | `VARIABLE_NOT_SET` (WARNING) |
 
-## RequiredFields parity note (honest scope)
+## RequiredFields parity note
 
-The PO.Frontend `RequiredFields` rule fires when `field.required && isNilOrEmpty(field.value)`.
-On the canvas, `field.required` is attached to each *live* node field by
-actions-service-enriched node data, where the field name already matches.
+The PO.Frontend `RequiredFields` rule fires when `field.required && isNilOrEmpty(field.value)`
+(`ValidateRequiredFieldsInData.ts:15-16`). On the canvas every field a serviceType
+declares is present in node data with its `required` flag, so an *unbound*
+required field is present-with-empty-value and is flagged.
 
-Offline we recover `required` from the bundled registry (`bpmn-spec.json`), but
-the registry's required-field **names** are canonical designer names that do
-**not** always match the names a field is serialized under in exported BPMN
-(e.g. registry `url` vs serialized `path`; registry `name` vs serialized
-`messageName`). The registry also does not carry a name-alias map.
+Offline, `field.required` is recovered from the bundled registry
+(`bpmn-spec.json`, 128 `required` entries keyed by serviceType; names are the
+serialized names) and the model attaches the full required-name set as
+`uipath.requiredFieldNames`. The rule fires for a required field that is either
+**present-but-empty** OR entirely **absent** from the serialized data (an absent
+required field is the exported-BPMN form of the canvas's unbound field), in the
+frontend's context → inputs → outputs order, one finding per node. This reaches
+full parity for every serviceType present in the static registry.
 
-Therefore this port flags a required field only when a serialized field whose
-name matches a registry-required name is **present but empty** — the genuine
-"user left a required field blank" case, and a true subset of the canvas
-behavior. Required fields that are entirely **absent** from the serialized data
-are not flagged, because offline their absence is ambiguous (bound elsewhere,
-serialized under a different canonical name, or supplied by design-time
-enrichment that exported BPMN does not carry). This is the one rule that cannot
-reach full byte-for-byte parity offline; it is intentionally conservative to
-avoid false positives on valid processes.
+The single bounded exception is dynamic Integration-Service connector activity
+types whose required-ness is **not** in the static registry (it only
+materializes after a live `registry get` enrichment): for those,
+`requiredFieldNames` is undefined and absence cannot be judged, so the rule stays
+conservative (only present-but-empty fires). The frontend shares this exact
+limitation — it also needs the enrichment to know the field is required. See
+"Genuine residuals" above.

--- a/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
+++ b/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
@@ -1,0 +1,2473 @@
+{
+  "version": "1.0.0",
+  "source": "PO.Frontend registry generator (2026-04-14) + CLI notes",
+  "extractedFrom": {
+    "designSchemaUtils": "src/services/serialization/design-schema/design-schema-utils.ts",
+    "bpmnModdle": "src/services/serialization/bpmn-moddle.ts",
+    "fpsFormPropertiesUtils": "src/components/canvases/shared/panels/properties/fps/FPSFormPropertiesUtils.ts",
+    "constants": "src/constants.ts",
+    "designSchemaJsonDir": "src/services/serialization/design-schema/*.design-schema.json"
+  },
+  "extensionTypes": {
+    "Actions.HITL": {
+      "extensionType": "Actions.HITL",
+      "label": "Create action app task",
+      "bpmnElement": "bpmn:UserTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:UserTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "appId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "appVersion",
+          "type": "number",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "actions",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "taskTitle",
+          "type": "string",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "HitlTaskArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Actions.HITL",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:UserTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Actions.HITL\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"appId\" value=\"{appId}\" />\n        <uipath:input name=\"appVersion\" value=\"{appVersion}\" />\n        <uipath:input name=\"actions\" value=\"{actions}\" />\n        <uipath:input name=\"key\" value=\"{key}\" />\n        <uipath:input name=\"taskTitle\" value=\"{taskTitle}\" />\n      </uipath:context>\n      <uipath:input name=\"HitlTaskArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Actions.HITL\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:UserTask>",
+      "discoveryNotes": "Uses getSupportedHumanTasks(search, systemName) to list available action app tasks",
+      "contextFieldNotes": "Note: 'folderKey' field in design schema has name='key' (the actual XML context input name)"
+    },
+    "Orchestrator.StartJob": {
+      "extensionType": "Orchestrator.StartJob",
+      "label": "Start and wait for RPA workflow",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartJob\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('process', search) to list available processes"
+    },
+    "Orchestrator.StartAgentJob": {
+      "extensionType": "Orchestrator.StartAgentJob",
+      "label": "Start and wait for agent",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartAgentJob\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('agent', search) to list available agents"
+    },
+    "Orchestrator.BusinessRules": {
+      "extensionType": "Orchestrator.BusinessRules",
+      "label": "Execute business rule [Preview]",
+      "bpmnElement": "bpmn:BusinessRuleTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:BusinessRuleTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.BusinessRules",
+      "outputName": "Execute business rule [Preview]",
+      "useRelativeSource": true,
+      "bindingPattern": "businessRule",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:BusinessRuleTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.BusinessRules\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Execute business rule [Preview]\" type=\"Orchestrator.BusinessRules\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:BusinessRuleTask>",
+      "discoveryNotes": "Uses getOrchestratorBusinessRules() to list available business rules"
+    },
+    "Intsvc.ActivityExecution": {
+      "extensionType": "Intsvc.ActivityExecution",
+      "label": "Execute connector activity",
+      "bpmnElement": "bpmn:SendTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:SendTask"
+        },
+        "intermediateEvent": {
+          "type": "bpmn:IntermediateThrowEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        },
+        "endEvent": {
+          "type": "bpmn:EndEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "result",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:SendTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.ActivityExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"result\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:SendTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections. Activity/connector metadata comes from Integration Service catalog.",
+      "inputNotes": "isSplitInputs=false in design schema; inputs are sent as separate <uipath:input> elements, not merged into a single JSON body",
+      "extensionTagNotes": "In isExecution array, NOT in isEvents array, so uses uipath:activity"
+    },
+    "Intsvc.HttpExecution": {
+      "extensionType": "Intsvc.HttpExecution",
+      "label": "Execute HTTP request (Legacy)",
+      "bpmnElement": "bpmn:SendTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:SendTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "mode",
+          "displayName": "Mode",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": "manual"
+        },
+        {
+          "name": "method",
+          "displayName": "HTTP Method",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": "GET"
+        },
+        {
+          "name": "url",
+          "displayName": "URL",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": ""
+        },
+        {
+          "name": "headers",
+          "displayName": "Headers",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "{}"
+        },
+        {
+          "name": "parameters",
+          "displayName": "Query Parameters",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "{}"
+        },
+        {
+          "name": "body",
+          "displayName": "Request Body",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "null"
+        }
+      ],
+      "inputPattern": "none",
+      "outputSource": "=response",
+      "outputType": "jsonSchema",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:SendTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.HttpExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"mode\" value=\"manual\" />\n        <uipath:input name=\"method\" value=\"GET\" />\n        <uipath:input name=\"url\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"headers\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"parameters\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"body\" value=\"=bindings.{bindingId}\" />\n      </uipath:context>\n      <uipath:output name=\"response\" type=\"jsonSchema\" source=\"=response\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:SendTask>",
+      "inputNotes": "No jsonBody in design schema input section; all configuration is in context fields"
+    },
+    "Intsvc.UnifiedHttpRequest": {
+      "extensionType": "Intsvc.UnifiedHttpRequest",
+      "label": "Execute HTTP request",
+      "bpmnElement": "bpmn:SendTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:SendTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "mode",
+          "displayName": "Mode",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": "manual"
+        },
+        {
+          "name": "method",
+          "displayName": "HTTP Method",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": "GET"
+        },
+        {
+          "name": "url",
+          "displayName": "URL",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": ""
+        },
+        {
+          "name": "headers",
+          "displayName": "Headers",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "{}"
+        },
+        {
+          "name": "parameters",
+          "displayName": "Query Parameters",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "{}"
+        },
+        {
+          "name": "body",
+          "displayName": "Request Body",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": "null"
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "outputSource": "=response",
+      "outputType": "jsonSchema",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "designSchemaSharedWith": "Intsvc.HttpExecution",
+      "xmlTemplate": "<bpmn:SendTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.UnifiedHttpRequest\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"mode\" value=\"manual\" />\n        <uipath:input name=\"method\" value=\"GET\" />\n        <uipath:input name=\"url\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"headers\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"parameters\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"body\" value=\"=bindings.{bindingId}\" />\n      </uipath:context>\n      <uipath:output name=\"response\" type=\"jsonSchema\" source=\"=response\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:SendTask>",
+      "inputNotes": "In the isExecution array. Despite the design schema having no jsonBody, inputs are managed by the IS connector framework and serialized as separate <uipath:input> elements. The design schema context fields (mode, method, url, headers, parameters, body) are used for the HttpRequestV2Properties panel.",
+      "contextFieldNotes": "Context fields above come from the legacy design schema (shared with Intsvc.HttpExecution). In the FPS ImplementationSection, this type is routed through IntsvcActivityProperties (IS connector framework), NOT HttpRequestProperties. The IS connector auto-initializes with HTTP_ACTIVITY_CONFIG and manages context dynamically. When used via the uipath.http-request shortcut node, it uses HttpRequestV2Properties which manages these context fields directly.",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity. Shares design schema with Intsvc.HttpExecution but uses IS connector framework at runtime."
+    },
+    "Intsvc.WaitForEvent": {
+      "extensionType": "Intsvc.WaitForEvent",
+      "label": "Wait for connector event",
+      "bpmnElement": "bpmn:ReceiveTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ReceiveTask"
+        },
+        "intermediateEvent": {
+          "type": "bpmn:IntermediateCatchEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        },
+        "boundaryEvent": {
+          "type": "bpmn:BoundaryEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        }
+      },
+      "extensionTag": "uipath:event",
+      "contextFields": [],
+      "inputPattern": "separateInputs",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "result",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:ReceiveTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:event version=\"v1\">\n      <uipath:type value=\"Intsvc.WaitForEvent\" version=\"v1\" />\n      <uipath:output name=\"result\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:event>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ReceiveTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "inputNotes": "isSplitInputs=false; inputs are defined in input.fields (not jsonBody). Sent as separate <uipath:input> elements.",
+      "contextFieldNotes": "Context fields are empty in design schema; all field definitions are in inputFields below",
+      "extensionTagNotes": "In isEvents array, uses uipath:event",
+      "inputFields": [
+        {
+          "name": "connectionId",
+          "displayName": "Connection ID",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null,
+          "description": "Connection ID for the IS connector (bindable)"
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Integration Service connector identifier"
+        },
+        {
+          "name": "folderId",
+          "displayName": "Folder ID",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder ID for the connector connection"
+        },
+        {
+          "name": "folderPath",
+          "displayName": "Folder path",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder path for the connector connection"
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder key for the connector connection"
+        },
+        {
+          "name": "operation",
+          "displayName": "Operation",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Connector event operation to wait for"
+        },
+        {
+          "name": "objectName",
+          "displayName": "Object name",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Object name associated with the event trigger"
+        },
+        {
+          "name": "filter",
+          "displayName": "Filter",
+          "type": "object",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": {},
+          "description": "Filter criteria for the event"
+        },
+        {
+          "name": "parameters",
+          "displayName": "Parameters",
+          "type": "object",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": {},
+          "description": "Additional parameters for the event"
+        }
+      ]
+    },
+    "Intsvc.EventTrigger": {
+      "extensionType": "Intsvc.EventTrigger",
+      "label": "Wait for connector event (trigger)",
+      "bpmnElement": "bpmn:StartEvent",
+      "placements": {
+        "startEvent": {
+          "type": "bpmn:StartEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        }
+      },
+      "extensionTag": "uipath:event",
+      "contextFields": [],
+      "inputPattern": "separateInputs",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "result",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:StartEvent id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:event version=\"v1\">\n      <uipath:type value=\"Intsvc.EventTrigger\" version=\"v1\" />\n      <uipath:output name=\"result\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:event>\n  </bpmn:extensionElements>\n  <bpmn:messageEventDefinition />\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:StartEvent>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "inputNotes": "isSplitInputs=false; inputs defined in input.fields. Sent as separate <uipath:input> elements.",
+      "contextFieldNotes": "Context fields are empty in design schema; all field definitions are in inputFields below",
+      "extensionTagNotes": "In isEvents array, uses uipath:event",
+      "inputFields": [
+        {
+          "name": "connectionId",
+          "displayName": "Connection ID",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null,
+          "description": "Connection ID for the IS connector (bindable)"
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Integration Service connector identifier"
+        },
+        {
+          "name": "folderId",
+          "displayName": "Folder ID",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder ID for the connector connection"
+        },
+        {
+          "name": "folderPath",
+          "displayName": "Folder path",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder path for the connector connection"
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Folder key for the connector connection"
+        },
+        {
+          "name": "operation",
+          "displayName": "Operation",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Connector event operation to trigger on"
+        },
+        {
+          "name": "objectName",
+          "displayName": "Object name",
+          "type": "string",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "description": "Object name associated with the event trigger"
+        },
+        {
+          "name": "filter",
+          "displayName": "Filter",
+          "type": "object",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": {},
+          "description": "Filter criteria for the event trigger"
+        },
+        {
+          "name": "parameters",
+          "displayName": "Parameters",
+          "type": "object",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": {},
+          "description": "Additional parameters for the event trigger"
+        }
+      ]
+    },
+    "Intsvc.AsyncExecution": {
+      "extensionType": "Intsvc.AsyncExecution",
+      "label": "Start and wait for external agent",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.AsyncExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "inputNotes": "isSplitInputs=false in design schema; inputs are sent as separate <uipath:input> elements",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity"
+    },
+    "Intsvc.SyncAgentExecution": {
+      "extensionType": "Intsvc.SyncAgentExecution",
+      "label": "Start and wait for external agent",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "designSchemaSharedWith": "Intsvc.AsyncExecution",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.SyncAgentExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity"
+    },
+    "Intsvc.AsyncAgentExecution": {
+      "extensionType": "Intsvc.AsyncAgentExecution",
+      "label": "Start and wait for external agent",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "designSchemaSharedWith": "Intsvc.AsyncExecution",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.AsyncAgentExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity"
+    },
+    "Intsvc.SyncWorkflowExecution": {
+      "extensionType": "Intsvc.SyncWorkflowExecution",
+      "label": "Start and wait for external workflow",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "designSchemaSharedWith": "Intsvc.AsyncExecution",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.SyncWorkflowExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity"
+    },
+    "Intsvc.AsyncWorkflowExecution": {
+      "extensionType": "Intsvc.AsyncWorkflowExecution",
+      "label": "Start and wait for external workflow",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "activity",
+          "displayName": "Activity",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": true,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connectorKey",
+          "displayName": "Connector key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "connection",
+          "displayName": "Connection",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": true,
+          "defaultValue": null
+        },
+        {
+          "name": "folderKey",
+          "displayName": "Folder key",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "method",
+          "displayName": "Method",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "path",
+          "displayName": "Path",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "response",
+      "useRelativeSource": false,
+      "bindingPattern": "connection",
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "designSchemaSharedWith": "Intsvc.AsyncExecution",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.AsyncWorkflowExecution\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"activity\" value=\"{activity}\" />\n        <uipath:input name=\"connectorKey\" value=\"{connectorKey}\" />\n        <uipath:input name=\"connection\" value=\"=bindings.{bindingId}\" />\n        <uipath:input name=\"folderKey\" value=\"{folderKey}\" />\n        <uipath:input name=\"method\" value=\"{method}\" />\n        <uipath:input name=\"path\" value=\"{path}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getConnectorConnections(connectorKey) to list available connections",
+      "extensionTagNotes": "In isExecution array, uses uipath:activity"
+    },
+    "Orchestrator.ExecuteApiWorkflowAsync": {
+      "extensionType": "Orchestrator.ExecuteApiWorkflowAsync",
+      "label": "Start and wait for API workflow [Preview]",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.ExecuteApiWorkflowAsync\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getResourceCatalogProcesses('API', search) to list available API workflows"
+    },
+    "Orchestrator.CreateQueueItem": {
+      "extensionType": "Orchestrator.CreateQueueItem",
+      "label": "Create queue item",
+      "bpmnElement": "bpmn:SendTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:SendTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "queueName",
+          "displayName": "Queue name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "queue",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "ItemData",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Orchestrator.CreateQueueItem",
+      "outputName": "response",
+      "useRelativeSource": true,
+      "bindingPattern": "queue",
+      "bindingInfo": {
+        "resource": "queue",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "queueName"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:SendTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.CreateQueueItem\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"queueName\" value=\"{queueName}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n      </uipath:context>\n      <uipath:input name=\"ItemData\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"Orchestrator.CreateQueueItem\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:SendTask>",
+      "discoveryNotes": "Uses getQueueDefinitions(serviceType, search) to list available queues"
+    },
+    "Orchestrator.CreateAndWaitForQueueItem": {
+      "extensionType": "Orchestrator.CreateAndWaitForQueueItem",
+      "label": "Create and wait for queue item",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "queueName",
+          "displayName": "Queue name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "queue",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "ItemData",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Orchestrator.CreateQueueItem",
+      "outputName": "response",
+      "useRelativeSource": true,
+      "bindingPattern": "queue",
+      "bindingInfo": {
+        "resource": "queue",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "queueName"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "designSchemaSharedWith": "Orchestrator.CreateQueueItem",
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.CreateAndWaitForQueueItem\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"queueName\" value=\"{queueName}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n      </uipath:context>\n      <uipath:input name=\"ItemData\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"Orchestrator.CreateQueueItem\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "discoveryNotes": "Uses getQueueDefinitions(serviceType, search) to list available queues"
+    },
+    "Orchestrator.StartAgenticProcess": {
+      "extensionType": "Orchestrator.StartAgenticProcess",
+      "label": "Start and wait for agentic process",
+      "bpmnElement": "bpmn:CallActivity",
+      "placements": {
+        "activity": {
+          "type": "bpmn:CallActivity"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:CallActivity id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartAgenticProcess\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:CallActivity>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('ProcessOrchestration', search, 0, 100, true) to list available agentic processes"
+    },
+    "Orchestrator.StartAgenticProcessAsync": {
+      "extensionType": "Orchestrator.StartAgenticProcessAsync",
+      "label": "Start agentic process",
+      "bpmnElement": "bpmn:CallActivity",
+      "placements": {
+        "activity": {
+          "type": "bpmn:CallActivity"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:CallActivity id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartAgenticProcessAsync\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:CallActivity>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('ProcessOrchestration', search, 0, 100, true) to list available agentic processes"
+    },
+    "Orchestrator.StartCaseMgmtProcess": {
+      "extensionType": "Orchestrator.StartCaseMgmtProcess",
+      "label": "Start and wait for case management",
+      "bpmnElement": "bpmn:CallActivity",
+      "placements": {
+        "activity": {
+          "type": "bpmn:CallActivity"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:CallActivity id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartCaseMgmtProcess\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:CallActivity>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('caseManagement', search, 0, 100, true) to list available case management processes"
+    },
+    "Orchestrator.StartCaseMgmtProcessAsync": {
+      "extensionType": "Orchestrator.StartCaseMgmtProcessAsync",
+      "label": "Start case management",
+      "bpmnElement": "bpmn:CallActivity",
+      "placements": {
+        "activity": {
+          "type": "bpmn:CallActivity"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "releaseKey",
+          "displayName": "Process",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "bindingInfo": {
+            "resource": "process",
+            "resourceKeyPattern": "${metadata.key}",
+            "propertyAttribute": "Key"
+          }
+        },
+        {
+          "name": "folderId",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "folderPath",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "name",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "JobArguments",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": "Orchestrator.RunJob",
+      "outputName": "Process response",
+      "useRelativeSource": true,
+      "bindingPattern": "process",
+      "bindingInfo": {
+        "resource": "process",
+        "resourceKeyPattern": "${metadata.key}",
+        "propertyAttribute": "Key",
+        "contextField": "releaseKey"
+      },
+      "requiresDiscovery": true,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:CallActivity id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Orchestrator.StartCaseMgmtProcessAsync\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"releaseKey\" value=\"{releaseKey}\" />\n        <uipath:input name=\"folderId\" value=\"{folderId}\" />\n        <uipath:input name=\"folderPath\" value=\"{folderPath}\" />\n        <uipath:input name=\"name\" value=\"{name}\" />\n      </uipath:context>\n      <uipath:input name=\"JobArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Orchestrator.RunJob\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:CallActivity>",
+      "discoveryNotes": "Uses getSupportedOrchestratorTasks('caseManagement', search, 0, 100, true) to list available case management processes"
+    },
+    "A2A.AgentExecution": {
+      "extensionType": "A2A.AgentExecution",
+      "label": "Start and wait for A2A agent",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {
+        "activity": {
+          "type": "bpmn:ServiceTask"
+        }
+      },
+      "extensionTag": "uipath:activity",
+      "contextFields": [],
+      "inputPattern": "mergedBody",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "A2A.AgentExecution",
+      "outputName": "a2aResponse",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": true,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"A2A.AgentExecution\" version=\"v1\" />\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"a2aResponse\" type=\"A2A.AgentExecution\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "inputFieldNotes": "Auto-initialized by A2AFPSFormControl on load. Version is set to v2. Outputs include a2aResponse (jsonSchema with A2A response schema, source=result) and Error (any, source=Error).",
+      "outputNotes": "Output schema includes: isSuccess (boolean), response (string), sessionId (string), status (string), taskId (string), artifacts (array of {index, parts, metadata}). Also includes Error output (type=any, source=Error).",
+      "inputFields": [
+        {
+          "name": "agentUrl",
+          "displayName": "Agent URL",
+          "type": "string",
+          "required": true,
+          "description": "URL of the A2A agent endpoint"
+        },
+        {
+          "name": "skillId",
+          "displayName": "Skill ID",
+          "type": "string",
+          "required": true,
+          "description": "Identifier for the specific skill to invoke on the agent"
+        },
+        {
+          "name": "input",
+          "displayName": "Input",
+          "type": "string",
+          "required": true,
+          "description": "Input text/message to send to the A2A agent"
+        },
+        {
+          "name": "authToken",
+          "displayName": "Auth Token",
+          "type": "string",
+          "required": true,
+          "description": "Authentication token for the A2A agent"
+        },
+        {
+          "name": "agentName",
+          "displayName": "Agent Name",
+          "type": "string",
+          "required": true,
+          "description": "Display name of the A2A agent"
+        }
+      ]
+    },
+    "BPMN.Variables": {
+      "extensionType": "BPMN.Variables",
+      "label": "BPMN Variables",
+      "bpmnElement": "bpmn:Task",
+      "placements": {},
+      "extensionTag": "uipath:mapping",
+      "contextFields": [],
+      "inputPattern": "none",
+      "outputSource": null,
+      "outputType": null,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:Task id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:mapping version=\"v1\">\n      <uipath:type value=\"BPMN.Variables\" version=\"v1\" />\n    </uipath:mapping>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:Task>",
+      "inputNotes": "Variable mappings use uipath:mapping with direct input/output elements, not a jsonBody pattern",
+      "bpmnElementNotes": "Also used on bpmn:StartEvent and bpmn:EndEvent for variable mappings. On bpmn:Task with no serviceType, defaults to BPMN.Variables.",
+      "extensionTagNotes": "Uses uipath:mapping (not uipath:activity). createExtensionTask checks for serviceType=BPMN.Variables on StartEvent/EndEvent/Task and routes to createModdleExtensionVariableMapping."
+    },
+    "BPMN.ScriptTask": {
+      "extensionType": "BPMN.ScriptTask",
+      "label": "Execute script",
+      "bpmnElement": "bpmn:ScriptTask",
+      "placements": {},
+      "extensionTag": "uipath:mapping",
+      "contextFields": [],
+      "inputPattern": "scriptArgs",
+      "inputName": "args",
+      "inputTarget": "bodyField",
+      "outputSource": null,
+      "outputType": null,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:ScriptTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:mapping version=\"v1\">\n      <uipath:type value=\"BPMN.ScriptTask\" version=\"v1\" />\n      <uipath:input name=\"args\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n    </uipath:mapping>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ScriptTask>",
+      "inputNotes": "Inputs are merged into a single json input named 'args' with target 'bodyField'. An inputSchema is created from the input variables.",
+      "extensionTagNotes": "bpmn:ScriptTask is routed through createModdleExtensionVariableMapping (same as BPMN.Variables). Inputs are merged into a single 'args' JSON body with inputSchema."
+    },
+    "Intsvc.TimerTrigger": {
+      "extensionType": "Intsvc.TimerTrigger",
+      "label": "Timer trigger",
+      "bpmnElement": "bpmn:StartEvent",
+      "placements": {},
+      "extensionTag": "uipath:activity",
+      "contextFields": [],
+      "inputPattern": "none",
+      "outputSource": ".",
+      "outputType": "custom",
+      "outputName": "result",
+      "useRelativeSource": false,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:StartEvent id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Intsvc.TimerTrigger\" version=\"v1\" />\n      <uipath:output name=\"result\" type=\"custom\" source=\".\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:timerEventDefinition><bpmn:timeDuration xsi:type=\"bpmn:tFormalExpression\">PT1H</bpmn:timeDuration></bpmn:timerEventDefinition>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:StartEvent>",
+      "inputNotes": "No jsonBody, no input fields, no isSplitInputs in design schema",
+      "bpmnElementNotes": "Used via timer event definition on start events; not directly in FPS_TO_NODE_MAPPING",
+      "extensionTagNotes": "NOT in isEvents array, uses uipath:activity. However, isIntsvcTriggerDesignSchemaType returns true.",
+      "inputFields": []
+    },
+    "Maestro.ReceiveMessageEvent": {
+      "extensionType": "Maestro.ReceiveMessageEvent",
+      "label": "Receive internal message",
+      "bpmnElement": "bpmn:IntermediateCatchEvent",
+      "placements": {
+        "startEvent": {
+          "type": "bpmn:StartEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        },
+        "intermediateEvent": {
+          "type": "bpmn:IntermediateCatchEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        },
+        "boundaryEvent": {
+          "type": "bpmn:BoundaryEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        }
+      },
+      "extensionTag": "uipath:event",
+      "contextFields": [
+        {
+          "name": "name",
+          "displayName": "Message name",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "_label",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "separateInputs",
+      "inputName": "ItemData",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Maestro.ReceiveMessageEvent",
+      "outputName": "response",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:IntermediateCatchEvent id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:event version=\"v1\">\n      <uipath:type value=\"Maestro.ReceiveMessageEvent\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"name\" value=\"{name}\" />\n        <uipath:input name=\"_label\" value=\"{_label}\" />\n      </uipath:context>\n      <uipath:input name=\"ItemData\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"Maestro.ReceiveMessageEvent\" var=\"{varId}\" />\n    </uipath:event>\n  </bpmn:extensionElements>\n  <bpmn:messageEventDefinition />\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:IntermediateCatchEvent>",
+      "inputNotes": "isSplitInputs=true in design schema but NOT in isSplitInputsEvents code array, so inputs are NOT merged into ItemData for this type. They remain separate.",
+      "extensionTagNotes": "In isEvents array, uses uipath:event",
+      "inputFields": [
+        {
+          "name": "Reference",
+          "displayName": "Reference",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "target": "bodyField",
+          "description": "Correlation reference to match this receive event to its sender"
+        }
+      ]
+    },
+    "Maestro.SendMessageEvent": {
+      "extensionType": "Maestro.SendMessageEvent",
+      "label": "Send internal message",
+      "bpmnElement": "bpmn:IntermediateThrowEvent",
+      "placements": {
+        "intermediateEvent": {
+          "type": "bpmn:IntermediateThrowEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        },
+        "endEvent": {
+          "type": "bpmn:EndEvent",
+          "eventDefinition": {
+            "type": "bpmn:MessageEventDefinition"
+          }
+        }
+      },
+      "extensionTag": "uipath:event",
+      "contextFields": [
+        {
+          "name": "name",
+          "displayName": "Message name",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "_label",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "inputSchema",
+          "displayName": "Input schema",
+          "type": "jsonSchema",
+          "required": true,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "splitInputsItemData",
+      "inputName": "ItemData",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Maestro.SendMessageEvent",
+      "outputName": "response",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:IntermediateThrowEvent id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:event version=\"v1\">\n      <uipath:type value=\"Maestro.SendMessageEvent\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"name\" value=\"{name}\" />\n        <uipath:input name=\"_label\" value=\"{_label}\" />\n        <uipath:input name=\"inputSchema\" value=\"{inputSchema}\" />\n      </uipath:context>\n      <uipath:input name=\"ItemData\" type=\"json\" target=\"body\"><![CDATA[{\"Reference\":\"\",\"SpecificContent\":{},\"Error\":\"\",\"TimeToLive\":\"\"}]]></uipath:input>\n      <uipath:output name=\"response\" type=\"Maestro.SendMessageEvent\" var=\"{varId}\" />\n    </uipath:event>\n  </bpmn:extensionElements>\n  <bpmn:messageEventDefinition />\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:IntermediateThrowEvent>",
+      "inputNotes": "In isSplitInputsEvents array. Inputs are merged into a single ItemData JSON body at serialization time. Uses SEND_MESSAGE_EVENT_INPUT_SCHEMA as the inputSchema.",
+      "extensionTagNotes": "In isEvents array, uses uipath:event",
+      "inputFields": [
+        {
+          "name": "Reference",
+          "displayName": "Reference",
+          "type": "string",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "target": "body",
+          "description": "Correlation reference to match this send event to its receiver"
+        },
+        {
+          "name": "SpecificContent",
+          "displayName": "Item information",
+          "type": "json",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "target": "body",
+          "description": "JSON payload with the message content"
+        },
+        {
+          "name": "TimeToLive",
+          "displayName": "Time to live",
+          "type": "duration",
+          "required": false,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null,
+          "target": "body",
+          "description": "Duration after which the message expires if not consumed"
+        }
+      ]
+    },
+    "Maestro.CaseRulesEvaluator": {
+      "extensionType": "Maestro.CaseRulesEvaluator",
+      "label": "Case rules evaluator",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {},
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "caseDeterministicRules",
+          "displayName": "Case deterministic rules",
+          "type": "json",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "caseCurrentExecutionState",
+          "displayName": "Case current execution state",
+          "type": "json",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "_label",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "caseManagerInput",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Maestro.CaseRulesEvaluator",
+      "outputName": "schedulerOutput",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Maestro.CaseRulesEvaluator\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"caseDeterministicRules\" value=\"{caseDeterministicRules}\" />\n        <uipath:input name=\"caseCurrentExecutionState\" value=\"{caseCurrentExecutionState}\" />\n        <uipath:input name=\"_label\" value=\"{_label}\" />\n      </uipath:context>\n      <uipath:input name=\"caseManagerInput\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"schedulerOutput\" type=\"Maestro.CaseRulesEvaluator\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "bpmnElementNotes": "Not in FPS_TO_NODE_MAPPING activity section; used internally for case management processes. Likely bpmn:ServiceTask or bpmn:Task."
+    },
+    "Maestro.CaseManagerGuardrails": {
+      "extensionType": "Maestro.CaseManagerGuardrails",
+      "label": "Case manager guardrails",
+      "bpmnElement": "bpmn:ServiceTask",
+      "placements": {},
+      "extensionTag": "uipath:activity",
+      "contextFields": [
+        {
+          "name": "decisions",
+          "displayName": "Decisions",
+          "type": "json",
+          "required": true,
+          "hidden": false,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        },
+        {
+          "name": "_label",
+          "type": "string",
+          "required": false,
+          "hidden": true,
+          "isPrimaryKey": false,
+          "binding": false,
+          "defaultValue": null
+        }
+      ],
+      "inputPattern": "mergedBody",
+      "inputName": "body",
+      "inputTarget": "body",
+      "outputSource": null,
+      "outputType": "Maestro.CaseManagerGuardrails",
+      "outputName": "guardrailsOutput",
+      "useRelativeSource": true,
+      "bindingPattern": "none",
+      "requiresDiscovery": false,
+      "isDynamic": false,
+      "xmlTemplate": "<bpmn:ServiceTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Maestro.CaseManagerGuardrails\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"decisions\" value=\"{decisions}\" />\n        <uipath:input name=\"_label\" value=\"{_label}\" />\n      </uipath:context>\n      <uipath:input name=\"body\" type=\"json\" target=\"body\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"guardrailsOutput\" type=\"Maestro.CaseManagerGuardrails\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ServiceTask>",
+      "bpmnElementNotes": "Not in FPS_TO_NODE_MAPPING activity section; used internally for case management processes. Likely bpmn:ServiceTask or bpmn:Task."
+    }
+  },
+  "bpmnElements": {
+    "gateways": {
+      "bpmn:ExclusiveGateway": {
+        "bpmnElement": "bpmn:ExclusiveGateway",
+        "category": "gateway"
+      },
+      "bpmn:ParallelGateway": {
+        "bpmnElement": "bpmn:ParallelGateway",
+        "category": "gateway"
+      },
+      "bpmn:InclusiveGateway": {
+        "bpmnElement": "bpmn:InclusiveGateway",
+        "category": "gateway"
+      },
+      "bpmn:ComplexGateway": {
+        "bpmnElement": "bpmn:ComplexGateway",
+        "category": "gateway"
+      },
+      "bpmn:EventBasedGateway": {
+        "bpmnElement": "bpmn:EventBasedGateway",
+        "category": "gateway"
+      },
+      "uipath.control-flow.decision": {
+        "bpmnElement": "uipath.control-flow.decision",
+        "category": "gateway"
+      },
+      "uipath.control-flow.switch": {
+        "bpmnElement": "uipath.control-flow.switch",
+        "category": "gateway"
+      }
+    },
+    "tasks": {
+      "bpmn:Task": {
+        "bpmnElement": "bpmn:Task",
+        "category": "task"
+      },
+      "bpmn:UserTask": {
+        "bpmnElement": "bpmn:UserTask",
+        "category": "task"
+      },
+      "bpmn:ServiceTask": {
+        "bpmnElement": "bpmn:ServiceTask",
+        "category": "task"
+      },
+      "bpmn:SendTask": {
+        "bpmnElement": "bpmn:SendTask",
+        "category": "task"
+      },
+      "bpmn:ReceiveTask": {
+        "bpmnElement": "bpmn:ReceiveTask",
+        "category": "task"
+      },
+      "bpmn:ManualTask": {
+        "bpmnElement": "bpmn:ManualTask",
+        "category": "task"
+      },
+      "bpmn:BusinessRuleTask": {
+        "bpmnElement": "bpmn:BusinessRuleTask",
+        "category": "task"
+      },
+      "bpmn:ScriptTask": {
+        "bpmnElement": "bpmn:ScriptTask",
+        "category": "task"
+      },
+      "bpmn:CallActivity": {
+        "bpmnElement": "bpmn:CallActivity",
+        "category": "task"
+      },
+      "bpmn:SubProcess": {
+        "bpmnElement": "bpmn:SubProcess",
+        "category": "task",
+        "variants": [
+          "collapsed",
+          "expanded",
+          "eventSubprocess"
+        ]
+      },
+      "bpmn:Transaction": {
+        "bpmnElement": "bpmn:Transaction",
+        "category": "task"
+      }
+    },
+    "events": {
+      "bpmn:StartEvent": {
+        "bpmnElement": "bpmn:StartEvent",
+        "category": "event",
+        "eventDefinitions": [
+          {
+            "type": "none"
+          },
+          {
+            "type": "bpmn:MessageEventDefinition"
+          },
+          {
+            "type": "bpmn:TimerEventDefinition"
+          },
+          {
+            "type": "bpmn:ConditionalEventDefinition"
+          },
+          {
+            "type": "bpmn:SignalEventDefinition"
+          }
+        ]
+      },
+      "bpmn:IntermediateThrowEvent": {
+        "bpmnElement": "bpmn:IntermediateThrowEvent",
+        "category": "event",
+        "eventDefinitions": [
+          {
+            "type": "none"
+          },
+          {
+            "type": "bpmn:MessageEventDefinition"
+          },
+          {
+            "type": "bpmn:EscalationEventDefinition"
+          },
+          {
+            "type": "bpmn:SignalEventDefinition"
+          },
+          {
+            "type": "bpmn:LinkEventDefinition"
+          },
+          {
+            "type": "bpmn:CompensateEventDefinition"
+          }
+        ]
+      },
+      "bpmn:IntermediateCatchEvent": {
+        "bpmnElement": "bpmn:IntermediateCatchEvent",
+        "category": "event",
+        "eventDefinitions": [
+          {
+            "type": "bpmn:MessageEventDefinition"
+          },
+          {
+            "type": "bpmn:TimerEventDefinition"
+          },
+          {
+            "type": "bpmn:EscalationEventDefinition"
+          },
+          {
+            "type": "bpmn:SignalEventDefinition"
+          },
+          {
+            "type": "bpmn:ConditionalEventDefinition"
+          },
+          {
+            "type": "bpmn:LinkEventDefinition"
+          },
+          {
+            "type": "bpmn:CompensateEventDefinition"
+          }
+        ]
+      },
+      "bpmn:EndEvent": {
+        "bpmnElement": "bpmn:EndEvent",
+        "category": "event",
+        "eventDefinitions": [
+          {
+            "type": "none"
+          },
+          {
+            "type": "bpmn:MessageEventDefinition"
+          },
+          {
+            "type": "bpmn:EscalationEventDefinition"
+          },
+          {
+            "type": "bpmn:ErrorEventDefinition"
+          },
+          {
+            "type": "bpmn:CompensateEventDefinition"
+          },
+          {
+            "type": "bpmn:SignalEventDefinition"
+          },
+          {
+            "type": "bpmn:TerminateEventDefinition"
+          }
+        ]
+      },
+      "bpmn:BoundaryEvent": {
+        "bpmnElement": "bpmn:BoundaryEvent",
+        "category": "event",
+        "eventDefinitions": [
+          {
+            "type": "bpmn:MessageEventDefinition"
+          },
+          {
+            "type": "bpmn:TimerEventDefinition"
+          },
+          {
+            "type": "bpmn:EscalationEventDefinition"
+          },
+          {
+            "type": "bpmn:ConditionalEventDefinition"
+          },
+          {
+            "type": "bpmn:ErrorEventDefinition"
+          },
+          {
+            "type": "bpmn:SignalEventDefinition"
+          },
+          {
+            "type": "bpmn:CompensateEventDefinition"
+          },
+          {
+            "type": "bpmn:MessageEventDefinition",
+            "interrupting": false
+          },
+          {
+            "type": "bpmn:TimerEventDefinition",
+            "interrupting": false
+          },
+          {
+            "type": "bpmn:EscalationEventDefinition",
+            "interrupting": false
+          },
+          {
+            "type": "bpmn:ConditionalEventDefinition",
+            "interrupting": false
+          },
+          {
+            "type": "bpmn:SignalEventDefinition",
+            "interrupting": false
+          }
+        ]
+      }
+    },
+    "data": {
+      "bpmn:DataStoreReference": {
+        "bpmnElement": "bpmn:DataStoreReference",
+        "category": "data"
+      },
+      "bpmn:DataObjectReference": {
+        "bpmnElement": "bpmn:DataObjectReference",
+        "category": "data"
+      }
+    },
+    "participants": {
+      "bpmn:Participant": {
+        "bpmnElement": "bpmn:Participant",
+        "category": "participant"
+      }
+    },
+    "uipathShortcuts": {
+      "uipath.agent": {
+        "bpmnElement": "uipath.agent",
+        "category": "uipathShortcut"
+      },
+      "uipath.human-in-the-loop": {
+        "bpmnElement": "uipath.human-in-the-loop",
+        "category": "uipathShortcut"
+      },
+      "uipath.api-workflow": {
+        "bpmnElement": "uipath.api-workflow",
+        "category": "uipathShortcut"
+      },
+      "uipath.process-orchestration": {
+        "bpmnElement": "uipath.process-orchestration",
+        "category": "uipathShortcut"
+      },
+      "uipath.rpa-workflow": {
+        "bpmnElement": "uipath.rpa-workflow",
+        "category": "uipathShortcut"
+      },
+      "uipath.connector-activity": {
+        "bpmnElement": "uipath.connector-activity",
+        "category": "uipathShortcut"
+      },
+      "uipath.connector-trigger": {
+        "bpmnElement": "uipath.connector-trigger",
+        "category": "uipathShortcut"
+      },
+      "uipath.http-request": {
+        "bpmnElement": "uipath.http-request",
+        "category": "uipathShortcut"
+      },
+      "uipath.timer-activity": {
+        "bpmnElement": "uipath.timer-activity",
+        "category": "uipathShortcut",
+        "eventDefinition": "bpmn:TimerEventDefinition"
+      },
+      "uipath.timer-trigger": {
+        "bpmnElement": "uipath.timer-trigger",
+        "category": "uipathShortcut",
+        "eventDefinition": "bpmn:TimerEventDefinition"
+      }
+    }
+  },
+  "serializationRules": {
+    "extensionTagResolution": {
+      "description": "How the frontend determines which XML extension tag to use",
+      "rules": [
+        "If serviceType is in isEvents array [Intsvc.WaitForEvent, Intsvc.EventTrigger, Maestro.ReceiveMessageEvent, Maestro.SendMessageEvent] => uipath:event",
+        "If serviceType is BPMN.Variables on bpmn:StartEvent, bpmn:EndEvent, or bpmn:Task => uipath:mapping",
+        "If nodeType is bpmn:ScriptTask or bpmn:SubProcess => uipath:mapping",
+        "Otherwise => uipath:activity"
+      ]
+    },
+    "isEventsArray": [
+      "Intsvc.WaitForEvent",
+      "Intsvc.EventTrigger",
+      "Maestro.ReceiveMessageEvent",
+      "Maestro.SendMessageEvent"
+    ],
+    "isExecutionArray": [
+      "Intsvc.ActivityExecution",
+      "Intsvc.AsyncExecution",
+      "Intsvc.SyncAgentExecution",
+      "Intsvc.AsyncAgentExecution",
+      "Intsvc.SyncWorkflowExecution",
+      "Intsvc.AsyncWorkflowExecution",
+      "Intsvc.UnifiedHttpRequest"
+    ],
+    "isSplitInputsEventsArray": [
+      "Maestro.SendMessageEvent"
+    ]
+  }
+}

--- a/skills/uipath-maestro-bpmn/validator/model.mjs
+++ b/skills/uipath-maestro-bpmn/validator/model.mjs
@@ -151,7 +151,12 @@ function buildNodeUiPath(el, requiredFieldIndex) {
     uipath = uipath ?? {};
     uipath.variables = mapVariables(vars);
   }
-  // Mark required fields from the registry onto serialized fields by name match.
+  // Mark required fields from the registry onto serialized fields by name match,
+  // and attach the full required-name set so RequiredFieldsRule can also detect
+  // required fields that are entirely ABSENT from the serialized data (frontend
+  // RequiredFieldsRule iterates every field in the node's data and fires on
+  // `field.required && isNilOrEmpty(field.value)` — an unbound required field is
+  // present-with-empty-value on canvas, which corresponds to absent-in-XML here).
   const st = uipath?.serviceType;
   const requiredNames = st ? requiredFieldIndex.get(st) : undefined;
   if (requiredNames) {
@@ -159,6 +164,7 @@ function buildNodeUiPath(el, requiredFieldIndex) {
       if (!Array.isArray(group)) continue;
       for (const f of group) if (requiredNames.has(f.name)) f.required = true;
     }
+    uipath.requiredFieldNames = [...requiredNames];
   }
   return uipath;
 }

--- a/skills/uipath-maestro-bpmn/validator/model.mjs
+++ b/skills/uipath-maestro-bpmn/validator/model.mjs
@@ -1,0 +1,392 @@
+// Reconstruct the PO.Frontend Node[]/Edge[]/CanvasState model from a parsed
+// bpmn-moddle tree. This is the integration layer (Phase 1). It mirrors
+// PO.Frontend/src/services/serialization/bpmn-from-xml.ts closely enough that
+// the ported rule engine in rules.mjs sees the same fields it sees on canvas.
+//
+// PHASE 2 NOTE: this file and validate-bpmn.mjs are the only integration glue.
+// rules.mjs (the rule logic) is the swap target for the future npm package.
+
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Registry: required-field metadata (bpmn-spec.json). Bundled so RequiredFields
+// runs fully offline. Maps serviceType -> Set<requiredFieldName>.
+// ---------------------------------------------------------------------------
+let _requiredFieldIndex;
+function loadRequiredFieldIndex() {
+  if (_requiredFieldIndex) return _requiredFieldIndex;
+  const index = new Map();
+  try {
+    const spec = JSON.parse(readFileSync(join(__dirname, "bpmn-spec.json"), "utf8"));
+    for (const [serviceType, def] of Object.entries(spec.extensionTypes ?? {})) {
+      const names = new Set();
+      for (const f of def.contextFields ?? []) {
+        // Only fields the user can actually populate. Hidden fields with a
+        // default are auto-filled by the designer and never empty in practice,
+        // so requiring them offline would false-positive; skip hidden+defaulted.
+        if (f.required && !(f.hidden && f.defaultValue !== null && f.defaultValue !== undefined)) {
+          names.add(f.name);
+        }
+      }
+      for (const f of def.inputFields ?? []) {
+        if (f.required) names.add(f.name);
+      }
+      if (names.size) index.set(serviceType, names);
+    }
+  } catch {
+    // Registry not bundled: RequiredFields degrades to a no-op (documented).
+  }
+  _requiredFieldIndex = index;
+  return index;
+}
+
+// ---------------------------------------------------------------------------
+// moddle helpers
+// ---------------------------------------------------------------------------
+const ext = (el) => el?.extensionElements?.values ?? [];
+const findExt = (el, type) => ext(el).find((e) => e.$type === type);
+
+function eventDefinitionOf(el) {
+  const defs = el?.eventDefinitions;
+  if (!defs || !defs.length) return undefined;
+  const d = defs[0];
+  const out = { type: d.$type, id: d.id };
+  if (d.errorRef) out.errorRef = d.errorRef.id ?? d.errorRef;
+  if (d.messageRef) out.messageRef = d.messageRef.id ?? d.messageRef;
+  if (d.signalRef) out.signalRef = d.signalRef.id ?? d.signalRef;
+  if (d.escalationRef) out.escalationRef = d.escalationRef.id ?? d.escalationRef;
+  if (d.$type === "bpmn:TimerEventDefinition") {
+    if (d.timeDuration) {
+      out.timerType = "timeDuration";
+      out.timeDuration = d.timeDuration.body ?? d.timeDuration;
+    } else if (d.timeCycle) {
+      out.timerType = "timeCycle";
+      out.timeCycle = d.timeCycle.body ?? d.timeCycle;
+    } else if (d.timeDate) {
+      out.timerType = "timeDate";
+      out.timeDate = d.timeDate.body ?? d.timeDate;
+    }
+  }
+  return out;
+}
+
+// Map a uipath:Activity / uipath:Event extension element into the frontend
+// `node.data.uipath` shape consumed by the rules.
+function mapUiPathActivity(actEl) {
+  const uipath = {};
+  uipath.serviceType = actEl.type?.value ?? actEl.type ?? undefined;
+  uipath.version = actEl.type?.version ?? actEl.version ?? "v1";
+
+  const mapInput = (i) => ({ name: i.name, type: i.type, subType: i.subType, value: i.value, target: i.target, body: i.body });
+  const mapOutput = (o) => ({
+    name: o.name,
+    type: o.type,
+    subType: o.subType,
+    source: o.source,
+    var: o.var,
+    body: o.body,
+    custom: o.custom === "true" || o.custom === true,
+    target: o.target,
+  });
+
+  uipath.context = (actEl.context?.input ?? []).map(mapInput);
+  uipath.inputs = (actEl.input ?? []).map(mapInput);
+  uipath.outputs = (actEl.output ?? []).map(mapOutput);
+  return uipath;
+}
+
+function mapErrorMapping(emEl) {
+  return (emEl?.error ?? []).map((e) => ({
+    id: e.id,
+    errorRef: e.errorRef,
+    priority: e.priority,
+    condition: e.condition,
+    detail: e.detail,
+    retryable: e.retryable === "true" || e.retryable === true,
+  }));
+}
+
+function mapVariables(varsEl) {
+  if (!varsEl) return undefined;
+  const map = (v) => ({
+    id: v.id,
+    name: v.name,
+    type: v.type,
+    subType: v.subType,
+    canonicalId: v.canonicalId,
+    elementId: v.elementId,
+    default: v.default,
+  });
+  return {
+    inputs: (varsEl.input ?? []).map(map),
+    inputOutputs: (varsEl.inputOutput ?? []).map(map),
+    outputs: (varsEl.output ?? []).map(map),
+  };
+}
+
+// Populate node.data.uipath from a flow element's extensionElements.
+// `requiredFieldIndex` supplies, per serviceType, the registry's required field
+// names; matching serialized fields get `required: true` so RequiredFields can
+// run offline with the same `field.required && isNilOrEmpty(value)` semantics
+// the canvas uses.
+function buildNodeUiPath(el, requiredFieldIndex) {
+  const act = findExt(el, "uipath:Activity") ?? findExt(el, "uipath:Event");
+  const em = findExt(el, "uipath:ErrorMapping");
+  const vars = findExt(el, "uipath:Variables");
+  let uipath;
+  if (act) uipath = mapUiPathActivity(act);
+  if (em) {
+    uipath = uipath ?? {};
+    uipath.errorMapping = mapErrorMapping(em);
+  }
+  if (vars) {
+    uipath = uipath ?? {};
+    uipath.variables = mapVariables(vars);
+  }
+  // Mark required fields from the registry onto serialized fields by name match.
+  const st = uipath?.serviceType;
+  const requiredNames = st ? requiredFieldIndex.get(st) : undefined;
+  if (requiredNames) {
+    for (const group of [uipath.context, uipath.inputs, uipath.outputs]) {
+      if (!Array.isArray(group)) continue;
+      for (const f of group) if (requiredNames.has(f.name)) f.required = true;
+    }
+  }
+  return uipath;
+}
+
+const ABSTRACT_ACTIVITY = new Set([
+  "bpmn:Task",
+  "bpmn:ServiceTask",
+  "bpmn:UserTask",
+  "bpmn:ScriptTask",
+  "bpmn:SendTask",
+  "bpmn:ReceiveTask",
+  "bpmn:BusinessRuleTask",
+  "bpmn:ManualTask",
+  "bpmn:CallActivity",
+  "bpmn:SubProcess",
+  "bpmn:AdHocSubProcess",
+  "bpmn:Transaction",
+]);
+const ABSTRACT_EVENT = new Set([
+  "bpmn:StartEvent",
+  "bpmn:EndEvent",
+  "bpmn:IntermediateCatchEvent",
+  "bpmn:IntermediateThrowEvent",
+  "bpmn:BoundaryEvent",
+]);
+function abstractTypeOf(type) {
+  if (ABSTRACT_ACTIVITY.has(type)) return "bpmn:Activity";
+  if (ABSTRACT_EVENT.has(type)) return "bpmn:Event";
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Build a flat Node for one flow element. `parentId`/`parentElement` describe
+// the containing Process or SubProcess.
+// ---------------------------------------------------------------------------
+function buildNode(el, parent, requiredFieldIndex) {
+  const data = {};
+  data.label = el.name ?? undefined;
+
+  const ed = eventDefinitionOf(el);
+  if (ed) data.eventDefinition = ed;
+
+  if (el.$type === "bpmn:SubProcess") data.triggeredByEvent = el.triggeredByEvent === true;
+  if (el.$type === "bpmn:BoundaryEvent" && el.attachedToRef) data.attachedToId = el.attachedToRef.id ?? el.attachedToRef;
+
+  const uipath = buildNodeUiPath(el, requiredFieldIndex);
+  if (uipath) data.uipath = uipath;
+
+  if (parent) data.parentElement = { id: parent.id, type: parent.$type };
+
+  return {
+    id: el.id,
+    type: el.$type,
+    parentId: parent && parent.$type === "bpmn:SubProcess" ? parent.id : undefined,
+    abstractType: abstractTypeOf(el.$type),
+    data,
+  };
+}
+
+function buildEdge(el, parent) {
+  const data = {};
+  if (el.name) data.label = el.name;
+  if (el.conditionExpression) {
+    let body = el.conditionExpression.body ?? el.conditionExpression;
+    if (typeof body === "string" && body && !body.startsWith("=")) body = `=${body}`;
+    data.conditionExpression = body;
+  }
+  // defaultFlow: source gateway's @default points to this flow.
+  const source = el.sourceRef;
+  if (source?.default && (source.default.id ?? source.default) === el.id) data.defaultFlow = true;
+  if (parent) data.parentElement = { id: parent.id, type: parent.$type };
+  return {
+    id: el.id,
+    type: el.$type,
+    source: el.sourceRef?.id ?? el.sourceRef,
+    target: el.targetRef?.id ?? el.targetRef,
+    data,
+  };
+}
+
+const FLOW_EDGE_TYPES = new Set(["bpmn:SequenceFlow", "bpmn:MessageFlow", "bpmn:Association"]);
+
+// Recursively collect nodes & edges for one container (Process or SubProcess).
+// `rootParentId` is the parentId assigned to the container's direct flow nodes:
+//   undefined for a stand-alone process (frontend root scope), or the pool id
+//   when the process is contained in a collaboration participant. Sub-process
+//   children carry parentId = sub-process id (frontend behavior).
+function collectContainer(container, requiredFieldIndex, nodesOut, edgesOut, rootParentId) {
+  const flowElements = container.flowElements ?? [];
+  for (const el of flowElements) {
+    if (FLOW_EDGE_TYPES.has(el.$type)) {
+      edgesOut.push(buildEdge(el, container));
+      continue;
+    }
+    const node = buildNode(el, container, requiredFieldIndex);
+    // Override parentId for direct children of a Process container.
+    if (container.$type === "bpmn:Process") node.parentId = rootParentId;
+    nodesOut.push(node);
+    if (el.$type === "bpmn:SubProcess") {
+      collectContainer(el, requiredFieldIndex, nodesOut, edgesOut, rootParentId);
+    }
+  }
+}
+
+function buildRootUiPath(processEl) {
+  const vars = findExt(processEl, "uipath:Variables");
+  if (!vars) return undefined;
+  return { variables: mapVariables(vars) };
+}
+
+// ---------------------------------------------------------------------------
+// Public: build the full model (CanvasState-like) from a moddle definitions.
+// ---------------------------------------------------------------------------
+export function buildModel(definitions) {
+  const requiredFieldIndex = loadRequiredFieldIndex();
+  const rootElements = definitions.rootElements ?? [];
+
+  // Global event objects (Errors/Messages/Signals/Escalations).
+  const objects = { errors: [], messages: [], signals: [], escalations: [] };
+  for (const el of rootElements) {
+    if (el.$type === "bpmn:Error") objects.errors.push({ id: el.id, name: el.name, errorCode: el.errorCode });
+    else if (el.$type === "bpmn:Message") objects.messages.push({ id: el.id, name: el.name });
+    else if (el.$type === "bpmn:Signal") objects.signals.push({ id: el.id, name: el.name });
+    else if (el.$type === "bpmn:Escalation") objects.escalations.push({ id: el.id, name: el.name, escalationCode: el.escalationCode });
+  }
+
+  const collaboration = rootElements.find((e) => e.$type === "bpmn:Collaboration");
+  const processes = rootElements.filter((e) => e.$type === "bpmn:Process");
+  const processById = new Map(processes.map((p) => [p.id, p]));
+
+  const diagramsById = {};
+  let rootDiagramId;
+  let rootNode;
+
+  const procContainerNode = (proc, parentId) => ({
+    id: proc.id,
+    type: "bpmn:Process",
+    parentId,
+    abstractType: undefined,
+    data: { label: proc.name, uipath: buildRootUiPath(proc) },
+  });
+
+  if (collaboration) {
+    // Single collaboration diagram: pools + every participant's process flow
+    // nodes, with collaboration-level message flows. Pool lookup (walk parentId
+    // up to bpmn:Participant) resolves because each process's flow nodes get
+    // parentId = pool id, and the Process container node sits under the pool.
+    const nodes = [];
+    const edges = [];
+    for (const p of collaboration.participants ?? []) {
+      nodes.push({
+        id: p.id,
+        type: "bpmn:Participant",
+        parentId: undefined,
+        abstractType: undefined,
+        data: { label: p.name, processRef: p.processRef?.id ?? p.processRef },
+      });
+      const proc = processById.get(p.processRef?.id ?? p.processRef);
+      if (proc) {
+        nodes.push(procContainerNode(proc, p.id));
+        collectContainer(proc, requiredFieldIndex, nodes, edges, p.id);
+        if (!rootNode) rootNode = procContainerNode(proc, undefined);
+      }
+    }
+    for (const mf of collaboration.messageFlows ?? []) {
+      edges.push(buildEdge(mf, collaboration));
+    }
+    rootDiagramId = collaboration.id;
+    diagramsById[collaboration.id] = {
+      diagramId: collaboration.id,
+      root: { id: collaboration.id, type: collaboration.$type },
+      nodes,
+      edges,
+    };
+  } else {
+    // Stand-alone process(es): one diagram each, root-scope flow nodes at
+    // parentId undefined (frontend root scope). The Process container node is
+    // included so container-scoped rules (SingleBlankStartEvent) can see it.
+    for (const proc of processes) {
+      const nodes = [procContainerNode(proc, undefined)];
+      const edges = [];
+      collectContainer(proc, requiredFieldIndex, nodes, edges, undefined);
+      const diagramId = proc.id;
+      diagramsById[diagramId] = {
+        diagramId,
+        root: { id: proc.id, type: proc.$type },
+        nodes,
+        edges,
+      };
+      if (!rootDiagramId) {
+        rootDiagramId = diagramId;
+        rootNode = procContainerNode(proc, undefined);
+      }
+    }
+  }
+
+  return {
+    rootDiagramId,
+    root: rootNode ?? { id: "root", type: "bpmn:Process", data: {} },
+    diagramsById,
+    objects,
+  };
+}
+
+// Build the set of known variable identifiers for variable-existence checks:
+// ids AND names AND canonicalIds, across root + every node scope.
+export function collectKnownVariableIds(canvasState) {
+  const ids = new Set();
+  const add = (v) => {
+    if (v?.id) ids.add(v.id);
+    if (v?.name) ids.add(v.name);
+    if (v?.canonicalId) ids.add(v.canonicalId);
+  };
+  const rv = canvasState.root?.data?.uipath?.variables;
+  for (const v of rv?.inputs ?? []) add(v);
+  for (const v of rv?.inputOutputs ?? []) add(v);
+  for (const v of rv?.outputs ?? []) add(v);
+  for (const d of Object.values(canvasState.diagramsById)) {
+    for (const n of d.nodes) {
+      const nv = n.data?.uipath?.variables;
+      for (const v of nv?.inputs ?? []) add(v);
+      for (const v of nv?.inputOutputs ?? []) add(v);
+      for (const v of nv?.outputs ?? []) add(v);
+    }
+  }
+  return ids;
+}
+
+// Convenience: all nodes / all edges across every diagram (for global checks).
+export function allNodes(canvasState) {
+  return Object.values(canvasState.diagramsById).flatMap((d) => d.nodes);
+}
+export function allEdges(canvasState) {
+  return Object.values(canvasState.diagramsById).flatMap((d) => d.edges);
+}

--- a/skills/uipath-maestro-bpmn/validator/model.mjs
+++ b/skills/uipath-maestro-bpmn/validator/model.mjs
@@ -134,7 +134,11 @@ function mapVariables(varsEl) {
 // run offline with the same `field.required && isNilOrEmpty(value)` semantics
 // the canvas uses.
 function buildNodeUiPath(el, requiredFieldIndex) {
-  const act = findExt(el, "uipath:Activity") ?? findExt(el, "uipath:Event");
+  // Script tasks / BPMN.Variables nodes carry their IO under uipath:Mapping,
+  // which has the same { type, context, input, output } shape as
+  // uipath:Activity / uipath:Event. Treat all three uniformly so node-output
+  // variables (e.g. a script writing `var="x"`) are recovered.
+  const act = findExt(el, "uipath:Activity") ?? findExt(el, "uipath:Event") ?? findExt(el, "uipath:Mapping");
   const em = findExt(el, "uipath:ErrorMapping");
   const vars = findExt(el, "uipath:Variables");
   let uipath;
@@ -218,9 +222,16 @@ function buildEdge(el, parent) {
   const data = {};
   if (el.name) data.label = el.name;
   if (el.conditionExpression) {
+    // A FormalExpression moddle element carries its text in `.body`; an empty
+    // `<conditionExpression/>` element has no `.body` (undefined). Only a real
+    // string body is a condition — never fall back to the moddle object itself,
+    // which would crash the string-based rules (matches frontend: an empty
+    // conditionExpression element means "no condition expression").
     let body = el.conditionExpression.body ?? el.conditionExpression;
-    if (typeof body === "string" && body && !body.startsWith("=")) body = `=${body}`;
-    data.conditionExpression = body;
+    if (typeof body === "string") {
+      if (body && !body.startsWith("=")) body = `=${body}`;
+      data.conditionExpression = body;
+    }
   }
   // defaultFlow: source gateway's @default points to this flow.
   const source = el.sourceRef;
@@ -378,6 +389,16 @@ export function collectKnownVariableIds(canvasState) {
       for (const v of nv?.inputs ?? []) add(v);
       for (const v of nv?.inputOutputs ?? []) add(v);
       for (const v of nv?.outputs ?? []) add(v);
+      // A node's outputs each DECLARE a variable via their `var` attribute
+      // (frontend mapNodeOutputsToVariables: `id: v.var`). These variables are
+      // available to downstream nodes/edges, so they count as known. Without
+      // this, a gateway condition reading a variable written by an upstream
+      // script/task output false-positives as VARIABLE_DOES_NOT_EXIST.
+      for (const o of n.data?.uipath?.outputs ?? []) {
+        if (o.var) ids.add(o.var);
+        if (o.name) ids.add(o.name);
+        if (o.canonicalId) ids.add(o.canonicalId);
+      }
     }
   }
   return ids;

--- a/skills/uipath-maestro-bpmn/validator/package.json
+++ b/skills/uipath-maestro-bpmn/validator/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "uipath-maestro-bpmn-validator",
+  "private": true,
+  "type": "module",
+  "description": "Offline semantic validator for UiPath Maestro BPMN XML. Reconstructs the PO.Frontend Node/Edge/CanvasState model from the parsed BPMN and runs all 19 PO.Frontend validation rules.",
+  "bin": { "validate-bpmn": "./validate-bpmn.mjs" },
+  "scripts": { "test": "node test/run-tests.mjs" },
+  "dependencies": {
+    "bpmn-moddle": "^9.0.2",
+    "luxon": "^3.4.4"
+  }
+}

--- a/skills/uipath-maestro-bpmn/validator/rules.mjs
+++ b/skills/uipath-maestro-bpmn/validator/rules.mjs
@@ -1,0 +1,1081 @@
+// Self-contained Maestro BPMN validation rule engine.
+//
+// This module is a faithful, offline port of the PO.Frontend canvas validation
+// rule engine (PO.Frontend/src/services/validation/bpmn/). It operates on the
+// reconstructed Node[]/Edge[]/CanvasState model (see model.mjs), which mirrors
+// the frontend's `Node[]`/`Edge[]` derived from the same BPMN XML.
+//
+// PHASE 2 NOTE: this file is intentionally the *only* place rule logic lives.
+// When the rules ship as a published npm package, this module is replaced by an
+// import of that package with NO behavior change — model.mjs and
+// validate-bpmn.mjs stay as the integration layer.
+//
+// Each rule cites the PO.Frontend source it is ported from.
+
+import { Duration } from "luxon";
+
+export const SEVERITY = { ERROR: "ERROR", WARNING: "WARNING" };
+
+// ---------------------------------------------------------------------------
+// Lookup maps — port of ValidateBpmnFlowUtils.buildValidationLookupMaps.
+// ---------------------------------------------------------------------------
+export function buildValidationLookupMaps(nodes, edges) {
+  const nodeById = new Map();
+  const nodesByParentId = new Map();
+  const edgesBySource = new Map();
+  const edgesByTarget = new Map();
+
+  for (const node of nodes) {
+    nodeById.set(node.id, node);
+    const parentId = node.parentId;
+    const siblings = nodesByParentId.get(parentId);
+    if (siblings) siblings.push(node);
+    else nodesByParentId.set(parentId, [node]);
+  }
+  for (const edge of edges) {
+    const s = edgesBySource.get(edge.source);
+    if (s) s.push(edge);
+    else edgesBySource.set(edge.source, [edge]);
+    const t = edgesByTarget.get(edge.target);
+    if (t) t.push(edge);
+    else edgesByTarget.set(edge.target, [edge]);
+  }
+  return { nodeById, nodesByParentId, edgesBySource, edgesByTarget };
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+function dotGet(obj, prop, defaultValue) {
+  const parts = String(prop).match(/[^.[\]]+|\[\d+\]/g) ?? [];
+  let cur = obj;
+  for (const raw of parts) {
+    if (cur === null || typeof cur !== "object") return defaultValue;
+    const key = /^\[\d+\]$/.test(raw) ? Number(raw.slice(1, -1)) : raw;
+    cur = cur[key];
+  }
+  return cur === undefined ? defaultValue : cur;
+}
+
+// Port of EventObjectUtil.getEventObjectDetailsMapping (Errors branch only;
+// the boundary-event rule only consults bpmn:ErrorEventDefinition).
+function getEventObjectDetailsMapping(bpmnType) {
+  if (bpmnType === "bpmn:ErrorEventDefinition") {
+    return { type: "errors", accessor: "data.eventDefinition.errorRef", code: "errorCode" };
+  }
+  return undefined;
+}
+
+function isNilOrEmpty(value) {
+  return value === undefined || value === null || (typeof value === "string" && value.trim() === "");
+}
+
+// ---------------------------------------------------------------------------
+// Variable / expression helpers — port of VariableUtil.ts
+// ---------------------------------------------------------------------------
+
+// Captures the first segment after the prefix: e.g. "vars.response" / vars["response"].
+const VAR_REFS_REGEX = /(^|\b)(vars|result)(?:\.([\w]+)|\["([^"]+)"\])/g;
+
+// Special namespaces that are NOT user-declared variables. `iterator.` and
+// `metadata.` never start with `vars.`, so they are excluded by the regex
+// itself; `error` is the boundary-error context exposed as `vars.error`, which
+// IS matched by the regex and therefore must be skipped explicitly here.
+const BUILTIN_NON_VARIABLE_VARS_SEGMENTS = new Set(["error"]);
+
+/**
+ * Port of VariableUtil.validateNoAssignments. Returns true if the expression
+ * contains an assignment operator (excluding comparison/arrow operators).
+ */
+export function expressionHasAssignment(expression) {
+  if (!expression) return false;
+  const offset = expression.startsWith("=") ? 1 : 0;
+  const body = expression.slice(offset);
+  if (!body.trim()) return false;
+  const sanitized = body
+    .replaceAll(/"(?:[^"\\]|\\.)*"/g, (m) => " ".repeat(m.length))
+    .replaceAll(/'(?:[^'\\]|\\.)*'/g, (m) => " ".repeat(m.length))
+    .replaceAll(/`(?:[^`\\]|\\.)*`/g, (m) => " ".repeat(m.length))
+    .replaceAll(/\/(?:[^/\\]|\\.)*\/[gimsuy]*/g, (m) => " ".repeat(m.length));
+  const assignmentRegex =
+    /(\?\?=|&&=|\|\|=|>>>=|<<=|>>=|\*\*=|\+=|-=|\*=|\/=|%=|&=|\|=|\^=|(?<![!=<>+\-*/%.&|^?])=(?![=>]))/;
+  return assignmentRegex.test(sanitized);
+}
+
+/**
+ * Collect every `vars.X` / `result.X` reference in an expression that does NOT
+ * resolve against the supplied set of known variable identifiers. Resolution
+ * matches against BOTH variable ids and names (see model: each variable
+ * contributes id + name + canonicalId). Built-in segments (error) are skipped.
+ */
+export function findUnknownVariableRefs(expression, knownIds) {
+  if (!expression) return [];
+  const out = [];
+  for (const match of expression.matchAll(VAR_REFS_REGEX)) {
+    const prefix = match[2];
+    const seg = match[3] ?? match[4];
+    if (!seg) continue;
+    if (prefix === "result") continue; // `result.` is a node-local output alias, not a declared var
+    if (BUILTIN_NON_VARIABLE_VARS_SEGMENTS.has(seg)) continue;
+    if (knownIds.has(seg)) continue;
+    // Nested-path tolerance: vars.foo.bar resolves if `foo` is known.
+    let resolved = false;
+    for (const id of knownIds) {
+      if (seg === id || seg.startsWith(`${id}.`)) {
+        resolved = true;
+        break;
+      }
+    }
+    if (!resolved) out.push(match[0]);
+  }
+  return [...new Set(out)];
+}
+
+// ---------------------------------------------------------------------------
+// ISO-8601 duration helpers — port of DateUtil.ts
+// ---------------------------------------------------------------------------
+function isValidIso8601(value) {
+  return Duration.fromISO(value).isValid;
+}
+function hasIso8601WeekDesignator(value) {
+  return /W/i.test(value);
+}
+
+// ===========================================================================
+// RULE 1: ConditionalFlowRule
+// ===========================================================================
+export function validateConditionalSequenceFlow(nodes, _edges, lookupMaps) {
+  const errors = [];
+  const { edgesBySource, nodeById } = lookupMaps;
+  for (const node of nodes) {
+    if (node.type !== "bpmn:ExclusiveGateway") continue;
+    const outgoing = edgesBySource.get(node.id) ?? [];
+    const nonAnnotation = outgoing.filter((f) => nodeById.get(f.target)?.type !== "bpmn:TextAnnotation");
+    if (nonAnnotation.length <= 1) continue;
+    const hasDefault = nonAnnotation.some((f) => Boolean(f.data?.defaultFlow));
+    const missing = nonAnnotation.filter((f) => !f.data?.conditionExpression && !f.data?.defaultFlow);
+    if (missing.length === 0) continue;
+    for (const flow of missing) {
+      errors.push({
+        code: "MISSING_CONDITION_EXPRESSION",
+        message: "Sequence flow is missing condition expression",
+        severity: SEVERITY.ERROR,
+        sourceId: flow.source,
+        targetId: flow.target,
+        elementId: flow.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 2: ConnectionRule
+// ===========================================================================
+const baseAllowedTargets = new Set(["bpmn:TextAnnotation"]);
+const commonAllowedTargets = new Set([
+  ...baseAllowedTargets,
+  "bpmn:IntermediateThrowEvent",
+  "bpmn:IntermediateCatchEvent",
+  "bpmn:EndEvent",
+  "bpmn:ExclusiveGateway",
+  "bpmn:ParallelGateway",
+  "bpmn:InclusiveGateway",
+  "bpmn:ComplexGateway",
+  "bpmn:Task",
+  "bpmn:UserTask",
+  "bpmn:ServiceTask",
+  "bpmn:SendTask",
+  "bpmn:ReceiveTask",
+  "bpmn:ManualTask",
+  "bpmn:BusinessRuleTask",
+  "bpmn:ScriptTask",
+  "bpmn:CallActivity",
+  "bpmn:SubProcess",
+  "bpmn:AdHocSubProcess",
+  "bpmn:Transaction",
+]);
+const activityAllowedTargets = new Set([
+  ...commonAllowedTargets,
+  "bpmn:EventBasedGateway",
+  "bpmn:DataOutput",
+  "bpmn:DataStoreReference",
+  "bpmn:DataObjectReference",
+]);
+// Port of BPMNTypes.allowedTargetNodeTypesForSourceNodeType (concrete entries).
+const allowedTargetNodeTypesForSourceNodeType = {
+  "bpmn:StartEvent": commonAllowedTargets,
+  "bpmn:IntermediateThrowEvent": commonAllowedTargets,
+  "bpmn:IntermediateCatchEvent": commonAllowedTargets,
+  "bpmn:BoundaryEvent": commonAllowedTargets,
+  "bpmn:EndEvent": new Set(["bpmn:TextAnnotation"]),
+  "bpmn:ExclusiveGateway": commonAllowedTargets,
+  "bpmn:ParallelGateway": commonAllowedTargets,
+  "bpmn:InclusiveGateway": commonAllowedTargets,
+  "bpmn:ComplexGateway": commonAllowedTargets,
+  "bpmn:EventBasedGateway": new Set(["bpmn:IntermediateCatchEvent", "bpmn:TextAnnotation"]),
+  "bpmn:Task": activityAllowedTargets,
+  "bpmn:UserTask": activityAllowedTargets,
+  "bpmn:ServiceTask": activityAllowedTargets,
+  "bpmn:SendTask": activityAllowedTargets,
+  "bpmn:ReceiveTask": activityAllowedTargets,
+  "bpmn:ManualTask": activityAllowedTargets,
+  "bpmn:BusinessRuleTask": activityAllowedTargets,
+  "bpmn:ScriptTask": activityAllowedTargets,
+  "bpmn:CallActivity": activityAllowedTargets,
+  "bpmn:SubProcess": activityAllowedTargets,
+  "bpmn:AdHocSubProcess": activityAllowedTargets,
+  "bpmn:Transaction": activityAllowedTargets,
+  "bpmn:TextAnnotation": new Set(),
+  "bpmn:Participant": baseAllowedTargets,
+  "bpmn:Lane": baseAllowedTargets,
+};
+
+function canNodeTypesBeConnected(sourceNode, targetNode) {
+  const s = sourceNode?.type;
+  const t = targetNode?.type;
+  if (!sourceNode || !s || !targetNode || !t) return false;
+  const allowed = allowedTargetNodeTypesForSourceNodeType[s];
+  // Unknown source type: be permissive (frontend falls back to abstract-type
+  // inheritance which we cannot fully model offline; do not invent failures).
+  if (!allowed) return true;
+  return allowed.has(t);
+}
+
+export function validateConnections(nodes, edges, lookupMaps) {
+  const { nodeById } = lookupMaps;
+  const errors = [];
+  for (const edge of edges) {
+    // Only sequence flows participate in node-type connection rules; message
+    // flows/associations have separate rules. Frontend `Edge[]` for a diagram
+    // are predominantly sequence flows.
+    if (edge.type && edge.type !== "bpmn:SequenceFlow") continue;
+    const sourceNode = nodeById.get(edge.source);
+    const targetNode = nodeById.get(edge.target);
+    if (!sourceNode || !targetNode) {
+      errors.push({
+        code: "INVALID_CONNECTION",
+        message: "Broken flow line: references an element that no longer exists.",
+        severity: SEVERITY.WARNING,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+      continue;
+    }
+    if (sourceNode.id === targetNode.id) {
+      errors.push({
+        code: "INVALID_CONNECTION",
+        message: "Invalid connection: source and target cannot be the same.",
+        severity: SEVERITY.WARNING,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+      continue;
+    }
+    if (!canNodeTypesBeConnected(sourceNode, targetNode)) {
+      errors.push({
+        code: "INVALID_CONNECTION_TYPE",
+        message: `${sourceNode.type} cannot connect to ${targetNode.type}.`,
+        severity: SEVERITY.WARNING,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 3: DuplicateErrorEventSubprocessRule
+// ===========================================================================
+function getErrorObject(canvasState, errorRef) {
+  const errorObjects = canvasState.objects?.errors ?? [];
+  return errorObjects.find((o) => o.id === errorRef);
+}
+
+export function validateDuplicateErrorEventSubprocess(nodes, canvasState, lookupMaps) {
+  const { nodesByParentId } = lookupMaps;
+  const infos = [];
+  const eventSubprocesses = nodes.filter((n) => n.type === "bpmn:SubProcess" && n.data?.triggeredByEvent === true);
+  for (const sp of eventSubprocesses) {
+    const children = nodesByParentId.get(sp.id) ?? [];
+    const starts = children.filter((c) => c.type === "bpmn:StartEvent" && c.data?.eventDefinition?.type === "bpmn:ErrorEventDefinition");
+    for (const se of starts) {
+      const ed = se.data?.eventDefinition ?? {};
+      infos.push({ node: sp, errorRef: ed.errorRef, errorCode: getErrorObject(canvasState, ed.errorRef)?.errorCode });
+    }
+  }
+  const grouped = new Map();
+  for (const i of infos) {
+    const scope = i.node.parentId || "root";
+    const arr = grouped.get(scope) ?? [];
+    arr.push(i);
+    grouped.set(scope, arr);
+  }
+  const errors = [];
+  for (const [, scoped] of grouped) {
+    const catchAll = scoped.filter((i) => i.errorRef === undefined);
+    if (catchAll.length > 1) {
+      for (const i of catchAll) {
+        errors.push({
+          code: "MULTIPLE_CATCH_ALL_ERROR_EVENT_SUBPROCESS",
+          message: "Only one catch-all error event subprocess is allowed per scope.",
+          severity: SEVERITY.ERROR,
+          elementId: i.node.id,
+        });
+      }
+    }
+    const byCode = new Map();
+    for (const i of scoped) {
+      if (i.errorRef !== undefined && i.errorRef !== "" && i.errorCode) {
+        const arr = byCode.get(i.errorCode) ?? [];
+        arr.push(i);
+        byCode.set(i.errorCode, arr);
+      }
+    }
+    for (const [, same] of byCode) {
+      if (same.length > 1) {
+        for (const i of same) {
+          errors.push({
+            code: "DUPLICATE_ERROR_EVENT_SUBPROCESS",
+            message: "Only one error event subprocess is allowed per error code per scope.",
+            severity: SEVERITY.ERROR,
+            elementId: i.node.id,
+          });
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 4: EmptyStartEventDefinitionInSubProcessRule
+// ===========================================================================
+export function validateEventSubProcessStart(nodes, _edges, lookupMaps) {
+  const { nodesByParentId } = lookupMaps;
+  const errors = [];
+  const allowed = [
+    "bpmn:TimerEventDefinition",
+    "bpmn:MessageEventDefinition",
+    "bpmn:ErrorEventDefinition",
+    "bpmn:SignalEventDefinition",
+    "bpmn:EscalationEventDefinition",
+  ];
+  for (const node of nodes) {
+    if (node.type !== "bpmn:SubProcess") continue;
+    const isEventSubprocess = node.data?.triggeredByEvent === true;
+    const children = nodesByParentId.get(node.id) ?? [];
+    const starts = children.filter((c) => c.type === "bpmn:StartEvent");
+    for (const se of starts) {
+      const ed = se.data?.eventDefinition;
+      if (isEventSubprocess) {
+        if (!ed) {
+          errors.push({
+            code: "START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS",
+            message: "Start event in an event sub-process must have an event definition.",
+            severity: SEVERITY.ERROR,
+            elementId: se.id,
+            sourceId: node.id,
+          });
+        } else if (ed.type && !allowed.includes(ed.type)) {
+          errors.push({
+            code: "INVALID_EVENT_DEFINITION_IN_EVENT_SUBPROCESS",
+            message: "Start event in an event sub-process must use Timer/Message/Error/Signal/Escalation.",
+            severity: SEVERITY.ERROR,
+            elementId: se.id,
+            sourceId: node.id,
+          });
+        }
+      } else if (ed) {
+        errors.push({
+          code: "START_EVENT_WITH_DEFINITION_IN_SUBPROCESS",
+          message: "Start event in a regular sub-process must not have an event definition.",
+          severity: SEVERITY.ERROR,
+          elementId: se.id,
+          sourceId: node.id,
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 5: ErrorBoundaryEventRule (validate + duplicate)
+// ===========================================================================
+export function validateErrorBoundaryEvents(nodes, canvasState) {
+  const errors = [];
+  for (const node of nodes) {
+    if (node.type !== "bpmn:BoundaryEvent") continue;
+    const ed = node.data?.eventDefinition;
+    if (!ed || ed.type !== "bpmn:ErrorEventDefinition") continue;
+    const details = getEventObjectDetailsMapping(ed.type);
+    if (!details) continue;
+    const errorRefId = dotGet(node, details.accessor);
+    if (!errorRefId && ed.errorRef !== undefined) {
+      errors.push({
+        code: "ERROR_BOUNDARY_EVENT_EMPTY_ERROR_REF",
+        message: "Error boundary event has an empty error reference.",
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+      continue;
+    }
+    if (errorRefId) {
+      const errorObject = (canvasState.objects?.[details.type] ?? []).find((o) => o.id === errorRefId);
+      if (errorObject && details.code && (!dotGet(errorObject, details.code) || String(dotGet(errorObject, details.code)).trim() === "")) {
+        errors.push({
+          code: "ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE",
+          message: `Error '${errorObject.name || "Unknown"}' referenced by boundary event must have an error code.`,
+          severity: SEVERITY.ERROR,
+          elementId: node.id,
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+export function validateDuplicateErrorBoundaryEvents(nodes, canvasState) {
+  const errors = [];
+  const byTask = new Map();
+  for (const node of nodes) {
+    if (node.type !== "bpmn:BoundaryEvent") continue;
+    const ed = node.data?.eventDefinition;
+    if (!ed || ed.type !== "bpmn:ErrorEventDefinition") continue;
+    const attachedToId = node.data?.attachedToId;
+    if (!attachedToId) continue;
+    const arr = byTask.get(attachedToId) ?? [];
+    arr.push(node);
+    byTask.set(attachedToId, arr);
+  }
+  for (const [, events] of byTask) {
+    const catchAll = events.filter((n) => n.data?.eventDefinition?.errorRef === undefined);
+    if (catchAll.length > 1) {
+      for (const e of catchAll) {
+        errors.push({
+          code: "MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK",
+          message: "Only one catch-all error boundary event is allowed per task.",
+          severity: SEVERITY.ERROR,
+          elementId: e.id,
+        });
+      }
+    }
+    const byCode = new Map();
+    for (const n of events) {
+      const ref = n.data?.eventDefinition?.errorRef;
+      if (ref !== undefined && ref !== "") {
+        const code = getErrorObject(canvasState, ref)?.errorCode;
+        if (code) {
+          const arr = byCode.get(code) ?? [];
+          arr.push(n);
+          byCode.set(code, arr);
+        }
+      }
+    }
+    for (const [, same] of byCode) {
+      if (same.length > 1) {
+        for (const n of same) {
+          errors.push({
+            code: "DUPLICATE_ERROR_BOUNDARY_EVENT_ON_TASK",
+            message: "Only one error boundary event is allowed per error code per task.",
+            severity: SEVERITY.ERROR,
+            elementId: n.id,
+          });
+        }
+      }
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 6: ErrorEndEventRule
+// ===========================================================================
+export function validateErrorEndEvents(nodes) {
+  const errors = [];
+  for (const node of nodes) {
+    if (node.type !== "bpmn:EndEvent") continue;
+    const ed = node.data?.eventDefinition;
+    if (!ed || ed.type !== "bpmn:ErrorEventDefinition") continue;
+    if (!ed.errorRef) {
+      errors.push({
+        code: "ERROR_END_EVENT_MISSING_EXCEPTION",
+        message: "Error end event is missing a configured exception (errorRef).",
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 7: FakeJoinRule
+// ===========================================================================
+// On the canvas, the rule keys off the abstract node types `bpmn:Activity` and
+// `bpmn:Event`. On the reconstructed model we carry an `abstractType` derived
+// from the concrete BPMN type so this stays faithful. EndEvent is classified
+// as `bpmn:Event` on the canvas too, BUT the canvas models a converging end as
+// a gateway join, so it never sees a multi-incoming end event. We replicate the
+// frontend's observable behavior: tasks/activities and intermediate events flag
+// on multiple incoming; end events do not (converging onto one end is idiomatic
+// and the skill's own gateway-boundary-error fixture relies on it).
+function fakeJoinAbstractType(node) {
+  return node.abstractType; // "bpmn:Activity" | "bpmn:Event" | undefined
+}
+export function validateFakeJoins(nodes, edges, lookupMaps) {
+  if (!nodes || !edges) return [];
+  const errors = [];
+  const { edgesByTarget } = lookupMaps;
+  for (const node of nodes) {
+    const at = fakeJoinAbstractType(node);
+    const isFakeJoinCandidate = at === "bpmn:Activity" || (at === "bpmn:Event" && node.type !== "bpmn:EndEvent");
+    if (!isFakeJoinCandidate) continue;
+    const incoming = (edgesByTarget.get(node.id) ?? []).filter((e) => !e.type || e.type === "bpmn:SequenceFlow");
+    if (incoming.length > 1) {
+      errors.push({
+        code: "FAKE_JOIN",
+        message: "Activities and events should not have multiple incoming flows.",
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 8: MessageFlowObjectsPoolRule
+// ===========================================================================
+function buildNodeToPoolMap(nodes, nodeById) {
+  const map = new Map();
+  for (const node of nodes) {
+    let cur = node;
+    while (cur) {
+      if (cur.type === "bpmn:Participant") {
+        map.set(node.id, cur.id);
+        break;
+      }
+      if (!cur.parentId) break;
+      const parent = nodeById.get(cur.parentId);
+      if (!parent) break;
+      cur = parent;
+    }
+  }
+  return map;
+}
+export function validateMessageFlowCrossPool(nodes, edges, lookupMaps) {
+  const errors = [];
+  if (!nodes.some((n) => n.type === "bpmn:Participant")) return errors;
+  const nodeToPool = buildNodeToPoolMap(nodes, lookupMaps.nodeById);
+  for (const edge of edges) {
+    if (edge.type !== "bpmn:MessageFlow") continue;
+    const sp = nodeToPool.get(edge.source);
+    const tp = nodeToPool.get(edge.target);
+    if (sp && tp && sp === tp) {
+      errors.push({
+        code: "SAME_POOL_MESSAGE_FLOW",
+        message: "Message flow cannot connect elements within the same pool.",
+        severity: SEVERITY.ERROR,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 9: MissingResourceRule
+// ===========================================================================
+const SERVICE_TYPES_REQUIRING_RESOURCE = new Set([
+  "Orchestrator.StartAgentJob",
+  "Orchestrator.StartJob",
+  "Orchestrator.CreateQueueItem",
+  "Orchestrator.CreateAndWaitForQueueItem",
+  "Orchestrator.ExecuteApiWorkflowAsync",
+  "Actions.HITL",
+  "Orchestrator.StartAgenticProcess",
+  "Orchestrator.StartAgenticProcessAsync",
+  "Orchestrator.StartCaseMgmtProcess",
+  "Orchestrator.StartCaseMgmtProcessAsync",
+]);
+function hasResourceBinding(uipath) {
+  if (!uipath?.context) return false;
+  const releaseKey = uipath.context.find((c) => c.name === "releaseKey")?.value;
+  if (releaseKey) return true;
+  const name = uipath.context.find((c) => c.name === "name")?.value;
+  return !!name;
+}
+export function validateMissingResource(nodes) {
+  const errors = [];
+  for (const node of nodes) {
+    const uipath = node.data?.uipath;
+    const serviceType = uipath?.serviceType;
+    if (!serviceType || !SERVICE_TYPES_REQUIRING_RESOURCE.has(serviceType)) continue;
+    if (hasResourceBinding(uipath)) continue;
+    const label = node.data?.label || node.id;
+    errors.push({
+      code: "MISSING_RESOURCE",
+      message: `Service task '${label}' has no bound resource.`,
+      severity: SEVERITY.WARNING,
+      elementId: node.id,
+    });
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 10: MissingRootVariableRule
+// ===========================================================================
+export function validateMissingRootVariables(nodes, canvasState) {
+  const errors = [];
+  const rootIds = new Set();
+  const rv = canvasState.root?.data?.uipath?.variables;
+  for (const v of rv?.inputOutputs ?? []) if (v.id) rootIds.add(v.id);
+  for (const v of rv?.outputs ?? []) if (v.id) rootIds.add(v.id);
+
+  const findNode = (id) => {
+    for (const d of Object.values(canvasState.diagramsById)) {
+      const n = d.nodes.find((x) => x.id === id);
+      if (n) return n;
+    }
+    return undefined;
+  };
+  const collectNodeVarIds = (node) => {
+    const ids = new Set();
+    const nv = node.data?.uipath?.variables;
+    for (const v of nv?.inputOutputs ?? []) if (v.id) ids.add(v.id);
+    for (const v of nv?.outputs ?? []) if (v.id) ids.add(v.id);
+    return ids;
+  };
+  const scopeIdsFor = (node) => {
+    const result = new Set(rootIds);
+    let cur = node;
+    const visited = new Set();
+    while (true) {
+      const pe = cur?.data?.parentElement;
+      if (pe?.type !== "bpmn:SubProcess" || visited.has(pe.id)) break;
+      visited.add(pe.id);
+      const spNode = findNode(pe.id);
+      if (spNode) for (const id of collectNodeVarIds(spNode)) result.add(id);
+      cur = spNode;
+    }
+    return result;
+  };
+
+  for (const node of nodes) {
+    const outputs = node.data?.uipath?.outputs ?? [];
+    if (!outputs.length) continue;
+    const scopeIds = scopeIdsFor(node);
+    const missing = outputs.some((o) => o.var && !scopeIds.has(o.var));
+    if (missing) {
+      errors.push({
+        code: "MISSING_ROOT_VARIABLE",
+        message: `Node '${node.data?.label ?? node.id}' references an output variable with no matching scope variable.`,
+        severity: SEVERITY.WARNING,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 11: NoAssignmentsRule
+// ===========================================================================
+export function validateNoAssignmentsInExpressions(nodes, edges) {
+  if (!nodes || !edges) return [];
+  const errors = [];
+  for (const edge of edges) {
+    const expr = edge.data?.conditionExpression;
+    if (expr && expressionHasAssignment(expr)) {
+      errors.push({
+        code: "ASSIGNMENT_NOT_ALLOWED",
+        message: "Expression must not contain an assignment operator.",
+        severity: SEVERITY.WARNING,
+        elementId: edge.id,
+        sourceId: edge.source,
+        targetId: edge.target,
+      });
+    }
+  }
+  for (const node of nodes) {
+    const mappings = node.data?.uipath?.errorMapping;
+    if (!Array.isArray(mappings)) continue;
+    for (const m of mappings) {
+      if (m?.condition && expressionHasAssignment(m.condition)) {
+        errors.push({
+          code: "ASSIGNMENT_NOT_ALLOWED",
+          message: "Error-mapping condition must not contain an assignment operator.",
+          severity: SEVERITY.WARNING,
+          elementId: node.id,
+        });
+      }
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 12: RequiredFieldsRule  (sourced from bpmn-spec.json registry metadata)
+// ===========================================================================
+// Faithful port of ValidateRequiredFieldsInData.findRequiredFieldErrorInData:
+//   for each field in context, then inputs, then outputs (frontend order),
+//   if (field.required && isNilOrEmpty(field.value)) → first error.
+//
+// On canvas, `field.required` is attached to each live node field by the
+// actions-service-enriched node data. Offline we recover that flag from the
+// bundled registry (bpmn-spec.json): the model marks a serialized field
+// `required` ONLY when its name matches a registry-required field name for the
+// node's serviceType (model.mjs). Required fields that are simply ABSENT from
+// the serialized data are NOT flagged — offline, absence is ambiguous (the
+// value may be bound elsewhere, serialized under a different canonical name, or
+// supplied by design-time enrichment that exported BPMN does not carry). This
+// keeps the rule a true subset of the canvas behavior with no false positives.
+export function validateRequiredFields(nodes) {
+  const errors = [];
+  for (const node of nodes) {
+    const uipath = node.data?.uipath;
+    if (!uipath) continue;
+    const validateFields = (fields) => {
+      if (!Array.isArray(fields)) return undefined;
+      for (const field of fields) {
+        if (field.required && isNilOrEmpty(field.value ?? field.body)) return field;
+      }
+      return undefined;
+    };
+    const bad = validateFields(uipath.context) ?? validateFields(uipath.inputs) ?? validateFields(uipath.outputs);
+    if (bad) {
+      const label = node.data?.label ?? node.id;
+      errors.push({
+        code: "EMPTY_REQUIRED_FIELD",
+        message: `The field '${bad.name}' in node '${label}' is required but has no value.`,
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 13: SequenceFlowPoolCrossingRule
+// ===========================================================================
+export function validateSequenceFlowPoolCrossing(nodes, edges, lookupMaps) {
+  const errors = [];
+  if (!nodes.some((n) => n.type === "bpmn:Participant")) return errors;
+  const nodeById = lookupMaps.nodeById;
+  const nodeToPool = buildNodeToPoolMap(nodes, nodeById);
+  for (const edge of edges) {
+    if (edge.type !== "bpmn:SequenceFlow") continue;
+    const sp = nodeToPool.get(edge.source);
+    const tp = nodeToPool.get(edge.target);
+    const targetNode = nodeById.get(edge.target);
+    if (sp !== tp && targetNode?.type !== "bpmn:StartEvent") {
+      errors.push({
+        code: "CROSSING_POOL_BOUNDARY",
+        message: "Sequence flow cannot cross pool boundaries.",
+        severity: SEVERITY.ERROR,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 14: SequenceFlowSubProcessCrossingRule
+// ===========================================================================
+function getLogicalParent(node, nodeMap) {
+  const actualParent = node.parentId ? nodeMap.get(node.parentId) : undefined;
+  if (node.type === "bpmn:BoundaryEvent") {
+    const attachedToId = node.data?.attachedToId;
+    const attachedTo = attachedToId ? nodeMap.get(attachedToId) : undefined;
+    if (attachedTo) return attachedTo.parentId ? nodeMap.get(attachedTo.parentId) : undefined;
+  }
+  return actualParent;
+}
+export function validateSequenceFlowSubProcessCrossing(_nodes, edges, lookupMaps) {
+  const errors = [];
+  const nodeMap = lookupMaps.nodeById;
+  for (const edge of edges) {
+    if (edge.type !== "bpmn:SequenceFlow") continue;
+    const sourceNode = nodeMap.get(edge.source);
+    const targetNode = nodeMap.get(edge.target);
+    if (!sourceNode || !targetNode) continue;
+    const sp = getLogicalParent(sourceNode, nodeMap);
+    const tp = getLogicalParent(targetNode, nodeMap);
+    if ((sp?.type === "bpmn:SubProcess" || tp?.type === "bpmn:SubProcess") && sp?.id !== tp?.id) {
+      errors.push({
+        code: "CROSSING_SUBPROCESS_BOUNDARY",
+        message: "Sequence flow cannot cross sub-process boundaries.",
+        severity: SEVERITY.ERROR,
+        sourceId: edge.source,
+        targetId: edge.target,
+        elementId: edge.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 15: SingleBlankStartEventRule
+// ===========================================================================
+export function validateSingleBlankStartEvent(nodes, edges, lookupMaps) {
+  if (!nodes || !edges) return [];
+  const errors = [];
+  const { nodesByParentId } = lookupMaps;
+  const isBlankStart = (n) => n.type === "bpmn:StartEvent" && !n.data?.eventDefinition;
+  const containers = nodes.filter((n) => n.type === "bpmn:Process" || n.type === "bpmn:SubProcess");
+  for (const container of containers) {
+    const scopeNodes = container.type === "bpmn:Process" ? (nodesByParentId.get(undefined) ?? []) : (nodesByParentId.get(container.id) ?? []);
+    const blanks = scopeNodes.filter(isBlankStart);
+    if (blanks.length > 1) {
+      const type = container.type === "bpmn:SubProcess" ? "Sub-process" : "Process";
+      errors.push({
+        code: "MULTIPLE_BLANK_START_EVENTS",
+        message: `${type} should have at most one blank start event.`,
+        severity: SEVERITY.ERROR,
+        elementId: container.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 16: SingleStartEventInEventSubProcessRule
+// ===========================================================================
+export function validateSingleStartEventInEventSubProcess(nodes, _edges, lookupMaps) {
+  const errors = [];
+  const { nodesByParentId } = lookupMaps;
+  for (const node of nodes) {
+    if (!(node.type === "bpmn:SubProcess" && node.data?.triggeredByEvent === true)) continue;
+    const children = nodesByParentId.get(node.id) ?? [];
+    const starts = children.filter((c) => c.type === "bpmn:StartEvent");
+    if (starts.length > 1) {
+      errors.push({
+        code: "MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS",
+        message: "Event sub-process can have only one start event.",
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+        sourceId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 17: SuperfluousGatewayRule
+// ===========================================================================
+export function validateSuperfluousGateway(nodes, edges, lookupMaps) {
+  if (!nodes || !edges) return [];
+  const errors = [];
+  const { edgesBySource, edgesByTarget } = lookupMaps;
+  const isGateway = (t) => t === "bpmn:ExclusiveGateway" || t === "bpmn:ParallelGateway" || t === "bpmn:InclusiveGateway";
+  for (const node of nodes) {
+    if (!isGateway(node.type)) continue;
+    const incoming = edgesByTarget.get(node.id) ?? [];
+    const outgoing = edgesBySource.get(node.id) ?? [];
+    if (incoming.length === 1 && outgoing.length === 1) {
+      errors.push({
+        code: "SUPERFLUOUS_GATEWAY",
+        message: "Gateway should have at least two sources or targets.",
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 18: TaskTimerRule
+// ===========================================================================
+const MIN_TIMER_MINUTES = 15;
+const MAX_TIMER_MINUTES = 90 * 24 * 60;
+function isTimerValueOutOfRange(value) {
+  if (value == null || value === "") return false;
+  const str = String(value);
+  if (str.startsWith("@") || str.startsWith("=")) return false;
+  const minutes = Number(str);
+  if (Number.isNaN(minutes)) return false;
+  return minutes < MIN_TIMER_MINUTES || minutes > MAX_TIMER_MINUTES;
+}
+export function validateTaskTimerRange(nodes) {
+  if (!nodes) return [];
+  const errors = [];
+  for (const node of nodes) {
+    const uipath = node.data?.uipath;
+    if (uipath?.serviceType !== "actions") continue;
+    const timer = uipath.context?.find((c) => c.name === "Timer");
+    if (timer?.value == null || timer.value === "") continue;
+    if (isTimerValueOutOfRange(timer.value)) {
+      errors.push({
+        code: "TASK_TIMER_OUT_OF_RANGE",
+        message: `Task timer for '${node.data?.label ?? node.id}' must be between 15 minutes and 90 days.`,
+        severity: SEVERITY.WARNING,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ===========================================================================
+// RULE 19: TimerDurationRule
+// ===========================================================================
+export function validateTimerDuration(nodes) {
+  if (!nodes) return [];
+  const errors = [];
+  for (const node of nodes) {
+    const ed = node.data?.eventDefinition;
+    if (ed?.timerType !== "timeDuration") continue;
+    const value = ed.timeDuration;
+    if (!value) continue;
+    if (value.startsWith("=") || value.startsWith("@")) continue;
+    const label = node.data?.label ?? node.id;
+    if (!isValidIso8601(value)) {
+      errors.push({
+        code: "TIMER_DURATION_INVALID",
+        message: `Timer duration '${value}' on '${label}' is not a valid ISO 8601 duration.`,
+        severity: SEVERITY.ERROR,
+        elementId: node.id,
+      });
+      continue;
+    }
+    if (hasIso8601WeekDesignator(value)) {
+      errors.push({
+        code: "TIMER_DURATION_WEEK_UNSUPPORTED",
+        message: `Timer duration '${value}' on '${label}' uses the unsupported week (W) designator.`,
+        severity: SEVERITY.WARNING,
+        elementId: node.id,
+      });
+    }
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Variable-existence check across all nodes & edges of the whole model.
+// Port of VariableUtil.validateVariablesInAllNodesAndEdges (the existence half).
+// `knownIds` is built from variable ids AND names AND canonicalIds (model.mjs).
+// ---------------------------------------------------------------------------
+export function validateVariableExistence(allNodes, allEdges, knownIds) {
+  const errors = [];
+  const flag = (expr, elementId, extra = {}) => {
+    const unknown = findUnknownVariableRefs(expr, knownIds);
+    for (const ref of unknown) {
+      errors.push({
+        code: "VARIABLE_DOES_NOT_EXIST",
+        message: `Variable reference '${ref}' does not resolve to a declared variable.`,
+        severity: SEVERITY.ERROR,
+        elementId,
+        ...extra,
+      });
+    }
+  };
+  for (const edge of allEdges) {
+    if (edge.data?.conditionExpression) {
+      flag(edge.data.conditionExpression, edge.id, { sourceId: edge.source, targetId: edge.target });
+    }
+  }
+  for (const node of allNodes) {
+    const uipath = node.data?.uipath;
+    if (!uipath) continue;
+    const exprs = [];
+    for (const c of uipath.context ?? []) {
+      if (typeof c.value === "string") exprs.push(c.value);
+      if (typeof c.body === "string") exprs.push(c.body);
+    }
+    for (const i of uipath.inputs ?? []) {
+      if (typeof i.value === "string") exprs.push(i.value);
+      if (typeof i.body === "string") exprs.push(i.body);
+    }
+    for (const o of uipath.outputs ?? []) {
+      if (o.custom && typeof o.source === "string") exprs.push(o.source);
+      if (o.custom && typeof o.body === "string") exprs.push(o.body);
+    }
+    for (const m of uipath.errorMapping ?? []) {
+      if (typeof m.condition === "string") exprs.push(m.condition);
+    }
+    for (const expr of exprs) flag(expr, node.id);
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator: run every rule against one diagram's CanvasState. Mirrors the
+// per-diagram loop in ValidateBpmnFlowUtils.validateBpmnFlow.
+// ---------------------------------------------------------------------------
+export function validateDiagram(diagram, canvasState, options = {}) {
+  const nodes = diagram.nodes;
+  const edges = diagram.edges;
+  const lm = buildValidationLookupMaps(nodes, edges);
+  const errors = [];
+  errors.push(...validateConnections(nodes, edges, lm));
+  errors.push(...validateMessageFlowCrossPool(nodes, edges, lm));
+  errors.push(...validateSequenceFlowSubProcessCrossing(nodes, edges, lm));
+  errors.push(...validateSequenceFlowPoolCrossing(nodes, edges, lm));
+  errors.push(...validateConditionalSequenceFlow(nodes, edges, lm));
+  errors.push(...validateSuperfluousGateway(nodes, edges, lm));
+  errors.push(...validateFakeJoins(nodes, edges, lm));
+  errors.push(...validateSingleBlankStartEvent(nodes, edges, lm));
+  errors.push(...validateEventSubProcessStart(nodes, edges, lm));
+  errors.push(...validateSingleStartEventInEventSubProcess(nodes, edges, lm));
+  errors.push(...validateErrorBoundaryEvents(nodes, canvasState));
+  errors.push(...validateDuplicateErrorBoundaryEvents(nodes, canvasState));
+  errors.push(...validateErrorEndEvents(nodes));
+  errors.push(...validateDuplicateErrorEventSubprocess(nodes, canvasState, lm));
+  errors.push(...validateRequiredFields(nodes));
+  errors.push(...validateMissingResource(nodes));
+  errors.push(...validateNoAssignmentsInExpressions(nodes, edges));
+  if (options.enableMissingRootVariableValidation) {
+    errors.push(...validateMissingRootVariables(nodes, canvasState));
+  }
+  errors.push(...validateTaskTimerRange(nodes));
+  errors.push(...validateTimerDuration(nodes));
+  return errors;
+}
+
+export const RULE_CODES = [
+  "MISSING_CONDITION_EXPRESSION",
+  "INVALID_CONNECTION",
+  "INVALID_CONNECTION_TYPE",
+  "DUPLICATE_ERROR_EVENT_SUBPROCESS",
+  "MULTIPLE_CATCH_ALL_ERROR_EVENT_SUBPROCESS",
+  "START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS",
+  "INVALID_EVENT_DEFINITION_IN_EVENT_SUBPROCESS",
+  "START_EVENT_WITH_DEFINITION_IN_SUBPROCESS",
+  "ERROR_BOUNDARY_EVENT_EMPTY_ERROR_REF",
+  "ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE",
+  "MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK",
+  "DUPLICATE_ERROR_BOUNDARY_EVENT_ON_TASK",
+  "ERROR_END_EVENT_MISSING_EXCEPTION",
+  "FAKE_JOIN",
+  "SAME_POOL_MESSAGE_FLOW",
+  "MISSING_RESOURCE",
+  "MISSING_ROOT_VARIABLE",
+  "ASSIGNMENT_NOT_ALLOWED",
+  "EMPTY_REQUIRED_FIELD",
+  "CROSSING_POOL_BOUNDARY",
+  "CROSSING_SUBPROCESS_BOUNDARY",
+  "MULTIPLE_BLANK_START_EVENTS",
+  "MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS",
+  "SUPERFLUOUS_GATEWAY",
+  "TASK_TIMER_OUT_OF_RANGE",
+  "TIMER_DURATION_INVALID",
+  "TIMER_DURATION_WEEK_UNSUPPORTED",
+  "VARIABLE_DOES_NOT_EXIST",
+];

--- a/skills/uipath-maestro-bpmn/validator/rules.mjs
+++ b/skills/uipath-maestro-bpmn/validator/rules.mjs
@@ -104,31 +104,55 @@ export function expressionHasAssignment(expression) {
 
 /**
  * Collect every `vars.X` / `result.X` reference in an expression that does NOT
- * resolve against the supplied set of known variable identifiers. Resolution
- * matches against BOTH variable ids and names (see model: each variable
- * contributes id + name + canonicalId). Built-in segments (error) are skipped.
+ * resolve. Mirrors VariableUtil.getVariablesInExpression (the `nonExisting`
+ * half) + the result-validity split in validateVariablesInExpression:758-782.
+ *
+ *  - `vars.X` resolves against `knownIds` (variable ids/names/canonicalIds,
+ *    declared anywhere) — matches `existingIdsSet` semantics in the frontend.
+ *  - `result.X` resolves ONLY against the referencing element's OWN output
+ *    identifiers (`resultIds`); a `result.X` that names no output of this
+ *    element is flagged, exactly like `isResultVariableValidForElement`
+ *    (VariableUtil.ts:166-178) pushing it onto the non-existing set
+ *    (VariableUtil.ts:263 treats the unresolved result ref as non-existing).
+ *
+ * `resultIds` defaults to an empty set: in contexts where result refs are not
+ * element-local (e.g. edge conditions, which have no own outputs) every
+ * `result.X` is unresolved, matching the frontend.
  */
-export function findUnknownVariableRefs(expression, knownIds) {
+export function findUnknownVariableRefs(expression, knownIds, resultIds = new Set()) {
   if (!expression) return [];
   const out = [];
+  const resolvesAgainst = (seg, ids) => {
+    if (ids.has(seg)) return true;
+    // Nested-path tolerance: foo.bar resolves if `foo` is known.
+    for (const id of ids) {
+      if (seg === id || seg.startsWith(`${id}.`)) return true;
+    }
+    return false;
+  };
   for (const match of expression.matchAll(VAR_REFS_REGEX)) {
     const prefix = match[2];
     const seg = match[3] ?? match[4];
     if (!seg) continue;
-    if (prefix === "result") continue; // `result.` is a node-local output alias, not a declared var
-    if (BUILTIN_NON_VARIABLE_VARS_SEGMENTS.has(seg)) continue;
-    if (knownIds.has(seg)) continue;
-    // Nested-path tolerance: vars.foo.bar resolves if `foo` is known.
-    let resolved = false;
-    for (const id of knownIds) {
-      if (seg === id || seg.startsWith(`${id}.`)) {
-        resolved = true;
-        break;
-      }
+    if (prefix === "result") {
+      // `result.X` is a node-local output alias; valid only if X names one of
+      // this element's own outputs (frontend isResultVariableValidForElement).
+      if (!resolvesAgainst(seg, resultIds)) out.push(match[0]);
+      continue;
     }
-    if (!resolved) out.push(match[0]);
+    if (BUILTIN_NON_VARIABLE_VARS_SEGMENTS.has(seg)) continue;
+    if (!resolvesAgainst(seg, knownIds)) out.push(match[0]);
   }
   return [...new Set(out)];
+}
+
+// ---------------------------------------------------------------------------
+// Port of Tools.getAccessorFromType — selects which field of a custom output
+// carries the user expression to validate.
+function getAccessorFromType(type) {
+  if (type === "json" || type === "jsonSchema" || type === "array") return "body";
+  if (type === "file" || type === "octet-stream") return "target";
+  return "source";
 }
 
 // ---------------------------------------------------------------------------
@@ -236,9 +260,14 @@ function canNodeTypesBeConnected(sourceNode, targetNode) {
   const t = targetNode?.type;
   if (!sourceNode || !s || !targetNode || !t) return false;
   const allowed = allowedTargetNodeTypesForSourceNodeType[s];
-  // Unknown source type: be permissive (frontend falls back to abstract-type
-  // inheritance which we cannot fully model offline; do not invent failures).
-  if (!allowed) return true;
+  // No matching rule for the source type → frontend `canNodeTypesBeConnected`
+  // returns false (BPMNTypesUtils.ts:51-82: after the explicit-rule and
+  // inherited-rule loops exhaust with no match it `return false`). The
+  // abstract-type inheritance the frontend additionally walks is already folded
+  // into our concrete allow-map (every concrete activity/event type has an
+  // explicit entry above), so an unknown source type genuinely has no rule and
+  // must be rejected as INVALID_CONNECTION_TYPE.
+  if (!allowed) return false;
   return allowed.has(t);
 }
 
@@ -740,34 +769,52 @@ export function validateNoAssignmentsInExpressions(nodes, edges) {
 //   for each field in context, then inputs, then outputs (frontend order),
 //   if (field.required && isNilOrEmpty(field.value)) → first error.
 //
-// On canvas, `field.required` is attached to each live node field by the
-// actions-service-enriched node data. Offline we recover that flag from the
-// bundled registry (bpmn-spec.json): the model marks a serialized field
-// `required` ONLY when its name matches a registry-required field name for the
-// node's serviceType (model.mjs). Required fields that are simply ABSENT from
-// the serialized data are NOT flagged — offline, absence is ambiguous (the
-// value may be bound elsewhere, serialized under a different canonical name, or
-// supplied by design-time enrichment that exported BPMN does not carry). This
-// keeps the rule a true subset of the canvas behavior with no false positives.
+// On canvas, EVERY field a serviceType declares is present in the node data with
+// its `required` flag set; an unbound required field is present-with-empty-value
+// and the frontend fires on it. In exported BPMN an unbound required field is
+// simply ABSENT. To reach parity, we treat an absent required field exactly as
+// the frontend treats an unbound one: present with an empty value. The required-
+// field names come from the bundled registry (bpmn-spec.json) per serviceType
+// (model.mjs attaches them as `uipath.requiredFieldNames`).
+//
+// BOUNDARY: For dynamic IS-connector activity types whose required-ness is NOT
+// in the static spec — it only materializes after a `registry get` enrichment —
+// `requiredFieldNames` is undefined and absence cannot be judged offline, so we
+// stay conservative (only present-but-empty fires). The frontend needs the same
+// enrichment to know those fields are required, so this is shared, not a gap.
 export function validateRequiredFields(nodes) {
   if (!nodes) return []; // frontend RequiredFieldsRule guards null inputs
   const errors = [];
   for (const node of nodes) {
     const uipath = node.data?.uipath;
     if (!uipath) continue;
-    const validateFields = (fields) => {
+    // First (frontend order): present fields flagged when required + empty value.
+    const firstEmptyPresent = (fields) => {
       if (!Array.isArray(fields)) return undefined;
       for (const field of fields) {
-        if (field.required && isNilOrEmpty(field.value ?? field.body)) return field;
+        if (field.required && isNilOrEmpty(field.value)) return field;
       }
       return undefined;
     };
-    const bad = validateFields(uipath.context) ?? validateFields(uipath.inputs) ?? validateFields(uipath.outputs);
-    if (bad) {
+    let badName;
+    const present = firstEmptyPresent(uipath.context) ?? firstEmptyPresent(uipath.inputs) ?? firstEmptyPresent(uipath.outputs);
+    if (present) badName = present.name;
+    else if (Array.isArray(uipath.requiredFieldNames)) {
+      // No present-but-empty required field; check for an entirely ABSENT one
+      // (treated by the frontend as present-with-empty, hence required+empty).
+      const presentNames = new Set();
+      for (const group of [uipath.context, uipath.inputs, uipath.outputs]) {
+        if (!Array.isArray(group)) continue;
+        for (const f of group) if (f.name) presentNames.add(f.name);
+      }
+      const absent = uipath.requiredFieldNames.find((name) => !presentNames.has(name));
+      if (absent) badName = absent;
+    }
+    if (badName !== undefined) {
       const label = node.data?.label ?? node.id;
       errors.push({
         code: "EMPTY_REQUIRED_FIELD",
-        message: `The field '${bad.name}' in node '${label}' is required but has no value.`,
+        message: `The field '${badName}' in node '${label}' is required but has no value.`,
         severity: SEVERITY.ERROR,
         elementId: node.id,
       });
@@ -985,8 +1032,8 @@ export function validateTimerDuration(nodes) {
 // ---------------------------------------------------------------------------
 export function validateVariableExistence(allNodes, allEdges, knownIds) {
   const errors = [];
-  const flag = (expr, elementId, extra = {}) => {
-    const unknown = findUnknownVariableRefs(expr, knownIds);
+  const flag = (expr, elementId, resultIds, extra = {}) => {
+    const unknown = findUnknownVariableRefs(expr, knownIds, resultIds);
     for (const ref of unknown) {
       errors.push({
         code: "VARIABLE_DOES_NOT_EXIST",
@@ -997,14 +1044,23 @@ export function validateVariableExistence(allNodes, allEdges, knownIds) {
       });
     }
   };
+  // Edge conditions have no element-local outputs → result.X never resolves.
   for (const edge of allEdges) {
     if (edge.data?.conditionExpression) {
-      flag(edge.data.conditionExpression, edge.id, { sourceId: edge.source, targetId: edge.target });
+      flag(edge.data.conditionExpression, edge.id, new Set(), { sourceId: edge.source, targetId: edge.target });
     }
   }
   for (const node of allNodes) {
     const uipath = node.data?.uipath;
     if (!uipath) continue;
+    // result.X is validated against THIS element's own output identifiers
+    // (var/name/canonicalId), per VariableUtil.isResultVariableValidForElement.
+    const resultIds = new Set();
+    for (const o of uipath.outputs ?? []) {
+      if (o.var) resultIds.add(o.var);
+      if (o.name) resultIds.add(o.name);
+      if (o.canonicalId) resultIds.add(o.canonicalId);
+    }
     const exprs = [];
     for (const c of uipath.context ?? []) {
       if (typeof c.value === "string") exprs.push(c.value);
@@ -1014,14 +1070,268 @@ export function validateVariableExistence(allNodes, allEdges, knownIds) {
       if (typeof i.value === "string") exprs.push(i.value);
       if (typeof i.body === "string") exprs.push(i.body);
     }
+    // Custom-output expressions: gate the field by accessor type, mirroring
+    // VariableUtil.ts:952-968 (source only when accessor is `source`, body only
+    // when accessor is `body`).
     for (const o of uipath.outputs ?? []) {
-      if (o.custom && typeof o.source === "string") exprs.push(o.source);
-      if (o.custom && typeof o.body === "string") exprs.push(o.body);
+      if (!o.custom) continue;
+      const accessor = getAccessorFromType(o.type);
+      if (accessor === "source" && typeof o.source === "string") exprs.push(o.source);
+      else if (accessor === "body" && typeof o.body === "string") exprs.push(o.body);
     }
     for (const m of uipath.errorMapping ?? []) {
       if (typeof m.condition === "string") exprs.push(m.condition);
     }
-    for (const expr of exprs) flag(expr, node.id);
+    for (const expr of exprs) flag(expr, node.id, resultIds);
+  }
+  return errors;
+}
+
+// ---------------------------------------------------------------------------
+// VARIABLE_NOT_SET — port of the flow-reachability half of
+// VariableUtil.validateVariablesInExpression (VariableUtil.ts:758-866).
+//
+// A variable can be DECLARED (exists in the known-id set) yet NOT SET at a given
+// element because no flow path reaches that element from the node that produces
+// it. The frontend computes, per element, the set of variables available via a
+// backward walk over sequence-flow edges (+ scope/parent chain, boundary
+// re-parenting, event-subprocess shared scope, subprocess EndEvent exposure),
+// then warns on every referenced+declared variable not in that set.
+//
+// Faithful port of:
+//   getSourceEdgeMappings              (VariableUtil.ts:121-130)
+//   mapNodeOutputsToVariables          (VariableUtil.ts:539-579, uipath outputs)
+//   getVariablesForSubProcess          (VariableUtil.ts:495-525)
+//   getAvailableVariablesFromSourceNodes (VariableUtil.ts:303-389)
+//   getAvailableVariablesForElement    (VariableUtil.ts:401-481)
+// Skipped entirely for Case Management (VariableUtil.ts:826-828).
+// ---------------------------------------------------------------------------
+
+// A node output declares a variable whose identifier is `var` (falling back to
+// `value` when shouldIdFallbackToValue, per the frontend mapNodeOutputsToVariables).
+// Returns id + canonicalId + name. The frontend's availability match keys on
+// id/canonicalId; this port additionally includes `name`, consistent with the
+// rest of the port's variable resolution (collectKnownVariableIds /
+// findUnknownVariableRefs resolve by id AND name AND canonicalId), because
+// exported BPMN expressions may reference a variable by its serialized name.
+function nodeOutputVariableIds(node, idFallbackToValue) {
+  const ids = [];
+  for (const o of node?.data?.uipath?.outputs ?? []) {
+    const id = o.var ?? (idFallbackToValue ? (o.value ?? "") : "");
+    if (id) ids.push(id);
+    if (o.canonicalId) ids.push(o.canonicalId);
+    if (o.name) ids.push(o.name);
+  }
+  return ids;
+}
+
+// Port of getVariablesForSubProcess: the variables a subprocess EXPOSES to a
+// sibling selection (the subprocess node's own outputs + its EndEvent children's
+// outputs). `isSelfSelected` is always false here (the selection is never the
+// subprocess being traversed past), matching the edge-traversal path.
+function subProcessExposedVarIds(subProcessId, nodes) {
+  const ids = [];
+  for (const node of nodes) {
+    const outs = nodeOutputVariableIds(node, false);
+    if (!outs.length) continue;
+    if (node.id === subProcessId) {
+      for (const i of outs) ids.push(i);
+      continue;
+    }
+    if (node.parentId === subProcessId || node.data?.parentElement?.id === subProcessId) {
+      if (node.type === "bpmn:EndEvent") for (const i of outs) ids.push(i);
+    }
+  }
+  return ids;
+}
+
+// Backward BFS over sequence-flow edges from `selectionElementId`, collecting
+// every available variable id. Port of getAvailableVariablesFromSourceNodes.
+function availableVarIdsFromSourceNodes(selectionElementId, selectionElementType, nodes, edges, rootVarIds, nodeById) {
+  const edgeToSource = new Map();
+  const sourceToEdges = new Map();
+  for (const edge of edges) {
+    edgeToSource.set(edge.id, edge.source);
+    const arr = sourceToEdges.get(edge.target) ?? [];
+    arr.push(edge.id);
+    sourceToEdges.set(edge.target, arr);
+  }
+
+  const available = new Set(rootVarIds); // root variables are globally available
+  const visitedEdges = new Set();
+
+  // The selected element's own outputs are available.
+  const selected = nodeById.get(selectionElementId);
+  if (selected) for (const i of nodeOutputVariableIds(selected, true)) available.add(i);
+
+  const edgesToVisit = [];
+  let currentEdgeId = selectionElementId;
+  if (selectionElementType === "node") {
+    edgesToVisit.push(...(sourceToEdges.get(selectionElementId) ?? []));
+    currentEdgeId = edgesToVisit.shift();
+  }
+
+  while (currentEdgeId) {
+    let sourceNode = nodeById.get(edgeToSource.get(currentEdgeId) ?? "");
+    // Boundary events have no incoming edge; re-parent to their host.
+    if (sourceNode?.type === "bpmn:BoundaryEvent" && sourceNode?.id) {
+      const parentId = sourceNode.parentId;
+      sourceNode = parentId ? nodeById.get(parentId) : undefined;
+    }
+    if (sourceNode?.type !== "bpmn:SubProcess" && sourceNode?.id) {
+      for (const i of nodeOutputVariableIds(sourceNode, true)) available.add(i);
+    }
+    if (sourceNode?.type === "bpmn:SubProcess" && sourceNode?.id) {
+      for (const i of subProcessExposedVarIds(sourceNode.id, nodes)) available.add(i);
+    }
+    visitedEdges.add(currentEdgeId);
+
+    let nextEdge = sourceToEdges.get(sourceNode?.id ?? "");
+    if (!nextEdge && sourceNode?.parentId) {
+      const sourceParent = nodeById.get(sourceNode.parentId);
+      if (sourceParent?.type === "bpmn:SubProcess") nextEdge = sourceToEdges.get(sourceParent.id);
+    }
+    edgesToVisit.push(...(nextEdge ?? []).filter((e) => !visitedEdges.has(e)));
+    currentEdgeId = edgesToVisit.shift();
+  }
+  return available;
+}
+
+// Port of getAvailableVariablesForElement: source-node BFS + subprocess scope +
+// parent chain (with event-subprocess shared-scope handling).
+function availableVarIdsForElement(selectionElementId, selectionElementType, nodes, edges, rootVarIds, nodeById) {
+  const available = availableVarIdsFromSourceNodes(selectionElementId, selectionElementType, nodes, edges, rootVarIds, nodeById);
+
+  const selected = nodeById.get(selectionElementId);
+  if (selected?.type === "bpmn:SubProcess") {
+    // Self-selected: expose all child variables.
+    for (const node of nodes) {
+      if (node.parentId === selectionElementId || node.data?.parentElement?.id === selectionElementId) {
+        for (const i of nodeOutputVariableIds(node, false)) available.add(i);
+      }
+    }
+  }
+
+  let parentElementId = selected?.data?.parentElement?.id;
+  if (!parentElementId) return available;
+
+  const visitedParentIds = new Set();
+  while (parentElementId && !visitedParentIds.has(parentElementId)) {
+    visitedParentIds.add(parentElementId);
+    const parentNode = nodeById.get(parentElementId);
+    if (!parentNode) break;
+
+    const isParentEventSubprocess = parentNode.type === "bpmn:SubProcess" && parentNode.data?.triggeredByEvent === true;
+    if (isParentEventSubprocess) {
+      const grandparentNodeId = parentNode.data?.parentElement?.id;
+      if (!grandparentNodeId) break;
+      for (const node of nodes) {
+        const nodeScope = node.data?.parentElement?.id;
+        if (nodeScope === grandparentNodeId && node.id !== parentElementId) {
+          if (node.type === "bpmn:SubProcess") {
+            for (const i of subProcessExposedVarIds(node.id, nodes)) available.add(i);
+          } else {
+            for (const i of nodeOutputVariableIds(node, true)) available.add(i);
+          }
+        }
+      }
+      parentElementId = grandparentNodeId;
+      continue;
+    }
+
+    for (const i of availableVarIdsFromSourceNodes(parentElementId, "node", nodes, edges, rootVarIds, nodeById)) available.add(i);
+    parentElementId = parentNode.data?.parentElement?.id;
+  }
+  return available;
+}
+
+// Collect the `vars.X` identifiers in an expression that are DECLARED (resolve
+// against the model's known ids) — these are the candidates for VARIABLE_NOT_SET.
+function declaredVarRefsInExpression(expression, knownIds) {
+  if (!expression) return [];
+  const out = new Set();
+  for (const match of expression.matchAll(VAR_REFS_REGEX)) {
+    const prefix = match[2];
+    if (prefix !== "vars") continue;
+    const seg = match[3] ?? match[4];
+    if (!seg || BUILTIN_NON_VARIABLE_VARS_SEGMENTS.has(seg)) continue;
+    let resolvedId;
+    if (knownIds.has(seg)) resolvedId = seg;
+    else {
+      for (const id of knownIds) {
+        if (seg.startsWith(`${id}.`)) {
+          resolvedId = id;
+          break;
+        }
+      }
+    }
+    if (resolvedId) out.add(resolvedId);
+  }
+  return [...out];
+}
+
+// `varExpressionsForElement` mirrors getInputExpressions + the output accessor
+// gate used by the frontend node loop (VariableUtil.ts:949-971).
+function varExpressionsForNode(uipath) {
+  const exprs = [];
+  for (const c of uipath.context ?? []) {
+    if (typeof c.value === "string") exprs.push(c.value);
+    if (typeof c.body === "string") exprs.push(c.body);
+  }
+  for (const i of uipath.inputs ?? []) {
+    if (typeof i.value === "string") exprs.push(i.value);
+    if (typeof i.body === "string") exprs.push(i.body);
+  }
+  for (const o of uipath.outputs ?? []) {
+    if (!o.custom) continue;
+    const accessor = getAccessorFromType(o.type);
+    if (accessor === "source" && typeof o.source === "string") exprs.push(o.source);
+    else if (accessor === "body" && typeof o.body === "string") exprs.push(o.body);
+  }
+  return exprs;
+}
+
+// Emit VARIABLE_NOT_SET (WARNING) for declared variables referenced at an
+// element that are not reachable in flow order. Skipped for Case Management.
+export function validateVariableNotSet(allNodes, allEdges, knownIds, canvasState, options = {}) {
+  if (options.isCaseManagement) return []; // frontend skips (VariableUtil.ts:826-828)
+  const errors = [];
+  const nodeById = new Map(allNodes.map((n) => [n.id, n]));
+
+  // Root variable identifiers (id + canonicalId + name) — globally available.
+  // `name` included for the same port-consistency reason as nodeOutputVariableIds.
+  const rootVarIds = [];
+  const rv = canvasState?.root?.data?.uipath?.variables;
+  for (const v of [...(rv?.inputs ?? []), ...(rv?.inputOutputs ?? [])]) {
+    if (v.id) rootVarIds.push(v.id);
+    if (v.canonicalId) rootVarIds.push(v.canonicalId);
+    if (v.name) rootVarIds.push(v.name);
+  }
+
+  const check = (elementId, elementType, expression) => {
+    const declared = declaredVarRefsInExpression(expression, knownIds);
+    if (!declared.length) return;
+    const available = availableVarIdsForElement(elementId, elementType, allNodes, allEdges, rootVarIds, nodeById);
+    for (const ref of declared) {
+      if (!available.has(ref)) {
+        errors.push({
+          code: "VARIABLE_NOT_SET",
+          message: `Variable '${ref}' is not set at this point in the flow.`,
+          severity: SEVERITY.WARNING,
+          elementId,
+        });
+      }
+    }
+  };
+
+  for (const edge of allEdges) {
+    if (typeof edge.data?.conditionExpression === "string") check(edge.id, "edge", edge.data.conditionExpression);
+  }
+  for (const node of allNodes) {
+    const uipath = node.data?.uipath;
+    if (!uipath) continue;
+    const expr = varExpressionsForNode(uipath).join(" ; ");
+    if (expr) check(node.id, "node", expr);
   }
   return errors;
 }
@@ -1089,4 +1399,5 @@ export const RULE_CODES = [
   "TIMER_DURATION_INVALID",
   "TIMER_DURATION_WEEK_UNSUPPORTED",
   "VARIABLE_DOES_NOT_EXIST",
+  "VARIABLE_NOT_SET",
 ];

--- a/skills/uipath-maestro-bpmn/validator/rules.mjs
+++ b/skills/uipath-maestro-bpmn/validator/rules.mjs
@@ -517,25 +517,35 @@ export function validateErrorEndEvents(nodes) {
 // ===========================================================================
 // RULE 7: FakeJoinRule
 // ===========================================================================
-// On the canvas, the rule keys off the abstract node types `bpmn:Activity` and
-// `bpmn:Event`. On the reconstructed model we carry an `abstractType` derived
-// from the concrete BPMN type so this stays faithful. EndEvent is classified
-// as `bpmn:Event` on the canvas too, BUT the canvas models a converging end as
-// a gateway join, so it never sees a multi-incoming end event. We replicate the
-// frontend's observable behavior: tasks/activities and intermediate events flag
-// on multiple incoming; end events do not (converging onto one end is idiomatic
-// and the skill's own gateway-boundary-error fixture relies on it).
-function fakeJoinAbstractType(node) {
-  return node.abstractType; // "bpmn:Activity" | "bpmn:Event" | undefined
+// FAITHFUL-PORT NOTE (drift resolved by matching the frontend's *actual*
+// behavior — see validator/test/integration.test.mjs and README "FakeJoin"):
+//
+// The PO.Frontend FakeJoinRule fires only when `node.type === "bpmn:Activity"`
+// or `node.type === "bpmn:Event"` — a LITERAL string equality against the
+// abstract BPMN type names (FakeJoinRule.ts, isActivityOrEvent). However, on the
+// real canvas every node carries its CONCRETE `$type` (`bpmn:Task`,
+// `bpmn:EndEvent`, ...): bpmn-from-xml.ts sets `type: $type` and the validation
+// layer compares concrete types everywhere (ValidateBpmnFlowUtils compares
+// `=== "bpmn:StartEvent"`). The abstract names are never assigned to a real
+// node, so on exported BPMN this frontend rule is effectively DORMANT — it never
+// fires. The rule's own source carries a TODO admitting it must be rewritten to
+// walk the inherited-type chain, which it does not yet do.
+//
+// Our model reconstructs CONCRETE types from the XML, mirroring the canvas.
+// To match the frontend's observable behavior on real BPMN (and avoid the
+// false positives an earlier hand-port produced on valid files), we apply the
+// frontend's exact predicate: literal equality on `node.type`. This keeps the
+// port faithful — same inputs, same outputs as the frontend — rather than
+// inventing a stricter rule the frontend does not have.
+function isFrontendFakeJoinType(type) {
+  return type === "bpmn:Activity" || type === "bpmn:Event";
 }
 export function validateFakeJoins(nodes, edges, lookupMaps) {
   if (!nodes || !edges) return [];
   const errors = [];
   const { edgesByTarget } = lookupMaps;
   for (const node of nodes) {
-    const at = fakeJoinAbstractType(node);
-    const isFakeJoinCandidate = at === "bpmn:Activity" || (at === "bpmn:Event" && node.type !== "bpmn:EndEvent");
-    if (!isFakeJoinCandidate) continue;
+    if (!isFrontendFakeJoinType(node.type)) continue;
     const incoming = (edgesByTarget.get(node.id) ?? []).filter((e) => !e.type || e.type === "bpmn:SequenceFlow");
     if (incoming.length > 1) {
       errors.push({
@@ -740,6 +750,7 @@ export function validateNoAssignmentsInExpressions(nodes, edges) {
 // supplied by design-time enrichment that exported BPMN does not carry). This
 // keeps the rule a true subset of the canvas behavior with no false positives.
 export function validateRequiredFields(nodes) {
+  if (!nodes) return []; // frontend RequiredFieldsRule guards null inputs
   const errors = [];
   for (const node of nodes) {
     const uipath = node.data?.uipath;

--- a/skills/uipath-maestro-bpmn/validator/samples/invalid-conditional-and-variable.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/samples/invalid-conditional-and-variable.bpmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_Invalid" targetNamespace="http://uipath.com/synthetic/maestro-bpmn/invalid">
+  <bpmn:process id="Process_Invalid" name="Invalid Sample" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:input id="Var_Request" name="request" type="string" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start"><bpmn:outgoing>Flow_S_G</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gw" name="Route"><bpmn:incoming>Flow_S_G</bpmn:incoming><bpmn:outgoing>Flow_G_A</bpmn:outgoing><bpmn:outgoing>Flow_G_B</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="A"><bpmn:incoming>Flow_G_A</bpmn:incoming></bpmn:task>
+    <bpmn:task id="B"><bpmn:incoming>Flow_G_B</bpmn:incoming></bpmn:task>
+    <bpmn:sequenceFlow id="Flow_S_G" sourceRef="Start" targetRef="Gw" />
+    <bpmn:sequenceFlow id="Flow_G_A" sourceRef="Gw" targetRef="A"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=vars.DoesNotExist == "x"</bpmn:conditionExpression></bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_G_B" sourceRef="Gw" targetRef="B" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_Invalid">
+    <bpmndi:BPMNPlane id="Plane_Invalid" bpmnElement="Process_Invalid">
+      <bpmndi:BPMNShape id="Sh_Start" bpmnElement="Start"><dc:Bounds x="100" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Sh_Gw" bpmnElement="Gw"><dc:Bounds x="200" y="93" width="50" height="50" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Sh_A" bpmnElement="A"><dc:Bounds x="320" y="40" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Sh_B" bpmnElement="B"><dc:Bounds x="320" y="160" width="100" height="80" /></bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/samples/valid-baseline.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/samples/valid-baseline.bpmn
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:uipath="http://uipath.org/schema/bpmn" id="Definitions_Valid" targetNamespace="http://uipath.com/synthetic/maestro-bpmn/valid">
+  <bpmn:process id="Process_Valid" name="Valid Baseline" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:input id="Var_Request" name="request" type="string" />
+        <uipath:output id="Var_Result" name="result" type="string" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start" name="Start">
+      <bpmn:outgoing>Flow_Start_Gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gw" name="Route" default="Flow_Gw_B">
+      <bpmn:incoming>Flow_Start_Gw</bpmn:incoming>
+      <bpmn:outgoing>Flow_Gw_A</bpmn:outgoing>
+      <bpmn:outgoing>Flow_Gw_B</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Task_A" name="Task A">
+      <bpmn:incoming>Flow_Gw_A</bpmn:incoming>
+      <bpmn:outgoing>Flow_A_End</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Task_B" name="Task B">
+      <bpmn:incoming>Flow_Gw_B</bpmn:incoming>
+      <bpmn:outgoing>Flow_B_End</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="End" name="End">
+      <bpmn:incoming>Flow_A_End</bpmn:incoming>
+      <bpmn:incoming>Flow_B_End</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_Start_Gw" sourceRef="Start" targetRef="Gw" />
+    <bpmn:sequenceFlow id="Flow_Gw_A" sourceRef="Gw" targetRef="Task_A">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">=vars.request == "a"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_Gw_B" sourceRef="Gw" targetRef="Task_B" />
+    <bpmn:sequenceFlow id="Flow_A_End" sourceRef="Task_A" targetRef="End" />
+    <bpmn:sequenceFlow id="Flow_B_End" sourceRef="Task_B" targetRef="End" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_Valid">
+    <bpmndi:BPMNPlane id="Plane_Valid" bpmnElement="Process_Valid">
+      <bpmndi:BPMNShape id="S_Start" bpmnElement="Start"><dc:Bounds x="100" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gw" bpmnElement="Gw"><dc:Bounds x="200" y="93" width="50" height="50" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_A" bpmnElement="Task_A"><dc:Bounds x="320" y="40" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_B" bpmnElement="Task_B"><dc:Bounds x="320" y="160" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End" bpmnElement="End"><dc:Bounds x="500" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E1" bpmnElement="Flow_Start_Gw"><di:waypoint x="136" y="118" /><di:waypoint x="200" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E2" bpmnElement="Flow_Gw_A"><di:waypoint x="225" y="93" /><di:waypoint x="320" y="80" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E3" bpmnElement="Flow_Gw_B"><di:waypoint x="225" y="143" /><di:waypoint x="320" y="200" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E4" bpmnElement="Flow_A_End"><di:waypoint x="420" y="80" /><di:waypoint x="500" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E5" bpmnElement="Flow_B_End"><di:waypoint x="420" y="200" /><di:waypoint x="500" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/A.2.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/A.2.0.bpmn
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373649889746" name="A.2.0" targetNamespace="http://www.trisotech.com/definitions/_1373649889746" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="WFP-6-">
+        <semantic:startEvent name="Start Event" id="_6b5db6a9-037a-49ad-9201-09201e2aaa97">
+            <semantic:outgoing>_b50f530c-3450-4e1a-b81f-ea346dc6e1cb</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="_5a972b87-735d-454a-b31c-f52fb3afc5c7">
+            <semantic:incoming>_b50f530c-3450-4e1a-b81f-ea346dc6e1cb</semantic:incoming>
+            <semantic:outgoing>_fe74c141-8843-4b00-a704-5e5e13be53b0</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event" id="_258f51eb-b764-4a71-b681-3a01cca14143">
+            <semantic:incoming>_a3d40a56-9b7f-417e-911e-d39e7f18b90c</semantic:incoming>
+            <semantic:incoming>_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 2" id="_4f7d62d7-f0e6-46bc-be00-69e02da38f65">
+            <semantic:incoming>_f1478fb7-98c4-4c01-8c15-68bd04c91535</semantic:incoming>
+            <semantic:outgoing>_a3d40a56-9b7f-417e-911e-d39e7f18b90c</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee">
+            <semantic:incoming>_a1570a53-28d2-41b1-a3a2-3e50c00d747e</semantic:incoming>
+            <semantic:outgoing>_e9ebc7c7-995d-46db-86ce-d823bc2b4687</semantic:outgoing>
+        </semantic:task>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Gateway&#10;(Split Flow)" id="_35fe57a7-1302-44e2-bf58-032f11af7ecb">
+            <semantic:incoming>_fe74c141-8843-4b00-a704-5e5e13be53b0</semantic:incoming>
+            <semantic:outgoing>_f1478fb7-98c4-4c01-8c15-68bd04c91535</semantic:outgoing>
+            <semantic:outgoing>_a1570a53-28d2-41b1-a3a2-3e50c00d747e</semantic:outgoing>
+            <semantic:outgoing>_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 4" id="_7d399717-1aba-47ac-8d7d-8aaa033255e0">
+            <semantic:incoming>_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b</semantic:incoming>
+            <semantic:outgoing>_698b593f-18eb-42ea-b8cd-bcd51e1514cc</semantic:outgoing>
+        </semantic:task>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Gateway&#10;(Merge Flows)" id="_33c66216-391c-49c2-aa19-d8f0b7f5f91d">
+            <semantic:incoming>_e9ebc7c7-995d-46db-86ce-d823bc2b4687</semantic:incoming>
+            <semantic:incoming>_698b593f-18eb-42ea-b8cd-bcd51e1514cc</semantic:incoming>
+            <semantic:outgoing>_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow sourceRef="_6b5db6a9-037a-49ad-9201-09201e2aaa97" targetRef="_5a972b87-735d-454a-b31c-f52fb3afc5c7" name="" id="_b50f530c-3450-4e1a-b81f-ea346dc6e1cb"/>
+        <semantic:sequenceFlow sourceRef="_5a972b87-735d-454a-b31c-f52fb3afc5c7" targetRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" name="" id="_fe74c141-8843-4b00-a704-5e5e13be53b0"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" name="" id="_f1478fb7-98c4-4c01-8c15-68bd04c91535"/>
+        <semantic:sequenceFlow sourceRef="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" targetRef="_258f51eb-b764-4a71-b681-3a01cca14143" name="" id="_a3d40a56-9b7f-417e-911e-d39e7f18b90c"/>
+        <semantic:sequenceFlow sourceRef="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" targetRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" name="" id="_e9ebc7c7-995d-46db-86ce-d823bc2b4687"/>
+        <semantic:sequenceFlow sourceRef="_7d399717-1aba-47ac-8d7d-8aaa033255e0" targetRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" name="" id="_698b593f-18eb-42ea-b8cd-bcd51e1514cc"/>
+        <semantic:sequenceFlow sourceRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" targetRef="_258f51eb-b764-4a71-b681-3a01cca14143" name="" id="_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" name="" id="_a1570a53-28d2-41b1-a3a2-3e50c00d747e"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_7d399717-1aba-47ac-8d7d-8aaa033255e0" name="" id="_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.2.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="WFP-6-">
+            <bpmndi:BPMNShape bpmnElement="_6b5db6a9-037a-49ad-9201-09201e2aaa97" id="S1373649889871__6b5db6a9-037a-49ad-9201-09201e2aaa97">
+                <dc:Bounds height="30.0" width="30.0" x="186.0" y="276.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="153.67766754457273" y="311.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_5a972b87-735d-454a-b31c-f52fb3afc5c7" id="S1373649889873__5a972b87-735d-454a-b31c-f52fb3afc5c7">
+                <dc:Bounds height="68.0" width="83.0" x="252.0" y="257.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="257.3333333333333" y="284.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_258f51eb-b764-4a71-b681-3a01cca14143" id="S1373649889874__258f51eb-b764-4a71-b681-3a01cca14143">
+                <dc:Bounds height="32.0" width="32.0" x="736.0" y="244.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="656.5963254593175" y="257.5976244140626"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" id="S1373649889875__4f7d62d7-f0e6-46bc-be00-69e02da38f65">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="172.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="199.58187638256646"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" id="S1373649889876__e6eb725a-34bc-45c7-aed0-9f9596cd7bee">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="257.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="284.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_35fe57a7-1302-44e2-bf58-032f11af7ecb" isMarkerVisible="false" id="S1373649889877__35fe57a7-1302-44e2-bf58-032f11af7ecb">
+                <dc:Bounds height="42.0" width="42.0" x="399.0" y="270.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="336.7931758530184" y="311.26591304208245"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7d399717-1aba-47ac-8d7d-8aaa033255e0" id="S1373649889878__7d399717-1aba-47ac-8d7d-8aaa033255e0">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="352.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="379.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" isMarkerVisible="false" id="S1373649889879__33c66216-391c-49c2-aa19-d8f0b7f5f91d">
+                <dc:Bounds height="42.0" width="42.0" x="621.0" y="315.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="654.3207349081365" y="347.41024725332187"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_a3d40a56-9b7f-417e-911e-d39e7f18b90c" id="E1373649889881__a3d40a56-9b7f-417e-911e-d39e7f18b90c">
+                <di:waypoint x="563.0" y="206.0"/>
+                <di:waypoint x="752.0" y="206.0"/>
+                <di:waypoint x="752.0" y="244.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b50f530c-3450-4e1a-b81f-ea346dc6e1cb" id="E1373649889882__b50f530c-3450-4e1a-b81f-ea346dc6e1cb">
+                <di:waypoint x="216.0" y="291.0"/>
+                <di:waypoint x="234.0" y="291.0"/>
+                <di:waypoint x="252.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_fe74c141-8843-4b00-a704-5e5e13be53b0" id="E1373649889883__fe74c141-8843-4b00-a704-5e5e13be53b0">
+                <di:waypoint x="335.0" y="291.0"/>
+                <di:waypoint x="353.0" y="291.0"/>
+                <di:waypoint x="399.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b" id="E1373649889884__20ebb3c1-5178-4c7c-a91d-23e58f2aa73b">
+                <di:waypoint x="420.0" y="312.0"/>
+                <di:waypoint x="420.0" y="386.0"/>
+                <di:waypoint x="480.0" y="386.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5" id="E1373649889885__d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5">
+                <di:waypoint x="663.0" y="336.0"/>
+                <di:waypoint x="752.0" y="336.0"/>
+                <di:waypoint x="752.0" y="276.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e9ebc7c7-995d-46db-86ce-d823bc2b4687" id="E1373649889886__e9ebc7c7-995d-46db-86ce-d823bc2b4687">
+                <di:waypoint x="563.0" y="291.0"/>
+                <di:waypoint x="642.0" y="291.0"/>
+                <di:waypoint x="642.0" y="315.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_f1478fb7-98c4-4c01-8c15-68bd04c91535" id="E1373649889887__f1478fb7-98c4-4c01-8c15-68bd04c91535">
+                <di:waypoint x="420.0" y="270.0"/>
+                <di:waypoint x="420.0" y="206.0"/>
+                <di:waypoint x="480.0" y="206.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a1570a53-28d2-41b1-a3a2-3e50c00d747e" id="E1373649889888__a1570a53-28d2-41b1-a3a2-3e50c00d747e">
+                <di:waypoint x="440.0" y="291.0"/>
+                <di:waypoint x="458.0" y="291.0"/>
+                <di:waypoint x="480.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_698b593f-18eb-42ea-b8cd-bcd51e1514cc" id="E1373649889889__698b593f-18eb-42ea-b8cd-bcd51e1514cc">
+                <di:waypoint x="563.0" y="386.0"/>
+                <di:waypoint x="642.0" y="386.0"/>
+                <di:waypoint x="642.0" y="357.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373649889872">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/A.2.1.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/A.2.1.bpmn
@@ -1,0 +1,333 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bonitaConnector="http://www.bonitasoft.org/studio/connector/definition/6.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di_1="http://www.omg.org/spec/DD/20100524/DI" xmlns:java="http://jcp.org/en/jsr/detail?id=270" xmlns:model="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:style="http://www.w4.eu/spec/DataComposer/20120927/Diagram/Style" xmlns:w4="http://www.w4.eu/spec/BPMN/20110701/MODEL" xmlns:w4graph="http://www.w4.eu/spec/BPMN/20110930/GRAPH" xsi:schemaLocation="schemaLocation http://www.omg.org/spec/BPMN/20100524/MODEL" id="Bpmn_Definitions_--SwsH2BEeWQ6qGdY3x14w" w4:version="1.0" exporter="BonitaSoft" exporterVersion="6.3.3" expressionLanguage="http://groovy.codehaus.org/" name="A.2.1" targetNamespace="http://bonitasoft.com/_To9ZoDOCEeSknpIVFCxNIQ" typeLanguage="http://www.w3.org/2001/XMLSchema" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0">
+  <model:process id="_To9ZoTOCEeSknpIVFCxNIQ" name="A.2.1" isExecutable="false" processType="None">
+    <model:extensionElements>
+      <w4graph:graphStyle>
+        <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        <w4graph:root gridVisible="true" snapToGrid="true" rulerVisible="true" snapToGuide="true" rulerUnit="Pixels">
+          <Grid spacing="15" color="230,230,230"/>
+          <VerticalRuler/>
+          <HorizontalRuler/>
+        </w4graph:root>
+      </w4graph:graphStyle>
+    </model:extensionElements>
+    <model:ioSpecification id="_cVGqYDOCEeSknpIVFCxNIQ">
+      <model:inputSet id="_cVHRcDOCEeSknpIVFCxNIQ"/>
+      <model:outputSet id="_cVH4gDOCEeSknpIVFCxNIQ"/>
+    </model:ioSpecification>
+    <model:startEvent id="_To9ZojOCEeSknpIVFCxNIQ" name="Start Event" isInterrupting="true">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="109,183,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:outgoing>_To9Z5DOCEeSknpIVFCxNIQ</model:outgoing>
+    </model:startEvent>
+    <model:task id="_To9ZpzOCEeSknpIVFCxNIQ" name="Task 1" completionQuantity="1" isForCompensation="false" startQuantity="1">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z5DOCEeSknpIVFCxNIQ</model:incoming>
+      <model:outgoing>_To9Z5zOCEeSknpIVFCxNIQ</model:outgoing>
+    </model:task>
+    <model:endEvent id="_To9ZsTOCEeSknpIVFCxNIQ" name="End Event">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="190,0,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z7TOCEeSknpIVFCxNIQ</model:incoming>
+      <model:incoming>_To9Z9jOCEeSknpIVFCxNIQ</model:incoming>
+    </model:endEvent>
+    <model:task id="_To9ZtjOCEeSknpIVFCxNIQ" name="Task 2" completionQuantity="1" default="Bpmn_SequenceFlow_edepQQbbEealeL5I4Yl3Dw" isForCompensation="false" startQuantity="1">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z6jOCEeSknpIVFCxNIQ</model:incoming>
+      <model:outgoing>_To9Z7TOCEeSknpIVFCxNIQ</model:outgoing>
+      <model:outgoing>Bpmn_SequenceFlow_edepQQbbEealeL5I4Yl3Dw</model:outgoing>
+    </model:task>
+    <model:task id="_To9ZwDOCEeSknpIVFCxNIQ" name="Task 3" completionQuantity="1" isForCompensation="false" startQuantity="1">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z-TOCEeSknpIVFCxNIQ</model:incoming>
+      <model:incoming>Bpmn_SequenceFlow_edepQQbbEealeL5I4Yl3Dw</model:incoming>
+      <model:incoming>Bpmn_SequenceFlow_f9nmUQbbEealeL5I4Yl3Dw</model:incoming>
+      <model:outgoing>_To9Z8DOCEeSknpIVFCxNIQ</model:outgoing>
+    </model:task>
+    <model:exclusiveGateway id="_To9ZyjOCEeSknpIVFCxNIQ" name="Gateway&#xD;&#xA;(Split Flow)" gatewayDirection="Unspecified" default="_To9Z6jOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="185,139,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z5zOCEeSknpIVFCxNIQ</model:incoming>
+      <model:outgoing>_To9Z6jOCEeSknpIVFCxNIQ</model:outgoing>
+      <model:outgoing>_To9Z-TOCEeSknpIVFCxNIQ</model:outgoing>
+      <model:outgoing>_To9Z_DOCEeSknpIVFCxNIQ</model:outgoing>
+    </model:exclusiveGateway>
+    <model:task id="_To9ZzzOCEeSknpIVFCxNIQ" name="Task 4" completionQuantity="1" default="Bpmn_SequenceFlow_f9nmUQbbEealeL5I4Yl3Dw" isForCompensation="false" startQuantity="1">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z_DOCEeSknpIVFCxNIQ</model:incoming>
+      <model:outgoing>_To9Z8zOCEeSknpIVFCxNIQ</model:outgoing>
+      <model:outgoing>Bpmn_SequenceFlow_f9nmUQbbEealeL5I4Yl3Dw</model:outgoing>
+    </model:task>
+    <model:exclusiveGateway id="_To9Z2TOCEeSknpIVFCxNIQ" name="Gateway&#10;(Merge Flows)" gatewayDirection="Unspecified">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="185,139,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:incoming>_To9Z8DOCEeSknpIVFCxNIQ</model:incoming>
+      <model:incoming>_To9Z8zOCEeSknpIVFCxNIQ</model:incoming>
+      <model:outgoing>_To9Z9jOCEeSknpIVFCxNIQ</model:outgoing>
+    </model:exclusiveGateway>
+    <model:sequenceFlow id="_To9Z5DOCEeSknpIVFCxNIQ" name="" sourceRef="_To9ZojOCEeSknpIVFCxNIQ" targetRef="_To9ZpzOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z5zOCEeSknpIVFCxNIQ" name="" sourceRef="_To9ZpzOCEeSknpIVFCxNIQ" targetRef="_To9ZyjOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z6jOCEeSknpIVFCxNIQ" name="Default" sourceRef="_To9ZyjOCEeSknpIVFCxNIQ" targetRef="_To9ZtjOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z7TOCEeSknpIVFCxNIQ" name="Condition" sourceRef="_To9ZtjOCEeSknpIVFCxNIQ" targetRef="_To9ZsTOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:conditionExpression xsi:type="model:tFormalExpression" id="_cVKUwTOCEeSknpIVFCxNIQ" language="http://www.w3.org/1999/XPath">true</model:conditionExpression>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z8DOCEeSknpIVFCxNIQ" sourceRef="_To9ZwDOCEeSknpIVFCxNIQ" targetRef="_To9Z2TOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z8zOCEeSknpIVFCxNIQ" name="condition" sourceRef="_To9ZzzOCEeSknpIVFCxNIQ" targetRef="_To9Z2TOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:conditionExpression xsi:type="model:tFormalExpression" id="_cVKUwzOCEeSknpIVFCxNIQ" language="http://www.w3.org/1999/XPath"/>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z9jOCEeSknpIVFCxNIQ" name="" sourceRef="_To9Z2TOCEeSknpIVFCxNIQ" targetRef="_To9ZsTOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:conditionExpression xsi:type="model:tFormalExpression" id="_cVKUxDOCEeSknpIVFCxNIQ" language="http://www.w3.org/1999/XPath"/>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z-TOCEeSknpIVFCxNIQ" name="" sourceRef="_To9ZyjOCEeSknpIVFCxNIQ" targetRef="_To9ZwDOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:conditionExpression xsi:type="model:tFormalExpression" id="_cVKUxTOCEeSknpIVFCxNIQ" language="http://www.w3.org/1999/XPath"/>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="_To9Z_DOCEeSknpIVFCxNIQ" name="" sourceRef="_To9ZyjOCEeSknpIVFCxNIQ" targetRef="_To9ZzzOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+      <model:conditionExpression xsi:type="model:tFormalExpression" id="_cVKUxjOCEeSknpIVFCxNIQ" language="http://www.w3.org/1999/XPath"/>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="Bpmn_SequenceFlow_edepQQbbEealeL5I4Yl3Dw" isImmediate="true" sourceRef="_To9ZtjOCEeSknpIVFCxNIQ" targetRef="_To9ZwDOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+    <model:sequenceFlow id="Bpmn_SequenceFlow_f9nmUQbbEealeL5I4Yl3Dw" isImmediate="true" sourceRef="_To9ZzzOCEeSknpIVFCxNIQ" targetRef="_To9ZwDOCEeSknpIVFCxNIQ">
+      <model:extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </model:extensionElements>
+    </model:sequenceFlow>
+  </model:process>
+  <di:BPMNDiagram id="Bpmndi_BPMNDiagram_--TXwH2BEeWQ6qGdY3x14w" name="A.2.1">
+    <di:BPMNPlane id="plane__To9ZoDOCEeSknpIVFCxNIQ" bpmnElement="_To9ZoTOCEeSknpIVFCxNIQ">
+      <di:BPMNShape id="_To9aGzOCEeSknpIVFCxNIQ" bpmnElement="_To9ZojOCEeSknpIVFCxNIQ" color:background-color="#6db700">
+        <dc:Bounds height="30.0" width="30.0" x="198.0" y="302.0"/>
+        <di:BPMNLabel id="_cVJGoTOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="63.0" x="182.0" y="332.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aHzOCEeSknpIVFCxNIQ" bpmnElement="_To9ZpzOCEeSknpIVFCxNIQ" color:background-color="#c2d7eb">
+        <dc:Bounds height="50.0" width="100.0" x="272.0" y="292.0"/>
+        <di:BPMNLabel id="_cVJGojOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="44.0" x="300.0" y="310.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aIjOCEeSknpIVFCxNIQ" bpmnElement="_To9ZsTOCEeSknpIVFCxNIQ" color:background-color="#be0000">
+        <dc:Bounds height="30.0" width="30.0" x="836.0" y="292.0"/>
+        <di:BPMNLabel id="_cVJGozOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="56.0" x="780.0" y="300.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aJjOCEeSknpIVFCxNIQ" bpmnElement="_To9ZtjOCEeSknpIVFCxNIQ" color:background-color="#c2d7eb">
+        <dc:Bounds height="50.0" width="100.0" x="540.0" y="207.0"/>
+        <di:BPMNLabel id="_cVJtsDOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="44.0" x="568.0" y="225.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aKTOCEeSknpIVFCxNIQ" bpmnElement="_To9ZwDOCEeSknpIVFCxNIQ" color:background-color="#c2d7eb">
+        <dc:Bounds height="50.0" width="100.0" x="540.0" y="292.0"/>
+        <di:BPMNLabel id="_cVJtsTOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="44.0" x="568.0" y="310.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aLDOCEeSknpIVFCxNIQ" bpmnElement="_To9ZyjOCEeSknpIVFCxNIQ" color:background-color="#b98b00">
+        <dc:Bounds height="43.0" width="43.0" x="459.0" y="295.0"/>
+        <di:BPMNLabel id="_cVJtsjOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="28.0" width="68.0" x="391.0" y="338.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aMDOCEeSknpIVFCxNIQ" bpmnElement="_To9ZzzOCEeSknpIVFCxNIQ" color:background-color="#c2d7eb">
+        <dc:Bounds height="50.0" width="100.0" x="540.0" y="387.0"/>
+        <di:BPMNLabel id="_cVJtszOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="14.0" width="44.0" x="568.0" y="405.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNShape id="_To9aMzOCEeSknpIVFCxNIQ" bpmnElement="_To9Z2TOCEeSknpIVFCxNIQ" color:background-color="#b98b00">
+        <dc:Bounds height="43.0" width="43.0" x="681.0" y="350.0"/>
+        <di:BPMNLabel id="_cVJttDOCEeSknpIVFCxNIQ" labelStyle="_cVJGoDOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="28.0" width="79.0" x="724.0" y="393.0"/>
+        </di:BPMNLabel>
+      </di:BPMNShape>
+      <di:BPMNEdge id="_To-AuTOCEeSknpIVFCxNIQ" bpmnElement="_To9Z5DOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="228.0" y="316.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="272.0" y="316.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-AvjOCEeSknpIVFCxNIQ" bpmnElement="_To9Z5zOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="372.0" y="317.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="459.0" y="317.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-AwzOCEeSknpIVFCxNIQ" bpmnElement="_To9Z6jOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="480.0" y="295.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="480.0" y="231.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="540.0" y="231.0"/>
+        <di:BPMNLabel id="Bpmndi_BPMNLabel_CmaCsH2JEeWQ6qGdY3x14w" labelStyle="_cVFcQTOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="15.0" width="51.0" x="485.0" y="236.0"/>
+        </di:BPMNLabel>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-AyDOCEeSknpIVFCxNIQ" bpmnElement="_To9Z7TOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="640.0" y="228.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="850.0" y="228.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="850.0" y="292.0"/>
+        <di:BPMNLabel id="Bpmndi_BPMNLabel_I4N4YH4gEeWe1Mf7vUgLJg" labelStyle="_cVFcQTOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="15.0" width="63.0" x="645.0" y="238.0"/>
+        </di:BPMNLabel>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-AzjOCEeSknpIVFCxNIQ" bpmnElement="_To9Z8DOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="640.0" y="316.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="702.0" y="316.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="702.0" y="350.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-A0zOCEeSknpIVFCxNIQ" bpmnElement="_To9Z8zOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="640.0" y="418.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="702.0" y="418.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="702.0" y="393.0"/>
+        <di:BPMNLabel id="Bpmndi_BPMNLabel_HOBncH4gEeWe1Mf7vUgLJg" labelStyle="_cVFcQTOCEeSknpIVFCxNIQ">
+          <dc:Bounds height="15.0" width="63.0" x="645.0" y="423.0"/>
+        </di:BPMNLabel>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-A2TOCEeSknpIVFCxNIQ" bpmnElement="_To9Z9jOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="724.0" y="371.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="850.0" y="371.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="850.0" y="322.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-A3jOCEeSknpIVFCxNIQ" bpmnElement="_To9Z-TOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="502.0" y="317.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="540.0" y="317.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="_To-A4zOCEeSknpIVFCxNIQ" bpmnElement="_To9Z_DOCEeSknpIVFCxNIQ">
+        <di_1:waypoint xsi:type="dc:Point" x="480.0" y="338.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="480.0" y="406.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="540.0" y="406.0"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="Bpmndi_BPMNEdge_edepQgbbEealeL5I4Yl3Dw" bpmnElement="Bpmn_SequenceFlow_edepQQbbEealeL5I4Yl3Dw">
+        <di_1:waypoint xsi:type="dc:Point" x="590.0" y="257.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="590.0" y="292.0"/>
+        <di:BPMNLabel id="Bpmndi_BPMNLabel_edepQwbbEealeL5I4Yl3Dw" labelStyle="Bpmndi_BPMNLabelStyle_edhFgAbbEealeL5I4Yl3Dw"/>
+      </di:BPMNEdge>
+      <di:BPMNEdge id="Bpmndi_BPMNEdge_f9nmUgbbEealeL5I4Yl3Dw" bpmnElement="Bpmn_SequenceFlow_f9nmUQbbEealeL5I4Yl3Dw">
+        <di_1:waypoint xsi:type="dc:Point" x="590.0" y="387.0"/>
+        <di_1:waypoint xsi:type="dc:Point" x="590.0" y="342.0"/>
+        <di:BPMNLabel id="Bpmndi_BPMNLabel_f9nmUwbbEealeL5I4Yl3Dw" labelStyle="Bpmndi_BPMNLabelStyle_f9qCkAbbEealeL5I4Yl3Dw"/>
+      </di:BPMNEdge>
+    </di:BPMNPlane>
+    <di:BPMNLabelStyle id="_cVFcQTOCEeSknpIVFCxNIQ">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="_cVJGoDOCEeSknpIVFCxNIQ">
+      <dc:Font name="Arial" size="11.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_qtSqgAbaEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_yNGD8AbaEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_6jUIAAbaEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_Tu18UAbbEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_Y8qFAAbbEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_Rj7j8AbbEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_edhFgAbbEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+    <di:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_f9qCkAbbEealeL5I4Yl3Dw">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </di:BPMNLabelStyle>
+  </di:BPMNDiagram>
+</model:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/B.1.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/B.1.0.bpmn
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373655174418" name="B.1.0" targetNamespace="http://www.trisotech.com/definitions/_1373655174418" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:dataStore capacity="0" isUnlimited="false" id="DS1373655174514" name="Data&#10;Store Reference"/>
+	<semantic:globalTask name="Global Task" id="global-task"/>
+    <semantic:process isExecutable="false" id="Process_ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+        <semantic:startEvent name="Start Event None 1" id="_200f43e7-1385-46e2-a380-3ef16ebe7847">
+            <semantic:outgoing>_60ed96e6-5954-48de-861b-7d1e3c1fb23e</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Abstract Task 4" id="_c57a5344-213f-4834-a6c3-94ce878b413c">
+            <semantic:incoming>_60ed96e6-5954-48de-861b-7d1e3c1fb23e</semantic:incoming>
+            <semantic:outgoing>_6c6288e8-43f6-4085-87c7-1ff21c38fe17</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event None 2" id="_ed405919-9fd6-47d0-bb00-9be7d5467efb">
+            <semantic:incoming>_6c6288e8-43f6-4085-87c7-1ff21c38fe17</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_200f43e7-1385-46e2-a380-3ef16ebe7847" targetRef="_c57a5344-213f-4834-a6c3-94ce878b413c" name="" id="_60ed96e6-5954-48de-861b-7d1e3c1fb23e"/>
+        <semantic:sequenceFlow sourceRef="_c57a5344-213f-4834-a6c3-94ce878b413c" targetRef="_ed405919-9fd6-47d0-bb00-9be7d5467efb" name="" id="_6c6288e8-43f6-4085-87c7-1ff21c38fe17"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-6-1">
+        <semantic:startEvent name="Start Event Timer" id="_e314751e-5c3a-41f2-a1ae-4cb99efa0916">
+            <semantic:outgoing>_3eaa52c9-8d39-43d1-9528-b4047ff7fcdf</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:startEvent>
+        <semantic:endEvent name="End Event None 1" id="_94efa7e0-2322-4fc3-a5bf-6c6296488927">
+            <semantic:incoming>_bbb25218-69a3-4401-823f-22f468cbd80d</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Abstract Task 1" id="_219b9ca1-d4c5-497d-a4f7-06a44a6da20e">
+            <semantic:incoming>_3eaa52c9-8d39-43d1-9528-b4047ff7fcdf</semantic:incoming>
+            <semantic:outgoing>_a1505d79-bbc0-42cf-866a-401a2f94b675</semantic:outgoing>
+        </semantic:task>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User&#10;Task 2" id="_f7eade87-bb98-47d3-85c7-66033a62b124">
+            <semantic:incoming>_a1505d79-bbc0-42cf-866a-401a2f94b675</semantic:incoming>
+            <semantic:outgoing>_ba610e14-bf4c-4150-a1b1-460fe6a29f83</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 3" id="_ec919941-53ec-403d-97e1-6a163a063f21">
+            <semantic:incoming>_ba610e14-bf4c-4150-a1b1-460fe6a29f83</semantic:incoming>
+            <semantic:outgoing>_bbb25218-69a3-4401-823f-22f468cbd80d</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:sequenceFlow sourceRef="_e314751e-5c3a-41f2-a1ae-4cb99efa0916" targetRef="_219b9ca1-d4c5-497d-a4f7-06a44a6da20e" name="" id="_3eaa52c9-8d39-43d1-9528-b4047ff7fcdf"/>
+        <semantic:sequenceFlow sourceRef="_219b9ca1-d4c5-497d-a4f7-06a44a6da20e" targetRef="_f7eade87-bb98-47d3-85c7-66033a62b124" name="" id="_a1505d79-bbc0-42cf-866a-401a2f94b675"/>
+        <semantic:sequenceFlow sourceRef="_f7eade87-bb98-47d3-85c7-66033a62b124" targetRef="_ec919941-53ec-403d-97e1-6a163a063f21" name="" id="_ba610e14-bf4c-4150-a1b1-460fe6a29f83"/>
+        <semantic:sequenceFlow sourceRef="_ec919941-53ec-403d-97e1-6a163a063f21" targetRef="_94efa7e0-2322-4fc3-a5bf-6c6296488927" name="" id="_bbb25218-69a3-4401-823f-22f468cbd80d"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-6-2">
+        <semantic:laneSet id="ls_0623a9bd-fd34-462a-b09d-85cb5004be78">
+            <semantic:lane name="Lane 1" id="_4a6df7ac-26d8-4718-ac05-90af463d5e23">
+                <semantic:flowNodeRef>_2ee553a1-cb03-41e3-b285-345c826fc88d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_fa3a8e53-5be0-4f0b-8680-d2498e255209</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_ba16239e-181e-4b9f-bc5b-0bb2ee973450</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_93021cd0-6f49-485d-966f-209744c748de</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_3c8c32c3-089a-4643-bf42-6c37c0dac7e0</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a38484e2-7bdb-48b1-b62e-139d51d6a147</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_be29f267-9d56-46ef-8bbc-e13513b25fce</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_1237e756-d53c-4591-a731-dafffbf0b3f9</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane name="Lane 2" id="_3400f56a-4565-47d1-91db-0ba17b958cb2">
+                <semantic:flowNodeRef>_1eb62392-1f21-4a63-bbcb-c78880c3165e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_7706e700-2aed-4b94-8070-961f118aab8f</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_ad81e6ba-40f5-43c1-9602-47d2e58804c8</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_33f30031-2e29-46b6-b080-30a192a36b45</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_7e6ccf38-e740-4537-a439-a8e984d066de</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_fea1c5af-6c76-403f-809e-26d476d92741</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_ae916437-d9aa-4e3d-a7c3-34998c410beb</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:dataObject isCollection="false" id="DF1373655174778" name="Data Object"/>
+        <semantic:endEvent name="End Event Message" id="_2ee553a1-cb03-41e3-b285-345c826fc88d">
+            <semantic:incoming>_994697ca-8927-4c84-a9a6-8682f8dee032</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Message_1373655174960"/>
+        </semantic:endEvent>
+        <semantic:callActivity completionQuantity="1" isForCompensation="false" startQuantity="1" name="Call Activity Calling a Global Task" id="_fa3a8e53-5be0-4f0b-8680-d2498e255209" calledElement="global-task">
+            <semantic:incoming>_eeb6812d-d182-489f-aea2-493ab8732cfd</semantic:incoming>
+            <semantic:outgoing>_61abe245-5604-46ba-8152-94d6e68ffda4</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:callActivity calledElement="Process_ba16239e-181e-4b9f-bc5b-0bb2ee973450" name="Call Activity - Expanded" id="_ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+            <semantic:incoming>_10a16fd5-0d56-4fdb-8529-0a0610a573be</semantic:incoming>
+            <semantic:outgoing>_f5c5d52a-204f-4f97-b872-817d63cf36ab</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Exclusive Gateway Convergence 1" id="_93021cd0-6f49-485d-966f-209744c748de">
+            <semantic:incoming>_61abe245-5604-46ba-8152-94d6e68ffda4</semantic:incoming>
+            <semantic:incoming>_f5c5d52a-204f-4f97-b872-817d63cf36ab</semantic:incoming>
+            <semantic:outgoing>_994697ca-8927-4c84-a9a6-8682f8dee032</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Exclusive Gateway Divergence 1" id="_3c8c32c3-089a-4643-bf42-6c37c0dac7e0">
+            <semantic:incoming>_d30f7fb3-ec91-4a60-b73e-42419417f3be</semantic:incoming>
+            <semantic:outgoing>_9d489bd9-9435-4692-bc98-4cdda4a61569</semantic:outgoing>
+            <semantic:outgoing>_eeb6812d-d182-489f-aea2-493ab8732cfd</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:startEvent name="Start Event&#10;Message" id="_a38484e2-7bdb-48b1-b62e-139d51d6a147">
+            <semantic:outgoing>_a63c8cd6-eee8-4fbe-be5e-f6980b180b52</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Message_1373655174959"/>
+        </semantic:startEvent>
+        <semantic:parallelGateway gatewayDirection="Unspecified" name="Parallel Gateway Divergence" id="_be29f267-9d56-46ef-8bbc-e13513b25fce">
+            <semantic:incoming>_a63c8cd6-eee8-4fbe-be5e-f6980b180b52</semantic:incoming>
+            <semantic:outgoing>_ab34472d-95a4-459c-a13b-5ed8b8b75eca</semantic:outgoing>
+            <semantic:outgoing>_d30f7fb3-ec91-4a60-b73e-42419417f3be</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:callActivity calledElement="WFP-0-" name="Call Activity Collapsed" id="_1237e756-d53c-4591-a731-dafffbf0b3f9">
+            <semantic:incoming>_9d489bd9-9435-4692-bc98-4cdda4a61569</semantic:incoming>
+            <semantic:outgoing>_10a16fd5-0d56-4fdb-8529-0a0610a573be</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Collapsed Sub-Process" id="_1eb62392-1f21-4a63-bbcb-c78880c3165e">
+            <semantic:incoming>_6ee42e88-3d90-4259-83c0-9abd4574a15a</semantic:incoming>
+            <semantic:outgoing>_d234800f-72d3-46cb-b603-30f1da7b1205</semantic:outgoing>
+        </semantic:subProcess>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 5" id="_7706e700-2aed-4b94-8070-961f118aab8f">
+            <semantic:incoming>_ab34472d-95a4-459c-a13b-5ed8b8b75eca</semantic:incoming>
+            <semantic:outgoing>_00d30c39-29a7-4c36-86e3-bc6e893efb42</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Exclusive Gateway Divergence 2" id="_ad81e6ba-40f5-43c1-9602-47d2e58804c8">
+            <semantic:incoming>_00d30c39-29a7-4c36-86e3-bc6e893efb42</semantic:incoming>
+            <semantic:outgoing>_6ee42e88-3d90-4259-83c0-9abd4574a15a</semantic:outgoing>
+            <semantic:outgoing>_6a248585-952e-40ff-82ec-b6d8f410b73a</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Exclusive Gateway Convergence 2" id="_33f30031-2e29-46b6-b080-30a192a36b45">
+            <semantic:incoming>_8f68b889-83a4-44ad-9777-d39acdd5415e</semantic:incoming>
+            <semantic:incoming>_657f30ba-0690-4a14-8b8e-d8939efcc7bd</semantic:incoming>
+            <semantic:outgoing>_54f45351-aa18-4c65-b0d0-edc3aa0a140d</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Sub Process - Expanded" id="_7e6ccf38-e740-4537-a439-a8e984d066de">
+            <semantic:incoming>_d234800f-72d3-46cb-b603-30f1da7b1205</semantic:incoming>
+            <semantic:outgoing>_8f68b889-83a4-44ad-9777-d39acdd5415e</semantic:outgoing>
+            <semantic:startEvent name="Start Event None 2" id="_1df01cbc-5d8c-444e-b1db-da3efdee254a">
+                <semantic:outgoing>_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Abstract Task 6" id="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4">
+                <semantic:incoming>_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a</semantic:incoming>
+                <semantic:outgoing>_062ae395-4aba-408b-ac64-4987752be95b</semantic:outgoing>
+            </semantic:task>
+            <semantic:endEvent name="End Event None 3" id="_4f744697-3643-41a9-9d07-84c78e2df64b">
+                <semantic:incoming>_062ae395-4aba-408b-ac64-4987752be95b</semantic:incoming>
+            </semantic:endEvent>
+            <semantic:sequenceFlow sourceRef="_1df01cbc-5d8c-444e-b1db-da3efdee254a" targetRef="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" name="" id="_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a"/>
+            <semantic:sequenceFlow sourceRef="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" targetRef="_4f744697-3643-41a9-9d07-84c78e2df64b" name="" id="_062ae395-4aba-408b-ac64-4987752be95b"/>
+        </semantic:subProcess>
+        <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 7" id="_fea1c5af-6c76-403f-809e-26d476d92741">
+            <semantic:incoming>_6a248585-952e-40ff-82ec-b6d8f410b73a</semantic:incoming>
+            <semantic:outgoing>_657f30ba-0690-4a14-8b8e-d8939efcc7bd</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="Din1373655174951"/>
+                <semantic:dataOutput id="Dout1373655174952"/>
+                <semantic:inputSet>
+                    <semantic:dataInputRefs>Din1373655174951</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet>
+                    <semantic:dataOutputRefs>Dout1373655174952</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_73afd30d-7d54-4897-9350-1f7d301ef1b2">
+                <semantic:sourceRef>_3d35229f-2c75-4d5d-a066-2d14e46e442e</semantic:sourceRef>
+                <semantic:targetRef>Din1373655174951</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_fa10ebaf-7088-4def-8cc3-d959b8876b06">
+                <semantic:sourceRef>Dout1373655174952</semantic:sourceRef>
+                <semantic:targetRef>_b9385abf-d293-40b7-848b-8add4db48415</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:serviceTask>
+        <semantic:endEvent name="End Event Terminate" id="_ae916437-d9aa-4e3d-a7c3-34998c410beb">
+            <semantic:incoming>_54f45351-aa18-4c65-b0d0-edc3aa0a140d</semantic:incoming>
+            <semantic:terminateEventDefinition/>
+        </semantic:endEvent>
+        <semantic:dataObjectReference dataObjectRef="DF1373655174778" name="Data Object" id="_3d35229f-2c75-4d5d-a066-2d14e46e442e"/>
+        <semantic:dataStoreReference dataStoreRef="DS1373655174514" name="Data&#10;Store Reference" id="_b9385abf-d293-40b7-848b-8add4db48415"/>
+        <semantic:sequenceFlow sourceRef="_a38484e2-7bdb-48b1-b62e-139d51d6a147" targetRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" name="" id="_a63c8cd6-eee8-4fbe-be5e-f6980b180b52"/>
+        <semantic:sequenceFlow sourceRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" targetRef="_7706e700-2aed-4b94-8070-961f118aab8f" name="" id="_ab34472d-95a4-459c-a13b-5ed8b8b75eca"/>
+        <semantic:sequenceFlow sourceRef="_7e6ccf38-e740-4537-a439-a8e984d066de" targetRef="_33f30031-2e29-46b6-b080-30a192a36b45" name="" id="_8f68b889-83a4-44ad-9777-d39acdd5415e"/>
+        <semantic:sequenceFlow sourceRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" targetRef="_3c8c32c3-089a-4643-bf42-6c37c0dac7e0" name="" id="_d30f7fb3-ec91-4a60-b73e-42419417f3be"/>
+        <semantic:sequenceFlow sourceRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" targetRef="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" name="" id="_10a16fd5-0d56-4fdb-8529-0a0610a573be"/>
+        <semantic:sequenceFlow sourceRef="_1eb62392-1f21-4a63-bbcb-c78880c3165e" targetRef="_7e6ccf38-e740-4537-a439-a8e984d066de" name="" id="_d234800f-72d3-46cb-b603-30f1da7b1205"/>
+        <semantic:sequenceFlow sourceRef="_fa3a8e53-5be0-4f0b-8680-d2498e255209" targetRef="_93021cd0-6f49-485d-966f-209744c748de" name="" id="_61abe245-5604-46ba-8152-94d6e68ffda4"/>
+        <semantic:sequenceFlow sourceRef="_7706e700-2aed-4b94-8070-961f118aab8f" targetRef="_ad81e6ba-40f5-43c1-9602-47d2e58804c8" name="" id="_00d30c39-29a7-4c36-86e3-bc6e893efb42"/>
+        <semantic:sequenceFlow sourceRef="_ad81e6ba-40f5-43c1-9602-47d2e58804c8" targetRef="_1eb62392-1f21-4a63-bbcb-c78880c3165e" name="" id="_6ee42e88-3d90-4259-83c0-9abd4574a15a"/>
+        <semantic:sequenceFlow sourceRef="_ad81e6ba-40f5-43c1-9602-47d2e58804c8" targetRef="_fea1c5af-6c76-403f-809e-26d476d92741" name="" id="_6a248585-952e-40ff-82ec-b6d8f410b73a"/>
+        <semantic:sequenceFlow sourceRef="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" targetRef="_93021cd0-6f49-485d-966f-209744c748de" name="" id="_f5c5d52a-204f-4f97-b872-817d63cf36ab"/>
+        <semantic:sequenceFlow sourceRef="_fea1c5af-6c76-403f-809e-26d476d92741" targetRef="_33f30031-2e29-46b6-b080-30a192a36b45" name="" id="_657f30ba-0690-4a14-8b8e-d8939efcc7bd"/>
+        <semantic:sequenceFlow sourceRef="_33f30031-2e29-46b6-b080-30a192a36b45" targetRef="_ae916437-d9aa-4e3d-a7c3-34998c410beb" name="" id="_54f45351-aa18-4c65-b0d0-edc3aa0a140d"/>
+        <semantic:sequenceFlow sourceRef="_3c8c32c3-089a-4643-bf42-6c37c0dac7e0" targetRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" name="" id="_9d489bd9-9435-4692-bc98-4cdda4a61569"/>
+        <semantic:sequenceFlow sourceRef="_3c8c32c3-089a-4643-bf42-6c37c0dac7e0" targetRef="_fa3a8e53-5be0-4f0b-8680-d2498e255209" name="" id="_eeb6812d-d182-489f-aea2-493ab8732cfd"/>
+        <semantic:sequenceFlow sourceRef="_93021cd0-6f49-485d-966f-209744c748de" targetRef="_2ee553a1-cb03-41e3-b285-345c826fc88d" name="" id="_994697ca-8927-4c84-a9a6-8682f8dee032"/>
+        <semantic:textAnnotation id="_4815ea6a-ede2-489b-8b37-2cdb2835b02c">
+            <semantic:text>Text Annotation</semantic:text>
+        </semantic:textAnnotation>
+        <semantic:association associationDirection="None" sourceRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" targetRef="_4815ea6a-ede2-489b-8b37-2cdb2835b02c" id="_5362a7ef-ce7e-4a91-9c38-66c07b1b5f49"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-0-">
+        <semantic:startEvent name="Start Event None 3" id="_18770c5c-c117-4570-aaf2-8c7a6910c34d">
+            <semantic:outgoing>_107de09e-8506-4d2b-ad00-3341be723dff</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Abstract Task 8" id="_47207d3b-8dc2-4679-bf33-c1e7e677765b">
+            <semantic:incoming>_107de09e-8506-4d2b-ad00-3341be723dff</semantic:incoming>
+            <semantic:outgoing>_2e21b112-d974-4add-9bee-91dafbed0a22</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event None 4" id="_ab12c75c-eaf3-4ae1-9021-ee556711757f">
+            <semantic:incoming>_2e21b112-d974-4add-9bee-91dafbed0a22</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_18770c5c-c117-4570-aaf2-8c7a6910c34d" targetRef="_47207d3b-8dc2-4679-bf33-c1e7e677765b" name="" id="_107de09e-8506-4d2b-ad00-3341be723dff"/>
+        <semantic:sequenceFlow sourceRef="_47207d3b-8dc2-4679-bf33-c1e7e677765b" targetRef="_ab12c75c-eaf3-4ae1-9021-ee556711757f" name="" id="_2e21b112-d974-4add-9bee-91dafbed0a22"/>
+    </semantic:process>
+    <semantic:message id="Message_1373655174959"/>
+    <semantic:message id="Message_1373655174960"/>
+    <semantic:category id="Cat1373655174961">
+        <semantic:categoryValue value="Group" id="Value_Cat1373655174961"/>
+    </semantic:category>
+    <semantic:collaboration id="C1373655174958">
+        <semantic:participant name="Participant" processRef="WFP-6-1" id="_cde15ee4-b395-43a3-9f5e-9028446f8a52"/>
+        <semantic:participant name="Pool" processRef="WFP-6-2" id="_0623a9bd-fd34-462a-b09d-85cb5004be78"/>
+        <semantic:messageFlow messageRef="Message_1373655174959" name="Message Flow 1" sourceRef="_219b9ca1-d4c5-497d-a4f7-06a44a6da20e" targetRef="_a38484e2-7bdb-48b1-b62e-139d51d6a147" id="_5d195b1c-ffea-4b53-b98f-78d9616a5038"/>
+        <semantic:messageFlow messageRef="Message_1373655174960" name="Message&#10;Flow 2" sourceRef="_2ee553a1-cb03-41e3-b285-345c826fc88d" targetRef="_ec919941-53ec-403d-97e1-6a163a063f21" id="_9428f666-fc8a-41be-8a77-9b280e14e7ae"/>
+        <semantic:group categoryValueRef="Value_Cat1373655174961" id="_bd04180e-49f6-4cf0-a7d6-da59e2840b4b"/>
+    </semantic:collaboration>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="B.1.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="C1373655174958">
+            <bpmndi:BPMNShape bpmnElement="_cde15ee4-b395-43a3-9f5e-9028446f8a52" isHorizontal="true" id="S1373655174918__cde15ee4-b395-43a3-9f5e-9028446f8a52">
+                <dc:Bounds height="180.0" width="1104.0" x="48.0" y="72.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="53.3635647444375" width="12.804751171874997" x="52.0" y="135.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0623a9bd-fd34-462a-b09d-85cb5004be78" isHorizontal="true" id="S1373655174920__0623a9bd-fd34-462a-b09d-85cb5004be78">
+                <dc:Bounds height="788.0" width="1164.0" x="49.0" y="352.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="24.316811814750004" width="12.804751171874997" x="53.0" y="733.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4a6df7ac-26d8-4718-ac05-90af463d5e23" isHorizontal="true" id="S1373655174921__4a6df7ac-26d8-4718-ac05-90af463d5e23">
+                <dc:Bounds height="313.0" width="1133.0" x="80.0" y="352.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="35.5928127913125" width="12.804751171874997" x="80.0" y="490.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3400f56a-4565-47d1-91db-0ba17b958cb2" isHorizontal="true" id="S1373655174922__3400f56a-4565-47d1-91db-0ba17b958cb2">
+                <dc:Bounds height="474.0" width="1133.0" x="80.0" y="666.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="35.5928127913125" width="12.804751171874997" x="80.0" y="885.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_200f43e7-1385-46e2-a380-3ef16ebe7847" id="S1373655174923__200f43e7-1385-46e2-a380-3ef16ebe7847">
+                <dc:Bounds height="30.0" width="30.0" x="625.0" y="425.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="592.6776675445728" y="460.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_c57a5344-213f-4834-a6c3-94ce878b413c" id="S1373655174924__c57a5344-213f-4834-a6c3-94ce878b413c">
+                <dc:Bounds height="68.0" width="83.0" x="713.0" y="406.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="718.3333333333334" y="427.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ed405919-9fd6-47d0-bb00-9be7d5467efb" id="S1373655174925__ed405919-9fd6-47d0-bb00-9be7d5467efb">
+                <dc:Bounds height="32.0" width="32.0" x="839.0" y="424.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="807.5963254593177" y="461.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e314751e-5c3a-41f2-a1ae-4cb99efa0916" id="S1373655174926__e314751e-5c3a-41f2-a1ae-4cb99efa0916">
+                <dc:Bounds height="30.0" width="30.0" x="120.0" y="147.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="87.67766754457271" y="182.33333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_94efa7e0-2322-4fc3-a5bf-6c6296488927" id="S1373655174927__94efa7e0-2322-4fc3-a5bf-6c6296488927">
+                <dc:Bounds height="32.0" width="32.0" x="1090.0" y="146.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1058.5963254593175" y="183.33333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_219b9ca1-d4c5-497d-a4f7-06a44a6da20e" id="S1373655174928__219b9ca1-d4c5-497d-a4f7-06a44a6da20e">
+                <dc:Bounds height="68.0" width="83.0" x="204.0" y="128.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="209.33333333333334" y="149.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_f7eade87-bb98-47d3-85c7-66033a62b124" id="S1373655174929__f7eade87-bb98-47d3-85c7-66033a62b124">
+                <dc:Bounds height="68.0" width="83.0" x="341.0" y="128.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="346.3333333333333" y="149.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ec919941-53ec-403d-97e1-6a163a063f21" id="S1373655174930__ec919941-53ec-403d-97e1-6a163a063f21">
+                <dc:Bounds height="68.0" width="83.0" x="972.0" y="128.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="977.3333333333334" y="149.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_2ee553a1-cb03-41e3-b285-345c826fc88d" id="S1373655174931__2ee553a1-cb03-41e3-b285-345c826fc88d">
+                <dc:Bounds height="32.0" width="32.0" x="1062.0" y="437.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1030.5963254593175" y="474.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_fa3a8e53-5be0-4f0b-8680-d2498e255209" id="S1373655174932__fa3a8e53-5be0-4f0b-8680-d2498e255209">
+                <dc:Bounds height="80.0" width="98.0" x="450.0" y="549.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="38.404653515625" width="87.14960629921266" x="455.3333333333333" y="569.7819252106915"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" isExpanded="true" id="S1373655174933__ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+                <dc:Bounds height="150.0" width="330.0" x="590.0" y="378.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="12.804751171875008" width="115.60807158037508" x="595.3333333333334" y="383.3333333333335"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_93021cd0-6f49-485d-966f-209744c748de" isMarkerVisible="false" id="S1373655174934__93021cd0-6f49-485d-966f-209744c748de">
+                <dc:Bounds height="42.0" width="42.0" x="977.0" y="432.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="953.541079060992" y="392.6228456785188"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3c8c32c3-089a-4643-bf42-6c37c0dac7e0" isMarkerVisible="false" id="S1373655174935__3c8c32c3-089a-4643-bf42-6c37c0dac7e0">
+                <dc:Bounds height="42.0" width="42.0" x="344.0" y="432.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="317.32073490813644" y="400.3944992218256"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a38484e2-7bdb-48b1-b62e-139d51d6a147" id="S1373655174936__a38484e2-7bdb-48b1-b62e-139d51d6a147">
+                <dc:Bounds height="30.0" width="30.0" x="158.0" y="438.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="125.67766754457271" y="473.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_be29f267-9d56-46ef-8bbc-e13513b25fce" id="S1373655174937__be29f267-9d56-46ef-8bbc-e13513b25fce">
+                <dc:Bounds height="42.0" width="42.0" x="230.0" y="432.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="203.1395042578419" y="394.3944992218256"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1237e756-d53c-4591-a731-dafffbf0b3f9" isExpanded="false" id="S1373655174938__1237e756-d53c-4591-a731-dafffbf0b3f9">
+                <dc:Bounds height="68.0" width="83.0" x="455.0" y="419.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="460.3333333333333" y="440.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1eb62392-1f21-4a63-bbcb-c78880c3165e" isExpanded="false" id="S1373655174939__1eb62392-1f21-4a63-bbcb-c78880c3165e">
+                <dc:Bounds height="68.0" width="83.0" x="406.0" y="749.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="38.404653515625" width="72.48293963254594" x="411.3333333333333" y="763.7819252106915"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7706e700-2aed-4b94-8070-961f118aab8f" id="S1373655174940__7706e700-2aed-4b94-8070-961f118aab8f">
+                <dc:Bounds height="68.0" width="83.0" x="175.0" y="749.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="180.33333333333334" y="770.181900796629"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ad81e6ba-40f5-43c1-9602-47d2e58804c8" isMarkerVisible="false" id="S1373655174941__ad81e6ba-40f5-43c1-9602-47d2e58804c8">
+                <dc:Bounds height="42.0" width="42.0" x="304.0" y="762.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="276.89432860892373" y="729.4289433163138"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_33f30031-2e29-46b6-b080-30a192a36b45" isMarkerVisible="false" id="S1373655174942__33f30031-2e29-46b6-b080-30a192a36b45">
+                <dc:Bounds height="42.0" width="42.0" x="955.0" y="762.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="931.8155884514442" y="728.6228456785187"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7e6ccf38-e740-4537-a439-a8e984d066de" isExpanded="true" id="S1373655174943__7e6ccf38-e740-4537-a439-a8e984d066de">
+                <dc:Bounds height="156.0" width="330.0" x="574.0" y="705.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="12.804751171875008" width="120.96244169756255" x="579.3333333333334" y="710.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1df01cbc-5d8c-444e-b1db-da3efdee254a" id="S1373655174944__1df01cbc-5d8c-444e-b1db-da3efdee254a">
+                <dc:Bounds height="30.0" width="30.0" x="610.0" y="767.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="577.6776675445728" y="802.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" id="S1373655174945__6936f794-7bbb-4aa1-ae48-3a35bab4e2f4">
+                <dc:Bounds height="68.0" width="83.0" x="694.0" y="748.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="699.3333333333334" y="769.181900796629"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4f744697-3643-41a9-9d07-84c78e2df64b" id="S1373655174946__4f744697-3643-41a9-9d07-84c78e2df64b">
+                <dc:Bounds height="32.0" width="32.0" x="836.0" y="766.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="804.5963254593177" y="803.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_fea1c5af-6c76-403f-809e-26d476d92741" id="S1373655174947__fea1c5af-6c76-403f-809e-26d476d92741">
+                <dc:Bounds height="68.0" width="83.0" x="472.0" y="966.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="477.3333333333333" y="987.181900796629"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ae916437-d9aa-4e3d-a7c3-34998c410beb" id="S1373655174948__ae916437-d9aa-4e3d-a7c3-34998c410beb">
+                <dc:Bounds height="32.0" width="32.0" x="1051.0" y="767.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1019.5963254593177" y="804.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3d35229f-2c75-4d5d-a066-2d14e46e442e" id="S1373655174949__3d35229f-2c75-4d5d-a066-2d14e46e442e">
+                <dc:Bounds height="38.0" width="30.0" x="397.0" y="891.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.60470234375" width="100.26666666666667" x="365.1028871391077" y="943.9897939506758"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_b9385abf-d293-40b7-848b-8add4db48415" id="S1373655174950__b9385abf-d293-40b7-848b-8add4db48415">
+                <dc:Bounds height="27.0" width="32.0" x="649.0" y="1058.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="38.404653515625" width="94.93333333333335" x="617.6583333333334" y="1087.8797673242188"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4815ea6a-ede2-489b-8b37-2cdb2835b02c" id="S1373655174953__4815ea6a-ede2-489b-8b37-2cdb2835b02c">
+                <dc:Bounds height="23.0" width="102.0" x="528.0" y="288.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_bd04180e-49f6-4cf0-a7d6-da59e2840b4b" id="S1373655174962__bd04180e-49f6-4cf0-a7d6-da59e2840b4b">
+                <dc:Bounds height="168.0" width="365.0" x="143.0" y="699.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="12.804751171874997" width="32.6140530256875" x="467.03476587195036" y="681.9747763871801"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_54f45351-aa18-4c65-b0d0-edc3aa0a140d" id="E1373655174963__54f45351-aa18-4c65-b0d0-edc3aa0a140d">
+                <di:waypoint x="997.0" y="783.0"/>
+                <di:waypoint x="1015.0" y="783.0"/>
+                <di:waypoint x="1051.0" y="783.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5362a7ef-ce7e-4a91-9c38-66c07b1b5f49" id="E1373655174964__5362a7ef-ce7e-4a91-9c38-66c07b1b5f49">
+                <di:waypoint x="497.0" y="419.0"/>
+                <di:waypoint x="497.0" y="300.0"/>
+                <di:waypoint x="528.0" y="300.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_eeb6812d-d182-489f-aea2-493ab8732cfd" id="E1373655174965__eeb6812d-d182-489f-aea2-493ab8732cfd">
+                <di:waypoint x="365.0" y="474.0"/>
+                <di:waypoint x="365.0" y="589.0"/>
+                <di:waypoint x="450.0" y="589.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_fa10ebaf-7088-4def-8cc3-d959b8876b06" sourceElement="S1373655174947__fea1c5af-6c76-403f-809e-26d476d92741" id="E1373655174966__fa10ebaf-7088-4def-8cc3-d959b8876b06">
+                <di:waypoint x="527.0" y="1034.0"/>
+                <di:waypoint x="527.0" y="1071.0"/>
+                <di:waypoint x="649.0" y="1071.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a63c8cd6-eee8-4fbe-be5e-f6980b180b52" id="E1373655174967__a63c8cd6-eee8-4fbe-be5e-f6980b180b52">
+                <di:waypoint x="188.0" y="453.0"/>
+                <di:waypoint x="230.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a" id="E1373655174968__2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a">
+                <di:waypoint x="640.0" y="782.0"/>
+                <di:waypoint x="658.0" y="782.0"/>
+                <di:waypoint x="694.0" y="782.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_6ee42e88-3d90-4259-83c0-9abd4574a15a" id="E1373655174969__6ee42e88-3d90-4259-83c0-9abd4574a15a">
+                <di:waypoint x="346.0" y="783.0"/>
+                <di:waypoint x="364.0" y="783.0"/>
+                <di:waypoint x="406.0" y="783.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_657f30ba-0690-4a14-8b8e-d8939efcc7bd" id="E1373655174970__657f30ba-0690-4a14-8b8e-d8939efcc7bd">
+                <di:waypoint x="555.0" y="1000.0"/>
+                <di:waypoint x="976.0" y="1000.0"/>
+                <di:waypoint x="976.0" y="804.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_8f68b889-83a4-44ad-9777-d39acdd5415e" id="E1373655174971__8f68b889-83a4-44ad-9777-d39acdd5415e">
+                <di:waypoint x="904.0" y="783.0"/>
+                <di:waypoint x="922.0" y="783.0"/>
+                <di:waypoint x="955.0" y="783.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_ba610e14-bf4c-4150-a1b1-460fe6a29f83" id="E1373655174972__ba610e14-bf4c-4150-a1b1-460fe6a29f83">
+                <di:waypoint x="424.0" y="162.0"/>
+                <di:waypoint x="972.0" y="162.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_60ed96e6-5954-48de-861b-7d1e3c1fb23e" id="E1373655174973__60ed96e6-5954-48de-861b-7d1e3c1fb23e">
+                <di:waypoint x="655.0" y="440.0"/>
+                <di:waypoint x="673.0" y="440.0"/>
+                <di:waypoint x="713.0" y="440.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_f5c5d52a-204f-4f97-b872-817d63cf36ab" id="E1373655174974__f5c5d52a-204f-4f97-b872-817d63cf36ab">
+                <di:waypoint x="920.0" y="453.0"/>
+                <di:waypoint x="977.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_d30f7fb3-ec91-4a60-b73e-42419417f3be" id="E1373655174975__d30f7fb3-ec91-4a60-b73e-42419417f3be">
+                <di:waypoint x="272.0" y="453.0"/>
+                <di:waypoint x="344.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_9428f666-fc8a-41be-8a77-9b280e14e7ae" id="E1373655174976__9428f666-fc8a-41be-8a77-9b280e14e7ae">
+                <di:waypoint x="1078.0" y="437.0"/>
+                <di:waypoint x="1078.0" y="312.0"/>
+                <di:waypoint x="1013.0" y="312.0"/>
+                <di:waypoint x="1013.0" y="196.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="966.436755781357" y="299.9501761363344"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_73afd30d-7d54-4897-9350-1f7d301ef1b2" targetElement="S1373655174947__fea1c5af-6c76-403f-809e-26d476d92741" id="E1373655174977__73afd30d-7d54-4897-9350-1f7d301ef1b2">
+                <di:waypoint x="427.0" y="910.0"/>
+                <di:waypoint x="513.0" y="910.0"/>
+                <di:waypoint x="514.0" y="966.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_062ae395-4aba-408b-ac64-4987752be95b" id="E1373655174978__062ae395-4aba-408b-ac64-4987752be95b">
+                <di:waypoint x="777.0" y="782.0"/>
+                <di:waypoint x="795.0" y="782.0"/>
+                <di:waypoint x="836.0" y="782.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a1505d79-bbc0-42cf-866a-401a2f94b675" id="E1373655174979__a1505d79-bbc0-42cf-866a-401a2f94b675">
+                <di:waypoint x="287.0" y="162.0"/>
+                <di:waypoint x="341.0" y="162.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5d195b1c-ffea-4b53-b98f-78d9616a5038" id="E1373655174980__5d195b1c-ffea-4b53-b98f-78d9616a5038">
+                <di:waypoint x="246.0" y="196.0"/>
+                <di:waypoint x="246.0" y="300.0"/>
+                <di:waypoint x="173.0" y="300.0"/>
+                <di:waypoint x="173.0" y="438.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373655174919">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="196.44330587137927" y="281.9169925395219"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_00d30c39-29a7-4c36-86e3-bc6e893efb42" id="E1373655174981__00d30c39-29a7-4c36-86e3-bc6e893efb42">
+                <di:waypoint x="258.0" y="783.0"/>
+                <di:waypoint x="276.0" y="783.0"/>
+                <di:waypoint x="304.0" y="783.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_d234800f-72d3-46cb-b603-30f1da7b1205" id="E1373655174982__d234800f-72d3-46cb-b603-30f1da7b1205">
+                <di:waypoint x="490.0" y="783.0"/>
+                <di:waypoint x="508.0" y="783.0"/>
+                <di:waypoint x="574.0" y="783.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_6c6288e8-43f6-4085-87c7-1ff21c38fe17" id="E1373655174983__6c6288e8-43f6-4085-87c7-1ff21c38fe17">
+                <di:waypoint x="796.0" y="440.0"/>
+                <di:waypoint x="814.0" y="440.0"/>
+                <di:waypoint x="839.0" y="440.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_994697ca-8927-4c84-a9a6-8682f8dee032" id="E1373655174984__994697ca-8927-4c84-a9a6-8682f8dee032">
+                <di:waypoint x="1019.0" y="453.0"/>
+                <di:waypoint x="1062.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_9d489bd9-9435-4692-bc98-4cdda4a61569" id="E1373655174985__9d489bd9-9435-4692-bc98-4cdda4a61569">
+                <di:waypoint x="386.0" y="453.0"/>
+                <di:waypoint x="404.0" y="453.0"/>
+                <di:waypoint x="455.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_bbb25218-69a3-4401-823f-22f468cbd80d" id="E1373655174986__bbb25218-69a3-4401-823f-22f468cbd80d">
+                <di:waypoint x="1055.0" y="162.0"/>
+                <di:waypoint x="1073.0" y="162.0"/>
+                <di:waypoint x="1090.0" y="162.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_61abe245-5604-46ba-8152-94d6e68ffda4" id="E1373655174987__61abe245-5604-46ba-8152-94d6e68ffda4">
+                <di:waypoint x="548.0" y="589.0"/>
+                <di:waypoint x="998.0" y="589.0"/>
+                <di:waypoint x="998.0" y="474.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_6a248585-952e-40ff-82ec-b6d8f410b73a" id="E1373655174988__6a248585-952e-40ff-82ec-b6d8f410b73a">
+                <di:waypoint x="325.0" y="804.0"/>
+                <di:waypoint x="325.0" y="1000.0"/>
+                <di:waypoint x="472.0" y="1000.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_ab34472d-95a4-459c-a13b-5ed8b8b75eca" id="E1373655174989__ab34472d-95a4-459c-a13b-5ed8b8b75eca">
+                <di:waypoint x="251.0" y="474.0"/>
+                <di:waypoint x="251.0" y="588.0"/>
+                <di:waypoint x="217.0" y="588.0"/>
+                <di:waypoint x="217.0" y="749.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_3eaa52c9-8d39-43d1-9528-b4047ff7fcdf" id="E1373655174990__3eaa52c9-8d39-43d1-9528-b4047ff7fcdf">
+                <di:waypoint x="150.0" y="162.0"/>
+                <di:waypoint x="168.0" y="162.0"/>
+                <di:waypoint x="204.0" y="162.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_10a16fd5-0d56-4fdb-8529-0a0610a573be" id="E1373655174991__10a16fd5-0d56-4fdb-8529-0a0610a573be">
+                <di:waypoint x="538.0" y="453.0"/>
+                <di:waypoint x="556.0" y="453.0"/>
+                <di:waypoint x="590.0" y="453.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373655174919">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/B.2.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/B.2.0.bpmn
@@ -1,0 +1,1709 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373638079286" name="B.2.0" targetNamespace="http://www.trisotech.com/definitions/_1373638079286" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:globalUserTask implementation="##WebService" name="Call Activity calling a Global User Task" id="_d4afdad7-65a5-40c6-9fee-e13ba4c0bed4"/>
+    <semantic:dataStore capacity="0" isUnlimited="false" id="DS1373638079677" name="Data Store Reference" />
+    <semantic:process isExecutable="false" id="Process_ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+        <semantic:startEvent name="Start Event 3" id="_200f43e7-1385-46e2-a380-3ef16ebe7847">
+            <semantic:outgoing>_60ed96e6-5954-48de-861b-7d1e3c1fb23e</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:startEvent name="Start Event 4 Conditional" id="_cba8fbed-2bb6-40a9-8ac5-83e827ce9d9f">
+            <semantic:outgoing>_c72ddf62-21b8-4895-a7bf-7a765f5981eb</semantic:outgoing>
+            <semantic:conditionalEventDefinition>
+                <semantic:condition/>
+            </semantic:conditionalEventDefinition>
+        </semantic:startEvent>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 12 Muti-Inst. Seq." id="_c57a5344-213f-4834-a6c3-94ce878b413c">
+            <semantic:incoming>_60ed96e6-5954-48de-861b-7d1e3c1fb23e</semantic:incoming>
+            <semantic:incoming>_c72ddf62-21b8-4895-a7bf-7a765f5981eb</semantic:incoming>
+            <semantic:outgoing>_6c6288e8-43f6-4085-87c7-1ff21c38fe17</semantic:outgoing>
+            <semantic:multiInstanceLoopCharacteristics isSequential="true"/>
+        </semantic:userTask>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 13" id="_7f4fe4ea-901f-4c74-bcd4-e933495712fd">
+            <semantic:incoming>_6c6288e8-43f6-4085-87c7-1ff21c38fe17</semantic:incoming>
+            <semantic:outgoing>_088b81bd-2a43-43a7-86c9-34c1cdd5f11b</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:boundaryEvent attachedToRef="_7f4fe4ea-901f-4c74-bcd4-e933495712fd" cancelActivity="true" parallelMultiple="false" name="Boundary Intermediate Event Interrupting Message" id="_86b052b4-225c-424e-b900-bb94bdd77cec">
+            <semantic:outgoing>_99e68e88-586e-4f77-9506-f30903307209</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 14" id="_3bfec246-ab94-4807-a79a-3df91ac13800">
+            <semantic:incoming>_088b81bd-2a43-43a7-86c9-34c1cdd5f11b</semantic:incoming>
+            <semantic:outgoing>_9ff30396-5ef2-42c0-ab4b-5343fbb0af21</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:endEvent name="End Event 5 Terminate" id="_778ff738-a5af-4373-a8da-0fbbfae9e00a">
+            <semantic:incoming>_99e68e88-586e-4f77-9506-f30903307209</semantic:incoming>
+            <semantic:terminateEventDefinition/>
+        </semantic:endEvent>
+        <semantic:endEvent name="End Event 4" id="_ed405919-9fd6-47d0-bb00-9be7d5467efb">
+            <semantic:incoming>_9ff30396-5ef2-42c0-ab4b-5343fbb0af21</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_200f43e7-1385-46e2-a380-3ef16ebe7847" targetRef="_c57a5344-213f-4834-a6c3-94ce878b413c" name="" id="_60ed96e6-5954-48de-861b-7d1e3c1fb23e"/>
+        <semantic:sequenceFlow sourceRef="_c57a5344-213f-4834-a6c3-94ce878b413c" targetRef="_7f4fe4ea-901f-4c74-bcd4-e933495712fd" name="" id="_6c6288e8-43f6-4085-87c7-1ff21c38fe17"/>
+        <semantic:sequenceFlow sourceRef="_3bfec246-ab94-4807-a79a-3df91ac13800" targetRef="_ed405919-9fd6-47d0-bb00-9be7d5467efb" name="" id="_9ff30396-5ef2-42c0-ab4b-5343fbb0af21"/>
+        <semantic:sequenceFlow sourceRef="_86b052b4-225c-424e-b900-bb94bdd77cec" targetRef="_778ff738-a5af-4373-a8da-0fbbfae9e00a" name="" id="_99e68e88-586e-4f77-9506-f30903307209"/>
+        <semantic:sequenceFlow sourceRef="_cba8fbed-2bb6-40a9-8ac5-83e827ce9d9f" targetRef="_c57a5344-213f-4834-a6c3-94ce878b413c" name="" id="_c72ddf62-21b8-4895-a7bf-7a765f5981eb"/>
+        <semantic:sequenceFlow sourceRef="_7f4fe4ea-901f-4c74-bcd4-e933495712fd" targetRef="_3bfec246-ab94-4807-a79a-3df91ac13800" name="" id="_088b81bd-2a43-43a7-86c9-34c1cdd5f11b"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-6-1">
+        <semantic:dataObject isCollection="false" id="DF1373638080458" name="Data Object"/>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 8" id="_c9870992-6643-4094-acfd-d76e5e37941b">
+            <semantic:incoming>_e6537f9d-e5ea-4abc-a6e8-add13a11b536</semantic:incoming>
+            <semantic:outgoing>_8321494b-9c3c-483a-b4d2-79e6254211c0</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:boundaryEvent attachedToRef="_c9870992-6643-4094-acfd-d76e5e37941b" cancelActivity="false" parallelMultiple="false" name="" id="_708d55c8-684a-4e3b-a69d-69c620cd0ac0">
+            <semantic:outgoing>_da47ac6a-4ea1-4bf6-ad3e-8cc60c0ea8a9</semantic:outgoing>
+            <semantic:escalationEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 5" id="_2a08c361-be51-437e-a86d-c62798c14e83">
+            <semantic:incoming>_dbae7e12-67c2-4256-8c50-5811c207ba55</semantic:incoming>
+            <semantic:outgoing>_b41b9c86-bc41-4b6e-ac32-70e1342e6128</semantic:outgoing>
+        </semantic:task>
+        <semantic:boundaryEvent attachedToRef="_2a08c361-be51-437e-a86d-c62798c14e83" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Conditional" id="_732c0641-b12f-448b-b9f8-a68b355782e3">
+            <semantic:outgoing>_54574511-c29e-4157-bb8f-8b26f15faaf5</semantic:outgoing>
+            <semantic:conditionalEventDefinition>
+                <semantic:condition/>
+            </semantic:conditionalEventDefinition>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 9" id="_8f41085a-3302-4cfc-9231-23bb4b43c7a1">
+            <semantic:incoming>_da47ac6a-4ea1-4bf6-ad3e-8cc60c0ea8a9</semantic:incoming>
+            <semantic:outgoing>_5f52bb2a-c49d-43ae-9253-7b89a8251b2b</semantic:outgoing>
+        </semantic:task>
+        <semantic:startEvent name="Start Event 1 Timer" id="_4e71bf73-1719-401e-a9a2-85dc89fc1150">
+            <semantic:outgoing>_2c124731-3338-46e0-81b5-b435f34941c8</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:startEvent>
+        <semantic:endEvent name="End Event 3 Signal" id="_5cc02d0f-c090-4e48-8da3-f32cbbca9565">
+            <semantic:incoming>_875031ae-f87c-45a3-ae60-ba0cb0ce0bc1</semantic:incoming>
+            <semantic:signalEventDefinition/>
+        </semantic:endEvent>
+        <semantic:endEvent name="End Event 1&#10;Message" id="_b67ba682-c8d6-465b-b538-c287db18d1be">
+            <semantic:incoming>_2752e07c-f2e4-4384-8721-70e4abea9765</semantic:incoming>
+            <semantic:messageEventDefinition/>
+        </semantic:endEvent>
+        <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 3" id="_0e87da16-736e-45b2-95e5-8f45940f3adf">
+            <semantic:incoming>_e1f948a6-db76-4c35-ba36-e430eecb63a4</semantic:incoming>
+            <semantic:outgoing>_4474c77a-01bb-435e-929a-7eb71bd824a8</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="Din1373638080886"/>
+                <semantic:inputSet>
+                    <semantic:dataInputRefs>Din1373638080886</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_f906ca20-8666-41ff-9d37-b76e09ac4f94">
+                <semantic:sourceRef>_aa8c769a-276c-4589-b182-7c7bbd0a9e1e</semantic:sourceRef>
+                <semantic:targetRef>Din1373638080886</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 4" id="_ac1fde31-c0cd-4a8a-9728-a5fb49602de7">
+            <semantic:incoming>_a9966baf-d9b9-4be1-a4d9-2906ab5add30</semantic:incoming>
+            <semantic:outgoing>_b8694c28-408b-4394-b476-41e2a5bcfd94</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:inclusiveGateway default="_be19c2da-316a-47f6-ad7b-eb6c82bf8609" gatewayDirection="Unspecified" name="Inclusive Gateway 1" id="_dec393e7-f182-4d31-b05f-e33ac3a5e35f">
+            <semantic:incoming>_4474c77a-01bb-435e-929a-7eb71bd824a8</semantic:incoming>
+            <semantic:outgoing>_a9966baf-d9b9-4be1-a4d9-2906ab5add30</semantic:outgoing>
+            <semantic:outgoing>_be19c2da-316a-47f6-ad7b-eb6c82bf8609</semantic:outgoing>
+        </semantic:inclusiveGateway>
+        <semantic:parallelGateway gatewayDirection="Unspecified" name="Parallel Gateway 2" id="_397c783e-ad6a-4cf3-8266-9b41962c83bd">
+            <semantic:incoming>_8321494b-9c3c-483a-b4d2-79e6254211c0</semantic:incoming>
+            <semantic:incoming>_b41b9c86-bc41-4b6e-ac32-70e1342e6128</semantic:incoming>
+            <semantic:incoming>_de249cbe-d431-4e1f-bc8c-a90aec438683</semantic:incoming>
+            <semantic:outgoing>_2752e07c-f2e4-4384-8721-70e4abea9765</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Conditional Catch" id="_c9cb2415-6a2e-49d6-84b9-27babcde4088">
+            <semantic:incoming>_5f52bb2a-c49d-43ae-9253-7b89a8251b2b</semantic:incoming>
+            <semantic:outgoing>_e503a157-f034-4a8a-ae12-aa524a8ebeee</semantic:outgoing>
+            <semantic:conditionalEventDefinition>
+                <semantic:condition/>
+            </semantic:conditionalEventDefinition>
+        </semantic:intermediateCatchEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 10" id="_a01498ae-086c-4adc-9229-ec3135bc2bcf">
+            <semantic:incoming>_e503a157-f034-4a8a-ae12-aa524a8ebeee</semantic:incoming>
+            <semantic:outgoing>_875031ae-f87c-45a3-ae60-ba0cb0ce0bc1</semantic:outgoing>
+        </semantic:task>
+        <semantic:sendTask implementation="##WebService" messageRef="Message_1373638080955" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Send Task 2" id="_76ee26df-2c95-495b-9d9a-cb806aea6baf">
+            <semantic:incoming>_19a7094a-7bdf-4819-af86-be22d2cfdc49</semantic:incoming>
+            <semantic:outgoing>_e1f948a6-db76-4c35-ba36-e430eecb63a4</semantic:outgoing>
+        </semantic:sendTask>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Collapsed Sub-Process 1 Multi-Instances" id="_149a6e1d-0385-4d0f-a90c-c2150a291a67">
+            <semantic:incoming>_e0fbb051-0e07-43cc-a8bf-158492541c0f</semantic:incoming>
+            <semantic:outgoing>_dbae7e12-67c2-4256-8c50-5811c207ba55</semantic:outgoing>
+            <semantic:multiInstanceLoopCharacteristics isSequential="false"/>
+        </semantic:subProcess>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Sub-Process 1" id="_303e68ec-dbb3-4d90-8a96-26e0be44f5f3">
+            <semantic:incoming>_ce63770e-9f4b-4bc0-a56c-88401c59f0bf</semantic:incoming>
+            <semantic:outgoing>_e6537f9d-e5ea-4abc-a6e8-add13a11b536</semantic:outgoing>
+            <semantic:startEvent name="Start Event 2" id="_ef372c4d-6c65-4ad2-bc22-5c25e5d0870e">
+                <semantic:outgoing>_c68194b4-3618-4655-b128-7eec67483c84</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:userTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="User Task 7 Standard Loop" id="_b9343536-6490-4559-8365-71d5c4cbb7cb">
+                <semantic:incoming>_c68194b4-3618-4655-b128-7eec67483c84</semantic:incoming>
+                <semantic:outgoing>_87ffa0fa-1a2d-4149-bbe9-04e20bc1014b</semantic:outgoing>
+                <semantic:standardLoopCharacteristics testBefore="false"/>
+            </semantic:userTask>
+            <semantic:endEvent name="End Event 2" id="_a9b9c08d-377a-49a8-a869-f82308702018">
+                <semantic:incoming>_87ffa0fa-1a2d-4149-bbe9-04e20bc1014b</semantic:incoming>
+            </semantic:endEvent>
+            <semantic:sequenceFlow sourceRef="_ef372c4d-6c65-4ad2-bc22-5c25e5d0870e" targetRef="_b9343536-6490-4559-8365-71d5c4cbb7cb" name="" id="_c68194b4-3618-4655-b128-7eec67483c84"/>
+            <semantic:sequenceFlow sourceRef="_b9343536-6490-4559-8365-71d5c4cbb7cb" targetRef="_a9b9c08d-377a-49a8-a869-f82308702018" name="" id="_87ffa0fa-1a2d-4149-bbe9-04e20bc1014b"/>
+        </semantic:subProcess>
+        <semantic:intermediateThrowEvent name="Intermediate Event Signal Throw 1" id="_0326fdf5-7c71-41d9-838c-ab141a1b1ed0">
+            <semantic:incoming>_b8694c28-408b-4394-b476-41e2a5bcfd94</semantic:incoming>
+            <semantic:outgoing>_e0fbb051-0e07-43cc-a8bf-158492541c0f</semantic:outgoing>
+            <semantic:signalEventDefinition/>
+        </semantic:intermediateThrowEvent>
+        <semantic:callActivity calledElement="_d4afdad7-65a5-40c6-9fee-e13ba4c0bed4" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Call Activity calling a Global User Task" id="_a74c1d4d-db90-43ff-8920-139a300b39a5">
+            <semantic:incoming>_be19c2da-316a-47f6-ad7b-eb6c82bf8609</semantic:incoming>
+            <semantic:outgoing>_ce63770e-9f4b-4bc0-a56c-88401c59f0bf</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 6" id="_f3698a93-fe0b-4f49-bfa6-68d055936af3">
+            <semantic:incoming>_54574511-c29e-4157-bb8f-8b26f15faaf5</semantic:incoming>
+            <semantic:outgoing>_de249cbe-d431-4e1f-bc8c-a90aec438683</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Abstract Task 1" id="_d84e5824-7bb7-4057-9dba-6c8794f7948c">
+            <semantic:incoming>_2c124731-3338-46e0-81b5-b435f34941c8</semantic:incoming>
+            <semantic:outgoing>_19a7094a-7bdf-4819-af86-be22d2cfdc49</semantic:outgoing>
+        </semantic:task>
+        <semantic:dataObjectReference dataObjectRef="DF1373638080458" name="Data Object" id="_aa8c769a-276c-4589-b182-7c7bbd0a9e1e"/>
+        <semantic:sequenceFlow sourceRef="_4e71bf73-1719-401e-a9a2-85dc89fc1150" targetRef="_d84e5824-7bb7-4057-9dba-6c8794f7948c" name="" id="_2c124731-3338-46e0-81b5-b435f34941c8"/>
+        <semantic:sequenceFlow sourceRef="_d84e5824-7bb7-4057-9dba-6c8794f7948c" targetRef="_76ee26df-2c95-495b-9d9a-cb806aea6baf" name="" id="_19a7094a-7bdf-4819-af86-be22d2cfdc49"/>
+        <semantic:sequenceFlow sourceRef="_76ee26df-2c95-495b-9d9a-cb806aea6baf" targetRef="_0e87da16-736e-45b2-95e5-8f45940f3adf" name="" id="_e1f948a6-db76-4c35-ba36-e430eecb63a4"/>
+        <semantic:sequenceFlow sourceRef="_149a6e1d-0385-4d0f-a90c-c2150a291a67" targetRef="_2a08c361-be51-437e-a86d-c62798c14e83" name="" id="_dbae7e12-67c2-4256-8c50-5811c207ba55"/>
+        <semantic:sequenceFlow sourceRef="_0e87da16-736e-45b2-95e5-8f45940f3adf" targetRef="_dec393e7-f182-4d31-b05f-e33ac3a5e35f" name="" id="_4474c77a-01bb-435e-929a-7eb71bd824a8"/>
+        <semantic:sequenceFlow sourceRef="_dec393e7-f182-4d31-b05f-e33ac3a5e35f" targetRef="_ac1fde31-c0cd-4a8a-9728-a5fb49602de7" name="Conditional Sequence Flow" id="_a9966baf-d9b9-4be1-a4d9-2906ab5add30"/>
+        <semantic:sequenceFlow sourceRef="_dec393e7-f182-4d31-b05f-e33ac3a5e35f" targetRef="_a74c1d4d-db90-43ff-8920-139a300b39a5" name="Default Sequence Flow 1" id="_be19c2da-316a-47f6-ad7b-eb6c82bf8609"/>
+        <semantic:sequenceFlow sourceRef="_ac1fde31-c0cd-4a8a-9728-a5fb49602de7" targetRef="_0326fdf5-7c71-41d9-838c-ab141a1b1ed0" name="" id="_b8694c28-408b-4394-b476-41e2a5bcfd94"/>
+        <semantic:sequenceFlow sourceRef="_a74c1d4d-db90-43ff-8920-139a300b39a5" targetRef="_303e68ec-dbb3-4d90-8a96-26e0be44f5f3" name="" id="_ce63770e-9f4b-4bc0-a56c-88401c59f0bf"/>
+        <semantic:sequenceFlow sourceRef="_0326fdf5-7c71-41d9-838c-ab141a1b1ed0" targetRef="_149a6e1d-0385-4d0f-a90c-c2150a291a67" name="" id="_e0fbb051-0e07-43cc-a8bf-158492541c0f"/>
+        <semantic:sequenceFlow sourceRef="_397c783e-ad6a-4cf3-8266-9b41962c83bd" targetRef="_b67ba682-c8d6-465b-b538-c287db18d1be" name="" id="_2752e07c-f2e4-4384-8721-70e4abea9765"/>
+        <semantic:sequenceFlow sourceRef="_303e68ec-dbb3-4d90-8a96-26e0be44f5f3" targetRef="_c9870992-6643-4094-acfd-d76e5e37941b" name="" id="_e6537f9d-e5ea-4abc-a6e8-add13a11b536"/>
+        <semantic:sequenceFlow sourceRef="_708d55c8-684a-4e3b-a69d-69c620cd0ac0" targetRef="_8f41085a-3302-4cfc-9231-23bb4b43c7a1" name="" id="_da47ac6a-4ea1-4bf6-ad3e-8cc60c0ea8a9"/>
+        <semantic:sequenceFlow sourceRef="_c9870992-6643-4094-acfd-d76e5e37941b" targetRef="_397c783e-ad6a-4cf3-8266-9b41962c83bd" name="" id="_8321494b-9c3c-483a-b4d2-79e6254211c0"/>
+        <semantic:sequenceFlow sourceRef="_732c0641-b12f-448b-b9f8-a68b355782e3" targetRef="_f3698a93-fe0b-4f49-bfa6-68d055936af3" name="" id="_54574511-c29e-4157-bb8f-8b26f15faaf5"/>
+        <semantic:sequenceFlow sourceRef="_2a08c361-be51-437e-a86d-c62798c14e83" targetRef="_397c783e-ad6a-4cf3-8266-9b41962c83bd" name="" id="_b41b9c86-bc41-4b6e-ac32-70e1342e6128"/>
+        <semantic:sequenceFlow sourceRef="_f3698a93-fe0b-4f49-bfa6-68d055936af3" targetRef="_397c783e-ad6a-4cf3-8266-9b41962c83bd" name="" id="_de249cbe-d431-4e1f-bc8c-a90aec438683"/>
+        <semantic:sequenceFlow sourceRef="_8f41085a-3302-4cfc-9231-23bb4b43c7a1" targetRef="_c9cb2415-6a2e-49d6-84b9-27babcde4088" name="" id="_5f52bb2a-c49d-43ae-9253-7b89a8251b2b"/>
+        <semantic:sequenceFlow sourceRef="_a01498ae-086c-4adc-9229-ec3135bc2bcf" targetRef="_5cc02d0f-c090-4e48-8da3-f32cbbca9565" name="" id="_875031ae-f87c-45a3-ae60-ba0cb0ce0bc1"/>
+        <semantic:sequenceFlow sourceRef="_c9cb2415-6a2e-49d6-84b9-27babcde4088" targetRef="_a01498ae-086c-4adc-9229-ec3135bc2bcf" name="" id="_e503a157-f034-4a8a-ae12-aa524a8ebeee"/>
+        <semantic:textAnnotation id="_4815ea6a-ede2-489b-8b37-2cdb2835b02c">
+            <semantic:text>Annotation</semantic:text>
+        </semantic:textAnnotation>
+        <semantic:association associationDirection="None" sourceRef="_303e68ec-dbb3-4d90-8a96-26e0be44f5f3" targetRef="_4815ea6a-ede2-489b-8b37-2cdb2835b02c" id="_5362a7ef-ce7e-4a91-9c38-66c07b1b5f49"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-6-2">
+        <semantic:laneSet id="ls_55bb31e8-9e62-48ea-8f0e-1a748c04bbf6">
+            <semantic:lane name="Lane 1" id="_4a6df7ac-26d8-4718-ac05-90af463d5e23">
+                <semantic:flowNodeRef>_7e6ccf38-e740-4537-a439-a8e984d066de</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_fa90f891-fc07-463a-97c9-2ee0812351e1</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_1237e756-d53c-4591-a731-dafffbf0b3f9</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_73343358-7838-48a1-baf2-2b0266e3a55b</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_137281ee-758e-4c36-8942-74c5d807e1b3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_15e9a3bf-53de-40d8-8364-7f534b175ff4</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_dbca671f-08b6-4b58-a614-62b98fa36be5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f2081fdb-3b8a-480b-9f61-fbf683e2018c</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_be29f267-9d56-46ef-8bbc-e13513b25fce</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_3a19ce2d-e30d-461c-aeaa-b2acb118f9a4</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_ba16239e-181e-4b9f-bc5b-0bb2ee973450</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_087d0602-ff51-491e-a021-d2e7c940dbd8</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a38484e2-7bdb-48b1-b62e-139d51d6a147</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_c889aa27-e389-48eb-aa18-613ec53614e7</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f27040d5-765c-493c-bbe7-9fb6ad04cbdc</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_796ccbc5-ad88-465c-849a-87447a0283d3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_05c6bc89-5265-435c-8a9e-533c44a6888b</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_511d95ed-38f9-473e-9466-525285a007f5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_187063b6-107e-4ac9-bdb3-e8ce9d83763d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_663e9963-9cf6-4032-9652-3a20f50dcda3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_034907bf-d3d7-4629-818c-14c3e69d5bc6</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane name="Lane 2" id="_3400f56a-4565-47d1-91db-0ba17b958cb2">
+                <semantic:flowNodeRef>_d58753a7-d38b-49cd-914d-14e4cdaa4449</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_147b1900-7e7d-4b8f-b243-0155265f1c00</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_25beeb17-acc3-4cca-9590-f1cd2f353434</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_928cd158-ebe1-4c0a-9c3e-42e77d663aa2</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_0ab0e0ac-f88b-4402-9986-e95a72dfc8a3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_242b8e6c-681c-438e-ab34-729255121eff</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_25a1f26b-d8b8-4b9b-b768-f14b8d104f9c</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_8476a0f7-36b7-4666-a3b2-c18efcc68a94</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_10ecbff1-cd15-4a5c-9aa5-6f2a35479416</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_4f5e6e50-d9d0-4f97-959a-d1b8e1e32788</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_cbebc7f2-9fb5-4fbf-a6dc-13140c784da7</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_df7727a0-f509-45eb-bb89-85753f439576</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_189118eb-65fc-43e8-8a34-a155b113914f</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_d92d850c-37ac-47ea-9344-dc986289de47</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_1215d072-524b-4724-99d7-a0a406435904</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_dfb273c6-0ad3-4030-9e72-638adf7ca75f</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_56ab3884-4b26-4398-be6f-5f0bb5f81be4</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Sub-Process 2" id="_7e6ccf38-e740-4537-a439-a8e984d066de">
+            <semantic:incoming>_3e8b97e7-d6a5-44dc-b5ca-6f2c39ba4911</semantic:incoming>
+            <semantic:outgoing>_70617827-824b-4797-b424-4179b8b6cbdd</semantic:outgoing>
+            <semantic:startEvent name="Start Event 5 None" id="_1df01cbc-5d8c-444e-b1db-da3efdee254a">
+                <semantic:outgoing>_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 22" id="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4">
+                <semantic:incoming>_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a</semantic:incoming>
+                <semantic:outgoing>_062ae395-4aba-408b-ac64-4987752be95b</semantic:outgoing>
+                <semantic:multiInstanceLoopCharacteristics isSequential="false"/>
+            </semantic:serviceTask>
+            <semantic:endEvent name="End Event 8 None" id="_4f744697-3643-41a9-9d07-84c78e2df64b">
+                <semantic:incoming>_062ae395-4aba-408b-ac64-4987752be95b</semantic:incoming>
+            </semantic:endEvent>
+            <semantic:sequenceFlow sourceRef="_1df01cbc-5d8c-444e-b1db-da3efdee254a" targetRef="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" name="" id="_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a"/>
+            <semantic:sequenceFlow sourceRef="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" targetRef="_4f744697-3643-41a9-9d07-84c78e2df64b" name="" id="_062ae395-4aba-408b-ac64-4987752be95b"/>
+        </semantic:subProcess>
+        <semantic:boundaryEvent attachedToRef="_7e6ccf38-e740-4537-a439-a8e984d066de" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Timer" id="_5a6baa94-303a-4750-bde2-e1cd6edace37">
+            <semantic:outgoing>_e59dbf35-3f4e-4701-bc2a-75e32cbaa732</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="_7e6ccf38-e740-4537-a439-a8e984d066de" cancelActivity="true" parallelMultiple="false" name="Boundary Intermediate Event Interrupting Error" id="_3c56e6dc-bc87-4d98-b499-462c5b741c5a">
+            <semantic:outgoing>_708324bb-26d0-4358-a96f-a4fabc14069f</semantic:outgoing>
+            <semantic:errorEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:serviceTask implementation="##WebService" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Service Task 15" id="_fa90f891-fc07-463a-97c9-2ee0812351e1">
+            <semantic:incoming>_c1931975-c1c3-499e-8a57-89b61affba3a</semantic:incoming>
+            <semantic:outgoing>_c8c10b02-ea53-4a0c-b605-b3252d5560cd</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:boundaryEvent attachedToRef="_fa90f891-fc07-463a-97c9-2ee0812351e1" cancelActivity="true" parallelMultiple="false" name="Boundary Intermediate Event Interrupting Conditional" id="_68ca1f8b-5028-4079-9e35-619b529f4d71">
+            <semantic:outgoing>_78361e03-8ab9-4317-b8f6-2daa90f20f54</semantic:outgoing>
+            <semantic:conditionalEventDefinition>
+                <semantic:condition/>
+            </semantic:conditionalEventDefinition>
+        </semantic:boundaryEvent>
+        <semantic:callActivity calledElement="WFP-0-" name="Collapsed Call Activity" id="_1237e756-d53c-4591-a731-dafffbf0b3f9">
+            <semantic:incoming>_837a8629-1540-473c-b41f-7e13ad80c052</semantic:incoming>
+            <semantic:outgoing>_b77e4b02-22b9-4a57-b0f9-4248410d0675</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:boundaryEvent attachedToRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Escalation" id="_45ceee21-0f15-4bf8-87a9-b3f808173e61">
+            <semantic:outgoing>_07b92d12-375f-41c5-b0a9-8961ac773afe</semantic:outgoing>
+            <semantic:escalationEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 23" id="_73343358-7838-48a1-baf2-2b0266e3a55b">
+            <semantic:incoming>_70617827-824b-4797-b424-4179b8b6cbdd</semantic:incoming>
+            <semantic:incoming>_2257c019-bc17-4ba9-9e07-a9de7913ada3</semantic:incoming>
+            <semantic:outgoing>_02f751bb-2e42-489a-bef1-cc5360d5c3d8</semantic:outgoing>
+        </semantic:task>
+        <semantic:boundaryEvent attachedToRef="_73343358-7838-48a1-baf2-2b0266e3a55b" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Signal" id="_e454657a-0173-41a4-a4c7-d16ec224f2e1">
+            <semantic:outgoing>_a639a36d-a1df-43b1-8ed1-e06afa899733</semantic:outgoing>
+            <semantic:signalEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 21" id="_137281ee-758e-4c36-8942-74c5d807e1b3">
+            <semantic:incoming>_2a32599c-d1f4-4f2c-bf65-0f0e4f6ac87f</semantic:incoming>
+            <semantic:outgoing>_3e8b97e7-d6a5-44dc-b5ca-6f2c39ba4911</semantic:outgoing>
+        </semantic:task>
+        <semantic:boundaryEvent attachedToRef="_137281ee-758e-4c36-8942-74c5d807e1b3" cancelActivity="true" parallelMultiple="false" name="Boundary Intermediate Event Interrupting Timer" id="_79341f54-50d4-4c60-85f3-fe8839a7554b">
+            <semantic:outgoing>_4c3f3102-d31a-4a71-a3d0-b65cb61a94ea</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 17" id="_15e9a3bf-53de-40d8-8364-7f534b175ff4">
+            <semantic:incoming>_b77e4b02-22b9-4a57-b0f9-4248410d0675</semantic:incoming>
+            <semantic:outgoing>_ce44f766-7c92-43e2-93cf-1e2ba7110c4a</semantic:outgoing>
+        </semantic:task>
+        <semantic:boundaryEvent attachedToRef="_15e9a3bf-53de-40d8-8364-7f534b175ff4" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Message" id="_e369fd30-1a71-4d0e-b4d7-2174dd5ba388">
+            <semantic:outgoing>_504b3bd1-54f6-4f20-8244-32f4ec639248</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 18" id="_dbca671f-08b6-4b58-a614-62b98fa36be5">
+            <semantic:incoming>_8b98cde1-aec2-46e8-8be2-d9aa244fcda6</semantic:incoming>
+            <semantic:incoming>_07b92d12-375f-41c5-b0a9-8961ac773afe</semantic:incoming>
+            <semantic:outgoing>_bd5730fa-544e-4a99-a238-57171787d52c</semantic:outgoing>
+        </semantic:task>
+        <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Message Catch" id="_f2081fdb-3b8a-480b-9f61-fbf683e2018c">
+            <semantic:incoming>_7cae752c-c2bd-438b-8d24-48196805a4e8</semantic:incoming>
+            <semantic:outgoing>_e062c113-2da3-40f1-845e-6fd48ccc880f</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:intermediateCatchEvent>
+        <semantic:eventBasedGateway eventGatewayType="Exclusive" instantiate="false" gatewayDirection="Unspecified" name="Event Base Gateway 3" id="_be29f267-9d56-46ef-8bbc-e13513b25fce">
+            <semantic:incoming>_168f4ce9-ccf7-4833-b38b-0140ff601d40</semantic:incoming>
+            <semantic:outgoing>_ab34472d-95a4-459c-a13b-5ed8b8b75eca</semantic:outgoing>
+            <semantic:outgoing>_5853836e-d7ca-45e2-852a-7db8c3c642bb</semantic:outgoing>
+            <semantic:outgoing>_7cae752c-c2bd-438b-8d24-48196805a4e8</semantic:outgoing>
+        </semantic:eventBasedGateway>
+        <semantic:intermediateThrowEvent name="" id="_3a19ce2d-e30d-461c-aeaa-b2acb118f9a4">
+            <semantic:incoming>_bd5730fa-544e-4a99-a238-57171787d52c</semantic:incoming>
+            <semantic:outgoing>_2257c019-bc17-4ba9-9e07-a9de7913ada3</semantic:outgoing>
+            <semantic:escalationEventDefinition/>
+        </semantic:intermediateThrowEvent>
+        <semantic:callActivity calledElement="Process_ba16239e-181e-4b9f-bc5b-0bb2ee973450" name="Expanded Call Activity" id="_ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+            <semantic:incoming>_5106fe5e-184d-4069-8c1c-54f81fd577a9</semantic:incoming>
+            <semantic:outgoing>_c1931975-c1c3-499e-8a57-89b61affba3a</semantic:outgoing>
+        </semantic:callActivity>
+        <semantic:endEvent name="End Event 7 None" id="_087d0602-ff51-491e-a021-d2e7c940dbd8">
+            <semantic:incoming>_ce44f766-7c92-43e2-93cf-1e2ba7110c4a</semantic:incoming>
+            <semantic:incoming>_b54d5ab0-66d8-4595-8a89-9d3e255f75ba</semantic:incoming>
+            <semantic:incoming>_02f751bb-2e42-489a-bef1-cc5360d5c3d8</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:exclusiveGateway default="_670ceb69-cd3a-46e8-96a0-a520a8fc589b" gatewayDirection="Unspecified" name="Exclusive Gateway 4" id="_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e">
+            <semantic:incoming>_8095da9c-0faa-47b9-85d4-2df24e021770</semantic:incoming>
+            <semantic:outgoing>_670ceb69-cd3a-46e8-96a0-a520a8fc589b</semantic:outgoing>
+            <semantic:outgoing>_8b98cde1-aec2-46e8-8be2-d9aa244fcda6</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:startEvent name="Start Event 2 Message" id="_a38484e2-7bdb-48b1-b62e-139d51d6a147">
+            <semantic:outgoing>_a63c8cd6-eee8-4fbe-be5e-f6980b180b52</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Message_1373638080955"/>
+        </semantic:startEvent>
+        <semantic:endEvent name="End Event 6&#10;Message" id="_c889aa27-e389-48eb-aa18-613ec53614e7">
+            <semantic:incoming>_cc2f1bcd-2a97-48c7-94ae-0899e56402ea</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Message_1373638080954"/>
+        </semantic:endEvent>
+        <semantic:intermediateThrowEvent name="Intermediate Event Link" id="_f27040d5-765c-493c-bbe7-9fb6ad04cbdc">
+            <semantic:incoming>_78361e03-8ab9-4317-b8f6-2daa90f20f54</semantic:incoming>
+            <semantic:linkEventDefinition name="Intermediate Event Link"/>
+        </semantic:intermediateThrowEvent>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Collapsed Sub-Process 2" id="_0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447">
+            <semantic:incoming>_e062c113-2da3-40f1-845e-6fd48ccc880f</semantic:incoming>
+            <semantic:outgoing>_8095da9c-0faa-47b9-85d4-2df24e021770</semantic:outgoing>
+        </semantic:subProcess>
+        <semantic:intermediateThrowEvent name="Intermediate Event Message Throw" id="_796ccbc5-ad88-465c-849a-87447a0283d3">
+            <semantic:incoming>_670ceb69-cd3a-46e8-96a0-a520a8fc589b</semantic:incoming>
+            <semantic:outgoing>_837a8629-1540-473c-b41f-7e13ad80c052</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:intermediateThrowEvent>
+        <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Message Catch 2" id="_05c6bc89-5265-435c-8a9e-533c44a6888b">
+            <semantic:incoming>_ab34472d-95a4-459c-a13b-5ed8b8b75eca</semantic:incoming>
+            <semantic:outgoing>_2a32599c-d1f4-4f2c-bf65-0f0e4f6ac87f</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:intermediateCatchEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 11" id="_511d95ed-38f9-473e-9466-525285a007f5">
+            <semantic:incoming>_a63c8cd6-eee8-4fbe-be5e-f6980b180b52</semantic:incoming>
+            <semantic:outgoing>_168f4ce9-ccf7-4833-b38b-0140ff601d40</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 19" id="_187063b6-107e-4ac9-bdb3-e8ce9d83763d">
+            <semantic:incoming>_504b3bd1-54f6-4f20-8244-32f4ec639248</semantic:incoming>
+            <semantic:outgoing>_b54d5ab0-66d8-4595-8a89-9d3e255f75ba</semantic:outgoing>
+        </semantic:task>
+        <semantic:receiveTask implementation="##WebService" instantiate="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Receive Task 16" id="_f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb">
+            <semantic:incoming>_c8c10b02-ea53-4a0c-b605-b3252d5560cd</semantic:incoming>
+            <semantic:outgoing>_cc2f1bcd-2a97-48c7-94ae-0899e56402ea</semantic:outgoing>
+        </semantic:receiveTask>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 24" id="_663e9963-9cf6-4032-9652-3a20f50dcda3">
+            <semantic:incoming>_a639a36d-a1df-43b1-8ed1-e06afa899733</semantic:incoming>
+            <semantic:outgoing>_9e4cd50c-cd6b-4523-8dbe-ebece9b823cb</semantic:outgoing>
+        </semantic:task>
+        <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Timer Catch" id="_034907bf-d3d7-4629-818c-14c3e69d5bc6">
+            <semantic:incoming>_5853836e-d7ca-45e2-852a-7db8c3c642bb</semantic:incoming>
+            <semantic:outgoing>_5106fe5e-184d-4069-8c1c-54f81fd577a9</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:intermediateCatchEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 32" id="_d58753a7-d38b-49cd-914d-14e4cdaa4449">
+            <semantic:incoming>_a3fffd23-7ce0-4199-8918-c9df7a2c8158</semantic:incoming>
+            <semantic:outgoing>_b9a903b5-4525-42d1-ae5b-24f26d774556</semantic:outgoing>
+        </semantic:task>
+        <semantic:boundaryEvent attachedToRef="_d58753a7-d38b-49cd-914d-14e4cdaa4449" cancelActivity="true" parallelMultiple="false" name="" id="_209105e0-96fc-4278-8451-3b2a1dd18ec9">
+            <semantic:outgoing>_aa88dfff-5242-4699-b722-a593e54537ce</semantic:outgoing>
+            <semantic:signalEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:endEvent name="End Event 14" id="_147b1900-7e7d-4b8f-b243-0155265f1c00">
+            <semantic:incoming>_219e1df4-5bfe-4485-a4fd-dcfeeaa7c3d6</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:startEvent name="Start Event 6 Signal" id="_25beeb17-acc3-4cca-9590-f1cd2f353434">
+            <semantic:outgoing>_7c690c39-4274-40c5-a0d2-b503acabbf93</semantic:outgoing>
+            <semantic:signalEventDefinition/>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 28" id="_928cd158-ebe1-4c0a-9c3e-42e77d663aa2">
+            <semantic:incoming>_831dbaee-1434-45fc-9c7e-bedd44ad9ea7</semantic:incoming>
+            <semantic:outgoing>_202c373c-f243-413d-904e-9132a0c0e923</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 33" id="_0ab0e0ac-f88b-4402-9986-e95a72dfc8a3">
+            <semantic:incoming>_aa88dfff-5242-4699-b722-a593e54537ce</semantic:incoming>
+            <semantic:outgoing>_219e1df4-5bfe-4485-a4fd-dcfeeaa7c3d6</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 25" id="_242b8e6c-681c-438e-ab34-729255121eff">
+            <semantic:incoming>_7c690c39-4274-40c5-a0d2-b503acabbf93</semantic:incoming>
+            <semantic:outgoing>_fdd08093-e5b4-4e9e-8088-26887892078a</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 30" id="_25a1f26b-d8b8-4b9b-b768-f14b8d104f9c">
+            <semantic:incoming>_e59dbf35-3f4e-4701-bc2a-75e32cbaa732</semantic:incoming>
+            <semantic:outgoing>_37312691-7037-44d1-8696-fc6f2021e7a6</semantic:outgoing>
+        </semantic:task>
+        <semantic:intermediateThrowEvent name="Intermediate Event Signal Throw 2" id="_8476a0f7-36b7-4666-a3b2-c18efcc68a94">
+            <semantic:incoming>_be71b068-7fa6-4f76-b0a3-8760f4a2911a</semantic:incoming>
+            <semantic:outgoing>_f61be5ab-acb2-4348-a9a0-bdfdde0c42ad</semantic:outgoing>
+            <semantic:signalEventDefinition/>
+        </semantic:intermediateThrowEvent>
+        <semantic:inclusiveGateway gatewayDirection="Unspecified" name="Inclusive Gateway 6" id="_10ecbff1-cd15-4a5c-9aa5-6f2a35479416">
+            <semantic:incoming>_00140039-2e5d-4c58-9197-1f8512b54c99</semantic:incoming>
+            <semantic:incoming>_f61be5ab-acb2-4348-a9a0-bdfdde0c42ad</semantic:incoming>
+            <semantic:outgoing>_831dbaee-1434-45fc-9c7e-bedd44ad9ea7</semantic:outgoing>
+        </semantic:inclusiveGateway>
+        <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Link" id="_4f5e6e50-d9d0-4f97-959a-d1b8e1e32788">
+            <semantic:outgoing>_c9768243-8e1a-4b09-907b-3f27fa831a6e</semantic:outgoing>
+            <semantic:linkEventDefinition name="Intermediate Event Link"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 26" id="_cbebc7f2-9fb5-4fbf-a6dc-13140c784da7">
+            <semantic:incoming>_022aa2b9-f472-49be-b00b-2eec7f075acf</semantic:incoming>
+            <semantic:outgoing>_be71b068-7fa6-4f76-b0a3-8760f4a2911a</semantic:outgoing>
+        </semantic:task>
+        <semantic:parallelGateway gatewayDirection="Unspecified" name="Parallel Gateway 7" id="_df7727a0-f509-45eb-bb89-85753f439576">
+            <semantic:incoming>_202c373c-f243-413d-904e-9132a0c0e923</semantic:incoming>
+            <semantic:incoming>_b9a903b5-4525-42d1-ae5b-24f26d774556</semantic:incoming>
+            <semantic:outgoing>_0dbfad2a-7b07-4b7b-87b4-3819d28f175d</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Expanded Sub-Process 3" id="_189118eb-65fc-43e8-8a34-a155b113914f">
+            <semantic:incoming>_40d118ea-6a9b-4210-a1f1-e093831e0df0</semantic:incoming>
+            <semantic:incoming>_c9768243-8e1a-4b09-907b-3f27fa831a6e</semantic:incoming>
+            <semantic:outgoing>_a3fffd23-7ce0-4199-8918-c9df7a2c8158</semantic:outgoing>
+            <semantic:startEvent name="Start Event 7" id="_21976b84-4ddd-4ddc-a5a3-825335550796">
+                <semantic:outgoing>_1f05bcca-f418-4dc6-a78c-a9dde2fab53d</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:intermediateCatchEvent parallelMultiple="false" name="Intermediate Event Signal Catch" id="_e233b5e1-244d-422e-8886-4588b7566122">
+                <semantic:incoming>_1f05bcca-f418-4dc6-a78c-a9dde2fab53d</semantic:incoming>
+                <semantic:outgoing>_03b1de69-7605-4fc2-9797-2309271c208c</semantic:outgoing>
+                <semantic:signalEventDefinition/>
+            </semantic:intermediateCatchEvent>
+            <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 31" id="_6d90f706-17c9-4635-87c2-ccab31e9a32d">
+                <semantic:incoming>_03b1de69-7605-4fc2-9797-2309271c208c</semantic:incoming>
+                <semantic:outgoing>_955edc35-abcc-4cdb-a890-0d7ec15167ae</semantic:outgoing>
+            </semantic:task>
+            <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Exclusive Gateway 7" id="_84918a6a-5e98-40c6-9155-c081bb5bdee8">
+                <semantic:incoming>_955edc35-abcc-4cdb-a890-0d7ec15167ae</semantic:incoming>
+                <semantic:outgoing>_8021571a-7a77-426b-b824-545cc61f7334</semantic:outgoing>
+                <semantic:outgoing>_5d70a293-03ea-4a73-bed0-65ad145796d6</semantic:outgoing>
+            </semantic:exclusiveGateway>
+            <semantic:endEvent name="End Event 13 Error" id="_d60db966-c03d-4f0e-a5bd-945525fa0aaf">
+                <semantic:incoming>_5d70a293-03ea-4a73-bed0-65ad145796d6</semantic:incoming>
+                <semantic:errorEventDefinition/>
+            </semantic:endEvent>
+            <semantic:endEvent name="End Event 12" id="_cd7b1449-fc16-4015-befe-cc9b5aa1df27">
+                <semantic:incoming>_8021571a-7a77-426b-b824-545cc61f7334</semantic:incoming>
+            </semantic:endEvent>
+            <semantic:sequenceFlow sourceRef="_21976b84-4ddd-4ddc-a5a3-825335550796" targetRef="_e233b5e1-244d-422e-8886-4588b7566122" name="" id="_1f05bcca-f418-4dc6-a78c-a9dde2fab53d"/>
+            <semantic:sequenceFlow sourceRef="_e233b5e1-244d-422e-8886-4588b7566122" targetRef="_6d90f706-17c9-4635-87c2-ccab31e9a32d" name="" id="_03b1de69-7605-4fc2-9797-2309271c208c"/>
+            <semantic:sequenceFlow sourceRef="_6d90f706-17c9-4635-87c2-ccab31e9a32d" targetRef="_84918a6a-5e98-40c6-9155-c081bb5bdee8" name="" id="_955edc35-abcc-4cdb-a890-0d7ec15167ae"/>
+            <semantic:sequenceFlow sourceRef="_84918a6a-5e98-40c6-9155-c081bb5bdee8" targetRef="_cd7b1449-fc16-4015-befe-cc9b5aa1df27" name="" id="_8021571a-7a77-426b-b824-545cc61f7334"/>
+            <semantic:sequenceFlow sourceRef="_84918a6a-5e98-40c6-9155-c081bb5bdee8" targetRef="_d60db966-c03d-4f0e-a5bd-945525fa0aaf" name="" id="_5d70a293-03ea-4a73-bed0-65ad145796d6"/>
+        </semantic:subProcess>
+        <semantic:endEvent name="End Event 10" id="_d92d850c-37ac-47ea-9344-dc986289de47">
+            <semantic:incoming>_e03319e1-0dff-4337-9443-b053651000a0</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:parallelGateway gatewayDirection="Unspecified" name="Parallel Gateway 5" id="_1215d072-524b-4724-99d7-a0a406435904">
+            <semantic:incoming>_fdd08093-e5b4-4e9e-8088-26887892078a</semantic:incoming>
+            <semantic:outgoing>_022aa2b9-f472-49be-b00b-2eec7f075acf</semantic:outgoing>
+            <semantic:outgoing>_40d118ea-6a9b-4210-a1f1-e093831e0df0</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:endEvent name="End Event 11 Escalation" id="_dfb273c6-0ad3-4030-9e72-638adf7ca75f">
+            <semantic:incoming>_9e4cd50c-cd6b-4523-8dbe-ebece9b823cb</semantic:incoming>
+            <semantic:incoming>_37312691-7037-44d1-8696-fc6f2021e7a6</semantic:incoming>
+            <semantic:incoming>_0dbfad2a-7b07-4b7b-87b4-3819d28f175d</semantic:incoming>
+            <semantic:escalationEventDefinition/>
+        </semantic:endEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 29" id="_56ab3884-4b26-4398-be6f-5f0bb5f81be4">
+            <semantic:incoming>_708324bb-26d0-4358-a96f-a4fabc14069f</semantic:incoming>
+            <semantic:outgoing>_e03319e1-0dff-4337-9443-b053651000a0</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 27" id="_0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e">
+            <semantic:incoming>_4c3f3102-d31a-4a71-a3d0-b65cb61a94ea</semantic:incoming>
+            <semantic:outgoing>_00140039-2e5d-4c58-9197-1f8512b54c99</semantic:outgoing>
+        </semantic:task>
+        <semantic:dataStoreReference dataStoreRef="DS1373638079677" name="Data Store Reference" id="_b9385abf-d293-40b7-848b-8add4db48415"/>
+        <semantic:sequenceFlow sourceRef="_a38484e2-7bdb-48b1-b62e-139d51d6a147" targetRef="_511d95ed-38f9-473e-9466-525285a007f5" name="" id="_a63c8cd6-eee8-4fbe-be5e-f6980b180b52"/>
+        <semantic:sequenceFlow sourceRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" targetRef="_05c6bc89-5265-435c-8a9e-533c44a6888b" name="" id="_ab34472d-95a4-459c-a13b-5ed8b8b75eca"/>
+        <semantic:sequenceFlow sourceRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" targetRef="_034907bf-d3d7-4629-818c-14c3e69d5bc6" name="" id="_5853836e-d7ca-45e2-852a-7db8c3c642bb"/>
+        <semantic:sequenceFlow sourceRef="_511d95ed-38f9-473e-9466-525285a007f5" targetRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" name="" id="_168f4ce9-ccf7-4833-b38b-0140ff601d40"/>
+        <semantic:sequenceFlow sourceRef="_be29f267-9d56-46ef-8bbc-e13513b25fce" targetRef="_f2081fdb-3b8a-480b-9f61-fbf683e2018c" name="" id="_7cae752c-c2bd-438b-8d24-48196805a4e8"/>
+        <semantic:sequenceFlow sourceRef="_034907bf-d3d7-4629-818c-14c3e69d5bc6" targetRef="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" name="" id="_5106fe5e-184d-4069-8c1c-54f81fd577a9"/>
+        <semantic:sequenceFlow sourceRef="_f2081fdb-3b8a-480b-9f61-fbf683e2018c" targetRef="_0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447" name="" id="_e062c113-2da3-40f1-845e-6fd48ccc880f"/>
+        <semantic:sequenceFlow sourceRef="_05c6bc89-5265-435c-8a9e-533c44a6888b" targetRef="_137281ee-758e-4c36-8942-74c5d807e1b3" name="" id="_2a32599c-d1f4-4f2c-bf65-0f0e4f6ac87f"/>
+        <semantic:sequenceFlow sourceRef="_0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447" targetRef="_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e" name="" id="_8095da9c-0faa-47b9-85d4-2df24e021770"/>
+        <semantic:sequenceFlow sourceRef="_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e" targetRef="_796ccbc5-ad88-465c-849a-87447a0283d3" name="Default Sequence Flow 2" id="_670ceb69-cd3a-46e8-96a0-a520a8fc589b"/>
+        <semantic:sequenceFlow sourceRef="_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e" targetRef="_dbca671f-08b6-4b58-a614-62b98fa36be5" name="" id="_8b98cde1-aec2-46e8-8be2-d9aa244fcda6"/>
+        <semantic:sequenceFlow sourceRef="_796ccbc5-ad88-465c-849a-87447a0283d3" targetRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" name="" id="_837a8629-1540-473c-b41f-7e13ad80c052"/>
+        <semantic:sequenceFlow sourceRef="_79341f54-50d4-4c60-85f3-fe8839a7554b" targetRef="_0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e" name="" id="_4c3f3102-d31a-4a71-a3d0-b65cb61a94ea"/>
+        <semantic:sequenceFlow sourceRef="_45ceee21-0f15-4bf8-87a9-b3f808173e61" targetRef="_dbca671f-08b6-4b58-a614-62b98fa36be5" name="" id="_07b92d12-375f-41c5-b0a9-8961ac773afe"/>
+        <semantic:sequenceFlow sourceRef="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" targetRef="_fa90f891-fc07-463a-97c9-2ee0812351e1" name="" id="_c1931975-c1c3-499e-8a57-89b61affba3a"/>
+        <semantic:sequenceFlow sourceRef="_25beeb17-acc3-4cca-9590-f1cd2f353434" targetRef="_242b8e6c-681c-438e-ab34-729255121eff" name="" id="_7c690c39-4274-40c5-a0d2-b503acabbf93"/>
+        <semantic:sequenceFlow sourceRef="_242b8e6c-681c-438e-ab34-729255121eff" targetRef="_1215d072-524b-4724-99d7-a0a406435904" name="" id="_fdd08093-e5b4-4e9e-8088-26887892078a"/>
+        <semantic:sequenceFlow sourceRef="_1215d072-524b-4724-99d7-a0a406435904" targetRef="_cbebc7f2-9fb5-4fbf-a6dc-13140c784da7" name="" id="_022aa2b9-f472-49be-b00b-2eec7f075acf"/>
+        <semantic:sequenceFlow sourceRef="_1215d072-524b-4724-99d7-a0a406435904" targetRef="_189118eb-65fc-43e8-8a34-a155b113914f" name="" id="_40d118ea-6a9b-4210-a1f1-e093831e0df0"/>
+        <semantic:sequenceFlow sourceRef="_fa90f891-fc07-463a-97c9-2ee0812351e1" targetRef="_f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb" name="" id="_c8c10b02-ea53-4a0c-b605-b3252d5560cd"/>
+        <semantic:sequenceFlow sourceRef="_68ca1f8b-5028-4079-9e35-619b529f4d71" targetRef="_f27040d5-765c-493c-bbe7-9fb6ad04cbdc" name="" id="_78361e03-8ab9-4317-b8f6-2daa90f20f54"/>
+        <semantic:sequenceFlow sourceRef="_f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb" targetRef="_c889aa27-e389-48eb-aa18-613ec53614e7" name="" id="_cc2f1bcd-2a97-48c7-94ae-0899e56402ea"/>
+        <semantic:sequenceFlow sourceRef="_4f5e6e50-d9d0-4f97-959a-d1b8e1e32788" targetRef="_189118eb-65fc-43e8-8a34-a155b113914f" name="" id="_c9768243-8e1a-4b09-907b-3f27fa831a6e"/>
+        <semantic:sequenceFlow sourceRef="_cbebc7f2-9fb5-4fbf-a6dc-13140c784da7" targetRef="_8476a0f7-36b7-4666-a3b2-c18efcc68a94" name="" id="_be71b068-7fa6-4f76-b0a3-8760f4a2911a"/>
+        <semantic:sequenceFlow sourceRef="_137281ee-758e-4c36-8942-74c5d807e1b3" targetRef="_7e6ccf38-e740-4537-a439-a8e984d066de" name="" id="_3e8b97e7-d6a5-44dc-b5ca-6f2c39ba4911"/>
+        <semantic:sequenceFlow sourceRef="_0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e" targetRef="_10ecbff1-cd15-4a5c-9aa5-6f2a35479416" name="" id="_00140039-2e5d-4c58-9197-1f8512b54c99"/>
+        <semantic:sequenceFlow sourceRef="_8476a0f7-36b7-4666-a3b2-c18efcc68a94" targetRef="_10ecbff1-cd15-4a5c-9aa5-6f2a35479416" name="" id="_f61be5ab-acb2-4348-a9a0-bdfdde0c42ad"/>
+        <semantic:sequenceFlow sourceRef="_dbca671f-08b6-4b58-a614-62b98fa36be5" targetRef="_3a19ce2d-e30d-461c-aeaa-b2acb118f9a4" name="" id="_bd5730fa-544e-4a99-a238-57171787d52c"/>
+        <semantic:sequenceFlow sourceRef="_1237e756-d53c-4591-a731-dafffbf0b3f9" targetRef="_15e9a3bf-53de-40d8-8364-7f534b175ff4" name="" id="_b77e4b02-22b9-4a57-b0f9-4248410d0675"/>
+        <semantic:sequenceFlow sourceRef="_15e9a3bf-53de-40d8-8364-7f534b175ff4" targetRef="_087d0602-ff51-491e-a021-d2e7c940dbd8" name="" id="_ce44f766-7c92-43e2-93cf-1e2ba7110c4a"/>
+        <semantic:sequenceFlow sourceRef="_7e6ccf38-e740-4537-a439-a8e984d066de" targetRef="_73343358-7838-48a1-baf2-2b0266e3a55b" name="" id="_70617827-824b-4797-b424-4179b8b6cbdd"/>
+        <semantic:sequenceFlow sourceRef="_187063b6-107e-4ac9-bdb3-e8ce9d83763d" targetRef="_087d0602-ff51-491e-a021-d2e7c940dbd8" name="" id="_b54d5ab0-66d8-4595-8a89-9d3e255f75ba"/>
+        <semantic:sequenceFlow sourceRef="_e369fd30-1a71-4d0e-b4d7-2174dd5ba388" targetRef="_187063b6-107e-4ac9-bdb3-e8ce9d83763d" name="" id="_504b3bd1-54f6-4f20-8244-32f4ec639248"/>
+        <semantic:sequenceFlow sourceRef="_3c56e6dc-bc87-4d98-b499-462c5b741c5a" targetRef="_56ab3884-4b26-4398-be6f-5f0bb5f81be4" name="" id="_708324bb-26d0-4358-a96f-a4fabc14069f"/>
+        <semantic:sequenceFlow sourceRef="_56ab3884-4b26-4398-be6f-5f0bb5f81be4" targetRef="_d92d850c-37ac-47ea-9344-dc986289de47" name="" id="_e03319e1-0dff-4337-9443-b053651000a0"/>
+        <semantic:sequenceFlow sourceRef="_5a6baa94-303a-4750-bde2-e1cd6edace37" targetRef="_25a1f26b-d8b8-4b9b-b768-f14b8d104f9c" name="" id="_e59dbf35-3f4e-4701-bc2a-75e32cbaa732"/>
+        <semantic:sequenceFlow sourceRef="_3a19ce2d-e30d-461c-aeaa-b2acb118f9a4" targetRef="_73343358-7838-48a1-baf2-2b0266e3a55b" name="" id="_2257c019-bc17-4ba9-9e07-a9de7913ada3"/>
+        <semantic:sequenceFlow sourceRef="_73343358-7838-48a1-baf2-2b0266e3a55b" targetRef="_087d0602-ff51-491e-a021-d2e7c940dbd8" name="" id="_02f751bb-2e42-489a-bef1-cc5360d5c3d8"/>
+        <semantic:sequenceFlow sourceRef="_e454657a-0173-41a4-a4c7-d16ec224f2e1" targetRef="_663e9963-9cf6-4032-9652-3a20f50dcda3" name="" id="_a639a36d-a1df-43b1-8ed1-e06afa899733"/>
+        <semantic:sequenceFlow sourceRef="_663e9963-9cf6-4032-9652-3a20f50dcda3" targetRef="_dfb273c6-0ad3-4030-9e72-638adf7ca75f" name="" id="_9e4cd50c-cd6b-4523-8dbe-ebece9b823cb"/>
+        <semantic:sequenceFlow sourceRef="_189118eb-65fc-43e8-8a34-a155b113914f" targetRef="_d58753a7-d38b-49cd-914d-14e4cdaa4449" name="" id="_a3fffd23-7ce0-4199-8918-c9df7a2c8158"/>
+        <semantic:sequenceFlow sourceRef="_25a1f26b-d8b8-4b9b-b768-f14b8d104f9c" targetRef="_dfb273c6-0ad3-4030-9e72-638adf7ca75f" name="" id="_37312691-7037-44d1-8696-fc6f2021e7a6"/>
+        <semantic:sequenceFlow sourceRef="_10ecbff1-cd15-4a5c-9aa5-6f2a35479416" targetRef="_928cd158-ebe1-4c0a-9c3e-42e77d663aa2" name="" id="_831dbaee-1434-45fc-9c7e-bedd44ad9ea7"/>
+        <semantic:sequenceFlow sourceRef="_928cd158-ebe1-4c0a-9c3e-42e77d663aa2" targetRef="_df7727a0-f509-45eb-bb89-85753f439576" name="" id="_202c373c-f243-413d-904e-9132a0c0e923"/>
+        <semantic:sequenceFlow sourceRef="_df7727a0-f509-45eb-bb89-85753f439576" targetRef="_dfb273c6-0ad3-4030-9e72-638adf7ca75f" name="" id="_0dbfad2a-7b07-4b7b-87b4-3819d28f175d"/>
+        <semantic:sequenceFlow sourceRef="_209105e0-96fc-4278-8451-3b2a1dd18ec9" targetRef="_0ab0e0ac-f88b-4402-9986-e95a72dfc8a3" name="" id="_aa88dfff-5242-4699-b722-a593e54537ce"/>
+        <semantic:sequenceFlow sourceRef="_0ab0e0ac-f88b-4402-9986-e95a72dfc8a3" targetRef="_147b1900-7e7d-4b8f-b243-0155265f1c00" name="" id="_219e1df4-5bfe-4485-a4fd-dcfeeaa7c3d6"/>
+        <semantic:sequenceFlow sourceRef="_d58753a7-d38b-49cd-914d-14e4cdaa4449" targetRef="_df7727a0-f509-45eb-bb89-85753f439576" name="" id="_b9a903b5-4525-42d1-ae5b-24f26d774556"/>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-0-">
+        <semantic:startEvent name="Start Event 8" id="_820dcc70-45ac-4a1e-88ae-f1b4ff925ef6">
+            <semantic:outgoing>_1c5e547a-2391-4133-8199-850cdc024971</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 34" id="_13fbe8ab-af64-4b54-8efb-4c91dd6c6c18">
+            <semantic:incoming>_1c5e547a-2391-4133-8199-850cdc024971</semantic:incoming>
+            <semantic:outgoing>_af94c58e-db10-449f-978d-03e3b375b5a5</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event 15" id="_3cec2a74-8a45-4ef3-a196-690ba64f1b2b">
+            <semantic:incoming>_af94c58e-db10-449f-978d-03e3b375b5a5</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_820dcc70-45ac-4a1e-88ae-f1b4ff925ef6" targetRef="_13fbe8ab-af64-4b54-8efb-4c91dd6c6c18" name="" id="_1c5e547a-2391-4133-8199-850cdc024971"/>
+        <semantic:sequenceFlow sourceRef="_13fbe8ab-af64-4b54-8efb-4c91dd6c6c18" targetRef="_3cec2a74-8a45-4ef3-a196-690ba64f1b2b" name="" id="_af94c58e-db10-449f-978d-03e3b375b5a5"/>
+    </semantic:process>
+    <semantic:message id="Message_1373638080954"/>
+    <semantic:message id="Message_1373638080955"/>
+    <semantic:category id="Cat1373638080956">
+        <semantic:categoryValue value="Group" id="Value_Cat1373638080956"/>
+    </semantic:category>
+    <semantic:collaboration id="C1373638080953">
+        <semantic:participant name="Participant" processRef="WFP-6-1" id="_cde15ee4-b395-43a3-9f5e-9028446f8a52"/>
+        <semantic:participant name="Pool" processRef="WFP-6-2" id="_55bb31e8-9e62-48ea-8f0e-1a748c04bbf6"/>
+        <semantic:messageFlow messageRef="Message_1373638080954" name="Message Flow 2" sourceRef="_c889aa27-e389-48eb-aa18-613ec53614e7" targetRef="_a01498ae-086c-4adc-9229-ec3135bc2bcf" id="_9428f666-fc8a-41be-8a77-9b280e14e7ae"/>
+        <semantic:messageFlow messageRef="Message_1373638080955" name="Message Flow 1" sourceRef="_76ee26df-2c95-495b-9d9a-cb806aea6baf" targetRef="_a38484e2-7bdb-48b1-b62e-139d51d6a147" id="_09e7cb23-4a1b-4165-b93a-cf635c223ee5"/>
+        <semantic:group categoryValueRef="Value_Cat1373638080956" id="_48d300c1-487a-409b-a04a-b195e222ef90"/>
+    </semantic:collaboration>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="B.2.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="C1373638080953">
+            <bpmndi:BPMNShape bpmnElement="_cde15ee4-b395-43a3-9f5e-9028446f8a52" isHorizontal="true" id="S1373638080848__cde15ee4-b395-43a3-9f5e-9028446f8a52">
+                <dc:Bounds height="318.0" width="1954.0" x="14.0" y="72.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="53.3635647444375" width="12.804751171874997" x="18.0" y="204.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_55bb31e8-9e62-48ea-8f0e-1a748c04bbf6" isHorizontal="true" id="S1373638080850__55bb31e8-9e62-48ea-8f0e-1a748c04bbf6">
+                <dc:Bounds height="1092.0" width="1862.0" x="13.0" y="414.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="24.316811814750004" width="12.804751171874997" x="17.0" y="947.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4a6df7ac-26d8-4718-ac05-90af463d5e23" isHorizontal="true" id="S1373638080851__4a6df7ac-26d8-4718-ac05-90af463d5e23">
+                <dc:Bounds height="660.0" width="1831.0" x="44.0" y="414.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="35.5928127913125" width="12.804751171874997" x="44.0" y="726.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3400f56a-4565-47d1-91db-0ba17b958cb2" isHorizontal="true" id="S1373638080852__3400f56a-4565-47d1-91db-0ba17b958cb2">
+                <dc:Bounds height="432.0" width="1831.0" x="44.0" y="1074.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="35.5928127913125" width="12.804751171874997" x="44.0" y="1272.0"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_200f43e7-1385-46e2-a380-3ef16ebe7847" id="S1373638080853__200f43e7-1385-46e2-a380-3ef16ebe7847">
+                <dc:Bounds height="30.0" width="30.0" x="546.0" y="456.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="513.6776675445727" y="491.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_cba8fbed-2bb6-40a9-8ac5-83e827ce9d9f" id="S1373638080854__cba8fbed-2bb6-40a9-8ac5-83e827ce9d9f">
+                <dc:Bounds height="30.0" width="30.0" x="546.0" y="534.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="513.6776675445727" y="569.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_c57a5344-213f-4834-a6c3-94ce878b413c" id="S1373638080855__c57a5344-213f-4834-a6c3-94ce878b413c">
+                <dc:Bounds height="68.0" width="83.0" x="640.0" y="456.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="72.48293963254594" x="645.3333333333334" y="464.38194962475393"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7f4fe4ea-901f-4c74-bcd4-e933495712fd" id="S1373638080856__7f4fe4ea-901f-4c74-bcd4-e933495712fd">
+                <dc:Bounds height="68.0" width="83.0" x="763.0" y="456.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="768.3333333333334" y="477.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_86b052b4-225c-424e-b900-bb94bdd77cec" id="S1373638080857__86b052b4-225c-424e-b900-bb94bdd77cec">
+                <dc:Bounds height="32.0" width="32.0" x="802.0" y="508.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="770.5963254453334" y="545.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3bfec246-ab94-4807-a79a-3df91ac13800" id="S1373638080858__3bfec246-ab94-4807-a79a-3df91ac13800">
+                <dc:Bounds height="68.0" width="83.0" x="885.0" y="456.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="890.3333333333334" y="477.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_778ff738-a5af-4373-a8da-0fbbfae9e00a" id="S1373638080859__778ff738-a5af-4373-a8da-0fbbfae9e00a">
+                <dc:Bounds height="32.0" width="32.0" x="920.0" y="543.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="888.5963254593177" y="580.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ed405919-9fd6-47d0-bb00-9be7d5467efb" id="S1373638080860__ed405919-9fd6-47d0-bb00-9be7d5467efb">
+                <dc:Bounds height="32.0" width="32.0" x="1003.0" y="474.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="971.5963254593177" y="511.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_c9870992-6643-4094-acfd-d76e5e37941b" id="S1373638080861__c9870992-6643-4094-acfd-d76e5e37941b">
+                <dc:Bounds height="68.0" width="83.0" x="1139.0" y="235.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="1144.3333333333333" y="256.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_708d55c8-684a-4e3b-a69d-69c620cd0ac0" id="S1373638080862__708d55c8-684a-4e3b-a69d-69c620cd0ac0">
+                <dc:Bounds height="32.0" width="32.0" x="1179.0" y="287.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_2a08c361-be51-437e-a86d-c62798c14e83" id="S1373638080863__2a08c361-be51-437e-a86d-c62798c14e83">
+                <dc:Bounds height="68.0" width="83.0" x="1367.0" y="119.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1372.3333333333333" y="146.58187638256646"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_732c0641-b12f-448b-b9f8-a68b355782e3" id="S1373638080864__732c0641-b12f-448b-b9f8-a68b355782e3">
+                <dc:Bounds height="32.0" width="32.0" x="1407.0" y="171.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="1379.7407285949394" y="208.40536438462212"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_8f41085a-3302-4cfc-9231-23bb4b43c7a1" id="S1373638080865__8f41085a-3302-4cfc-9231-23bb4b43c7a1">
+                <dc:Bounds height="68.0" width="83.0" x="1331.0" y="297.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1336.3333333333333" y="324.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4e71bf73-1719-401e-a9a2-85dc89fc1150" id="S1373638080866__4e71bf73-1719-401e-a9a2-85dc89fc1150">
+                <dc:Bounds height="30.0" width="30.0" x="71.0" y="139.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="38.67766754457273" y="174.33333333333337"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_5cc02d0f-c090-4e48-8da3-f32cbbca9565" id="S1373638080867__5cc02d0f-c090-4e48-8da3-f32cbbca9565">
+                <dc:Bounds height="32.0" width="32.0" x="1705.0" y="315.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1673.5963254593175" y="352.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_b67ba682-c8d6-465b-b538-c287db18d1be" id="S1373638080868__b67ba682-c8d6-465b-b538-c287db18d1be">
+                <dc:Bounds height="32.0" width="32.0" x="1753.0" y="198.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="117.33333333333331" x="1716.3963254593177" y="239.21339685962118"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0e87da16-736e-45b2-95e5-8f45940f3adf" id="S1373638080869__0e87da16-736e-45b2-95e5-8f45940f3adf">
+                <dc:Bounds height="68.0" width="83.0" x="401.0" y="120.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="406.3333333333333" y="141.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ac1fde31-c0cd-4a8a-9728-a5fb49602de7" id="S1373638080870__ac1fde31-c0cd-4a8a-9728-a5fb49602de7">
+                <dc:Bounds height="68.0" width="83.0" x="701.0" y="120.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="706.3333333333334" y="141.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_dec393e7-f182-4d31-b05f-e33ac3a5e35f" id="S1373638080871__dec393e7-f182-4d31-b05f-e33ac3a5e35f">
+                <dc:Bounds height="42.0" width="42.0" x="538.0" y="133.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="511.3207349081364" y="179.39449922182564"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_397c783e-ad6a-4cf3-8266-9b41962c83bd" id="S1373638080872__397c783e-ad6a-4cf3-8266-9b41962c83bd">
+                <dc:Bounds height="42.0" width="42.0" x="1649.0" y="193.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1622.3207349081365" y="245.88896299673985"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_c9cb2415-6a2e-49d6-84b9-27babcde4088" id="S1373638080873__c9cb2415-6a2e-49d6-84b9-27babcde4088">
+                <dc:Bounds height="32.0" width="32.0" x="1473.0" y="315.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1441.5963254453334" y="352.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a01498ae-086c-4adc-9229-ec3135bc2bcf" id="S1373638080874__a01498ae-086c-4adc-9229-ec3135bc2bcf">
+                <dc:Bounds height="68.0" width="83.0" x="1563.0" y="297.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1568.3333333333333" y="324.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_76ee26df-2c95-495b-9d9a-cb806aea6baf" id="S1373638080875__76ee26df-2c95-495b-9d9a-cb806aea6baf">
+                <dc:Bounds height="68.0" width="83.0" x="264.0" y="120.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="269.3333333333333" y="141.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_149a6e1d-0385-4d0f-a90c-c2150a291a67" isExpanded="false" id="S1373638080876__149a6e1d-0385-4d0f-a90c-c2150a291a67">
+                <dc:Bounds height="79.0" width="97.0" x="1084.0" y="114.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="86.18773333333334" x="1089.3333333333333" y="127.77544311079544"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_303e68ec-dbb3-4d90-8a96-26e0be44f5f3" isExpanded="true" id="S1373638080877__303e68ec-dbb3-4d90-8a96-26e0be44f5f3">
+                <dc:Bounds height="119.0" width="299.0" x="785.0" y="204.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="123.93131376787507" x="790.3333333333334" y="208.88253109965927"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ef372c4d-6c65-4ad2-bc22-5c25e5d0870e" id="S1373638080878__ef372c4d-6c65-4ad2-bc22-5c25e5d0870e">
+                <dc:Bounds height="30.0" width="30.0" x="815.0" y="248.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="782.6776675445728" y="283.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_b9343536-6490-4559-8365-71d5c4cbb7cb" id="S1373638080879__b9343536-6490-4559-8365-71d5c4cbb7cb">
+                <dc:Bounds height="68.0" width="83.0" x="890.0" y="230.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="38.404653515625" width="72.48293963254594" x="895.3333333333334" y="244.78192521069144"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a9b9c08d-377a-49a8-a869-f82308702018" id="S1373638080880__a9b9c08d-377a-49a8-a869-f82308702018">
+                <dc:Bounds height="32.0" width="32.0" x="1026.0" y="248.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="994.5963254593177" y="285.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0326fdf5-7c71-41d9-838c-ab141a1b1ed0" id="S1373638080881__0326fdf5-7c71-41d9-838c-ab141a1b1ed0">
+                <dc:Bounds height="32.0" width="32.0" x="889.0" y="138.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="857.5963254453334" y="175.33333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a74c1d4d-db90-43ff-8920-139a300b39a5" id="S1373638080882__a74c1d4d-db90-43ff-8920-139a300b39a5">
+                <dc:Bounds height="80.0" width="97.0" x="634.0" y="224.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="86.60892388451433" x="639.3333333333334" y="238.60313788531235"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_f3698a93-fe0b-4f49-bfa6-68d055936af3" id="S1373638080883__f3698a93-fe0b-4f49-bfa6-68d055936af3">
+                <dc:Bounds height="68.0" width="83.0" x="1503.0" y="180.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1508.3333333333333" y="207.58187638256646"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_d84e5824-7bb7-4057-9dba-6c8794f7948c" id="S1373638080884__d84e5824-7bb7-4057-9dba-6c8794f7948c">
+                <dc:Bounds height="68.0" width="83.0" x="137.0" y="120.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="142.33333333333334" y="141.18190079662895"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_aa8c769a-276c-4589-b182-7c7bbd0a9e1e" id="S1373638080885__aa8c769a-276c-4589-b182-7c7bbd0a9e1e">
+                <dc:Bounds height="38.0" width="30.0" x="365.0" y="266.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875001" width="100.26666666666667" x="329.9847769028871" y="307.04644331170033"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4815ea6a-ede2-489b-8b37-2cdb2835b02c" id="S1373638080887__4815ea6a-ede2-489b-8b37-2cdb2835b02c">
+                <dc:Bounds height="23.0" width="102.0" x="930.0" y="344.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7e6ccf38-e740-4537-a439-a8e984d066de" isExpanded="true" id="S1373638080888__7e6ccf38-e740-4537-a439-a8e984d066de">
+                <dc:Bounds height="132.0" width="330.0" x="727.0" y="842.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="123.93131376787507" x="732.3333333333334" y="847.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1df01cbc-5d8c-444e-b1db-da3efdee254a" id="S1373638080889__1df01cbc-5d8c-444e-b1db-da3efdee254a">
+                <dc:Bounds height="30.0" width="30.0" x="763.0" y="892.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="730.6776675445728" y="927.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_6936f794-7bbb-4aa1-ae48-3a35bab4e2f4" id="S1373638080890__6936f794-7bbb-4aa1-ae48-3a35bab4e2f4">
+                <dc:Bounds height="68.0" width="83.0" x="847.0" y="873.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="852.3333333333334" y="894.181900796629"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4f744697-3643-41a9-9d07-84c78e2df64b" id="S1373638080891__4f744697-3643-41a9-9d07-84c78e2df64b">
+                <dc:Bounds height="32.0" width="32.0" x="989.0" y="891.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="957.5963254593177" y="928.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_5a6baa94-303a-4750-bde2-e1cd6edace37" id="S1373638080892__5a6baa94-303a-4750-bde2-e1cd6edace37">
+                <dc:Bounds height="32.0" width="32.0" x="989.0" y="958.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="957.5963254453334" y="994.350453575746"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3c56e6dc-bc87-4d98-b499-462c5b741c5a" id="S1373638080893__3c56e6dc-bc87-4d98-b499-462c5b741c5a">
+                <dc:Bounds height="32.0" width="32.0" x="870.0" y="958.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="38.404653515625" width="94.93333333333335" x="838.5963254453334" y="994.7504291616835"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_fa90f891-fc07-463a-97c9-2ee0812351e1" id="S1373638080894__fa90f891-fc07-463a-97c9-2ee0812351e1">
+                <dc:Bounds height="68.0" width="83.0" x="1152.0" y="463.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="1157.3333333333333" y="484.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_68ca1f8b-5028-4079-9e35-619b529f4d71" id="S1373638080895__68ca1f8b-5028-4079-9e35-619b529f4d71">
+                <dc:Bounds height="32.0" width="32.0" x="1192.0" y="515.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="1160.5963254453334" y="550.281565400754"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1237e756-d53c-4591-a731-dafffbf0b3f9" isExpanded="false" id="S1373638080896__1237e756-d53c-4591-a731-dafffbf0b3f9">
+                <dc:Bounds height="75.0" width="92.0" x="1024.0" y="628.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="81.51472544533334" x="1029.3333333333333" y="652.4870793277614"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_45ceee21-0f15-4bf8-87a9-b3f808173e61" id="S1373638080897__45ceee21-0f15-4bf8-87a9-b3f808173e61">
+                <dc:Bounds height="32.0" width="32.0" x="1081.0" y="687.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="1049.5963254453334" y="722.1799072531645"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_73343358-7838-48a1-baf2-2b0266e3a55b" id="S1373638080898__73343358-7838-48a1-baf2-2b0266e3a55b">
+                <dc:Bounds height="68.0" width="83.0" x="1281.0" y="874.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1286.3333333333333" y="901.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e454657a-0173-41a4-a4c7-d16ec224f2e1" id="S1373638080899__e454657a-0173-41a4-a4c7-d16ec224f2e1">
+                <dc:Bounds height="32.0" width="32.0" x="1321.0" y="926.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="1289.5963254453334" y="964.3347055442501"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_137281ee-758e-4c36-8942-74c5d807e1b3" id="S1373638080900__137281ee-758e-4c36-8942-74c5d807e1b3">
+                <dc:Bounds height="68.0" width="83.0" x="540.0" y="874.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="545.3333333333334" y="901.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_79341f54-50d4-4c60-85f3-fe8839a7554b" id="S1373638080901__79341f54-50d4-4c60-85f3-fe8839a7554b">
+                <dc:Bounds height="32.0" width="32.0" x="579.0" y="926.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="547.5963254453334" y="963.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_15e9a3bf-53de-40d8-8364-7f534b175ff4" id="S1373638080902__15e9a3bf-53de-40d8-8364-7f534b175ff4">
+                <dc:Bounds height="68.0" width="83.0" x="1378.0" y="632.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1383.3333333333333" y="659.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e369fd30-1a71-4d0e-b4d7-2174dd5ba388" id="S1373638080903__e369fd30-1a71-4d0e-b4d7-2174dd5ba388">
+                <dc:Bounds height="32.0" width="32.0" x="1418.0" y="684.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="51.204604687499994" width="94.93333333333335" x="1386.5963254453332" y="719.336760652926"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_dbca671f-08b6-4b58-a614-62b98fa36be5" id="S1373638080904__dbca671f-08b6-4b58-a614-62b98fa36be5">
+                <dc:Bounds height="68.0" width="83.0" x="1156.0" y="754.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1161.3333333333333" y="781.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_f2081fdb-3b8a-480b-9f61-fbf683e2018c" id="S1373638080905__f2081fdb-3b8a-480b-9f61-fbf683e2018c">
+                <dc:Bounds height="32.0" width="32.0" x="424.0" y="650.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="392.5963254453333" y="687.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_be29f267-9d56-46ef-8bbc-e13513b25fce" id="S1373638080906__be29f267-9d56-46ef-8bbc-e13513b25fce">
+                <dc:Bounds height="42.0" width="42.0" x="312.0" y="645.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="285.32073490813644" y="692.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_3a19ce2d-e30d-461c-aeaa-b2acb118f9a4" id="S1373638080907__3a19ce2d-e30d-461c-aeaa-b2acb118f9a4">
+                <dc:Bounds height="32.0" width="32.0" x="1307.0" y="772.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ba16239e-181e-4b9f-bc5b-0bb2ee973450" isExpanded="true" id="S1373638080908__ba16239e-181e-4b9f-bc5b-0bb2ee973450">
+                <dc:Bounds height="185.0" width="547.0" x="519.0" y="427.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="109.09244658037508" x="524.3333333333334" y="432.35168326463616"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_087d0602-ff51-491e-a021-d2e7c940dbd8" id="S1373638080909__087d0602-ff51-491e-a021-d2e7c940dbd8">
+                <dc:Bounds height="32.0" width="32.0" x="1623.0" y="650.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1591.5963254593182" y="695.5346322880783"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_49e94b5f-ce21-4c2b-b78d-3cde5c09c15e" isMarkerVisible="true" id="S1373638080910__49e94b5f-ce21-4c2b-b78d-3cde5c09c15e">
+                <dc:Bounds height="42.0" width="42.0" x="681.0" y="645.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="654.3207349081366" y="692.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a38484e2-7bdb-48b1-b62e-139d51d6a147" id="S1373638080911__a38484e2-7bdb-48b1-b62e-139d51d6a147">
+                <dc:Bounds height="30.0" width="30.0" x="116.0" y="651.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="83.67766754457271" y="686.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_c889aa27-e389-48eb-aa18-613ec53614e7" id="S1373638080912__c889aa27-e389-48eb-aa18-613ec53614e7">
+                <dc:Bounds height="32.0" width="32.0" x="1623.0" y="481.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1591.5963254593175" y="518.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_f27040d5-765c-493c-bbe7-9fb6ad04cbdc" id="S1373638080913__f27040d5-765c-493c-bbe7-9fb6ad04cbdc">
+                <dc:Bounds height="32.0" width="32.0" x="1307.0" y="573.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1275.5963254453334" y="610.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447" isExpanded="false" id="S1373638080914__0263ca9e-2ca0-4f4e-b7dd-86e15dcf2447">
+                <dc:Bounds height="68.0" width="83.0" x="540.0" y="632.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="38.404653515625" width="72.48293963254594" x="545.3333333333334" y="646.7819252106915"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_796ccbc5-ad88-465c-849a-87447a0283d3" id="S1373638080915__796ccbc5-ad88-465c-849a-87447a0283d3">
+                <dc:Bounds height="32.0" width="32.0" x="875.0" y="650.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="843.5963254453334" y="687.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_05c6bc89-5265-435c-8a9e-533c44a6888b" id="S1373638080916__05c6bc89-5265-435c-8a9e-533c44a6888b">
+                <dc:Bounds height="32.0" width="32.0" x="398.0" y="892.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="366.5963254453333" y="929.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_511d95ed-38f9-473e-9466-525285a007f5" id="S1373638080917__511d95ed-38f9-473e-9466-525285a007f5">
+                <dc:Bounds height="68.0" width="83.0" x="180.0" y="632.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="185.33333333333334" y="659.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_187063b6-107e-4ac9-bdb3-e8ce9d83763d" id="S1373638080918__187063b6-107e-4ac9-bdb3-e8ce9d83763d">
+                <dc:Bounds height="68.0" width="83.0" x="1491.0" y="740.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1496.3333333333333" y="767.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb" id="S1373638080919__f07e4bd2-768d-42c6-a8d5-24d1c3bfa3cb">
+                <dc:Bounds height="68.0" width="83.0" x="1429.0" y="463.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="72.48293963254594" x="1434.3333333333333" y="484.1819007966289"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_663e9963-9cf6-4032-9652-3a20f50dcda3" id="S1373638080920__663e9963-9cf6-4032-9652-3a20f50dcda3">
+                <dc:Bounds height="68.0" width="83.0" x="1491.0" y="970.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1496.3333333333333" y="997.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_034907bf-d3d7-4629-818c-14c3e69d5bc6" id="S1373638080921__034907bf-d3d7-4629-818c-14c3e69d5bc6">
+                <dc:Bounds height="32.0" width="32.0" x="412.0" y="500.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="380.5963254453333" y="537.3333333333334"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_d58753a7-d38b-49cd-914d-14e4cdaa4449" id="S1373638080922__d58753a7-d38b-49cd-914d-14e4cdaa4449">
+                <dc:Bounds height="68.0" width="83.0" x="1089.0" y="1346.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1094.3333333333333" y="1373.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_209105e0-96fc-4278-8451-3b2a1dd18ec9" id="S1373638080923__209105e0-96fc-4278-8451-3b2a1dd18ec9">
+                <dc:Bounds height="32.0" width="32.0" x="1129.0" y="1398.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_147b1900-7e7d-4b8f-b243-0155265f1c00" id="S1373638080924__147b1900-7e7d-4b8f-b243-0155265f1c00">
+                <dc:Bounds height="32.0" width="32.0" x="1411.0" y="1436.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1379.5963254593175" y="1473.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_25beeb17-acc3-4cca-9590-f1cd2f353434" id="S1373638080925__25beeb17-acc3-4cca-9590-f1cd2f353434">
+                <dc:Bounds height="30.0" width="30.0" x="303.0" y="1231.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="270.67766754457267" y="1266.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_928cd158-ebe1-4c0a-9c3e-42e77d663aa2" id="S1373638080926__928cd158-ebe1-4c0a-9c3e-42e77d663aa2">
+                <dc:Bounds height="68.0" width="83.0" x="882.0" y="1154.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="887.3333333333334" y="1181.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0ab0e0ac-f88b-4402-9986-e95a72dfc8a3" id="S1373638080927__0ab0e0ac-f88b-4402-9986-e95a72dfc8a3">
+                <dc:Bounds height="68.0" width="83.0" x="1275.0" y="1418.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1280.3333333333333" y="1445.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_242b8e6c-681c-438e-ab34-729255121eff" id="S1373638080928__242b8e6c-681c-438e-ab34-729255121eff">
+                <dc:Bounds height="68.0" width="83.0" x="381.0" y="1212.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="386.3333333333333" y="1239.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_25a1f26b-d8b8-4b9b-b768-f14b8d104f9c" id="S1373638080929__25a1f26b-d8b8-4b9b-b768-f14b8d104f9c">
+                <dc:Bounds height="68.0" width="83.0" x="1276.0" y="1098.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1281.3333333333333" y="1125.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_8476a0f7-36b7-4666-a3b2-c18efcc68a94" id="S1373638080930__8476a0f7-36b7-4666-a3b2-c18efcc68a94">
+                <dc:Bounds height="32.0" width="32.0" x="741.0" y="1230.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="709.5963254453334" y="1267.333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_10ecbff1-cd15-4a5c-9aa5-6f2a35479416" id="S1373638080931__10ecbff1-cd15-4a5c-9aa5-6f2a35479416">
+                <dc:Bounds height="42.0" width="42.0" x="807.0" y="1167.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="96.0" x="779.7874015748029" y="1219.0979226743725"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4f5e6e50-d9d0-4f97-959a-d1b8e1e32788" id="S1373638080932__4f5e6e50-d9d0-4f97-959a-d1b8e1e32788">
+                <dc:Bounds height="32.0" width="32.0" x="473.0" y="1394.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="441.5963254453333" y="1431.333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_cbebc7f2-9fb5-4fbf-a6dc-13140c784da7" id="S1373638080933__cbebc7f2-9fb5-4fbf-a6dc-13140c784da7">
+                <dc:Bounds height="68.0" width="83.0" x="603.0" y="1212.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="608.3333333333334" y="1239.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_df7727a0-f509-45eb-bb89-85753f439576" id="S1373638080934__df7727a0-f509-45eb-bb89-85753f439576">
+                <dc:Bounds height="42.0" width="42.0" x="1197.0" y="1241.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1170.3207349081367" y="1289.8732149652435"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_189118eb-65fc-43e8-8a34-a155b113914f" isExpanded="true" id="S1373638080935__189118eb-65fc-43e8-8a34-a155b113914f">
+                <dc:Bounds height="170.0" width="413.0" x="603.0" y="1298.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="123.93131376787507" x="608.3333333333334" y="1303.0232044858028"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_21976b84-4ddd-4ddc-a5a3-825335550796" id="S1373638080936__21976b84-4ddd-4ddc-a5a3-825335550796">
+                <dc:Bounds height="30.0" width="30.0" x="624.0" y="1336.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="591.6776675445728" y="1371.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e233b5e1-244d-422e-8886-4588b7566122" id="S1373638080937__e233b5e1-244d-422e-8886-4588b7566122">
+                <dc:Bounds height="32.0" width="32.0" x="691.0" y="1335.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="659.5963254453334" y="1372.333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_6d90f706-17c9-4635-87c2-ccab31e9a32d" id="S1373638080938__6d90f706-17c9-4635-87c2-ccab31e9a32d">
+                <dc:Bounds height="68.0" width="83.0" x="757.0" y="1317.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="762.3333333333334" y="1344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_84918a6a-5e98-40c6-9155-c081bb5bdee8" isMarkerVisible="true" id="S1373638080939__84918a6a-5e98-40c6-9155-c081bb5bdee8">
+                <dc:Bounds height="42.0" width="42.0" x="875.0" y="1331.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="848.3207349081366" y="1378.333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_d60db966-c03d-4f0e-a5bd-945525fa0aaf" id="S1373638080940__d60db966-c03d-4f0e-a5bd-945525fa0aaf">
+                <dc:Bounds height="32.0" width="32.0" x="955.0" y="1394.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="923.5963254593177" y="1431.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_cd7b1449-fc16-4015-befe-cc9b5aa1df27" id="S1373638080941__cd7b1449-fc16-4015-befe-cc9b5aa1df27">
+                <dc:Bounds height="32.0" width="32.0" x="958.0" y="1335.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="929.2084979056809" y="1372.9522023310271"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_d92d850c-37ac-47ea-9344-dc986289de47" id="S1373638080942__d92d850c-37ac-47ea-9344-dc986289de47">
+                <dc:Bounds height="32.0" width="32.0" x="1147.0" y="1110.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1115.5963254593175" y="1147.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1215d072-524b-4724-99d7-a0a406435904" id="S1373638080943__1215d072-524b-4724-99d7-a0a406435904">
+                <dc:Bounds height="42.0" width="42.0" x="513.0" y="1225.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="486.3207349081364" y="1277.7944748077632"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_dfb273c6-0ad3-4030-9e72-638adf7ca75f" id="S1373638080944__dfb273c6-0ad3-4030-9e72-638adf7ca75f">
+                <dc:Bounds height="32.0" width="32.0" x="1631.0" y="1246.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="1599.5963254593175" y="1283.333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_56ab3884-4b26-4398-be6f-5f0bb5f81be4" id="S1373638080945__56ab3884-4b26-4398-be6f-5f0bb5f81be4">
+                <dc:Bounds height="68.0" width="83.0" x="1000.0" y="1092.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="1005.3333333333335" y="1119.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e" id="S1373638080946__0e99d67a-a88a-4631-85cc-aa1f9cd8cc5e">
+                <dc:Bounds height="68.0" width="83.0" x="699.0" y="1086.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="704.3333333333334" y="1113.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_b9385abf-d293-40b7-848b-8add4db48415" id="S1373638080947__b9385abf-d293-40b7-848b-8add4db48415">
+                <dc:Bounds height="27.0" width="32.0" x="531.0" y="751.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="499.6583333333333" y="781.5197648828125"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_48d300c1-487a-409b-a04a-b195e222ef90" id="S1373638080957__48d300c1-487a-409b-a04a-b195e222ef90">
+                <dc:Bounds height="500.0" width="330.0" x="165.0" y="483.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171874997" width="32.6140530256875" x="454.3859469743125" y="465.6702591886722"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_8b98cde1-aec2-46e8-8be2-d9aa244fcda6" id="E1373638080958__8b98cde1-aec2-46e8-8be2-d9aa244fcda6">
+                <di:waypoint x="702.0" y="687.0"/>
+                <di:waypoint x="702.0" y="800.0"/>
+                <di:waypoint x="1156.0" y="799.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_be71b068-7fa6-4f76-b0a3-8760f4a2911a" id="E1373638080959__be71b068-7fa6-4f76-b0a3-8760f4a2911a">
+                <di:waypoint x="686.0" y="1246.0"/>
+                <di:waypoint x="704.0" y="1246.0"/>
+                <di:waypoint x="741.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_fdd08093-e5b4-4e9e-8088-26887892078a" id="E1373638080960__fdd08093-e5b4-4e9e-8088-26887892078a">
+                <di:waypoint x="465.0" y="1246.0"/>
+                <di:waypoint x="483.0" y="1246.0"/>
+                <di:waypoint x="513.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b41b9c86-bc41-4b6e-ac32-70e1342e6128" id="E1373638080961__b41b9c86-bc41-4b6e-ac32-70e1342e6128">
+                <di:waypoint x="1450.0" y="153.0"/>
+                <di:waypoint x="1669.0" y="153.0"/>
+                <di:waypoint x="1670.0" y="193.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2752e07c-f2e4-4384-8721-70e4abea9765" id="E1373638080963__2752e07c-f2e4-4384-8721-70e4abea9765">
+                <di:waypoint x="1690.0" y="214.0"/>
+                <di:waypoint x="1753.0" y="214.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_088b81bd-2a43-43a7-86c9-34c1cdd5f11b" id="E1373638080964__088b81bd-2a43-43a7-86c9-34c1cdd5f11b">
+                <di:waypoint x="846.0" y="490.0"/>
+                <di:waypoint x="885.0" y="490.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a" id="E1373638080965__2d1047ce-fdd5-4cb6-9f0c-0ee8d6d3044a">
+                <di:waypoint x="794.0" y="907.0"/>
+                <di:waypoint x="812.0" y="907.0"/>
+                <di:waypoint x="847.0" y="907.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_cc2f1bcd-2a97-48c7-94ae-0899e56402ea" id="E1373638080966__cc2f1bcd-2a97-48c7-94ae-0899e56402ea">
+                <di:waypoint x="1512.0" y="497.0"/>
+                <di:waypoint x="1530.0" y="497.0"/>
+                <di:waypoint x="1623.0" y="497.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_aa88dfff-5242-4699-b722-a593e54537ce" id="E1373638080967__aa88dfff-5242-4699-b722-a593e54537ce">
+                <di:waypoint x="1145.0" y="1430.0"/>
+                <di:waypoint x="1145.0" y="1452.0"/>
+                <di:waypoint x="1275.0" y="1452.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_0dbfad2a-7b07-4b7b-87b4-3819d28f175d" id="E1373638080968__0dbfad2a-7b07-4b7b-87b4-3819d28f175d">
+                <di:waypoint x="1239.0" y="1262.0"/>
+                <di:waypoint x="1631.0" y="1262.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_3e8b97e7-d6a5-44dc-b5ca-6f2c39ba4911" id="E1373638080969__3e8b97e7-d6a5-44dc-b5ca-6f2c39ba4911">
+                <di:waypoint x="623.0" y="908.0"/>
+                <di:waypoint x="641.0" y="908.0"/>
+                <di:waypoint x="727.0" y="908.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_7cae752c-c2bd-438b-8d24-48196805a4e8" id="E1373638080970__7cae752c-c2bd-438b-8d24-48196805a4e8">
+                <di:waypoint x="354.0" y="666.0"/>
+                <di:waypoint x="372.0" y="666.0"/>
+                <di:waypoint x="424.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_60ed96e6-5954-48de-861b-7d1e3c1fb23e" id="E1373638080971__60ed96e6-5954-48de-861b-7d1e3c1fb23e">
+                <di:waypoint x="576.0" y="471.0"/>
+                <di:waypoint x="594.0" y="471.0"/>
+                <di:waypoint x="594.0" y="479.0"/>
+                <di:waypoint x="640.0" y="479.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e03319e1-0dff-4337-9443-b053651000a0" id="E1373638080972__e03319e1-0dff-4337-9443-b053651000a0">
+                <di:waypoint x="1083.0" y="1126.0"/>
+                <di:waypoint x="1101.0" y="1126.0"/>
+                <di:waypoint x="1147.0" y="1126.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_9428f666-fc8a-41be-8a77-9b280e14e7ae" id="E1373638080973__9428f666-fc8a-41be-8a77-9b280e14e7ae">
+                <di:waypoint x="1639.0" y="481.0"/>
+                <di:waypoint x="1639.0" y="463.0"/>
+                <di:waypoint x="1605.0" y="463.0"/>
+                <di:waypoint x="1605.0" y="365.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="1565.0237567304075" y="469.02249280629366"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e503a157-f034-4a8a-ae12-aa524a8ebeee" id="E1373638080974__e503a157-f034-4a8a-ae12-aa524a8ebeee">
+                <di:waypoint x="1505.0" y="331.0"/>
+                <di:waypoint x="1523.0" y="331.0"/>
+                <di:waypoint x="1563.0" y="331.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_de249cbe-d431-4e1f-bc8c-a90aec438683" id="E1373638080975__de249cbe-d431-4e1f-bc8c-a90aec438683">
+                <di:waypoint x="1586.0" y="214.0"/>
+                <di:waypoint x="1604.0" y="214.0"/>
+                <di:waypoint x="1649.0" y="214.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_ce44f766-7c92-43e2-93cf-1e2ba7110c4a" id="E1373638080976__ce44f766-7c92-43e2-93cf-1e2ba7110c4a">
+                <di:waypoint x="1461.0" y="666.0"/>
+                <di:waypoint x="1479.0" y="666.0"/>
+                <di:waypoint x="1623.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_07b92d12-375f-41c5-b0a9-8961ac773afe" id="E1373638080977__07b92d12-375f-41c5-b0a9-8961ac773afe">
+                <di:waypoint x="1098.0" y="720.0"/>
+                <di:waypoint x="1098.0" y="777.0"/>
+                <di:waypoint x="1156.0" y="776.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_062ae395-4aba-408b-ac64-4987752be95b" id="E1373638080978__062ae395-4aba-408b-ac64-4987752be95b">
+                <di:waypoint x="930.0" y="907.0"/>
+                <di:waypoint x="948.0" y="907.0"/>
+                <di:waypoint x="989.0" y="907.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_37312691-7037-44d1-8696-fc6f2021e7a6" id="E1373638080979__37312691-7037-44d1-8696-fc6f2021e7a6">
+                <di:waypoint x="1359.0" y="1132.0"/>
+                <di:waypoint x="1647.0" y="1132.0"/>
+                <di:waypoint x="1647.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2a32599c-d1f4-4f2c-bf65-0f0e4f6ac87f" id="E1373638080980__2a32599c-d1f4-4f2c-bf65-0f0e4f6ac87f">
+                <di:waypoint x="430.0" y="908.0"/>
+                <di:waypoint x="448.0" y="908.0"/>
+                <di:waypoint x="540.0" y="908.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_19a7094a-7bdf-4819-af86-be22d2cfdc49" id="E1373638080981__19a7094a-7bdf-4819-af86-be22d2cfdc49">
+                <di:waypoint x="220.0" y="154.0"/>
+                <di:waypoint x="264.0" y="154.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_875031ae-f87c-45a3-ae60-ba0cb0ce0bc1" id="E1373638080982__875031ae-f87c-45a3-ae60-ba0cb0ce0bc1">
+                <di:waypoint x="1646.0" y="331.0"/>
+                <di:waypoint x="1664.0" y="331.0"/>
+                <di:waypoint x="1705.0" y="331.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_8321494b-9c3c-483a-b4d2-79e6254211c0" id="E1373638080983__8321494b-9c3c-483a-b4d2-79e6254211c0">
+                <di:waypoint x="1222.0" y="269.0"/>
+                <di:waypoint x="1669.0" y="269.0"/>
+                <di:waypoint x="1670.0" y="234.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_955edc35-abcc-4cdb-a890-0d7ec15167ae" id="E1373638080984__955edc35-abcc-4cdb-a890-0d7ec15167ae">
+                <di:waypoint x="841.0" y="1351.0"/>
+                <di:waypoint x="859.0" y="1351.0"/>
+                <di:waypoint x="875.0" y="1351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a3fffd23-7ce0-4199-8918-c9df7a2c8158" id="E1373638080985__a3fffd23-7ce0-4199-8918-c9df7a2c8158">
+                <di:waypoint x="1015.0" y="1379.0"/>
+                <di:waypoint x="1033.0" y="1379.0"/>
+                <di:waypoint x="1089.0" y="1380.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_40d118ea-6a9b-4210-a1f1-e093831e0df0" id="E1373638080986__40d118ea-6a9b-4210-a1f1-e093831e0df0">
+                <di:waypoint x="534.0" y="1267.0"/>
+                <di:waypoint x="534.0" y="1339.0"/>
+                <di:waypoint x="603.0" y="1338.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_1f05bcca-f418-4dc6-a78c-a9dde2fab53d" id="E1373638080987__1f05bcca-f418-4dc6-a78c-a9dde2fab53d">
+                <di:waypoint x="654.0" y="1351.0"/>
+                <di:waypoint x="691.0" y="1351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_7c690c39-4274-40c5-a0d2-b503acabbf93" id="E1373638080988__7c690c39-4274-40c5-a0d2-b503acabbf93">
+                <di:waypoint x="333.0" y="1246.0"/>
+                <di:waypoint x="351.0" y="1246.0"/>
+                <di:waypoint x="381.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e1f948a6-db76-4c35-ba36-e430eecb63a4" id="E1373638080989__e1f948a6-db76-4c35-ba36-e430eecb63a4">
+                <di:waypoint x="347.0" y="154.0"/>
+                <di:waypoint x="401.0" y="154.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_9e4cd50c-cd6b-4523-8dbe-ebece9b823cb" id="E1373638080990__9e4cd50c-cd6b-4523-8dbe-ebece9b823cb">
+                <di:waypoint x="1574.0" y="1004.0"/>
+                <di:waypoint x="1647.0" y="1004.0"/>
+                <di:waypoint x="1647.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_03b1de69-7605-4fc2-9797-2309271c208c" id="E1373638080991__03b1de69-7605-4fc2-9797-2309271c208c">
+                <di:waypoint x="723.0" y="1351.0"/>
+                <di:waypoint x="741.0" y="1351.0"/>
+                <di:waypoint x="757.0" y="1351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_9ff30396-5ef2-42c0-ab4b-5343fbb0af21" id="E1373638080992__9ff30396-5ef2-42c0-ab4b-5343fbb0af21">
+                <di:waypoint x="968.0" y="490.0"/>
+                <di:waypoint x="986.0" y="490.0"/>
+                <di:waypoint x="1003.0" y="490.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a639a36d-a1df-43b1-8ed1-e06afa899733" id="E1373638080993__a639a36d-a1df-43b1-8ed1-e06afa899733">
+                <di:waypoint x="1337.0" y="958.0"/>
+                <di:waypoint x="1337.0" y="1004.0"/>
+                <di:waypoint x="1491.0" y="1004.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5f52bb2a-c49d-43ae-9253-7b89a8251b2b" id="E1373638080994__5f52bb2a-c49d-43ae-9253-7b89a8251b2b">
+                <di:waypoint x="1414.0" y="331.0"/>
+                <di:waypoint x="1432.0" y="331.0"/>
+                <di:waypoint x="1473.0" y="331.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_504b3bd1-54f6-4f20-8244-32f4ec639248" id="E1373638080995__504b3bd1-54f6-4f20-8244-32f4ec639248">
+                <di:waypoint x="1434.0" y="716.0"/>
+                <di:waypoint x="1434.0" y="775.0"/>
+                <di:waypoint x="1491.0" y="774.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5d70a293-03ea-4a73-bed0-65ad145796d6" id="E1373638080996__5d70a293-03ea-4a73-bed0-65ad145796d6">
+                <di:waypoint x="896.0" y="1372.0"/>
+                <di:waypoint x="896.0" y="1410.0"/>
+                <di:waypoint x="955.0" y="1410.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e59dbf35-3f4e-4701-bc2a-75e32cbaa732" id="E1373638080997__e59dbf35-3f4e-4701-bc2a-75e32cbaa732">
+                <di:waypoint x="1005.0" y="990.0"/>
+                <di:waypoint x="1005.0" y="1050.0"/>
+                <di:waypoint x="1238.0" y="1050.0"/>
+                <di:waypoint x="1238.0" y="1132.0"/>
+                <di:waypoint x="1276.0" y="1132.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2257c019-bc17-4ba9-9e07-a9de7913ada3" id="E1373638080998__2257c019-bc17-4ba9-9e07-a9de7913ada3">
+                <di:waypoint x="1323.0" y="804.0"/>
+                <di:waypoint x="1323.0" y="822.0"/>
+                <di:waypoint x="1323.0" y="874.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c9768243-8e1a-4b09-907b-3f27fa831a6e" id="E1373638080999__c9768243-8e1a-4b09-907b-3f27fa831a6e">
+                <di:waypoint x="505.0" y="1410.0"/>
+                <di:waypoint x="523.0" y="1410.0"/>
+                <di:waypoint x="603.0" y="1410.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e0fbb051-0e07-43cc-a8bf-158492541c0f" id="E1373638081000__e0fbb051-0e07-43cc-a8bf-158492541c0f">
+                <di:waypoint x="921.0" y="154.0"/>
+                <di:waypoint x="939.0" y="154.0"/>
+                <di:waypoint x="1084.0" y="153.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e062c113-2da3-40f1-845e-6fd48ccc880f" id="E1373638081001__e062c113-2da3-40f1-845e-6fd48ccc880f">
+                <di:waypoint x="457.0" y="666.0"/>
+                <di:waypoint x="475.0" y="666.0"/>
+                <di:waypoint x="540.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_00140039-2e5d-4c58-9197-1f8512b54c99" id="E1373638081002__00140039-2e5d-4c58-9197-1f8512b54c99">
+                <di:waypoint x="782.0" y="1120.0"/>
+                <di:waypoint x="827.0" y="1120.0"/>
+                <di:waypoint x="828.0" y="1167.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5362a7ef-ce7e-4a91-9c38-66c07b1b5f49" id="E1373638081003__5362a7ef-ce7e-4a91-9c38-66c07b1b5f49">
+                <di:waypoint x="827.0" y="323.0"/>
+                <di:waypoint x="827.0" y="356.0"/>
+                <di:waypoint x="930.0" y="356.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_708324bb-26d0-4358-a96f-a4fabc14069f" id="E1373638081004__708324bb-26d0-4358-a96f-a4fabc14069f">
+                <di:waypoint x="886.0" y="990.0"/>
+                <di:waypoint x="886.0" y="1126.0"/>
+                <di:waypoint x="1000.0" y="1126.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_78361e03-8ab9-4317-b8f6-2daa90f20f54" id="E1373638081005__78361e03-8ab9-4317-b8f6-2daa90f20f54">
+                <di:waypoint x="1208.0" y="547.0"/>
+                <di:waypoint x="1208.0" y="589.0"/>
+                <di:waypoint x="1307.0" y="589.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e6537f9d-e5ea-4abc-a6e8-add13a11b536" id="E1373638081006__e6537f9d-e5ea-4abc-a6e8-add13a11b536">
+                <di:waypoint x="1083.0" y="268.0"/>
+                <di:waypoint x="1101.0" y="268.0"/>
+                <di:waypoint x="1139.0" y="269.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a9966baf-d9b9-4be1-a4d9-2906ab5add30" id="E1373638081007__a9966baf-d9b9-4be1-a4d9-2906ab5add30">
+                <di:waypoint x="580.0" y="154.0"/>
+                <di:waypoint x="598.0" y="154.0"/>
+                <di:waypoint x="701.0" y="154.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="593.1708259530576" y="141.2017410256909"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_168f4ce9-ccf7-4833-b38b-0140ff601d40" id="E1373638081008__168f4ce9-ccf7-4833-b38b-0140ff601d40">
+                <di:waypoint x="263.0" y="666.0"/>
+                <di:waypoint x="281.0" y="666.0"/>
+                <di:waypoint x="312.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a63c8cd6-eee8-4fbe-be5e-f6980b180b52" id="E1373638081009__a63c8cd6-eee8-4fbe-be5e-f6980b180b52">
+                <di:waypoint x="146.0" y="666.0"/>
+                <di:waypoint x="164.0" y="666.0"/>
+                <di:waypoint x="180.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_670ceb69-cd3a-46e8-96a0-a520a8fc589b" id="E1373638081010__670ceb69-cd3a-46e8-96a0-a520a8fc589b">
+                <di:waypoint x="723.0" y="666.0"/>
+                <di:waypoint x="875.0" y="666.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="751.5027638886821" y="653.2002670099429"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5853836e-d7ca-45e2-852a-7db8c3c642bb" id="E1373638081011__5853836e-d7ca-45e2-852a-7db8c3c642bb">
+                <di:waypoint x="333.0" y="645.0"/>
+                <di:waypoint x="333.0" y="516.0"/>
+                <di:waypoint x="412.0" y="516.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_54574511-c29e-4157-bb8f-8b26f15faaf5" id="E1373638081012__54574511-c29e-4157-bb8f-8b26f15faaf5">
+                <di:waypoint x="1423.0" y="203.0"/>
+                <di:waypoint x="1423.0" y="213.0"/>
+                <di:waypoint x="1503.0" y="214.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b9a903b5-4525-42d1-ae5b-24f26d774556" id="E1373638081013__b9a903b5-4525-42d1-ae5b-24f26d774556">
+                <di:waypoint x="1172.0" y="1380.0"/>
+                <di:waypoint x="1218.0" y="1380.0"/>
+                <di:waypoint x="1218.0" y="1282.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_202c373c-f243-413d-904e-9132a0c0e923" id="E1373638081014__202c373c-f243-413d-904e-9132a0c0e923">
+                <di:waypoint x="965.0" y="1188.0"/>
+                <di:waypoint x="1218.0" y="1188.0"/>
+                <di:waypoint x="1218.0" y="1241.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_02f751bb-2e42-489a-bef1-cc5360d5c3d8" id="E1373638081015__02f751bb-2e42-489a-bef1-cc5360d5c3d8">
+                <di:waypoint x="1364.0" y="908.0"/>
+                <di:waypoint x="1638.0" y="908.0"/>
+                <di:waypoint x="1639.0" y="682.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b8694c28-408b-4394-b476-41e2a5bcfd94" id="E1373638081016__b8694c28-408b-4394-b476-41e2a5bcfd94">
+                <di:waypoint x="784.0" y="154.0"/>
+                <di:waypoint x="802.0" y="154.0"/>
+                <di:waypoint x="889.0" y="154.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_4474c77a-01bb-435e-929a-7eb71bd824a8" id="E1373638081017__4474c77a-01bb-435e-929a-7eb71bd824a8">
+                <di:waypoint x="484.0" y="154.0"/>
+                <di:waypoint x="502.0" y="154.0"/>
+                <di:waypoint x="538.0" y="154.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c72ddf62-21b8-4895-a7bf-7a765f5981eb" id="E1373638081018__c72ddf62-21b8-4895-a7bf-7a765f5981eb">
+                <di:waypoint x="576.0" y="549.0"/>
+                <di:waypoint x="594.0" y="549.0"/>
+                <di:waypoint x="594.0" y="502.0"/>
+                <di:waypoint x="640.0" y="502.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_8021571a-7a77-426b-b824-545cc61f7334" id="E1373638081019__8021571a-7a77-426b-b824-545cc61f7334">
+                <di:waypoint x="917.0" y="1351.0"/>
+                <di:waypoint x="958.0" y="1351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_831dbaee-1434-45fc-9c7e-bedd44ad9ea7" id="E1373638081020__831dbaee-1434-45fc-9c7e-bedd44ad9ea7">
+                <di:waypoint x="848.0" y="1188.0"/>
+                <di:waypoint x="866.0" y="1188.0"/>
+                <di:waypoint x="882.0" y="1188.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_f906ca20-8666-41ff-9d37-b76e09ac4f94" targetElement="S1373638080869__0e87da16-736e-45b2-95e5-8f45940f3adf" id="E1373638081021__f906ca20-8666-41ff-9d37-b76e09ac4f94">
+                <di:waypoint x="395.0" y="284.0"/>
+                <di:waypoint x="442.0" y="284.0"/>
+                <di:waypoint x="442.0" y="188.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b77e4b02-22b9-4a57-b0f9-4248410d0675" id="E1373638081022__b77e4b02-22b9-4a57-b0f9-4248410d0675">
+                <di:waypoint x="1116.0" y="666.0"/>
+                <di:waypoint x="1134.0" y="666.0"/>
+                <di:waypoint x="1378.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_dbae7e12-67c2-4256-8c50-5811c207ba55" id="E1373638081023__dbae7e12-67c2-4256-8c50-5811c207ba55">
+                <di:waypoint x="1181.0" y="153.0"/>
+                <di:waypoint x="1199.0" y="153.0"/>
+                <di:waypoint x="1367.0" y="153.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_219e1df4-5bfe-4485-a4fd-dcfeeaa7c3d6" id="E1373638081024__219e1df4-5bfe-4485-a4fd-dcfeeaa7c3d6">
+                <di:waypoint x="1358.0" y="1452.0"/>
+                <di:waypoint x="1376.0" y="1452.0"/>
+                <di:waypoint x="1411.0" y="1452.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_6c6288e8-43f6-4085-87c7-1ff21c38fe17" id="E1373638081025__6c6288e8-43f6-4085-87c7-1ff21c38fe17">
+                <di:waypoint x="723.0" y="490.0"/>
+                <di:waypoint x="763.0" y="490.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_837a8629-1540-473c-b41f-7e13ad80c052" id="E1373638081026__837a8629-1540-473c-b41f-7e13ad80c052">
+                <di:waypoint x="907.0" y="666.0"/>
+                <di:waypoint x="925.0" y="666.0"/>
+                <di:waypoint x="1024.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2c124731-3338-46e0-81b5-b435f34941c8" id="E1373638081027__2c124731-3338-46e0-81b5-b435f34941c8">
+                <di:waypoint x="101.0" y="154.0"/>
+                <di:waypoint x="119.0" y="154.0"/>
+                <di:waypoint x="137.0" y="154.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_4c3f3102-d31a-4a71-a3d0-b65cb61a94ea" id="E1373638081028__4c3f3102-d31a-4a71-a3d0-b65cb61a94ea">
+                <di:waypoint x="595.0" y="958.0"/>
+                <di:waypoint x="595.0" y="1120.0"/>
+                <di:waypoint x="699.0" y="1120.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_70617827-824b-4797-b424-4179b8b6cbdd" id="E1373638081029__70617827-824b-4797-b424-4179b8b6cbdd">
+                <di:waypoint x="1057.0" y="908.0"/>
+                <di:waypoint x="1075.0" y="908.0"/>
+                <di:waypoint x="1281.0" y="908.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c8c10b02-ea53-4a0c-b605-b3252d5560cd" id="E1373638081030__c8c10b02-ea53-4a0c-b605-b3252d5560cd">
+                <di:waypoint x="1236.0" y="497.0"/>
+                <di:waypoint x="1254.0" y="497.0"/>
+                <di:waypoint x="1429.0" y="497.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_09e7cb23-4a1b-4165-b93a-cf635c223ee5" messageVisibleKind="initiating" id="E1373638081031__09e7cb23-4a1b-4165-b93a-cf635c223ee5">
+                <di:waypoint x="305.0" y="188.0"/>
+                <di:waypoint x="305.0" y="342.0"/>
+                <di:waypoint x="130.0" y="342.0"/>
+                <di:waypoint x="131.0" y="651.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="167.10533963254568" y="359.56612835107035"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_f61be5ab-acb2-4348-a9a0-bdfdde0c42ad" id="E1373638081032__f61be5ab-acb2-4348-a9a0-bdfdde0c42ad">
+                <di:waypoint x="773.0" y="1246.0"/>
+                <di:waypoint x="827.0" y="1246.0"/>
+                <di:waypoint x="828.0" y="1209.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_da47ac6a-4ea1-4bf6-ad3e-8cc60c0ea8a9" id="E1373638081033__da47ac6a-4ea1-4bf6-ad3e-8cc60c0ea8a9">
+                <di:waypoint x="1195.0" y="319.0"/>
+                <di:waypoint x="1195.0" y="331.0"/>
+                <di:waypoint x="1331.0" y="331.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c1931975-c1c3-499e-8a57-89b61affba3a" id="E1373638081034__c1931975-c1c3-499e-8a57-89b61affba3a">
+                <di:waypoint x="1066.0" y="486.0"/>
+                <di:waypoint x="1084.0" y="486.0"/>
+                <di:waypoint x="1152.0" y="485.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b54d5ab0-66d8-4595-8a89-9d3e255f75ba" id="E1373638081035__b54d5ab0-66d8-4595-8a89-9d3e255f75ba">
+                <di:waypoint x="1574.0" y="774.0"/>
+                <di:waypoint x="1639.0" y="774.0"/>
+                <di:waypoint x="1639.0" y="682.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_022aa2b9-f472-49be-b00b-2eec7f075acf" id="E1373638081036__022aa2b9-f472-49be-b00b-2eec7f075acf">
+                <di:waypoint x="554.0" y="1246.0"/>
+                <di:waypoint x="572.0" y="1246.0"/>
+                <di:waypoint x="603.0" y="1246.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_8095da9c-0faa-47b9-85d4-2df24e021770" id="E1373638081037__8095da9c-0faa-47b9-85d4-2df24e021770">
+                <di:waypoint x="623.0" y="666.0"/>
+                <di:waypoint x="641.0" y="666.0"/>
+                <di:waypoint x="681.0" y="666.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_bd5730fa-544e-4a99-a238-57171787d52c" id="E1373638081038__bd5730fa-544e-4a99-a238-57171787d52c">
+                <di:waypoint x="1239.0" y="788.0"/>
+                <di:waypoint x="1257.0" y="788.0"/>
+                <di:waypoint x="1307.0" y="788.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_99e68e88-586e-4f77-9506-f30903307209" id="E1373638081039__99e68e88-586e-4f77-9506-f30903307209">
+                <di:waypoint x="818.0" y="540.0"/>
+                <di:waypoint x="818.0" y="558.0"/>
+                <di:waypoint x="920.0" y="559.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_ab34472d-95a4-459c-a13b-5ed8b8b75eca" id="E1373638081040__ab34472d-95a4-459c-a13b-5ed8b8b75eca">
+                <di:waypoint x="333.0" y="686.0"/>
+                <di:waypoint x="333.0" y="907.0"/>
+                <di:waypoint x="398.0" y="908.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_be19c2da-316a-47f6-ad7b-eb6c82bf8609" id="E1373638081041__be19c2da-316a-47f6-ad7b-eb6c82bf8609">
+                <di:waypoint x="559.0" y="175.0"/>
+                <di:waypoint x="559.0" y="264.0"/>
+                <di:waypoint x="634.0" y="264.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373638080849">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="509.59632545931754" y="221.39449922182564"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_87ffa0fa-1a2d-4149-bbe9-04e20bc1014b" id="E1373638081042__87ffa0fa-1a2d-4149-bbe9-04e20bc1014b">
+                <di:waypoint x="973.0" y="264.0"/>
+                <di:waypoint x="991.0" y="264.0"/>
+                <di:waypoint x="1026.0" y="264.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_5106fe5e-184d-4069-8c1c-54f81fd577a9" id="E1373638081043__5106fe5e-184d-4069-8c1c-54f81fd577a9">
+                <di:waypoint x="444.0" y="516.0"/>
+                <di:waypoint x="462.0" y="516.0"/>
+                <di:waypoint x="519.0" y="516.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c68194b4-3618-4655-b128-7eec67483c84" id="E1373638081044__c68194b4-3618-4655-b128-7eec67483c84">
+                <di:waypoint x="845.0" y="264.0"/>
+                <di:waypoint x="863.0" y="264.0"/>
+                <di:waypoint x="890.0" y="264.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_ce63770e-9f4b-4bc0-a56c-88401c59f0bf" id="E1373638081045__ce63770e-9f4b-4bc0-a56c-88401c59f0bf">
+                <di:waypoint x="731.0" y="264.0"/>
+                <di:waypoint x="749.0" y="264.0"/>
+                <di:waypoint x="785.0" y="264.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373638080849">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.2.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.2.0.bpmn
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions
+    xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://www.trisotech.com/definitions/_1aa4e08d-219c-418c-8aed-5ddf4cd45a41" id="_1aa4e08d-219c-418c-8aed-5ddf4cd45a41" exporter="BPMN 2.0 Web Modeler" exporterVersion="4.2.3" name="C.2.0" targetNamespace="http://www.trisotech.com/definitions/_1aa4e08d-219c-418c-8aed-5ddf4cd45a41" expressionLanguage="http://www.w3.org/1999/XPath" typeLanguage="http://www.w3.org/2001/XMLSchema">
+    <semantic:message id="Message_1404332496319"/>
+    <semantic:message id="Message_1404332496320"/>
+    <semantic:message id="Message_1404332496321"/>
+    <semantic:message id="Message_1404332496322"/>
+    <semantic:message id="Message_1404332496323"/>
+    <semantic:collaboration id="C1404332496310">
+        <semantic:participant id="__bb6766c5-51e3-4f04-aedc-6c9e4afe0582" name="Carrier" processRef="WFP-Page_1-2"/>
+        <semantic:participant id="__3cf88d6c-e5e4-489e-bc73-e2a18be946bf" name="Credit Card Company" processRef="WFP-Page_1-1"/>
+        <semantic:participant id="__6f70606b-6781-4f26-b207-5bfff80115d8" name="Customer" processRef="WFP-Page_1-3"/>
+        <semantic:participant id="__a42178ea-f777-4c5b-a0a1-c4014aee6431" name="Amazon" processRef="WFP-Page_1-4"/>
+        <semantic:messageFlow id="__13e0b8fd-91fe-4bbc-87ae-5ad657f6ef99" messageRef="Message_1404332496322" sourceRef="__f867d5f7-db1e-4015-9856-c53bc9cb4b51" targetRef="_95a2fb99-bb98-4d26-b5ec-3dae3a32fd79"/>
+        <semantic:messageFlow id="__5cdd91dd-32f6-4102-b475-bd6c7992f509" messageRef="Message_1404332496323" sourceRef="__c1a19847-8b3e-42db-a95d-9f21cffc50a3" targetRef="__e6a9dd54-6cb0-4713-8b77-e659f2658e40"/>
+        <semantic:messageFlow id="__789952b8-abba-4f3f-81cd-24cbb4d0d615" messageRef="Message_1404332496321" sourceRef="_f35ee29d-018c-47e2-afeb-eebc2e25925e" targetRef="__fd16081c-ecf9-4e0f-857f-f3404a7ee784"/>
+        <semantic:messageFlow id="__86b33cf0-1b17-437f-a7cf-510e0766561f" name="Send Credit Card Information" messageRef="Message_1404332496319" sourceRef="_2f24e6da-b44f-4e30-8d85-fd35fd56e209" targetRef="__0ef615c7-5456-45c8-9cfb-f1fe30c44436"/>
+        <semantic:messageFlow id="__0c171c64-b342-4f84-8020-a63b6a5b296d" messageRef="Message_1404332496320" sourceRef="__4011aa2d-a7a9-4e1a-9f16-8a662d138bd4" targetRef="_2f24e6da-b44f-4e30-8d85-fd35fd56e209"/>
+    </semantic:collaboration>
+    <semantic:process isExecutable="false" id="WFP-Page_1-1">
+        <semantic:task id="__a7183fc9-402a-418c-bf2a-3b1927d3798d" name="Take Payment" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__f3f918b3-abee-4e59-8131-212d0d86b056</semantic:incoming>
+            <semantic:outgoing>__47cf5284-b9ff-4136-93fd-f0f32b87810f</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__47cf5284-b9ff-4136-93fd-f0f32b87810f" sourceRef="__a7183fc9-402a-418c-bf2a-3b1927d3798d" targetRef="__4011aa2d-a7a9-4e1a-9f16-8a662d138bd4"/>
+        <semantic:sequenceFlow id="__f3f918b3-abee-4e59-8131-212d0d86b056" sourceRef="__0ef615c7-5456-45c8-9cfb-f1fe30c44436" targetRef="__a7183fc9-402a-418c-bf2a-3b1927d3798d"/>
+        <semantic:startEvent id="__0ef615c7-5456-45c8-9cfb-f1fe30c44436" name="Receive Credit Card Information" isInterrupting="true">
+            <semantic:outgoing>__f3f918b3-abee-4e59-8131-212d0d86b056</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Message_1404332496319"/>
+        </semantic:startEvent>
+        <semantic:endEvent id="__4011aa2d-a7a9-4e1a-9f16-8a662d138bd4" name="Send Result">
+            <semantic:incoming>__47cf5284-b9ff-4136-93fd-f0f32b87810f</semantic:incoming>
+            <semantic:messageEventDefinition messageRef="Message_1404332496320"/>
+        </semantic:endEvent>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-Page_1-2">
+        <semantic:task id="__f867d5f7-db1e-4015-9856-c53bc9cb4b51" name="Deliver Items" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__36fbe220-08cc-45e8-847b-3f55002979c2</semantic:incoming>
+            <semantic:outgoing>__b355021c-ac23-48bf-9d1a-45c32565ba39</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__b355021c-ac23-48bf-9d1a-45c32565ba39" sourceRef="__f867d5f7-db1e-4015-9856-c53bc9cb4b51" targetRef="__6c41ae4a-64fd-40f9-a764-059b26ef8ebf"/>
+        <semantic:sequenceFlow id="__36fbe220-08cc-45e8-847b-3f55002979c2" sourceRef="__a9de74be-ce4b-4d59-bafd-cf6f61f48867" targetRef="__f867d5f7-db1e-4015-9856-c53bc9cb4b51"/>
+        <semantic:task id="__a9de74be-ce4b-4d59-bafd-cf6f61f48867" name="Load Truck" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__474f19b8-f608-4d20-a49e-907485a789c5</semantic:incoming>
+            <semantic:outgoing>__36fbe220-08cc-45e8-847b-3f55002979c2</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__474f19b8-f608-4d20-a49e-907485a789c5" sourceRef="__e6a9dd54-6cb0-4713-8b77-e659f2658e40" targetRef="__a9de74be-ce4b-4d59-bafd-cf6f61f48867"/>
+        <semantic:endEvent id="__6c41ae4a-64fd-40f9-a764-059b26ef8ebf">
+            <semantic:incoming>__b355021c-ac23-48bf-9d1a-45c32565ba39</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:startEvent id="__e6a9dd54-6cb0-4713-8b77-e659f2658e40" name="Pick items" isInterrupting="true">
+            <semantic:outgoing>__474f19b8-f608-4d20-a49e-907485a789c5</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Message_1404332496323"/>
+        </semantic:startEvent>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-Page_1-3">
+        <semantic:startEvent id="__f5b8cb41-0574-4c29-aaaa-84ecce589f84">
+            <semantic:outgoing>__6fd770bc-8f12-4927-96cd-e3cc53d862d3</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:sequenceFlow id="__6fd770bc-8f12-4927-96cd-e3cc53d862d3" sourceRef="__f5b8cb41-0574-4c29-aaaa-84ecce589f84" targetRef="__f61e9ae0-855f-4ce6-9e3a-4b4f5c7dd0b8"/>
+        <semantic:task id="__be386700-06c2-4a29-b861-c516940667fe" name="Add Item to Cart" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__e8a6634d-4c67-4ec3-b8cf-18bf3987c281</semantic:incoming>
+            <semantic:outgoing>__82227f00-3d5e-446e-a2e7-50b907ed7c8c</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__82227f00-3d5e-446e-a2e7-50b907ed7c8c" sourceRef="__be386700-06c2-4a29-b861-c516940667fe" targetRef="__509f09eb-5518-4995-b98b-db3cf3f8ea00"/>
+        <semantic:sequenceFlow id="__e8a6634d-4c67-4ec3-b8cf-18bf3987c281" sourceRef="__f61e9ae0-855f-4ce6-9e3a-4b4f5c7dd0b8" targetRef="__be386700-06c2-4a29-b861-c516940667fe"/>
+        <semantic:subProcess id="__5ffa1675-9ad7-46f8-b19a-85cd5878496f" name="Checkout" startQuantity="1" completionQuantity="1" isForCompensation="false" triggeredByEvent="false">
+            <semantic:incoming>__a12a7547-373d-47ec-890d-af5c177203ee</semantic:incoming>
+            <semantic:outgoing>__5d3be9f3-3f7a-4778-89e5-1bf4951472c2</semantic:outgoing>
+            <semantic:startEvent id="__a1c27e25-4aa2-43dc-8a20-b713e8393d7f">
+                <semantic:outgoing>__00bc466e-cf1f-473c-aa39-c78bba5cef82</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:sequenceFlow id="__00bc466e-cf1f-473c-aa39-c78bba5cef82" sourceRef="__a1c27e25-4aa2-43dc-8a20-b713e8393d7f" targetRef="_2f24e6da-b44f-4e30-8d85-fd35fd56e209"/>
+            <semantic:task id="_2f24e6da-b44f-4e30-8d85-fd35fd56e209" name="Pay Order" startQuantity="1" completionQuantity="1" isForCompensation="false">
+                <semantic:incoming>__00bc466e-cf1f-473c-aa39-c78bba5cef82</semantic:incoming>
+                <semantic:incoming>_63cf98c9-d0b1-4595-a4f2-9589439b311c</semantic:incoming>
+                <semantic:outgoing>_520aac43-77a5-40e8-84a4-ec51e17ad9b2</semantic:outgoing>
+            </semantic:task>
+            <semantic:sequenceFlow id="_520aac43-77a5-40e8-84a4-ec51e17ad9b2" sourceRef="_2f24e6da-b44f-4e30-8d85-fd35fd56e209" targetRef="_bb4a73bd-2291-4494-8677-5560d4842f79"/>
+            <semantic:sequenceFlow id="_63cf98c9-d0b1-4595-a4f2-9589439b311c" name="Yes" sourceRef="_29a5e7c6-e54e-4c61-ba35-59ae446a3462" targetRef="_2f24e6da-b44f-4e30-8d85-fd35fd56e209"/>
+            <semantic:exclusiveGateway id="_29a5e7c6-e54e-4c61-ba35-59ae446a3462" name="Retry?" gatewayDirection="Unspecified">
+                <semantic:incoming>_bfa5c7b2-f5d2-4487-a307-b2ea662bd059</semantic:incoming>
+                <semantic:outgoing>_ad0872cc-e2a9-4c44-98c6-c64e0638f37e</semantic:outgoing>
+                <semantic:outgoing>_63cf98c9-d0b1-4595-a4f2-9589439b311c</semantic:outgoing>
+            </semantic:exclusiveGateway>
+            <semantic:sequenceFlow id="_ad0872cc-e2a9-4c44-98c6-c64e0638f37e" name="No" sourceRef="_29a5e7c6-e54e-4c61-ba35-59ae446a3462" targetRef="_7ea6639e-e773-4236-94bf-78f149188c30"/>
+            <semantic:sequenceFlow id="_bfa5c7b2-f5d2-4487-a307-b2ea662bd059" name="No" sourceRef="_bb4a73bd-2291-4494-8677-5560d4842f79" targetRef="_29a5e7c6-e54e-4c61-ba35-59ae446a3462"/>
+            <semantic:exclusiveGateway id="_bb4a73bd-2291-4494-8677-5560d4842f79" name="Payment accepted?" gatewayDirection="Unspecified">
+                <semantic:incoming>_520aac43-77a5-40e8-84a4-ec51e17ad9b2</semantic:incoming>
+                <semantic:outgoing>_bfa5c7b2-f5d2-4487-a307-b2ea662bd059</semantic:outgoing>
+                <semantic:outgoing>_50edb87c-9e46-48b1-a311-ef00e6e431e8</semantic:outgoing>
+            </semantic:exclusiveGateway>
+            <semantic:sequenceFlow id="_50edb87c-9e46-48b1-a311-ef00e6e431e8" name="Yes" sourceRef="_bb4a73bd-2291-4494-8677-5560d4842f79" targetRef="_f35ee29d-018c-47e2-afeb-eebc2e25925e"/>
+            <semantic:endEvent id="_7ea6639e-e773-4236-94bf-78f149188c30">
+                <semantic:incoming>_ad0872cc-e2a9-4c44-98c6-c64e0638f37e</semantic:incoming>
+                <semantic:errorEventDefinition/>
+            </semantic:endEvent>
+            <semantic:intermediateThrowEvent id="_f35ee29d-018c-47e2-afeb-eebc2e25925e" name="Send Order">
+                <semantic:incoming>_50edb87c-9e46-48b1-a311-ef00e6e431e8</semantic:incoming>
+                <semantic:outgoing>_30c47018-b9e8-4d09-81e2-2b592f75a5cf</semantic:outgoing>
+                <semantic:messageEventDefinition messageRef="Message_1404332496321"/>
+            </semantic:intermediateThrowEvent>
+            <semantic:sequenceFlow id="_30c47018-b9e8-4d09-81e2-2b592f75a5cf" sourceRef="_f35ee29d-018c-47e2-afeb-eebc2e25925e" targetRef="_df393d97-f22e-4442-95be-918b8fdd4c3c"/>
+            <semantic:endEvent id="_df393d97-f22e-4442-95be-918b8fdd4c3c">
+                <semantic:incoming>_30c47018-b9e8-4d09-81e2-2b592f75a5cf</semantic:incoming>
+            </semantic:endEvent>
+        </semantic:subProcess>
+        <semantic:sequenceFlow id="__a12a7547-373d-47ec-890d-af5c177203ee" name="Yes" sourceRef="__509f09eb-5518-4995-b98b-db3cf3f8ea00" targetRef="__5ffa1675-9ad7-46f8-b19a-85cd5878496f"/>
+        <semantic:sequenceFlow id="__5d3be9f3-3f7a-4778-89e5-1bf4951472c2" sourceRef="__5ffa1675-9ad7-46f8-b19a-85cd5878496f" targetRef="_95a2fb99-bb98-4d26-b5ec-3dae3a32fd79"/>
+        <semantic:boundaryEvent id="__cec149db-adae-4b69-8ea4-b866f2eef248" attachedToRef="__5ffa1675-9ad7-46f8-b19a-85cd5878496f">
+            <semantic:outgoing>__dc6ef6c1-9c24-48ae-800f-2f9fb76d7ce6</semantic:outgoing>
+            <semantic:errorEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:sequenceFlow id="__dc6ef6c1-9c24-48ae-800f-2f9fb76d7ce6" sourceRef="__cec149db-adae-4b69-8ea4-b866f2eef248" targetRef="__8f9632f2-9fdb-4e3c-8b10-6a05091de766"/>
+        <semantic:endEvent id="__e03c9539-b011-46b1-a381-0eee5f0521b8">
+            <semantic:incoming>__92bd8ebf-e3b1-4270-96bb-2f6d6978c64a</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow id="__92bd8ebf-e3b1-4270-96bb-2f6d6978c64a" sourceRef="_95a2fb99-bb98-4d26-b5ec-3dae3a32fd79" targetRef="__e03c9539-b011-46b1-a381-0eee5f0521b8"/>
+        <semantic:task id="_95a2fb99-bb98-4d26-b5ec-3dae3a32fd79" name="Receive items" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__5d3be9f3-3f7a-4778-89e5-1bf4951472c2</semantic:incoming>
+            <semantic:outgoing>__92bd8ebf-e3b1-4270-96bb-2f6d6978c64a</semantic:outgoing>
+        </semantic:task>
+        <semantic:exclusiveGateway id="__509f09eb-5518-4995-b98b-db3cf3f8ea00" name="Done Shopping?" gatewayDirection="Unspecified">
+            <semantic:incoming>__82227f00-3d5e-446e-a2e7-50b907ed7c8c</semantic:incoming>
+            <semantic:outgoing>__ffc1486a-8a32-490a-8835-d14cc5ab0a97</semantic:outgoing>
+            <semantic:outgoing>__a12a7547-373d-47ec-890d-af5c177203ee</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow id="__ffc1486a-8a32-490a-8835-d14cc5ab0a97" name="No" sourceRef="__509f09eb-5518-4995-b98b-db3cf3f8ea00" targetRef="__f61e9ae0-855f-4ce6-9e3a-4b4f5c7dd0b8"/>
+        <semantic:task id="__f61e9ae0-855f-4ce6-9e3a-4b4f5c7dd0b8" name="Browse Products on Amazon" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__6fd770bc-8f12-4927-96cd-e3cc53d862d3</semantic:incoming>
+            <semantic:incoming>__ffc1486a-8a32-490a-8835-d14cc5ab0a97</semantic:incoming>
+            <semantic:outgoing>__e8a6634d-4c67-4ec3-b8cf-18bf3987c281</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent id="__8f9632f2-9fdb-4e3c-8b10-6a05091de766">
+            <semantic:incoming>__dc6ef6c1-9c24-48ae-800f-2f9fb76d7ce6</semantic:incoming>
+        </semantic:endEvent>
+    </semantic:process>
+    <semantic:process isExecutable="false" id="WFP-Page_1-4">
+        <semantic:laneSet>
+            <semantic:lane id="__15a180db-97af-4058-ac0a-4a31247fb797" name="Picker">
+                <semantic:flowNodeRef>__fd16081c-ecf9-4e0f-857f-f3404a7ee784</semantic:flowNodeRef>
+                <semantic:flowNodeRef>__f4846d41-bca9-4788-9ce2-30ff4b9d6b7b</semantic:flowNodeRef>
+                <semantic:flowNodeRef>__200e3ce9-3381-4d13-8c7e-4f8790388070</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="__75b31592-10d5-4d4b-993e-0df32d5977ac" name="Packager">
+                <semantic:flowNodeRef>__ac1dc01c-14c2-47cf-9bc9-2b39f5fcd379</semantic:flowNodeRef>
+                <semantic:flowNodeRef>__c1a19847-8b3e-42db-a95d-9f21cffc50a3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>__5a9abc77-7371-4213-bede-4056f9cb7808</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:startEvent id="__fd16081c-ecf9-4e0f-857f-f3404a7ee784" name="Receive Order" isInterrupting="true">
+            <semantic:outgoing>__4ad47bad-fac8-4269-9a9b-3f68613c7fc8</semantic:outgoing>
+            <semantic:messageEventDefinition messageRef="Message_1404332496321"/>
+        </semantic:startEvent>
+        <semantic:sequenceFlow id="__4ad47bad-fac8-4269-9a9b-3f68613c7fc8" sourceRef="__fd16081c-ecf9-4e0f-857f-f3404a7ee784" targetRef="__f4846d41-bca9-4788-9ce2-30ff4b9d6b7b"/>
+        <semantic:task id="__f4846d41-bca9-4788-9ce2-30ff4b9d6b7b" name="Pick items" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__4ad47bad-fac8-4269-9a9b-3f68613c7fc8</semantic:incoming>
+            <semantic:outgoing>__ce6b77ab-3b91-4ca0-b6c2-48980892e47e</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__ce6b77ab-3b91-4ca0-b6c2-48980892e47e" sourceRef="__f4846d41-bca9-4788-9ce2-30ff4b9d6b7b" targetRef="__200e3ce9-3381-4d13-8c7e-4f8790388070"/>
+        <semantic:task id="__200e3ce9-3381-4d13-8c7e-4f8790388070" name="Place in bin" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__ce6b77ab-3b91-4ca0-b6c2-48980892e47e</semantic:incoming>
+            <semantic:outgoing>__04700d0b-5231-46f6-ae74-698ba3864a60</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__04700d0b-5231-46f6-ae74-698ba3864a60" sourceRef="__200e3ce9-3381-4d13-8c7e-4f8790388070" targetRef="__ac1dc01c-14c2-47cf-9bc9-2b39f5fcd379"/>
+        <semantic:task id="__ac1dc01c-14c2-47cf-9bc9-2b39f5fcd379" name="Receive and Package&#10;items" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__04700d0b-5231-46f6-ae74-698ba3864a60</semantic:incoming>
+            <semantic:outgoing>__c18acafe-53f8-4e7d-a6df-d12b60b5ae53</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__c18acafe-53f8-4e7d-a6df-d12b60b5ae53" sourceRef="__ac1dc01c-14c2-47cf-9bc9-2b39f5fcd379" targetRef="__c1a19847-8b3e-42db-a95d-9f21cffc50a3"/>
+        <semantic:task id="__c1a19847-8b3e-42db-a95d-9f21cffc50a3" name="Send to carrier dock" startQuantity="1" completionQuantity="1" isForCompensation="false">
+            <semantic:incoming>__c18acafe-53f8-4e7d-a6df-d12b60b5ae53</semantic:incoming>
+            <semantic:outgoing>__18abb53a-b7c0-414e-9428-1d1a14f2e96b</semantic:outgoing>
+        </semantic:task>
+        <semantic:sequenceFlow id="__18abb53a-b7c0-414e-9428-1d1a14f2e96b" sourceRef="__c1a19847-8b3e-42db-a95d-9f21cffc50a3" targetRef="__5a9abc77-7371-4213-bede-4056f9cb7808"/>
+        <semantic:endEvent id="__5a9abc77-7371-4213-bede-4056f9cb7808">
+            <semantic:incoming>__18abb53a-b7c0-414e-9428-1d1a14f2e96b</semantic:incoming>
+        </semantic:endEvent>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="Page_1" name="Buying at Amazon Collaboration" documentation="">
+        <bpmndi:BPMNPlane bpmnElement="C1404332496310" id="Page_1_plane">
+            <bpmndi:BPMNShape id="_d156d69d-91b2-4d6e-a25f-034244e746f4" bpmnElement="__bb6766c5-51e3-4f04-aedc-6c9e4afe0582" isHorizontal="true">
+                <dc:Bounds x="1102" y="639" width="586" height="150"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="34.8125" width="12" x="1106.5" y="696.09375"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9e3d896e-b494-4c86-93fc-044cefddb34e" bpmnElement="__f867d5f7-db1e-4015-9856-c53bc9cb4b51">
+                <dc:Bounds x="1474" y="683" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="68.46875" x="1487.765625" y="714.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_6b75d079-357e-49bf-a361-72b295e395a4" bpmnElement="__b355021c-ac23-48bf-9d1a-45c32565ba39">
+                <di:waypoint x="1571" y="721"/>
+                <di:waypoint x="1619" y="721"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fe8ba97f-4313-42a0-b728-fe8dbc65b96c" bpmnElement="__36fbe220-08cc-45e8-847b-3f55002979c2">
+                <di:waypoint x="1356" y="721"/>
+                <di:waypoint x="1475" y="721"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_f840ac48-7fab-46ca-82be-7d85908b23de" bpmnElement="__a9de74be-ce4b-4d59-bafd-cf6f61f48867">
+                <dc:Bounds x="1259" y="683" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="58.375" x="1277.8125" y="714.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_1dbe0923-aa28-4908-84e3-9eccef9db46c" bpmnElement="__474f19b8-f608-4d20-a49e-907485a789c5">
+                <di:waypoint x="1193" y="721"/>
+                <di:waypoint x="1260" y="721"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_1803f4c7-e215-4029-8ff6-bbf2daf31109" bpmnElement="__6c41ae4a-64fd-40f9-a764-059b26ef8ebf">
+                <dc:Bounds x="1619" y="703" width="36" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8b49d284-965c-446a-a216-ebccd0691d22" bpmnElement="__e6a9dd54-6cb0-4713-8b77-e659f2658e40">
+                <dc:Bounds x="1161" y="705" width="32" height="32"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="52.75" x="1149.625" y="687.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_841b32fb-4579-4ce5-9d5d-57b3cbbaec14" bpmnElement="__3cf88d6c-e5e4-489e-bc73-e2a18be946bf" isHorizontal="true">
+                <dc:Bounds x="785" y="63" width="382" height="132"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="113.375" width="12" x="790" y="72.3125"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_76535f92-31eb-4b60-8452-3eedd40ab184" bpmnElement="__a7183fc9-402a-418c-bf2a-3b1927d3798d">
+                <dc:Bounds x="931" y="91" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="76.34375" x="940.453125" y="123"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_8fb6b2d9-a592-4cc3-b960-70c230e25059" bpmnElement="__47cf5284-b9ff-4136-93fd-f0f32b87810f">
+                <di:waypoint x="1027" y="130"/>
+                <di:waypoint x="1087" y="129"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ab4cd126-18c0-458a-a5ba-cc1d02bd6941" bpmnElement="__f3f918b3-abee-4e59-8131-212d0d86b056">
+                <di:waypoint x="880" y="129"/>
+                <di:waypoint x="931" y="130"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_5b5df749-2e58-4dd2-aa92-90420c83b3a2" bpmnElement="__0ef615c7-5456-45c8-9cfb-f1fe30c44436">
+                <dc:Bounds x="849" y="113" width="31" height="32"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="40" width="77.46875" x="827.703125" y="70"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6160434e-d9c9-4cd2-a2fd-276b06de88a7" bpmnElement="__4011aa2d-a7a9-4e1a-9f16-8a662d138bd4">
+                <dc:Bounds x="1087" y="111" width="35" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="26" width="32.5625" x="1087.34375" y="75"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_47d14f7b-f0f5-47ac-a2e6-08b1de420e57" bpmnElement="__6f70606b-6781-4f26-b207-5bfff80115d8" isHorizontal="true">
+                <dc:Bounds x="215" y="275" width="1467" height="295"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="49.40625" width="12.015625" x="219.5" y="398.01652144128"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5c88e114-2108-4511-ae55-585af71fbc97" bpmnElement="__f5b8cb41-0574-4c29-aaaa-84ecce589f84">
+                <dc:Bounds x="288" y="378.5" width="32" height="32"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_48ee3c9b-dc2f-418d-94b0-30f1634d1e9e" bpmnElement="__6fd770bc-8f12-4927-96cd-e3cc53d862d3">
+                <di:waypoint x="320" y="394.5"/>
+                <di:waypoint x="364" y="395.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_b211f152-3674-4d56-8d38-6c254ec685cd" bpmnElement="__be386700-06c2-4a29-b861-c516940667fe">
+                <dc:Bounds x="521.5" y="356.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="86.4375" x="526.28125" y="388.75"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_6074abbe-7294-4260-9553-f3f2ec74b231" bpmnElement="__82227f00-3d5e-446e-a2e7-50b907ed7c8c">
+                <di:waypoint x="618.5" y="395.5"/>
+                <di:waypoint x="685" y="395"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3470f558-68b6-4a09-bddf-5c9af1f6690e" bpmnElement="__e8a6634d-4c67-4ec3-b8cf-18bf3987c281">
+                <di:waypoint x="460" y="395.5"/>
+                <di:waypoint x="522.5" y="395.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_8f85b3d6-6223-446d-b4c5-2e98ae9b7ec9" bpmnElement="__5ffa1675-9ad7-46f8-b19a-85cd5878496f" isExpanded="true">
+                <dc:Bounds x="828" y="290" width="547" height="209"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12.015625" width="48.28125" x="836" y="297.5679626464844"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_74f66f18-53f0-44ce-9bac-8a7fd2016ac8" bpmnElement="__a12a7547-373d-47ec-890d-af5c177203ee">
+                <di:waypoint x="727" y="395"/>
+                <di:waypoint x="829" y="395"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="19.09375" x="767.953125" y="400"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4ca78b71-fa50-4ff1-a162-67359576eb8f" bpmnElement="__5d3be9f3-3f7a-4778-89e5-1bf4951472c2">
+                <di:waypoint x="1376" y="395"/>
+                <di:waypoint x="1477" y="394.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_2c370da6-1a92-4fae-9882-fcf3f3092c91" bpmnElement="__a1c27e25-4aa2-43dc-8a20-b713e8393d7f">
+                <dc:Bounds x="849" y="379" width="32" height="32"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_596917da-c2c9-417f-a68c-14ab21616fd5" bpmnElement="__00bc466e-cf1f-473c-aa39-c78bba5cef82">
+                <di:waypoint x="881" y="395"/>
+                <di:waypoint x="930" y="395"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_45e1c9ba-8c28-47f1-869d-6eb35b54d28f" bpmnElement="_2f24e6da-b44f-4e30-8d85-fd35fd56e209">
+                <dc:Bounds x="930" y="357" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="52.75" x="951.25" y="388.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_20bf2105-3693-4753-8076-ab2a637902a7" bpmnElement="_520aac43-77a5-40e8-84a4-ec51e17ad9b2">
+                <di:waypoint x="1026" y="396"/>
+                <di:waypoint x="1050" y="395"/>
+                <di:waypoint x="1050" y="346"/>
+                <di:waypoint x="1072" y="346"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_61c970c9-a769-4a9c-9794-46e823c4816e" bpmnElement="_63cf98c9-d0b1-4595-a4f2-9589439b311c">
+                <di:waypoint x="1072" y="459"/>
+                <di:waypoint x="978" y="458"/>
+                <di:waypoint x="978" y="433"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="19.09375" x="968.078125" y="463"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_7bcd012d-110a-49d6-a428-f8eaa7ba8859" bpmnElement="_29a5e7c6-e54e-4c61-ba35-59ae446a3462" isMarkerVisible="true">
+                <dc:Bounds x="1071" y="437" width="42" height="42"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="33.6875" x="1075.322998046875" y="485"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_8b312c63-944c-4f8f-ab5b-fb94ddc0ed46" bpmnElement="_ad0872cc-e2a9-4c44-98c6-c64e0638f37e">
+                <di:waypoint x="1114" y="459"/>
+                <di:waypoint x="1165" y="458"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12.015625" width="14.609375" x="1132.3619889139934" y="463.1942490435134"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_0f61322d-baeb-453d-bbe3-85e2d09b55d9" bpmnElement="_bfa5c7b2-f5d2-4487-a307-b2ea662bd059">
+                <di:waypoint x="1093" y="367"/>
+                <di:waypoint x="1093" y="438"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="14.609375" x="1084.86200234625" y="407.0625"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_290ffce5-3fa6-4fd1-84fb-2ec24a0b3a97" bpmnElement="_bb4a73bd-2291-4494-8677-5560d4842f79" isMarkerVisible="true">
+                <dc:Bounds x="1072" y="325" width="41" height="41"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12.015625" width="105.5" x="1037.416748046875" y="309.0178571428571"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_62e2c7a0-693e-4203-9daf-12a8d5e10795" bpmnElement="_50edb87c-9e46-48b1-a311-ef00e6e431e8">
+                <di:waypoint x="1113" y="346"/>
+                <di:waypoint x="1204" y="346"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="19.09375" x="1149.43231484625" y="350.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_d8692549-20fe-4b24-8f94-f6917e5f3465" bpmnElement="_7ea6639e-e773-4236-94bf-78f149188c30">
+                <dc:Bounds x="1165" y="440" width="36" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d46c1239-177f-4c83-98c3-1448831c562f" bpmnElement="_f35ee29d-018c-47e2-afeb-eebc2e25925e">
+                <dc:Bounds x="1204" y="328" width="36" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="60.625" x="1191.854248046875" y="369.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_9729f22a-c0f0-41d0-a7f0-5e18fe0751c4" bpmnElement="_30c47018-b9e8-4d09-81e2-2b592f75a5cf">
+                <di:waypoint x="1240" y="346"/>
+                <di:waypoint x="1284" y="346"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_3220bd86-e721-4d9e-9f12-2f7293617842" bpmnElement="_df393d97-f22e-4442-95be-918b8fdd4c3c">
+                <dc:Bounds x="1284" y="328" width="36" height="35"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6f3fa34a-6ee9-4490-9ec3-50548e45d2cf" bpmnElement="__cec149db-adae-4b69-8ea4-b866f2eef248">
+                <dc:Bounds x="1335" y="481" width="35" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_bd7f52ee-93f6-4736-a13f-d1acdb1630d4" bpmnElement="__dc6ef6c1-9c24-48ae-800f-2f9fb76d7ce6">
+                <di:waypoint x="1352" y="517"/>
+                <di:waypoint x="1352" y="546"/>
+                <di:waypoint x="1431" y="546"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_b5a71451-bb2d-45fb-b075-0b4981303b99" bpmnElement="__e03c9539-b011-46b1-a381-0eee5f0521b8">
+                <dc:Bounds x="1614" y="376.5" width="36" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_07140a2c-1e99-4404-8313-93a372c2d6ae" bpmnElement="__92bd8ebf-e3b1-4270-96bb-2f6d6978c64a">
+                <di:waypoint x="1573" y="395.5"/>
+                <di:waypoint x="1614" y="394.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_beca97c9-7c08-4f6a-861e-62959c6bf196" bpmnElement="_95a2fb99-bb98-4d26-b5ec-3dae3a32fd79">
+                <dc:Bounds x="1476" y="356.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="74.09375" x="1486.953125" y="388.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_77042d9f-425c-4c6a-b1ed-3a1f7aad33df" bpmnElement="__509f09eb-5518-4995-b98b-db3cf3f8ea00" isMarkerVisible="true">
+                <dc:Bounds x="685" y="374" width="42" height="41"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12.015625" width="89.8125" x="660.59375" y="420.709346269406"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_46f456b4-a7b4-461a-9cdc-f62ff777fb94" bpmnElement="__ffc1486a-8a32-490a-8835-d14cc5ab0a97">
+                <di:waypoint x="706" y="374"/>
+                <di:waypoint x="706" y="315.5"/>
+                <di:waypoint x="412" y="315.5"/>
+                <di:waypoint x="412" y="357.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="14.59375" x="557.703125" y="320.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_686fd5b2-cf88-40ac-80e1-18c4edc862c6" bpmnElement="__f61e9ae0-855f-4ce6-9e3a-4b4f5c7dd0b8">
+                <dc:Bounds x="363" y="356.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="26" width="85.3125" x="368.34375" y="381.75"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_98d47a62-e02d-4cef-b598-468e0f5d6651" bpmnElement="__8f9632f2-9fdb-4e3c-8b10-6a05091de766">
+                <dc:Bounds x="1431" y="527" width="36" height="35"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_248ca90e-cd8a-4bcd-8389-846dd2f35be1" bpmnElement="__a42178ea-f777-4c5b-a0a1-c4014aee6431" isHorizontal="true">
+                <dc:Bounds x="214" y="633" width="776" height="254"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="43.78125" width="12" x="218.5" y="738.109375"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9bb7ab63-1897-4f65-b55d-e67b9f519e88" bpmnElement="__15a180db-97af-4058-ac0a-4a31247fb797" isHorizontal="true">
+                <dc:Bounds x="244" y="633" width="746" height="135"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="31.4375" width="12" x="248.5" y="684.78125"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_a7b7ffc8-f701-4c59-a1d4-a9d5bf95ef5c" bpmnElement="__fd16081c-ecf9-4e0f-857f-f3404a7ee784">
+                <dc:Bounds x="288" y="675" width="32" height="32"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="75.21875" x="266.390625" y="716.59375"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_f1b8e3b1-fd7e-4fdb-98e0-aa35fa62e160" bpmnElement="__4ad47bad-fac8-4269-9a9b-3f68613c7fc8">
+                <di:waypoint x="320" y="691"/>
+                <di:waypoint x="368" y="692"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_1d93dd43-7d59-4efc-b288-6fcf57e00b26" bpmnElement="__f4846d41-bca9-4788-9ce2-30ff4b9d6b7b">
+                <dc:Bounds x="368" y="653" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="52.75" x="389.125" y="685"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_60ed1a2c-fab7-4617-881f-67733c0bc41b" bpmnElement="__ce6b77ab-3b91-4ca0-b6c2-48980892e47e">
+                <di:waypoint x="464" y="692"/>
+                <di:waypoint x="500" y="692"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_99312dc9-2800-4107-88ea-405a3e42e20e" bpmnElement="__200e3ce9-3381-4d13-8c7e-4f8790388070">
+                <dc:Bounds x="500" y="653" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="12" width="64" x="515.5" y="685"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_5a056820-21ec-484a-ac1b-9caf84481e8a" bpmnElement="__04700d0b-5231-46f6-ae74-698ba3864a60">
+                <di:waypoint x="596" y="692"/>
+                <di:waypoint x="618.5" y="692"/>
+                <di:waypoint x="618.5" y="828"/>
+                <di:waypoint x="641" y="828"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_ef978cb8-c159-4f43-831a-9a3aba990372" bpmnElement="__75b31592-10d5-4d4b-993e-0df32d5977ac" isHorizontal="true">
+                <dc:Bounds x="244" y="768" width="746" height="119"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="48.28125" width="12" x="248.5" y="803.359375"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_497efc7e-04af-4725-bc36-fc85925783a4" bpmnElement="__ac1dc01c-14c2-47cf-9bc9-2b39f5fcd379">
+                <dc:Bounds x="641" y="790" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="40" width="66.21875" x="655.390625" y="807.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_0bbeed98-39d7-44ef-8b9d-f7600fb8ac20" bpmnElement="__c18acafe-53f8-4e7d-a6df-d12b60b5ae53">
+                <di:waypoint x="737" y="828"/>
+                <di:waypoint x="784" y="828"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_8707335d-fc8f-4e32-a2b7-3ecd2ac8d86c" bpmnElement="__c1a19847-8b3e-42db-a95d-9f21cffc50a3">
+                <dc:Bounds x="783" y="790" width="96" height="76"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="26" width="77.46875" x="792.265625" y="814.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_c71d97f8-5c20-4527-bed2-528e37dad504" bpmnElement="__18abb53a-b7c0-414e-9428-1d1a14f2e96b">
+                <di:waypoint x="880" y="828"/>
+                <di:waypoint x="922" y="828"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNShape id="_d286b0e6-9940-4d58-ad5d-f1f472bd3c2b" bpmnElement="__5a9abc77-7371-4213-bede-4056f9cb7808">
+                <dc:Bounds x="922" y="810" width="36" height="36"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_2fdcb9da-45a4-46c7-aab8-491d8dee9acd" bpmnElement="__13e0b8fd-91fe-4bbc-87ae-5ad657f6ef99">
+                <di:waypoint x="1523" y="683"/>
+                <di:waypoint x="1524" y="433.5"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8485f43a-fb2b-4466-b254-49452751e656" bpmnElement="__5cdd91dd-32f6-4102-b475-bd6c7992f509">
+                <di:waypoint x="848" y="790"/>
+                <di:waypoint x="848" y="762"/>
+                <di:waypoint x="1177" y="762"/>
+                <di:waypoint x="1177" y="736"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d16a9f5d-c29a-4114-b7c6-65b2921b6c74" bpmnElement="__789952b8-abba-4f3f-81cd-24cbb4d0d615">
+                <di:waypoint x="1222" y="364"/>
+                <di:waypoint x="1222" y="519.5"/>
+                <di:waypoint x="304" y="519.5"/>
+                <di:waypoint x="304" y="675"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a3b1d7c1-82fb-4b28-ad4f-c1daf17cc1c7" bpmnElement="__86b33cf0-1b17-437f-a7cf-510e0766561f">
+                <di:waypoint x="949" y="357"/>
+                <di:waypoint x="949" y="228"/>
+                <di:waypoint x="864" y="228"/>
+                <di:waypoint x="864" y="145"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1">
+                    <dc:Bounds height="26" width="90.921875" x="857.0390625" y="233"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f10d64de-2a78-421b-8a62-69bb9560958c" bpmnElement="__0c171c64-b342-4f84-8020-a63b6a5b296d">
+                <di:waypoint x="1106" y="147"/>
+                <di:waypoint x="1106" y="230"/>
+                <di:waypoint x="1007" y="230"/>
+                <di:waypoint x="1007" y="357"/>
+                <bpmndi:BPMNLabel labelStyle="LSPage_1"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LSPage_1">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.3.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.3.0.bpmn
@@ -1,0 +1,671 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Created by Process Modeler 6 SR1 for Microsoft Visio (http://www.itp-commerce.com)-->
+<definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:itp="http://www.itp-commerce.com/BPMN2.0" xmlns:style="http://www.w4.eu/spec/DataComposer/20120927/Diagram/Style" xmlns:w4="http://www.w4.eu/spec/BPMN/20110701/MODEL" xmlns:w4graph="http://www.w4.eu/spec/BPMN/20110930/GRAPH" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL schemas/BPMN20.xsd" id="_5033f8b0-0396-494b-a52c-787034420443" itp:version="1.0" itp:author="Stephan Fischli" itp:creationDate="04.11.2008 15:43:58" itp:modificationDate="26.03.2015 10:49:31" itp:createdWithVersion="5.2739.13641 SR6" itp:conformanceSubClass="Full" w4:version="1.0" exporter="W4_BPMN_Composer" exporterVersion="9.2.0.0" expressionLanguage="http://www.w3.org/1999/XPath" name="C.3.0" targetNamespace="http://www.itp-commerce.com" typeLanguage="http://www.w3.org/2001/XMLSchema">
+  <process id="_8170787a-3207-434d-9bea-4787059f444f" name="Fridge Repair Process" isExecutable="true" processType="Private">
+    <extensionElements>
+      <itp:systemDefinedAttributes>
+        <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+        <attribute name="ExternalId" type="String"/>
+        <attribute name="KPICost" type="Float" value="1" format="Currency;Fr.;;KPI;2"/>
+        <attribute name="KPIDuration" type="Float" value="1" format="Duration;;;KPI;3">
+          <attribute name="KPIActiveTime" type="Float" value="1" format="Duration;;;KPI;3"/>
+          <attribute name="KPIWaitTime" type="Float" value="0" format="Duration;;;KPI;3"/>
+        </attribute>
+        <attribute name="QualityAnalysis" type="String">
+          <attribute name="KeyData" type="String">
+            <attribute name="ElementsCountKey" type="String" value="43"/>
+            <attribute name="ErrorsKey" type="String" value="0"/>
+            <attribute name="WarningsKey" type="String" value="0"/>
+            <attribute name="InformationKey" type="String" value="0"/>
+            <attribute name="MethodAndStyleKey" type="String" value="0"/>
+            <attribute name="eCHKey" type="String" value="0"/>
+            <attribute name="DescriptiveConformanceSubClassKey" type="String" value="41"/>
+            <attribute name="AnalyticConformanceSubClassKey" type="String" value="43"/>
+            <attribute name="ExecutableConformanceSubClassKey" type="String" value="41"/>
+            <attribute name="StartEventsKey" type="String" value="1"/>
+            <attribute name="ActivitiesKey" type="String" value="1"/>
+            <attribute name="SubLevelsKey" type="String" value="1"/>
+            <attribute name="GatewaysKey" type="String" value="3"/>
+            <attribute name="GatesKey" type="String" value="0"/>
+            <attribute name="BlackboxPoolsKey" type="String" value="2"/>
+            <attribute name="UnlinkedSubProcessesKey" type="String" value="0"/>
+            <attribute name="UnlinkedCallActivitiesKey" type="String" value="0"/>
+            <attribute name="EndMessageEventsKey" type="String" value="1"/>
+            <attribute name="TypedTasksKey" type="String" value="7"/>
+            <attribute name="UntypedTasksKey" type="String" value="0"/>
+            <attribute name="ReadingDataObjectsKey" type="String" value="0"/>
+            <attribute name="WritingDataObjectsKey" type="String" value="0"/>
+            <attribute name="UnnamedDataObjectsKey" type="String" value="0"/>
+            <attribute name="UnnamedDataStoresKey" type="String" value="0"/>
+            <attribute name="ActivitesWithoutRoleKey" type="String" value="0"/>
+            <attribute name="TextAnnotationFlowElementRatioKey" type="String" value="0"/>
+            <attribute name="OrComplexGatewaysKey" type="String" value="0"/>
+            <attribute name="CollaborationTasksKey" type="String" value="0"/>
+          </attribute>
+          <attribute name="ProcessAnalysis" type="String" value="98"/>
+          <attribute name="ProcessExecution" type="String" value="71"/>
+          <attribute name="DiagramInterchange" type="String" value="71"/>
+          <attribute name="ProcessSimulation" type="String" value="100"/>
+        </attribute>
+      </itp:systemDefinedAttributes>
+      <w4graph:graphStyle>
+        <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        <w4graph:root gridVisible="true" snapToGrid="true" rulerVisible="true" snapToGuide="true" rulerUnit="Pixels">
+          <Grid spacing="15" color="230,230,230"/>
+          <VerticalRuler/>
+          <HorizontalRuler/>
+        </w4graph:root>
+      </w4graph:graphStyle>
+    </extensionElements>
+    <startEvent id="_cc9778bd-edd8-4df2-ba15-56c310f90e62" name="Receive customer request" isInterrupting="true">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="109,183,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <outgoing>_a5af06ae-bd69-464d-bbaf-3d7418702d77</outgoing>
+      <messageEventDefinition id="Bpmn_MessageEventDefinition_vaRFsAO9EeWi8fS3WiOizw" messageRef="_6840c92f-f02c-46b3-9565-f5e5b1792ba0"/>
+    </startEvent>
+    <userTask id="_c73a5f4a-72f1-4e11-bb40-2f98da75fb9a" name="Analyse customer request" completionQuantity="2" isForCompensation="false" startQuantity="2" implementation="##WebService">
+      <documentation id="Bpmn_Documentation_jcmzwe_bEeSGoscwBjzAjw" textFormat="text/plain">First contact with customer</documentation>
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+          <attribute name="KPICost" type="Float" value="0" format="Currency;SFr.;;KPI;2"/>
+          <attribute name="KPIDuration" type="Float" value="120" format="Duration;;;KPI;3">
+            <attribute name="KPIActiveTime" type="Float" value="120" format="Duration;;;KPI;3;0.5"/>
+            <attribute name="KPIWaitTime" type="Float" value="0" format="Duration;;;KPI;3"/>
+          </attribute>
+          <attribute name="Resource" type="String" value="PHBlcmZvcm1lci1hc3NpZ25tZW50cz4NCiAgPHBlcmZvcm1lci1hc3NpZ25tZW50IHNjZW5hcmlvLXJlZi1pZD0iNTE4MDY2MTEtZDdlYy00MWY3LTgxNzMtYjAxYjk2OWUxOTc0IiBwZXJmb3JtZXItcmVmLWlkPSJkZmJjMzg4OC05ZDI1LTQzYjktYWEyYS02NzAxZDYwMzhlYTAiIHByaW9yaXR5PSI0IiBtYXgtY2FwYWNpdHk9IjEwMCIgY3JpdGljYWwtY2FwYWNpdHk9IjgwIiAvPg0KPC9wZXJmb3JtZXItYXNzaWdubWVudHM+"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_a5af06ae-bd69-464d-bbaf-3d7418702d77</incoming>
+      <outgoing>_acb2aca3-8851-48f0-b127-7b3c9db5e18d</outgoing>
+      <potentialOwner id="Bpmn_PotentialOwner_H_12wBqHEeWDuOtG0oS24A" name="Potential Owner">
+        <resourceRef>Bpmn_Resource__7wrkBqGEeWDuOtG0oS24A</resourceRef>
+      </potentialOwner>
+    </userTask>
+    <userTask id="_a92069f7-377b-4dbd-a1fd-1da071aabf6d" name="Replace fridge" completionQuantity="1" isForCompensation="false" startQuantity="1" implementation="WebService">
+      <documentation id="Bpmn_Documentation_jcna0O_bEeSGoscwBjzAjw" textFormat="text/plain">Fridge replaced if still under warranty.</documentation>
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+          <attribute name="KPICost" type="Float" value="0" format="Currency;SFr.;;KPI;2"/>
+          <attribute name="KPIDuration" type="Float" value="60" format="Duration;;;KPI;3">
+            <attribute name="KPIActiveTime" type="Float" value="60" format="Duration;;;KPI;3;0.5"/>
+            <attribute name="KPIWaitTime" type="Float" value="0" format="Duration;;;KPI;3"/>
+          </attribute>
+          <attribute name="Resource" type="String" value="PHBlcmZvcm1lci1hc3NpZ25tZW50cz4NCiAgPHBlcmZvcm1lci1hc3NpZ25tZW50IHNjZW5hcmlvLXJlZi1pZD0iNTE4MDY2MTEtZDdlYy00MWY3LTgxNzMtYjAxYjk2OWUxOTc0IiBwZXJmb3JtZXItcmVmLWlkPSJkZmJjMzg4OC05ZDI1LTQzYjktYWEyYS02NzAxZDYwMzhlYTAiIG1heC1jYXBhY2l0eT0iMTAwIiBjcml0aWNhbC1jYXBhY2l0eT0iODAiIC8+DQo8L3BlcmZvcm1lci1hc3NpZ25tZW50cz4="/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_b99800c3-c340-460c-a43e-098014a365d0</incoming>
+      <incoming>_3fb323d5-2c59-487a-af63-804208f6c5cb</incoming>
+      <outgoing>_c5756bb9-6e6f-42d1-8799-c2d673499eb8</outgoing>
+    </userTask>
+    <endEvent id="_177bd313-c6c9-4df5-8f82-313beb30d2eb" name="Fridge replaced">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="190,0,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_c5756bb9-6e6f-42d1-8799-c2d673499eb8</incoming>
+    </endEvent>
+    <exclusiveGateway id="_604be023-654c-44df-a64c-365254a100cd" name="Service type" gatewayDirection="Diverging">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="185,139,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_acb2aca3-8851-48f0-b127-7b3c9db5e18d</incoming>
+      <outgoing>_b99800c3-c340-460c-a43e-098014a365d0</outgoing>
+      <outgoing>_437e5969-1e61-4cb9-aa76-4f8854f32eeb</outgoing>
+      <outgoing>_ada039b6-94dd-4a15-a6b1-c7fe662c64ee</outgoing>
+    </exclusiveGateway>
+    <endEvent id="_b3dc1906-d4d3-40c5-aaf6-5a74148ae887" name="Emergency repair completed">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="190,0,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_cf380e47-1401-4e7e-b710-193b626e49eb</incoming>
+    </endEvent>
+    <exclusiveGateway id="_2b6bc88e-d3be-4704-87d1-c264bf704589" name="Service level" gatewayDirection="Diverging">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="185,139,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_ada039b6-94dd-4a15-a6b1-c7fe662c64ee</incoming>
+      <outgoing>_cddf9325-a85b-4347-8c57-8b909fa77ae9</outgoing>
+      <outgoing>_be893987-caec-4605-b078-bd96b7cd6c12</outgoing>
+    </exclusiveGateway>
+    <userTask id="_d034722f-751d-4f37-a3d7-47993822e979" name="Perform repair (standard level)" completionQuantity="1" isForCompensation="false" startQuantity="1" implementation="WebService">
+      <documentation id="Bpmn_Documentation_jcoo8O_bEeSGoscwBjzAjw" textFormat="text/plain"><![CDATA[Standard service level is common for most customer support.
+This level guarantees the fridge will be repaired in a reasonable amount of time.
+Customers may decide to raise the service level to Premium while waiting for the standard service to solve the issue.]]></documentation>
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+          <attribute name="KPICost" type="Float" value="0" format="Currency;SFr.;;KPI;2"/>
+          <attribute name="KPIDuration" type="Float" value="36000" format="Duration;;;KPI;3">
+            <attribute name="KPIActiveTime" type="Float" value="21600" format="Duration;;;KPI;3;0.3"/>
+            <attribute name="KPIWaitTime" type="Float" value="14400" format="Duration;;;KPI;3"/>
+          </attribute>
+          <attribute name="Resource" type="String" value="PHBlcmZvcm1lci1hc3NpZ25tZW50cz4NCiAgPHBlcmZvcm1lci1hc3NpZ25tZW50IHNjZW5hcmlvLXJlZi1pZD0iNTE4MDY2MTEtZDdlYy00MWY3LTgxNzMtYjAxYjk2OWUxOTc0IiBwZXJmb3JtZXItcmVmLWlkPSIxYWZkYWNjMS0zMDk4LTQ4YzAtOGUwNS1mYWQwZjZkMTg5OTAiIG1heC1jYXBhY2l0eT0iMjAwIiBjcml0aWNhbC1jYXBhY2l0eT0iMTgwIiAvPg0KPC9wZXJmb3JtZXItYXNzaWdubWVudHM+"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_cddf9325-a85b-4347-8c57-8b909fa77ae9</incoming>
+      <outgoing>_435d9320-bbf4-48ad-aa56-16cb5483e95b</outgoing>
+    </userTask>
+    <userTask id="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba" name="Perform repair (premium level)" completionQuantity="1" isForCompensation="false" startQuantity="1" implementation="WebService">
+      <documentation id="Bpmn_Documentation_jcoo8e_bEeSGoscwBjzAjw" textFormat="text/plain"><![CDATA[These customers get special service in case of damage.
+This service level guarantees less than two days to solve the issue.]]></documentation>
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+          <attribute name="KPICost" type="Float" value="0" format="Currency;SFr.;;KPI;2"/>
+          <attribute name="KPIDuration" type="Float" value="8100" format="Duration;;;KPI;3">
+            <attribute name="KPIActiveTime" type="Float" value="7200" format="Duration;;;KPI;3;0.3"/>
+            <attribute name="KPIWaitTime" type="Float" value="900" format="Duration;;;KPI;3"/>
+          </attribute>
+          <attribute name="Resource" type="String" value="PHBlcmZvcm1lci1hc3NpZ25tZW50cz4NCiAgPHBlcmZvcm1lci1hc3NpZ25tZW50IHNjZW5hcmlvLXJlZi1pZD0iNTE4MDY2MTEtZDdlYy00MWY3LTgxNzMtYjAxYjk2OWUxOTc0IiBwZXJmb3JtZXItcmVmLWlkPSJkOGIzZTMyZC1lMDRmLTRhYzgtOWYyMC0wZDkzMTI3YWZlYWUiIHByaW9yaXR5PSI0IiBtYXgtY2FwYWNpdHk9IjEwMCIgY3JpdGljYWwtY2FwYWNpdHk9IjgwIiAvPg0KPC9wZXJmb3JtZXItYXNzaWdubWVudHM+"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="194,215,235" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_be893987-caec-4605-b078-bd96b7cd6c12</incoming>
+      <incoming>Bpmn_SequenceFlow_-dQQwBqHEeWDuOtG0oS24A</incoming>
+      <outgoing>_d54c5707-af7a-4b36-a059-46681bbf0004</outgoing>
+    </userTask>
+    <endEvent id="_dcee5c64-3010-4ee5-b480-bce856e6f29c" name="Repair completed">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="190,0,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_435d9320-bbf4-48ad-aa56-16cb5483e95b</incoming>
+      <incoming>_d54c5707-af7a-4b36-a059-46681bbf0004</incoming>
+    </endEvent>
+    <exclusiveGateway id="_936c0bfa-5ebf-4546-8d1a-cce556148788" name="Successful?" gatewayDirection="Diverging">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="185,139,0" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_b22c01a4-1eef-4f52-9b16-a201a9621619</incoming>
+      <outgoing>_cf380e47-1401-4e7e-b710-193b626e49eb</outgoing>
+      <outgoing>_3fb323d5-2c59-487a-af63-804208f6c5cb</outgoing>
+    </exclusiveGateway>
+    <subProcess id="_cd6f230f-13c3-4027-aa3e-57de601a1ab2" itp:isCollapsed="true" itp:logicalSheetId="fc8f260a-6c44-4b3d-84e1-7a58181d251b" name="Perform emergency repair" completionQuantity="1" isForCompensation="false" startQuantity="1" triggeredByEvent="false">
+      <documentation id="Bpmn_Documentation_jcpQAO_bEeSGoscwBjzAjw" textFormat="text/plain">This is a special case for handling emergencies for clients such as Hospitals or Commercial fridges.</documentation>
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+          <attribute name="KPICost" type="Float" value="0" format="Currency;SFr.;;KPI;2"/>
+          <attribute name="KPIDuration" type="Float" value="14400" format="Duration;;;KPI;3">
+            <attribute name="KPIActiveTime" type="Float" value="14400" format="Duration;;;KPI;3;0.3"/>
+            <attribute name="KPIWaitTime" type="Float" value="0" format="Duration;;;KPI;3"/>
+          </attribute>
+          <attribute name="Resource" type="String" value="PHBlcmZvcm1lci1hc3NpZ25tZW50cz4NCiAgPHBlcmZvcm1lci1hc3NpZ25tZW50IHNjZW5hcmlvLXJlZi1pZD0iNTE4MDY2MTEtZDdlYy00MWY3LTgxNzMtYjAxYjk2OWUxOTc0IiBwZXJmb3JtZXItcmVmLWlkPSI4YjY4ZjIxOS1jOGU2LTQ5ODctYjAyMi1iNTgwMTYyM2YzOTciIG1heC1jYXBhY2l0eT0iMTAwIiBjcml0aWNhbC1jYXBhY2l0eT0iODAiIC8+DQo8L3BlcmZvcm1lci1hc3NpZ25tZW50cz4="/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="153,153,153" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <incoming>_437e5969-1e61-4cb9-aa76-4f8854f32eeb</incoming>
+      <incoming>Bpmn_SequenceFlow_tcbpgBqGEeWDuOtG0oS24A</incoming>
+      <outgoing>_b22c01a4-1eef-4f52-9b16-a201a9621619</outgoing>
+    </subProcess>
+    <sequenceFlow id="_acb2aca3-8851-48f0-b127-7b3c9db5e18d" sourceRef="_c73a5f4a-72f1-4e11-bb40-2f98da75fb9a" targetRef="_604be023-654c-44df-a64c-365254a100cd">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_b99800c3-c340-460c-a43e-098014a365d0" name="Warranty" sourceRef="_604be023-654c-44df-a64c-365254a100cd" targetRef="_a92069f7-377b-4dbd-a1fd-1da071aabf6d">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_437e5969-1e61-4cb9-aa76-4f8854f32eeb" name="Emergency service" sourceRef="_604be023-654c-44df-a64c-365254a100cd" targetRef="_cd6f230f-13c3-4027-aa3e-57de601a1ab2">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_ada039b6-94dd-4a15-a6b1-c7fe662c64ee" name="Regular repair service" sourceRef="_604be023-654c-44df-a64c-365254a100cd" targetRef="_2b6bc88e-d3be-4704-87d1-c264bf704589">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_cddf9325-a85b-4347-8c57-8b909fa77ae9" name="Standard" sourceRef="_2b6bc88e-d3be-4704-87d1-c264bf704589" targetRef="_d034722f-751d-4f37-a3d7-47993822e979">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_be893987-caec-4605-b078-bd96b7cd6c12" name="Premium" sourceRef="_2b6bc88e-d3be-4704-87d1-c264bf704589" targetRef="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <conditionExpression xsi:type="tFormalExpression" id="Bpmn_FormalExpression_ipW2kBqIEeWDuOtG0oS24A"><![CDATA[Service Level == 'Premium']]></conditionExpression>
+    </sequenceFlow>
+    <sequenceFlow id="_435d9320-bbf4-48ad-aa56-16cb5483e95b" sourceRef="_d034722f-751d-4f37-a3d7-47993822e979" targetRef="_dcee5c64-3010-4ee5-b480-bce856e6f29c">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_d54c5707-af7a-4b36-a059-46681bbf0004" sourceRef="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba" targetRef="_dcee5c64-3010-4ee5-b480-bce856e6f29c">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_b22c01a4-1eef-4f52-9b16-a201a9621619" sourceRef="_cd6f230f-13c3-4027-aa3e-57de601a1ab2" targetRef="_936c0bfa-5ebf-4546-8d1a-cce556148788">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_c5756bb9-6e6f-42d1-8799-c2d673499eb8" sourceRef="_a92069f7-377b-4dbd-a1fd-1da071aabf6d" targetRef="_177bd313-c6c9-4df5-8f82-313beb30d2eb">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_cf380e47-1401-4e7e-b710-193b626e49eb" name="yes" sourceRef="_936c0bfa-5ebf-4546-8d1a-cce556148788" targetRef="_b3dc1906-d4d3-40c5-aaf6-5a74148ae887">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_3fb323d5-2c59-487a-af63-804208f6c5cb" name="no" sourceRef="_936c0bfa-5ebf-4546-8d1a-cce556148788" targetRef="_a92069f7-377b-4dbd-a1fd-1da071aabf6d">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <sequenceFlow id="_a5af06ae-bd69-464d-bbaf-3d7418702d77" sourceRef="_cc9778bd-edd8-4df2-ba15-56c310f90e62" targetRef="_c73a5f4a-72f1-4e11-bb40-2f98da75fb9a">
+      <extensionElements>
+        <itp:systemDefinedAttributes>
+          <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+          <attribute name="ExternalId" type="String"/>
+        </itp:systemDefinedAttributes>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <boundaryEvent id="Bpmn_BoundaryEvent_sS9gABqGEeWDuOtG0oS24A" name="2 hours" attachedToRef="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba" cancelActivity="true">
+      <extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="0,0,0" foreground="0,0,0" autoResize="false" borderColor="255,255,255" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="true" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <outgoing>Bpmn_SequenceFlow_tcbpgBqGEeWDuOtG0oS24A</outgoing>
+      <timerEventDefinition id="Bpmn_TimerEventDefinition_88uHkBqGEeWDuOtG0oS24A">
+        <timeDuration xsi:type="tFormalExpression" id="Bpmn_FormalExpression_8pPK4BqGEeWDuOtG0oS24A" language="http://www.w3.org/1999/XPath"><![CDATA[PT2H]]></timeDuration>
+      </timerEventDefinition>
+    </boundaryEvent>
+    <sequenceFlow id="Bpmn_SequenceFlow_tcbpgBqGEeWDuOtG0oS24A" isImmediate="true" sourceRef="Bpmn_BoundaryEvent_sS9gABqGEeWDuOtG0oS24A" targetRef="_cd6f230f-13c3-4027-aa3e-57de601a1ab2">
+      <extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+    <boundaryEvent id="Bpmn_BoundaryEvent_LwKtwhqHEeWDuOtG0oS24A" attachedToRef="_d034722f-751d-4f37-a3d7-47993822e979" cancelActivity="true">
+      <extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="0,0,0" foreground="0,0,0" autoResize="false" borderColor="255,255,255" collapsed="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+      <outgoing>Bpmn_SequenceFlow_-dQQwBqHEeWDuOtG0oS24A</outgoing>
+      <messageEventDefinition id="Bpmn_MessageEventDefinition_zhREUBqHEeWDuOtG0oS24A" messageRef="_6840c92f-f02c-46b3-9565-f5e5b1792ba0"/>
+    </boundaryEvent>
+    <sequenceFlow id="Bpmn_SequenceFlow_-dQQwBqHEeWDuOtG0oS24A" isImmediate="true" sourceRef="Bpmn_BoundaryEvent_LwKtwhqHEeWDuOtG0oS24A" targetRef="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba">
+      <extensionElements>
+        <w4graph:graphStyle>
+          <w4graph:basic background="255,255,255" foreground="0,0,0" autoResize="false" borderColor="100,100,100" collapsed="false"/>
+          <w4graph:line routerType="Rectilinear" automaticRoute="false" closestRoute="false" avoidObstacleRoute="false"/>
+        </w4graph:graphStyle>
+      </extensionElements>
+    </sequenceFlow>
+  </process>
+  <message id="_6840c92f-f02c-46b3-9565-f5e5b1792ba0" name="Service Level">
+    <extensionElements>
+      <itp:systemDefinedAttributes>
+        <attribute name="Hyperlinks" type="String" value="0 Hyperlinks"/>
+        <attribute name="ExternalId" type="String"/>
+      </itp:systemDefinedAttributes>
+    </extensionElements>
+  </message>
+  <resource id="Bpmn_Resource__7wrkBqGEeWDuOtG0oS24A" name="User"/>
+  <bpmndi:BPMNDiagram id="Bpmndi_BPMNDiagram_jcwkwO_bEeSGoscwBjzAjw" name="Fridge Repair Process (1)" resolution="72.0">
+    <bpmndi:BPMNPlane id="_1" bpmnElement="_8170787a-3207-434d-9bea-4787059f444f">
+      <bpmndi:BPMNShape id="_1BF9B2F3-F30D-4FD6-A820-C247ADFA711C" itp:label="Receive customer request" itp:elementType="startEvent" color:background-color="#6db700" color:border-color="#000000" bpmnElement="_cc9778bd-edd8-4df2-ba15-56c310f90e62">
+        <dc:Bounds height="17.0" width="17.0" x="64.0" y="140.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcxy4O_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="95.0" x="25.0" y="157.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_E1F1DCD4-3EF3-4AE1-A299-CA9DD87394A9" itp:label="Analyse customer request" itp:elementType="userTask" color:background-color="#c2d7eb" color:border-color="#000000" bpmnElement="_c73a5f4a-72f1-4e11-bb40-2f98da75fb9a">
+        <dc:Bounds height="59.0" width="121.0" x="164.0" y="119.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcxy4e_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="101.0" x="174.0" y="134.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_435CF240-46A5-42AD-BF44-42FFC0F07528" itp:label="Replace fridge" itp:elementType="userTask" color:background-color="#c2d7eb" color:border-color="#000000" bpmnElement="_a92069f7-377b-4dbd-a1fd-1da071aabf6d">
+        <dc:Bounds height="59.0" width="121.0" x="728.0" y="82.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcxy4u_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="85.0" x="746.0" y="104.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_EAB1A438-E5B0-499F-A12D-AF064D4E8CC0" itp:label="Fridge replaced" itp:elementType="endEvent" color:background-color="#be0000" color:border-color="#000000" bpmnElement="_177bd313-c6c9-4df5-8f82-313beb30d2eb">
+        <dc:Bounds height="17.0" width="17.0" x="968.0" y="102.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcxy4-_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="83.0" x="935.0" y="119.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_E1E0CD2C-68F5-4FA5-8030-3EC58F72EA27" itp:label="Service type" itp:elementType="exclusiveGateway" color:background-color="#b98b00" color:border-color="#000000" bpmnElement="_604be023-654c-44df-a64c-365254a100cd">
+        <dc:Bounds height="31.0" width="31.0" x="369.0" y="133.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcyZ8O_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="69.0" x="400.0" y="164.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_76095EFE-FB8D-4DE6-814F-2270E01AD1B6" itp:label="Emergency repair completed" itp:elementType="endEvent" color:background-color="#be0000" color:border-color="#000000" bpmnElement="_b3dc1906-d4d3-40c5-aaf6-5a74148ae887">
+        <dc:Bounds height="17.0" width="17.0" x="960.0" y="252.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcyZ8e_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="95.0" x="921.0" y="269.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_E906D9C4-7070-4E7D-AAFE-0465F605AA03" itp:label="Service level" itp:elementType="exclusiveGateway" color:background-color="#b98b00" color:border-color="#000000" bpmnElement="_2b6bc88e-d3be-4704-87d1-c264bf704589">
+        <dc:Bounds height="31.0" width="31.0" x="369.0" y="430.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcyZ8u_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="73.0" x="296.0" y="461.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_4DEC803E-A8C9-45DF-B46D-586C0E00B70D" itp:label="Perform repair (standard level)" itp:elementType="userTask" color:background-color="#c2d7eb" color:border-color="#000000" bpmnElement="_d034722f-751d-4f37-a3d7-47993822e979">
+        <dc:Bounds height="59.0" width="121.0" x="504.0" y="584.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jcyZ8-_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="90.0" x="519.0" y="599.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_F97318A7-9E18-4D7D-89EC-3191F6897A72" itp:label="Perform repair (premium level)" itp:elementType="userTask" color:background-color="#c2d7eb" color:border-color="#000000" bpmnElement="_6a34496f-8cf7-42e5-88a9-d1af98cc3cba">
+        <dc:Bounds height="59.0" width="121.0" x="504.0" y="416.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jczBAO_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="87.0" x="521.0" y="431.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_A458F0A3-C866-435A-AA83-9EB586E9F159" itp:label="Repair completed" itp:elementType="endEvent" color:background-color="#be0000" color:border-color="#000000" bpmnElement="_dcee5c64-3010-4ee5-b480-bce856e6f29c">
+        <dc:Bounds height="17.0" width="17.0" x="962.0" y="437.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jczBAe_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="91.0" x="925.0" y="423.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_C965CE25-28B4-4971-B66F-CBA0D6F291E0" itp:label="Successful?" itp:elementType="exclusiveGateway" color:background-color="#b98b00" color:border-color="#000000" bpmnElement="_936c0bfa-5ebf-4546-8d1a-cce556148788">
+        <dc:Bounds height="31.0" width="31.0" x="768.0" y="245.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jczBAu_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="69.0" x="749.0" y="276.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_44EE9D7D-A31D-463D-8804-483D05C6CF42" itp:label="Perform emergency repair" itp:elementType="subProcess" color:background-color="#999999" color:border-color="#000000" bpmnElement="_cd6f230f-13c3-4027-aa3e-57de601a1ab2">
+        <dc:Bounds height="59.0" width="121.0" x="504.0" y="231.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jczBA-_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="97.0" x="516.0" y="246.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="_0F47EA76-94CD-4643-A488-490A89F16822" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_acb2aca3-8851-48f0-b127-7b3c9db5e18d">
+        <di:waypoint xsi:type="dc:Point" x="285.0" y="149.0"/>
+        <di:waypoint xsi:type="dc:Point" x="369.0" y="149.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_FF23DD77-941C-49B1-88AF-4847097E6B49" itp:label="Warranty" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_b99800c3-c340-460c-a43e-098014a365d0">
+        <di:waypoint xsi:type="dc:Point" x="385.0" y="133.0"/>
+        <di:waypoint xsi:type="dc:Point" x="385.0" y="111.0"/>
+        <di:waypoint xsi:type="dc:Point" x="728.0" y="111.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jczoEu_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="53.0" x="390.0" y="116.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_619D999C-1964-4026-A196-FE0113FDADA8" itp:label="Emergency service" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_437e5969-1e61-4cb9-aa76-4f8854f32eeb">
+        <di:waypoint xsi:type="dc:Point" x="400.0" y="149.0"/>
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="149.0"/>
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="231.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc0PIO_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="101.0" x="569.0" y="154.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_8C0818ED-B4E7-46E6-BE2B-F3931A463889" itp:label="Regular repair service" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_ada039b6-94dd-4a15-a6b1-c7fe662c64ee">
+        <di:waypoint xsi:type="dc:Point" x="384.0" y="164.0"/>
+        <di:waypoint xsi:type="dc:Point" x="384.0" y="430.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc0PIe_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="28.0" width="78.0" x="389.0" y="283.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_A456930F-0FE9-45B9-A4C0-EF465F0C9EC4" itp:label="Standard" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_cddf9325-a85b-4347-8c57-8b909fa77ae9">
+        <di:waypoint xsi:type="dc:Point" x="384.0" y="461.0"/>
+        <di:waypoint xsi:type="dc:Point" x="384.0" y="609.0"/>
+        <di:waypoint xsi:type="dc:Point" x="504.0" y="609.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc0PIu_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="52.0" x="389.0" y="614.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_5FE8E799-C6D8-48A1-A9D1-9737073726D1" itp:label="Premium" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_be893987-caec-4605-b078-bd96b7cd6c12">
+        <di:waypoint xsi:type="dc:Point" x="400.0" y="446.0"/>
+        <di:waypoint xsi:type="dc:Point" x="504.0" y="446.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc0PI-_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="48.0" x="428.0" y="451.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_4A53C1A1-42C9-4475-B6A9-3798D9EEEEFB" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_435d9320-bbf4-48ad-aa56-16cb5483e95b">
+        <di:waypoint xsi:type="dc:Point" x="625.0" y="612.0"/>
+        <di:waypoint xsi:type="dc:Point" x="969.0" y="612.0"/>
+        <di:waypoint xsi:type="dc:Point" x="969.0" y="454.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_7DF74040-E9E3-4DD4-A637-207B563C697F" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_d54c5707-af7a-4b36-a059-46681bbf0004">
+        <di:waypoint xsi:type="dc:Point" x="625.0" y="446.0"/>
+        <di:waypoint xsi:type="dc:Point" x="962.0" y="446.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_1B6D3757-9455-4000-8CBF-162518262CC4" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_b22c01a4-1eef-4f52-9b16-a201a9621619">
+        <di:waypoint xsi:type="dc:Point" x="625.0" y="260.0"/>
+        <di:waypoint xsi:type="dc:Point" x="768.0" y="260.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_BEF6DF3F-AA58-4F04-A04B-DEED916C0B5E" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_c5756bb9-6e6f-42d1-8799-c2d673499eb8">
+        <di:waypoint xsi:type="dc:Point" x="849.0" y="112.0"/>
+        <di:waypoint xsi:type="dc:Point" x="968.0" y="112.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_6E623C3D-0A6B-4933-935A-2941B81A4DAD" itp:label="yes" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_cf380e47-1401-4e7e-b710-193b626e49eb">
+        <di:waypoint xsi:type="dc:Point" x="799.0" y="261.0"/>
+        <di:waypoint xsi:type="dc:Point" x="960.0" y="261.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc1dQO_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="26.0" x="866.0" y="266.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_ED4E0978-EEA1-48D8-97A6-CDE203B6FB79" itp:label="no" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_3fb323d5-2c59-487a-af63-804208f6c5cb">
+        <di:waypoint xsi:type="dc:Point" x="783.0" y="245.0"/>
+        <di:waypoint xsi:type="dc:Point" x="783.0" y="141.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_jc1dQe_bEeSGoscwBjzAjw" color:color="#000000" labelStyle="_ea62b61f-473a-454a-a9bc-14475ce28686">
+          <dc:Bounds height="14.0" width="20.0" x="788.0" y="226.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="_55E23507-9E27-4074-A5D7-FB4D8A0A5328" itp:label="(unnamed)" itp:elementType="sequenceFlow" color:border-color="#000000" bpmnElement="_a5af06ae-bd69-464d-bbaf-3d7418702d77">
+        <di:waypoint xsi:type="dc:Point" x="81.0" y="149.0"/>
+        <di:waypoint xsi:type="dc:Point" x="164.0" y="149.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Bpmndi_BPMNShape_sUfxEBqGEeWDuOtG0oS24A" bpmnElement="Bpmn_BoundaryEvent_sS9gABqGEeWDuOtG0oS24A" isHorizontal="true" isMessageVisible="true" color:background-color="#2953e7">
+        <dc:Bounds height="24.0" width="24.0" x="552.0" y="463.0"/>
+        <bpmndi:BPMNLabel id="Bpmndi_BPMNLabel_sUfxERqGEeWDuOtG0oS24A" labelStyle="Bpmndi_BPMNLabelStyle_sWbDsRqGEeWDuOtG0oS24A">
+          <dc:Bounds height="13.0" width="48.0" x="576.0" y="487.0"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_tcukcBqGEeWDuOtG0oS24A" bpmnElement="Bpmn_SequenceFlow_tcbpgBqGEeWDuOtG0oS24A">
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="487.0"/>
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="517.0"/>
+        <di:waypoint xsi:type="dc:Point" x="651.0" y="517.0"/>
+        <di:waypoint xsi:type="dc:Point" x="651.0" y="342.0"/>
+        <di:waypoint xsi:type="dc:Point" x="532.0" y="342.0"/>
+        <di:waypoint xsi:type="dc:Point" x="532.0" y="290.0"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Bpmndi_BPMNShape_Lwzm8BqHEeWDuOtG0oS24A" bpmnElement="Bpmn_BoundaryEvent_LwKtwhqHEeWDuOtG0oS24A" isHorizontal="true" isMessageVisible="true" color:background-color="#2953e7">
+        <dc:Bounds height="24.0" width="24.0" x="552.0" y="631.0"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Bpmndi_BPMNEdge_-dRe4BqHEeWDuOtG0oS24A" bpmnElement="Bpmn_SequenceFlow_-dQQwBqHEeWDuOtG0oS24A">
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="655.0"/>
+        <di:waypoint xsi:type="dc:Point" x="564.0" y="674.0"/>
+        <di:waypoint xsi:type="dc:Point" x="651.0" y="674.0"/>
+        <di:waypoint xsi:type="dc:Point" x="651.0" y="550.0"/>
+        <di:waypoint xsi:type="dc:Point" x="534.0" y="550.0"/>
+        <di:waypoint xsi:type="dc:Point" x="534.0" y="475.0"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="_ea62b61f-473a-454a-a9bc-14475ce28686">
+      <dc:Font name="Arial" size="11.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_sWbDsBqGEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_sWbDsRqGEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="11.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_tdDUkBqGEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_LxeVUBqHEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_PtBk4BqHEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_8D_TUBqHEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="Bpmndi_BPMNLabelStyle_-dmPABqHEeWDuOtG0oS24A">
+      <dc:Font name="Segoe UI" size="12.0"/>
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.4.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.4.0.bpmn
@@ -1,0 +1,1045 @@
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed" xmlns:drools="http://www.jboss.org/drools" xmlns:openapi="https://openapis.org/omg/extension/1.0"                xmlns="http://www.trisotech.com/definitions/_e7ccc12c-2987-48ae-92aa-08112101d9c9" id="_e7ccc12c-2987-48ae-92aa-08112101d9c9" targetNamespace="http://www.trisotech.com/definitions/_e7ccc12c-2987-48ae-92aa-08112101d9c9" expressionLanguage="http://www.w3.org/1999/XPath" exporter="BPMN Modeler" exporterVersion="6.2.0" name="C.4.0" trisobpmn:logoChoice="Default">
+    <semantic:itemDefinition structureRef="string" triso:basicType="true" triso:definitionType="http://www.trisotech.com/2015/triso/modeling/ItemDefinitionType" id="_triso-default-bpmnItemDefinition-string_id" triso:name="triso_string"/>
+    <semantic:signal id="_bf41cec3-da5e-4fc7-87f9-7520a720192b" name="New employee hired"/>
+    <semantic:collaboration id="_085241a5-fb5c-44d3-8844-5366f865e353">
+        <semantic:participant id="_06745dd2-cbc6-4742-b11c-69281e5dcbdb" name="Money Bank" processRef="_42cba3a9-a8ab-40b5-b9a4-2e8f32be364e"/>
+    </semantic:collaboration>
+    <semantic:collaboration id="_674b5898-d454-4114-a8eb-66c790366e94">
+        <semantic:participant id="_b5172765-a1c1-4c6e-8e57-9eabaf8cecdf" name="IT" processRef="_f0035388-f829-470c-b82b-0b15c3da3399"/>
+    </semantic:collaboration>
+    <semantic:collaboration id="_bbdf487b-c3a3-4bfa-8ba3-79be59f08203">
+        <semantic:participant id="_1422af8d-518b-49f1-9563-9b6939de2818" name="Payroll" processRef="_da743a6f-d9e5-4fcf-8a96-d2fd5cfb73d4"/>
+    </semantic:collaboration>
+    <semantic:collaboration id="_8d4bb408-4175-4fbb-8131-18c32b7aa022">
+        <semantic:participant id="_fab40827-7808-470a-93b6-4a3318bf0c0e" name="Facilities" processRef="_3486bf55-0a7f-4ff1-be15-1555669f58ad"/>
+    </semantic:collaboration>
+    <semantic:dataStore id="_d367181e-c25a-407e-a5fb-817a27698a30" name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isUnlimited="false"/>
+    <semantic:dataStore id="_7c793f30-d450-4a8e-becf-f168b14317ea" name="User Management" isUnlimited="false"/>
+    <semantic:dataStore id="_2addcc9a-638e-4496-b84f-5b0e28fe6536" name="Payroll system" isUnlimited="false"/>
+    <semantic:process id="_42cba3a9-a8ab-40b5-b9a4-2e8f32be364e" name="Money Bank - Process" triso:defaultName="true" isClosed="false">
+        <semantic:laneSet>
+            <semantic:lane id="_ff7ff8f6-a4f1-4e93-84e1-01cdb85eb755" name="HR Department">
+                <semantic:flowNodeRef>_a4220c17-364f-4a08-ae9c-757a6468b295</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f8973a92-3d84-4672-a1a3-b0df154121e1</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f9e3cd76-809a-48b5-be1c-e84fc4324268</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_aa275782-c989-49ba-bf94-c58916ca7bb5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_987b9b74-333a-4043-a72a-daadf667acc7</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_305ddf53-49a8-4105-ad06-70272a2332aa</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_0e71ed63-93f9-44b6-a89d-da9628652926</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_eba690b9-34ef-49e4-b265-1411809d9302</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_67944b4c-4950-45a2-a131-1c4679c6b433</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_4c95f4a0-f4ec-45ed-9fdb-7b236155d6f5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_82da02ca-ee9a-4403-9f3b-aad030e089b9</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="_937b5086-463f-4c8c-837d-f5eee5cbc1f4" name="Responsible Department">
+                <semantic:flowNodeRef>_986cf801-0780-49d3-91cd-2cc6d3c1aac3</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_855451b0-5298-48b2-a81d-84ecbcca0a85</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_72da5cee-0456-4c3c-ba8d-6dd085d6f52d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_e3d3ac43-74a3-48ff-9a02-e64b1358cc34</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_80f70d22-fb42-403f-8bdb-6805e9467bb7</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_fe77c2f2-278f-4752-9d03-aa0c8a12af1e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_db9147a9-7fbc-4657-a506-15e777f2cfd9</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_74e2cc7b-99ca-426b-ad53-ad70a56506aa</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_19808f32-dfb5-462d-aaa6-e662f9932dba</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_351b058e-c37c-4fb7-9d32-24075f53ce02</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_52401cbb-02b8-4eaf-84f1-1edbc0854a4a</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_36baf139-fb74-43ef-8936-d490238c2825</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:startEvent id="_a4220c17-364f-4a08-ae9c-757a6468b295" name="Candidate accepted offer">
+            <semantic:outgoing>_6d1a9d5a-127d-477a-8dbe-268f125f20d8</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:userTask id="_f8973a92-3d84-4672-a1a3-b0df154121e1" name="Send &#10;candidate Contract" implementation="##unspecified">
+            <semantic:incoming>_6d1a9d5a-127d-477a-8dbe-268f125f20d8</semantic:incoming>
+            <semantic:incoming>_9ca6c9e6-4aff-4ec8-9fd3-2743c06483c3</semantic:incoming>
+            <semantic:outgoing>_4d3df0ce-e5be-443b-a379-8dcd4aae4de9</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_f9e3cd76-809a-48b5-be1c-e84fc4324268" name="Contract terms accepted ?" gatewayDirection="Diverging">
+            <semantic:incoming>_4d3df0ce-e5be-443b-a379-8dcd4aae4de9</semantic:incoming>
+            <semantic:outgoing>_237c8380-5449-446e-a323-aad80181176d</semantic:outgoing>
+            <semantic:outgoing>_7e9d8b8b-faa9-4264-858b-7454702c4ec2</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_aa275782-c989-49ba-bf94-c58916ca7bb5" name="Get signature on contract and notify responsible department" implementation="##unspecified">
+            <semantic:incoming>_237c8380-5449-446e-a323-aad80181176d</semantic:incoming>
+            <semantic:outgoing>_41254af9-ca6b-49ae-a58e-c48f4c6120d2</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" id="_d0960287-a964-4916-b4fe-b1238d9e3e75"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_2850d02b-5efe-4fa8-82c9-eac458b2e4d8">
+                    <semantic:dataOutputRefs>_d0960287-a964-4916-b4fe-b1238d9e3e75</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_5c5f0068-874e-4dbb-ad30-ae8389921645">
+                <semantic:sourceRef>_d0960287-a964-4916-b4fe-b1238d9e3e75</semantic:sourceRef>
+                <semantic:targetRef>_f00a95f6-043e-4ec1-8731-153a707e950c</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:userTask id="_987b9b74-333a-4043-a72a-daadf667acc7" name="Review terms of contract" implementation="##unspecified">
+            <semantic:incoming>_7e9d8b8b-faa9-4264-858b-7454702c4ec2</semantic:incoming>
+            <semantic:outgoing>_9ca6c9e6-4aff-4ec8-9fd3-2743c06483c3</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_305ddf53-49a8-4105-ad06-70272a2332aa" name="Non-exclusive Gateway" gatewayDirection="Diverging">
+            <semantic:incoming>_41254af9-ca6b-49ae-a58e-c48f4c6120d2</semantic:incoming>
+            <semantic:outgoing>_d1c906b1-8f68-4485-94ea-00e732fba73e</semantic:outgoing>
+            <semantic:outgoing>_0811a8cc-1fde-4319-a718-7fb3ce64ae0b</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:userTask id="_0e71ed63-93f9-44b6-a89d-da9628652926" name="Inform employee of company policies" implementation="##unspecified">
+            <semantic:incoming>_d1c906b1-8f68-4485-94ea-00e732fba73e</semantic:incoming>
+            <semantic:outgoing>_5ae80bdd-cda7-491b-b3f7-bce2c4b35a83</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_eba690b9-34ef-49e4-b265-1411809d9302" name="Introduce employee to company Mission, Vision and Values" implementation="##unspecified">
+            <semantic:incoming>_5ae80bdd-cda7-491b-b3f7-bce2c4b35a83</semantic:incoming>
+            <semantic:outgoing>_15f3cde0-eeb5-4ad2-820a-114815aa782d</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_67944b4c-4950-45a2-a131-1c4679c6b433" name="Perform training for time reports sick leave and holidays" implementation="##unspecified">
+            <semantic:incoming>_15f3cde0-eeb5-4ad2-820a-114815aa782d</semantic:incoming>
+            <semantic:outgoing>_2d93c5db-2e41-463b-a1a6-63a05616d912</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_4c95f4a0-f4ec-45ed-9fdb-7b236155d6f5" name="Register for medical insurance" implementation="##unspecified">
+            <semantic:incoming>_2d93c5db-2e41-463b-a1a6-63a05616d912</semantic:incoming>
+            <semantic:outgoing>_3104b7bb-a417-4557-8c1b-d95b1c7e36a4</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_82da02ca-ee9a-4403-9f3b-aad030e089b9" name="Non-exclusive Gateway" gatewayDirection="Converging">
+            <semantic:incoming>_3104b7bb-a417-4557-8c1b-d95b1c7e36a4</semantic:incoming>
+            <semantic:incoming>_71b2c3f1-0d34-4cfb-956c-cedf83660dfb</semantic:incoming>
+            <semantic:outgoing>_cad69ba8-8b26-41f9-87a1-372a899dcbf3</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:dataStoreReference id="_f00a95f6-043e-4ec1-8731-153a707e950c" name="Employee Details" dataStoreRef="_d367181e-c25a-407e-a5fb-817a27698a30"/>
+        <semantic:userTask id="_986cf801-0780-49d3-91cd-2cc6d3c1aac3" name="Request preparations for a new employee" implementation="##unspecified">
+            <semantic:incoming>_0811a8cc-1fde-4319-a718-7fb3ce64ae0b</semantic:incoming>
+            <semantic:outgoing>_3bb98d19-0d0b-4f47-a097-30c60183e334</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:intermediateThrowEvent id="_855451b0-5298-48b2-a81d-84ecbcca0a85" name="New employee in department X">
+            <semantic:incoming>_3bb98d19-0d0b-4f47-a097-30c60183e334</semantic:incoming>
+            <semantic:outgoing>_71b2c3f1-0d34-4cfb-956c-cedf83660dfb</semantic:outgoing>
+            <semantic:dataInput id="_d5083b64-f0cd-479b-a773-b477a20408b5" name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id"/>
+            <semantic:dataInputAssociation id="_7a5b52f3-ad7e-4c5c-9ac2-432c8318b821">
+                <semantic:sourceRef>_f00a95f6-043e-4ec1-8731-153a707e950c</semantic:sourceRef>
+                <semantic:targetRef>_d5083b64-f0cd-479b-a773-b477a20408b5</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:inputSet id="_e304d0f8-6eaa-4a79-a6ff-b08e993d0d06">
+                <semantic:dataInputRefs>_d5083b64-f0cd-479b-a773-b477a20408b5</semantic:dataInputRefs>
+            </semantic:inputSet>
+            <semantic:signalEventDefinition id="_e027a3d0-02f7-40a6-b84c-3b49282070ba" signalRef="_bf41cec3-da5e-4fc7-87f9-7520a720192b"/>
+        </semantic:intermediateThrowEvent>
+        <semantic:userTask id="_72da5cee-0456-4c3c-ba8d-6dd085d6f52d" name="Introduce new employee to the team" implementation="##unspecified">
+            <semantic:incoming>_cad69ba8-8b26-41f9-87a1-372a899dcbf3</semantic:incoming>
+            <semantic:outgoing>_2ef25e1e-bbdd-4cba-b411-6091ec8669d6</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_e3d3ac43-74a3-48ff-9a02-e64b1358cc34" name="Perform training for position" implementation="##unspecified">
+            <semantic:incoming>_2ef25e1e-bbdd-4cba-b411-6091ec8669d6</semantic:incoming>
+            <semantic:outgoing>_240df34c-86c2-49fe-b1ec-58ea25d35c1f</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_80f70d22-fb42-403f-8bdb-6805e9467bb7" name="Non-exclusive Gateway" gatewayDirection="Diverging">
+            <semantic:incoming>_240df34c-86c2-49fe-b1ec-58ea25d35c1f</semantic:incoming>
+            <semantic:outgoing>_2be942a3-d921-4ad9-bce7-33e3411d98b4</semantic:outgoing>
+            <semantic:outgoing>_4b186d86-fae1-4f55-a3b6-b90fa27affc1</semantic:outgoing>
+            <semantic:outgoing>_c1307108-5b3d-48af-ae53-11b30dd31bed</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:intermediateCatchEvent id="_fe77c2f2-278f-4752-9d03-aa0c8a12af1e" name="Input from Payroll ready">
+            <semantic:incoming>_4b186d86-fae1-4f55-a3b6-b90fa27affc1</semantic:incoming>
+            <semantic:outgoing>_e82e6ee3-24d6-419a-96c0-a147f1943c23</semantic:outgoing>
+            <semantic:messageEventDefinition id="_9e9bd4fc-0a94-4956-ac98-daf2ddeb001c"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:intermediateCatchEvent id="_db9147a9-7fbc-4657-a506-15e777f2cfd9" name="Input from Facilities ready">
+            <semantic:incoming>_c1307108-5b3d-48af-ae53-11b30dd31bed</semantic:incoming>
+            <semantic:outgoing>_c8da08ab-0b59-4c21-9386-f857d624c471</semantic:outgoing>
+            <semantic:messageEventDefinition id="_3454f552-d717-4f8c-ae58-971bef888af0"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:intermediateCatchEvent id="_74e2cc7b-99ca-426b-ad53-ad70a56506aa" name="Input from IT ready">
+            <semantic:incoming>_2be942a3-d921-4ad9-bce7-33e3411d98b4</semantic:incoming>
+            <semantic:outgoing>_16e4630e-39c0-4e94-ab65-a8a622245adf</semantic:outgoing>
+            <semantic:messageEventDefinition id="_940a88a5-974a-4583-afed-4510a94e5249"/>
+        </semantic:intermediateCatchEvent>
+        <semantic:parallelGateway id="_19808f32-dfb5-462d-aaa6-e662f9932dba" name="Non-exclusive Gateway" gatewayDirection="Converging">
+            <semantic:incoming>_e82e6ee3-24d6-419a-96c0-a147f1943c23</semantic:incoming>
+            <semantic:incoming>_16e4630e-39c0-4e94-ab65-a8a622245adf</semantic:incoming>
+            <semantic:incoming>_c8da08ab-0b59-4c21-9386-f857d624c471</semantic:incoming>
+            <semantic:outgoing>_ece7bc06-ccf7-49f5-b5f1-99e1103cf538</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:userTask id="_351b058e-c37c-4fb7-9d32-24075f53ce02" name="Compile welcome package" implementation="##unspecified">
+            <semantic:incoming>_ece7bc06-ccf7-49f5-b5f1-99e1103cf538</semantic:incoming>
+            <semantic:outgoing>_c8454490-8090-4cf7-a164-d0aded7bc4da</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_52401cbb-02b8-4eaf-84f1-1edbc0854a4a" name="Give employee welcome package" implementation="##unspecified">
+            <semantic:incoming>_c8454490-8090-4cf7-a164-d0aded7bc4da</semantic:incoming>
+            <semantic:outgoing>_0fdd6987-6236-4972-a7be-3431ed6654ec</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:endEvent id="_36baf139-fb74-43ef-8936-d490238c2825" name="End Event">
+            <semantic:incoming>_0fdd6987-6236-4972-a7be-3431ed6654ec</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow id="_6d1a9d5a-127d-477a-8dbe-268f125f20d8" sourceRef="_a4220c17-364f-4a08-ae9c-757a6468b295" targetRef="_f8973a92-3d84-4672-a1a3-b0df154121e1"/>
+        <semantic:sequenceFlow id="_4d3df0ce-e5be-443b-a379-8dcd4aae4de9" sourceRef="_f8973a92-3d84-4672-a1a3-b0df154121e1" targetRef="_f9e3cd76-809a-48b5-be1c-e84fc4324268"/>
+        <semantic:sequenceFlow id="_237c8380-5449-446e-a323-aad80181176d" name="Yes" sourceRef="_f9e3cd76-809a-48b5-be1c-e84fc4324268" targetRef="_aa275782-c989-49ba-bf94-c58916ca7bb5"/>
+        <semantic:sequenceFlow id="_7e9d8b8b-faa9-4264-858b-7454702c4ec2" name="No" sourceRef="_f9e3cd76-809a-48b5-be1c-e84fc4324268" targetRef="_987b9b74-333a-4043-a72a-daadf667acc7"/>
+        <semantic:sequenceFlow id="_41254af9-ca6b-49ae-a58e-c48f4c6120d2" sourceRef="_aa275782-c989-49ba-bf94-c58916ca7bb5" targetRef="_305ddf53-49a8-4105-ad06-70272a2332aa"/>
+        <semantic:sequenceFlow id="_d1c906b1-8f68-4485-94ea-00e732fba73e" sourceRef="_305ddf53-49a8-4105-ad06-70272a2332aa" targetRef="_0e71ed63-93f9-44b6-a89d-da9628652926"/>
+        <semantic:sequenceFlow id="_5ae80bdd-cda7-491b-b3f7-bce2c4b35a83" sourceRef="_0e71ed63-93f9-44b6-a89d-da9628652926" targetRef="_eba690b9-34ef-49e4-b265-1411809d9302"/>
+        <semantic:sequenceFlow id="_15f3cde0-eeb5-4ad2-820a-114815aa782d" sourceRef="_eba690b9-34ef-49e4-b265-1411809d9302" targetRef="_67944b4c-4950-45a2-a131-1c4679c6b433"/>
+        <semantic:sequenceFlow id="_2d93c5db-2e41-463b-a1a6-63a05616d912" sourceRef="_67944b4c-4950-45a2-a131-1c4679c6b433" targetRef="_4c95f4a0-f4ec-45ed-9fdb-7b236155d6f5"/>
+        <semantic:sequenceFlow id="_3104b7bb-a417-4557-8c1b-d95b1c7e36a4" sourceRef="_4c95f4a0-f4ec-45ed-9fdb-7b236155d6f5" targetRef="_82da02ca-ee9a-4403-9f3b-aad030e089b9"/>
+        <semantic:sequenceFlow id="_0811a8cc-1fde-4319-a718-7fb3ce64ae0b" sourceRef="_305ddf53-49a8-4105-ad06-70272a2332aa" targetRef="_986cf801-0780-49d3-91cd-2cc6d3c1aac3"/>
+        <semantic:sequenceFlow id="_3bb98d19-0d0b-4f47-a097-30c60183e334" sourceRef="_986cf801-0780-49d3-91cd-2cc6d3c1aac3" targetRef="_855451b0-5298-48b2-a81d-84ecbcca0a85"/>
+        <semantic:sequenceFlow id="_71b2c3f1-0d34-4cfb-956c-cedf83660dfb" sourceRef="_855451b0-5298-48b2-a81d-84ecbcca0a85" targetRef="_82da02ca-ee9a-4403-9f3b-aad030e089b9"/>
+        <semantic:sequenceFlow id="_cad69ba8-8b26-41f9-87a1-372a899dcbf3" sourceRef="_82da02ca-ee9a-4403-9f3b-aad030e089b9" targetRef="_72da5cee-0456-4c3c-ba8d-6dd085d6f52d"/>
+        <semantic:sequenceFlow id="_2ef25e1e-bbdd-4cba-b411-6091ec8669d6" sourceRef="_72da5cee-0456-4c3c-ba8d-6dd085d6f52d" targetRef="_e3d3ac43-74a3-48ff-9a02-e64b1358cc34"/>
+        <semantic:sequenceFlow id="_240df34c-86c2-49fe-b1ec-58ea25d35c1f" sourceRef="_e3d3ac43-74a3-48ff-9a02-e64b1358cc34" targetRef="_80f70d22-fb42-403f-8bdb-6805e9467bb7"/>
+        <semantic:sequenceFlow id="_2be942a3-d921-4ad9-bce7-33e3411d98b4" sourceRef="_80f70d22-fb42-403f-8bdb-6805e9467bb7" targetRef="_74e2cc7b-99ca-426b-ad53-ad70a56506aa"/>
+        <semantic:sequenceFlow id="_4b186d86-fae1-4f55-a3b6-b90fa27affc1" sourceRef="_80f70d22-fb42-403f-8bdb-6805e9467bb7" targetRef="_fe77c2f2-278f-4752-9d03-aa0c8a12af1e"/>
+        <semantic:sequenceFlow id="_c1307108-5b3d-48af-ae53-11b30dd31bed" sourceRef="_80f70d22-fb42-403f-8bdb-6805e9467bb7" targetRef="_db9147a9-7fbc-4657-a506-15e777f2cfd9"/>
+        <semantic:sequenceFlow id="_e82e6ee3-24d6-419a-96c0-a147f1943c23" sourceRef="_fe77c2f2-278f-4752-9d03-aa0c8a12af1e" targetRef="_19808f32-dfb5-462d-aaa6-e662f9932dba"/>
+        <semantic:sequenceFlow id="_16e4630e-39c0-4e94-ab65-a8a622245adf" sourceRef="_74e2cc7b-99ca-426b-ad53-ad70a56506aa" targetRef="_19808f32-dfb5-462d-aaa6-e662f9932dba"/>
+        <semantic:sequenceFlow id="_c8da08ab-0b59-4c21-9386-f857d624c471" sourceRef="_db9147a9-7fbc-4657-a506-15e777f2cfd9" targetRef="_19808f32-dfb5-462d-aaa6-e662f9932dba"/>
+        <semantic:sequenceFlow id="_ece7bc06-ccf7-49f5-b5f1-99e1103cf538" sourceRef="_19808f32-dfb5-462d-aaa6-e662f9932dba" targetRef="_351b058e-c37c-4fb7-9d32-24075f53ce02"/>
+        <semantic:sequenceFlow id="_c8454490-8090-4cf7-a164-d0aded7bc4da" sourceRef="_351b058e-c37c-4fb7-9d32-24075f53ce02" targetRef="_52401cbb-02b8-4eaf-84f1-1edbc0854a4a"/>
+        <semantic:sequenceFlow id="_0fdd6987-6236-4972-a7be-3431ed6654ec" sourceRef="_52401cbb-02b8-4eaf-84f1-1edbc0854a4a" targetRef="_36baf139-fb74-43ef-8936-d490238c2825"/>
+        <semantic:sequenceFlow id="_9ca6c9e6-4aff-4ec8-9fd3-2743c06483c3" sourceRef="_987b9b74-333a-4043-a72a-daadf667acc7" targetRef="_f8973a92-3d84-4672-a1a3-b0df154121e1"/>
+    </semantic:process>
+    <semantic:process id="_f0035388-f829-470c-b82b-0b15c3da3399" name="IT - Process" triso:defaultName="true" isClosed="false">
+        <semantic:startEvent id="_e9306b3f-3a77-42e1-b53e-2ed8ee45486d" name="New &#10;employee&#10;hired">
+            <semantic:outgoing>_495f04a4-ed17-4e7b-a952-11c06c2230d1</semantic:outgoing>
+            <semantic:dataOutput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_e96a6b5c-b24a-4221-8d35-cd3a4e68641e"/>
+            <semantic:dataOutputAssociation id="_ed210028-7993-4aa4-b2f7-951ab85243be">
+                <semantic:sourceRef>_e96a6b5c-b24a-4221-8d35-cd3a4e68641e</semantic:sourceRef>
+                <semantic:targetRef>_e355b511-e181-4e7b-a9b1-30cb48dd6cab</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="_2d74cb72-2fcc-4869-b5f0-b867a7f2f7ec">
+                <semantic:dataOutputRefs>_e96a6b5c-b24a-4221-8d35-cd3a4e68641e</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition id="_5ec0186c-9f7d-43b1-ba20-571cfe42bc5c" signalRef="_bf41cec3-da5e-4fc7-87f9-7520a720192b"/>
+        </semantic:startEvent>
+        <semantic:userTask id="_7e9d2e5a-21f7-493b-9ae4-03245aa33a5c" name="Create domain account" implementation="##unspecified">
+            <semantic:incoming>_495f04a4-ed17-4e7b-a952-11c06c2230d1</semantic:incoming>
+            <semantic:outgoing>_0bccc7f6-0f56-49bc-98df-59d70433c043</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" id="_b1d40770-825b-4d23-a026-db95f815d520"/>
+                <semantic:dataOutput name="User Management" id="_18dcd171-c602-488e-b53b-0289e2fae114"/>
+                <semantic:inputSet id="_c228336b-c661-4e3a-920f-8e13f4844656">
+                    <semantic:dataInputRefs>_b1d40770-825b-4d23-a026-db95f815d520</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_3c50eff0-7da3-42bf-96be-d7e22f4a2bb5">
+                    <semantic:dataOutputRefs>_18dcd171-c602-488e-b53b-0289e2fae114</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_c4eff1b8-8817-418b-9ef9-5d3738d43659">
+                <semantic:sourceRef>_e355b511-e181-4e7b-a9b1-30cb48dd6cab</semantic:sourceRef>
+                <semantic:targetRef>_b1d40770-825b-4d23-a026-db95f815d520</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_0282dbd7-a11b-4cac-84e2-0f26bf86b853">
+                <semantic:sourceRef>_18dcd171-c602-488e-b53b-0289e2fae114</semantic:sourceRef>
+                <semantic:targetRef>_b60be020-1f04-46c2-b1a9-19bfc66ead82</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:manualTask id="_c29af228-0768-4dfe-945a-17755e173674" name="Prepare workstation">
+            <semantic:incoming>_0bccc7f6-0f56-49bc-98df-59d70433c043</semantic:incoming>
+            <semantic:outgoing>_dcec1142-90eb-41a8-b809-458b713ab94c</semantic:outgoing>
+        </semantic:manualTask>
+        <semantic:userTask id="_912f731a-fb6b-499b-a3f4-4c1632d606bd" name="Assign required applications and permissions" implementation="##unspecified">
+            <semantic:incoming>_dcec1142-90eb-41a8-b809-458b713ab94c</semantic:incoming>
+            <semantic:outgoing>_be72815e-ed18-4d77-9252-1ab0a7438dc9</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="User Management" id="_4b0aa8de-e86c-492a-a5da-fd80464b71bd"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_7809a0c3-5349-4e66-bf42-fa19126dd198">
+                    <semantic:dataOutputRefs>_4b0aa8de-e86c-492a-a5da-fd80464b71bd</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_17c38035-fb11-4abb-b2b6-1cbd14acdab0">
+                <semantic:sourceRef>_4b0aa8de-e86c-492a-a5da-fd80464b71bd</semantic:sourceRef>
+                <semantic:targetRef>_b60be020-1f04-46c2-b1a9-19bfc66ead82</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:serviceTask id="_9db2d136-aa33-4de2-be76-554e7843363d" name="Configure workstation" implementation="##WebService">
+            <semantic:incoming>_be72815e-ed18-4d77-9252-1ab0a7438dc9</semantic:incoming>
+            <semantic:outgoing>_ba635734-5672-4f1b-b753-3b08c778c64e</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="User Management" id="_4606e5ae-aaa4-4416-9576-68f29181c5b2"/>
+                <semantic:inputSet id="_3b4c5d5b-b5bc-4155-8ff6-adb9f629de15">
+                    <semantic:dataInputRefs>_4606e5ae-aaa4-4416-9576-68f29181c5b2</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_de54f4cb-0603-4389-ab3a-9edb9cbfec2a">
+                <semantic:sourceRef>_b60be020-1f04-46c2-b1a9-19bfc66ead82</semantic:sourceRef>
+                <semantic:targetRef>_4606e5ae-aaa4-4416-9576-68f29181c5b2</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:serviceTask>
+        <semantic:userTask id="_ad173aff-cfe3-4098-8c65-02f783ad9e1f" name="Prepare IT part of welcome package" implementation="##unspecified">
+            <semantic:incoming>_ba635734-5672-4f1b-b753-3b08c778c64e</semantic:incoming>
+            <semantic:outgoing>_c904a36b-64f6-46e3-8ef1-9f2ecc3faaff</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:endEvent id="_c82dd8eb-ce54-4aa7-b8c4-b8d3e8fd654e" name="Workstation and permissions ready">
+            <semantic:incoming>_c904a36b-64f6-46e3-8ef1-9f2ecc3faaff</semantic:incoming>
+            <semantic:messageEventDefinition id="_2f246656-2c54-430d-ad1b-9c50428d1b9d"/>
+        </semantic:endEvent>
+        <semantic:dataStoreReference id="_e355b511-e181-4e7b-a9b1-30cb48dd6cab" name="Employee Details" dataStoreRef="_d367181e-c25a-407e-a5fb-817a27698a30"/>
+        <semantic:dataStoreReference id="_b60be020-1f04-46c2-b1a9-19bfc66ead82" name="User Management" dataStoreRef="_7c793f30-d450-4a8e-becf-f168b14317ea"/>
+        <semantic:sequenceFlow id="_495f04a4-ed17-4e7b-a952-11c06c2230d1" sourceRef="_e9306b3f-3a77-42e1-b53e-2ed8ee45486d" targetRef="_7e9d2e5a-21f7-493b-9ae4-03245aa33a5c"/>
+        <semantic:sequenceFlow id="_0bccc7f6-0f56-49bc-98df-59d70433c043" sourceRef="_7e9d2e5a-21f7-493b-9ae4-03245aa33a5c" targetRef="_c29af228-0768-4dfe-945a-17755e173674"/>
+        <semantic:sequenceFlow id="_dcec1142-90eb-41a8-b809-458b713ab94c" sourceRef="_c29af228-0768-4dfe-945a-17755e173674" targetRef="_912f731a-fb6b-499b-a3f4-4c1632d606bd"/>
+        <semantic:sequenceFlow id="_be72815e-ed18-4d77-9252-1ab0a7438dc9" sourceRef="_912f731a-fb6b-499b-a3f4-4c1632d606bd" targetRef="_9db2d136-aa33-4de2-be76-554e7843363d"/>
+        <semantic:sequenceFlow id="_ba635734-5672-4f1b-b753-3b08c778c64e" sourceRef="_9db2d136-aa33-4de2-be76-554e7843363d" targetRef="_ad173aff-cfe3-4098-8c65-02f783ad9e1f"/>
+        <semantic:sequenceFlow id="_c904a36b-64f6-46e3-8ef1-9f2ecc3faaff" sourceRef="_ad173aff-cfe3-4098-8c65-02f783ad9e1f" targetRef="_c82dd8eb-ce54-4aa7-b8c4-b8d3e8fd654e"/>
+        <semantic:textAnnotation id="_246c3cf7-fb4b-4c05-8ece-55c77fb4dc1e">
+            <semantic:text>With PowerShell</semantic:text>
+        </semantic:textAnnotation>
+        <semantic:association id="_fa0de585-aa40-40bb-a3a5-965d956e884d" sourceRef="_9db2d136-aa33-4de2-be76-554e7843363d" targetRef="_246c3cf7-fb4b-4c05-8ece-55c77fb4dc1e" associationDirection="None"/>
+    </semantic:process>
+    <semantic:process id="_da743a6f-d9e5-4fcf-8a96-d2fd5cfb73d4" name="Payroll - Process" triso:defaultName="true" isClosed="false">
+        <semantic:startEvent id="_3d4130c6-48c9-47fe-8e95-2eeb56060e2b" name="New &#10;employee&#10;hired">
+            <semantic:outgoing>_6b24f6f7-bc44-4d73-ab54-1ac8b638423e</semantic:outgoing>
+            <semantic:dataOutput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" id="_06fff5da-cd41-4538-a6b8-cd73c6368aa3"/>
+            <semantic:dataOutputAssociation id="_fba68566-2c5e-49e2-8f1e-2feff2873742">
+                <semantic:sourceRef>_06fff5da-cd41-4538-a6b8-cd73c6368aa3</semantic:sourceRef>
+                <semantic:targetRef>_16498c9e-c33f-4f92-9033-714b89582a7c</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="_0b28282c-3c90-4b70-920c-a6898a3fc18a">
+                <semantic:dataOutputRefs>_06fff5da-cd41-4538-a6b8-cd73c6368aa3</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition id="_1f790746-cb6c-4eaa-85a8-a0a6c0fa7602" signalRef="_bf41cec3-da5e-4fc7-87f9-7520a720192b"/>
+        </semantic:startEvent>
+        <semantic:userTask id="_ae47ce79-bd91-452b-be68-47a2ea589e75" name="Validate provided information" implementation="##unspecified">
+            <semantic:incoming>_6b24f6f7-bc44-4d73-ab54-1ac8b638423e</semantic:incoming>
+            <semantic:outgoing>_d110be18-ff17-4375-818b-6463eff4e2d6</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" id="_b3935a94-0b1b-4cd7-8a3b-a10f5b8b5e34"/>
+                <semantic:inputSet id="_4dbfa005-dede-45b3-adfd-f81e5900e5a6">
+                    <semantic:dataInputRefs>_b3935a94-0b1b-4cd7-8a3b-a10f5b8b5e34</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_3ba0a27a-2a49-458b-8680-be1330f46f3a">
+                <semantic:sourceRef>_16498c9e-c33f-4f92-9033-714b89582a7c</semantic:sourceRef>
+                <semantic:targetRef>_b3935a94-0b1b-4cd7-8a3b-a10f5b8b5e34</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_fa14ca2d-ea97-49a2-b75e-72e7d27d6fd1" name="All necessary data available?" gatewayDirection="Diverging">
+            <semantic:incoming>_d110be18-ff17-4375-818b-6463eff4e2d6</semantic:incoming>
+            <semantic:outgoing>_ca6f904d-e30d-4777-a7dd-661650e1e3a2</semantic:outgoing>
+            <semantic:outgoing>_12e2f256-ec10-4a8d-934c-329143c588d8</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:manualTask id="_788443d9-65f0-43a4-96a8-63e8d6f380a7" name="Clarify missing points">
+            <semantic:incoming>_ca6f904d-e30d-4777-a7dd-661650e1e3a2</semantic:incoming>
+            <semantic:outgoing>_7b347349-7441-4e5c-ab24-2e614051f222</semantic:outgoing>
+            <semantic:standardLoopCharacteristics id="_be244352-1e67-4664-9a10-5d088542f02e" testBefore="false"/>
+        </semantic:manualTask>
+        <semantic:userTask id="_9dbd92a5-5c0a-4039-b741-bf4ede54ccf0" name="Update payroll system" implementation="##unspecified">
+            <semantic:incoming>_12e2f256-ec10-4a8d-934c-329143c588d8</semantic:incoming>
+            <semantic:incoming>_7b347349-7441-4e5c-ab24-2e614051f222</semantic:incoming>
+            <semantic:outgoing>_46c8bd85-1b7f-45fb-81c6-23d22300c0cd</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="Payroll system" id="_de11bfcc-129c-4570-b4f0-2b395f932f16"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_468ab3e6-4b63-4f54-9d07-16c8f1320ef1">
+                    <semantic:dataOutputRefs>_de11bfcc-129c-4570-b4f0-2b395f932f16</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_079db308-7d1e-497d-962e-23499236c981">
+                <semantic:sourceRef>_de11bfcc-129c-4570-b4f0-2b395f932f16</semantic:sourceRef>
+                <semantic:targetRef>_a9cffac5-6e03-41de-83bf-d34304f28b1a</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:endEvent id="_efbd0983-76cd-4a4c-acf3-6dde71d7c760" name="Payroll ready">
+            <semantic:incoming>_46c8bd85-1b7f-45fb-81c6-23d22300c0cd</semantic:incoming>
+            <semantic:messageEventDefinition id="_0be7d261-5be3-40e4-a6fd-954d9c836607"/>
+        </semantic:endEvent>
+        <semantic:dataStoreReference id="_16498c9e-c33f-4f92-9033-714b89582a7c" name="Employee Details" dataStoreRef="_d367181e-c25a-407e-a5fb-817a27698a30"/>
+        <semantic:dataStoreReference id="_a9cffac5-6e03-41de-83bf-d34304f28b1a" name="Payroll system" dataStoreRef="_2addcc9a-638e-4496-b84f-5b0e28fe6536"/>
+        <semantic:sequenceFlow id="_6b24f6f7-bc44-4d73-ab54-1ac8b638423e" sourceRef="_3d4130c6-48c9-47fe-8e95-2eeb56060e2b" targetRef="_ae47ce79-bd91-452b-be68-47a2ea589e75"/>
+        <semantic:sequenceFlow id="_d110be18-ff17-4375-818b-6463eff4e2d6" sourceRef="_ae47ce79-bd91-452b-be68-47a2ea589e75" targetRef="_fa14ca2d-ea97-49a2-b75e-72e7d27d6fd1"/>
+        <semantic:sequenceFlow id="_ca6f904d-e30d-4777-a7dd-661650e1e3a2" name="No" sourceRef="_fa14ca2d-ea97-49a2-b75e-72e7d27d6fd1" targetRef="_788443d9-65f0-43a4-96a8-63e8d6f380a7"/>
+        <semantic:sequenceFlow id="_12e2f256-ec10-4a8d-934c-329143c588d8" name="Yes" sourceRef="_fa14ca2d-ea97-49a2-b75e-72e7d27d6fd1" targetRef="_9dbd92a5-5c0a-4039-b741-bf4ede54ccf0"/>
+        <semantic:sequenceFlow id="_7b347349-7441-4e5c-ab24-2e614051f222" sourceRef="_788443d9-65f0-43a4-96a8-63e8d6f380a7" targetRef="_9dbd92a5-5c0a-4039-b741-bf4ede54ccf0"/>
+        <semantic:sequenceFlow id="_46c8bd85-1b7f-45fb-81c6-23d22300c0cd" sourceRef="_9dbd92a5-5c0a-4039-b741-bf4ede54ccf0" targetRef="_efbd0983-76cd-4a4c-acf3-6dde71d7c760"/>
+    </semantic:process>
+    <semantic:process id="_3486bf55-0a7f-4ff1-be15-1555669f58ad" name="Facilities - Process" triso:defaultName="true" isClosed="false">
+        <semantic:startEvent id="_94a62738-dc7a-49f6-81d8-f5642f7ae850" name="New &#10;employee &#10;hired">
+            <semantic:outgoing>_ea0e1abf-e9f6-406a-96fb-12fcdf765634</semantic:outgoing>
+            <semantic:dataOutput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_811f33cd-dd3b-4ecd-aa83-342ee7ccb86c"/>
+            <semantic:dataOutputAssociation id="_2ae32762-1124-45f5-a01b-7292f9721c7d">
+                <semantic:sourceRef>_811f33cd-dd3b-4ecd-aa83-342ee7ccb86c</semantic:sourceRef>
+                <semantic:targetRef>_9931ba94-ede8-4f53-8081-878c549ba1c8</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:outputSet id="_e0d2138c-bd9b-400c-9501-7fdfc1b41f5f">
+                <semantic:dataOutputRefs>_811f33cd-dd3b-4ecd-aa83-342ee7ccb86c</semantic:dataOutputRefs>
+            </semantic:outputSet>
+            <semantic:signalEventDefinition id="_3acc62e3-0cfd-400d-8691-3f05b1589d95" signalRef="_bf41cec3-da5e-4fc7-87f9-7520a720192b"/>
+        </semantic:startEvent>
+        <semantic:manualTask id="_2bf94039-15a1-44bb-9d14-81358777466c" name="Prepare&#10;access &#10;card">
+            <semantic:incoming>_ea0e1abf-e9f6-406a-96fb-12fcdf765634</semantic:incoming>
+            <semantic:outgoing>_4436759d-6848-4400-93e5-3971c69b2f67</semantic:outgoing>
+        </semantic:manualTask>
+        <semantic:userTask id="_737503c8-10bc-483f-8871-5461d822b469" name="Configure access details" implementation="##unspecified">
+            <semantic:incoming>_4436759d-6848-4400-93e5-3971c69b2f67</semantic:incoming>
+            <semantic:outgoing>_f405a593-5f87-4f62-862e-bcf9f776bc95</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Employee Details" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" id="_946f3a81-8249-481e-afc4-07647f204192"/>
+                <semantic:inputSet id="_9e2a6ff5-7f57-4b9a-873c-e3905310f0c7">
+                    <semantic:dataInputRefs>_946f3a81-8249-481e-afc4-07647f204192</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_ad35d446-d8b5-46d9-b2b0-61178b689754">
+                <semantic:sourceRef>_9931ba94-ede8-4f53-8081-878c549ba1c8</semantic:sourceRef>
+                <semantic:targetRef>_946f3a81-8249-481e-afc4-07647f204192</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:endEvent id="_5ee09fe4-f38f-454d-b6e4-1c3703a6a239" name="Access &#10;card &#10;ready">
+            <semantic:incoming>_f405a593-5f87-4f62-862e-bcf9f776bc95</semantic:incoming>
+            <semantic:messageEventDefinition id="_a4a343f5-62b7-4939-95c4-93b2520d5fa6"/>
+        </semantic:endEvent>
+        <semantic:dataStoreReference id="_9931ba94-ede8-4f53-8081-878c549ba1c8" name="Employee Details" dataStoreRef="_d367181e-c25a-407e-a5fb-817a27698a30"/>
+        <semantic:sequenceFlow id="_ea0e1abf-e9f6-406a-96fb-12fcdf765634" sourceRef="_94a62738-dc7a-49f6-81d8-f5642f7ae850" targetRef="_2bf94039-15a1-44bb-9d14-81358777466c"/>
+        <semantic:sequenceFlow id="_4436759d-6848-4400-93e5-3971c69b2f67" sourceRef="_2bf94039-15a1-44bb-9d14-81358777466c" targetRef="_737503c8-10bc-483f-8871-5461d822b469"/>
+        <semantic:sequenceFlow id="_f405a593-5f87-4f62-862e-bcf9f776bc95" sourceRef="_737503c8-10bc-483f-8871-5461d822b469" targetRef="_5ee09fe4-f38f-454d-b6e4-1c3703a6a239"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_1484687a-1f56-4a0b-8eac-a76d5806a31e" name="Onboarding employee">
+        <bpmndi:BPMNPlane bpmnElement="_085241a5-fb5c-44d3-8844-5366f865e353" id="_1484687a-1f56-4a0b-8eac-a76d5806a31e_plane" trisobpmn:diagramWidth="2921.147186279297" trisobpmn:diagramHeight="881">
+            <bpmndi:BPMNShape id="_3749e466-3409-4b7c-89d8-54e08885d6bc" bpmnElement="_06745dd2-cbc6-4742-b11c-69281e5dcbdb" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="64.5" y="0" width="2681.647186279297" height="831"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="825" width="12" x="69.5" y="3"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d370e393-c6f2-475e-917f-09f4964c9b52" bpmnElement="_ff7ff8f6-a4f1-4e93-84e1-01cdb85eb755" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="94.5" y="0" width="2651.647186279297" height="416"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="410" width="12" x="99.5" y="3"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0fc32220-cf89-48dd-b450-1f1091f8c8ad" bpmnElement="_a4220c17-364f-4a08-ae9c-757a6468b295" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="169.75" y="150" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="110" x="130.75" y="192"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_766c6bb5-a843-412e-9391-a2147091152b" bpmnElement="_f8973a92-3d84-4672-a1a3-b0df154121e1" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="256.75" y="128" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="40" width="89" x="260.25" y="146"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5600e418-7e5a-4cc6-b9ca-b4213b7a6160" bpmnElement="_f9e3cd76-809a-48b5-be1c-e84fc4324268" isMarkerVisible="false" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="407.75" y="145.98780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="25.999999999999993" width="110" x="373.5367965698242" y="191.72996445213045"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9f2d5722-e003-42e7-b6c3-35b9cdd490a3" bpmnElement="_aa275782-c989-49ba-bf94-c58916ca7bb5" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="504.32359313964844" y="122.5" width="110" height="87"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="54.00000000000001" width="103" x="507.82359313964844" y="139"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_380036af-542a-491e-aeb5-c5cca87f1347" bpmnElement="_987b9b74-333a-4043-a72a-daadf667acc7" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="380.5367965698242" y="14.987805426120758" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="89" x="384.0367965698242" y="39.98780542612076"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f5d84b57-47b7-42c6-aed2-d57e7610c3d4" bpmnElement="_305ddf53-49a8-4105-ad06-70272a2332aa" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="657.3235931396484" y="145.98780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="110" x="624.1103897094727" y="202.72996445213045"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b8384b73-bdb5-4c97-890d-8288edd98ee3" bpmnElement="_0e71ed63-93f9-44b6-a89d-da9628652926" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="753.8971862792969" y="128" width="123" height="75"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="116" x="757.3971862792969" y="152.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0aec75e6-880e-4583-9498-95ad7ac0fb51" bpmnElement="_eba690b9-34ef-49e4-b265-1411809d9302" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="936.8971862792969" y="126" width="132" height="79"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="40" width="125" x="940.3971862792969" y="145.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e117ae34-2933-433c-baae-bc7651c257cf" bpmnElement="_67944b4c-4950-45a2-a131-1c4679c6b433" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1123.8971862792969" y="127.5" width="127" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="40" width="120" x="1127.3971862792969" y="145.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_95a0def1-fb43-4883-b9f0-86ca2f7e7de9" bpmnElement="_4c95f4a0-f4ec-45ed-9fdb-7b236155d6f5" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1313.8971862792969" y="125.5" width="138" height="80"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="131" x="1317.3971862792969" y="152.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_568d4d42-8887-4688-b3b9-0922fd5277a5" bpmnElement="_82da02ca-ee9a-4403-9f3b-aad030e089b9" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1485.8971862792969" y="145.48780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="110" x="1442.683982849121" y="212.22996445213045"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f00a95f6-043e-4ec1-8731-153a707e950c_di" bpmnElement="_f00a95f6-043e-4ec1-8731-153a707e950c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="542.8235931396484" y="288.0035009384155" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="86.09375" x="517.2767181396484" y="322.5035009384155"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8fa1fa6c-b968-4a6e-b47a-459a3856edca" bpmnElement="_937b5086-463f-4c8c-837d-f5eee5cbc1f4" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="94.5" y="416" width="2651.647186279297" height="415"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="409" width="12" x="99.5" y="419"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b716c6ef-1766-4277-9b6e-eddcdd14ee0f" bpmnElement="_986cf801-0780-49d3-91cd-2cc6d3c1aac3" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="814.75" y="482" width="109" height="78"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="40" width="102" x="818.25" y="501"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5e80be06-3fba-4f17-a911-c6ca533848e1" bpmnElement="_855451b0-5298-48b2-a81d-84ecbcca0a85" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1026.75" y="502" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="110" x="989.75" y="548"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_41110662-ea36-4416-ba55-362b23367a49" bpmnElement="_72da5cee-0456-4c3c-ba8d-6dd085d6f52d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1608.8971862792969" y="504" width="135" height="78"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="128" x="1612.3971862792969" y="530"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7e0c5f22-cb34-4a2e-a5dd-c1d6cbdafbf7" bpmnElement="_e3d3ac43-74a3-48ff-9a02-e64b1358cc34" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1788" y="503.5" width="143" height="79"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="136" x="1791.5" y="537"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_dc08aa13-e114-4ed0-b184-3316bec5da43" bpmnElement="_80f70d22-fb42-403f-8bdb-6805e9467bb7" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1971" y="522.9878054261208" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="69.078125" x="1957.4609375" y="569.7867955565453"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e603b2cd-9310-49d6-9709-e27025c3120c" bpmnElement="_fe77c2f2-278f-4752-9d03-aa0c8a12af1e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2106.5735931396484" y="525" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="86.75" x="2081.1985931396484" y="571"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bfb99784-02d5-4ca8-962d-af9209e87a20" bpmnElement="_db9147a9-7fbc-4657-a506-15e777f2cfd9" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2106.5735931396484" y="607.5" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="95.859375" x="2076.6439056396484" y="653.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_215e9467-cadf-41dc-b654-20d5f9e8cf65" bpmnElement="_74e2cc7b-99ca-426b-ad53-ad70a56506aa" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2106.5735931396484" y="443" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="110" x="2069.5735931396484" y="489"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6541360b-2b46-4786-9b15-d56da6431907" bpmnElement="_19808f32-dfb5-462d-aaa6-e662f9932dba" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2220.5735931396484" y="522.9878054261208" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="110" x="2188.3603897094727" y="577.7299644521305"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c31e1ecd-58d1-499e-85d0-75260bd0fa13" bpmnElement="_351b058e-c37c-4fb7-9d32-24075f53ce02" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2340.147186279297" y="504" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="89" x="2343.647186279297" y="529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d06b6549-21ab-4601-91da-37d06bfaa140" bpmnElement="_52401cbb-02b8-4eaf-84f1-1edbc0854a4a" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2506.147186279297" y="504" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="26" width="89" x="2509.647186279297" y="529"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_045ed3aa-7b15-4c40-8f0c-d7c372b70747" bpmnElement="_36baf139-fb74-43ef-8936-d490238c2825" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2685.147186279297" y="524" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="51.6875" x="2677.303436279297" y="570"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_9da227a1-c898-461e-9583-23f6049a2097" color:border-color="#000000" bpmnElement="_6d1a9d5a-127d-477a-8dbe-268f125f20d8">
+                <di:waypoint x="200.75" y="166"/>
+                <di:waypoint x="256.75" y="166"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1176db00-a909-4ad9-9bbe-2a5d077ef476" color:border-color="#000000" bpmnElement="_4d3df0ce-e5be-443b-a379-8dcd4aae4de9">
+                <di:waypoint x="351.75" y="166"/>
+                <di:waypoint x="407.75" y="166"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f17e17a1-2c4a-4951-8812-719fe7bb2fc3" color:border-color="#000000" bpmnElement="_237c8380-5449-446e-a323-aad80181176d">
+                <di:waypoint x="449.75" y="165.78679555654526"/>
+                <di:waypoint x="504.32359313964844" y="166"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="110" x="422.0367965698242" y="170.89339777827263"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4495b6ef-8ccd-472e-ad2c-207110964857" color:border-color="#000000" bpmnElement="_7e9d8b8b-faa9-4264-858b-7454702c4ec2">
+                <di:waypoint x="428.75" y="144.78679555654526"/>
+                <di:waypoint x="428.5367965698242" y="90.98780542612076"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+                    <dc:Bounds height="12" width="110" x="385.645379751065" y="107.38729656510947"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_097a92dd-5c1e-41d0-9fdb-3ea4121e4fec" color:border-color="#000000" bpmnElement="_41254af9-ca6b-49ae-a58e-c48f4c6120d2">
+                <di:waypoint x="613.1777598063151" y="166"/>
+                <di:waypoint x="657.3235931396484" y="166"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1418de84-a6bc-4b01-9437-a8754ebb1b77" color:border-color="#000000" bpmnElement="_d1c906b1-8f68-4485-94ea-00e732fba73e">
+                <di:waypoint x="699.3235931396484" y="165.78679555654526"/>
+                <di:waypoint x="753.8971862792969" y="165.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6e3c4d19-ec7c-444a-a4aa-3801dce83ce5" color:border-color="#000000" bpmnElement="_5ae80bdd-cda7-491b-b3f7-bce2c4b35a83">
+                <di:waypoint x="875.6159362792969" y="165.5"/>
+                <di:waypoint x="936.8971862792969" y="165.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_db66a543-513b-4373-af5f-6225785c0c89" color:border-color="#000000" bpmnElement="_15f3cde0-eeb5-4ad2-820a-114815aa782d">
+                <di:waypoint x="1067.5221862792969" y="165.5"/>
+                <di:waypoint x="1123.8971862792969" y="165.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6c565cb9-89d0-4dbf-84ae-a5a54fd0d1a0" color:border-color="#000000" bpmnElement="_2d93c5db-2e41-463b-a1a6-63a05616d912">
+                <di:waypoint x="1249.5742696126301" y="165.5"/>
+                <di:waypoint x="1313.8971862792969" y="165.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_232893b5-ab30-4eae-b66f-69bf83569ec4" color:border-color="#000000" bpmnElement="_3104b7bb-a417-4557-8c1b-d95b1c7e36a4">
+                <di:waypoint x="1450.4596862792969" y="165.5"/>
+                <di:waypoint x="1485.8971862792969" y="165.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_97780495-2bfe-4e61-98ae-259d9b0206c6" color:border-color="#000000" bpmnElement="_5c5f0068-874e-4dbb-ad30-ae8389921645" sourceElement="_9f2d5722-e003-42e7-b6c3-35b9cdd490a3">
+                <di:waypoint x="559.3235931396484" y="209.5"/>
+                <di:waypoint x="559.3235931396484" y="288.0035009384155"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a3376d5f-c6c6-41f3-b28d-b5d2620ca924" color:border-color="#000000" bpmnElement="_0811a8cc-1fde-4319-a718-7fb3ce64ae0b">
+                <di:waypoint x="678.3235931396484" y="186.78679555654526"/>
+                <di:waypoint x="678.3235931396484" y="521"/>
+                <di:waypoint x="814.75" y="521"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_254af713-830a-43c3-8fc7-ea53fdbb3ba6" color:border-color="#000000" bpmnElement="_3bb98d19-0d0b-4f47-a097-30c60183e334">
+                <di:waypoint x="922.6145833333334" y="521"/>
+                <di:waypoint x="1026.75" y="520"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_94dc1151-53ff-4aaa-9acd-c77f7e108bba" color:border-color="#000000" bpmnElement="_7a5b52f3-ad7e-4c5c-9ac2-432c8318b821" targetElement="_5e80be06-3fba-4f17-a911-c6ca533848e1">
+                <di:waypoint x="575.3235931396484" y="309.9035009384155"/>
+                <di:waypoint x="1044.75" y="309.9035009384155"/>
+                <di:waypoint x="1044.75" y="503"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_acdcd3cc-f825-41da-ace1-afa8fc80da12" color:border-color="#000000" bpmnElement="_71b2c3f1-0d34-4cfb-956c-cedf83660dfb">
+                <di:waypoint x="1061.75" y="520"/>
+                <di:waypoint x="1506.8971862792969" y="520"/>
+                <di:waypoint x="1506.8971862792969" y="185.51219457387924"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7a316415-7bce-4473-af3c-bc87fb4fcc8b" color:border-color="#000000" bpmnElement="_cad69ba8-8b26-41f9-87a1-372a899dcbf3">
+                <di:waypoint x="1527.8971862792969" y="165.28679555654526"/>
+                <di:waypoint x="1568.8971862792969" y="165.28679555654526"/>
+                <di:waypoint x="1568.8971862792969" y="543"/>
+                <di:waypoint x="1608.8971862792969" y="543"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9e890c3b-be33-44ee-86e5-2b31df360664" color:border-color="#000000" bpmnElement="_2ef25e1e-bbdd-4cba-b411-6091ec8669d6">
+                <di:waypoint x="1742.4909362792969" y="543"/>
+                <di:waypoint x="1788" y="543"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_e6ba8cab-acc0-4343-b745-be2d76aea146" color:border-color="#000000" bpmnElement="_240df34c-86c2-49fe-b1ec-58ea25d35c1f">
+                <di:waypoint x="1929.5104166666667" y="543"/>
+                <di:waypoint x="1971" y="543"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4c1933bb-3494-4a80-90a8-fd8fdf9cc49c" color:border-color="#000000" bpmnElement="_2be942a3-d921-4ad9-bce7-33e3411d98b4">
+                <di:waypoint x="1992" y="521.7867955565453"/>
+                <di:waypoint x="1992" y="461"/>
+                <di:waypoint x="2106.5735931396484" y="461"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_cc915b4e-6aee-4a5b-9860-c6bad45826c2" color:border-color="#000000" bpmnElement="_4b186d86-fae1-4f55-a3b6-b90fa27affc1">
+                <di:waypoint x="2013" y="542.7867955565453"/>
+                <di:waypoint x="2106.5735931396484" y="543"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_18531d14-a26a-412d-82e8-2267c3f163a7" color:border-color="#000000" bpmnElement="_c1307108-5b3d-48af-ae53-11b30dd31bed">
+                <di:waypoint x="1992" y="563.7867955565453"/>
+                <di:waypoint x="1992" y="625.5"/>
+                <di:waypoint x="2106.5735931396484" y="625.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d0e034a0-0fc5-4a30-8c29-048696cad14b" color:border-color="#000000" bpmnElement="_e82e6ee3-24d6-419a-96c0-a147f1943c23">
+                <di:waypoint x="2141.5735931396484" y="543"/>
+                <di:waypoint x="2220.5735931396484" y="543"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a510dba7-4d08-461d-870b-0a0f29f54475" color:border-color="#000000" bpmnElement="_16e4630e-39c0-4e94-ab65-a8a622245adf">
+                <di:waypoint x="2141.5735931396484" y="461"/>
+                <di:waypoint x="2241.5735931396484" y="461"/>
+                <di:waypoint x="2241.5735931396484" y="522.9878054261208"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5ec092ff-3b9f-443e-9aa8-bb4e7292d72a" color:border-color="#000000" bpmnElement="_c8da08ab-0b59-4c21-9386-f857d624c471">
+                <di:waypoint x="2136.5935931396484" y="637.52"/>
+                <di:waypoint x="2241.5735931396484" y="637.52"/>
+                <di:waypoint x="2241.5735931396484" y="563.0121945738792"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fecb7648-09b1-414e-abfe-af9ecc770f55" color:border-color="#000000" bpmnElement="_ece7bc06-ccf7-49f5-b5f1-99e1103cf538">
+                <di:waypoint x="2262.5735931396484" y="542.7867955565453"/>
+                <di:waypoint x="2340.147186279297" y="542"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_60eb8f3b-4c82-469d-bb6b-5df428160a84" color:border-color="#000000" bpmnElement="_c8454490-8090-4cf7-a164-d0aded7bc4da">
+                <di:waypoint x="2435.147186279297" y="542"/>
+                <di:waypoint x="2506.147186279297" y="542"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8a524b27-75e0-4180-b33d-c4a03a2e2db8" color:border-color="#000000" bpmnElement="_0fdd6987-6236-4972-a7be-3431ed6654ec">
+                <di:waypoint x="2601.147186279297" y="542"/>
+                <di:waypoint x="2685.147186279297" y="542"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_654dcd36-20f2-4208-ab4a-4df94a382551" color:border-color="#000000" bpmnElement="_9ca6c9e6-4aff-4ec8-9fd3-2743c06483c3">
+                <di:waypoint x="380.5367965698242" y="52.98780542612076"/>
+                <di:waypoint x="236.75" y="52.98780542612076"/>
+                <di:waypoint x="236.75" y="143.2"/>
+                <di:waypoint x="256.75" y="143.2"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_1484687a-1f56-4a0b-8eac-a76d5806a31e_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="_2197e5f3-4fb0-4665-aeb8-338e750d4939" name="IT">
+        <bpmndi:BPMNPlane bpmnElement="_674b5898-d454-4114-a8eb-66c790366e94" id="_2197e5f3-4fb0-4665-aeb8-338e750d4939_plane" trisobpmn:diagramWidth="1485" trisobpmn:diagramHeight="1050">
+            <bpmndi:BPMNShape id="_e8db1051-4bc8-4175-9ee8-144816d12c6d" bpmnElement="_b5172765-a1c1-4c6e-8e57-9eabaf8cecdf" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="163.5" y="145" width="1050" height="245"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="239" width="12" x="168.5" y="148"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_31425989-fb2c-4478-b0a6-7664a804479a" bpmnElement="_e9306b3f-3a77-42e1-b53e-2ed8ee45486d" color:background-color="#ffffff" color:border-color="#000000" trisobpmn:isInterrupting="true">
+                <dc:Bounds x="212.5" y="234" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="40" width="110" x="173.5" y="276"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_1a10a2dd-257b-400e-a167-76a3e9190e35" bpmnElement="_7e9d2e5a-21f7-493b-9ae4-03245aa33a5c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="299.5" y="212" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="26" width="89" x="303" y="237"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e355b511-e181-4e7b-a9b1-30cb48dd6cab_di" bpmnElement="_e355b511-e181-4e7b-a9b1-30cb48dd6cab" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="275" y="326.0035009384155" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="12" width="86.09375" x="249.453125" y="360.5035009384155"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5c458aae-3e08-43b7-b2f3-8a68751a8a48" bpmnElement="_c29af228-0768-4dfe-945a-17755e173674" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="450.5" y="212" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="26" width="89" x="454" y="237"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bd25abf0-b667-4a33-8063-44b06a700124" bpmnElement="_912f731a-fb6b-499b-a3f4-4c1632d606bd" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="601.5" y="212" width="125" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="40" width="118" x="605" y="230"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_fcb12451-974b-444b-bce0-8a49461e89b8" bpmnElement="_9db2d136-aa33-4de2-be76-554e7843363d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="752.5" y="212" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="26" width="89" x="756" y="237"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b60be020-1f04-46c2-b1a9-19bfc66ead82_di" bpmnElement="_b60be020-1f04-46c2-b1a9-19bfc66ead82" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="647.5" y="326.0035009384155" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="12" width="110" x="609" y="359.7881538456884"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_386e45fe-e573-4a59-bb1f-0ebae1895995" bpmnElement="_246c3cf7-fb4b-4c05-8ece-55c77fb4dc1e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="860.5" y="328.5" width="100" height="23"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="12" width="94" x="865.5" y="336.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d5a46681-6b2b-4b56-acd4-1ff534a5a886" bpmnElement="_ad173aff-cfe3-4098-8c65-02f783ad9e1f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="903.5" y="212" width="128" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="26" width="121" x="907" y="237"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_13cbe925-d85a-4ac1-88f8-84c935e28f94" bpmnElement="_c82dd8eb-ce54-4aa7-b8c4-b8d3e8fd654e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1098.5" y="232" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+                    <dc:Bounds height="26" width="110" x="1061.5" y="278"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_07885bba-fdc4-42c3-aae7-cf0a7557c9e6" color:border-color="#000000" bpmnElement="_495f04a4-ed17-4e7b-a952-11c06c2230d1">
+                <di:waypoint x="243.5" y="250"/>
+                <di:waypoint x="299.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_2d1770d1-6167-4ab3-b42d-a0995cdf7fd2" color:border-color="#000000" bpmnElement="_ed210028-7993-4aa4-b2f7-951ab85243be" sourceElement="_31425989-fb2c-4478-b0a6-7664a804479a">
+                <di:waypoint x="228.5" y="265"/>
+                <di:waypoint x="228.5" y="339.5035009384155"/>
+                <di:waypoint x="275" y="339.5035009384155"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4fae6953-a2f6-440c-9f28-f0d912238e49" color:border-color="#000000" bpmnElement="_c4eff1b8-8817-418b-9ef9-5d3738d43659" targetElement="_1a10a2dd-257b-400e-a167-76a3e9190e35">
+                <di:waypoint x="307.5" y="347.9035009384155"/>
+                <di:waypoint x="318.7" y="347.9035009384155"/>
+                <di:waypoint x="318.7" y="288"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_c33e21d4-e8b0-4384-a03b-060ae157b2db" color:border-color="#000000" bpmnElement="_0bccc7f6-0f56-49bc-98df-59d70433c043">
+                <di:waypoint x="394.5" y="250"/>
+                <di:waypoint x="450.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ada17f10-d861-40f0-9e38-f94ddd7cb446" color:border-color="#000000" bpmnElement="_dcec1142-90eb-41a8-b809-458b713ab94c">
+                <di:waypoint x="545.5" y="250"/>
+                <di:waypoint x="601.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_e34211bd-f47d-439b-8d1d-6a4be661d9ac" color:border-color="#000000" bpmnElement="_be72815e-ed18-4d77-9252-1ab0a7438dc9">
+                <di:waypoint x="725.1979166666666" y="250"/>
+                <di:waypoint x="752.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_e1f60cb1-c5c1-431e-8fc8-3edec72862bd" color:border-color="#000000" bpmnElement="_0282dbd7-a11b-4cac-84e2-0f26bf86b853" sourceElement="_1a10a2dd-257b-400e-a167-76a3e9190e35">
+                <di:waypoint x="363.5" y="288"/>
+                <di:waypoint x="363.5" y="339.5035009384155"/>
+                <di:waypoint x="647.5" y="339.5035009384155"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_210886c3-6d7e-41c9-8000-021a773d1e37" color:border-color="#000000" bpmnElement="_17c38035-fb11-4abb-b2b6-1cbd14acdab0" sourceElement="_bd25abf0-b667-4a33-8063-44b06a700124">
+                <di:waypoint x="664" y="287"/>
+                <di:waypoint x="664" y="326.0035009384155"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_e78fa102-5de0-4f77-9c6f-3b0610e26810" color:border-color="#000000" bpmnElement="_de54f4cb-0603-4389-ab3a-9edb9cbfec2a" targetElement="_fcb12451-974b-444b-bce0-8a49461e89b8">
+                <di:waypoint x="680.5" y="339.5035009384155"/>
+                <di:waypoint x="800.5" y="339.5035009384155"/>
+                <di:waypoint x="800.5" y="288"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_b17c6d84-fdbd-4e66-84a8-bab17f68b1e9" color:border-color="#000000" bpmnElement="_fa0de585-aa40-40bb-a3a5-965d956e884d">
+                <di:waypoint x="816.5" y="288"/>
+                <di:waypoint x="816.5" y="340.92"/>
+                <di:waypoint x="860.5" y="340.92"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_b3eaff8f-9b42-4d53-8fe3-e9747025ccfe" color:border-color="#000000" bpmnElement="_ba635734-5672-4f1b-b753-3b08c778c64e">
+                <di:waypoint x="847.5" y="250"/>
+                <di:waypoint x="903.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_0f5c946b-88bf-4152-ad97-d803dba3d575" color:border-color="#000000" bpmnElement="_c904a36b-64f6-46e3-8ef1-9f2ecc3faaff">
+                <di:waypoint x="1030.1666666666667" y="250"/>
+                <di:waypoint x="1098.5" y="250"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_2197e5f3-4fb0-4665-aeb8-338e750d4939_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="_a90a886a-6aa2-4cce-9593-8729f9f15e12" name="Payroll">
+        <bpmndi:BPMNPlane bpmnElement="_bbdf487b-c3a3-4bfa-8ba3-79be59f08203" id="_a90a886a-6aa2-4cce-9593-8729f9f15e12_plane" trisobpmn:diagramWidth="1485" trisobpmn:diagramHeight="1083.0121945738792">
+            <bpmndi:BPMNShape id="_05362210-f1ad-4e4a-9547-ed0f030b2de6" bpmnElement="_1422af8d-518b-49f1-9563-9b6939de2818" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="183.5" y="75" width="904" height="227.01219457387924"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="221.01219177246094" width="12" x="188.5" y="78.00000140070912"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9f0805fd-d2e9-4179-beaf-36c5a2f3e320" bpmnElement="_3d4130c6-48c9-47fe-8e95-2eeb56060e2b" color:background-color="#ffffff" color:border-color="#000000" trisobpmn:isInterrupting="true">
+                <dc:Bounds x="255.5" y="110" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="40" width="110" x="216.5" y="152"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_16498c9e-c33f-4f92-9033-714b89582a7c_di" bpmnElement="_16498c9e-c33f-4f92-9033-714b89582a7c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="299" y="195.00350093841553" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="12" width="86.09375" x="273.453125" y="229.50350093841553"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_a8acee9b-965d-43ad-b81d-d9a8332329ff" bpmnElement="_ae47ce79-bd91-452b-be68-47a2ea589e75" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="342.5" y="88" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="26" width="89" x="346" y="113"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_4810abb6-9d81-48dc-8765-69cf744b04d9" bpmnElement="_fa14ca2d-ea97-49a2-b75e-72e7d27d6fd1" isMarkerVisible="false" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="493.5" y="105.98780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="25.999999999999993" width="110" x="459.2867965698242" y="151.72996445213045"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_23baf531-d091-450d-b8be-d01c0360c2d6" bpmnElement="_788443d9-65f0-43a4-96a8-63e8d6f380a7" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="587.5" y="171" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="26" width="89" x="591" y="196"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_86f447c5-f810-4b4c-9004-a52704b7b685" bpmnElement="_9dbd92a5-5c0a-4039-b741-bf4ede54ccf0" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="742.5" y="100" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="26" width="89" x="746" y="125"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_819e2bb4-afc0-4186-9c79-8e64392556c6" bpmnElement="_efbd0983-76cd-4a4c-acf3-6dde71d7c760" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="893.5" y="120" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="12" width="64.6875" x="879.15625" y="166"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_a9cffac5-6e03-41de-83bf-d34304f28b1a_di" bpmnElement="_a9cffac5-6e03-41de-83bf-d34304f28b1a" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="788" y="226.00350093841553" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="12" width="71.515625" x="769.7421875" y="260.5035009384155"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_49810a74-b9bc-4311-86f4-2b3cdd888fc4" color:border-color="#000000" bpmnElement="_fba68566-2c5e-49e2-8f1e-2feff2873742" sourceElement="_9f0805fd-d2e9-4179-beaf-36c5a2f3e320">
+                <di:waypoint x="271.5" y="141"/>
+                <di:waypoint x="271.5" y="208.50350093841553"/>
+                <di:waypoint x="299" y="208.50350093841553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d2fe9ea3-8151-4d31-a5b6-1ac12b294383" color:border-color="#000000" bpmnElement="_6b24f6f7-bc44-4d73-ab54-1ac8b638423e">
+                <di:waypoint x="286.5" y="126"/>
+                <di:waypoint x="342.5" y="126"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5adb85bb-2d27-4825-8830-1d0b7bc5a866" color:border-color="#000000" bpmnElement="_d110be18-ff17-4375-818b-6463eff4e2d6">
+                <di:waypoint x="437.5" y="126"/>
+                <di:waypoint x="493.5" y="126"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_28adef3a-caa9-41e3-b596-26fdffc3b983" color:border-color="#000000" bpmnElement="_ca6f904d-e30d-4777-a7dd-661650e1e3a2">
+                <di:waypoint x="514.5" y="146.78679555654526"/>
+                <di:waypoint x="514.5" y="196.32999999999998"/>
+                <di:waypoint x="587.5" y="196.32999999999998"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="12" width="110" x="459.5" y="201.32999999999998"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4720f124-df5b-4ee8-94ca-59c6abf381ef" color:border-color="#000000" bpmnElement="_12e2f256-ec10-4a8d-934c-329143c588d8">
+                <di:waypoint x="535.5" y="125.78679555654526"/>
+                <di:waypoint x="742.5" y="125.33398048483019"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+                    <dc:Bounds height="12" width="110" x="584.5" y="130.55839777827262"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_58e67e6b-b9a9-4cca-81c4-6ab92cf2fe39" color:border-color="#000000" bpmnElement="_7b347349-7441-4e5c-ab24-2e614051f222">
+                <di:waypoint x="682.5" y="231.8"/>
+                <di:waypoint x="712.5" y="231.8"/>
+                <di:waypoint x="712.5" y="160.8"/>
+                <di:waypoint x="742.5" y="160.8"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9d5199f7-1280-4de6-8140-5e1710226180" color:border-color="#000000" bpmnElement="_46c8bd85-1b7f-45fb-81c6-23d22300c0cd">
+                <di:waypoint x="837.5" y="138"/>
+                <di:waypoint x="893.5" y="138"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6ea98553-e4f4-4ae8-9288-ffb9f2dabcb9" color:border-color="#000000" bpmnElement="_079db308-7d1e-497d-962e-23499236c981" sourceElement="_86f447c5-f810-4b4c-9004-a52704b7b685">
+                <di:waypoint x="774.5" y="176"/>
+                <di:waypoint x="774.5" y="200.50175046920776"/>
+                <di:waypoint x="804.5" y="200.50175046920776"/>
+                <di:waypoint x="804.5" y="226.00350093841553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fe9f4a75-7c37-471c-b522-8c5a571dd27a" color:border-color="#000000" bpmnElement="_3ba0a27a-2a49-458b-8680-be1330f46f3a" targetElement="_a8acee9b-965d-43ad-b81d-d9a8332329ff">
+                <di:waypoint x="331.5" y="216.90350093841553"/>
+                <di:waypoint x="406.5" y="216.90350093841553"/>
+                <di:waypoint x="406.5" y="164"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_a90a886a-6aa2-4cce-9593-8729f9f15e12_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf" name="Facilities">
+        <bpmndi:BPMNPlane bpmnElement="_8d4bb408-4175-4fbb-8131-18c32b7aa022" id="_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_plane" trisobpmn:diagramWidth="1485" trisobpmn:diagramHeight="1051">
+            <bpmndi:BPMNShape id="_8d8b3e45-8133-4380-8f76-fed71c2aec2e" bpmnElement="_fab40827-7808-470a-93b6-4a3318bf0c0e" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="171.5" y="84" width="626" height="201"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="195" width="12" x="176.5" y="87"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_20bbbbca-b24b-4616-8a07-1727bf94f42d" bpmnElement="_94a62738-dc7a-49f6-81d8-f5642f7ae850" color:background-color="#ffffff" color:border-color="#000000" trisobpmn:isInterrupting="true">
+                <dc:Bounds x="290.5" y="134.00175046920776" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="40" width="110" x="251.5" y="176.00175046920776"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_574668ad-2e2e-4790-9b6f-dee98ff3ad03" bpmnElement="_2bf94039-15a1-44bb-9d14-81358777466c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="380.5" y="112.00175046920776" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="40" width="89" x="384" y="130.00175046920776"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0dcdca57-3026-4882-9278-45777a2be00d" bpmnElement="_737503c8-10bc-483f-8871-5461d822b469" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="531.5" y="112.00175046920776" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="26" width="89" x="535" y="137.00175046920776"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_90372e1e-93cc-4e36-998c-7b90ce0a6be9" bpmnElement="_5ee09fe4-f38f-454d-b6e4-1c3703a6a239" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="682.5" y="132.00175046920776" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="40" width="110" x="645.5" y="178.00175046920776"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9931ba94-ede8-4f53-8081-878c549ba1c8_di" bpmnElement="_9931ba94-ede8-4f53-8081-878c549ba1c8" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="349" y="229.0052514076233" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+                    <dc:Bounds height="12" width="86.09375" x="323.453125" y="263.5052514076233"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_ddd7b23f-240b-46f5-8c71-489105237005" color:border-color="#000000" bpmnElement="_ea0e1abf-e9f6-406a-96fb-12fcdf765634">
+                <di:waypoint x="321.5" y="150.00175046920776"/>
+                <di:waypoint x="380.5" y="150.00175046920776"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8c56240e-f2c7-4b1f-a79c-fd9c76a7b485" color:border-color="#000000" bpmnElement="_4436759d-6848-4400-93e5-3971c69b2f67">
+                <di:waypoint x="475.5" y="150.00175046920776"/>
+                <di:waypoint x="531.5" y="150.00175046920776"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_858ffd73-166f-483a-99fa-0b124614d49c" color:border-color="#000000" bpmnElement="_f405a593-5f87-4f62-862e-bcf9f776bc95">
+                <di:waypoint x="626.5" y="150.00175046920776"/>
+                <di:waypoint x="682.5" y="150.00175046920776"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7a06e60e-3aa3-4d3b-931e-55b9b77d5792" color:border-color="#000000" bpmnElement="_2ae32762-1124-45f5-a01b-7292f9721c7d" sourceElement="_20bbbbca-b24b-4616-8a07-1727bf94f42d">
+                <di:waypoint x="306.5" y="165.00175046920776"/>
+                <di:waypoint x="306.5" y="242.5052514076233"/>
+                <di:waypoint x="349" y="242.5052514076233"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_61bdfc55-1c20-4ed1-82d9-85cc59fcac7d" color:border-color="#000000" bpmnElement="_ad35d446-d8b5-46d9-b2b0-61178b689754" targetElement="_0dcdca57-3026-4882-9278-45777a2be00d">
+                <di:waypoint x="382" y="242.5052514076233"/>
+                <di:waypoint x="595.5" y="242.5052514076233"/>
+                <di:waypoint x="595.5" y="188.00175046920776"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_8a47c0f3-6b5d-44cc-afca-f79008ba1ebf_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.5.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.5.0.bpmn
@@ -1,0 +1,1176 @@
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed"             xmlns="http://www.trisotech.com/definitions/_5f5fbc02-46c1-4615-b2bd-89b2d938ac0b" id="_5f5fbc02-46c1-4615-b2bd-89b2d938ac0b" targetNamespace="http://www.trisotech.com/definitions/_5f5fbc02-46c1-4615-b2bd-89b2d938ac0b" expressionLanguage="http://www.w3.org/1999/XPath" exporter="BPMN Modeler" exporterVersion="6.1.19.201902051502" name="C.5.0" trisobpmn:logoChoice="None">
+    <semantic:collaboration id="_906eeac9-47e3-41c3-a8db-b8abb8fd95e6">
+        <semantic:participant id="_f200a9f1-5554-4868-b895-707186915d62" name="Bank" processRef="_3d1ef204-2d4c-4643-8fc5-c319cc032ec0"/>
+    </semantic:collaboration>
+    <semantic:dataStore id="_776bd6ca-5f18-432f-a748-f1930bfdf16e" name="Bank System"/>
+    <semantic:dataStore id="_46aee7ee-fab2-4735-80cc-fa78092ef92e" name="Customer Data (temporary storage)"/>
+    <semantic:process id="_3d1ef204-2d4c-4643-8fc5-c319cc032ec0" name="Bank - Process" triso:defaultName="true" isClosed="false">
+        <semantic:laneSet>
+            <semantic:lane id="_2935f981-e194-4a1b-bb22-846ad3c0f72c" name="Private Customer Account Manager">
+                <semantic:flowNodeRef>_0254d83d-d943-466f-8b62-20e87cdfda4e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_945cd271-46b6-4d71-83a1-530e445af820</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_17db66a1-badd-4942-9ebd-02bc5595cdde</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_138f9ebc-0211-4051-b7c0-1c55695d5246</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_664f14a9-c1f1-490a-bbec-1f66ba4e7fe4</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_d22de266-6170-4783-91f9-40832e4cc58d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a4936291-3787-404c-bec7-8a3f3c5fd6e5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_87785f46-7026-4d3c-b2c0-6a9468da67f6</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a73027a7-615e-4a4d-95ee-c4cd78ab30c4</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_2b156883-2852-4665-aba0-d9bc57c7c225</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_9c5d383f-df57-4012-b490-fa36f9f90eed</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_3355cffe-aab4-4a05-8388-becf8ad599ae</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_be6ea91a-4f8e-4240-86e8-f85036aee96f</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_000a0565-911b-4f71-9993-1177021edd97</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_f006114d-c7cb-4ce0-9bfe-f0938c36a53e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_b9338c62-a257-47dd-8c2e-88b80b73c330</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_b360104e-8410-4b99-827a-776e2083fb96</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_8055ae64-cafd-4fd0-be36-2216e3b02e37</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_2fd5c7d3-797d-45a5-a0d8-dfa60654ba5e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_09074897-556d-4fd2-afb6-2f6c774e1820</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_54d66428-417b-447e-89d5-e726c1f12659</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_29b4f749-037a-4199-b33f-3cd3a3c7805e</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_3f3a831c-9b08-4827-92b3-3877a749e3df</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="_af0d417a-6492-48d6-ace2-f70b807564a8" name="Corporate Account Manager">
+                <semantic:flowNodeRef>_f0422f0d-396b-4ee7-ad83-fdd34a8bab71</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a393c065-4412-4b16-b04f-52d07e76b518</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_05a1a66a-9308-41c7-a611-4fc57627a058</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_acfa265a-a449-4e30-baa0-1ba47dbea418</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="_1c6c313d-4950-47a0-b6bf-c51a4b2ea7ed" name="Head of Market Service">
+                <semantic:flowNodeRef>_1fc87527-9cad-4f8e-b9c7-ebe106cbe98d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_5f56934b-8a7e-4c35-b9f7-bf2605711bfd</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_1da34f39-8338-4ecb-a93f-90349fa10260</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_1cf552d4-5152-4595-9218-84f31533bc70</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:startEvent id="_0254d83d-d943-466f-8b62-20e87cdfda4e" name="Customer interested in Bank offer">
+            <semantic:outgoing>_bac89998-7084-4b2e-a2ea-dff839336d74</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:userTask id="_945cd271-46b6-4d71-83a1-530e445af820" name="Interview customer" implementation="##unspecified">
+            <semantic:incoming>_bac89998-7084-4b2e-a2ea-dff839336d74</semantic:incoming>
+            <semantic:outgoing>_c132a484-8828-4f03-9a57-8201f4e9e864</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:userTask id="_17db66a1-badd-4942-9ebd-02bc5595cdde" name="Prove/Provide identity" implementation="##unspecified">
+            <semantic:incoming>_c132a484-8828-4f03-9a57-8201f4e9e864</semantic:incoming>
+            <semantic:outgoing>_14c352ad-cd81-4a92-89e6-85f6e658e7bb</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput id="_e75ca33b-71b4-405b-82b7-26b036834ad0" name="ID document"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_2fd4dffa-bee0-48b8-a33e-a6fe462224d7">
+                    <semantic:dataOutputRefs>_e75ca33b-71b4-405b-82b7-26b036834ad0</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_e5e5b852-0c5f-4f5f-8c6c-a1d8245024b4">
+                <semantic:sourceRef>_e75ca33b-71b4-405b-82b7-26b036834ad0</semantic:sourceRef>
+                <semantic:targetRef>_dca1cc5b-74a4-453f-8ad2-61609dde35ff</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_138f9ebc-0211-4051-b7c0-1c55695d5246" name="Legal entity or individual?" gatewayDirection="Diverging">
+            <semantic:incoming>_14c352ad-cd81-4a92-89e6-85f6e658e7bb</semantic:incoming>
+            <semantic:outgoing>_fcb09e30-bfe6-46b9-af01-6777c60026f2</semantic:outgoing>
+            <semantic:outgoing>_6912e5ed-5cae-4798-b6e6-8d367ddb3f60</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_664f14a9-c1f1-490a-bbec-1f66ba4e7fe4" name="Obtain supporting data and documents of the customer" implementation="##unspecified">
+            <semantic:incoming>_b6414e79-5e61-4a8e-a584-65201c4ea9a9</semantic:incoming>
+            <semantic:outgoing>_8e88b32b-90d5-4ca4-a969-00b667a92d29</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_28d09a7b-8274-45b9-8ae1-66995807edf0" name="ID document"/>
+                <semantic:inputSet id="_91229d44-17f5-41db-ba5a-6041c238ad6a">
+                    <semantic:dataInputRefs>_28d09a7b-8274-45b9-8ae1-66995807edf0</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_8a1de917-0cd0-4cb3-a449-5d10733575ee">
+                <semantic:sourceRef>_dca1cc5b-74a4-453f-8ad2-61609dde35ff</semantic:sourceRef>
+                <semantic:targetRef>_28d09a7b-8274-45b9-8ae1-66995807edf0</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:userTask id="_d22de266-6170-4783-91f9-40832e4cc58d" name="Check customer documents" implementation="##unspecified">
+            <semantic:incoming>_8e88b32b-90d5-4ca4-a969-00b667a92d29</semantic:incoming>
+            <semantic:outgoing>_c2f47722-9bb7-416c-b6bc-cff4e3a6eb65</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_f129e42a-e180-4068-970d-1895015a5a4e" name="ID document"/>
+                <semantic:dataOutput id="_59c497a7-8a58-41f7-ab3f-e823fc8843e6" name="ID document"/>
+                <semantic:inputSet id="_12650346-51b8-4431-807b-987777273d0b">
+                    <semantic:dataInputRefs>_f129e42a-e180-4068-970d-1895015a5a4e</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_adf81738-a454-46bf-96b3-736985455e4c">
+                    <semantic:dataOutputRefs>_59c497a7-8a58-41f7-ab3f-e823fc8843e6</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_e4d5f0c6-49e2-4467-80da-4818237bbbed">
+                <semantic:sourceRef>_dca1cc5b-74a4-453f-8ad2-61609dde35ff</semantic:sourceRef>
+                <semantic:targetRef>_f129e42a-e180-4068-970d-1895015a5a4e</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_1cfb93bd-7a02-481d-a42c-c69c614a4b00">
+                <semantic:sourceRef>_59c497a7-8a58-41f7-ab3f-e823fc8843e6</semantic:sourceRef>
+                <semantic:targetRef>_e0b6d1fe-4ddf-4e22-b84c-6d676afb389a</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_a4936291-3787-404c-bec7-8a3f3c5fd6e5" name="Data complete?" gatewayDirection="Diverging">
+            <semantic:incoming>_c2f47722-9bb7-416c-b6bc-cff4e3a6eb65</semantic:incoming>
+            <semantic:outgoing>_eec53048-291a-4802-8fec-012857f845eb</semantic:outgoing>
+            <semantic:outgoing>_664f3a71-3efa-4c94-8797-815f2e377cf7</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_87785f46-7026-4d3c-b2c0-6a9468da67f6" name="Copy, sign, and scan documents" implementation="##unspecified">
+            <semantic:incoming>_60066421-3da9-4318-8df2-d8b16b3011bb</semantic:incoming>
+            <semantic:outgoing>_65fba7be-af41-4ebe-b4e8-a8f7a830a702</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_da43ba9b-0964-4360-bba3-a63d040f0a76" name="ID document"/>
+                <semantic:dataOutput id="_581f63c2-d888-4329-9161-760518a3668d" name="ID document"/>
+                <semantic:inputSet id="_5b1eeb3a-06d7-4ab4-a50b-3507eaf6a96d">
+                    <semantic:dataInputRefs>_da43ba9b-0964-4360-bba3-a63d040f0a76</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_b96d5da8-9e1e-4ba2-ad01-e6616577cd91">
+                    <semantic:dataOutputRefs>_581f63c2-d888-4329-9161-760518a3668d</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_24b56549-d0fc-44d1-9fcf-b136ef8f420c">
+                <semantic:sourceRef>_e0b6d1fe-4ddf-4e22-b84c-6d676afb389a</semantic:sourceRef>
+                <semantic:targetRef>_da43ba9b-0964-4360-bba3-a63d040f0a76</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_fc3badce-d027-4ab8-91a5-bfcf3be7daa5">
+                <semantic:sourceRef>_581f63c2-d888-4329-9161-760518a3668d</semantic:sourceRef>
+                <semantic:targetRef>_4f982ccc-c9e4-43b1-832e-b82992d4d400</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:userTask id="_a73027a7-615e-4a4d-95ee-c4cd78ab30c4" name="File documents in customer file" implementation="##unspecified">
+            <semantic:incoming>_65fba7be-af41-4ebe-b4e8-a8f7a830a702</semantic:incoming>
+            <semantic:outgoing>_0cf86177-f481-4c25-8801-cd18d91ddec6</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_0fed0a5a-5936-4ce7-aca5-472138e30238" name="ID document"/>
+                <semantic:dataOutput id="_4c2bb575-fa47-4f1c-9aed-e10b9633884f" name="Customer Data (temporary storage)"/>
+                <semantic:inputSet id="_a0daf95f-d885-47dc-b92b-bab63009296e">
+                    <semantic:dataInputRefs>_0fed0a5a-5936-4ce7-aca5-472138e30238</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_e4533bfc-2668-4df5-b387-d4cf6576aa51">
+                    <semantic:dataOutputRefs>_4c2bb575-fa47-4f1c-9aed-e10b9633884f</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_6518fef7-dc30-4737-84ee-f33ceba4a844">
+                <semantic:sourceRef>_4f982ccc-c9e4-43b1-832e-b82992d4d400</semantic:sourceRef>
+                <semantic:targetRef>_0fed0a5a-5936-4ce7-aca5-472138e30238</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_ed10a8d7-01db-4221-a281-03174f633376">
+                <semantic:sourceRef>_4c2bb575-fa47-4f1c-9aed-e10b9633884f</semantic:sourceRef>
+                <semantic:targetRef>_c5285566-0657-47c5-a7ad-d09e144377f3</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_2b156883-2852-4665-aba0-d9bc57c7c225" gatewayDirection="Diverging">
+            <semantic:incoming>_0cf86177-f481-4c25-8801-cd18d91ddec6</semantic:incoming>
+            <semantic:outgoing>_8bd8a9d5-84da-4e96-b2af-9b8e003ad5a3</semantic:outgoing>
+            <semantic:outgoing>_f47c4e3f-3339-4c96-b8b0-829022bada78</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:userTask id="_9c5d383f-df57-4012-b490-fa36f9f90eed" name="Add personal data" implementation="##unspecified">
+            <semantic:incoming>_8bd8a9d5-84da-4e96-b2af-9b8e003ad5a3</semantic:incoming>
+            <semantic:outgoing>_c7c63b1c-bdd1-443b-903b-7c31da1e6eb9</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput id="_0ff75fcb-3aa9-4a0c-9bbf-64e31ffec23a" name="Customer data"/>
+                <semantic:dataOutput id="_ffecd813-8488-4289-8a5b-60ca006a7e6c" name="Customer Data (temporary storage)"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_613918ad-e459-4b79-a85f-b34c1e875097">
+                    <semantic:dataOutputRefs>_0ff75fcb-3aa9-4a0c-9bbf-64e31ffec23a</semantic:dataOutputRefs>
+                    <semantic:dataOutputRefs>_ffecd813-8488-4289-8a5b-60ca006a7e6c</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_a1577e31-32ee-46db-be07-c31f1f047a5e">
+                <semantic:sourceRef>_0ff75fcb-3aa9-4a0c-9bbf-64e31ffec23a</semantic:sourceRef>
+                <semantic:targetRef>_be9fc840-d916-4495-9061-989af6035030</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:dataOutputAssociation id="_aa4bda11-11a7-441a-b50f-7296b83542e4">
+                <semantic:sourceRef>_ffecd813-8488-4289-8a5b-60ca006a7e6c</semantic:sourceRef>
+                <semantic:targetRef>_c5285566-0657-47c5-a7ad-d09e144377f3</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_3355cffe-aab4-4a05-8388-becf8ad599ae" gatewayDirection="Converging">
+            <semantic:incoming>_c7c63b1c-bdd1-443b-903b-7c31da1e6eb9</semantic:incoming>
+            <semantic:incoming>_a4eaa7b6-f9ef-458a-ba70-e1fd3ff0595a</semantic:incoming>
+            <semantic:outgoing>_1a933b26-7ac6-47a8-85de-07e658241e1e</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:userTask id="_be6ea91a-4f8e-4240-86e8-f85036aee96f" name="Perform risk assessment of the customer" implementation="##unspecified">
+            <semantic:incoming>_1a933b26-7ac6-47a8-85de-07e658241e1e</semantic:incoming>
+            <semantic:outgoing>_40c01bbe-095a-4937-a334-95fa5b5225cc</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_721254f5-d2c9-4bc5-b1eb-2499e2fea042" name="Customer data"/>
+                <semantic:dataOutput id="_7c351bcf-ed3d-481b-a696-254d32fda486" name="Customer Data (temporary storage)"/>
+                <semantic:inputSet id="_d0f0b35b-fc63-4e62-a45d-925fa79845cf">
+                    <semantic:dataInputRefs>_721254f5-d2c9-4bc5-b1eb-2499e2fea042</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_e1621c49-620d-475b-9a23-3fc9c1800ee9">
+                    <semantic:dataOutputRefs>_7c351bcf-ed3d-481b-a696-254d32fda486</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_9f68656f-415d-4288-be20-fd75bcd92f6a">
+                <semantic:sourceRef>_4257e72e-9c36-4832-8134-b68b8919de7e</semantic:sourceRef>
+                <semantic:targetRef>_721254f5-d2c9-4bc5-b1eb-2499e2fea042</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_2fdc6abd-cfec-425d-b386-fe8b61371495">
+                <semantic:sourceRef>_7c351bcf-ed3d-481b-a696-254d32fda486</semantic:sourceRef>
+                <semantic:targetRef>_c5285566-0657-47c5-a7ad-d09e144377f3</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_000a0565-911b-4f71-9993-1177021edd97" name="Subject to approval?" gatewayDirection="Diverging">
+            <semantic:incoming>_40c01bbe-095a-4937-a334-95fa5b5225cc</semantic:incoming>
+            <semantic:outgoing>_1887adee-8291-4640-a5fa-3dc5f33d5a34</semantic:outgoing>
+            <semantic:outgoing>_e88d64c7-3aaf-4a5f-9787-4e5ba696312b</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_f006114d-c7cb-4ce0-9bfe-f0938c36a53e" name="Document risk assessment" implementation="##unspecified">
+            <semantic:incoming>_7ab3e406-ce00-40e0-88f7-c64bcb0b864f</semantic:incoming>
+            <semantic:outgoing>_f2b37ee6-7727-4106-bdd4-d93c4db15703</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_7e58a64a-6396-4158-9a76-a0597a566f67" name="Customer data"/>
+                <semantic:dataOutput id="_e3b88a3e-9f69-4bd4-ada3-e277fd53656e" name="Customer Data (temporary storage)"/>
+                <semantic:inputSet id="_b0706d89-92f6-481e-89f0-4a9ad5a1b1d5">
+                    <semantic:dataInputRefs>_7e58a64a-6396-4158-9a76-a0597a566f67</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_f0d63836-16aa-4f31-a122-01dc1fd556cb">
+                    <semantic:dataOutputRefs>_e3b88a3e-9f69-4bd4-ada3-e277fd53656e</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_a8b81881-5b94-4d11-8b5c-5e9b76878dcd">
+                <semantic:sourceRef>_4257e72e-9c36-4832-8134-b68b8919de7e</semantic:sourceRef>
+                <semantic:targetRef>_7e58a64a-6396-4158-9a76-a0597a566f67</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_c7006cb5-a9f4-4528-8fca-9083fc7559ed">
+                <semantic:sourceRef>_e3b88a3e-9f69-4bd4-ada3-e277fd53656e</semantic:sourceRef>
+                <semantic:targetRef>_c5285566-0657-47c5-a7ad-d09e144377f3</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:callActivity id="_b9338c62-a257-47dd-8c2e-88b80b73c330" name="Check for connected clients" calledElement="_774bc005-0917-43d5-ab70-0f9fe123fbd1">
+            <semantic:incoming>_f2b37ee6-7727-4106-bdd4-d93c4db15703</semantic:incoming>
+            <semantic:outgoing>_f974945f-f2a6-4547-9d35-0d26049dcd6f</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_32c34c33-47cf-4481-8310-401ce5b04a35" name="Customer data"/>
+                <semantic:dataOutput id="_f87c9123-3f07-420c-ae9f-4e29e3af5130" name="Customer data"/>
+                <semantic:inputSet id="_2d5efe68-8501-481d-96d4-6ab41ed2d4a1">
+                    <semantic:dataInputRefs>_32c34c33-47cf-4481-8310-401ce5b04a35</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_7ab57802-2e41-4a0e-90de-cfd521600034">
+                    <semantic:dataOutputRefs>_f87c9123-3f07-420c-ae9f-4e29e3af5130</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_10466056-a9bd-4d46-b6ca-60cc6c5f6b13">
+                <semantic:sourceRef>_4257e72e-9c36-4832-8134-b68b8919de7e</semantic:sourceRef>
+                <semantic:targetRef>_32c34c33-47cf-4481-8310-401ce5b04a35</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_39450d6b-b008-4af2-bb98-35d65093922e">
+                <semantic:sourceRef>_f87c9123-3f07-420c-ae9f-4e29e3af5130</semantic:sourceRef>
+                <semantic:targetRef>_dd653cc9-c874-4cfe-ba6c-146726809ea5</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:callActivity>
+        <semantic:userTask id="_b360104e-8410-4b99-827a-776e2083fb96" name="Create customer in the system" implementation="##unspecified">
+            <semantic:incoming>_f974945f-f2a6-4547-9d35-0d26049dcd6f</semantic:incoming>
+            <semantic:outgoing>_0b3ae343-49aa-49dc-8b88-fe97b4ada3eb</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_42e1d578-55c2-4ea6-9b6f-a32ee680ec72" name="Customer data"/>
+                <semantic:dataInput id="_e4a8fda6-25e5-4d3a-af66-6bdc77e82aed" name="Customer Data (temporary storage)"/>
+                <semantic:dataOutput id="_174d4bae-bb40-4877-86d7-6e1f88b9353e" name="Bank System"/>
+                <semantic:inputSet id="_2a408dec-555c-4fa0-a9cc-08bad960c9c8">
+                    <semantic:dataInputRefs>_42e1d578-55c2-4ea6-9b6f-a32ee680ec72</semantic:dataInputRefs>
+                    <semantic:dataInputRefs>_e4a8fda6-25e5-4d3a-af66-6bdc77e82aed</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_41ca4899-93f5-4f71-b5c0-6aa3f91ed081">
+                    <semantic:dataOutputRefs>_174d4bae-bb40-4877-86d7-6e1f88b9353e</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_bd748ab9-bd4e-47d1-8f69-cc8e451e0b2b">
+                <semantic:sourceRef>_dd653cc9-c874-4cfe-ba6c-146726809ea5</semantic:sourceRef>
+                <semantic:targetRef>_42e1d578-55c2-4ea6-9b6f-a32ee680ec72</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataInputAssociation id="_48edea23-f132-4ec7-b296-35c091e1755b">
+                <semantic:sourceRef>_66f4a1ff-fd8a-4002-ade7-7a4d1b1d529c</semantic:sourceRef>
+                <semantic:targetRef>_e4a8fda6-25e5-4d3a-af66-6bdc77e82aed</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_8eaa28a5-123c-4224-ad2a-218525c6c79e">
+                <semantic:sourceRef>_174d4bae-bb40-4877-86d7-6e1f88b9353e</semantic:sourceRef>
+                <semantic:targetRef>_ffd44905-4f54-4fe0-a156-0312c2a7a3cc</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:endEvent id="_8055ae64-cafd-4fd0-be36-2216e3b02e37" name="Identity determined and new customer created">
+            <semantic:incoming>_0b3ae343-49aa-49dc-8b88-fe97b4ada3eb</semantic:incoming>
+            <semantic:signalEventDefinition id="_8c6f817f-0d1e-464a-96bc-e32dbfa8110d"/>
+        </semantic:endEvent>
+        <semantic:userTask id="_2fd5c7d3-797d-45a5-a0d8-dfa60654ba5e" name="Complete data and documents" implementation="##unspecified">
+            <semantic:incoming>_664f3a71-3efa-4c94-8797-815f2e377cf7</semantic:incoming>
+            <semantic:outgoing>_52e3c106-b055-40a0-a9f9-db9529adfb38</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput id="_f0fd8c00-f695-4115-87b6-6aa5eaa1f7c4" name="ID document"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_9d7b0978-2803-4fef-b491-bec904315432">
+                    <semantic:dataOutputRefs>_f0fd8c00-f695-4115-87b6-6aa5eaa1f7c4</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_a290cb0f-07ce-4e95-8d51-eb98307b3beb">
+                <semantic:sourceRef>_f0fd8c00-f695-4115-87b6-6aa5eaa1f7c4</semantic:sourceRef>
+                <semantic:targetRef>_e0b6d1fe-4ddf-4e22-b84c-6d676afb389a</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:userTask id="_09074897-556d-4fd2-afb6-2f6c774e1820" name="Perform know your customer (KYC) activities" implementation="##unspecified">
+            <semantic:incoming>_f47c4e3f-3339-4c96-b8b0-829022bada78</semantic:incoming>
+            <semantic:outgoing>_a4eaa7b6-f9ef-458a-ba70-e1fd3ff0595a</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_3fcd7c6a-65c8-434d-9998-5c8722c6810b" name="Customer data"/>
+                <semantic:dataOutput id="_a130c3b1-aa52-47f6-8818-fc567f559ce2" name="Customer data"/>
+                <semantic:dataOutput id="_b6f553cf-dc70-4169-a2a0-0943cb92953a" name="Customer Data (temporary storage)"/>
+                <semantic:inputSet id="_3d521f50-0d38-4e83-9992-f8910130aa81">
+                    <semantic:dataInputRefs>_3fcd7c6a-65c8-434d-9998-5c8722c6810b</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_0e1a0a39-c100-4eab-91fc-bef562e23e68">
+                    <semantic:dataOutputRefs>_a130c3b1-aa52-47f6-8818-fc567f559ce2</semantic:dataOutputRefs>
+                    <semantic:dataOutputRefs>_b6f553cf-dc70-4169-a2a0-0943cb92953a</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_b181f888-d411-4665-aeea-89569a373e98">
+                <semantic:sourceRef>_be9fc840-d916-4495-9061-989af6035030</semantic:sourceRef>
+                <semantic:targetRef>_3fcd7c6a-65c8-434d-9998-5c8722c6810b</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_8234f225-632d-4b63-b7b4-9ee05ebd4971">
+                <semantic:sourceRef>_a130c3b1-aa52-47f6-8818-fc567f559ce2</semantic:sourceRef>
+                <semantic:targetRef>_4257e72e-9c36-4832-8134-b68b8919de7e</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:dataOutputAssociation id="_9f70cdff-8fb7-432d-84f0-29db168610fa">
+                <semantic:sourceRef>_b6f553cf-dc70-4169-a2a0-0943cb92953a</semantic:sourceRef>
+                <semantic:targetRef>_c5285566-0657-47c5-a7ad-d09e144377f3</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_54d66428-417b-447e-89d5-e726c1f12659" gatewayDirection="Converging">
+            <semantic:incoming>_fcb09e30-bfe6-46b9-af01-6777c60026f2</semantic:incoming>
+            <semantic:incoming>_afc35597-a482-432a-8ace-17adaf609572</semantic:incoming>
+            <semantic:outgoing>_b6414e79-5e61-4a8e-a584-65201c4ea9a9</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:exclusiveGateway id="_29b4f749-037a-4199-b33f-3cd3a3c7805e" gatewayDirection="Converging">
+            <semantic:incoming>_eec53048-291a-4802-8fec-012857f845eb</semantic:incoming>
+            <semantic:incoming>_52e3c106-b055-40a0-a9f9-db9529adfb38</semantic:incoming>
+            <semantic:outgoing>_60066421-3da9-4318-8df2-d8b16b3011bb</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:exclusiveGateway id="_3f3a831c-9b08-4827-92b3-3877a749e3df" gatewayDirection="Converging">
+            <semantic:incoming>_1887adee-8291-4640-a5fa-3dc5f33d5a34</semantic:incoming>
+            <semantic:incoming>_8a77d7f6-320a-47ff-a155-57ee200df478</semantic:incoming>
+            <semantic:outgoing>_7ab3e406-ce00-40e0-88f7-c64bcb0b864f</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:dataObjectReference id="_dca1cc5b-74a4-453f-8ad2-61609dde35ff" name="ID document [for analysis]" dataObjectRef="_0fa2af52-a3d6-4be6-9ecc-9fad8ca4d448">
+            <semantic:dataState name="for analysis"/>
+        </semantic:dataObjectReference>
+        <semantic:dataObjectReference id="_e0b6d1fe-4ddf-4e22-b84c-6d676afb389a" name="ID document [analysed]" dataObjectRef="_0fa2af52-a3d6-4be6-9ecc-9fad8ca4d448">
+            <semantic:dataState name="analysed"/>
+        </semantic:dataObjectReference>
+        <semantic:dataObjectReference id="_4f982ccc-c9e4-43b1-832e-b82992d4d400" name="ID document [scanned]" dataObjectRef="_0fa2af52-a3d6-4be6-9ecc-9fad8ca4d448">
+            <semantic:dataState name="scanned"/>
+        </semantic:dataObjectReference>
+        <semantic:dataObjectReference id="_be9fc840-d916-4495-9061-989af6035030" name="Customer data [for KYC analysis]" dataObjectRef="_79993b0e-60c2-487b-a12e-0cbecc2ef5c1">
+            <semantic:dataState name="for KYC analysis"/>
+        </semantic:dataObjectReference>
+        <semantic:dataObjectReference id="_4257e72e-9c36-4832-8134-b68b8919de7e" name="Customer data [for risk assessment]" dataObjectRef="_79993b0e-60c2-487b-a12e-0cbecc2ef5c1">
+            <semantic:dataState name="for risk assessment"/>
+        </semantic:dataObjectReference>
+        <semantic:dataObjectReference id="_dd653cc9-c874-4cfe-ba6c-146726809ea5" name="Customer data [with connected clients analysis]" dataObjectRef="_79993b0e-60c2-487b-a12e-0cbecc2ef5c1">
+            <semantic:dataState name="with connected clients analysis"/>
+        </semantic:dataObjectReference>
+        <semantic:dataStoreReference id="_ffd44905-4f54-4fe0-a156-0312c2a7a3cc" name="Bank System" dataStoreRef="_776bd6ca-5f18-432f-a748-f1930bfdf16e"/>
+        <semantic:dataStoreReference id="_66f4a1ff-fd8a-4002-ade7-7a4d1b1d529c" name="Customer Data (temporary storage)" dataStoreRef="_46aee7ee-fab2-4735-80cc-fa78092ef92e"/>
+        <semantic:dataStoreReference id="_c5285566-0657-47c5-a7ad-d09e144377f3" name="Customer Data (temporary storage)" dataStoreRef="_46aee7ee-fab2-4735-80cc-fa78092ef92e"/>
+        <semantic:userTask id="_f0422f0d-396b-4ee7-ad83-fdd34a8bab71" name="Document the identity of the economic owner" implementation="##unspecified">
+            <semantic:incoming>_6912e5ed-5cae-4798-b6e6-8d367ddb3f60</semantic:incoming>
+            <semantic:outgoing>_a8da83e1-4e09-4a7b-a09f-1f869b372176</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_9d9659ca-4d33-4d6a-903a-dfeed15cee9a" name="ID document"/>
+                <semantic:inputSet id="_0ded1261-c1bd-49de-8f5b-3d46c4d5a095">
+                    <semantic:dataInputRefs>_9d9659ca-4d33-4d6a-903a-dfeed15cee9a</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_e470d57d-3556-40dd-b518-5ed19b3f63d9">
+                <semantic:sourceRef>_dca1cc5b-74a4-453f-8ad2-61609dde35ff</semantic:sourceRef>
+                <semantic:targetRef>_9d9659ca-4d33-4d6a-903a-dfeed15cee9a</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_a393c065-4412-4b16-b04f-52d07e76b518" name="Identity of the economic owner certifiable?" gatewayDirection="Diverging">
+            <semantic:incoming>_a8da83e1-4e09-4a7b-a09f-1f869b372176</semantic:incoming>
+            <semantic:outgoing>_afc35597-a482-432a-8ace-17adaf609572</semantic:outgoing>
+            <semantic:outgoing>_470d1a12-e1fa-4471-b753-cfd7dbe20d80</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_05a1a66a-9308-41c7-a611-4fc57627a058" name="End business relation" implementation="##unspecified">
+            <semantic:incoming>_470d1a12-e1fa-4471-b753-cfd7dbe20d80</semantic:incoming>
+            <semantic:outgoing>_461976fc-e457-4a39-baf3-785885c58896</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:endEvent id="_acfa265a-a449-4e30-baa0-1ba47dbea418" name="Business relation ended">
+            <semantic:incoming>_461976fc-e457-4a39-baf3-785885c58896</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:userTask id="_1fc87527-9cad-4f8e-b9c7-ebe106cbe98d" name="Check risk and decide about approval" implementation="##unspecified">
+            <semantic:incoming>_e88d64c7-3aaf-4a5f-9787-4e5ba696312b</semantic:incoming>
+            <semantic:outgoing>_c3e90e5c-e5cf-4cfb-b15d-bdedcf0719ca</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput id="_85c0085f-9a81-472b-a54c-51943f4c247c" name="Customer data"/>
+                <semantic:inputSet id="_312af7f4-e30b-4606-aeb3-dd5008632579">
+                    <semantic:dataInputRefs>_85c0085f-9a81-472b-a54c-51943f4c247c</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_f4536257-490a-4f11-8174-59c44fe6d51d">
+                <semantic:sourceRef>_4257e72e-9c36-4832-8134-b68b8919de7e</semantic:sourceRef>
+                <semantic:targetRef>_85c0085f-9a81-472b-a54c-51943f4c247c</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_5f56934b-8a7e-4c35-b9f7-bf2605711bfd" name="Approval?" gatewayDirection="Diverging">
+            <semantic:incoming>_c3e90e5c-e5cf-4cfb-b15d-bdedcf0719ca</semantic:incoming>
+            <semantic:outgoing>_8a77d7f6-320a-47ff-a155-57ee200df478</semantic:outgoing>
+            <semantic:outgoing>_ae94e0c1-aa12-433f-bd44-a4d8a70a089e</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:task id="_1da34f39-8338-4ecb-a93f-90349fa10260" name="Reject customer request">
+            <semantic:incoming>_ae94e0c1-aa12-433f-bd44-a4d8a70a089e</semantic:incoming>
+            <semantic:outgoing>_f7820843-8922-430e-ab4a-974a1e35d89b</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent id="_1cf552d4-5152-4595-9218-84f31533bc70" name="No business relation created">
+            <semantic:incoming>_f7820843-8922-430e-ab4a-974a1e35d89b</semantic:incoming>
+            <semantic:signalEventDefinition id="_8374dba6-01d8-45b8-9703-103b2fdc79a7"/>
+        </semantic:endEvent>
+        <semantic:dataObject id="_0fa2af52-a3d6-4be6-9ecc-9fad8ca4d448" name="ID document" isCollection="false"/>
+        <semantic:dataObject id="_79993b0e-60c2-487b-a12e-0cbecc2ef5c1" name="Customer data" isCollection="false"/>
+        <semantic:sequenceFlow id="_bac89998-7084-4b2e-a2ea-dff839336d74" sourceRef="_0254d83d-d943-466f-8b62-20e87cdfda4e" targetRef="_945cd271-46b6-4d71-83a1-530e445af820"/>
+        <semantic:sequenceFlow id="_c132a484-8828-4f03-9a57-8201f4e9e864" sourceRef="_945cd271-46b6-4d71-83a1-530e445af820" targetRef="_17db66a1-badd-4942-9ebd-02bc5595cdde"/>
+        <semantic:sequenceFlow id="_14c352ad-cd81-4a92-89e6-85f6e658e7bb" sourceRef="_17db66a1-badd-4942-9ebd-02bc5595cdde" targetRef="_138f9ebc-0211-4051-b7c0-1c55695d5246"/>
+        <semantic:sequenceFlow id="_fcb09e30-bfe6-46b9-af01-6777c60026f2" name="Individual Person" sourceRef="_138f9ebc-0211-4051-b7c0-1c55695d5246" targetRef="_54d66428-417b-447e-89d5-e726c1f12659"/>
+        <semantic:sequenceFlow id="_8e88b32b-90d5-4ca4-a969-00b667a92d29" sourceRef="_664f14a9-c1f1-490a-bbec-1f66ba4e7fe4" targetRef="_d22de266-6170-4783-91f9-40832e4cc58d"/>
+        <semantic:sequenceFlow id="_c2f47722-9bb7-416c-b6bc-cff4e3a6eb65" sourceRef="_d22de266-6170-4783-91f9-40832e4cc58d" targetRef="_a4936291-3787-404c-bec7-8a3f3c5fd6e5"/>
+        <semantic:sequenceFlow id="_eec53048-291a-4802-8fec-012857f845eb" name="Yes" sourceRef="_a4936291-3787-404c-bec7-8a3f3c5fd6e5" targetRef="_29b4f749-037a-4199-b33f-3cd3a3c7805e"/>
+        <semantic:sequenceFlow id="_65fba7be-af41-4ebe-b4e8-a8f7a830a702" sourceRef="_87785f46-7026-4d3c-b2c0-6a9468da67f6" targetRef="_a73027a7-615e-4a4d-95ee-c4cd78ab30c4"/>
+        <semantic:sequenceFlow id="_0cf86177-f481-4c25-8801-cd18d91ddec6" sourceRef="_a73027a7-615e-4a4d-95ee-c4cd78ab30c4" targetRef="_2b156883-2852-4665-aba0-d9bc57c7c225"/>
+        <semantic:sequenceFlow id="_8bd8a9d5-84da-4e96-b2af-9b8e003ad5a3" sourceRef="_2b156883-2852-4665-aba0-d9bc57c7c225" targetRef="_9c5d383f-df57-4012-b490-fa36f9f90eed"/>
+        <semantic:sequenceFlow id="_c7c63b1c-bdd1-443b-903b-7c31da1e6eb9" sourceRef="_9c5d383f-df57-4012-b490-fa36f9f90eed" targetRef="_3355cffe-aab4-4a05-8388-becf8ad599ae"/>
+        <semantic:sequenceFlow id="_1a933b26-7ac6-47a8-85de-07e658241e1e" sourceRef="_3355cffe-aab4-4a05-8388-becf8ad599ae" targetRef="_be6ea91a-4f8e-4240-86e8-f85036aee96f"/>
+        <semantic:sequenceFlow id="_40c01bbe-095a-4937-a334-95fa5b5225cc" sourceRef="_be6ea91a-4f8e-4240-86e8-f85036aee96f" targetRef="_000a0565-911b-4f71-9993-1177021edd97"/>
+        <semantic:sequenceFlow id="_1887adee-8291-4640-a5fa-3dc5f33d5a34" name="No" sourceRef="_000a0565-911b-4f71-9993-1177021edd97" targetRef="_3f3a831c-9b08-4827-92b3-3877a749e3df"/>
+        <semantic:sequenceFlow id="_f2b37ee6-7727-4106-bdd4-d93c4db15703" sourceRef="_f006114d-c7cb-4ce0-9bfe-f0938c36a53e" targetRef="_b9338c62-a257-47dd-8c2e-88b80b73c330"/>
+        <semantic:sequenceFlow id="_f974945f-f2a6-4547-9d35-0d26049dcd6f" sourceRef="_b9338c62-a257-47dd-8c2e-88b80b73c330" targetRef="_b360104e-8410-4b99-827a-776e2083fb96"/>
+        <semantic:sequenceFlow id="_0b3ae343-49aa-49dc-8b88-fe97b4ada3eb" sourceRef="_b360104e-8410-4b99-827a-776e2083fb96" targetRef="_8055ae64-cafd-4fd0-be36-2216e3b02e37"/>
+        <semantic:sequenceFlow id="_664f3a71-3efa-4c94-8797-815f2e377cf7" name="No" sourceRef="_a4936291-3787-404c-bec7-8a3f3c5fd6e5" targetRef="_2fd5c7d3-797d-45a5-a0d8-dfa60654ba5e"/>
+        <semantic:sequenceFlow id="_52e3c106-b055-40a0-a9f9-db9529adfb38" sourceRef="_2fd5c7d3-797d-45a5-a0d8-dfa60654ba5e" targetRef="_29b4f749-037a-4199-b33f-3cd3a3c7805e"/>
+        <semantic:sequenceFlow id="_f47c4e3f-3339-4c96-b8b0-829022bada78" sourceRef="_2b156883-2852-4665-aba0-d9bc57c7c225" targetRef="_09074897-556d-4fd2-afb6-2f6c774e1820"/>
+        <semantic:sequenceFlow id="_a4eaa7b6-f9ef-458a-ba70-e1fd3ff0595a" sourceRef="_09074897-556d-4fd2-afb6-2f6c774e1820" targetRef="_3355cffe-aab4-4a05-8388-becf8ad599ae"/>
+        <semantic:sequenceFlow id="_6912e5ed-5cae-4798-b6e6-8d367ddb3f60" name="Legal Entity" sourceRef="_138f9ebc-0211-4051-b7c0-1c55695d5246" targetRef="_f0422f0d-396b-4ee7-ad83-fdd34a8bab71"/>
+        <semantic:sequenceFlow id="_a8da83e1-4e09-4a7b-a09f-1f869b372176" sourceRef="_f0422f0d-396b-4ee7-ad83-fdd34a8bab71" targetRef="_a393c065-4412-4b16-b04f-52d07e76b518"/>
+        <semantic:sequenceFlow id="_afc35597-a482-432a-8ace-17adaf609572" name="Yes" sourceRef="_a393c065-4412-4b16-b04f-52d07e76b518" targetRef="_54d66428-417b-447e-89d5-e726c1f12659"/>
+        <semantic:sequenceFlow id="_470d1a12-e1fa-4471-b753-cfd7dbe20d80" name="No" sourceRef="_a393c065-4412-4b16-b04f-52d07e76b518" targetRef="_05a1a66a-9308-41c7-a611-4fc57627a058"/>
+        <semantic:sequenceFlow id="_461976fc-e457-4a39-baf3-785885c58896" sourceRef="_05a1a66a-9308-41c7-a611-4fc57627a058" targetRef="_acfa265a-a449-4e30-baa0-1ba47dbea418"/>
+        <semantic:sequenceFlow id="_e88d64c7-3aaf-4a5f-9787-4e5ba696312b" name="Yes" sourceRef="_000a0565-911b-4f71-9993-1177021edd97" targetRef="_1fc87527-9cad-4f8e-b9c7-ebe106cbe98d"/>
+        <semantic:sequenceFlow id="_c3e90e5c-e5cf-4cfb-b15d-bdedcf0719ca" sourceRef="_1fc87527-9cad-4f8e-b9c7-ebe106cbe98d" targetRef="_5f56934b-8a7e-4c35-b9f7-bf2605711bfd"/>
+        <semantic:sequenceFlow id="_8a77d7f6-320a-47ff-a155-57ee200df478" name="Yes" sourceRef="_5f56934b-8a7e-4c35-b9f7-bf2605711bfd" targetRef="_3f3a831c-9b08-4827-92b3-3877a749e3df"/>
+        <semantic:sequenceFlow id="_ae94e0c1-aa12-433f-bd44-a4d8a70a089e" name="No" sourceRef="_5f56934b-8a7e-4c35-b9f7-bf2605711bfd" targetRef="_1da34f39-8338-4ecb-a93f-90349fa10260"/>
+        <semantic:sequenceFlow id="_f7820843-8922-430e-ab4a-974a1e35d89b" sourceRef="_1da34f39-8338-4ecb-a93f-90349fa10260" targetRef="_1cf552d4-5152-4595-9218-84f31533bc70"/>
+        <semantic:sequenceFlow id="_b6414e79-5e61-4a8e-a584-65201c4ea9a9" sourceRef="_54d66428-417b-447e-89d5-e726c1f12659" targetRef="_664f14a9-c1f1-490a-bbec-1f66ba4e7fe4"/>
+        <semantic:sequenceFlow id="_60066421-3da9-4318-8df2-d8b16b3011bb" sourceRef="_29b4f749-037a-4199-b33f-3cd3a3c7805e" targetRef="_87785f46-7026-4d3c-b2c0-6a9468da67f6"/>
+        <semantic:sequenceFlow id="_7ab3e406-ce00-40e0-88f7-c64bcb0b864f" sourceRef="_3f3a831c-9b08-4827-92b3-3877a749e3df" targetRef="_f006114d-c7cb-4ce0-9bfe-f0938c36a53e"/>
+    </semantic:process>
+    <semantic:process id="_774bc005-0917-43d5-ab70-0f9fe123fbd1" name="Check for connected clients" isClosed="false">
+        <semantic:startEvent id="_d8214574-bb4c-42ff-aabb-398eb95b2f2a" name="Check for connected clients">
+            <semantic:outgoing>_6c121fa1-4bab-4e82-98a6-672c6a6bb6f3</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:userTask id="_8b104885-149e-4af6-a459-d924dacd81b3" name="Check if group of connected clients exists" implementation="##unspecified">
+            <semantic:incoming>_6c121fa1-4bab-4e82-98a6-672c6a6bb6f3</semantic:incoming>
+            <semantic:outgoing>_4e00ba20-d2c5-47d6-b53f-b50d802855fd</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_080399c9-3c91-44c6-b510-80367e23a5af" name="Group of connected Clients existing?" gatewayDirection="Diverging">
+            <semantic:incoming>_4e00ba20-d2c5-47d6-b53f-b50d802855fd</semantic:incoming>
+            <semantic:outgoing>_e25b9c2d-690e-470b-8993-112002994fc2</semantic:outgoing>
+            <semantic:outgoing>_c329c58d-4a71-471f-acb9-b7f7113d8547</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:userTask id="_7507ae41-a1fa-405c-b4ea-85ed920eace5" name="Document group of connected clients according to Capital Requirements Regulation (CRR)" implementation="##unspecified">
+            <semantic:incoming>_e25b9c2d-690e-470b-8993-112002994fc2</semantic:incoming>
+            <semantic:outgoing>_20c68a0e-6aba-445b-94a3-6bb588dfa2d8</semantic:outgoing>
+        </semantic:userTask>
+        <semantic:endEvent id="_f7ce4bda-22c2-4ef9-aad9-5203dff18538">
+            <semantic:incoming>_90d759bb-90dc-48b7-8c06-ddf8664c36ff</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:exclusiveGateway id="_956bb101-c9f7-467d-b3e2-198fa1d3e12b" gatewayDirection="Converging">
+            <semantic:incoming>_20c68a0e-6aba-445b-94a3-6bb588dfa2d8</semantic:incoming>
+            <semantic:incoming>_c329c58d-4a71-471f-acb9-b7f7113d8547</semantic:incoming>
+            <semantic:outgoing>_90d759bb-90dc-48b7-8c06-ddf8664c36ff</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow id="_6c121fa1-4bab-4e82-98a6-672c6a6bb6f3" sourceRef="_d8214574-bb4c-42ff-aabb-398eb95b2f2a" targetRef="_8b104885-149e-4af6-a459-d924dacd81b3"/>
+        <semantic:sequenceFlow id="_4e00ba20-d2c5-47d6-b53f-b50d802855fd" sourceRef="_8b104885-149e-4af6-a459-d924dacd81b3" targetRef="_080399c9-3c91-44c6-b510-80367e23a5af"/>
+        <semantic:sequenceFlow id="_e25b9c2d-690e-470b-8993-112002994fc2" name="Yes" sourceRef="_080399c9-3c91-44c6-b510-80367e23a5af" targetRef="_7507ae41-a1fa-405c-b4ea-85ed920eace5"/>
+        <semantic:sequenceFlow id="_20c68a0e-6aba-445b-94a3-6bb588dfa2d8" sourceRef="_7507ae41-a1fa-405c-b4ea-85ed920eace5" targetRef="_956bb101-c9f7-467d-b3e2-198fa1d3e12b"/>
+        <semantic:sequenceFlow id="_90d759bb-90dc-48b7-8c06-ddf8664c36ff" sourceRef="_956bb101-c9f7-467d-b3e2-198fa1d3e12b" targetRef="_f7ce4bda-22c2-4ef9-aad9-5203dff18538"/>
+        <semantic:sequenceFlow id="_c329c58d-4a71-471f-acb9-b7f7113d8547" name="No" sourceRef="_080399c9-3c91-44c6-b510-80367e23a5af" targetRef="_956bb101-c9f7-467d-b3e2-198fa1d3e12b"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e" name="Create New Customer">
+        <bpmndi:BPMNPlane bpmnElement="_906eeac9-47e3-41c3-a8db-b8abb8fd95e6" id="_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_plane" trisobpmn:diagramWidth="3771.4415588378906" trisobpmn:diagramHeight="933.5239417864432">
+            <bpmndi:BPMNShape id="_c5d2909b-dbb7-4b69-bc63-6e60ce5c2e2e" bpmnElement="_f200a9f1-5554-4868-b895-707186915d62" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="197.5" y="50" width="3441.4415588378906" height="833.5239417864432"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="827.52392578125" width="12" x="202.5" y="53.00000800259659"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_701896c8-21f6-4298-beec-4fa2e63205fe" bpmnElement="_2935f981-e194-4a1b-bb22-846ad3c0f72c" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="227.5" y="50" width="3411.4415588378906" height="469.11302726946235"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="463.113037109375" width="12" x="232.5" y="52.99999508004362"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7a80c616-1f38-4e7d-b412-40b8b6921888" bpmnElement="_0254d83d-d943-466f-8b62-20e87cdfda4e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="322.5" y="250.82122670093054" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="99.03125" x="288.984375" y="292.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f3497a24-0269-4401-bcdb-b29ee06df37e" bpmnElement="_945cd271-46b6-4d71-83a1-530e445af820" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="411.5" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="415" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7490d7d1-c172-4371-94de-251d8f4e309c" bpmnElement="_17db66a1-badd-4942-9ebd-02bc5595cdde" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="562.5" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="566" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_cbbb8129-7038-4765-96dc-7975ded24e5f" bpmnElement="_138f9ebc-0211-4051-b7c0-1c55695d5246" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="713.5" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="680.2867965698242" y="213.55119115306104"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_be32eec9-a3f1-4764-9ced-21414785a1fd" bpmnElement="_664f14a9-c1f1-490a-bbec-1f66ba4e7fe4" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1099.0735931396484" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="54" width="89" x="1102.5735931396484" y="239.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e733cc7b-7337-4bf7-b442-5149bd6d9086" bpmnElement="_d22de266-6170-4783-91f9-40832e4cc58d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1263.0735931396484" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="1266.5735931396484" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bf8bc911-e825-4c9f-a17f-ce7594f2b0e3" bpmnElement="_a4936291-3787-404c-bec7-8a3f3c5fd6e5" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1414.0735931396484" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="1375.8603897094727" y="230.55119115306104"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6dd19c18-53ee-4487-87d1-2282dfbe0f9d" bpmnElement="_87785f46-7026-4d3c-b2c0-6a9468da67f6" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1710.6471862792969" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="1714.1471862792969" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6d462910-bef7-4f1b-b4e2-393877387296" bpmnElement="_a73027a7-615e-4a4d-95ee-c4cd78ab30c4" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1881.6471862792969" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="1885.1471862792969" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_185e1ced-a3a8-4118-b8b3-2c50814d57a5" bpmnElement="_2b156883-2852-4665-aba0-d9bc57c7c225" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2032.6471862792969" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7b9130ef-73b7-442a-8a57-1477f9ce167b" bpmnElement="_9c5d383f-df57-4012-b490-fa36f9f90eed" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2129.2207794189453" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="89" x="2132.7207794189453" y="260.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_80c0c382-87e6-4652-a4be-a2060abc04f5" bpmnElement="_3355cffe-aab4-4a05-8388-becf8ad599ae" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2367.2207794189453" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b3d3df90-e83a-4916-bd10-276d4229ac80" bpmnElement="_be6ea91a-4f8e-4240-86e8-f85036aee96f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2463.7943725585938" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="89" x="2467.2943725585938" y="246.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e5de0c4e-d95d-460f-ab29-7643759d0faa" bpmnElement="_000a0565-911b-4f71-9993-1177021edd97" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2614.7943725585938" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="2579.581169128418" y="223.55119115306104"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_2909b25a-a2f1-4d8c-93e5-085a6f7a8e1f" bpmnElement="_f006114d-c7cb-4ce0-9bfe-f0938c36a53e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2996.9415588378906" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="3000.4415588378906" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_1a35c023-bfda-41a8-a7a1-65fdaa238623" bpmnElement="_b9338c62-a257-47dd-8c2e-88b80b73c330" triso:targetpage="_07be6666-61a7-4857-9e9a-8e1b80fafb52" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3179.9415588378906" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="3183.4415588378906" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_46246362-cf80-46a2-9587-2d309372af39" bpmnElement="_b360104e-8410-4b99-827a-776e2083fb96" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3330.9415588378906" y="228.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="3334.4415588378906" y="253.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b6c9ddf6-b7b2-47d6-b3fc-3928ebb4541f" bpmnElement="_8055ae64-cafd-4fd0-be36-2216e3b02e37" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3481.9415588378906" y="248.82122670093054" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="93.546875" x="3453.1681213378906" y="294.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_10593785-0c6d-47d6-875a-e4aea635b9fd" bpmnElement="_2fd5c7d3-797d-45a5-a0d8-dfa60654ba5e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1487.6471862792969" y="405.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="1491.1471862792969" y="430.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_14e4d4bd-2e8c-43f5-94fd-169c3497a7ec" bpmnElement="_09074897-556d-4fd2-afb6-2f6c774e1820" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2261.2207794189453" y="405.82122670093054" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="89" x="2264.7207794189453" y="423.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c8db7f20-f71f-45f0-a489-a40e020424c6" bpmnElement="_54d66428-417b-447e-89d5-e726c1f12659" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="971.0735931396484" y="246.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0f8747c7-4b8f-4e9c-ab11-a2aa6bd642cb" bpmnElement="_29b4f749-037a-4199-b33f-3cd3a3c7805e" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1604.2132034301758" y="246.7019614758657" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_ff9c3117-91f4-4332-905a-66e07f3098d5" bpmnElement="_3f3a831c-9b08-4827-92b3-3877a749e3df" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2865.367965698242" y="246.70202391557723" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bb2e89e0-bb80-4eeb-afeb-5db811de5da5" bpmnElement="_dca1cc5b-74a4-453f-8ad2-61609dde35ff" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="608.5" y="395.82122670093054" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="508.5" y="401.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_180e0971-bf40-4d4d-9009-2968dae394f2" bpmnElement="_e0b6d1fe-4ddf-4e22-b84c-6d676afb389a" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1308.0735931396484" y="435.77760192819187" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="1212.0735931396484" y="450.77760192819187"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e03c0c8b-3bf1-4665-9120-85f4c4a07cff" bpmnElement="_4f982ccc-c9e4-43b1-832e-b82992d4d400" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1772.6471862792969" y="395.82122670093054" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="63.296875" x="1757.9987487792969" y="440.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f977f9cc-bf19-468b-9ddc-d29e3ba702ce" bpmnElement="_be9fc840-d916-4495-9061-989af6035030" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2225.2207794189453" y="319.82122670093054" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="2118.2207794189453" y="326.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e76119b0-7d7d-4b7e-81a5-36b3cbf34b66" bpmnElement="_4257e72e-9c36-4832-8134-b68b8919de7e" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2494.7943725585938" y="435.77760192819187" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="2456.7943725585938" y="480.77760192819187"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_ff257a45-8f91-46b5-893a-7e79e10f3885" bpmnElement="_dd653cc9-c874-4cfe-ba6c-146726809ea5" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3306.5735931396484" y="361.82122670093054" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="110" x="3268.5735931396484" y="406.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d02ce48e-307a-40d6-8dbc-85c0b0cef55d" bpmnElement="_ffd44905-4f54-4fe0-a156-0312c2a7a3cc" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3376.9415588378906" y="441.7811028666074" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="64.796875" x="3362.0431213378906" y="476.2811028666074"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_299d12f1-7084-4ef8-a106-580669e38a4c" bpmnElement="_66f4a1ff-fd8a-4002-ade7-7a4d1b1d529c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3362.4415588378906" y="109.82472763934607" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="3320.9415588378906" y="73.60938054661892"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_818603f3-cdcb-46d2-9636-0e81e5ee57e3" bpmnElement="_c5285566-0657-47c5-a7ad-d09e144377f3" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2171.1927917900402" y="109.82472763934607" width="33" height="27.992998123168945"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="110" x="2131.6927917900402" y="70.60938054661892"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_019f3e2a-6893-43ef-82f9-3c272c27840a" bpmnElement="_af0d417a-6492-48d6-ace2-f70b807564a8" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="227.5" y="519.1130272694623" width="3411.4415588378906" height="160.16001748020756"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="154.16001892089844" width="12" x="232.5" y="522.113026549117"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_4bb38569-92cc-47b2-87a8-c31a3e1b9807" bpmnElement="_f0422f0d-396b-4ee7-ad83-fdd34a8bab71" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="823.0735931396484" y="544.1130272694623" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="89" x="826.5735931396484" y="562.1130272694623"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_57bacee7-eca4-437c-bb4d-f3ea547ac448" bpmnElement="_a393c065-4412-4b16-b04f-52d07e76b518" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="971.0735931396484" y="561.8090321270513" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="81.421875" x="951.3626556396484" y="608.6080222574758"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c2b91fc7-a37d-4098-b5c9-5c47aa39b5f0" bpmnElement="_05a1a66a-9308-41c7-a611-4fc57627a058" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1067.6471862792969" y="543.8212267009305" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="1071.1471862792969" y="568.8212267009305"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0b0bd2c8-b649-4923-b0f7-d786060eaecd" bpmnElement="_acfa265a-a449-4e30-baa0-1ba47dbea418" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1218.6471862792969" y="563.8212267009305" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="83.765625" x="1194.7643737792969" y="609.8212267009305"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5cd57a29-5d2e-455a-bb61-e918b348da23" bpmnElement="_1c6c313d-4950-47a0-b6bf-c51a4b2ea7ed" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="227.5" y="679.2730447496699" width="3411.4415588378906" height="204.25089703677327"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="198.2509002685547" width="12" x="232.5" y="682.2730431337793"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_50461740-aba6-41bd-b559-732e06813c14" bpmnElement="_1fc87527-9cad-4f8e-b9c7-ebe106cbe98d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2711.367965698242" y="723.2730447496699" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="40" width="89" x="2714.867965698242" y="741.2730447496699"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_cd730709-05fd-4bfd-8d3a-ccb36287ba81" bpmnElement="_5f56934b-8a7e-4c35-b9f7-bf2605711bfd" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="2865.367965698242" y="741.2608501757907" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="50.53125" x="2861.102340698242" y="788.0598403062152"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_08b4159a-71d2-4a42-b412-26337cfa9a1c" bpmnElement="_1da34f39-8338-4ecb-a93f-90349fa10260" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3007.515151977539" y="723.2730447496699" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="89" x="3011.015151977539" y="748.2730447496699"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7eba20dc-dd3f-4d2e-b414-577608cf62d5" bpmnElement="_1cf552d4-5152-4595-9218-84f31533bc70" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="3201.515151977539" y="743.2730447496699" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="26" width="99.65625" x="3169.687026977539" y="789.2730447496699"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_84675510-efbf-4f5a-a676-080de7b7719c" color:border-color="#000000" bpmnElement="_bac89998-7084-4b2e-a2ea-dff839336d74">
+                <di:waypoint x="353.5" y="266.82122670093054"/>
+                <di:waypoint x="411.5" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a2de7f73-a6ca-4ca4-948f-93cc7496a884" color:border-color="#000000" bpmnElement="_c132a484-8828-4f03-9a57-8201f4e9e864">
+                <di:waypoint x="506.5" y="266.82122670093054"/>
+                <di:waypoint x="562.5" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_35c32f9a-b676-45c1-890e-caee02ddd666" color:border-color="#000000" bpmnElement="_14c352ad-cd81-4a92-89e6-85f6e658e7bb">
+                <di:waypoint x="657.5" y="266.82122670093054"/>
+                <di:waypoint x="713.5" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_65eb8cde-3bf2-461f-8a6e-868ff6959dad" color:border-color="#000000" bpmnElement="_fcb09e30-bfe6-46b9-af01-6777c60026f2">
+                <di:waypoint x="755.5" y="266.6080222574758"/>
+                <di:waypoint x="971.0735931396484" y="266.6080222574758"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="748.2867965698242" y="249.6080222574758"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_c690e558-d531-44bf-8fa8-80ac23d505e9" color:border-color="#000000" bpmnElement="_8e88b32b-90d5-4ca4-a969-00b667a92d29">
+                <di:waypoint x="1194.0735931396484" y="266.82122670093054"/>
+                <di:waypoint x="1263.0735931396484" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f5629969-d762-4129-b96a-61c4fa0c3b28" color:border-color="#000000" bpmnElement="_c2f47722-9bb7-416c-b6bc-cff4e3a6eb65">
+                <di:waypoint x="1358.0735931396484" y="266.82122670093054"/>
+                <di:waypoint x="1414.0735931396484" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a994ade6-572b-4fd5-b4d7-ac4065412bb0" color:border-color="#000000" bpmnElement="_eec53048-291a-4802-8fec-012857f845eb">
+                <di:waypoint x="1456.0735931396484" y="266.6080222574758"/>
+                <di:waypoint x="1604.2132034301758" y="266.5009516062902"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="1417.3603899288987" y="251.71415604974493"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_aaec115e-d91b-4721-b221-48ca84b47d1d" color:border-color="#000000" bpmnElement="_65fba7be-af41-4ebe-b4e8-a8f7a830a702">
+                <di:waypoint x="1805.6471862792969" y="266.82122670093054"/>
+                <di:waypoint x="1881.6471862792969" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5ae46c97-6b0a-452a-a135-a9fcabdf3cb7" color:border-color="#000000" bpmnElement="_0cf86177-f481-4c25-8801-cd18d91ddec6">
+                <di:waypoint x="1976.6471862792969" y="266.82122670093054"/>
+                <di:waypoint x="2032.6471862792969" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_151fd967-911a-4ab4-9f32-911543992639" color:border-color="#000000" bpmnElement="_8bd8a9d5-84da-4e96-b2af-9b8e003ad5a3">
+                <di:waypoint x="2074.647186279297" y="266.6080222574758"/>
+                <di:waypoint x="2129.2207794189453" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6a4b13b2-df47-4a44-8918-fbc37936f32f" color:border-color="#000000" bpmnElement="_c7c63b1c-bdd1-443b-903b-7c31da1e6eb9">
+                <di:waypoint x="2224.2207794189453" y="266.82122670093054"/>
+                <di:waypoint x="2367.2207794189453" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8aa0a861-4f38-46c3-893c-53bcd11813a8" color:border-color="#000000" bpmnElement="_1a933b26-7ac6-47a8-85de-07e658241e1e">
+                <di:waypoint x="2409.2207794189453" y="266.6080222574758"/>
+                <di:waypoint x="2463.7943725585938" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_dedfd0da-7035-4854-85d4-cd442d14ea39" color:border-color="#000000" bpmnElement="_40c01bbe-095a-4937-a334-95fa5b5225cc">
+                <di:waypoint x="2558.7943725585938" y="266.82122670093054"/>
+                <di:waypoint x="2614.7943725585938" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_da703f8a-64ff-4256-a0ba-0272301317b8" color:border-color="#000000" bpmnElement="_1887adee-8291-4640-a5fa-3dc5f33d5a34">
+                <di:waypoint x="2656.7943725585938" y="266.6080222574758"/>
+                <di:waypoint x="2865.367965698242" y="266.5010140460017"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="2624.081169128418" y="253.55451815173876"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f42f62f7-9a3f-432a-8cea-5b6aa068620b" color:border-color="#000000" bpmnElement="_f2b37ee6-7727-4106-bdd4-d93c4db15703">
+                <di:waypoint x="3091.9415588378906" y="266.82122670093054"/>
+                <di:waypoint x="3179.9415588378906" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fbefa2b8-e9cf-4a88-b5e9-99d899fbb1d0" color:border-color="#000000" bpmnElement="_f974945f-f2a6-4547-9d35-0d26049dcd6f">
+                <di:waypoint x="3274.9415588378906" y="266.82122670093054"/>
+                <di:waypoint x="3330.9415588378906" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d5977649-4daa-4017-ad8d-4c1209de8e30" color:border-color="#000000" bpmnElement="_0b3ae343-49aa-49dc-8b88-fe97b4ada3eb">
+                <di:waypoint x="3425.9415588378906" y="266.82122670093054"/>
+                <di:waypoint x="3481.9415588378906" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7372daa9-ad86-4e44-bf53-cc857d0030f7" color:border-color="#000000" bpmnElement="_664f3a71-3efa-4c94-8797-815f2e377cf7">
+                <di:waypoint x="1435.0735931396484" y="287.6080222574758"/>
+                <di:waypoint x="1435.0735931396484" y="431.1512267009306"/>
+                <di:waypoint x="1488.6471862792969" y="431.1512267009306"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="1396.0735931396484" y="299.1512267009306"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_35cc1b09-7647-48f5-b3f9-b406117a3de5" color:border-color="#000000" bpmnElement="_52e3c106-b055-40a0-a9f9-db9529adfb38">
+                <di:waypoint x="1582.6471862792969" y="443.82122670093054"/>
+                <di:waypoint x="1625.2132034301758" y="443.82122670093054"/>
+                <di:waypoint x="1625.2132034301758" y="287.5009516062902"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_df5e5e37-f270-400d-b22c-7f5b361672c3" color:border-color="#000000" bpmnElement="_f47c4e3f-3339-4c96-b8b0-829022bada78">
+                <di:waypoint x="2053.647186279297" y="287.6080222574758"/>
+                <di:waypoint x="2053.647186279297" y="443.82122670093054"/>
+                <di:waypoint x="2262.2207794189453" y="443.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_bba9a75c-9810-4909-9a7e-f157b3dcb9a3" color:border-color="#000000" bpmnElement="_a4eaa7b6-f9ef-458a-ba70-e1fd3ff0595a">
+                <di:waypoint x="2356.2207794189453" y="443.82122670093054"/>
+                <di:waypoint x="2388.2207794189453" y="443.82122670093054"/>
+                <di:waypoint x="2388.2207794189453" y="287.6080222574758"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6de241ec-c299-4493-8974-926137303900" color:border-color="#000000" bpmnElement="_6912e5ed-5cae-4798-b6e6-8d367ddb3f60">
+                <di:waypoint x="734.5" y="287.6080222574758"/>
+                <di:waypoint x="734.5" y="582.1130272694623"/>
+                <di:waypoint x="824.0735931396484" y="582.1130272694623"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="715.5" y="309.82122670093054"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_2cdd984f-2332-4179-8a23-49375bd5b7c3" color:border-color="#000000" bpmnElement="_a8da83e1-4e09-4a7b-a09f-1f869b372176">
+                <di:waypoint x="918.0735931396484" y="582.1130272694623"/>
+                <di:waypoint x="971.0735931396484" y="581.8212267009305"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5c585551-1aa2-43bf-99e1-1c30ee92444b" color:border-color="#000000" bpmnElement="_afc35597-a482-432a-8ace-17adaf609572">
+                <di:waypoint x="992.0735931396484" y="560.6080222574758"/>
+                <di:waypoint x="992.0735931396484" y="287.6080222574758"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="953.0735931396484" y="546.1080222574758"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9601c3d8-81fb-4bde-9a61-b3c17bea4f40" color:border-color="#000000" bpmnElement="_470d1a12-e1fa-4471-b753-cfd7dbe20d80">
+                <di:waypoint x="1013.0735931396484" y="581.6080222574758"/>
+                <di:waypoint x="1067.6471862792969" y="581.8212267009305"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="975.8603935250692" y="586.712671127736"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_72e95d65-8822-4843-a50a-5c99c604d9eb" color:border-color="#000000" bpmnElement="_461976fc-e457-4a39-baf3-785885c58896">
+                <di:waypoint x="1162.6471862792969" y="581.8212267009305"/>
+                <di:waypoint x="1218.6471862792969" y="581.8212267009305"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_875d9ea7-3bd1-489b-a16b-35e76de218ab" color:border-color="#000000" bpmnElement="_e88d64c7-3aaf-4a5f-9787-4e5ba696312b">
+                <di:waypoint x="2635.7943725585938" y="287.6080222574758"/>
+                <di:waypoint x="2635.7943725585938" y="761.2730447496699"/>
+                <di:waypoint x="2712.367965698242" y="761.2730447496699"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="2596.7943725585938" y="299.2730447496699"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_24b2b0f8-366c-42b3-9850-4a4e244ba685" color:border-color="#000000" bpmnElement="_c3e90e5c-e5cf-4cfb-b15d-bdedcf0719ca">
+                <di:waypoint x="2806.367965698242" y="761.2730447496699"/>
+                <di:waypoint x="2865.367965698242" y="761.2730447496699"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1c5a1f16-fc41-4cd9-b82d-2e0ba04ab830" color:border-color="#000000" bpmnElement="_8a77d7f6-320a-47ff-a155-57ee200df478">
+                <di:waypoint x="2886.367965698242" y="740.0598403062152"/>
+                <di:waypoint x="2886.367965698242" y="287.5010140460017"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="2847.367965698242" y="717.7804271761084"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_2cee126b-6174-4197-9cac-9bdd84ef3b8d" color:border-color="#000000" bpmnElement="_ae94e0c1-aa12-433f-bd44-a4d8a70a089e">
+                <di:waypoint x="2907.367965698242" y="761.0598403062152"/>
+                <di:waypoint x="3007.515151977539" y="761.2730447496699"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+                    <dc:Bounds height="12" width="110" x="2871.728355407715" y="743.1664425279425"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d41e82a4-7783-4208-8a92-0b3a8d894443" color:border-color="#000000" bpmnElement="_f7820843-8922-430e-ab4a-974a1e35d89b">
+                <di:waypoint x="3102.515151977539" y="761.2730447496699"/>
+                <di:waypoint x="3201.515151977539" y="761.2730447496699"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6105220b-5d5b-44b9-b00a-dadf12ae2e7b" color:border-color="#000000" bpmnElement="_e5e5b852-0c5f-4f5f-8c6c-a1d8245024b4" sourceElement="_7490d7d1-c172-4371-94de-251d8f4e309c">
+                <di:waypoint x="626.5" y="303.82122670093054"/>
+                <di:waypoint x="625.5" y="396.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3869efc0-dd34-4725-9615-599f77c4f936" color:border-color="#000000" bpmnElement="_8a1de917-0cd0-4cb3-a449-5d10733575ee" targetElement="_be32eec9-a3f1-4764-9ced-21414785a1fd">
+                <di:waypoint x="641.5" y="415.82122670093054"/>
+                <di:waypoint x="1147.0735931396484" y="415.82122670093054"/>
+                <di:waypoint x="1147.0735931396484" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7502a714-30dc-4336-b672-a210330bcc69" color:border-color="#000000" bpmnElement="_e4d5f0c6-49e2-4467-80da-4818237bbbed" targetElement="_e733cc7b-7337-4bf7-b442-5149bd6d9086">
+                <di:waypoint x="641.5" y="427.82122670093054"/>
+                <di:waypoint x="1295.0735931396484" y="427.82122670093054"/>
+                <di:waypoint x="1295.0735931396484" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ac31efcb-6dc9-454c-94bb-29971290d1ca" color:border-color="#000000" bpmnElement="_e470d57d-3556-40dd-b518-5ed19b3f63d9" targetElement="_4bb38569-92cc-47b2-87a8-c31a3e1b9807">
+                <di:waypoint x="625.5" y="434.82122670093054"/>
+                <di:waypoint x="625.5" y="604.9130272694623"/>
+                <di:waypoint x="824.0735931396484" y="604.9130272694623"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_16726b83-6d2c-4204-902a-3cb0bfa349ba" color:border-color="#000000" bpmnElement="_1cfb93bd-7a02-481d-a42c-c69c614a4b00" sourceElement="_e733cc7b-7337-4bf7-b442-5149bd6d9086">
+                <di:waypoint x="1327.0735931396484" y="303.82122670093054"/>
+                <di:waypoint x="1325.0735931396484" y="436.77760192819187"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_963f67d6-2167-40d0-a26d-42a90f942618" color:border-color="#000000" bpmnElement="_a290cb0f-07ce-4e95-8d51-eb98307b3beb" sourceElement="_10593785-0c6d-47d6-875a-e4aea635b9fd">
+                <di:waypoint x="1488.6471862792969" y="456.4812267009305"/>
+                <di:waypoint x="1341.0735931396484" y="455.77760192819187"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_370b167d-2be1-4436-a153-d5e4c83991d5" color:border-color="#000000" bpmnElement="_24b56549-d0fc-44d1-9fcf-b136ef8f420c" targetElement="_6dd19c18-53ee-4487-87d1-2282dfbe0f9d">
+                <di:waypoint x="1325.0735931396484" y="474.77760192819187"/>
+                <di:waypoint x="1325.0735931396484" y="496.77760192819187"/>
+                <di:waypoint x="1742.6471862792969" y="496.77760192819187"/>
+                <di:waypoint x="1742.6471862792969" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_c1865ea4-4ec8-47aa-8d28-69af49423e40" color:border-color="#000000" bpmnElement="_fc3badce-d027-4ab8-91a5-bfcf3be7daa5" sourceElement="_6dd19c18-53ee-4487-87d1-2282dfbe0f9d">
+                <di:waypoint x="1787.4471862792968" y="303.82122670093054"/>
+                <di:waypoint x="1787.4471862792968" y="348.32122670093054"/>
+                <di:waypoint x="1789.6471862792969" y="348.32122670093054"/>
+                <di:waypoint x="1789.6471862792969" y="396.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3fcc1d95-badc-4cf6-88bf-42c9152ccf62" color:border-color="#000000" bpmnElement="_6518fef7-dc30-4737-84ee-f33ceba4a844" targetElement="_6d462910-bef7-4f1b-b4e2-393877387296">
+                <di:waypoint x="1805.6471862792969" y="415.82122670093054"/>
+                <di:waypoint x="1929.6471862792969" y="415.82122670093054"/>
+                <di:waypoint x="1929.6471862792969" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ce6bcb67-5613-4efa-8de7-2d9b35bef156" color:border-color="#000000" bpmnElement="_a1577e31-32ee-46db-be07-c31f1f047a5e" sourceElement="_7b9130ef-73b7-442a-8a57-1477f9ce167b">
+                <di:waypoint x="2224.2207794189453" y="279.4812267009305"/>
+                <di:waypoint x="2242.2207794189453" y="279.4812267009305"/>
+                <di:waypoint x="2242.2207794189453" y="320.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_44fc7e91-761e-4833-ae9a-0000a0911e7a" color:border-color="#000000" bpmnElement="_b181f888-d411-4665-aeea-89569a373e98" targetElement="_14e4d4bd-2e8c-43f5-94fd-169c3497a7ec">
+                <di:waypoint x="2242.2207794189453" y="358.82122670093054"/>
+                <di:waypoint x="2242.2207794189453" y="421.0212267009306"/>
+                <di:waypoint x="2262.2207794189453" y="421.0212267009306"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_107fbe33-23be-4931-92e9-352e39f7c243" color:border-color="#000000" bpmnElement="_8234f225-632d-4b63-b7b4-9ee05ebd4971" sourceElement="_14e4d4bd-2e8c-43f5-94fd-169c3497a7ec">
+                <di:waypoint x="2356.2207794189453" y="456.4812267009305"/>
+                <di:waypoint x="2495.7943725585938" y="455.77760192819187"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_0b4c9235-ce87-447c-b0f9-68a609c049a4" color:border-color="#000000" bpmnElement="_9f68656f-415d-4288-be20-fd75bcd92f6a" targetElement="_b3d3df90-e83a-4916-bd10-276d4229ac80">
+                <di:waypoint x="2511.7943725585938" y="436.77760192819187"/>
+                <di:waypoint x="2511.7943725585938" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_090fe2ed-658f-48cb-8d23-8988131875d3" color:border-color="#000000" bpmnElement="_a8b81881-5b94-4d11-8b5c-5e9b76878dcd" targetElement="_2909b25a-a2f1-4d8c-93e5-085a6f7a8e1f">
+                <di:waypoint x="2527.7943725585938" y="455.77760192819187"/>
+                <di:waypoint x="3028.9415588378906" y="455.77760192819187"/>
+                <di:waypoint x="3028.9415588378906" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3e2441aa-432c-440c-a936-386b886b62c7" color:border-color="#000000" bpmnElement="_10466056-a9bd-4d46-b6ca-60cc6c5f6b13" targetElement="_1a35c023-bfda-41a8-a7a1-65fdaa238623">
+                <di:waypoint x="2527.7943725585938" y="455.77760192819187"/>
+                <di:waypoint x="3211.9415588378906" y="455.77760192819187"/>
+                <di:waypoint x="3211.9415588378906" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1af1bc35-e290-441c-96b6-cac604c6b885" color:border-color="#000000" bpmnElement="_f4536257-490a-4f11-8174-59c44fe6d51d" targetElement="_50461740-aba6-41bd-b559-732e06813c14">
+                <di:waypoint x="2527.7943725585938" y="467.77760192819187"/>
+                <di:waypoint x="2743.367965698242" y="467.77760192819187"/>
+                <di:waypoint x="2743.367965698242" y="724.2730447496699"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_02261fa0-79b1-485a-b608-8e6f62899979" color:border-color="#000000" bpmnElement="_39450d6b-b008-4af2-bb98-35d65093922e" sourceElement="_1a35c023-bfda-41a8-a7a1-65fdaa238623">
+                <di:waypoint x="3256.741558837891" y="303.82122670093054"/>
+                <di:waypoint x="3256.741558837891" y="381.82122670093054"/>
+                <di:waypoint x="3307.5735931396484" y="381.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_496508a5-76f5-4b57-ac6e-eb640bf54714" color:border-color="#000000" bpmnElement="_bd748ab9-bd4e-47d1-8f69-cc8e451e0b2b" targetElement="_46246362-cf80-46a2-9587-2d309372af39">
+                <di:waypoint x="3339.5735931396484" y="381.82122670093054"/>
+                <di:waypoint x="3362.9415588378906" y="381.82122670093054"/>
+                <di:waypoint x="3362.9415588378906" y="303.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6d5545c7-8b6d-48fe-a423-35201ac7c3dd" color:border-color="#000000" bpmnElement="_8eaa28a5-123c-4224-ad2a-218525c6c79e" sourceElement="_46246362-cf80-46a2-9587-2d309372af39">
+                <di:waypoint x="3394.9415588378906" y="303.82122670093054"/>
+                <di:waypoint x="3393.4415588378906" y="442.2811028666074"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1ee9f9b9-bb9b-40bf-bcf2-3a4b2b804322" color:border-color="#000000" bpmnElement="_48edea23-f132-4ec7-b296-35c091e1755b" targetElement="_46246362-cf80-46a2-9587-2d309372af39">
+                <di:waypoint x="3378.9415588378906" y="137.32472763934607"/>
+                <di:waypoint x="3378.9415588378906" y="229.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a945bd1f-3413-462f-8f64-7efa086a7d61" color:border-color="#000000" bpmnElement="_9f70cdff-8fb7-432d-84f0-29db168610fa" sourceElement="_14e4d4bd-2e8c-43f5-94fd-169c3497a7ec">
+                <di:waypoint x="2293.2207794189453" y="480.82122670093054"/>
+                <di:waypoint x="2293.2207794189453" y="496.82122670093054"/>
+                <di:waypoint x="2011.7413301201245" y="496.82122670093054"/>
+                <di:waypoint x="2011.7413301201245" y="131.72472763934604"/>
+                <di:waypoint x="2171.6927917900402" y="131.72472763934604"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_92fec7b6-e8e4-4dec-854c-7fddc81a6009" color:border-color="#000000" bpmnElement="_ed10a8d7-01db-4221-a281-03174f633376" sourceElement="_6d462910-bef7-4f1b-b4e2-393877387296">
+                <di:waypoint x="1929.6471862792969" y="229.82122670093054"/>
+                <di:waypoint x="1929.6471862792969" y="123.32472763934607"/>
+                <di:waypoint x="2171.6927917900402" y="123.32472763934607"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d00f65fe-fed4-4003-98c8-4379d68b594f" color:border-color="#000000" bpmnElement="_aa4bda11-11a7-441a-b50f-7296b83542e4" sourceElement="_7b9130ef-73b7-442a-8a57-1477f9ce167b">
+                <di:waypoint x="2177.2207794189453" y="229.82122670093054"/>
+                <di:waypoint x="2177.4927917900404" y="137.32472763934607"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6ce51af7-0d20-4efd-b049-973561586689" color:border-color="#000000" bpmnElement="_c7006cb5-a9f4-4528-8fca-9083fc7559ed" sourceElement="_2909b25a-a2f1-4d8c-93e5-085a6f7a8e1f">
+                <di:waypoint x="3044.9415588378906" y="229.82122670093054"/>
+                <di:waypoint x="3044.9415588378906" y="123.32472763934607"/>
+                <di:waypoint x="2203.6927917900402" y="123.32472763934607"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f8acca4d-50a2-46c9-8df2-015e73ec06b0" color:border-color="#000000" bpmnElement="_b6414e79-5e61-4a8e-a584-65201c4ea9a9">
+                <di:waypoint x="1013.0735931396484" y="266.6080222574758"/>
+                <di:waypoint x="1098.0735933321894" y="266.8206061514859"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5ecfcf09-da7e-4126-bbb4-cc76f7ff2907" color:border-color="#000000" bpmnElement="_60066421-3da9-4318-8df2-d8b16b3011bb">
+                <di:waypoint x="1646.2132034301758" y="266.5009516062902"/>
+                <di:waypoint x="1709.6471867181492" y="266.82028984201406"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_10208b6b-6ed2-41b5-8d79-3fcbe0acd1a9" color:border-color="#000000" bpmnElement="_7ab3e406-ce00-40e0-88f7-c64bcb0b864f">
+                <di:waypoint x="2907.367965698242" y="266.5010140460017"/>
+                <di:waypoint x="2995.9415588378906" y="266.82122670093054"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4d22332d-d94b-43c9-aa14-455a51a160e5" color:border-color="#000000" bpmnElement="_2fdc6abd-cfec-425d-b386-fe8b61371495" sourceElement="_b3d3df90-e83a-4916-bd10-276d4229ac80">
+                <di:waypoint x="2511.7943725585938" y="229.82122670093054"/>
+                <di:waypoint x="2511.7943725585938" y="189.5729771701383"/>
+                <di:waypoint x="2197.89279179004" y="189.5729771701383"/>
+                <di:waypoint x="2197.89279179004" y="137.32472763934607"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_2fcf7782-05d8-4e1d-a8d2-51ea0ec65d7e_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <bpmndi:BPMNDiagram id="_07be6666-61a7-4857-9e9a-8e1b80fafb52" name="Check for connected clients">
+        <bpmndi:BPMNPlane bpmnElement="_774bc005-0917-43d5-ab70-0f9fe123fbd1" id="_07be6666-61a7-4857-9e9a-8e1b80fafb52_plane" trisobpmn:diagramWidth="798.5735931396484" trisobpmn:diagramHeight="285.01219457387924">
+            <bpmndi:BPMNShape id="_42eb6a6a-dab0-42ea-8e86-111d9436efcc" bpmnElement="_d8214574-bb4c-42ff-aabb-398eb95b2f2a" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="50" y="72" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="26" width="100.890625" x="15.5546875" y="114"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_87a1d380-4cf4-4a8f-a996-d73e0bc813df" bpmnElement="_8b104885-149e-4af6-a459-d924dacd81b3" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="137" y="50" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="40" width="89" x="140.5" y="68"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8ca362bf-557d-4705-8efb-0a49726847a5" bpmnElement="_080399c9-3c91-44c6-b510-80367e23a5af" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="288" y="67.98780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="26" width="110" x="251.78679656982422" y="32.729964452130446"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e8d01477-5dd3-4105-85f0-f7e6fb1cbfb1" bpmnElement="_7507ae41-a1fa-405c-b4ea-85ed920eace5" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="407.7867965698242" y="159.01219457387924" width="140" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="68" width="133" x="411.2867965698242" y="163.01219457387924"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_d40ebd9c-fdd7-4def-bbfa-82edffbb9816" bpmnElement="_f7ce4bda-22c2-4ef9-aad9-5203dff18538" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="712.5735931396484" y="70" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c7a0a213-04dc-417d-bc3a-90a57ab23d98" bpmnElement="_956bb101-c9f7-467d-b3e2-198fa1d3e12b" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="584.2132034301758" y="67.98780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_1dda05d8-b802-4cf2-bdce-edd89d646694" color:border-color="#000000" bpmnElement="_6c121fa1-4bab-4e82-98a6-672c6a6bb6f3">
+                <di:waypoint x="81" y="88"/>
+                <di:waypoint x="137" y="88"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_825a5a27-79ab-472f-950e-e1132fcd8306" color:border-color="#000000" bpmnElement="_4e00ba20-d2c5-47d6-b53f-b50d802855fd">
+                <di:waypoint x="232" y="88"/>
+                <di:waypoint x="288" y="88"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8d4ad8b1-7129-42eb-90ae-4127caa8f366" color:border-color="#000000" bpmnElement="_e25b9c2d-690e-470b-8993-112002994fc2">
+                <di:waypoint x="309" y="108.78679555654526"/>
+                <di:waypoint x="309" y="197.01219457387924"/>
+                <di:waypoint x="409.2451299031576" y="197.01219457387924"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="12" width="110" x="273" y="114.01219457387924"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_0bac44fa-09f7-4ed8-ae07-168ecc0a25a3" color:border-color="#000000" bpmnElement="_20c68a0e-6aba-445b-94a3-6bb588dfa2d8">
+                <di:waypoint x="546.3284632364908" y="184.34219457387923"/>
+                <di:waypoint x="605.2132034301758" y="184.34219457387923"/>
+                <di:waypoint x="605.2132034301758" y="108.78679555654526"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_00b73d19-d9ed-48dd-abbc-5cabb23d91b3" color:border-color="#000000" bpmnElement="_90d759bb-90dc-48b7-8c06-ddf8664c36ff">
+                <di:waypoint x="626.2132034301758" y="87.78679555654526"/>
+                <di:waypoint x="713.5735931396484" y="89"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_c832b7cc-2d47-4a84-8ec7-fe96b59a1f04" color:border-color="#000000" bpmnElement="_c329c58d-4a71-471f-acb9-b7f7113d8547">
+                <di:waypoint x="330" y="87.78679555654526"/>
+                <di:waypoint x="584.2132034301758" y="87.78679555654526"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+                    <dc:Bounds height="12" width="110" x="288.1066017150879" y="71.78679555654526"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_07be6666-61a7-4857-9e9a-8e1b80fafb52_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.6.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.6.0.bpmn
@@ -1,0 +1,670 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed"              xmlns:drools="http://www.jboss.org/drools"  xmlns:openapi="https://openapis.org/omg/extension/1.0"  xmlns="http://www.trisotech.com/definitions/_af3cbf6a-9c69-460b-9a1d-276711d30213" id="_af3cbf6a-9c69-460b-9a1d-276711d30213" targetNamespace="http://www.trisotech.com/definitions/_af3cbf6a-9c69-460b-9a1d-276711d30213" expressionLanguage="http://www.w3.org/1999/XPath" exporter="BPMN Modeler" exporterVersion="6.2.9.1" name="Travel Booking with Event Subprocess" trisobpmn:logoChoice="Default">
+    <semantic:process id="_898aa942-9a96-4405-ae71-22b5e2e3d235" name="Simple Travel Booking" isClosed="false">
+        <semantic:ioSpecification>
+            <semantic:dataInput name="Travel Request" isCollection="false" id="_e8347f3a-e1a1-41d1-b2e1-4089c02028bc"/>
+            <semantic:dataOutput name="Itinerary" isCollection="false" id="_1a713fab-bf18-4975-afe3-d2bd2820023b"/>
+            <semantic:inputSet id="_41b1bf64-dba0-4ab1-a834-0ee931fb4cab">
+                <semantic:dataInputRefs>_e8347f3a-e1a1-41d1-b2e1-4089c02028bc</semantic:dataInputRefs>
+            </semantic:inputSet>
+            <semantic:outputSet id="_2d5ecd07-500d-4693-bb58-8682897d59e2">
+                <semantic:dataOutputRefs>_1a713fab-bf18-4975-afe3-d2bd2820023b</semantic:dataOutputRefs>
+            </semantic:outputSet>
+        </semantic:ioSpecification>
+        <semantic:intermediateCatchEvent id="_15fef309-6718-4352-9b71-f757bcd8c023" name="Offer Approved">
+            <semantic:incoming>_54044d90-3a1e-4a49-99a3-1497045c7235</semantic:incoming>
+            <semantic:outgoing>_c7c2f8e1-a93f-44d6-9a94-cb92d7466d73</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:intermediateCatchEvent>
+        <semantic:intermediateCatchEvent id="_e5c69e92-6f98-47c8-bc22-b75d38620f95" name="Cancel Request">
+            <semantic:incoming>_2403da0e-5b49-43fa-ba00-ec6c1f3e4790</semantic:incoming>
+            <semantic:outgoing>_f072c57e-dcc6-4a16-8f28-13a2cd6e43ed</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:intermediateCatchEvent>
+        <semantic:intermediateCatchEvent id="_87baeef0-f32e-4a93-b802-fdd588aaf729" name="24 Hours">
+            <semantic:incoming>_16857297-f0fb-4027-87f6-633a76267c84</semantic:incoming>
+            <semantic:outgoing>_649072fc-31c7-4e04-bc58-d4442a06f076</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:intermediateCatchEvent>
+        <semantic:intermediateThrowEvent id="_6a5cdbbf-2618-496e-b728-955dc215ef9d" name="Booking">
+            <semantic:incoming>_b792d502-a08e-4a3d-bdc1-1fc33a2022f6</semantic:incoming>
+            <semantic:outgoing>_c72535b8-43f7-4906-9f18-691e03050c24</semantic:outgoing>
+            <semantic:compensateEventDefinition/>
+        </semantic:intermediateThrowEvent>
+        <semantic:endEvent id="_88247168-b457-4663-aad0-753a0236c8df" name="Offer Expired">
+            <semantic:incoming>_51e34f49-b9eb-4f10-ac0a-7af81e1370ff</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:endEvent id="_7eb87eb8-0d7a-445b-b768-90d754a938ed" name="Request Cancelled">
+            <semantic:incoming>_e396fc69-5792-41e3-8a92-ee6b83cd0909</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sendTask id="_e839800f-ad4f-4bcc-aaf2-d38fe4a32bcd" name="Request&#10;Credit Card Information" startQuantity="1" completionQuantity="1" implementation="##WebService">
+            <semantic:incoming>_c7c2f8e1-a93f-44d6-9a94-cb92d7466d73</semantic:incoming>
+            <semantic:outgoing>_7efd61ea-979e-44f4-91c8-e212ae6b22c7</semantic:outgoing>
+        </semantic:sendTask>
+        <semantic:eventBasedGateway id="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d" gatewayDirection="Diverging" instantiate="false" eventGatewayType="Exclusive">
+            <semantic:incoming>_bcb8805c-5e93-41ec-991b-575d26ed3a9c</semantic:incoming>
+            <semantic:outgoing>_16857297-f0fb-4027-87f6-633a76267c84</semantic:outgoing>
+            <semantic:outgoing>_54044d90-3a1e-4a49-99a3-1497045c7235</semantic:outgoing>
+            <semantic:outgoing>_2403da0e-5b49-43fa-ba00-ec6c1f3e4790</semantic:outgoing>
+        </semantic:eventBasedGateway>
+        <semantic:startEvent id="_44e3f1fa-42cd-40b7-9980-a51ac49d5fa3" name="Receive Travel Request">
+            <semantic:outgoing>_9ec5ad1d-0662-42a4-9118-bca0bf744422</semantic:outgoing>
+            <semantic:messageEventDefinition id="_1087adb7-2560-4fec-a13c-5a91f257819c"/>
+        </semantic:startEvent>
+        <semantic:endEvent id="_42e03d0f-6c6b-4493-971f-c6928eb563b0" name="Booking &#10;Confirmed">
+            <semantic:incoming>_c69565cd-3a08-4532-b466-8f9a9ebdc1e1</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:endEvent id="_babdfa54-b55f-463f-9341-424b42db9760" name="Failed Credit&#10;Transaction">
+            <semantic:incoming>_94e0bd86-6659-4669-baee-ce671c7f33d6</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:endEvent id="_a68b0941-b7e3-4791-8e13-fd9622e4448c" name="Failed &#10;Booking">
+            <semantic:incoming>_ec8c7430-02e1-4298-9b00-33c4d56d0fac</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:subProcess id="_c38139c7-a2d1-47c7-b75a-19e14c7212c8" name="Make Booking" startQuantity="1" completionQuantity="1" triggeredByEvent="false">
+            <semantic:incoming>_7efd61ea-979e-44f4-91c8-e212ae6b22c7</semantic:incoming>
+            <semantic:outgoing>_f81560f5-e1c5-497d-a159-dce350f2283c</semantic:outgoing>
+            <semantic:endEvent id="_6ff2b954-2017-46dd-941e-4badd9326eac" name="Travel Booked">
+                <semantic:incoming>_eba304c2-42e8-4d65-a9dc-e2483fd8ad86</semantic:incoming>
+            </semantic:endEvent>
+            <semantic:startEvent id="_31a01c78-9a86-4b53-a485-e8a973ba6383">
+                <semantic:outgoing>_d51b76e8-b096-4376-ba01-7ca63ae51f70</semantic:outgoing>
+            </semantic:startEvent>
+            <semantic:subProcess id="_e880bf53-84ca-4776-aa75-d1bf53172240" name="Handle Compensation" startQuantity="1" completionQuantity="1" triggeredByEvent="true">
+                <semantic:endEvent id="_fc4826b1-1e63-49f6-8670-7cc8104e45ea">
+                    <semantic:incoming>_b3d5a547-87a4-460d-b7c1-53b6506127e9</semantic:incoming>
+                </semantic:endEvent>
+                <semantic:intermediateThrowEvent id="_99bf4db9-3616-4ed1-a0f8-b8175c3fd46f" name="Hotel">
+                    <semantic:incoming>_64d60a4e-90cf-4a9a-afbb-631739b6b704</semantic:incoming>
+                    <semantic:outgoing>_8d0dadf1-129e-4ba8-b829-3e7e176bf775</semantic:outgoing>
+                    <semantic:compensateEventDefinition/>
+                </semantic:intermediateThrowEvent>
+                <semantic:intermediateThrowEvent id="_e4b9fa74-efd8-409f-a2e4-ad917df767b4" name="Flight">
+                    <semantic:incoming>_3cd5068b-6df1-4a62-a06a-369d063f6160</semantic:incoming>
+                    <semantic:outgoing>_b62ef735-9d04-494a-aeb4-95fd4862cc45</semantic:outgoing>
+                    <semantic:compensateEventDefinition/>
+                </semantic:intermediateThrowEvent>
+                <semantic:startEvent id="_8af17ed4-6e13-463b-8333-d397b3002c65" name="Booking">
+                    <semantic:outgoing>_e0c52135-c57f-4ee6-b488-22bbab06dccc</semantic:outgoing>
+                    <semantic:compensateEventDefinition id="_434dc71e-6d59-4940-8e27-a911bf891cdf"/>
+                </semantic:startEvent>
+                <semantic:parallelGateway id="_c4ddacd9-6e12-49e3-b058-e71c0af08c68" gatewayDirection="Converging">
+                    <semantic:incoming>_8d0dadf1-129e-4ba8-b829-3e7e176bf775</semantic:incoming>
+                    <semantic:incoming>_b62ef735-9d04-494a-aeb4-95fd4862cc45</semantic:incoming>
+                    <semantic:outgoing>_b3d5a547-87a4-460d-b7c1-53b6506127e9</semantic:outgoing>
+                </semantic:parallelGateway>
+                <semantic:parallelGateway id="_08cd4ce0-bf7c-4a05-bacf-546daa51ce9c" gatewayDirection="Diverging">
+                    <semantic:incoming>_e0c52135-c57f-4ee6-b488-22bbab06dccc</semantic:incoming>
+                    <semantic:outgoing>_64d60a4e-90cf-4a9a-afbb-631739b6b704</semantic:outgoing>
+                    <semantic:outgoing>_3cd5068b-6df1-4a62-a06a-369d063f6160</semantic:outgoing>
+                </semantic:parallelGateway>
+                <semantic:sequenceFlow id="_b3d5a547-87a4-460d-b7c1-53b6506127e9" sourceRef="_c4ddacd9-6e12-49e3-b058-e71c0af08c68" targetRef="_fc4826b1-1e63-49f6-8670-7cc8104e45ea"/>
+                <semantic:sequenceFlow id="_8d0dadf1-129e-4ba8-b829-3e7e176bf775" sourceRef="_99bf4db9-3616-4ed1-a0f8-b8175c3fd46f" targetRef="_c4ddacd9-6e12-49e3-b058-e71c0af08c68"/>
+                <semantic:sequenceFlow id="_b62ef735-9d04-494a-aeb4-95fd4862cc45" sourceRef="_e4b9fa74-efd8-409f-a2e4-ad917df767b4" targetRef="_c4ddacd9-6e12-49e3-b058-e71c0af08c68"/>
+                <semantic:sequenceFlow id="_64d60a4e-90cf-4a9a-afbb-631739b6b704" sourceRef="_08cd4ce0-bf7c-4a05-bacf-546daa51ce9c" targetRef="_99bf4db9-3616-4ed1-a0f8-b8175c3fd46f"/>
+                <semantic:sequenceFlow id="_3cd5068b-6df1-4a62-a06a-369d063f6160" sourceRef="_08cd4ce0-bf7c-4a05-bacf-546daa51ce9c" targetRef="_e4b9fa74-efd8-409f-a2e4-ad917df767b4"/>
+                <semantic:sequenceFlow id="_e0c52135-c57f-4ee6-b488-22bbab06dccc" sourceRef="_8af17ed4-6e13-463b-8333-d397b3002c65" targetRef="_08cd4ce0-bf7c-4a05-bacf-546daa51ce9c"/>
+            </semantic:subProcess>
+            <semantic:parallelGateway id="_749dd603-40f5-40fb-89b4-0e305b29892c" gatewayDirection="Diverging">
+                <semantic:incoming>_d51b76e8-b096-4376-ba01-7ca63ae51f70</semantic:incoming>
+                <semantic:outgoing>_018e5307-4c8d-46fd-ba84-7b75409b3124</semantic:outgoing>
+                <semantic:outgoing>_b2d48080-6bb1-4ae9-85c9-916d87536a49</semantic:outgoing>
+            </semantic:parallelGateway>
+            <semantic:parallelGateway id="_6a68d4b4-7549-42ce-b903-9da8b2024d31" gatewayDirection="Converging">
+                <semantic:incoming>_b08efa4c-c27c-4654-9901-279a8c456a4f</semantic:incoming>
+                <semantic:incoming>_e6011c12-800f-44e6-8ae8-51866664afcf</semantic:incoming>
+                <semantic:outgoing>_eba304c2-42e8-4d65-a9dc-e2483fd8ad86</semantic:outgoing>
+            </semantic:parallelGateway>
+            <semantic:serviceTask id="_3a2f133c-3ae1-4e21-94b5-6e8cf51acd74" name="Cancel Hotel" isForCompensation="true" implementation="##WebService"/>
+            <semantic:serviceTask id="_b595ec43-0769-4864-8f2e-403c405c8217" name="Book Hotel" implementation="##WebService">
+                <semantic:incoming>_b2d48080-6bb1-4ae9-85c9-916d87536a49</semantic:incoming>
+                <semantic:outgoing>_e6011c12-800f-44e6-8ae8-51866664afcf</semantic:outgoing>
+            </semantic:serviceTask>
+            <semantic:serviceTask id="_ea5cc55d-bfce-49c6-8a1a-a8a41a85da12" name="Book Flight" implementation="##WebService">
+                <semantic:incoming>_018e5307-4c8d-46fd-ba84-7b75409b3124</semantic:incoming>
+                <semantic:outgoing>_b08efa4c-c27c-4654-9901-279a8c456a4f</semantic:outgoing>
+            </semantic:serviceTask>
+            <semantic:serviceTask id="_0198160d-b56c-4919-9920-db5f32d16b3f" name="Cancel Flight" isForCompensation="true" implementation="##WebService"/>
+            <semantic:boundaryEvent id="_b25ecc7c-4eff-4a70-96f2-6b2f94cf19b1" name="Hotel" attachedToRef="_b595ec43-0769-4864-8f2e-403c405c8217">
+                <semantic:compensateEventDefinition/>
+            </semantic:boundaryEvent>
+            <semantic:boundaryEvent id="_fe3f9094-097b-416d-adeb-4b7e7e753f3c" name="Flight" attachedToRef="_ea5cc55d-bfce-49c6-8a1a-a8a41a85da12">
+                <semantic:compensateEventDefinition/>
+            </semantic:boundaryEvent>
+            <semantic:sequenceFlow id="_d51b76e8-b096-4376-ba01-7ca63ae51f70" sourceRef="_31a01c78-9a86-4b53-a485-e8a973ba6383" targetRef="_749dd603-40f5-40fb-89b4-0e305b29892c"/>
+            <semantic:sequenceFlow id="_eba304c2-42e8-4d65-a9dc-e2483fd8ad86" sourceRef="_6a68d4b4-7549-42ce-b903-9da8b2024d31" targetRef="_6ff2b954-2017-46dd-941e-4badd9326eac"/>
+            <semantic:sequenceFlow id="_018e5307-4c8d-46fd-ba84-7b75409b3124" sourceRef="_749dd603-40f5-40fb-89b4-0e305b29892c" targetRef="_ea5cc55d-bfce-49c6-8a1a-a8a41a85da12"/>
+            <semantic:sequenceFlow id="_b08efa4c-c27c-4654-9901-279a8c456a4f" sourceRef="_ea5cc55d-bfce-49c6-8a1a-a8a41a85da12" targetRef="_6a68d4b4-7549-42ce-b903-9da8b2024d31"/>
+            <semantic:sequenceFlow id="_e6011c12-800f-44e6-8ae8-51866664afcf" sourceRef="_b595ec43-0769-4864-8f2e-403c405c8217" targetRef="_6a68d4b4-7549-42ce-b903-9da8b2024d31"/>
+            <semantic:sequenceFlow id="_b2d48080-6bb1-4ae9-85c9-916d87536a49" sourceRef="_749dd603-40f5-40fb-89b4-0e305b29892c" targetRef="_b595ec43-0769-4864-8f2e-403c405c8217"/>
+            <semantic:association id="_651344ad-d784-4ef2-9655-4bc6393ac323" sourceRef="_b25ecc7c-4eff-4a70-96f2-6b2f94cf19b1" targetRef="_3a2f133c-3ae1-4e21-94b5-6e8cf51acd74" associationDirection="One"/>
+            <semantic:association id="_98b2bd26-e113-4d19-b6a8-bcda781a823b" sourceRef="_fe3f9094-097b-416d-adeb-4b7e7e753f3c" targetRef="_0198160d-b56c-4919-9920-db5f32d16b3f" associationDirection="One"/>
+        </semantic:subProcess>
+        <semantic:sendTask id="_22612d45-65ca-4a74-a6eb-53af7ebcb5ff" name="Confirm Booking" implementation="##WebService">
+            <semantic:incoming>_65293cb4-b859-4ff7-bcd3-ba4e38cf8763</semantic:incoming>
+            <semantic:outgoing>_c69565cd-3a08-4532-b466-8f9a9ebdc1e1</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="Itinerary" isCollection="false" id="_29b8c649-e2a0-4dd3-804b-567e8cc71718"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_f4813b3e-2820-45ec-9506-0f2a4c7bd086">
+                    <semantic:dataOutputRefs>_29b8c649-e2a0-4dd3-804b-567e8cc71718</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_ef945053-2c76-4796-8d8b-afc6be8bbfec">
+                <semantic:sourceRef>_29b8c649-e2a0-4dd3-804b-567e8cc71718</semantic:sourceRef>
+                <semantic:targetRef>_1a713fab-bf18-4975-afe3-d2bd2820023b</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+        </semantic:sendTask>
+        <semantic:sendTask id="_c8fa5253-dde9-471e-b933-58b00e8f374c" name="Notify Failed Booking" implementation="##WebService">
+            <semantic:incoming>_8eac4fb5-c746-42e4-ab0b-80cdfaf76007</semantic:incoming>
+            <semantic:outgoing>_ec8c7430-02e1-4298-9b00-33c4d56d0fac</semantic:outgoing>
+        </semantic:sendTask>
+        <semantic:serviceTask id="_614d6469-2bb8-4ad6-a20a-db5db6321c6b" name="Charge Credit Card" implementation="##WebService">
+            <semantic:incoming>_f81560f5-e1c5-497d-a159-dce350f2283c</semantic:incoming>
+            <semantic:outgoing>_65293cb4-b859-4ff7-bcd3-ba4e38cf8763</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:sendTask id="_9cc2ac34-f12c-49e0-b37c-144e5a84fd92" name="Make Flights and Hotel Offer" implementation="##WebService">
+            <semantic:incoming>_9ec5ad1d-0662-42a4-9118-bca0bf744422</semantic:incoming>
+            <semantic:outgoing>_bcb8805c-5e93-41ec-991b-575d26ed3a9c</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Travel Request" isCollection="false" id="_9628422b-85a6-4857-8c14-7289b9fd9a8a"/>
+                <semantic:inputSet id="_5a361a87-dcba-4107-a625-026abada856d">
+                    <semantic:dataInputRefs>_9628422b-85a6-4857-8c14-7289b9fd9a8a</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_82006a49-2cc8-4814-83e2-28c5a85a4c4a">
+                <semantic:sourceRef>_e8347f3a-e1a1-41d1-b2e1-4089c02028bc</semantic:sourceRef>
+                <semantic:targetRef>_9628422b-85a6-4857-8c14-7289b9fd9a8a</semantic:targetRef>
+            </semantic:dataInputAssociation>
+        </semantic:sendTask>
+        <semantic:serviceTask id="_8afc49f0-42c2-4da9-8e79-e08dbe349776" name="Update Customer Record" implementation="##WebService">
+            <semantic:incoming>_f072c57e-dcc6-4a16-8f28-13a2cd6e43ed</semantic:incoming>
+            <semantic:outgoing>_e396fc69-5792-41e3-8a92-ee6b83cd0909</semantic:outgoing>
+        </semantic:serviceTask>
+        <semantic:sendTask id="_de7e721e-a073-4857-b8c3-c6ae886dbb46" name="Notify Customer&#10;Offer Expired" implementation="##WebService">
+            <semantic:incoming>_649072fc-31c7-4e04-bc58-d4442a06f076</semantic:incoming>
+            <semantic:incoming>_a0c99000-31e1-4de9-baf7-45c2d09ebbff</semantic:incoming>
+            <semantic:outgoing>_51e34f49-b9eb-4f10-ac0a-7af81e1370ff</semantic:outgoing>
+        </semantic:sendTask>
+        <semantic:sendTask id="_2d6586cf-81fc-4e2a-83ec-6cfff5b34bb0" name="Notify Failed Credit Transaction" implementation="##WebService">
+            <semantic:incoming>_c72535b8-43f7-4906-9f18-691e03050c24</semantic:incoming>
+            <semantic:outgoing>_94e0bd86-6659-4669-baee-ce671c7f33d6</semantic:outgoing>
+        </semantic:sendTask>
+        <semantic:boundaryEvent id="_6db9a77f-189f-4c07-b33b-e0c88f09e0db" attachedToRef="_614d6469-2bb8-4ad6-a20a-db5db6321c6b">
+            <semantic:outgoing>_b792d502-a08e-4a3d-bdc1-1fc33a2022f6</semantic:outgoing>
+            <semantic:errorEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:boundaryEvent id="_54d6e34f-4613-48d4-9143-b90927448adb" attachedToRef="_c38139c7-a2d1-47c7-b75a-19e14c7212c8">
+            <semantic:outgoing>_8eac4fb5-c746-42e4-ab0b-80cdfaf76007</semantic:outgoing>
+            <semantic:errorEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:boundaryEvent id="_32c4138c-74ae-484a-a7e5-0609370d7080" name="24 Hours" attachedToRef="_e839800f-ad4f-4bcc-aaf2-d38fe4a32bcd" cancelActivity="true">
+            <semantic:outgoing>_a0c99000-31e1-4de9-baf7-45c2d09ebbff</semantic:outgoing>
+            <semantic:timerEventDefinition>
+                <semantic:timeDate/>
+            </semantic:timerEventDefinition>
+        </semantic:boundaryEvent>
+        <semantic:sequenceFlow id="_c7c2f8e1-a93f-44d6-9a94-cb92d7466d73" sourceRef="_15fef309-6718-4352-9b71-f757bcd8c023" targetRef="_e839800f-ad4f-4bcc-aaf2-d38fe4a32bcd"/>
+        <semantic:sequenceFlow id="_16857297-f0fb-4027-87f6-633a76267c84" sourceRef="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d" targetRef="_87baeef0-f32e-4a93-b802-fdd588aaf729"/>
+        <semantic:sequenceFlow id="_54044d90-3a1e-4a49-99a3-1497045c7235" sourceRef="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d" targetRef="_15fef309-6718-4352-9b71-f757bcd8c023"/>
+        <semantic:sequenceFlow id="_2403da0e-5b49-43fa-ba00-ec6c1f3e4790" sourceRef="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d" targetRef="_e5c69e92-6f98-47c8-bc22-b75d38620f95"/>
+        <semantic:sequenceFlow id="_b792d502-a08e-4a3d-bdc1-1fc33a2022f6" sourceRef="_6db9a77f-189f-4c07-b33b-e0c88f09e0db" targetRef="_6a5cdbbf-2618-496e-b728-955dc215ef9d"/>
+        <semantic:sequenceFlow id="_c69565cd-3a08-4532-b466-8f9a9ebdc1e1" sourceRef="_22612d45-65ca-4a74-a6eb-53af7ebcb5ff" targetRef="_42e03d0f-6c6b-4493-971f-c6928eb563b0"/>
+        <semantic:sequenceFlow id="_8eac4fb5-c746-42e4-ab0b-80cdfaf76007" sourceRef="_54d6e34f-4613-48d4-9143-b90927448adb" targetRef="_c8fa5253-dde9-471e-b933-58b00e8f374c"/>
+        <semantic:sequenceFlow id="_ec8c7430-02e1-4298-9b00-33c4d56d0fac" sourceRef="_c8fa5253-dde9-471e-b933-58b00e8f374c" targetRef="_a68b0941-b7e3-4791-8e13-fd9622e4448c"/>
+        <semantic:sequenceFlow id="_65293cb4-b859-4ff7-bcd3-ba4e38cf8763" sourceRef="_614d6469-2bb8-4ad6-a20a-db5db6321c6b" targetRef="_22612d45-65ca-4a74-a6eb-53af7ebcb5ff"/>
+        <semantic:sequenceFlow id="_f81560f5-e1c5-497d-a159-dce350f2283c" sourceRef="_c38139c7-a2d1-47c7-b75a-19e14c7212c8" targetRef="_614d6469-2bb8-4ad6-a20a-db5db6321c6b"/>
+        <semantic:sequenceFlow id="_9ec5ad1d-0662-42a4-9118-bca0bf744422" sourceRef="_44e3f1fa-42cd-40b7-9980-a51ac49d5fa3" targetRef="_9cc2ac34-f12c-49e0-b37c-144e5a84fd92"/>
+        <semantic:sequenceFlow id="_bcb8805c-5e93-41ec-991b-575d26ed3a9c" sourceRef="_9cc2ac34-f12c-49e0-b37c-144e5a84fd92" targetRef="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d"/>
+        <semantic:sequenceFlow id="_f072c57e-dcc6-4a16-8f28-13a2cd6e43ed" sourceRef="_e5c69e92-6f98-47c8-bc22-b75d38620f95" targetRef="_8afc49f0-42c2-4da9-8e79-e08dbe349776"/>
+        <semantic:sequenceFlow id="_e396fc69-5792-41e3-8a92-ee6b83cd0909" sourceRef="_8afc49f0-42c2-4da9-8e79-e08dbe349776" targetRef="_7eb87eb8-0d7a-445b-b768-90d754a938ed"/>
+        <semantic:sequenceFlow id="_649072fc-31c7-4e04-bc58-d4442a06f076" sourceRef="_87baeef0-f32e-4a93-b802-fdd588aaf729" targetRef="_de7e721e-a073-4857-b8c3-c6ae886dbb46"/>
+        <semantic:sequenceFlow id="_51e34f49-b9eb-4f10-ac0a-7af81e1370ff" sourceRef="_de7e721e-a073-4857-b8c3-c6ae886dbb46" targetRef="_88247168-b457-4663-aad0-753a0236c8df"/>
+        <semantic:sequenceFlow id="_a0c99000-31e1-4de9-baf7-45c2d09ebbff" sourceRef="_32c4138c-74ae-484a-a7e5-0609370d7080" targetRef="_de7e721e-a073-4857-b8c3-c6ae886dbb46"/>
+        <semantic:sequenceFlow id="_c72535b8-43f7-4906-9f18-691e03050c24" sourceRef="_6a5cdbbf-2618-496e-b728-955dc215ef9d" targetRef="_2d6586cf-81fc-4e2a-83ec-6cfff5b34bb0"/>
+        <semantic:sequenceFlow id="_94e0bd86-6659-4669-baee-ce671c7f33d6" sourceRef="_2d6586cf-81fc-4e2a-83ec-6cfff5b34bb0" targetRef="_babdfa54-b55f-463f-9341-424b42db9760"/>
+        <semantic:sequenceFlow id="_7efd61ea-979e-44f4-91c8-e212ae6b22c7" sourceRef="_e839800f-ad4f-4bcc-aaf2-d38fe4a32bcd" targetRef="_c38139c7-a2d1-47c7-b75a-19e14c7212c8"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_f1aecfc3-a3da-4bde-bece-87786e25273d" name="Simple Travel Booking">
+        <bpmndi:BPMNPlane bpmnElement="_898aa942-9a96-4405-ae71-22b5e2e3d235" id="_f1aecfc3-a3da-4bde-bece-87786e25273d_plane" trisobpmn:diagramWidth="2031.3859249319685" trisobpmn:diagramHeight="892.2783205633923">
+            <bpmndi:BPMNShape id="_2822d817-4645-4b60-8389-daf235f520f2" bpmnElement="_c38139c7-a2d1-47c7-b75a-19e14c7212c8" isExpanded="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="741.2380994009592" y="169.90753406376786" width="748.3636683413284" height="672.3707864996245"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="27" width="41.514809861625" x="746.5714327342926" y="175.4968673971012"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c31bc98f-9f9f-421a-ba96-631e9c948516" bpmnElement="_e880bf53-84ca-4776-aa75-d1bf53172240" isExpanded="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="879.2380994009592" y="600.2783205633922" width="510.9999999999999" height="180.9999999999999"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="104.94693876787508" x="884.5714327342926" y="605.8996538967255"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_10819e13-1da9-4be8-a9c7-f743f643c08e" bpmnElement="_08cd4ce0-bf7c-4a05-bacf-546daa51ce9c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="994.0927477517912" y="670.7783205633922" width="42" height="41.999999999999886"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_88331ab1-e1f1-440a-a76f-7abcb60f429e" bpmnElement="_c4ddacd9-6e12-49e3-b058-e71c0af08c68" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1222.0927477517912" y="670.7783205633922" width="42" height="41.999999999999886"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f6e0e91b-3f87-4bf5-8832-9a2c8074685b" bpmnElement="_8af17ed4-6e13-463b-8333-d397b3002c65" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="911.0927477517911" y="673.7783205633922" width="32" height="31.999999999999886"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="39.75" x="907.2177477517911" y="715.7783205633922"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_fcd09684-31b7-44cf-8ce7-aaed3a5ccb1d" bpmnElement="_e4b9fa74-efd8-409f-a2e4-ad917df767b4" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1091.1663408914396" y="627.2783205633922" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="94.93333333333337" x="1059.762666336773" y="664.6116538967254"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_3c2dcfb2-c5a7-45e4-be8b-2b584ddba4d7" bpmnElement="_99bf4db9-3616-4ed1-a0f8-b8175c3fd46f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1060.1663408914396" y="723.6634766361556" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="94.93333333333337" x="1028.762666336773" y="760.9968099694888"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_5e38d408-aaf2-4aa1-9909-aab004fe73b9" bpmnElement="_fc4826b1-1e63-49f6-8670-7cc8104e45ea" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1301.0927477517912" y="673.7783205633922" width="36" height="35.999999999999886"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_df23fec5-6221-4c4d-a0fb-4118ea286ba1" bpmnElement="_31a01c78-9a86-4b53-a485-e8a973ba6383" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="838.8116925406076" y="317.6717547013318" width="30" height="30"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_58158b58-738f-444c-8e86-f476f442db96" bpmnElement="_6ff2b954-2017-46dd-941e-4badd9326eac" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1388.738099400959" y="316.6717547013318" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="1349.738099400959" y="357.5606435902207"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_93c28b1a-32b6-4a18-8102-229fd8853993" bpmnElement="_749dd603-40f5-40fb-89b4-0e305b29892c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="923.8116925406076" y="312.65956012745255" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c840aa26-3013-48d5-8d54-621c4096ebd0" bpmnElement="_6a68d4b4-7549-42ce-b903-9da8b2024d31" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1305.738099400959" y="312.65956012745255" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_2ade6242-6c43-4635-a3ce-c3bfa4c9221a" bpmnElement="_3a2f133c-3ae1-4e21-94b5-6e8cf51acd74" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1133.8116925406075" y="444.1714196893139" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="89" x="1137.3116925406075" y="476.1714196893139"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_698c8afd-daed-4c3d-b427-54819e12248d" bpmnElement="_b595ec43-0769-4864-8f2e-403c405c8217" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="976.8116925406076" y="367.6334196990515" width="95.99999999999989" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="89" x="980.3116925406075" y="399.6334196990515"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f384d5a2-bc83-400a-9655-248acfcf3b12" bpmnElement="_ea5cc55d-bfce-49c6-8a1a-a8a41a85da12" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="976.8116925406076" y="209.6334196990515" width="95.99999999999989" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="89" x="980.3116925406075" y="241.6334196990515"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_115ae712-2534-45c2-b208-fde7713b1b8a" bpmnElement="_0198160d-b56c-4919-9920-db5f32d16b3f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1133.8116925406075" y="302.86729684671246" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="89" x="1137.3116925406075" y="334.86729684671246"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c5083d17-61d7-42a8-9716-b2cc7778daae" bpmnElement="_b25ecc7c-4eff-4a70-96f2-6b2f94cf19b1" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1014.286137525952" y="427.8676188426698" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="975.286137525952" y="465.20095217600317"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_efbcedea-d9d9-4c58-9da2-542ddc8547f8" bpmnElement="_fe3f9094-097b-416d-adeb-4b7e7e753f3c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1015.1639438657883" y="269.8556687310013" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="976.1639438657883" y="307.1890020643346"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_22ac24b5-ae00-4f34-9195-0722cccf2e3a" bpmnElement="_a68b0941-b7e3-4791-8e13-fd9622e4448c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1925.325818703417" y="746.3491227969952" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="26" width="110" x="1886.325818703417" y="787.2380116858841"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_10ac118b-e6b2-46ce-9011-3818bee890a4" bpmnElement="_babdfa54-b55f-463f-9341-424b42db9760" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1925.325818703417" y="157.99999733619012" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="26" width="110" x="1886.325818703417" y="198.88888622507898"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_aea9e0ef-e914-40b5-8f99-1bed3ebf3e2d" bpmnElement="_42e03d0f-6c6b-4493-971f-c6928eb563b0" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1931.325818703417" y="324.8672941829026" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="26" width="110" x="1892.325818703417" y="365.7561830717915"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c8f8b44d-911e-4ce0-99ff-b7607117b60c" bpmnElement="_44e3f1fa-42cd-40b7-9980-a51ac49d5fa3" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="50" y="445.8431757821553" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="26" width="73.5" x="29.25" y="487.8431757821553"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_4216e519-394f-40fd-8257-6d31e1fc0aeb" bpmnElement="_7ab6dbdf-f55b-4be6-bb41-d99793135c1d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="269.0000000000001" y="440.8431757821553" width="42" height="42"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8a99595a-5185-454a-bc09-44a4d4d08f0d" bpmnElement="_e839800f-ad4f-4bcc-aaf2-d38fe4a32bcd" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="425.0000000000001" y="292.34317578215524" width="103" height="72.99999999999994"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="40" width="93" x="424.7528000000002" y="306.3274277506592"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_9bf8f08f-2725-44fc-ad11-268dd288bc52" bpmnElement="_7eb87eb8-0d7a-445b-b768-90d754a938ed" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="593.0000000000001" y="593.2085036569848" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="554.0000000000001" y="634.0973925458737"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_2fa14a46-2655-4a4c-aa18-0b1e4731d221" bpmnElement="_88247168-b457-4663-aad0-753a0236c8df" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="593.0000000000001" y="445.8431757821553" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="554.0000000000001" y="486.7320646710442"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_4d8b89b0-b227-4cdb-91c8-9f9f1e813165" bpmnElement="_54d6e34f-4613-48d4-9143-b90927448adb" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1474.7775437805517" y="746.0062997165755" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_0a4ca777-1b40-4968-8813-dc23f636707c" bpmnElement="_6a5cdbbf-2618-496e-b728-955dc215ef9d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1659.3258897703959" y="158" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="94.93333333333337" x="1625.9222152157292" y="143.33333333333337"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_59e246c5-2d5a-48d8-aa97-84f219084f95" bpmnElement="_87baeef0-f32e-4a93-b802-fdd588aaf729" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="342.0000000000001" y="445.8431757821553" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="303.0629921120002" y="483.17650911548867"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7a58c09a-f53a-43c4-9252-0061cb382522" bpmnElement="_e5c69e92-6f98-47c8-bc22-b75d38620f95" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="342.0000000000001" y="593.2085036569848" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="94.93333333333337" x="310.5963254453335" y="630.5418369903181"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_30c6812d-5c23-4592-bc4a-a6ebf0f20ba0" bpmnElement="_15fef309-6718-4352-9b71-f757bcd8c023" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="342.0000000000001" y="312.8431757821552" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="303.0629921120002" y="350.1765091154885"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_b9aa82b1-78ef-49a9-8198-ebb98ef2bd9e" bpmnElement="_22612d45-65ca-4a74-a6eb-53af7ebcb5ff" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1763.3713444082127" y="302.8672968467124" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="89" x="1766.8713444082127" y="334.8672968467124"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_109084fa-3c33-4456-8c37-cb5407782f39" bpmnElement="_c8fa5253-dde9-471e-b933-58b00e8f374c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1707.4460311605199" y="724.0062997165754" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="1710.9460311605199" y="749.0062997165754"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_edf63fb8-0bc6-4668-ad73-b560fece9328" bpmnElement="_614d6469-2bb8-4ad6-a20a-db5db6321c6b" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1587.840470226419" y="302.8672955744121" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="1591.340470226419" y="327.8672955744121"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8eb52f6a-0fd6-4fad-8ade-14bca1b066bf" bpmnElement="_9cc2ac34-f12c-49e0-b37c-144e5a84fd92" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="137" y="423.8431757821553" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="140.5" y="448.8431757821553"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_10c12b98-c9bd-4a87-ba0c-4792e3a697ad" bpmnElement="_8afc49f0-42c2-4da9-8e79-e08dbe349776" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="429.0000000000001" y="571.2085036569848" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="432.5000000000001" y="596.2085036569848"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_443776eb-7003-4ba6-90db-598ba57533cf" bpmnElement="_de7e721e-a073-4857-b8c3-c6ae886dbb46" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="429.0000000000001" y="423.8431757821553" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="432.5000000000001" y="448.8431757821553"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8c6cddf6-a98e-4039-ab11-6c15aebfd727" bpmnElement="_6db9a77f-189f-4c07-b33b-e0c88f09e0db" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1659.3258897703959" y="286.17530216489916" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_6fb25fab-7905-4cf1-a279-5b14abcb9f28" bpmnElement="_2d6586cf-81fc-4e2a-83ec-6cfff5b34bb0" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1757.3713444082127" y="136" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="26" width="89" x="1760.8713444082127" y="161"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c65837ca-37ac-4b04-a0ff-fd9c12e6139a" bpmnElement="_32c4138c-74ae-484a-a7e5-0609370d7080" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="480.92979118964297" y="349.782926275989" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+                    <dc:Bounds height="12" width="110" x="406.99278330164304" y="384.2545664660515"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_7c8104cd-ff50-4ec2-9001-0a1e6c5f7b9d" bpmnElement="_e8347f3a-e1a1-41d1-b2e1-4089c02028bc" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="106" y="320.8672968467124" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="76.109375" x="84.9453125" y="365.8672968467124"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_489c92db-ead0-48f0-a3a5-833617e42bdd" bpmnElement="_1a713fab-bf18-4975-afe3-d2bd2820023b" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1871" y="238.82896184443217" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+                    <dc:Bounds height="12" width="40.234375" x="1867.8828125" y="283.8289618444322"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_0d584770-64b2-4682-8641-9cee4dce7ba8" color:border-color="#000000" bpmnElement="_e0c52135-c57f-4ee6-b488-22bbab06dccc">
+                <di:waypoint x="943.0927477517911" y="690.8449872300589"/>
+                <di:waypoint x="994.0927477517912" y="691.7783205633922"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_0d048ab3-64d9-4fcf-a8f6-03e686e38016" color:border-color="#000000" bpmnElement="_3cd5068b-6df1-4a62-a06a-369d063f6160">
+                <di:waypoint x="1015.0927477517912" y="670.7783205633922"/>
+                <di:waypoint x="1015.0927477517912" y="643.2783205633922"/>
+                <di:waypoint x="1091.1663408914396" y="643.2783205633922"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_bf542a2e-6e41-4640-a0d4-fb149264f930" color:border-color="#000000" bpmnElement="_64d60a4e-90cf-4a9a-afbb-631739b6b704">
+                <di:waypoint x="1015.0927477517912" y="711.7783205633922"/>
+                <di:waypoint x="1015.0927477517912" y="739.6634766361557"/>
+                <di:waypoint x="1060.1663408914396" y="739.6634766361556"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8a6158ef-d4c5-47b3-a177-7e50896367ae" color:border-color="#000000" bpmnElement="_b62ef735-9d04-494a-aeb4-95fd4862cc45">
+                <di:waypoint x="1123.1663408914396" y="643.2783205633922"/>
+                <di:waypoint x="1243.0927477517912" y="643.2783205633922"/>
+                <di:waypoint x="1243.0927477517912" y="670.7783205633922"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_29052bac-21d1-4dea-8fee-3a4ffc093ee5" color:border-color="#000000" bpmnElement="_8d0dadf1-129e-4ba8-b829-3e7e176bf775">
+                <di:waypoint x="1092.1663408914396" y="739.6634766361556"/>
+                <di:waypoint x="1243.0927477517912" y="739.6634766361557"/>
+                <di:waypoint x="1243.0927477517912" y="711.7783205633922"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4e558ad4-dc28-4be6-9951-98521997c188" color:border-color="#000000" bpmnElement="_b3d5a547-87a4-460d-b7c1-53b6506127e9">
+                <di:waypoint x="1264.0927477517912" y="691.7783205633922"/>
+                <di:waypoint x="1301.0927477517912" y="691.7783205633922"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3966d4ad-cd46-48b8-a349-b1b0b974510a" color:border-color="#000000" bpmnElement="_b792d502-a08e-4a3d-bdc1-1fc33a2022f6">
+                <di:waypoint x="1675.3258897703959" y="287.0641910537881"/>
+                <di:waypoint x="1675.3258897703959" y="189.11111111111114"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7dc7952e-3ee7-4ec3-8595-23c444a8c3ae" color:border-color="#000000" bpmnElement="_2403da0e-5b49-43fa-ba00-ec6c1f3e4790">
+                <di:waypoint x="290.2153901886062" y="483.65601120487383"/>
+                <di:waypoint x="290.2153901886062" y="609.2085036569848"/>
+                <di:waypoint x="342.0000000000001" y="609.2085036569848"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_c3a5b091-fd7e-4544-bda3-def834c84290" color:border-color="#000000" bpmnElement="_54044d90-3a1e-4a49-99a3-1497045c7235">
+                <di:waypoint x="290.2153901886062" y="439.5828838552517"/>
+                <di:waypoint x="290.2153901886062" y="328.8431757821552"/>
+                <di:waypoint x="342.0000000000001" y="328.8431757821552"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8cc22665-6183-47e0-9a38-0cf4761cd9bb" color:border-color="#000000" bpmnElement="_16857297-f0fb-4027-87f6-633a76267c84">
+                <di:waypoint x="311.4307803772124" y="461.61944753006276"/>
+                <di:waypoint x="342.0000000000001" y="461.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_96b74c5a-8d04-4941-bd36-8d31911c7386" color:border-color="#000000" bpmnElement="_c7c2f8e1-a93f-44d6-9a94-cb92d7466d73">
+                <di:waypoint x="374.0000000000001" y="328.8431757821552"/>
+                <di:waypoint x="425.0000000000001" y="328.8431757821552"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d0eff7a2-f16e-4ff5-918b-22625e0553e7" color:border-color="#000000" bpmnElement="_d51b76e8-b096-4376-ba01-7ca63ae51f70">
+                <di:waypoint x="867.8741925406076" y="332.6717547013318"/>
+                <di:waypoint x="923.8116925406076" y="332.6717547013318"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ec04a088-5e15-4012-a766-78543c3ce6ed" color:border-color="#000000" bpmnElement="_eba304c2-42e8-4d65-a9dc-e2483fd8ad86">
+                <di:waypoint x="1347.738099400959" y="332.45855025787705"/>
+                <di:waypoint x="1389.626988289848" y="333.5606435902207"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a6e6b4dd-b683-4727-b2fa-39bb2d07871b" color:border-color="#000000" bpmnElement="_c69565cd-3a08-4532-b466-8f9a9ebdc1e1">
+                <di:waypoint x="1858.3713444082127" y="340.8672968467124"/>
+                <di:waypoint x="1930.325818703417" y="340.8672941829026"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4b24605c-c858-49cf-9349-6eb8a95ff593" color:border-color="#000000" bpmnElement="_8eac4fb5-c746-42e4-ab0b-80cdfaf76007">
+                <di:waypoint x="1505.8886548916628" y="762.0062997165755"/>
+                <di:waypoint x="1707.4460311605199" y="762.0062997165754"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7db2ea4d-1814-4617-93c9-4a1504d8484d" color:border-color="#000000" bpmnElement="_ec8c7430-02e1-4298-9b00-33c4d56d0fac">
+                <di:waypoint x="1802.4460311605199" y="762.0062997165754"/>
+                <di:waypoint x="1925.325818703417" y="762.3491227969952"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8d36bd8b-1a72-4a66-8532-6b73c5064dff" color:border-color="#000000" bpmnElement="_65293cb4-b859-4ff7-bcd3-ba4e38cf8763">
+                <di:waypoint x="1682.840470226419" y="340.8672955744121"/>
+                <di:waypoint x="1763.3713444082127" y="340.8672968467124"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_59926dec-94ba-4b32-8c19-8bdad8f8dd38" color:border-color="#000000" bpmnElement="_f81560f5-e1c5-497d-a159-dce350f2283c">
+                <di:waypoint x="1485.9951640722275" y="340.8672955744122"/>
+                <di:waypoint x="1588.840470226419" y="340.8672955744121"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_5736f5d9-2784-47ea-b595-3de421b21cb1" color:border-color="#000000" bpmnElement="_9ec5ad1d-0662-42a4-9118-bca0bf744422">
+                <di:waypoint x="81" y="461.8431757821553"/>
+                <di:waypoint x="137" y="461.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_f5b9f4cc-cb66-4256-b5d0-68ff0e9ceff9" color:border-color="#000000" bpmnElement="_bcb8805c-5e93-41ec-991b-575d26ed3a9c">
+                <di:waypoint x="232" y="461.8431757821553"/>
+                <di:waypoint x="269.0000000000001" y="461.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_7af0cdbf-9ae1-4551-abb5-4c9fabc4050d" color:border-color="#000000" bpmnElement="_f072c57e-dcc6-4a16-8f28-13a2cd6e43ed">
+                <di:waypoint x="373.1111111111112" y="609.2085036569848"/>
+                <di:waypoint x="429.0000000000001" y="609.2085036569848"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ad810b20-101a-4ad0-a5c0-6f6ccb7bd0bd" color:border-color="#000000" bpmnElement="_e396fc69-5792-41e3-8a92-ee6b83cd0909">
+                <di:waypoint x="524.0000000000001" y="609.2085036569848"/>
+                <di:waypoint x="593.0000000000001" y="609.2085036569848"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_dbdd3ed0-60b2-4158-adee-c070ce200a32" color:border-color="#000000" bpmnElement="_649072fc-31c7-4e04-bc58-d4442a06f076">
+                <di:waypoint x="373.1111111111112" y="461.8431757821553"/>
+                <di:waypoint x="429.0000000000001" y="461.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_6e9383a7-1a76-4f40-bd37-50be92b52a57" color:border-color="#000000" bpmnElement="_51e34f49-b9eb-4f10-ac0a-7af81e1370ff">
+                <di:waypoint x="524.0000000000001" y="461.8431757821553"/>
+                <di:waypoint x="593.0000000000001" y="461.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_2d36acd5-cd62-4974-aa1d-1e4954e6b8a4" color:border-color="#000000" bpmnElement="_a0c99000-31e1-4de9-baf7-45c2d09ebbff">
+                <di:waypoint x="496.9297911896431" y="380.89403738710007"/>
+                <di:waypoint x="496.9297911896431" y="402.8686065846277"/>
+                <di:waypoint x="477.0000000000001" y="402.8686065846277"/>
+                <di:waypoint x="477.0000000000001" y="424.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_87b05c12-ee5c-48d8-8b4d-1483c061de42" color:border-color="#000000" bpmnElement="_651344ad-d784-4ef2-9655-4bc6393ac323">
+                <di:waypoint x="1030.286137525952" y="458.9787299537809"/>
+                <di:waypoint x="1030.286137525952" y="482.1714196893139"/>
+                <di:waypoint x="1134.8116925406075" y="482.1714196893139"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_de070775-e37e-40fd-afe3-93c05cf89495" color:border-color="#000000" bpmnElement="_018e5307-4c8d-46fd-ba84-7b75409b3124">
+                <di:waypoint x="944.8116925406076" y="311.45855025787705"/>
+                <di:waypoint x="944.8116925406075" y="247.6334196990515"/>
+                <di:waypoint x="977.8116925406076" y="247.6334196990515"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_533970c6-a264-4f9b-8ce6-11074871b457" color:border-color="#000000" bpmnElement="_98b2bd26-e113-4d19-b6a8-bcda781a823b">
+                <di:waypoint x="1041.8483883102326" y="296.54011317544575"/>
+                <di:waypoint x="1041.8483883102326" y="340.8672968467124"/>
+                <di:waypoint x="1134.8116925406075" y="340.86729684671246"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8c3728ff-2dac-4308-9c06-1160cbb5c55f" color:border-color="#000000" bpmnElement="_b08efa4c-c27c-4654-9901-279a8c456a4f">
+                <di:waypoint x="1071.8116925406075" y="247.6334196990515"/>
+                <di:waypoint x="1326.738099400959" y="247.6334196990515"/>
+                <di:waypoint x="1326.738099400959" y="311.45855025787705"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_cb40523f-b828-414a-a083-aa2adc2bbdea" color:border-color="#000000" bpmnElement="_e6011c12-800f-44e6-8ae8-51866664afcf">
+                <di:waypoint x="1071.8116925406075" y="405.6334196990515"/>
+                <di:waypoint x="1326.738099400959" y="405.6334196990515"/>
+                <di:waypoint x="1326.738099400959" y="353.45855025787705"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_bdc3cb55-d91b-4298-bb47-a38da622102f" color:border-color="#000000" bpmnElement="_c72535b8-43f7-4906-9f18-691e03050c24">
+                <di:waypoint x="1690.437000881507" y="174"/>
+                <di:waypoint x="1757.3713444082127" y="174"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1d052d49-8f08-4762-89c3-714cbd83edfb" color:border-color="#000000" bpmnElement="_94e0bd86-6659-4669-baee-ce671c7f33d6">
+                <di:waypoint x="1852.3713444082127" y="174"/>
+                <di:waypoint x="1925.325818703417" y="173.99999733619012"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_3f0ef0a7-c555-4187-a2c4-68ed12b93799" color:border-color="#000000" bpmnElement="_b2d48080-6bb1-4ae9-85c9-916d87536a49">
+                <di:waypoint x="944.8116925406076" y="353.45855025787705"/>
+                <di:waypoint x="944.8116925406075" y="405.6334196990515"/>
+                <di:waypoint x="977.8116925406076" y="405.6334196990515"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_643ffc6c-ac1e-4f40-b8c6-662db3fc4955" color:border-color="#000000" bpmnElement="_7efd61ea-979e-44f4-91c8-e212ae6b22c7">
+                <di:waypoint x="527.0000000000001" y="328.8431757821552"/>
+                <di:waypoint x="741.2380994009592" y="328.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fa1439cb-56e1-4399-bfe8-638b37a16866" color:border-color="#000000" bpmnElement="_82006a49-2cc8-4814-83e2-28c5a85a4c4a" targetElement="_8eb52f6a-0fd6-4fad-8ade-14bca1b066bf">
+                <di:waypoint x="139" y="340.8672968467124"/>
+                <di:waypoint x="185" y="340.8672968467124"/>
+                <di:waypoint x="185" y="424.8431757821553"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_9f83d262-8e6a-47f5-84b3-86f560fbfcec" color:border-color="#000000" bpmnElement="_ef945053-2c76-4796-8d8b-afc6be8bbfec" sourceElement="_b9aa82b1-78ef-49a9-8198-ebb98ef2bd9e">
+                <di:waypoint x="1840.1713444082127" y="303.8672968467124"/>
+                <di:waypoint x="1840.1713444082127" y="258.8289618444322"/>
+                <di:waypoint x="1871.9999999999998" y="258.8289618444322"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_0">
+            <dc:Font name="Arial" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+        <bpmndi:BPMNLabelStyle id="LS_f1aecfc3-a3da-4bde-bece-87786e25273d_1">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.7.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/C.7.0.bpmn
@@ -1,0 +1,466 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<semantic:definitions xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:dmn="http://www.omg.org/spec/DMN/20180521/MODEL/" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:trisobpmn="http://www.trisotech.com/2014/triso/bpmn" xmlns:triso="http://www.trisotech.com/2015/triso/modeling" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:feel="http://www.omg.org/spec/DMN/20180521/FEEL/" xmlns:html="http://www.w3.org/1999/xhtml" xmlns:openapi="https://openapis.org/omg/extension/1.0" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:rss="http://purl.org/rss/2.0/" xmlns:trisofeed="http://trisotech.com/feed"                xmlns:drools="http://www.jboss.org/drools"  xmlns="http://www.trisotech.com/definitions/_7e80c232-2bf0-46e0-b77e-29ec586a23a6" id="_7e80c232-2bf0-46e0-b77e-29ec586a23a6" targetNamespace="http://www.trisotech.com/definitions/_7e80c232-2bf0-46e0-b77e-29ec586a23a6" expressionLanguage="http://www.omg.org/spec/DMN/20180521/FEEL/" typeLanguage="http://www.trisotech.com/2015/triso/modeling/ItemDefinitionType" exporter="Workflow Modeler" exporterVersion="6.12.3" name="Advertise a job vacancy" trisobpmn:logoChoice="None">
+    <semantic:itemDefinition structureRef="feel:string" isCollection="false" triso:basicType="true" triso:definitionType="http://www.trisotech.com/2015/triso/modeling/ItemDefinitionType" triso:name="triso_string" id="_triso-default-bpmnItemDefinition-string_id"/>
+    <semantic:itemDefinition structureRef="collectionOfString" isCollection="false" triso:basicType="false" triso:definitionType="http://www.trisotech.com/2015/triso/modeling/ItemDefinitionType" triso:name="Définition d'un item Collection de Texte" id="_bd0e1992-4669-4a5b-98ea-641930d87150"/>
+    <semantic:resource name="Hiring manager" id="_b5b6808a-be81-426c-98ae-f33f44a2f871"/>
+    <semantic:resource name="Recruiter" id="_dc7df8e9-cc60-4953-9ae5-a9ea25fd9c5b"/>
+    <semantic:collaboration id="_0322c8c5-b921-44cc-9bf7-261dcb16f257">
+        <semantic:participant id="_d3aa8a96-e9df-4336-9b0d-01b17e6587ad" name="EU Bank" processRef="_4a690dd7-809a-4fa9-ad63-515ac6685375"/>
+    </semantic:collaboration>
+    <semantic:process id="_4a690dd7-809a-4fa9-ad63-515ac6685375" name="EU Bank - Process" triso:defaultName="true" isClosed="false">
+        <semantic:ioSpecification>
+            <semantic:dataInput name="Role &#10;required" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_d08869ef-4951-4592-bb73-363cee03cb90"/>
+            <semantic:dataOutput name="Advertisement" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_b6464e75-dd3d-45d9-84cd-861c42a3bedf">
+                <semantic:dataState name="Approved"/>
+            </semantic:dataOutput>
+            <semantic:inputSet id="_e717d617-bac8-4278-ac70-3a9767e3b27f">
+                <semantic:dataInputRefs>_d08869ef-4951-4592-bb73-363cee03cb90</semantic:dataInputRefs>
+            </semantic:inputSet>
+            <semantic:outputSet id="_a8015818-8340-4ba0-a3c9-84ee85a353eb">
+                <semantic:dataOutputRefs>_b6464e75-dd3d-45d9-84cd-861c42a3bedf</semantic:dataOutputRefs>
+            </semantic:outputSet>
+        </semantic:ioSpecification>
+        <semantic:laneSet>
+            <semantic:lane id="_b836aa5e-fb94-4479-af77-64a3a5202451" name="Hiring manager">
+                <semantic:flowNodeRef>_5ba97787-8a90-4002-8277-b0895e45cf1f</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_392c86ba-38b5-4dc9-b98d-f97ad4c2add5</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_15b00027-5049-4081-8952-fd398e8b722a</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_26c40c03-5d1f-46c5-81f1-ddd485868125</semantic:flowNodeRef>
+            </semantic:lane>
+            <semantic:lane id="_dd32321b-8e95-4801-8eed-5451399b4378" name="Recruitment">
+                <semantic:flowNodeRef>_d3435084-f2c7-43cc-abcc-c679bc4232ac</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_b13d6fa3-fc78-40c7-ae77-609be07493e9</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_64eabfe9-6947-43eb-ac45-8d331745f86c</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_eae674ce-4d6e-48ac-819c-c79e0868e40d</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_0783f019-f40c-43d6-ab40-0f1c81f8d9e7</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_c456dbcc-bbe3-4c75-b57d-9427525c0a94</semantic:flowNodeRef>
+                <semantic:flowNodeRef>_a36ddf2f-23c1-46c5-86d4-bd2a0eb42535</semantic:flowNodeRef>
+            </semantic:lane>
+        </semantic:laneSet>
+        <semantic:startEvent id="_5ba97787-8a90-4002-8277-b0895e45cf1f" name="Job &#10;vacancy">
+            <semantic:outgoing>_a4c93e8a-2b52-4367-8381-a3f78450a075</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:userTask id="_392c86ba-38b5-4dc9-b98d-f97ad4c2add5" name="Write &#10;description" implementation="##unspecified">
+            <semantic:documentation textFormat="text/html">&lt;p&gt;A very specific requirement to the job vacancy has to be written and forwarded to the recruitment department.&lt;/p&gt;</semantic:documentation>
+            <semantic:incoming>_a4c93e8a-2b52-4367-8381-a3f78450a075</semantic:incoming>
+            <semantic:outgoing>_8a27a9ee-b8e5-49d8-8b7d-41a59d74b3f3</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="Description" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" triso:hidden="false" id="_31ca347a-7ad3-4416-9d4a-c080479329c7"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_0d01e81d-03c2-4002-ae80-53df972febb6">
+                    <semantic:dataOutputRefs>_31ca347a-7ad3-4416-9d4a-c080479329c7</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_e2734375-2aa0-418c-9f0b-8c2ca1022285">
+                <semantic:sourceRef>_31ca347a-7ad3-4416-9d4a-c080479329c7</semantic:sourceRef>
+                <semantic:targetRef>_bd7b6a15-4ef8-46a9-8be9-20a5abb32abd</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:performer id="_c663bd75-4868-4eb4-8829-0cbbd5ae4580">
+                <semantic:resourceRef>_b5b6808a-be81-426c-98ae-f33f44a2f871</semantic:resourceRef>
+            </semantic:performer>
+        </semantic:userTask>
+        <semantic:userTask id="_15b00027-5049-4081-8952-fd398e8b722a" name="Approve advertisement" implementation="##unspecified">
+            <semantic:documentation textFormat="text/html">&lt;p&gt;The job description edited to a job advertisement has to be checked and approved.&lt;/p&gt;</semantic:documentation>
+            <semantic:extensionElements>
+                <triso:graphRelations>
+                    <triso:systemRef predicate="where" id="_b90e53a0-9483-4733-a1cf-27316061fec3">_b0c02ccd-0b0f-4c3c-8009-9a6af23ccaeb</triso:systemRef>
+                </triso:graphRelations>
+            </semantic:extensionElements>
+            <semantic:incoming>_842553bd-02e1-45f7-aed0-c78e9dba9e2b</semantic:incoming>
+            <semantic:outgoing>_7b66938e-e5cb-4026-a863-1e6de6d11a79</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Advertisement" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_b02b2e9f-17f7-4663-b12c-255ee4351d42"/>
+                <semantic:dataOutput name="Advertisement" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" triso:hidden="false" id="_e115b5bb-0dd7-444f-b5ec-20cffffef082"/>
+                <semantic:inputSet id="_0cddfa48-58e5-47f8-92f0-a5153ae17d78">
+                    <semantic:dataInputRefs>_b02b2e9f-17f7-4663-b12c-255ee4351d42</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_9492b1d3-f6ff-4c9c-8707-07e2d7b07c89">
+                    <semantic:dataOutputRefs>_e115b5bb-0dd7-444f-b5ec-20cffffef082</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_9ce7bb4a-930c-4132-a09d-61b345cce434">
+                <semantic:sourceRef>_bac0224d-62f1-46aa-bb4c-5371c3983ffb</semantic:sourceRef>
+                <semantic:targetRef>_b02b2e9f-17f7-4663-b12c-255ee4351d42</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_adddc8ea-507e-4894-ac4b-92bca7e0a89f">
+                <semantic:sourceRef>_e115b5bb-0dd7-444f-b5ec-20cffffef082</semantic:sourceRef>
+                <semantic:targetRef>_b6464e75-dd3d-45d9-84cd-861c42a3bedf</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:performer id="_ceb60e9f-c1f4-43bc-aefd-6f346c176a6c">
+                <semantic:resourceRef>_b5b6808a-be81-426c-98ae-f33f44a2f871</semantic:resourceRef>
+            </semantic:performer>
+        </semantic:userTask>
+        <semantic:exclusiveGateway id="_26c40c03-5d1f-46c5-81f1-ddd485868125" name="Advertisement approved?" gatewayDirection="Diverging">
+            <semantic:incoming>_7b66938e-e5cb-4026-a863-1e6de6d11a79</semantic:incoming>
+            <semantic:outgoing>_d74707c7-6af3-4db7-9403-924bfdf6a7d8</semantic:outgoing>
+            <semantic:outgoing>_1d201a22-d500-4412-a32a-2c7e24ad4d6b</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:dataObjectReference id="_bd7b6a15-4ef8-46a9-8be9-20a5abb32abd" name="Description" dataObjectRef="_8f2796af-2fbe-4f72-80c1-96933c38990f"/>
+        <semantic:userTask id="_d3435084-f2c7-43cc-abcc-c679bc4232ac" name="Complete advertisement" implementation="##unspecified">
+            <semantic:documentation textFormat="text/html">&lt;p&gt;The job description received from the specialist department has to be completed (layout, additional information etc.) to a job advertisement in accordance to the guidelines and approved by the Hiring Manager.&lt;/p&gt;</semantic:documentation>
+            <semantic:extensionElements>
+                <triso:graphRelations>
+                    <triso:systemRef predicate="where" id="_2c8622ca-70fe-4f57-8bcd-5cbd8b1390b7">_b0c02ccd-0b0f-4c3c-8009-9a6af23ccaeb</triso:systemRef>
+                </triso:graphRelations>
+            </semantic:extensionElements>
+            <semantic:incoming>_8a27a9ee-b8e5-49d8-8b7d-41a59d74b3f3</semantic:incoming>
+            <semantic:incoming>_d74707c7-6af3-4db7-9403-924bfdf6a7d8</semantic:incoming>
+            <semantic:outgoing>_842553bd-02e1-45f7-aed0-c78e9dba9e2b</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Description" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" id="_c083f111-3c38-4250-9594-3f25b4620db3"/>
+                <semantic:dataOutput name="Advertisement" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false" triso:hidden="false" id="_50a31269-be15-435b-81e0-0a91b57ba10d"/>
+                <semantic:inputSet id="_9c3de1df-92ef-4b69-9585-311d8d45952f">
+                    <semantic:dataInputRefs>_c083f111-3c38-4250-9594-3f25b4620db3</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet id="_a4d61918-d67b-4038-b488-95c244824918">
+                    <semantic:dataOutputRefs>_50a31269-be15-435b-81e0-0a91b57ba10d</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_5c3fc96e-20d0-4879-8471-d41224632e24">
+                <semantic:sourceRef>_bd7b6a15-4ef8-46a9-8be9-20a5abb32abd</semantic:sourceRef>
+                <semantic:targetRef>_c083f111-3c38-4250-9594-3f25b4620db3</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:dataOutputAssociation id="_4164c380-3ee3-4a6a-8e66-5bc201416108">
+                <semantic:sourceRef>_50a31269-be15-435b-81e0-0a91b57ba10d</semantic:sourceRef>
+                <semantic:targetRef>_bac0224d-62f1-46aa-bb4c-5371c3983ffb</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:performer id="_41c0e9b3-8ef9-4657-baab-c59b6ba1b1c4">
+                <semantic:resourceRef>_dc7df8e9-cc60-4953-9ae5-a9ea25fd9c5b</semantic:resourceRef>
+            </semantic:performer>
+        </semantic:userTask>
+        <semantic:parallelGateway id="_b13d6fa3-fc78-40c7-ae77-609be07493e9" gatewayDirection="Diverging">
+            <semantic:incoming>_1d201a22-d500-4412-a32a-2c7e24ad4d6b</semantic:incoming>
+            <semantic:outgoing>_f476667f-44f5-4fec-9414-bf70d987853f</semantic:outgoing>
+            <semantic:outgoing>_f3187dce-c37e-4d5b-b49c-ed28965abb73</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:serviceTask id="_64eabfe9-6947-43eb-ac45-8d331745f86c" name="Publish on &#10;homepage" implementation="##WebService">
+            <semantic:documentation textFormat="text/html">&lt;p&gt;The approved job advertisement has to be published on the homepage.&lt;/p&gt;</semantic:documentation>
+            <semantic:extensionElements>
+                <triso:graphRelations>
+                    <triso:systemRef predicate="where" id="_4ee60d07-6419-4107-9da1-5551f25f2d96">_b0c02ccd-0b0f-4c3c-8009-9a6af23ccaeb</triso:systemRef>
+                </triso:graphRelations>
+            </semantic:extensionElements>
+            <semantic:incoming>_f476667f-44f5-4fec-9414-bf70d987853f</semantic:incoming>
+            <semantic:outgoing>_720cb9a3-20df-4da1-a923-5336b269c104</semantic:outgoing>
+            <semantic:performer id="_2d69e812-dd75-4405-ae41-5f64be302e5f">
+                <semantic:resourceRef>_dc7df8e9-cc60-4953-9ae5-a9ea25fd9c5b</semantic:resourceRef>
+            </semantic:performer>
+        </semantic:serviceTask>
+        <semantic:businessRuleTask id="_eae674ce-4d6e-48ac-819c-c79e0868e40d" name="Select &#10;other platforms" implementation="##unspecified">
+            <semantic:documentation textFormat="text/html">&lt;p&gt;3rd party career platforms have to be selected on which the job advertisement will be published.&lt;/p&gt;</semantic:documentation>
+            <semantic:incoming>_f3187dce-c37e-4d5b-b49c-ed28965abb73</semantic:incoming>
+            <semantic:outgoing>_64ac4473-a38f-4043-973a-69c497adc88a</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataOutput name="Selected&#10; platforms" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="true" triso:hidden="false" id="_3daad61f-55b2-4fbd-bc79-dff572a23d69"/>
+                <semantic:inputSet/>
+                <semantic:outputSet id="_a389083a-36ae-4975-b210-9464fe82c22e">
+                    <semantic:dataOutputRefs>_3daad61f-55b2-4fbd-bc79-dff572a23d69</semantic:dataOutputRefs>
+                </semantic:outputSet>
+            </semantic:ioSpecification>
+            <semantic:dataOutputAssociation id="_d65b0a3d-8c42-4be7-9ac1-7324aa3d31f8">
+                <semantic:sourceRef>_3daad61f-55b2-4fbd-bc79-dff572a23d69</semantic:sourceRef>
+                <semantic:targetRef>_c68abea8-c5b4-4aef-b1a5-1e81caec0cba</semantic:targetRef>
+            </semantic:dataOutputAssociation>
+            <semantic:performer id="_867590ee-ec0c-4f56-b0f0-32e444b73079">
+                <semantic:resourceRef>_dc7df8e9-cc60-4953-9ae5-a9ea25fd9c5b</semantic:resourceRef>
+            </semantic:performer>
+        </semantic:businessRuleTask>
+        <semantic:parallelGateway id="_0783f019-f40c-43d6-ab40-0f1c81f8d9e7" gatewayDirection="Converging">
+            <semantic:incoming>_720cb9a3-20df-4da1-a923-5336b269c104</semantic:incoming>
+            <semantic:incoming>_847352f2-ac0c-44be-9e24-f4c7f76bfe7e</semantic:incoming>
+            <semantic:outgoing>_c43defc5-4470-4bfe-8a8f-4d59ca6abeeb</semantic:outgoing>
+        </semantic:parallelGateway>
+        <semantic:endEvent id="_c456dbcc-bbe3-4c75-b57d-9427525c0a94" name="Vacancy &#10;advertised">
+            <semantic:incoming>_c43defc5-4470-4bfe-8a8f-4d59ca6abeeb</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:serviceTask id="_a36ddf2f-23c1-46c5-86d4-bd2a0eb42535" name="Publish on &#10;other platforms" implementation="##WebService">
+            <semantic:incoming>_64ac4473-a38f-4043-973a-69c497adc88a</semantic:incoming>
+            <semantic:outgoing>_847352f2-ac0c-44be-9e24-f4c7f76bfe7e</semantic:outgoing>
+            <semantic:ioSpecification>
+                <semantic:dataInput name="Selected&#10; platforms" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="true" id="_d130e681-7e04-48d6-be39-2b7cfe24b9d4"/>
+                <semantic:inputSet id="_f49af959-916f-43bc-9f37-00ef9c44e967">
+                    <semantic:dataInputRefs>_d130e681-7e04-48d6-be39-2b7cfe24b9d4</semantic:dataInputRefs>
+                </semantic:inputSet>
+                <semantic:outputSet/>
+            </semantic:ioSpecification>
+            <semantic:dataInputAssociation id="_505fa8cf-5697-4e35-bc4e-63df8e99093e">
+                <semantic:sourceRef>_c68abea8-c5b4-4aef-b1a5-1e81caec0cba</semantic:sourceRef>
+                <semantic:targetRef>_d130e681-7e04-48d6-be39-2b7cfe24b9d4</semantic:targetRef>
+            </semantic:dataInputAssociation>
+            <semantic:multiInstanceLoopCharacteristics id="_970a7f54-893a-495e-8cbc-545fd631f626" isSequential="false"/>
+        </semantic:serviceTask>
+        <semantic:dataObjectReference id="_bac0224d-62f1-46aa-bb4c-5371c3983ffb" name="Advertisement" dataObjectRef="_f60fe1d9-58bd-462c-9d62-153e530dc79d"/>
+        <semantic:dataObjectReference id="_c68abea8-c5b4-4aef-b1a5-1e81caec0cba" name="Selected&#10; platforms" dataObjectRef="_ef29e636-bdfe-4eb0-9633-7d0195a8ae3a"/>
+        <semantic:dataObject id="_ef29e636-bdfe-4eb0-9633-7d0195a8ae3a" name="Selected&#10; platforms" itemSubjectRef="_bd0e1992-4669-4a5b-98ea-641930d87150" isCollection="true"/>
+        <semantic:dataObject id="_8f2796af-2fbe-4f72-80c1-96933c38990f" name="Description" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false"/>
+        <semantic:dataObject id="_f60fe1d9-58bd-462c-9d62-153e530dc79d" name="Advertisement" itemSubjectRef="_triso-default-bpmnItemDefinition-string_id" isCollection="false"/>
+        <semantic:sequenceFlow id="_a4c93e8a-2b52-4367-8381-a3f78450a075" sourceRef="_5ba97787-8a90-4002-8277-b0895e45cf1f" targetRef="_392c86ba-38b5-4dc9-b98d-f97ad4c2add5"/>
+        <semantic:sequenceFlow id="_8a27a9ee-b8e5-49d8-8b7d-41a59d74b3f3" sourceRef="_392c86ba-38b5-4dc9-b98d-f97ad4c2add5" targetRef="_d3435084-f2c7-43cc-abcc-c679bc4232ac"/>
+        <semantic:sequenceFlow id="_842553bd-02e1-45f7-aed0-c78e9dba9e2b" sourceRef="_d3435084-f2c7-43cc-abcc-c679bc4232ac" targetRef="_15b00027-5049-4081-8952-fd398e8b722a"/>
+        <semantic:sequenceFlow id="_7b66938e-e5cb-4026-a863-1e6de6d11a79" sourceRef="_15b00027-5049-4081-8952-fd398e8b722a" targetRef="_26c40c03-5d1f-46c5-81f1-ddd485868125"/>
+        <semantic:sequenceFlow id="_d74707c7-6af3-4db7-9403-924bfdf6a7d8" name="No" sourceRef="_26c40c03-5d1f-46c5-81f1-ddd485868125" targetRef="_d3435084-f2c7-43cc-abcc-c679bc4232ac"/>
+        <semantic:sequenceFlow id="_1d201a22-d500-4412-a32a-2c7e24ad4d6b" name="Yes" sourceRef="_26c40c03-5d1f-46c5-81f1-ddd485868125" targetRef="_b13d6fa3-fc78-40c7-ae77-609be07493e9"/>
+        <semantic:sequenceFlow id="_f476667f-44f5-4fec-9414-bf70d987853f" sourceRef="_b13d6fa3-fc78-40c7-ae77-609be07493e9" targetRef="_64eabfe9-6947-43eb-ac45-8d331745f86c"/>
+        <semantic:sequenceFlow id="_f3187dce-c37e-4d5b-b49c-ed28965abb73" sourceRef="_b13d6fa3-fc78-40c7-ae77-609be07493e9" targetRef="_eae674ce-4d6e-48ac-819c-c79e0868e40d"/>
+        <semantic:sequenceFlow id="_720cb9a3-20df-4da1-a923-5336b269c104" sourceRef="_64eabfe9-6947-43eb-ac45-8d331745f86c" targetRef="_0783f019-f40c-43d6-ab40-0f1c81f8d9e7"/>
+        <semantic:sequenceFlow id="_64ac4473-a38f-4043-973a-69c497adc88a" triso:dataInputId="_4d02fe4c-1958-4a9a-b7b7-d29a9fb857db" triso:dataOutputId="_a450adf8-a041-4658-8e36-5a417fee6c2e" sourceRef="_eae674ce-4d6e-48ac-819c-c79e0868e40d" targetRef="_a36ddf2f-23c1-46c5-86d4-bd2a0eb42535"/>
+        <semantic:sequenceFlow id="_c43defc5-4470-4bfe-8a8f-4d59ca6abeeb" sourceRef="_0783f019-f40c-43d6-ab40-0f1c81f8d9e7" targetRef="_c456dbcc-bbe3-4c75-b57d-9427525c0a94"/>
+        <semantic:sequenceFlow id="_847352f2-ac0c-44be-9e24-f4c7f76bfe7e" sourceRef="_a36ddf2f-23c1-46c5-86d4-bd2a0eb42535" targetRef="_0783f019-f40c-43d6-ab40-0f1c81f8d9e7"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram id="_9786170f-6612-400e-a37d-2970ab70f1f3" name="C.7.0">
+        <bpmndi:BPMNPlane bpmnElement="_0322c8c5-b921-44cc-9bf7-261dcb16f257" id="_9786170f-6612-400e-a37d-2970ab70f1f3_plane" trisobpmn:diagramWidth="1583" trisobpmn:diagramHeight="924.0121945738792">
+            <bpmndi:BPMNShape id="_3946a034-888b-406b-a4bb-cdbee3f27655" bpmnElement="_d3aa8a96-e9df-4336-9b0d-01b17e6587ad" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="50" y="50" width="1483" height="824.0121945738792"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="818.01220703125" width="12.015625" x="55" y="52.99999377131468"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_dbc86830-61a4-4a1f-9e5f-69a97aa06e61" bpmnElement="_b836aa5e-fb94-4479-af77-64a3a5202451" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="80" y="50" width="1453" height="403"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="397" width="12.015625" x="85" y="53"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_e0800ebd-85ea-4c90-af70-c0cb3f35d7ef" bpmnElement="_5ba97787-8a90-4002-8277-b0895e45cf1f" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="163" y="277.5" width="32" height="32"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="124" y="319.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_8ce3cd47-c554-4454-80c4-7e045d45a7cc" bpmnElement="_392c86ba-38b5-4dc9-b98d-f97ad4c2add5" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="250" y="255.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="253.5" y="280.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_59a87229-94ce-4df6-ab1d-b669632dc093" bpmnElement="_15b00027-5049-4081-8952-fd398e8b722a" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="639" y="255.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="642.5" y="280.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_99380e5f-656e-4d5c-b43c-80a9b20c6cc8" bpmnElement="_26c40c03-5d1f-46c5-81f1-ddd485868125" isMarkerVisible="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="814" y="273.48780542612076" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="779.7867965698242" y="321.5170724034309"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_938dfdaf-0fe4-4def-b8cc-1aade8108f2e" bpmnElement="_d08869ef-4951-4592-bb73-363cee03cb90" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="136" y="130" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="98" y="175"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bd7b6a15-4ef8-46a9-8be9-20a5abb32abd_di" bpmnElement="_bd7b6a15-4ef8-46a9-8be9-20a5abb32abd" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="334" y="159.5" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="12.015625" width="110" x="296" y="204.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_927164d8-b3df-447f-bd7f-f5786c37c279" bpmnElement="_b6464e75-dd3d-45d9-84cd-861c42a3bedf" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="743.5" y="146" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="705.5" y="191"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_3f64498d-0903-4b45-8c4f-fd7fab12d54c" bpmnElement="_dd32321b-8e95-4801-8eed-5451399b4378" isHorizontal="true" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="80" y="453" width="1453" height="421.01219457387924"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="415.01220703125" width="12.015625" x="85" y="455.9999937713146"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_292acb9f-6f5b-402b-adc0-0bd34c2d558d" bpmnElement="_d3435084-f2c7-43cc-abcc-c679bc4232ac" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="443" y="566" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="446.5" y="591"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_975aa6c7-f142-47ed-a405-ce482d61eb2b" bpmnElement="_b13d6fa3-fc78-40c7-ae77-609be07493e9" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="929.2132034301758" y="583.9878054261208" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_fd4a4d27-2b4e-4f14-b7ff-f820f630a363" bpmnElement="_eae674ce-4d6e-48ac-819c-c79e0868e40d" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1013.7867965698242" y="643" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="1017.2867965698242" y="668"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f0775e8e-8c6a-44fd-838e-0872f5f93f0f" bpmnElement="_64eabfe9-6947-43eb-ac45-8d331745f86c" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1089.2867965698242" y="486.5" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="1092.7867965698242" y="511.5"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bc8f619b-ffc6-41ad-90c0-56dada9790d4" bpmnElement="_a36ddf2f-23c1-46c5-86d4-bd2a0eb42535" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1200.5" y="643" width="96" height="76"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26" width="89" x="1204" y="668"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_4a654e20-8f3e-4e42-bb84-56d1caf793d0" bpmnElement="_0783f019-f40c-43d6-ab40-0f1c81f8d9e7" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1323.7867965698242" y="583.9878054261208" width="41.57359313964844" height="40.024389147758484"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_f80d237a-08ab-4237-a706-0df1d4fda58b" bpmnElement="_c456dbcc-bbe3-4c75-b57d-9427525c0a94" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1452.3603897094727" y="586" width="36" height="36"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="1415.3603897094727" y="632"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_bac0224d-62f1-46aa-bb4c-5371c3983ffb_di" bpmnElement="_bac0224d-62f1-46aa-bb4c-5371c3983ffb" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="551" y="701" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="12.015625" width="110" x="513" y="746"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_c68abea8-c5b4-4aef-b1a5-1e81caec0cba_di" bpmnElement="_c68abea8-c5b4-4aef-b1a5-1e81caec0cba" color:background-color="#ffffff" color:border-color="#000000">
+                <dc:Bounds x="1101.5" y="774" width="34" height="40"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="26.015625" width="110" x="1063.5" y="819"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="_19374b5c-d456-43e2-bc4e-3f3553583ab4" color:border-color="#000000" bpmnElement="_a4c93e8a-2b52-4367-8381-a3f78450a075">
+                <di:waypoint x="194" y="293.5"/>
+                <di:waypoint x="250" y="293.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_cf13630a-2e86-4a3a-a2b1-8046c33ba0d9" color:border-color="#000000" bpmnElement="_8a27a9ee-b8e5-49d8-8b7d-41a59d74b3f3">
+                <di:waypoint x="346" y="293.5"/>
+                <di:waypoint x="394.5" y="293.5"/>
+                <di:waypoint x="394.5" y="604"/>
+                <di:waypoint x="443" y="604"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a60a45e1-047e-4b6b-835b-7f6018b7ad92" color:border-color="#000000" bpmnElement="_842553bd-02e1-45f7-aed0-c78e9dba9e2b">
+                <di:waypoint x="538" y="604"/>
+                <di:waypoint x="588.5" y="604"/>
+                <di:waypoint x="588.5" y="293.5"/>
+                <di:waypoint x="639" y="293.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_ef2bb966-fe1b-4a19-a84e-40b4ecc61d47" color:border-color="#000000" bpmnElement="_7b66938e-e5cb-4026-a863-1e6de6d11a79">
+                <di:waypoint x="734" y="293.5"/>
+                <di:waypoint x="814" y="293.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_4f9ac13d-ebf2-42e5-b3fc-15ba4cdcfbab" color:border-color="#000000" bpmnElement="_d74707c7-6af3-4db7-9403-924bfdf6a7d8">
+                <di:waypoint x="835" y="273.48780542612076"/>
+                <di:waypoint x="835" y="253.48780542612076"/>
+                <di:waypoint x="491" y="253.48780542612076"/>
+                <di:waypoint x="491" y="566"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:labelPosition="custom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="12.015625" width="110" x="796" y="199.38780542612068"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_fc80eee4-2fb2-415f-b847-92e979377e1b" color:border-color="#000000" bpmnElement="_1d201a22-d500-4412-a32a-2c7e24ad4d6b">
+                <di:waypoint x="856" y="293.28679555654526"/>
+                <di:waypoint x="892.6066017150879" y="293.28679555654526"/>
+                <di:waypoint x="892.6066017150879" y="603.7867955565453"/>
+                <di:waypoint x="929.2132034301758" y="603.7867955565453"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:labelPosition="custom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+                    <dc:Bounds height="12.015625" width="110" x="828.6066017150879" y="273.53679555654526"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a1bdc324-0e7c-4dd6-ba11-5abf577834dd" color:border-color="#000000" bpmnElement="_f476667f-44f5-4fec-9414-bf70d987853f">
+                <di:waypoint x="950.2132034301758" y="583.9878054261208"/>
+                <di:waypoint x="950.2132034301758" y="524.5"/>
+                <di:waypoint x="1089.2867965698242" y="524.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8e566432-8dca-46b3-b56e-0b681dbf2b69" color:border-color="#000000" bpmnElement="_f3187dce-c37e-4d5b-b49c-ed28965abb73">
+                <di:waypoint x="950.2132034301758" y="624.0121945738792"/>
+                <di:waypoint x="950.2132034301758" y="681"/>
+                <di:waypoint x="1013.7867965698242" y="681"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_a62d1fcf-2639-4f32-a919-0001e5403a72" color:border-color="#000000" bpmnElement="_720cb9a3-20df-4da1-a923-5336b269c104">
+                <di:waypoint x="1184.2867965698242" y="524.5"/>
+                <di:waypoint x="1344.7867965698242" y="524.5"/>
+                <di:waypoint x="1344.7867965698242" y="583.9878054261208"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_d481109d-4c89-406f-af68-5fda941707f9" color:border-color="#000000" bpmnElement="_64ac4473-a38f-4043-973a-69c497adc88a">
+                <di:waypoint x="1108.7867965698242" y="681"/>
+                <di:waypoint x="1201.5" y="681"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_8e6aa554-08d3-44ec-a4a8-4aa74b66351d" color:border-color="#000000" bpmnElement="_c43defc5-4470-4bfe-8a8f-4d59ca6abeeb">
+                <di:waypoint x="1365.7867965698242" y="603.7867955565453"/>
+                <di:waypoint x="1452.3603897094727" y="604"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_012d4172-086e-4cd7-8834-3f055e54f77f" color:border-color="#000000" bpmnElement="_847352f2-ac0c-44be-9e24-f4c7f76bfe7e">
+                <di:waypoint x="1296.5" y="681"/>
+                <di:waypoint x="1344.7867965698242" y="681"/>
+                <di:waypoint x="1344.7867965698242" y="624.0121945738792"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_e8b6f60a-4389-4b71-9d2e-c73bcca8ffda" color:border-color="#000000" bpmnElement="_e2734375-2aa0-418c-9f0b-8c2ca1022285" sourceElement="_8ce3cd47-c554-4454-80c4-7e045d45a7cc">
+                <di:waypoint x="298" y="256.5"/>
+                <di:waypoint x="298" y="179.5"/>
+                <di:waypoint x="334" y="179.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_115b0056-5e1b-483a-b8a9-81677d847e18" color:border-color="#000000" bpmnElement="_5c3fc96e-20d0-4879-8471-d41224632e24" targetElement="_292acb9f-6f5b-402b-adc0-0bd34c2d558d">
+                <di:waypoint x="367" y="179.5"/>
+                <di:waypoint x="462.20000000000005" y="179.5"/>
+                <di:waypoint x="462.20000000000005" y="566"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_850ff2e3-6389-4b70-895b-b9e4381e9b98" color:border-color="#000000" bpmnElement="_4164c380-3ee3-4a6a-8e66-5bc201416108" sourceElement="_292acb9f-6f5b-402b-adc0-0bd34c2d558d">
+                <di:waypoint x="491" y="641.05"/>
+                <di:waypoint x="491" y="721"/>
+                <di:waypoint x="551" y="721"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_1b44492b-f117-42e7-a97e-98e7e4b7f7e3" color:border-color="#000000" bpmnElement="_9ce7bb4a-930c-4132-a09d-61b345cce434" targetElement="_59a87229-94ce-4df6-ab1d-b669632dc093">
+                <di:waypoint x="584" y="721"/>
+                <di:waypoint x="687" y="721"/>
+                <di:waypoint x="687" y="331.5"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_2cdd2564-d1ab-4d16-8a55-3c66271890ca" color:border-color="#000000" bpmnElement="_adddc8ea-507e-4894-ac4b-92bca7e0a89f" sourceElement="_59a87229-94ce-4df6-ab1d-b669632dc093">
+                <di:waypoint x="703" y="255.5"/>
+                <di:waypoint x="703" y="166"/>
+                <di:waypoint x="743.5" y="166"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="_985753e3-a4ce-486b-908a-509d382259ed" color:border-color="#000000" sourceElement="_c68abea8-c5b4-4aef-b1a5-1e81caec0cba_di" targetElement="_d481109d-4c89-406f-af68-5fda941707f9">
+                <di:waypoint x="1118.5" y="774"/>
+                <di:waypoint x="1118.5" y="730"/>
+                <di:waypoint x="1151.5" y="730"/>
+                <di:waypoint x="1152.5" y="682"/>
+                <bpmndi:BPMNLabel color:color="#000000" triso:defaultBounds="true" triso:labelPosition="midbottom" labelStyle="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0"/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS_9786170f-6612-400e-a37d-2970ab70f1f3_0">
+            <dc:Font name="arial,helvetica,sans-serif" size="11" isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+    <semantic:relationship type="trisoExtension">
+        <semantic:extensionElements>
+            <triso:ProjectCharter>
+                <triso:projectDescription>&lt;p&gt;In this process, all activities are described how to advertise a job vacancy.&lt;/p&gt;</triso:projectDescription>
+                <triso:projectScope>&lt;p&gt;Aim: Advertisement of a job vacancy conformable to law and company guidelines.&lt;br /&gt;Trigger: Personnel requirements for filling job vacancies.&lt;br /&gt;Result:The advertisement for the job vacancy has been reviewed and published according to the guidelines&lt;/p&gt;</triso:projectScope>
+                <triso:projectGoals/>
+                <triso:projectChallenges/>
+                <triso:projectStakeholders>
+                    <triso:responsible/>
+                    <triso:accountable/>
+                    <triso:consulted/>
+                    <triso:informed/>
+                </triso:projectStakeholders>
+            </triso:ProjectCharter>
+            <triso:graphObjects>
+                <triso:system name="Online Recruiting System" id="_b0c02ccd-0b0f-4c3c-8009-9a6af23ccaeb"/>
+            </triso:graphObjects>
+            <triso:itemDefinitions>
+                <triso:itemDefinition name="collectionOfString" isCollection="true">
+                    <triso:typeRef>string</triso:typeRef>
+                </triso:itemDefinition>
+            </triso:itemDefinitions>
+        </semantic:extensionElements>
+        <semantic:source>_7e80c232-2bf0-46e0-b77e-29ec586a23a6</semantic:source>
+        <semantic:target>_7e80c232-2bf0-46e0-b77e-29ec586a23a6</semantic:target>
+    </semantic:relationship>
+</semantic:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Can_Parse_Complex_Process_With_Task_Gateway_BoundaryEvent_etc.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Can_Parse_Complex_Process_With_Task_Gateway_BoundaryEvent_etc.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn">
+    <bpmn:process id="Process_1">
+        <bpmn:startEvent id="Start_1" name="Start">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:task id="Task_1" name="Do Something">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+                <uipath:ioMapping>
+                    <uipath:input target="input1" source="inputExpr" />
+                </uipath:ioMapping>
+                <uipath:task>
+                    <uipath:taskParameters>
+                        <parameter name="param1" value="paramValue1" />
+                    </uipath:taskParameters>
+                    <uipath:ioMapping>
+                        <uipath:output target="output1" />
+                    </uipath:ioMapping>
+                </uipath:task>
+            </bpmn:extensionElements>
+        </bpmn:task>
+
+        <bpmn:unknownNode>
+            <bpmn:unknownAttribute>unknownValue</bpmn:unknownAttribute>
+        </bpmn:unknownNode>
+
+        <bpmn:exclusiveGateway id="Gateway_1" name="Decision">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+            <bpmn:outgoing>Flow_3</bpmn:outgoing>
+            <bpmn:outgoing>Flow_4</bpmn:outgoing>
+        </bpmn:exclusiveGateway>
+
+        <bpmn:endEvent id="End_1" name="End 1">
+            <bpmn:incoming>Flow_3</bpmn:incoming>
+        </bpmn:endEvent>
+
+        <bpmn:endEvent id="End_2" name="End 2">
+            <bpmn:incoming>Flow_5</bpmn:incoming>
+        </bpmn:endEvent>
+
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Task_1" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="Gateway_1" />
+        <bpmn:sequenceFlow id="Flow_3" sourceRef="Gateway_1" targetRef="End_1">
+            <bpmn:unknownElement>
+                <bpmn:unknownAttribute>unknownValue</bpmn:unknownAttribute>
+            </bpmn:unknownElement>
+            <bpmn:conditionExpression>x > 5</bpmn:conditionExpression>
+        </bpmn:sequenceFlow>
+        <bpmn:sequenceFlow id="Flow_4" sourceRef="Gateway_1" targetRef="intermediateCatchEvent_1" />
+        <bpmn:sequenceFlow id="Flow_5" sourceRef="intermediateCatchEvent_1" targetRef="End_2" />
+
+        <bpmn:documentation>
+            <bpmn:text>This is a documentation</bpmn:text>
+        </bpmn:documentation>
+
+        <bpmn:boundaryEvent
+                id="boundaryEvent_1" name="Non-Interrupting Boundary Event" attachedToRef="Task_1" cancelActivity="false">
+            <bpmn:timerEventDefinition>
+                <bpmn:timeDuration>R3/PT30M</bpmn:timeDuration>
+            </bpmn:timerEventDefinition>
+        </bpmn:boundaryEvent>
+
+        <bpmn:intermediateCatchEvent id="intermediateCatchEvent_1" name="Intermediate Catch Event">
+            <bpmn:incoming>Flow_4</bpmn:incoming>
+            <bpmn:outgoing>Flow_5</bpmn:outgoing>
+            <bpmn:timerEventDefinition>
+                <bpmn:timeDuration>PT1H</bpmn:timeDuration>
+            </bpmn:timerEventDefinition>
+        </bpmn:intermediateCatchEvent>
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/ExclusiveGatewayDefaultFlow.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/ExclusiveGatewayDefaultFlow.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1" name="XOR" default="flow_gw_to_script">
+      <bpmn:incoming>flow_start_to_gw</bpmn:incoming>
+      <bpmn:outgoing>flow_gw_to_script</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:scriptTask id="Activity_Script" name="Script Task" scriptFormat="JavaScript">
+      <bpmn:script>console.log('default branch')</bpmn:script>
+      <bpmn:incoming>flow_gw_to_script</bpmn:incoming>
+      <bpmn:outgoing>flow_script_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_script_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_gw" sourceRef="Event_start" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="flow_gw_to_script" sourceRef="Gateway_1" targetRef="Activity_Script" />
+    <bpmn:sequenceFlow id="flow_script_to_end" sourceRef="Activity_Script" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/ExternalAgentWorkflow.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/ExternalAgentWorkflow.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="0c66af93">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1"/>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="65acb40c-cd1d-4d8c-b336-9d22192e8e50"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge___Event_start-Activity_5oRmDa</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_5oRmDa" name="Start and Wait for External Agent">
+      <bpmn:incoming>edge___Event_start-Activity_5oRmDa</bpmn:incoming>
+      <bpmn:outgoing>edge___Activity_5oRmDa-Event_uRXtCv</bpmn:outgoing>
+        <bpmn:extensionElements>
+              <uipath:activity version="v1">
+                <uipath:type value="[extensionType]" version="v1"/>
+		            <uipath:context>
+        		            <uipath:input name="connectorKey" type="string"
+                      value="uipath-crewai-crewai"/>
+        		            <uipath:input name="connection" type="string"
+                      value="717ede25-7494-44d5-9d65-5dab660653f5"/>
+                    <uipath:input name="folderKey" type="string"
+                      value="717ede25-7494-44d5-9d65-5dab660653f6"/>
+                    <uipath:input name="folderPath" type="string"
+                      value="Shared"/>
+                    <uipath:input name="objectName" type="string"
+                      value="INVOKE_CREWAI_COMPLETION"/>
+                    <uipath:input name="eventMode" type="string"
+                      value="webhook"/>
+                    <uipath:input name="operation" type="string"
+                      value="WaitForCrewaiAgent"/>
+                    <uipath:input name="path" type="string"
+                      value="invoke-crewai-agent"/>
+		            </uipath:context>
+		            <uipath:input name="agent" type="string" value="researcher" target="query"/>
+		            <uipath:input name="body" type="json" target="body">
+                  <![CDATA[
+                    {
+                      "description": "Conduct a thorough research ",
+                      "expected_output": "\"A list with 10 bullet points about \" vars.v42119920.topic"
+                    }
+                  ]]>
+		            </uipath:input>
+		            <uipath:output name="response"
+			            type="jsonSchema"
+			            source="=result"
+			            var="vf57f5770" />
+              </uipath:activity>
+          </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_J6RdaW" attachedToRef="Activity_5oRmDa">
+      <bpmn:errorEventDefinition/>
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_uRXtCv">
+      <bpmn:incoming>edge___Activity_5oRmDa-Event_uRXtCv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge___Event_start-Activity_5oRmDa" sourceRef="Event_start" targetRef="Activity_5oRmDa"/>
+    <bpmn:sequenceFlow id="edge___Activity_5oRmDa-Event_uRXtCv" sourceRef="Activity_5oRmDa" targetRef="Event_uRXtCv"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Golden_Scenario.initial.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Golden_Scenario.initial.bpmn
@@ -1,0 +1,361 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1"/>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Invoice Created">
+      <bpmn:documentation>Data service AP invoice created</bpmn:documentation>
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="1853c465-21a5-4cd1-88ee-e3bb84700d52"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>xy-edge___Event_start-Activity_wEyFdi</bpmn:outgoing>
+      <bpmn:messageEventDefinition/>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_crXK5x" name="Is resolution required">
+      <bpmn:incoming>xy-edge___Activity_wEyFdi-Gateway_crXK5x</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Gateway_crXK5x-Activity_rm4sCD</bpmn:outgoing>
+      <bpmn:outgoing>xy-edge__Gateway_crXK5x-Activity_TXpbBw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_rm4sCD" name="Approve Invoice">
+      <bpmn:incoming>xy-edge___Gateway_crXK5x-Activity_rm4sCD</bpmn:incoming>
+      <bpmn:incoming>xy-edge__Gateway_qPUqCu-Activity_rm4sCD</bpmn:incoming>
+      <bpmn:outgoing>xy-edge__Activity_rm4sCD-Event_ZJQg8f</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_ZJQg8f" name="End">
+      <bpmn:incoming>xy-edge__Event_dWJgzS-Event_ZJQg8f</bpmn:incoming>
+      <bpmn:incoming>xy-edge__Activity_rm4sCD-Event_ZJQg8f</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_qPUqCu">
+      <bpmn:incoming>xy-edge__Activity_RyxxTV-Gateway_qPUqCu</bpmn:incoming>
+      <bpmn:incoming>xy-edge__Activity_TXpbBw-Gateway_qPUqCu</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Gateway_qPUqCu-Activity_YLux8m</bpmn:outgoing>
+      <bpmn:outgoing>xy-edge__Gateway_qPUqCu-Activity_rm4sCD</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:task id="Activity_wEyFdi" name="Invoice to PO Matching">
+      <bpmn:incoming>xy-edge___Event_start-Activity_wEyFdi</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Activity_wEyFdi-Gateway_crXK5x</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:task id="Activity_YLux8m" name="Notify Vendor">
+      <bpmn:incoming>xy-edge___Gateway_qPUqCu-Activity_YLux8m</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Activity_YLux8m-Gateway_flbv5e</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:userTask id="Activity_RyxxTV" name="Resolve Discrepancies">
+      <bpmn:incoming>xy-edge__Event_5gGCs9-Activity_RyxxTV</bpmn:incoming>
+      <bpmn:incoming>xy-edge__Event_R2OdAS-Activity_RyxxTV</bpmn:incoming>
+      <bpmn:outgoing>xy-edge__Activity_RyxxTV-Gateway_qPUqCu</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:eventBasedGateway id="Gateway_flbv5e">
+      <bpmn:incoming>xy-edge___Activity_YLux8m-Gateway_flbv5e</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Gateway_flbv5e-Event_dWJgzS</bpmn:outgoing>
+      <bpmn:outgoing>xy-edge___Gateway_flbv5e-Event_5gGCs9</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_dWJgzS" name="No response">
+      <bpmn:incoming>xy-edge___Gateway_flbv5e-Event_dWJgzS</bpmn:incoming>
+      <bpmn:outgoing>xy-edge__Event_dWJgzS-Event_ZJQg8f</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT20S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_5gGCs9">
+      <bpmn:incoming>xy-edge___Gateway_flbv5e-Event_5gGCs9</bpmn:incoming>
+      <bpmn:outgoing>xy-edge__Event_5gGCs9-Activity_RyxxTV</bpmn:outgoing>
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:task id="Activity_TXpbBw" name="Resolve Discrepancies Agent">
+      <bpmn:incoming>xy-edge__Gateway_crXK5x-Activity_TXpbBw</bpmn:incoming>
+      <bpmn:outgoing>xy-edge__Activity_TXpbBw-Gateway_qPUqCu</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:boundaryEvent id="Event_R2OdAS" attachedToRef="Activity_TXpbBw">
+      <bpmn:outgoing>xy-edge__Event_R2OdAS-Activity_RyxxTV</bpmn:outgoing>
+      <bpmn:errorEventDefinition/>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="xy-edge___Event_start-Activity_wEyFdi" sourceRef="Event_start" targetRef="Activity_wEyFdi"/>
+    <bpmn:sequenceFlow id="xy-edge___Activity_wEyFdi-Gateway_crXK5x" sourceRef="Activity_wEyFdi" targetRef="Gateway_crXK5x"/>
+    <bpmn:sequenceFlow id="xy-edge___Gateway_crXK5x-Activity_rm4sCD" name="No" sourceRef="Gateway_crXK5x" targetRef="Activity_rm4sCD">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="xy-edge___Gateway_qPUqCu-Activity_YLux8m" name="Rejected" sourceRef="Gateway_qPUqCu" targetRef="Activity_YLux8m">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="xy-edge__Gateway_qPUqCu-Activity_rm4sCD" name="Resolved" sourceRef="Gateway_qPUqCu" targetRef="Activity_rm4sCD"/>
+    <bpmn:sequenceFlow id="xy-edge__Activity_RyxxTV-Gateway_qPUqCu" sourceRef="Activity_RyxxTV" targetRef="Gateway_qPUqCu"/>
+    <bpmn:sequenceFlow id="xy-edge__Gateway_crXK5x-Activity_TXpbBw" name="Yes" sourceRef="Gateway_crXK5x" targetRef="Activity_TXpbBw">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="xy-edge__Activity_TXpbBw-Gateway_qPUqCu" sourceRef="Activity_TXpbBw" targetRef="Gateway_qPUqCu"/>
+    <bpmn:association id="xy-edge___Event_start-Text_JHUu9H" sourceRef="Event_start" targetRef="Text_JHUu9H"/>
+    <bpmn:association id="xy-edge___Activity_wEyFdi-Text_JTmDcU" sourceRef="Activity_wEyFdi" targetRef="Text_JTmDcU"/>
+    <bpmn:association id="xy-edge___Activity_RyxxTV-Text_ymZSfH" sourceRef="Activity_RyxxTV" targetRef="Text_ymZSfH"/>
+    <bpmn:association id="xy-edge___Activity_TXpbBw-Text_allb53" sourceRef="Activity_TXpbBw" targetRef="Text_allb53"/>
+    <bpmn:association id="xy-edge___Activity_YLux8m-Text_9QALjg" sourceRef="Activity_YLux8m" targetRef="Text_9QALjg"/>
+    <bpmn:sequenceFlow id="xy-edge___Activity_YLux8m-Gateway_flbv5e" sourceRef="Activity_YLux8m" targetRef="Gateway_flbv5e"/>
+    <bpmn:sequenceFlow id="xy-edge___Gateway_flbv5e-Event_dWJgzS" sourceRef="Gateway_flbv5e" targetRef="Event_dWJgzS"/>
+    <bpmn:sequenceFlow id="xy-edge___Gateway_flbv5e-Event_5gGCs9" sourceRef="Gateway_flbv5e" targetRef="Event_5gGCs9"/>
+    <bpmn:sequenceFlow id="xy-edge__Event_dWJgzS-Event_ZJQg8f" sourceRef="Event_dWJgzS" targetRef="Event_ZJQg8f"/>
+    <bpmn:sequenceFlow id="xy-edge__Event_5gGCs9-Activity_RyxxTV" sourceRef="Event_5gGCs9" targetRef="Activity_RyxxTV"/>
+    <bpmn:association id="xy-edge___Event_dWJgzS-Text_ZpgS6R" sourceRef="Event_dWJgzS" targetRef="Text_ZpgS6R"/>
+    <bpmn:association id="xy-edge___Event_5gGCs9-Text_bUKNbR" sourceRef="Event_5gGCs9" targetRef="Text_bUKNbR"/>
+    <bpmn:sequenceFlow id="xy-edge__Event_R2OdAS-Activity_RyxxTV" sourceRef="Event_R2OdAS" targetRef="Activity_RyxxTV"/>
+    <bpmn:sequenceFlow id="xy-edge__Activity_rm4sCD-Event_ZJQg8f" sourceRef="Activity_rm4sCD" targetRef="Event_ZJQg8f"/>
+    <bpmn:association id="xy-edge__Activity_rm4sCD-Text_GvGiGx" sourceRef="Activity_rm4sCD" targetRef="Text_GvGiGx"/>
+    <bpmn:textAnnotation id="Text_JHUu9H">
+      <bpmn:text>(Data Service) AP Invoice  entity item created trigger</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_JTmDcU">
+      <bpmn:text>(Automation) 2-way matching process </bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_ymZSfH">
+      <bpmn:text>(Action Center) App Task form with Invoice details and potential PO lookup logic</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_allb53">
+      <bpmn:text>(Agent) Resolve Discrepancies</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_9QALjg">
+      <bpmn:text>(Integration Service) Send email</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_GvGiGx">
+      <bpmn:text>(Automation or IS) Update Invoice status</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_ZpgS6R">
+      <bpmn:text>(Timer) wait 1 day before ending the process</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="Text_bUKNbR">
+      <bpmn:text>(Integration Service) Wait for email received trigger</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="200" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_crXK5x" bpmnElement="Gateway_crXK5x">
+        <dc:Bounds x="471.9565709969789" y="193" width="50" height="50"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="471.9565709969789" y="248" width="50" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_rm4sCD" bpmnElement="Activity_rm4sCD">
+        <dc:Bounds x="646.1280667266545" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="646.1280667266545" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_ZJQg8f" bpmnElement="Event_ZJQg8f">
+        <dc:Bounds x="1083.8582326283988" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1083.8582326283988" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_qPUqCu" bpmnElement="Gateway_qPUqCu">
+        <dc:Bounds x="671.1280667266545" y="362.3331509376673" width="50" height="50"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="671.1280667266545" y="417.3331509376673" width="50" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_wEyFdi" bpmnElement="Activity_wEyFdi">
+        <dc:Bounds x="294.7275679758308" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="294.7275679758308" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_YLux8m" bpmnElement="Activity_YLux8m">
+        <dc:Bounds x="908.8582326283988" y="347.3331509376673" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="908.8582326283988" y="432.3331509376673" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_RyxxTV" bpmnElement="Activity_RyxxTV">
+        <dc:Bounds x="646.1280667266545" y="627.5797192810089" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="646.1280667266545" y="712.5797192810089" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_JHUu9H" bpmnElement="Text_JHUu9H">
+        <dc:Bounds x="161" y="59" width="114" height="67"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="161" y="131" width="114" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_JTmDcU" bpmnElement="Text_JTmDcU">
+        <dc:Bounds x="294.7275679758308" y="50.001462681719914" width="120" height="53"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="294.7275679758308" y="108.00146268171991" width="120" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_ymZSfH" bpmnElement="Text_ymZSfH">
+        <dc:Bounds x="525.6871503347235" y="512.6060808439795" width="125" height="85"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="525.6871503347235" y="602.6060808439795" width="125" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_allb53" bpmnElement="Text_allb53">
+        <dc:Bounds x="291.7275679758308" y="353.8331509376673" width="106" height="67"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="291.7275679758308" y="425.8331509376673" width="106" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_9QALjg" bpmnElement="Text_9QALjg">
+        <dc:Bounds x="796.466144426491" y="481.95520822874937" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="796.466144426491" y="566.9552082287494" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_GvGiGx" bpmnElement="Text_GvGiGx">
+        <dc:Bounds x="689.0118580060423" y="36.501462681719914" width="143" height="69"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="689.0118580060423" y="110.50146268171991" width="143" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_flbv5e" bpmnElement="Gateway_flbv5e">
+        <dc:Bounds x="933.8582326283988" y="496.95520822874937" width="50" height="50"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="933.8582326283988" y="551.9552082287494" width="50" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_dWJgzS" bpmnElement="Event_dWJgzS">
+        <dc:Bounds x="1083.8582326283988" y="503.95520822874937" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1083.8582326283988" y="544.9552082287494" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_5gGCs9" bpmnElement="Event_5gGCs9">
+        <dc:Bounds x="941.4207347091495" y="649.5797192810089" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="941.4207347091495" y="690.5797192810089" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_ZpgS6R" bpmnElement="Text_ZpgS6R">
+        <dc:Bounds x="1219.8582326283988" y="381.95520822874937" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1219.8582326283988" y="466.95520822874937" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Text_bUKNbR" bpmnElement="Text_bUKNbR">
+        <dc:Bounds x="908.4207347091495" y="722.6212174164268" width="102" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="908.4207347091495" y="807.6212174164268" width="102" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_TXpbBw" bpmnElement="Activity_TXpbBw">
+        <dc:Bounds x="446.9565709969789" y="347.3331509376673" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="446.9565709969789" y="432.3331509376673" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_R2OdAS" bpmnElement="Event_R2OdAS">
+        <dc:Bounds x="479" y="409.3331509376673" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="479" y="450.3331509376673" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Event_start-Activity_wEyFdi" bpmnElement="xy-edge___Event_start-Activity_wEyFdi">
+        <di:waypoint x="236" y="218"/>
+        <di:waypoint x="294.7275679758308" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_wEyFdi-Gateway_crXK5x" bpmnElement="xy-edge___Activity_wEyFdi-Gateway_crXK5x">
+        <di:waypoint x="394.7275679758308" y="218"/>
+        <di:waypoint x="471.9565709969789" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Gateway_crXK5x-Activity_rm4sCD" bpmnElement="xy-edge___Gateway_crXK5x-Activity_rm4sCD">
+        <di:waypoint x="521.9565709969788" y="218"/>
+        <di:waypoint x="646.1280667266545" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Gateway_qPUqCu-Activity_YLux8m" bpmnElement="xy-edge___Gateway_qPUqCu-Activity_YLux8m">
+        <di:waypoint x="721.1280667266545" y="387"/>
+        <di:waypoint x="908.8582326283988" y="387"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Gateway_qPUqCu-Activity_rm4sCD" bpmnElement="xy-edge__Gateway_qPUqCu-Activity_rm4sCD">
+        <di:waypoint x="696" y="362.3331509376673"/>
+        <di:waypoint x="696" y="258"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Activity_RyxxTV-Gateway_qPUqCu" bpmnElement="xy-edge__Activity_RyxxTV-Gateway_qPUqCu">
+        <di:waypoint x="696" y="627.5797192810089"/>
+        <di:waypoint x="696" y="412.3331509376673"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Gateway_crXK5x-Activity_TXpbBw" bpmnElement="xy-edge__Gateway_crXK5x-Activity_TXpbBw">
+        <di:waypoint x="497" y="243"/>
+        <di:waypoint x="497" y="347.3331509376673"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Activity_TXpbBw-Gateway_qPUqCu" bpmnElement="xy-edge__Activity_TXpbBw-Gateway_qPUqCu">
+        <di:waypoint x="546.9565709969788" y="387"/>
+        <di:waypoint x="671.1280667266545" y="387"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Event_start-Text_JHUu9H" bpmnElement="xy-edge___Event_start-Text_JHUu9H">
+        <di:waypoint x="218" y="200"/>
+        <di:waypoint x="218" y="126"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_wEyFdi-Text_JTmDcU" bpmnElement="xy-edge___Activity_wEyFdi-Text_JTmDcU">
+        <di:waypoint x="345" y="178"/>
+        <di:waypoint x="345" y="141"/>
+        <di:waypoint x="355" y="141"/>
+        <di:waypoint x="355" y="103.00146268171991"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_RyxxTV-Text_ymZSfH" bpmnElement="xy-edge___Activity_RyxxTV-Text_ymZSfH">
+        <di:waypoint x="696" y="627.5797192810089"/>
+        <di:waypoint x="696" y="613"/>
+        <di:waypoint x="588" y="613"/>
+        <di:waypoint x="588" y="597.6060808439795"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_TXpbBw-Text_allb53" bpmnElement="xy-edge___Activity_TXpbBw-Text_allb53">
+        <di:waypoint x="446.9565709969789" y="387"/>
+        <di:waypoint x="397.7275679758308" y="387"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_YLux8m-Text_9QALjg" bpmnElement="xy-edge___Activity_YLux8m-Text_9QALjg">
+        <di:waypoint x="959" y="427.3331509376673"/>
+        <di:waypoint x="959" y="455"/>
+        <di:waypoint x="846" y="455"/>
+        <di:waypoint x="846" y="481.95520822874937"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_YLux8m-Gateway_flbv5e" bpmnElement="xy-edge___Activity_YLux8m-Gateway_flbv5e">
+        <di:waypoint x="959" y="427.3331509376673"/>
+        <di:waypoint x="959" y="496.95520822874937"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Gateway_flbv5e-Event_dWJgzS" bpmnElement="xy-edge___Gateway_flbv5e-Event_dWJgzS">
+        <di:waypoint x="983.8582326283988" y="522"/>
+        <di:waypoint x="1083.8582326283988" y="522"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Gateway_flbv5e-Event_5gGCs9" bpmnElement="xy-edge___Gateway_flbv5e-Event_5gGCs9">
+        <di:waypoint x="959" y="546.9552082287494"/>
+        <di:waypoint x="959" y="649.5797192810089"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Event_dWJgzS-Event_ZJQg8f" bpmnElement="xy-edge__Event_dWJgzS-Event_ZJQg8f">
+        <di:waypoint x="1102" y="503.95520822874937"/>
+        <di:waypoint x="1102" y="236"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Event_5gGCs9-Activity_RyxxTV" bpmnElement="xy-edge__Event_5gGCs9-Activity_RyxxTV">
+        <di:waypoint x="941.4207347091495" y="668"/>
+        <di:waypoint x="746.1280667266545" y="668"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Event_dWJgzS-Text_ZpgS6R" bpmnElement="xy-edge___Event_dWJgzS-Text_ZpgS6R">
+        <di:waypoint x="1119.8582326283988" y="522"/>
+        <di:waypoint x="1170" y="522"/>
+        <di:waypoint x="1170" y="422"/>
+        <di:waypoint x="1219.8582326283988" y="422"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Event_5gGCs9-Text_bUKNbR" bpmnElement="xy-edge___Event_5gGCs9-Text_bUKNbR">
+        <di:waypoint x="959" y="685.5797192810089"/>
+        <di:waypoint x="959" y="722.6212174164268"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Event_R2OdAS-Activity_RyxxTV" bpmnElement="xy-edge__Event_R2OdAS-Activity_RyxxTV">
+        <di:waypoint x="497" y="445.3331509376673"/>
+        <di:waypoint x="495" y="669"/>
+        <di:waypoint x="581" y="668"/>
+        <di:waypoint x="646.1280667266545" y="668"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Activity_rm4sCD-Event_ZJQg8f" bpmnElement="xy-edge__Activity_rm4sCD-Event_ZJQg8f">
+        <di:waypoint x="746.1280667266545" y="218"/>
+        <di:waypoint x="1083.8582326283988" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge__Activity_rm4sCD-Text_GvGiGx" bpmnElement="xy-edge__Activity_rm4sCD-Text_GvGiGx">
+        <di:waypoint x="696" y="178"/>
+        <di:waypoint x="696" y="142"/>
+        <di:waypoint x="761" y="142"/>
+        <di:waypoint x="761" y="105.50146268171991"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/InclusiveJoinRouteAwayBranch.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/InclusiveJoinRouteAwayBranch.bpmn
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_fork</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:inclusiveGateway id="Gateway_fork">
+      <bpmn:incoming>flow_start_to_fork</bpmn:incoming>
+      <bpmn:outgoing>flow_fork_to_a</bpmn:outgoing>
+      <bpmn:outgoing>flow_fork_to_xor</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:scriptTask id="Activity_A" name="Task A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_a</bpmn:incoming>
+      <bpmn:outgoing>flow_a_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:exclusiveGateway id="Gateway_xor" name="XOR" default="flow_xor_away">
+      <bpmn:incoming>flow_fork_to_xor</bpmn:incoming>
+      <bpmn:outgoing>flow_xor_to_join</bpmn:outgoing>
+      <bpmn:outgoing>flow_xor_away</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:scriptTask id="Activity_Away" name="Task Away" scriptFormat="JavaScript">
+      <bpmn:script>console.log('Away')</bpmn:script>
+      <bpmn:incoming>flow_xor_away</bpmn:incoming>
+      <bpmn:outgoing>flow_away_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:inclusiveGateway id="Gateway_join">
+      <bpmn:incoming>flow_a_to_join</bpmn:incoming>
+      <bpmn:incoming>flow_xor_to_join</bpmn:incoming>
+      <bpmn:outgoing>flow_join_to_d</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:scriptTask id="Activity_D" name="Task D" scriptFormat="JavaScript">
+      <bpmn:script>console.log('D')</bpmn:script>
+      <bpmn:incoming>flow_join_to_d</bpmn:incoming>
+      <bpmn:outgoing>flow_d_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end_main">
+      <bpmn:incoming>flow_d_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_end_away">
+      <bpmn:incoming>flow_away_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_fork" sourceRef="Event_start" targetRef="Gateway_fork" />
+    <bpmn:sequenceFlow id="flow_fork_to_a" sourceRef="Gateway_fork" targetRef="Activity_A" />
+    <bpmn:sequenceFlow id="flow_fork_to_xor" sourceRef="Gateway_fork" targetRef="Gateway_xor" />
+    <bpmn:sequenceFlow id="flow_a_to_join" sourceRef="Activity_A" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_xor_to_join" sourceRef="Gateway_xor" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_xor_away" sourceRef="Gateway_xor" targetRef="Activity_Away" />
+    <bpmn:sequenceFlow id="flow_away_to_end" sourceRef="Activity_Away" targetRef="Event_end_away" />
+    <bpmn:sequenceFlow id="flow_join_to_d" sourceRef="Gateway_join" targetRef="Activity_D" />
+    <bpmn:sequenceFlow id="flow_d_to_end" sourceRef="Activity_D" targetRef="Event_end_main" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_AsyncExecution_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_AsyncExecution_And_Create_CorrectModel.bpmn
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" >
+    <bpmn:process id="Process_1">
+
+        <bpmn:extensionElements>
+            <uipath:variables>
+              <uipath:inputOutput
+                id="vf57f5770"
+                elementId="Activity_b0ea8ed9"
+                name="Response"
+                type="json"
+                default="" />
+            </uipath:variables>
+            <uipath:bindings>
+              <uipath:binding
+                id="bda315f50"
+                name="Connection"
+                type="string"
+                default="fa9e0590-a6bb-11ef-b0e6-df3b66e154f8" />
+            </uipath:bindings>
+          </bpmn:extensionElements>
+
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:serviceTask name="Research task" id="Activity_b0ea8ed9">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+                <uipath:activity version="v1">
+                    <uipath:type value="[extensionType]" version="v1"/>
+                    <uipath:context>
+                        <uipath:input name="connectorKey" type="string"
+                                      value="uipath-crewai-crewai"/>
+                        <uipath:input name="connectionId" type="string"
+                                      value="=bindings.bda315f50"/>
+                        <!-- should be binded -->
+                        <uipath:input name="folderKey" type="string"
+                                      value="717ede25-7494-44d5-9d65-5dab660653f6"/>
+                        <uipath:input name="folderPath" type="string"
+                                      value="Shared"/>
+                        <uipath:input name="objectName" type="string"
+                                      value="INVOKE_CREWAI_COMPLETION"/>
+                        <uipath:input name="operation" type="string"
+                                      value="WaitForCrewaiAgent"/>
+                        <!-- not sure if this is needed -->
+                        <uipath:input name="path" type="string"
+                                      value="invoke-crewai-agent"/>
+                    </uipath:context>
+                    <uipath:input name="agent" type="string" value="researcher" target="query"/>
+                    <uipath:input name="body" type="json" target="body">
+                        <![CDATA[
+                            {
+                              "description": "Conduct a thorough research ",
+                              "expected_output": "\"A list with 10 bullet points about \" vars.v42119920.topic"
+                            }
+                          ]]>
+                    </uipath:input>
+                    <uipath:output name="response"
+                                   type="jsonSchema"
+                                   source="=result"
+                                   var="vf57f5770" />
+                </uipath:activity>
+            </bpmn:extensionElements>
+        </bpmn:serviceTask>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Activity_b0ea8ed9" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_b0ea8ed9" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_ExtractionValidation_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_ExtractionValidation_And_Create_CorrectModel.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" >
+    <bpmn:process id="Process_1">
+
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:serviceTask id="Activity_Validate" name="IxP Extraction Validation">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+              <uipath:activity version="v1">
+                <uipath:type value="IXP.ExtractionValidation" version="v2" />
+                <uipath:input name="extractionResult" type="jsonSchema" target="bodyField" value="= vars.content.extractionResult" />
+                <uipath:input name="documentId" type="string" target="bodyField" value="= vars.digitizedDocumentId" />
+                <uipath:input name="actionTitle" type="string" target="bodyField" value="Review Invoice Extraction" />
+                <uipath:input name="actionPriority" type="string" target="bodyField" value="Low" />
+                <uipath:input name="actionCatalog" type="string" target="bodyField" value="= vars.actionCatalog" />
+                <uipath:input name="actionFolder" type="string" target="bodyField" value="= vars.actionFolder" />
+                <uipath:input name="storageBucketName" type="string" target="bodyField" value="= vars.bucketName" />
+                <uipath:input name="storageBucketDirectoryPath" type="string" target="bodyField" value="= vars.bucketPath" />
+                <uipath:output name="Error" type="jsonSchema" source="=Error" var="validationError" />
+                <uipath:output name="content" type="jsonSchema" source="=result" var="validatedContent" />
+              </uipath:activity>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Activity_Validate" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_Validate" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_Extraction_FileUpload_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_Extraction_FileUpload_And_Create_CorrectModel.bpmn
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" >
+    <bpmn:process id="Process_1">
+
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:serviceTask id="Activity_Extract" name="IxP Extraction">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+              <uipath:activity version="v1">
+                <uipath:type value="IXP.Extraction" version="v2" />
+                <uipath:context>
+                    <uipath:input name="folderKey" type="string" value="=bindings.bFolderKey" />
+                    <uipath:input name="modelName" type="string" value="=bindings.bModelName" />
+                    <uipath:input name="digitizationMode" type="string" value="fileUpload" />
+                </uipath:context>
+                <uipath:input name="input" type="json" target="bodyField"><![CDATA[{"downloadedFileOutput":"=js:vars.start.output.invoice"}]]></uipath:input>
+                <uipath:output name="postmanapikey1.Error" type="jsonSchema" source="=Error" var="postmanapikey1.error" />
+                <uipath:output name="postmanapikey1.content" type="jsonSchema" source="=result" var="postmanapikey1.content" />
+              </uipath:activity>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Activity_Extract" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_Extract" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_Extraction_JobAttachment_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_IXP_Extraction_JobAttachment_And_Create_CorrectModel.bpmn
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" >
+    <bpmn:process id="Process_1">
+
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:serviceTask id="Activity_Extract" name="IxP Extraction">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+              <uipath:activity version="v1">
+                <uipath:type value="IXP.Extraction" version="v2" />
+                <uipath:context>
+                    <uipath:input name="folderKey" type="string" value="=bindings.bFolderKey" />
+                    <uipath:input name="modelName" type="string" value="=bindings.bModelName" />
+                    <uipath:input name="digitizationMode" type="string" value="jobAttachment" />
+                </uipath:context>
+                <uipath:input name="attachmentId" type="string" target="bodyField" value="= vars.attachmentId" />
+                <uipath:input name="fileName" type="string" target="bodyField" value="= vars.fileName" />
+                <uipath:input name="mimeType" type="string" target="bodyField" value="= vars.mimeType" />
+                <uipath:output name="Error" type="jsonSchema" source="=Error" var="error" />
+                <uipath:output name="content" type="jsonSchema" source="=result" var="content" />
+              </uipath:activity>
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Activity_Extract" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Activity_Extract" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_SubProcess_With_Multiple_Element_Types.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/Parse_SubProcess_With_Multiple_Element_Types.bpmn
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+                  xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+                  xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="Event_start" name="Start">
+      <bpmn:outgoing>Flow_1</bpmn:outgoing>
+    </bpmn:startEvent>
+
+    <bpmn:subProcess id="SubProcess_1" name="Complex SubProcess">
+      <bpmn:incoming>Flow_1</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+
+      <bpmn:startEvent id="SubProcess_Start" name="Sub Start">
+        <bpmn:outgoing>Flow_Sub_1</bpmn:outgoing>
+      </bpmn:startEvent>
+
+      <bpmn:task id="Task_1" name="Task One">
+        <bpmn:incoming>Flow_Sub_1</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_2</bpmn:outgoing>
+      </bpmn:task>
+
+      <bpmn:exclusiveGateway id="Gateway_1" name="Decision">
+        <bpmn:incoming>Flow_Sub_2</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_3</bpmn:outgoing>
+        <bpmn:outgoing>Flow_Sub_4</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+
+      <bpmn:task id="Task_2" name="Task Two">
+        <bpmn:incoming>Flow_Sub_3</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_5</bpmn:outgoing>
+      </bpmn:task>
+
+      <bpmn:intermediateCatchEvent id="Timer_1" name="Wait 5s">
+        <bpmn:incoming>Flow_Sub_4</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_6</bpmn:outgoing>
+        <bpmn:timerEventDefinition>
+          <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT5S</bpmn:timeDuration>
+        </bpmn:timerEventDefinition>
+      </bpmn:intermediateCatchEvent>
+
+      <bpmn:task id="Task_3" name="Task Three">
+        <bpmn:incoming>Flow_Sub_6</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_7</bpmn:outgoing>
+      </bpmn:task>
+
+      <bpmn:parallelGateway id="Gateway_2" name="Merge">
+        <bpmn:incoming>Flow_Sub_5</bpmn:incoming>
+        <bpmn:incoming>Flow_Sub_7</bpmn:incoming>
+        <bpmn:outgoing>Flow_Sub_8</bpmn:outgoing>
+      </bpmn:parallelGateway>
+
+      <bpmn:endEvent id="SubProcess_End" name="Sub End">
+        <bpmn:incoming>Flow_Sub_8</bpmn:incoming>
+      </bpmn:endEvent>
+
+      <bpmn:sequenceFlow id="Flow_Sub_1" sourceRef="SubProcess_Start" targetRef="Task_1"/>
+      <bpmn:sequenceFlow id="Flow_Sub_2" sourceRef="Task_1" targetRef="Gateway_1"/>
+      <bpmn:sequenceFlow id="Flow_Sub_3" sourceRef="Gateway_1" targetRef="Task_2"/>
+      <bpmn:sequenceFlow id="Flow_Sub_4" sourceRef="Gateway_1" targetRef="Timer_1"/>
+      <bpmn:sequenceFlow id="Flow_Sub_5" sourceRef="Task_2" targetRef="Gateway_2"/>
+      <bpmn:sequenceFlow id="Flow_Sub_6" sourceRef="Timer_1" targetRef="Task_3"/>
+      <bpmn:sequenceFlow id="Flow_Sub_7" sourceRef="Task_3" targetRef="Gateway_2"/>
+      <bpmn:sequenceFlow id="Flow_Sub_8" sourceRef="Gateway_2" targetRef="SubProcess_End"/>
+    </bpmn:subProcess>
+
+    <bpmn:endEvent id="Event_end" name="End">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+    </bpmn:endEvent>
+
+    <bpmn:sequenceFlow id="Flow_1" sourceRef="Event_start" targetRef="SubProcess_1"/>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="SubProcess_1" targetRef="Event_end"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/StartEventWithOutputs.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/StartEventWithOutputs.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Start event">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="bb939eb6-234d-4613-85d8-9be7d44ba41a" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="filesIn" type="string" source="=vars.seed" var="filesIn" custom="true" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_end</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_start_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_end" sourceRef="Event_start" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="160" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end" bpmnElement="Event_end">
+        <dc:Bounds x="246" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_flow_start_to_end" bpmnElement="flow_start_to_end">
+        <di:waypoint x="196" y="218" />
+        <di:waypoint x="246" y="218" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/StartGatewayEnd.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/StartGatewayEnd.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:inclusiveGateway id="Gateway_1" name="XOR" default="flow_gw_to_end">
+      <bpmn:incoming>flow_start_to_gw</bpmn:incoming>
+      <bpmn:outgoing>flow_gw_to_end</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_gw_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_gw" sourceRef="Event_start" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="flow_gw_to_end" sourceRef="Gateway_1" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="160" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_1" bpmnElement="Gateway_1" isMarkerVisible="true">
+        <dc:Bounds x="246" y="193" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end" bpmnElement="Event_end">
+        <dc:Bounds x="346" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_flow_start_to_gw" bpmnElement="flow_start_to_gw">
+        <di:waypoint x="196" y="218" />
+        <di:waypoint x="246" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_gw_to_end" bpmnElement="flow_gw_to_end">
+        <di:waypoint x="296" y="218" />
+        <di:waypoint x="346" y="218" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/all elements.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/all elements.bpmn
@@ -1,0 +1,516 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0wj0bbd" targetNamespace="http://bpmn.io/schema/bpmn" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="5ecc5f16">
+  <bpmn:process id="Process_0mv7p15" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="7" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_0mk32cd" name="Start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="efe78754-f0de-41a8-92ad-7a25230f301e" />
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:intermediateThrowEvent id="Event_0l2shfn" name="Intermediate" />
+    <bpmn:endEvent id="Event_1os1zgv" name="End" />
+    <bpmn:startEvent id="Event_0zvos65" name="Message">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="457542ad-0198-44a2-9040-87a4bf662de5" />
+      </bpmn:extensionElements>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_05rwem6" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_15fjgct" name="Timer">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="d2fcbddc-42ac-4b58-b654-d1ccacb831ba" />
+      </bpmn:extensionElements>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1ycwfpk" />
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_0np147t" name="Conditional">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="b2acf192-c6bd-4f4f-a0b0-942b58522257" />
+      </bpmn:extensionElements>
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_19psz7y">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:startEvent>
+    <bpmn:startEvent id="Event_0owri6g" name="Signal">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="c81c51d8-8344-4965-afa2-56c09c8215d0" />
+      </bpmn:extensionElements>
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0fj3c3u" />
+    </bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="Event_0hxp9iu" name="Message Catch">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0qdy5gm" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_1ei749w" name="Message Thow">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0fcuyg8" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_0a977ke" name="Timer Catch">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1suhzy8" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_0flmphj" name="Escalation Throw">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1bdhe6f" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_08lgz6z" name="Conditional Catch">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1p0fos6">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_0281d9f" name="Link Catch">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_04k2i7l" name="" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_0vuj4zz" name="Link Throw">
+      <bpmn:linkEventDefinition id="LinkEventDefinition_1w700b1" name="" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateThrowEvent id="Event_1l5zrre" name="Compensate Throw">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_02pqdqx" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_14z2v49" name="Signal Catch">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_14qowum" />
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateThrowEvent id="Event_1uz8idf" name="Signal Throw">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0uf4hvf" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_11dum6i" name="Message">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0psyje1" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_063o2ub" name="Error">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0mc66di" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_1pqx7xm" name="Compensate">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ho9bup" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0guh2rh" name="Signal">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_04e7p3s" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0hhhktn" name="Terminate">
+      <bpmn:terminateEventDefinition id="TerminateEventDefinition_1mbnucd" />
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_0pmqpgc" name="Escalation">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_0jnct7z" />
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_1dx4ix0" name="Exclusive" />
+    <bpmn:parallelGateway id="Gateway_1w26pi9" name="Parallel" />
+    <bpmn:inclusiveGateway id="Gateway_0i7b2wu" name="Inclusive" />
+    <bpmn:complexGateway id="Gateway_1q2137q" name="Complex" />
+    <bpmn:eventBasedGateway id="Gateway_1mzvww4" name="Gateway" />
+    <bpmn:task id="Activity_0awt79p" name="Activity" />
+    <bpmn:userTask id="Activity_1o7ta7z" name="User" />
+    <bpmn:serviceTask id="Activity_18n0m3d" name="Service" />
+    <bpmn:sendTask id="Activity_1a837s3" name="Send" />
+    <bpmn:receiveTask id="Activity_01vpyey" name="Receive" />
+    <bpmn:manualTask id="Activity_1uroqkr" name="Human" />
+    <bpmn:businessRuleTask id="Activity_1c2rvj9" name="Business rule" />
+    <bpmn:scriptTask id="Activity_1lirgn7" name="Script" scriptFormat="JavaScript">
+      <bpmn:script><![CDATA[return {};]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:callActivity id="Activity_1rhb5bx" name="Call activity" />
+    <bpmn:dataStoreReference id="DataStoreReference_0q67g3k" />
+    <bpmn:dataObjectReference id="DataObjectReference_0y7osq9" />
+    <bpmn:subProcess id="Activity_1wi7oqr">
+      <bpmn:startEvent id="Event_0xedgma" />
+    </bpmn:subProcess>
+    <bpmn:boundaryEvent id="Event_08av9ys" attachedToRef="Activity_1wi7oqr">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_16enpt0" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0lvihoc" attachedToRef="Activity_1wi7oqr">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0ric9m3" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_18vg8wz" attachedToRef="Activity_1wi7oqr">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1skqw9j">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0yhvw36" attachedToRef="Activity_1wi7oqr">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_10fljfm" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0kog3ox" attachedToRef="Activity_1wi7oqr">
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_0rj4w4v" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_0p6uyl9" attachedToRef="Activity_1wi7oqr">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0gj7k9r" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1ez2g68" attachedToRef="Activity_1wi7oqr">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0offre4" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1vkn6of" cancelActivity="false" attachedToRef="Activity_1wi7oqr">
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0ib2lpu" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1cjxyg0" attachedToRef="Activity_1wi7oqr" />
+    <bpmn:boundaryEvent id="Event_0djfq6b" cancelActivity="false" attachedToRef="Activity_1wi7oqr">
+      <bpmn:timerEventDefinition id="TimerEventDefinition_0y5yd4j" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_1jjna6i" cancelActivity="false" attachedToRef="Activity_1wi7oqr">
+      <bpmn:escalationEventDefinition id="EscalationEventDefinition_1qet6st" />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_047gkeg" cancelActivity="false" attachedToRef="Activity_1wi7oqr">
+      <bpmn:conditionalEventDefinition id="ConditionalEventDefinition_1lgngtd">
+        <bpmn:condition xsi:type="bpmn:tFormalExpression" />
+      </bpmn:conditionalEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_051j0c0" cancelActivity="false" attachedToRef="Activity_1wi7oqr">
+      <bpmn:signalEventDefinition id="SignalEventDefinition_0v4k0zx" />
+    </bpmn:boundaryEvent>
+    <bpmn:association id="Association_0t3kq6h" associationDirection="None" sourceRef="DataStoreReference_0q67g3k" targetRef="TextAnnotation_0eiihmf" />
+    <bpmn:association id="Association_06hpkks" associationDirection="None" sourceRef="DataObjectReference_0y7osq9" targetRef="TextAnnotation_02dth6m" />
+    <bpmn:group id="Group_13fnhcu" />
+    <bpmn:textAnnotation id="TextAnnotation_02dth6m">
+      <bpmn:text>data object</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:textAnnotation id="TextAnnotation_0eiihmf">
+      <bpmn:text>data store</bpmn:text>
+    </bpmn:textAnnotation>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0mv7p15">
+      <bpmndi:BPMNShape id="S_Group_13fnhcu" bpmnElement="Group_13fnhcu">
+        <dc:Bounds x="320" y="590" width="300" height="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="825" width="300" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_StartEvent_0mk32cd" bpmnElement="StartEvent_0mk32cd">
+        <dc:Bounds x="156" y="31" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="72" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0l2shfn" bpmnElement="Event_0l2shfn">
+        <dc:Bounds x="156" y="112" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="153" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1os1zgv" bpmnElement="Event_1os1zgv">
+        <dc:Bounds x="156" y="212" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="253" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0zvos65" bpmnElement="Event_0zvos65">
+        <dc:Bounds x="224" y="31" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="224" y="72" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_15fjgct" bpmnElement="Event_15fjgct">
+        <dc:Bounds x="294" y="31" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="294" y="72" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0np147t" bpmnElement="Event_0np147t">
+        <dc:Bounds x="360" y="31" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="360" y="72" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0owri6g" bpmnElement="Event_0owri6g">
+        <dc:Bounds x="424" y="31" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="424" y="72" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0hxp9iu" bpmnElement="Event_0hxp9iu">
+        <dc:Bounds x="224" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="224" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1ei749w" bpmnElement="Event_1ei749w">
+        <dc:Bounds x="292" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="292" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0a977ke" bpmnElement="Event_0a977ke">
+        <dc:Bounds x="360" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="360" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0flmphj" bpmnElement="Event_0flmphj">
+        <dc:Bounds x="424" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="424" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_08lgz6z" bpmnElement="Event_08lgz6z">
+        <dc:Bounds x="486" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="486" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0281d9f" bpmnElement="Event_0281d9f">
+        <dc:Bounds x="552" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="552" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0vuj4zz" bpmnElement="Event_0vuj4zz">
+        <dc:Bounds x="616" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="616" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1l5zrre" bpmnElement="Event_1l5zrre">
+        <dc:Bounds x="683" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="683" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_14z2v49" bpmnElement="Event_14z2v49">
+        <dc:Bounds x="743" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="743" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1uz8idf" bpmnElement="Event_1uz8idf">
+        <dc:Bounds x="809" y="113" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="809" y="154" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_11dum6i" bpmnElement="Event_11dum6i">
+        <dc:Bounds x="222" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="222" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_063o2ub" bpmnElement="Event_063o2ub">
+        <dc:Bounds x="356" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="356" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1pqx7xm" bpmnElement="Event_1pqx7xm">
+        <dc:Bounds x="422" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="422" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0guh2rh" bpmnElement="Event_0guh2rh">
+        <dc:Bounds x="486" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="486" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0hhhktn" bpmnElement="Event_0hhhktn">
+        <dc:Bounds x="552" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="552" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0pmqpgc" bpmnElement="Event_0pmqpgc">
+        <dc:Bounds x="292" y="211" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="292" y="252" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_1dx4ix0" bpmnElement="Gateway_1dx4ix0">
+        <dc:Bounds x="149" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="149" y="380" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_1w26pi9" bpmnElement="Gateway_1w26pi9">
+        <dc:Bounds x="215" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="215" y="380" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_0i7b2wu" bpmnElement="Gateway_0i7b2wu">
+        <dc:Bounds x="285" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="285" y="380" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_1q2137q" bpmnElement="Gateway_1q2137q">
+        <dc:Bounds x="351" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="351" y="380" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_1mzvww4" bpmnElement="Gateway_1mzvww4">
+        <dc:Bounds x="415" y="325" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="415" y="380" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_0awt79p" bpmnElement="Activity_0awt79p">
+        <dc:Bounds x="140" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="140" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1o7ta7z" bpmnElement="Activity_1o7ta7z">
+        <dc:Bounds x="260" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_18n0m3d" bpmnElement="Activity_18n0m3d">
+        <dc:Bounds x="380" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="380" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1a837s3" bpmnElement="Activity_1a837s3">
+        <dc:Bounds x="500" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="500" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_01vpyey" bpmnElement="Activity_01vpyey">
+        <dc:Bounds x="620" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="620" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1uroqkr" bpmnElement="Activity_1uroqkr">
+        <dc:Bounds x="740" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="740" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1c2rvj9" bpmnElement="Activity_1c2rvj9">
+        <dc:Bounds x="860" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="860" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1lirgn7" bpmnElement="Activity_1lirgn7">
+        <dc:Bounds x="980" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="980" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1rhb5bx" bpmnElement="Activity_1rhb5bx">
+        <dc:Bounds x="1100" y="450" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1100" y="535" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_DataStoreReference_0q67g3k" bpmnElement="DataStoreReference_0q67g3k">
+        <dc:Bounds x="149" y="785" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="149" y="840" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_DataObjectReference_0y7osq9" bpmnElement="DataObjectReference_0y7osq9">
+        <dc:Bounds x="156" y="645" width="36" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="700" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1wi7oqr" bpmnElement="Activity_1wi7oqr" isExpanded="true">
+        <dc:Bounds x="670" y="590" width="720" height="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="670" y="825" width="720" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0xedgma" bpmnElement="Event_0xedgma">
+        <dc:Bounds x="710" y="672" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="710" y="713" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_08av9ys" bpmnElement="Event_08av9ys">
+        <dc:Bounds x="692" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="692" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0lvihoc" bpmnElement="Event_0lvihoc">
+        <dc:Bounds x="742" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="742" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_18vg8wz" bpmnElement="Event_18vg8wz">
+        <dc:Bounds x="792" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="792" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0yhvw36" bpmnElement="Event_0yhvw36">
+        <dc:Bounds x="842" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="842" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0kog3ox" bpmnElement="Event_0kog3ox">
+        <dc:Bounds x="892" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="892" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0p6uyl9" bpmnElement="Event_0p6uyl9">
+        <dc:Bounds x="942" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="942" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1ez2g68" bpmnElement="Event_1ez2g68">
+        <dc:Bounds x="992" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="992" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1vkn6of" bpmnElement="Event_1vkn6of">
+        <dc:Bounds x="1062" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1062" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1cjxyg0" bpmnElement="Event_1cjxyg0">
+        <dc:Bounds x="652" y="764" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="652" y="805" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0djfq6b" bpmnElement="Event_0djfq6b">
+        <dc:Bounds x="1112" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1112" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_1jjna6i" bpmnElement="Event_1jjna6i">
+        <dc:Bounds x="1162" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1162" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_047gkeg" bpmnElement="Event_047gkeg">
+        <dc:Bounds x="1212" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1212" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_051j0c0" bpmnElement="Event_051j0c0">
+        <dc:Bounds x="1262" y="802" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1262" y="843" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_TextAnnotation_02dth6m" bpmnElement="TextAnnotation_02dth6m">
+        <dc:Bounds x="200" y="590" width="100" height="30" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="625" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_TextAnnotation_0eiihmf" bpmnElement="TextAnnotation_0eiihmf">
+        <dc:Bounds x="200" y="725" width="100" height="30" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="760" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_Association_0t3kq6h" bpmnElement="Association_0t3kq6h">
+        <di:waypoint x="199" y="787" />
+        <di:waypoint x="234" y="755" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Association_06hpkks" bpmnElement="Association_06hpkks">
+        <di:waypoint x="192" y="655" />
+        <di:waypoint x="232" y="620" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/all_sequence_flow_types.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/all_sequence_flow_types.bpmn
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0g0wkw3" targetNamespace="http://example.com/schema/bpmn">
+  <bpmn:process id="Process_0jsrcqv" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_1omufvy">
+      <bpmn:outgoing>Flow_1qbojo4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_116eaag" default="Flow_1io36a6">
+      <bpmn:incoming>Flow_0e2llvg</bpmn:incoming>
+      <bpmn:outgoing>Flow_07vj0qd</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1io36a6</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0e2llvg" name="Normal Sequence flow &#10; with label Font" sourceRef="Gateway_0qsbw8c" targetRef="Activity_116eaag" />
+    <bpmn:exclusiveGateway id="Gateway_0hq2be7" default="Flow_0v4ibpj">
+      <bpmn:incoming>Flow_0zxbqa5</bpmn:incoming>
+      <bpmn:outgoing>Flow_1nstpgm</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0v4ibpj</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0zxbqa5" name="Normal Sequence flow" sourceRef="Gateway_0qsbw8c" targetRef="Gateway_0hq2be7" />
+    <bpmn:endEvent id="Event_0445f4y">
+      <bpmn:incoming>Flow_06mrz3i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_07vj0qd" name="Conditional Sequence flow from Activity 1" sourceRef="Activity_116eaag" targetRef="Gateway_1b07tw9">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" />
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1nstpgm" name="Conditional Sequence flow from Gateway" sourceRef="Gateway_0hq2be7" targetRef="Gateway_1b07tw9">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression" />
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0v4ibpj" name="Default Sequence flow" sourceRef="Gateway_0hq2be7" targetRef="Gateway_02a5re3" />
+    <bpmn:sequenceFlow id="Flow_1io36a6" name="Default Sequence flow" sourceRef="Activity_116eaag" targetRef="Gateway_02a5re3" />
+    <bpmn:parallelGateway id="Gateway_02a5re3">
+      <bpmn:incoming>Flow_1io36a6</bpmn:incoming>
+      <bpmn:incoming>Flow_0v4ibpj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jjktak</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:exclusiveGateway id="Gateway_1b07tw9">
+      <bpmn:incoming>Flow_07vj0qd</bpmn:incoming>
+      <bpmn:incoming>Flow_0jjktak</bpmn:incoming>
+      <bpmn:incoming>Flow_1nstpgm</bpmn:incoming>
+      <bpmn:outgoing>Flow_04af1mr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0jjktak" sourceRef="Gateway_02a5re3" targetRef="Gateway_1b07tw9" />
+    <bpmn:sequenceFlow id="Flow_1qbojo4" sourceRef="StartEvent_1omufvy" targetRef="Gateway_0qsbw8c" />
+    <bpmn:parallelGateway id="Gateway_0qsbw8c">
+      <bpmn:incoming>Flow_1qbojo4</bpmn:incoming>
+      <bpmn:outgoing>Flow_0e2llvg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0zxbqa5</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_04af1mr" sourceRef="Gateway_1b07tw9" targetRef="Activity_04acs78" />
+    <bpmn:sequenceFlow id="Flow_06mrz3i" name="Default Sequence flow" sourceRef="Activity_04acs78" targetRef="Event_0445f4y" />
+    <bpmn:sequenceFlow id="Flow_0jud8xv" name="Conditional Sequence flow from Activity 2" sourceRef="Activity_04acs78" targetRef="Event_1tkvvjj">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_1tkvvjj">
+      <bpmn:incoming>Flow_0jud8xv</bpmn:incoming>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_0k2ly7l" />
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_04acs78" default="Flow_06mrz3i">
+      <bpmn:incoming>Flow_04af1mr</bpmn:incoming>
+      <bpmn:outgoing>Flow_06mrz3i</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0jud8xv</bpmn:outgoing>
+    </bpmn:task>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0jsrcqv">
+      <bpmndi:BPMNEdge id="Flow_0jud8xv_di" bpmnElement="Flow_0jud8xv">
+        <di:waypoint x="850" y="300" />
+        <di:waypoint x="850" y="440" />
+        <di:waypoint x="1032" y="440" />
+        <bpmndi:BPMNLabel labelStyle="BPMNLabelStyle_1">
+          <dc:Bounds x="853" y="330" width="73" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06mrz3i_di" bpmnElement="Flow_06mrz3i">
+        <di:waypoint x="900" y="260" />
+        <di:waypoint x="1032" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="926" y="226" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04af1mr_di" bpmnElement="Flow_04af1mr">
+        <di:waypoint x="755" y="260" />
+        <di:waypoint x="800" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qbojo4_di" bpmnElement="Flow_1qbojo4">
+        <di:waypoint x="192" y="260" />
+        <di:waypoint x="245" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jjktak_di" bpmnElement="Flow_0jjktak">
+        <di:waypoint x="515" y="260" />
+        <di:waypoint x="705" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1io36a6_di" bpmnElement="Flow_1io36a6">
+        <di:waypoint x="490" y="139" />
+        <di:waypoint x="490" y="235" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="396" y="171.00000000000023" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v4ibpj_di" bpmnElement="Flow_0v4ibpj">
+        <di:waypoint x="490" y="415" />
+        <di:waypoint x="490" y="285" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="396" y="356" width="88" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nstpgm_di" bpmnElement="Flow_1nstpgm">
+        <di:waypoint x="515" y="440" />
+        <di:waypoint x="730" y="440" />
+        <di:waypoint x="730" y="285" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="563" y="390" width="73" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07vj0qd_di" bpmnElement="Flow_07vj0qd">
+        <di:waypoint x="540" y="99" />
+        <di:waypoint x="730" y="99" />
+        <di:waypoint x="730" y="235" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="556" y="106" width="73" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zxbqa5_di" bpmnElement="Flow_0zxbqa5">
+        <di:waypoint x="270" y="285" />
+        <di:waypoint x="270" y="440" />
+        <di:waypoint x="465" y="440" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="275" y="456" width="89" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e2llvg_di" bpmnElement="Flow_0e2llvg">
+        <di:waypoint x="270" y="235" />
+        <di:waypoint x="270" y="99" />
+        <di:waypoint x="440" y="99" />
+        <bpmndi:BPMNLabel labelStyle="BPMNLabelStyle_2">
+          <dc:Bounds x="175" y="100" width="89" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1omufvy">
+        <dc:Bounds x="156" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_116eaag_di" bpmnElement="Activity_116eaag">
+        <dc:Bounds x="440" y="59" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0hq2be7_di" bpmnElement="Gateway_0hq2be7" isMarkerVisible="true">
+        <dc:Bounds x="465" y="415" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0445f4y_di" bpmnElement="Event_0445f4y">
+        <dc:Bounds x="1032" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1b5bwj7_di" bpmnElement="Gateway_02a5re3">
+        <dc:Bounds x="465" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1b07tw9_di" bpmnElement="Gateway_1b07tw9" isMarkerVisible="true">
+        <dc:Bounds x="705" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0eacrzg_di" bpmnElement="Gateway_0qsbw8c">
+        <dc:Bounds x="245" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_16z3xs7_di" bpmnElement="Event_1tkvvjj">
+        <dc:Bounds x="1032" y="422" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11qmyek_di" bpmnElement="Activity_04acs78">
+        <dc:Bounds x="800" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_1">
+      <dc:Font name="Ubuntu" size="9" isBold="true" isItalic="true" isUnderline="true" isStrikeThrough="false" />
+    </bpmndi:BPMNLabelStyle>
+    <bpmndi:BPMNLabelStyle id="BPMNLabelStyle_2">
+      <dc:Font name="Segoe UI" size="14" isBold="false" isItalic="true" isUnderline="false" isStrikeThrough="true" />
+    </bpmndi:BPMNLabelStyle>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/demo.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/demo.bpmn
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Web Modeler" exporterVersion="538c0e4" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.5.0" camunda:diagramRelationId="99e53a64-a5cb-44a1-ac1e-bccc311eca04">
+  <bpmn:process id="Process_1o1jtwi" name="New BPMN Diagram" isExecutable="true">
+    <bpmn:extensionElements>
+      <zeebe:properties>
+        <zeebe:property name="Money" value="100" />
+      </zeebe:properties>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0n5qtzg</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_0dlgexh" name="Deposit Money">
+      <bpmn:extensionElements>
+        <uipath:task name="DepositMoney" type="UiPath.RunOrchestratorJob">
+          <uipath:ioMapping>
+            <uipath:input target="BillAmount" source="1000" />
+            <uipath:input target="ActivityId" source="" />
+            <uipath:input target="ComplexObject" source="" />
+            <uipath:input target="InputArray" source="" />
+            <uipath:output target="BillAmountOutput" />
+            <uipath:output target="DepositMoneyOutput" />
+            <uipath:output target="ActivityIdOutput" />
+            <uipath:output target="ComplexOutput" />
+            <uipath:output target="ComplexObjectOutput" />
+            <uipath:output target="ArrayOutput" />
+          </uipath:ioMapping>
+          <uipath:taskParameters>
+            <uipath:taskParameter name="releaseKey" value="5AAE851E-B0DE-46B8-ABCE-CF83F6B5540D" />
+          </uipath:taskParameters>
+        </uipath:task>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0n5qtzg</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pfne6h</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0pfne6h" name="" sourceRef="Activity_0dlgexh" targetRef="Activity_0kzc9w6" />
+    <bpmn:task id="Activity_0kzc9w6" name="Send purchase approval request">
+      <bpmn:extensionElements>
+        <uipath:task name="PurchaseOrderV2" type="UiPath.HumanInLoopTask">
+          <uipath:ioMapping>
+            <uipath:input target="Item" source="test1" />
+            <uipath:input target="Price" source="500" />
+            <uipath:input target="OrderCreatedBy" source="tester" />
+            <uipath:input target="ActivityId" source="" />
+            <uipath:output target="Country" />
+            <uipath:output target="Comments" />
+            <uipath:output target="ActivityIdOutput" />
+            <uipath:output target="Action" />
+          </uipath:ioMapping>
+          <uipath:taskParameters>
+            <uipath:taskParameter name="appId" value="ID0b5e45d4cfc4491297001b3235a454d2" />
+            <uipath:taskParameter name="appVersion" value="1" />
+            <uipath:taskParameter name="title" value="PurchaseOrderV2" />
+            <uipath:taskParameter name="actions" value="Approve,Reject" />
+            <uipath:taskParameter name="appDesignerUrl" value="https://alpha.uipath.com/popoc/apps_/default/edit/ID0b5e45d4cfc4491297001b3235a454d2?el=VB" />
+          </uipath:taskParameters>
+        </uipath:task>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0pfne6h</bpmn:incoming>
+      <bpmn:incoming>Flow_0z0vbae</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h8delg</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_00gf5dy">
+      <bpmn:incoming>Flow_1qmpv7x</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0h8delg" sourceRef="Activity_0kzc9w6" targetRef="Gateway_1or67hp" />
+    <bpmn:exclusiveGateway id="Gateway_1or67hp">
+      <bpmn:incoming>Flow_0h8delg</bpmn:incoming>
+      <bpmn:outgoing>Flow_17z6xqs</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1153i54</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_17z6xqs" name="Approved" sourceRef="Gateway_1or67hp" targetRef="Activity_19bfqsa">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">Action="approved"</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:task id="Activity_19bfqsa" name="Send notification email">
+      <bpmn:extensionElements>
+        <uipath:task name="SendEmail" type="UiPath.RunOrchestratorJob">
+          <uipath:ioMapping>
+            <uipath:input target="DecisionInput" source="Action" />
+            <uipath:input target="ActivityId" source="" />
+            <uipath:output target="EmailSubject" />
+            <uipath:output target="ActivityIdOutput" />
+          </uipath:ioMapping>
+          <uipath:taskParameters>
+            <uipath:taskParameter name="releaseKey" value="CFE52CA0-F8F0-45D2-9303-B271F004599F" />
+          </uipath:taskParameters>
+        </uipath:task>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17z6xqs</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qmpv7x</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1qmpv7x" sourceRef="Activity_19bfqsa" targetRef="Event_00gf5dy" />
+    <bpmn:sequenceFlow id="Flow_0n5qtzg" sourceRef="StartEvent_1" targetRef="Activity_0dlgexh" />
+    <bpmn:sequenceFlow id="Flow_1153i54" name="Denied" sourceRef="Gateway_1or67hp" targetRef="Event_0cc4q2f" />
+    <bpmn:intermediateCatchEvent id="Event_0cc4q2f">
+      <bpmn:incoming>Flow_1153i54</bpmn:incoming>
+      <bpmn:outgoing>Flow_0z0vbae</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1orsb1n">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT30S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_0z0vbae" sourceRef="Event_0cc4q2f" targetRef="Activity_0kzc9w6" />
+    <bpmn:textAnnotation id="TextAnnotation_0mf0zgf">
+      <bpmn:text>Wait 30s</bpmn:text>
+    </bpmn:textAnnotation>
+    <bpmn:association id="Association_0yy4uxz" associationDirection="None" sourceRef="Event_0cc4q2f" targetRef="TextAnnotation_0mf0zgf" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1o1jtwi">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="182" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="225" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dlgexh_di" bpmnElement="Activity_0dlgexh">
+        <dc:Bounds x="330" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kzc9w6_di" bpmnElement="Activity_0kzc9w6">
+        <dc:Bounds x="520" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1or67hp_di" bpmnElement="Gateway_1or67hp" isMarkerVisible="true">
+        <dc:Bounds x="735" y="175" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1r7y8qc_di" bpmnElement="Event_0cc4q2f">
+        <dc:Bounds x="742" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_19bfqsa_di" bpmnElement="Activity_19bfqsa">
+        <dc:Bounds x="910" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00gf5dy_di" bpmnElement="Event_00gf5dy">
+        <dc:Bounds x="1122" y="182" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0yy4uxz_di" bpmnElement="Association_0yy4uxz">
+        <di:waypoint x="777" y="383" />
+        <di:waypoint x="811" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pfne6h_di" bpmnElement="Flow_0pfne6h">
+        <di:waypoint x="430" y="200" />
+        <di:waypoint x="520" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h8delg_di" bpmnElement="Flow_0h8delg">
+        <di:waypoint x="620" y="200" />
+        <di:waypoint x="735" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17z6xqs_di" bpmnElement="Flow_17z6xqs">
+        <di:waypoint x="785" y="200" />
+        <di:waypoint x="910" y="200" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="816" y="183" width="47" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qmpv7x_di" bpmnElement="Flow_1qmpv7x">
+        <di:waypoint x="1010" y="200" />
+        <di:waypoint x="1122" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n5qtzg_di" bpmnElement="Flow_0n5qtzg">
+        <di:waypoint x="218" y="200" />
+        <di:waypoint x="330" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1153i54_di" bpmnElement="Flow_1153i54">
+        <di:waypoint x="760" y="225" />
+        <di:waypoint x="760" y="372" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="742" y="296" width="35" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z0vbae_di" bpmnElement="Flow_0z0vbae">
+        <di:waypoint x="742" y="390" />
+        <di:waypoint x="570" y="390" />
+        <di:waypoint x="570" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0mf0zgf_di" bpmnElement="TextAnnotation_0mf0zgf">
+        <dc:Bounds x="800" y="340" width="100" height="30" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-001-collapsed.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-001-collapsed.bpmn
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.1.1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_001" name="Start">
+      <outgoing>SequenceFlow_001</outgoing>
+    </startEvent>
+    <task id="Task_001" name="Task01">
+      <incoming>SequenceFlow_001</incoming>
+      <outgoing>SequenceFlow_002</outgoing>
+    </task>
+    <sequenceFlow id="SequenceFlow_001" sourceRef="StartEvent_001" targetRef="Task_001" />
+    <exclusiveGateway id="ExclusiveGateway_001" name="Gateway">
+      <incoming>SequenceFlow_002</incoming>
+      <outgoing>Flow_003</outgoing>
+    </exclusiveGateway>
+    <sequenceFlow id="SequenceFlow_002" sourceRef="Task_001" targetRef="ExclusiveGateway_001" />
+    <subProcess id="SubProcess_001" name="SubProcess1">
+      <incoming>Flow_003</incoming>
+      <outgoing>Flow_004</outgoing>
+      <startEvent id="SP__StartEvent" name="SP_Start">
+        <outgoing>SP__Flow_001</outgoing>
+      </startEvent>
+      <task id="SP__Task_001" name="SP_Task">
+        <incoming>SP__Flow_001</incoming>
+        <outgoing>Flow_001</outgoing>
+      </task>
+      <endEvent id="SP__EndEvent" name="SP_End">
+        <incoming>Flow_001</incoming>
+      </endEvent>
+      <sequenceFlow id="Flow_001" sourceRef="SP__Task_001" targetRef="SP__EndEvent" />
+      <sequenceFlow id="SP__Flow_001" sourceRef="SP__StartEvent" targetRef="SP__Task_001" />
+    </subProcess>
+    <sequenceFlow id="Flow_003" sourceRef="ExclusiveGateway_001" targetRef="SubProcess_001" />
+    <task id="Task_002" name="Task02">
+      <incoming>Flow_004</incoming>
+      <outgoing>Flow_005</outgoing>
+    </task>
+    <sequenceFlow id="Flow_004" sourceRef="SubProcess_001" targetRef="Task_002" />
+    <endEvent id="EndEvent_001" name="End">
+      <incoming>Flow_005</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_005" sourceRef="Task_002" targetRef="EndEvent_001" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_001_di" bpmnElement="StartEvent_001">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="159" y="145" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_001_di" bpmnElement="Task_001">
+        <omgdc:Bounds x="240" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_001_di" bpmnElement="ExclusiveGateway_001" isMarkerVisible="true">
+        <omgdc:Bounds x="395" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="399" y="152" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_001_di" bpmnElement="SubProcess_001" isExpanded="false">
+        <omgdc:Bounds x="650" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_002_di" bpmnElement="Task_002">
+        <omgdc:Bounds x="980" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_001_di" bpmnElement="EndEvent_001">
+        <omgdc:Bounds x="1228" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="1236" y="145" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_001_di" bpmnElement="SequenceFlow_001">
+        <omgdi:waypoint x="188" y="120" />
+        <omgdi:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wnb4ke_di" bpmnElement="SequenceFlow_002">
+        <omgdi:waypoint x="340" y="120" />
+        <omgdi:waypoint x="395" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_003_di" bpmnElement="Flow_003">
+        <omgdi:waypoint x="445" y="120" />
+        <omgdi:waypoint x="650" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_004_di" bpmnElement="Flow_004">
+        <omgdi:waypoint x="750" y="120" />
+        <omgdi:waypoint x="980" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_005_di" bpmnElement="Flow_005">
+        <omgdi:waypoint x="1080" y="120" />
+        <omgdi:waypoint x="1228" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_013twmu">
+    <bpmndi:BPMNPlane id="BPMNPlane_0818s2n" bpmnElement="SubProcess_001">
+      <bpmndi:BPMNShape id="SP__StartEvent_di" bpmnElement="SP__StartEvent">
+        <omgdc:Bounds x="183" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="180" y="225" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__Task_001_di" bpmnElement="SP__Task_001">
+        <omgdc:Bounds x="303" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__EndEvent_di" bpmnElement="SP__EndEvent">
+        <omgdc:Bounds x="475" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="473" y="225" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SP__Flow_001_di" bpmnElement="SP__Flow_001">
+        <omgdi:waypoint x="219" y="200" />
+        <omgdi:waypoint x="303" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SP__Flow_002_di" bpmnElement="Flow_001">
+        <omgdi:waypoint x="403" y="200" />
+        <omgdi:waypoint x="475" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-001-expanded.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-001-expanded.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.1.1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_001" name="Start">
+      <outgoing>SequenceFlow_001</outgoing>
+    </startEvent>
+    <task id="Task_001" name="Task01">
+      <incoming>SequenceFlow_001</incoming>
+      <outgoing>SequenceFlow_002</outgoing>
+    </task>
+    <sequenceFlow id="SequenceFlow_001" sourceRef="StartEvent_001" targetRef="Task_001" />
+    <exclusiveGateway id="ExclusiveGateway_001" name="Gateway">
+      <incoming>SequenceFlow_002</incoming>
+      <outgoing>Flow_003</outgoing>
+    </exclusiveGateway>
+    <sequenceFlow id="SequenceFlow_002" sourceRef="Task_001" targetRef="ExclusiveGateway_001" />
+    <subProcess id="SubProcess_001" name="SubProcess1">
+      <incoming>Flow_003</incoming>
+      <outgoing>Flow_004</outgoing>
+      <startEvent id="SP__StartEvent" name="SP_Start">
+        <outgoing>SP__Flow_001</outgoing>
+      </startEvent>
+      <task id="SP__Task_001" name="SP_Task">
+        <incoming>SP__Flow_001</incoming>
+        <outgoing>Flow_001</outgoing>
+      </task>
+      <endEvent id="SP__EndEvent" name="SP_End">
+        <incoming>Flow_001</incoming>
+      </endEvent>
+      <sequenceFlow id="Flow_001" sourceRef="SP__Task_001" targetRef="SP__EndEvent" />
+      <sequenceFlow id="SP__Flow_001" sourceRef="SP__StartEvent" targetRef="SP__Task_001" />
+    </subProcess>
+    <sequenceFlow id="Flow_003" sourceRef="ExclusiveGateway_001" targetRef="SubProcess_001" />
+    <task id="Task_002" name="Task02">
+      <incoming>Flow_004</incoming>
+      <outgoing>Flow_005</outgoing>
+    </task>
+    <sequenceFlow id="Flow_004" sourceRef="SubProcess_001" targetRef="Task_002" />
+    <endEvent id="EndEvent_001" name="End">
+      <incoming>Flow_005</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_005" sourceRef="Task_002" targetRef="EndEvent_001" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_001_di" bpmnElement="StartEvent_001">
+        <omgdc:Bounds x="152" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="159" y="205" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_001_di" bpmnElement="Task_001">
+        <omgdc:Bounds x="240" y="140" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_001_di" bpmnElement="ExclusiveGateway_001" isMarkerVisible="true">
+        <omgdc:Bounds x="395" y="155" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="399" y="212" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_002_di" bpmnElement="Task_002">
+        <omgdc:Bounds x="980" y="140" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_001_di" bpmnElement="EndEvent_001">
+        <omgdc:Bounds x="1228" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="1236" y="205" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_001_di" bpmnElement="SubProcess_001" isExpanded="true">
+        <omgdc:Bounds x="510" y="80" width="380" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__StartEvent_di" bpmnElement="SP__StartEvent">
+        <omgdc:Bounds x="536" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="533" y="205" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__EndEvent_di" bpmnElement="SP__EndEvent">
+        <omgdc:Bounds x="828" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="826" y="205" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__Task_001_di" bpmnElement="SP__Task_001">
+        <omgdc:Bounds x="656" y="140" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SP__Flow_001_di" bpmnElement="SP__Flow_001">
+        <omgdi:waypoint x="572" y="180" />
+        <omgdi:waypoint x="656" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SP__Flow_002_di" bpmnElement="Flow_001">
+        <omgdi:waypoint x="756" y="180" />
+        <omgdi:waypoint x="828" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_001_di" bpmnElement="SequenceFlow_001">
+        <omgdi:waypoint x="188" y="180" />
+        <omgdi:waypoint x="240" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wnb4ke_di" bpmnElement="SequenceFlow_002">
+        <omgdi:waypoint x="340" y="180" />
+        <omgdi:waypoint x="395" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_003_di" bpmnElement="Flow_003">
+        <omgdi:waypoint x="445" y="180" />
+        <omgdi:waypoint x="510" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_004_di" bpmnElement="Flow_004">
+        <omgdi:waypoint x="890" y="180" />
+        <omgdi:waypoint x="980" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_005_di" bpmnElement="Flow_005">
+        <omgdi:waypoint x="1080" y="180" />
+        <omgdi:waypoint x="1228" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-003-collapsed_deeply-nested.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/expected-findings/subprocess-example-003-collapsed_deeply-nested.bpmn
@@ -1,0 +1,438 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:omgdi="http://www.omg.org/spec/DD/20100524/DI" xmlns:omgdc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="sid-38422fae-e03e-43a3-bef4-bd33b32041b2" targetNamespace="http://bpmn.io/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.1.1">
+  <process id="Process_1" isExecutable="false">
+    <startEvent id="StartEvent_001" name="Start">
+      <outgoing>SequenceFlow_001</outgoing>
+    </startEvent>
+    <task id="Task_001" name="Task01">
+      <incoming>SequenceFlow_001</incoming>
+      <outgoing>SequenceFlow_002</outgoing>
+    </task>
+    <sequenceFlow id="SequenceFlow_001" sourceRef="StartEvent_001" targetRef="Task_001" />
+    <exclusiveGateway id="ExclusiveGateway_001" name="Gateway">
+      <incoming>SequenceFlow_002</incoming>
+      <outgoing>Flow_003</outgoing>
+    </exclusiveGateway>
+    <sequenceFlow id="SequenceFlow_002" sourceRef="Task_001" targetRef="ExclusiveGateway_001" />
+    <subProcess id="SubProcess_001" name="SubProcess1">
+      <incoming>Flow_003</incoming>
+      <outgoing>Flow_004</outgoing>
+      <startEvent id="SP__StartEvent" name="SP_Start">
+        <outgoing>SP__Flow_001</outgoing>
+      </startEvent>
+      <task id="SP__Task_001" name="SP_Task">
+        <incoming>SP__Flow_001</incoming>
+        <outgoing>Flow_0xd4z3r</outgoing>
+      </task>
+      <endEvent id="SP__EndEvent" name="SP_End">
+        <incoming>Flow_001</incoming>
+      </endEvent>
+      <sequenceFlow id="Flow_001" sourceRef="Activity_0oy6w65" targetRef="SP__EndEvent" />
+      <sequenceFlow id="SP__Flow_001" sourceRef="SP__StartEvent" targetRef="SP__Task_001" />
+      <sequenceFlow id="Flow_0xd4z3r" sourceRef="SP__Task_001" targetRef="Activity_0oy6w65" />
+      <subProcess id="Activity_0oy6w65" name="Nested A">
+        <incoming>Flow_0xd4z3r</incoming>
+        <outgoing>Flow_001</outgoing>
+        <startEvent id="Event_0goqa7h" name="SP_Start">
+          <outgoing>Flow_15uv0e2</outgoing>
+        </startEvent>
+        <task id="Activity_1fkfhzf" name="SP_Task">
+          <incoming>Flow_15uv0e2</incoming>
+          <outgoing>Flow_1fsj4ze</outgoing>
+        </task>
+        <endEvent id="Event_1g1wmlg" name="SP_End">
+          <incoming>Flow_1ipyd3e</incoming>
+        </endEvent>
+        <subProcess id="Activity_11tjtzx" name="Nested B">
+          <incoming>Flow_1fsj4ze</incoming>
+          <outgoing>Flow_1ipyd3e</outgoing>
+          <startEvent id="Event_1gx00ia" name="SP_Start">
+            <outgoing>Flow_1c1x2fs</outgoing>
+          </startEvent>
+          <task id="Activity_1u7xbp6" name="SP_Task">
+            <incoming>Flow_1c1x2fs</incoming>
+            <outgoing>Flow_0ghlonz</outgoing>
+          </task>
+          <endEvent id="Event_1i8wadp" name="SP_End">
+            <incoming>Flow_1yx9xrg</incoming>
+          </endEvent>
+          <subProcess id="Activity_1s32o5p" name="Nested C">
+            <incoming>Flow_0ghlonz</incoming>
+            <outgoing>Flow_1yx9xrg</outgoing>
+            <startEvent id="Event_0bixp5g" name="SP_Start">
+              <outgoing>Flow_0054juf</outgoing>
+            </startEvent>
+            <task id="Activity_0iduubq" name="SP_Task">
+              <incoming>Flow_0054juf</incoming>
+              <outgoing>Flow_00jzk4d</outgoing>
+            </task>
+            <endEvent id="Event_0qcj09l" name="SP_End">
+              <incoming>Flow_1ni383n</incoming>
+            </endEvent>
+            <subProcess id="Activity_0myrfe0" name="Nested D">
+              <incoming>Flow_00jzk4d</incoming>
+              <outgoing>Flow_1ni383n</outgoing>
+              <startEvent id="Event_1dx3wx4" name="SP_Start">
+                <outgoing>Flow_1mk25an</outgoing>
+              </startEvent>
+              <task id="Activity_0hjcqjr" name="SP_Task">
+                <incoming>Flow_1mk25an</incoming>
+                <outgoing>Flow_1x80s8v</outgoing>
+              </task>
+              <endEvent id="Event_0e17gbs" name="SP_End">
+                <incoming>Flow_14nbk5j</incoming>
+              </endEvent>
+              <subProcess id="Activity_1dj3r9r" name="Nested E">
+                <incoming>Flow_1x80s8v</incoming>
+                <outgoing>Flow_14nbk5j</outgoing>
+                <startEvent id="Event_1mzr3lu" name="SP_Start">
+                  <outgoing>Flow_1idbgw7</outgoing>
+                </startEvent>
+                <task id="Activity_1sjg9sx" name="SP_Task">
+                  <incoming>Flow_1idbgw7</incoming>
+                  <outgoing>Flow_1uhlkwg</outgoing>
+                </task>
+                <endEvent id="Event_1cz0224" name="SP_End">
+                  <incoming>Flow_1huhpho</incoming>
+                </endEvent>
+                <subProcess id="Activity_1xr6kit" name="Nested F">
+                  <incoming>Flow_1uhlkwg</incoming>
+                  <outgoing>Flow_1huhpho</outgoing>
+                  <startEvent id="Event_0z6jlwp">
+                    <outgoing>Flow_1m1l3wu</outgoing>
+                  </startEvent>
+                  <task id="Activity_07x8su6" name="Last Task">
+                    <incoming>Flow_1m1l3wu</incoming>
+                    <outgoing>Flow_09jzhy5</outgoing>
+                  </task>
+                  <sequenceFlow id="Flow_1m1l3wu" sourceRef="Event_0z6jlwp" targetRef="Activity_07x8su6" />
+                  <endEvent id="Event_19r1pmb">
+                    <incoming>Flow_09jzhy5</incoming>
+                  </endEvent>
+                  <sequenceFlow id="Flow_09jzhy5" sourceRef="Activity_07x8su6" targetRef="Event_19r1pmb" />
+                </subProcess>
+                <sequenceFlow id="Flow_1idbgw7" sourceRef="Event_1mzr3lu" targetRef="Activity_1sjg9sx" />
+                <sequenceFlow id="Flow_1uhlkwg" sourceRef="Activity_1sjg9sx" targetRef="Activity_1xr6kit" />
+                <sequenceFlow id="Flow_1huhpho" sourceRef="Activity_1xr6kit" targetRef="Event_1cz0224" />
+              </subProcess>
+              <sequenceFlow id="Flow_1mk25an" sourceRef="Event_1dx3wx4" targetRef="Activity_0hjcqjr" />
+              <sequenceFlow id="Flow_1x80s8v" sourceRef="Activity_0hjcqjr" targetRef="Activity_1dj3r9r" />
+              <sequenceFlow id="Flow_14nbk5j" sourceRef="Activity_1dj3r9r" targetRef="Event_0e17gbs" />
+            </subProcess>
+            <sequenceFlow id="Flow_0054juf" sourceRef="Event_0bixp5g" targetRef="Activity_0iduubq" />
+            <sequenceFlow id="Flow_00jzk4d" sourceRef="Activity_0iduubq" targetRef="Activity_0myrfe0" />
+            <sequenceFlow id="Flow_1ni383n" sourceRef="Activity_0myrfe0" targetRef="Event_0qcj09l" />
+          </subProcess>
+          <sequenceFlow id="Flow_1c1x2fs" sourceRef="Event_1gx00ia" targetRef="Activity_1u7xbp6" />
+          <sequenceFlow id="Flow_0ghlonz" sourceRef="Activity_1u7xbp6" targetRef="Activity_1s32o5p" />
+          <sequenceFlow id="Flow_1yx9xrg" sourceRef="Activity_1s32o5p" targetRef="Event_1i8wadp" />
+        </subProcess>
+        <sequenceFlow id="Flow_15uv0e2" sourceRef="Event_0goqa7h" targetRef="Activity_1fkfhzf" />
+        <sequenceFlow id="Flow_1fsj4ze" sourceRef="Activity_1fkfhzf" targetRef="Activity_11tjtzx" />
+        <sequenceFlow id="Flow_1ipyd3e" sourceRef="Activity_11tjtzx" targetRef="Event_1g1wmlg" />
+      </subProcess>
+    </subProcess>
+    <sequenceFlow id="Flow_003" sourceRef="ExclusiveGateway_001" targetRef="SubProcess_001" />
+    <task id="Task_002" name="Task02">
+      <incoming>Flow_004</incoming>
+      <outgoing>Flow_005</outgoing>
+    </task>
+    <sequenceFlow id="Flow_004" sourceRef="SubProcess_001" targetRef="Task_002" />
+    <endEvent id="EndEvent_001" name="End">
+      <incoming>Flow_005</incoming>
+    </endEvent>
+    <sequenceFlow id="Flow_005" sourceRef="Task_002" targetRef="EndEvent_001" />
+  </process>
+  <bpmndi:BPMNDiagram id="BpmnDiagram_1">
+    <bpmndi:BPMNPlane id="BpmnPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="StartEvent_001_di" bpmnElement="StartEvent_001">
+        <omgdc:Bounds x="152" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="159" y="145" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_001_di" bpmnElement="Task_001">
+        <omgdc:Bounds x="240" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_001_di" bpmnElement="ExclusiveGateway_001" isMarkerVisible="true">
+        <omgdc:Bounds x="395" y="95" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="399" y="152" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SubProcess_001_di" bpmnElement="SubProcess_001" isExpanded="false">
+        <omgdc:Bounds x="650" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_002_di" bpmnElement="Task_002">
+        <omgdc:Bounds x="980" y="80" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_001_di" bpmnElement="EndEvent_001">
+        <omgdc:Bounds x="1228" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="1236" y="145" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_001_di" bpmnElement="SequenceFlow_001">
+        <omgdi:waypoint x="188" y="120" />
+        <omgdi:waypoint x="240" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wnb4ke_di" bpmnElement="SequenceFlow_002">
+        <omgdi:waypoint x="340" y="120" />
+        <omgdi:waypoint x="395" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_003_di" bpmnElement="Flow_003">
+        <omgdi:waypoint x="445" y="120" />
+        <omgdi:waypoint x="650" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_004_di" bpmnElement="Flow_004">
+        <omgdi:waypoint x="750" y="120" />
+        <omgdi:waypoint x="980" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_005_di" bpmnElement="Flow_005">
+        <omgdi:waypoint x="1080" y="120" />
+        <omgdi:waypoint x="1228" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_013twmu">
+    <bpmndi:BPMNPlane id="BPMNPlane_0818s2n" bpmnElement="SubProcess_001">
+      <bpmndi:BPMNShape id="SP__StartEvent_di" bpmnElement="SP__StartEvent">
+        <omgdc:Bounds x="183" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="180" y="225" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__Task_001_di" bpmnElement="SP__Task_001">
+        <omgdc:Bounds x="303" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="SP__EndEvent_di" bpmnElement="SP__EndEvent">
+        <omgdc:Bounds x="702" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="700" y="225" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_01kmy31_di" bpmnElement="Activity_0oy6w65">
+        <omgdc:Bounds x="490" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SP__Flow_002_di" bpmnElement="Flow_001">
+        <omgdi:waypoint x="590" y="200" />
+        <omgdi:waypoint x="702" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SP__Flow_001_di" bpmnElement="SP__Flow_001">
+        <omgdi:waypoint x="219" y="200" />
+        <omgdi:waypoint x="303" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xd4z3r_di" bpmnElement="Flow_0xd4z3r">
+        <omgdi:waypoint x="403" y="200" />
+        <omgdi:waypoint x="490" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0c5386g">
+    <bpmndi:BPMNPlane id="BPMNPlane_1p9mf44" bpmnElement="Activity_0oy6w65">
+      <bpmndi:BPMNShape id="BPMNShape_1fgv8a1" bpmnElement="Event_0goqa7h">
+        <omgdc:Bounds x="152" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="149" y="195" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1ear9nk" bpmnElement="Activity_1fkfhzf">
+        <omgdc:Bounds x="272" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0qjc4hw" bpmnElement="Event_1g1wmlg">
+        <omgdc:Bounds x="671" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="669" y="195" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0snr1fp" bpmnElement="Activity_11tjtzx">
+        <omgdc:Bounds x="459" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_13mztct" bpmnElement="Flow_15uv0e2">
+        <omgdi:waypoint x="188" y="170" />
+        <omgdi:waypoint x="272" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1ph9u3e" bpmnElement="Flow_1fsj4ze">
+        <omgdi:waypoint x="372" y="170" />
+        <omgdi:waypoint x="459" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0zl6wkh" bpmnElement="Flow_1ipyd3e">
+        <omgdi:waypoint x="559" y="170" />
+        <omgdi:waypoint x="671" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0qeygm5">
+    <bpmndi:BPMNPlane id="BPMNPlane_1joy4os" bpmnElement="Activity_11tjtzx">
+      <bpmndi:BPMNShape id="BPMNShape_129zim0" bpmnElement="Event_1gx00ia">
+        <omgdc:Bounds x="163" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="160" y="195" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0o9ua0q" bpmnElement="Activity_1u7xbp6">
+        <omgdc:Bounds x="283" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0pfw1zs" bpmnElement="Event_1i8wadp">
+        <omgdc:Bounds x="682" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="680" y="195" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_14azsnq" bpmnElement="Activity_1s32o5p">
+        <omgdc:Bounds x="470" y="130" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_08ya7f0" bpmnElement="Flow_1c1x2fs">
+        <omgdi:waypoint x="199" y="170" />
+        <omgdi:waypoint x="283" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_03ikwr6" bpmnElement="Flow_0ghlonz">
+        <omgdi:waypoint x="383" y="170" />
+        <omgdi:waypoint x="470" y="170" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0mse39l" bpmnElement="Flow_1yx9xrg">
+        <omgdi:waypoint x="570" y="170" />
+        <omgdi:waypoint x="682" y="170" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1hw99yb">
+    <bpmndi:BPMNPlane id="BPMNPlane_08zord9" bpmnElement="Activity_1s32o5p">
+      <bpmndi:BPMNShape id="BPMNShape_0tspu6n" bpmnElement="Event_0bixp5g">
+        <omgdc:Bounds x="183" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="180" y="225" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_017gpg5" bpmnElement="Activity_0iduubq">
+        <omgdc:Bounds x="303" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_065lq58" bpmnElement="Event_0qcj09l">
+        <omgdc:Bounds x="702" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="700" y="225" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_06hbgof" bpmnElement="Activity_0myrfe0">
+        <omgdc:Bounds x="490" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0u1cb4b" bpmnElement="Flow_0054juf">
+        <omgdi:waypoint x="219" y="200" />
+        <omgdi:waypoint x="303" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1mpsv5u" bpmnElement="Flow_00jzk4d">
+        <omgdi:waypoint x="403" y="200" />
+        <omgdi:waypoint x="490" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_094k3j6" bpmnElement="Flow_1ni383n">
+        <omgdi:waypoint x="590" y="200" />
+        <omgdi:waypoint x="702" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_176t4gc">
+    <bpmndi:BPMNPlane id="BPMNPlane_1ihq55m" bpmnElement="Activity_0myrfe0">
+      <bpmndi:BPMNShape id="BPMNShape_1ahj6tv" bpmnElement="Event_1dx3wx4">
+        <omgdc:Bounds x="172" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="169" y="215" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0vk46yc" bpmnElement="Activity_0hjcqjr">
+        <omgdc:Bounds x="292" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1nyt86l" bpmnElement="Event_0e17gbs">
+        <omgdc:Bounds x="691" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="689" y="215" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_1gyj7e4" bpmnElement="Activity_1dj3r9r">
+        <omgdc:Bounds x="479" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_0iqd664" bpmnElement="Flow_1mk25an">
+        <omgdi:waypoint x="208" y="190" />
+        <omgdi:waypoint x="292" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_1hozb9h" bpmnElement="Flow_1x80s8v">
+        <omgdi:waypoint x="392" y="190" />
+        <omgdi:waypoint x="479" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0yz8c0g" bpmnElement="Flow_14nbk5j">
+        <omgdi:waypoint x="579" y="190" />
+        <omgdi:waypoint x="691" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_0rrtqeq">
+    <bpmndi:BPMNPlane id="BPMNPlane_0hj902j" bpmnElement="Activity_1dj3r9r">
+      <bpmndi:BPMNShape id="BPMNShape_0kmmixy" bpmnElement="Event_1mzr3lu">
+        <omgdc:Bounds x="183" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="180" y="225" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_00tywvt" bpmnElement="Activity_1sjg9sx">
+        <omgdc:Bounds x="303" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0g5h4rx" bpmnElement="Event_1cz0224">
+        <omgdc:Bounds x="702" y="182" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <omgdc:Bounds x="700" y="225" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_09i4vv3" bpmnElement="Activity_1xr6kit">
+        <omgdc:Bounds x="490" y="160" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_1tgj1ls" bpmnElement="Flow_1idbgw7">
+        <omgdi:waypoint x="219" y="200" />
+        <omgdi:waypoint x="303" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_13cn8i8" bpmnElement="Flow_1uhlkwg">
+        <omgdi:waypoint x="403" y="200" />
+        <omgdi:waypoint x="490" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0wyo351" bpmnElement="Flow_1huhpho">
+        <omgdi:waypoint x="590" y="200" />
+        <omgdi:waypoint x="702" y="200" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_16b1dtm">
+    <bpmndi:BPMNPlane id="BPMNPlane_17151yi" bpmnElement="Activity_1xr6kit">
+      <bpmndi:BPMNShape id="Event_0z6jlwp_di" bpmnElement="Event_0z6jlwp">
+        <omgdc:Bounds x="212" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07x8su6_di" bpmnElement="Activity_07x8su6">
+        <omgdc:Bounds x="300" y="170" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_19r1pmb_di" bpmnElement="Event_19r1pmb">
+        <omgdc:Bounds x="452" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1m1l3wu_di" bpmnElement="Flow_1m1l3wu">
+        <omgdi:waypoint x="248" y="210" />
+        <omgdi:waypoint x="300" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09jzhy5_di" bpmnElement="Flow_09jzhy5">
+        <omgdi:waypoint x="400" y="210" />
+        <omgdi:waypoint x="452" y="210" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/A.1.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/A.1.0.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373649849716" name="A.1.0" targetNamespace="http://www.trisotech.com/definitions/_1373649849716" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="WFP-6-">
+        <semantic:startEvent name="Start Event" id="_93c466ab-b271-4376-a427-f4c353d55ce8">
+            <semantic:outgoing>_e16564d7-0c4c-413e-95f6-f668a3f851fb</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="_ec59e164-68b4-4f94-98de-ffb1c58a84af">
+            <semantic:incoming>_e16564d7-0c4c-413e-95f6-f668a3f851fb</semantic:incoming>
+            <semantic:outgoing>_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 2" id="_820c21c0-45f3-473b-813f-06381cc637cd">
+            <semantic:incoming>_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599</semantic:incoming>
+            <semantic:outgoing>_2aa47410-1b0e-4f8b-ad54-d6f798080cb4</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c">
+            <semantic:incoming>_2aa47410-1b0e-4f8b-ad54-d6f798080cb4</semantic:incoming>
+            <semantic:outgoing>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event" id="_a47df184-085b-49f7-bb82-031c84625821">
+            <semantic:incoming>_8e8fe679-eb3b-4c43-a4d6-891e7087ff80</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_93c466ab-b271-4376-a427-f4c353d55ce8" targetRef="_ec59e164-68b4-4f94-98de-ffb1c58a84af" name="" id="_e16564d7-0c4c-413e-95f6-f668a3f851fb"/>
+        <semantic:sequenceFlow sourceRef="_ec59e164-68b4-4f94-98de-ffb1c58a84af" targetRef="_820c21c0-45f3-473b-813f-06381cc637cd" name="" id="_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599"/>
+        <semantic:sequenceFlow sourceRef="_820c21c0-45f3-473b-813f-06381cc637cd" targetRef="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" name="" id="_2aa47410-1b0e-4f8b-ad54-d6f798080cb4"/>
+        <semantic:sequenceFlow sourceRef="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" targetRef="_a47df184-085b-49f7-bb82-031c84625821" name="" id="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.1.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="WFP-6-" id="MyPlane">
+            <bpmndi:BPMNShape bpmnElement="_93c466ab-b271-4376-a427-f4c353d55ce8" id="S1373649849857__93c466ab-b271-4376-a427-f4c353d55ce8">
+                <dc:Bounds height="30.0" width="30.0" x="186.0" y="336.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="153.67766754457273" y="371.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ec59e164-68b4-4f94-98de-ffb1c58a84af" id="S1373649849859__ec59e164-68b4-4f94-98de-ffb1c58a84af">
+                <dc:Bounds height="68.0" width="83.0" x="258.0" y="317.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="263.3333333333333" y="344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_820c21c0-45f3-473b-813f-06381cc637cd" id="S1373649849860__820c21c0-45f3-473b-813f-06381cc637cd">
+                <dc:Bounds height="68.0" width="83.0" x="390.0" y="317.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="395.3333333333333" y="344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e70a6fcb-913c-4a7b-a65d-e83adc73d69c" id="S1373649849861__e70a6fcb-913c-4a7b-a65d-e83adc73d69c">
+                <dc:Bounds height="68.0" width="83.0" x="522.0" y="317.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="527.3333333333334" y="344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_a47df184-085b-49f7-bb82-031c84625821" id="S1373649849862__a47df184-085b-49f7-bb82-031c84625821">
+                <dc:Bounds height="32.0" width="32.0" x="648.0" y="335.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649849858">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="616.5963254593177" y="372.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599" id="E1373649849864__d77dd5ec-e4e7-420e-bbe7-8ac9cd1df599">
+                <di:waypoint x="342.0" y="351.0"/>
+                <di:waypoint x="390.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e16564d7-0c4c-413e-95f6-f668a3f851fb" id="E1373649849865__e16564d7-0c4c-413e-95f6-f668a3f851fb">
+                <di:waypoint x="216.0" y="351.0"/>
+                <di:waypoint x="234.0" y="351.0"/>
+                <di:waypoint x="258.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_2aa47410-1b0e-4f8b-ad54-d6f798080cb4" id="E1373649849866__2aa47410-1b0e-4f8b-ad54-d6f798080cb4">
+                <di:waypoint x="474.0" y="351.0"/>
+                <di:waypoint x="522.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_8e8fe679-eb3b-4c43-a4d6-891e7087ff80" id="E1373649849867__8e8fe679-eb3b-4c43-a4d6-891e7087ff80">
+                <di:waypoint x="606.0" y="351.0"/>
+                <di:waypoint x="624.0" y="351.0"/>
+                <di:waypoint x="648.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373649849858">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/A.3.0.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/A.3.0.bpmn
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373649919111" name="A.3.0" targetNamespace="http://www.trisotech.com/definitions/_1373649919111" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="WFP-6-">
+        <semantic:startEvent name="Start Event" id="_1ac4b759-40e3-4dfb-b0e3-ad1d201d6c3d">
+            <semantic:outgoing>_83f6ca65-43f7-496e-a7eb-2a4a2fc28f22</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="_65f5459f-44ae-436d-a089-a91d6d78075b">
+            <semantic:incoming>_83f6ca65-43f7-496e-a7eb-2a4a2fc28f22</semantic:incoming>
+            <semantic:outgoing>_68ba9b96-b1e9-4691-bc25-a36bf5731502</semantic:outgoing>
+        </semantic:task>
+        <semantic:subProcess triggeredByEvent="false" completionQuantity="1" isForCompensation="false" startQuantity="1" name="Collapsed&#10;Sub-Process" id="_1ae31d1b-2559-4f78-a3ec-47986a49db48">
+            <semantic:incoming>_68ba9b96-b1e9-4691-bc25-a36bf5731502</semantic:incoming>
+            <semantic:outgoing>_250377d0-628d-463f-95f6-1f4ceed9bd8a</semantic:outgoing>
+        </semantic:subProcess>
+        <semantic:boundaryEvent attachedToRef="_1ae31d1b-2559-4f78-a3ec-47986a49db48" cancelActivity="false" parallelMultiple="false" name="Boundary Intermediate Event Non-Interrupting Message" id="_428dcbf5-8e5e-48e0-9c0c-d93003fa8c82">
+            <semantic:outgoing>_fe023d13-58bc-4f08-b60a-ebe4489f4190</semantic:outgoing>
+            <semantic:messageEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:boundaryEvent attachedToRef="_1ae31d1b-2559-4f78-a3ec-47986a49db48" cancelActivity="true" parallelMultiple="false" name="Boundary Intermediate Event Interrupting Escalation" id="_178e16eb-4c9e-4ea0-9644-7c5fb2b71825">
+            <semantic:outgoing>_7742093f-cd2c-415e-be71-d2514bc559c9</semantic:outgoing>
+            <semantic:escalationEventDefinition/>
+        </semantic:boundaryEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 4" id="_9fad8da5-a28c-4b6b-bb71-fbd5c65b9681">
+            <semantic:incoming>_7742093f-cd2c-415e-be71-d2514bc559c9</semantic:incoming>
+            <semantic:outgoing>_c425e783-e839-4990-9a2c-28b7341d9b2e</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event 1" id="_ce253897-4300-4b24-b71f-4c9535698c70">
+            <semantic:incoming>_719b757a-fc92-46bd-8d10-cca5a5bbf3bf</semantic:incoming>
+            <semantic:incoming>_88b9f814-764e-492b-b38d-d5e8dfa68400</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="_72204cd7-709c-4656-9554-3ae29b3844ce">
+            <semantic:incoming>_fe023d13-58bc-4f08-b60a-ebe4489f4190</semantic:incoming>
+            <semantic:outgoing>_88b9f814-764e-492b-b38d-d5e8dfa68400</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 2" id="_2d2d0d29-896f-49f9-8109-77a7304309c5">
+            <semantic:incoming>_250377d0-628d-463f-95f6-1f4ceed9bd8a</semantic:incoming>
+            <semantic:outgoing>_719b757a-fc92-46bd-8d10-cca5a5bbf3bf</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event 2" id="_10ce0b26-1b3e-46a2-85a5-62538ed2da13">
+            <semantic:incoming>_c425e783-e839-4990-9a2c-28b7341d9b2e</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="_1ac4b759-40e3-4dfb-b0e3-ad1d201d6c3d" targetRef="_65f5459f-44ae-436d-a089-a91d6d78075b" name="" id="_83f6ca65-43f7-496e-a7eb-2a4a2fc28f22"/>
+        <semantic:sequenceFlow sourceRef="_65f5459f-44ae-436d-a089-a91d6d78075b" targetRef="_1ae31d1b-2559-4f78-a3ec-47986a49db48" name="" id="_68ba9b96-b1e9-4691-bc25-a36bf5731502"/>
+        <semantic:sequenceFlow sourceRef="_178e16eb-4c9e-4ea0-9644-7c5fb2b71825" targetRef="_9fad8da5-a28c-4b6b-bb71-fbd5c65b9681" name="" id="_7742093f-cd2c-415e-be71-d2514bc559c9"/>
+        <semantic:sequenceFlow sourceRef="_428dcbf5-8e5e-48e0-9c0c-d93003fa8c82" targetRef="_72204cd7-709c-4656-9554-3ae29b3844ce" name="" id="_fe023d13-58bc-4f08-b60a-ebe4489f4190"/>
+        <semantic:sequenceFlow sourceRef="_1ae31d1b-2559-4f78-a3ec-47986a49db48" targetRef="_2d2d0d29-896f-49f9-8109-77a7304309c5" name="" id="_250377d0-628d-463f-95f6-1f4ceed9bd8a"/>
+        <semantic:sequenceFlow sourceRef="_2d2d0d29-896f-49f9-8109-77a7304309c5" targetRef="_ce253897-4300-4b24-b71f-4c9535698c70" name="" id="_719b757a-fc92-46bd-8d10-cca5a5bbf3bf"/>
+        <semantic:sequenceFlow sourceRef="_72204cd7-709c-4656-9554-3ae29b3844ce" targetRef="_ce253897-4300-4b24-b71f-4c9535698c70" name="" id="_88b9f814-764e-492b-b38d-d5e8dfa68400"/>
+        <semantic:sequenceFlow sourceRef="_9fad8da5-a28c-4b6b-bb71-fbd5c65b9681" targetRef="_10ce0b26-1b3e-46a2-85a5-62538ed2da13" name="" id="_c425e783-e839-4990-9a2c-28b7341d9b2e"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.3.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="WFP-6-">
+            <bpmndi:BPMNShape bpmnElement="_1ac4b759-40e3-4dfb-b0e3-ad1d201d6c3d" id="S1373649919252__1ac4b759-40e3-4dfb-b0e3-ad1d201d6c3d">
+                <dc:Bounds height="30.0" width="30.0" x="72.0" y="295.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="39.67766754457273" y="330.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_65f5459f-44ae-436d-a089-a91d6d78075b" id="S1373649919254__65f5459f-44ae-436d-a089-a91d6d78075b">
+                <dc:Bounds height="68.0" width="83.0" x="145.0" y="276.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="150.33333333333334" y="303.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_1ae31d1b-2559-4f78-a3ec-47986a49db48" isExpanded="false" id="S1373649919255__1ae31d1b-2559-4f78-a3ec-47986a49db48">
+                <dc:Bounds height="88.0" width="108.0" x="282.0" y="266.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="25.604702343750013" width="96.90813648293961" x="287.3333333333333" y="297.1897748123769"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_428dcbf5-8e5e-48e0-9c0c-d93003fa8c82" id="S1373649919256__428dcbf5-8e5e-48e0-9c0c-d93003fa8c82">
+                <dc:Bounds height="32.0" width="32.0" x="338.0" y="250.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="51.204604687499994" width="104.93333333333335" x="252.4591285949397" y="208.34455751275414"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_178e16eb-4c9e-4ea0-9644-7c5fb2b71825" id="S1373649919257__178e16eb-4c9e-4ea0-9644-7c5fb2b71825">
+                <dc:Bounds height="32.0" width="32.0" x="347.0" y="338.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="51.204604687499994" width="104.93333333333335" x="260.10712859493964" y="370.33175751275405"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_9fad8da5-a28c-4b6b-bb71-fbd5c65b9681" id="S1373649919258__9fad8da5-a28c-4b6b-bb71-fbd5c65b9681">
+                <dc:Bounds height="68.0" width="83.0" x="409.0" y="398.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="414.3333333333333" y="425.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_ce253897-4300-4b24-b71f-4c9535698c70" id="S1373649919259__ce253897-4300-4b24-b71f-4c9535698c70">
+                <dc:Bounds height="32.0" width="32.0" x="567.0" y="294.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="535.5963254593177" y="331.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_72204cd7-709c-4656-9554-3ae29b3844ce" id="S1373649919260__72204cd7-709c-4656-9554-3ae29b3844ce">
+                <dc:Bounds height="68.0" width="83.0" x="414.0" y="158.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="419.3333333333333" y="185.58187638256646"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_2d2d0d29-896f-49f9-8109-77a7304309c5" id="S1373649919261__2d2d0d29-896f-49f9-8109-77a7304309c5">
+                <dc:Bounds height="68.0" width="83.0" x="426.0" y="276.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="431.3333333333333" y="303.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_10ce0b26-1b3e-46a2-85a5-62538ed2da13" id="S1373649919262__10ce0b26-1b3e-46a2-85a5-62538ed2da13">
+                <dc:Bounds height="32.0" width="32.0" x="525.0" y="416.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649919253">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="493.59632545931754" y="453.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_250377d0-628d-463f-95f6-1f4ceed9bd8a" id="E1373649919264__250377d0-628d-463f-95f6-1f4ceed9bd8a">
+                <di:waypoint x="390.0" y="310.0"/>
+                <di:waypoint x="408.0" y="310.0"/>
+                <di:waypoint x="426.0" y="310.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_83f6ca65-43f7-496e-a7eb-2a4a2fc28f22" id="E1373649919265__83f6ca65-43f7-496e-a7eb-2a4a2fc28f22">
+                <di:waypoint x="102.0" y="310.0"/>
+                <di:waypoint x="145.0" y="310.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_7742093f-cd2c-415e-be71-d2514bc559c9" id="E1373649919266__7742093f-cd2c-415e-be71-d2514bc559c9">
+                <di:waypoint x="363.0" y="370.0"/>
+                <di:waypoint x="363.0" y="432.0"/>
+                <di:waypoint x="409.0" y="432.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_fe023d13-58bc-4f08-b60a-ebe4489f4190" id="E1373649919267__fe023d13-58bc-4f08-b60a-ebe4489f4190">
+                <di:waypoint x="354.0" y="250.0"/>
+                <di:waypoint x="354.0" y="192.0"/>
+                <di:waypoint x="414.0" y="192.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_88b9f814-764e-492b-b38d-d5e8dfa68400" id="E1373649919268__88b9f814-764e-492b-b38d-d5e8dfa68400">
+                <di:waypoint x="498.0" y="192.0"/>
+                <di:waypoint x="583.0" y="192.0"/>
+                <di:waypoint x="583.0" y="294.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_719b757a-fc92-46bd-8d10-cca5a5bbf3bf" id="E1373649919269__719b757a-fc92-46bd-8d10-cca5a5bbf3bf">
+                <di:waypoint x="509.0" y="310.0"/>
+                <di:waypoint x="527.0" y="310.0"/>
+                <di:waypoint x="567.0" y="310.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_c425e783-e839-4990-9a2c-28b7341d9b2e" id="E1373649919270__c425e783-e839-4990-9a2c-28b7341d9b2e">
+                <di:waypoint x="492.0" y="432.0"/>
+                <di:waypoint x="525.0" y="432.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_68ba9b96-b1e9-4691-bc25-a36bf5731502" id="E1373649919271__68ba9b96-b1e9-4691-bc25-a36bf5731502">
+                <di:waypoint x="228.0" y="310.0"/>
+                <di:waypoint x="246.0" y="310.0"/>
+                <di:waypoint x="282.0" y="310.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373649919253">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ApiWorkflow.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ApiWorkflow.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="e9d4d2b5">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="voQrcS9Fe" name="firstName" type="string" elementId="Activity_5VAjZC"/>
+        <uipath:inputOutput id="v8ehInscn" name="lastName" type="string" elementId="Activity_5VAjZC"/>
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="6317e2d1-69ab-464b-9d6c-95172d72f6fc"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge___Event_start-Activity_5VAjZC</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_5VAjZC" name="API-Demo">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Orchestrator.ExecuteApiWorkflowAsync" version="v1"/>
+          <uipath:context>
+            <uipath:input name="releaseKey" type="string" value="c4a041a3-b50c-4a2c-952d-1b9f9ea74a5e"/>
+            <uipath:input name="name" type="string" value="API-Demo"/>
+            <uipath:input name="folderKey" type="string" value="717ede25-7494-44d5-9d65-5dab660653f6"/>
+            <uipath:input name="folderPath" type="string" value="Shared"/>
+          </uipath:context>
+          <uipath:output name="firstName" type="string" source="=firstName" var="voQrcS9Fe"/>
+          <uipath:output name="lastName" type="string" source="=lastName" var="v8ehInscn"/>
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge___Event_start-Activity_5VAjZC</bpmn:incoming>
+      <bpmn:outgoing>edge___Activity_5VAjZC-Event_dNN82a</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_dNN82a">
+      <bpmn:incoming>edge___Activity_5VAjZC-Event_dNN82a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge___Event_start-Activity_5VAjZC" sourceRef="Event_start" targetRef="Activity_5VAjZC"/>
+    <bpmn:sequenceFlow id="edge___Activity_5VAjZC-Event_dNN82a" sourceRef="Activity_5VAjZC" targetRef="Event_dNN82a"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnNestedSubProcessTests.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnNestedSubProcessTests.bpmn
@@ -1,0 +1,102 @@
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="4ac19271">
+  <bpmn:process id="Process_1" name="Process" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="sp1Op" name="sp1OP" type="jsonSchema" elementId="Activity_2RKCY4" custom="true"><![CDATA[{"type":"object","$schema":"http://json-schema.org/draft-07/schema#"}]]></uipath:inputOutput>
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bxtI7ER5N" name="folderPath" type="string" resource="process" resourceKey="RPA Workflow" propertyAttribute="folderPath" />
+        <uipath:binding id="blJ2Uziju" name="name" type="string" default="RPA Workflow" resource="process" resourceKey="RPA Workflow" propertyAttribute="name" />
+        <uipath:binding id="bLVJKcVK4" name="uipath-asana-asana connection" type="string" default="445487ee-1712-41f0-a036-150570e77021" resource="Connection" resourceKey="445487ee-1712-41f0-a036-150570e77021" propertyAttribute="ConnectionId" />
+        <uipath:binding id="bLdOrC0UZ" name="FolderKey" type="string" default="a68864f4-5bc0-468a-84e3-f32dfd821b5c" resource="Connection" resourceKey="445487ee-1712-41f0-a036-150570e77021" propertyAttribute="folderKey" />
+      </uipath:bindings>
+      <uipath:migrationVersion version="8" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Start event">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="9dfd5ca3-9311-42fd-b2e2-9374931a8112" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_Event_start-Activity_2RKCY42OFIWy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="Activity_2RKCY4" name="">
+      <bpmn:extensionElements>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="sp1OP" type="json" var="sp1Op" custom="true"><![CDATA[=vars.sp2Op]]></uipath:output>
+        </uipath:mapping>
+        <uipath:variables version="v1">
+          <uipath:inputOutput id="splitChar" name="splitChar" type="integer" elementId="Event_8PZeBv" custom="true" />
+          <uipath:inputOutput id="intArr" name="intArr" type="jsonSchema" elementId="Event_8PZeBv" custom="true"><![CDATA[{"type":"array","items":{"type":"integer"},"$schema":"http://json-schema.org/draft-07/schema#"}]]></uipath:inputOutput>
+          <uipath:inputOutput id="sp2Op" name="sp2Op" type="jsonSchema" elementId="Activity_EzMuwg" custom="true"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"array","properties":{},"definitions":{},"x-uipath-original-type":"json"}]]></uipath:inputOutput>
+        </uipath:variables>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_Event_start-Activity_2RKCY42OFIWy</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_2RKCY4-Event_hnDLdz6oMO18</bpmn:outgoing>
+      <bpmn:startEvent id="Event_8PZeBv">
+        <bpmn:extensionElements>
+          <uipath:mapping version="v1">
+            <uipath:type value="BPMN.Variables" version="v1" />
+            <uipath:output name="splitChar" type="integer" source="999777" var="splitChar" custom="true" />
+            <uipath:output name="intArr" type="json" var="intArr" custom="true"><![CDATA[[1,2,3]]]></uipath:output>
+          </uipath:mapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>edge_Event_8PZeBv-Activity_EzMuwglgJVsW</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:subProcess id="Activity_EzMuwg" name="">
+        <bpmn:extensionElements>
+          <uipath:mapping version="v1">
+            <uipath:type value="BPMN.Variables" version="v1" />
+            <uipath:output name="sp2Op" type="json" var="sp2Op" custom="true"><![CDATA[=vars.rpaOut]]></uipath:output>
+          </uipath:mapping>
+          <uipath:variables version="v1">
+            <uipath:inputOutput id="error" name="Error" type="jsonSchema" elementId="Activity_4KaE8t"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+            <uipath:inputOutput id="rpaOut" name="rpaOUT" type="string" elementId="Activity_4KaE8t" custom="true" />
+          </uipath:variables>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Event_8PZeBv-Activity_EzMuwglgJVsW</bpmn:incoming>
+        <bpmn:outgoing>edge_Activity_EzMuwg-Event_OIiNBw</bpmn:outgoing>
+        <bpmn:multiInstanceLoopCharacteristics>
+          <bpmn:extensionElements>
+            <uipath:loopCharacteristics inputCollection="=vars.intArr" inputElement="iterator[0]" version="v1" />
+          </bpmn:extensionElements>
+        </bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:startEvent id="Event_ZGR0is">
+          <bpmn:outgoing>edge_Event_ZGR0is-Activity_4KaE8t</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:serviceTask id="Activity_4KaE8t" name="RPA Workflow">
+          <bpmn:extensionElements>
+            <uipath:activity version="v1">
+              <uipath:type value="Orchestrator.StartJob" version="v2" />
+              <uipath:context>
+                <uipath:input name="name" type="string" value="=bindings.blJ2Uziju" />
+                <uipath:input name="folderPath" type="string" value="=bindings.bxtI7ER5N" />
+                <uipath:input name="_label" type="string" value="RPA Workflow" />
+                <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"Error":{"type":"object","title":"Error"},"ip":{"type":"string","title":"ip"},"ip2":{"type":"string","title":"ip2"}},"required":[]}]]></uipath:inputSchema>
+              </uipath:context>
+              <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"Error":"","ip":"=vars.splitChar","ip2":"=vars.splitChar+ \" Updated\""}]]></uipath:input>
+              <uipath:output name="Error" type="jsonSchema" source="=Error" var="error" />
+              <uipath:output name="rpaOUT" type="string" source="=vars.splitChar+ &#34; Input&#34;" var="rpaOut" custom="true" />
+            </uipath:activity>
+          </bpmn:extensionElements>
+          <bpmn:incoming>edge_Event_ZGR0is-Activity_4KaE8t</bpmn:incoming>
+          <bpmn:outgoing>edge_Activity_4KaE8t-Event_vn2mt0</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:endEvent id="Event_vn2mt0">
+          <bpmn:incoming>edge_Activity_4KaE8t-Event_vn2mt0</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="edge_Event_ZGR0is-Activity_4KaE8t" sourceRef="Event_ZGR0is" targetRef="Activity_4KaE8t" />
+        <bpmn:sequenceFlow id="edge_Activity_4KaE8t-Event_vn2mt0" sourceRef="Activity_4KaE8t" targetRef="Event_vn2mt0" />
+      </bpmn:subProcess>
+      <bpmn:endEvent id="Event_OIiNBw">
+        <bpmn:incoming>edge_Activity_EzMuwg-Event_OIiNBw</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="edge_Activity_EzMuwg-Event_OIiNBw" sourceRef="Activity_EzMuwg" targetRef="Event_OIiNBw" />
+      <bpmn:sequenceFlow id="edge_Event_8PZeBv-Activity_EzMuwglgJVsW" sourceRef="Event_8PZeBv" targetRef="Activity_EzMuwg" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="Event_hnDLdz">
+      <bpmn:incoming>edge_Activity_2RKCY4-Event_hnDLdz6oMO18</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge_Event_start-Activity_2RKCY42OFIWy" sourceRef="Event_start" targetRef="Activity_2RKCY4" />
+    <bpmn:sequenceFlow id="edge_Activity_2RKCY4-Event_hnDLdz6oMO18" sourceRef="Activity_2RKCY4" targetRef="Event_hnDLdz" />
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnTimerBoundaryEvents.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnTimerBoundaryEvents.bpmn
@@ -1,0 +1,160 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="7e6db508">
+  <bpmn:process id="Process_1" name="Process" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="error" name="Error" type="jsonSchema" elementId="Event_U6alpL"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+        <uipath:inputOutput id="scriptResponse" name="scriptResponse" type="jsonSchema" elementId="Activity_Vbbfqo" />
+        <uipath:inputOutput id="error2" name="Error" type="jsonSchema" elementId="Activity_Vbbfqo"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+        <uipath:inputOutput id="error3" name="Error" type="jsonSchema" elementId="Activity_PYC2fm"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bdMNScrer" name="folderPath" type="string" resource="process" resourceKey="RPA Workflow" propertyAttribute="folderPath" />
+        <uipath:binding id="bsjJ0kJI0" name="name" type="string" default="RPA Workflow" resource="process" resourceKey="RPA Workflow" propertyAttribute="name" />
+      </uipath:bindings>
+      <uipath:migrationVersion version="11" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Start event">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="f58b4db9-96d7-47df-997d-9f6660668df2" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_Event_start-Activity_PYC2fm</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_PYC2fm" name="RPA Workflow">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Orchestrator.StartJob" version="v2" />
+          <uipath:context>
+            <uipath:input name="name" type="string" value="=bindings.bsjJ0kJI0" />
+            <uipath:input name="folderPath" type="string" value="=bindings.bdMNScrer" />
+            <uipath:input name="_label" type="string" value="RPA Workflow" />
+            <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"Error":{"type":"object"}},"required":[]}]]></uipath:inputSchema>
+          </uipath:context>
+          <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"Error":""}]]></uipath:input>
+          <uipath:output name="Error" type="jsonSchema" source="=Error" var="error3" />
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_Event_start-Activity_PYC2fm</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_PYC2fm-Event_vhtBn2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_U6alpL" attachedToRef="Activity_PYC2fm">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="uipath:Activity" version="v1" />
+          <uipath:output name="Error" type="jsonSchema" source="=Error" var="error" />
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_Event_U6alpL-Activity_Vbbfqo</bpmn:outgoing>
+      <bpmn:errorEventDefinition />
+    </bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="Event_aLyjoW" attachedToRef="Activity_PYC2fm">
+      <bpmn:outgoing>edge_yGapVi</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1500S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_vhtBn2">
+      <bpmn:incoming>edge_Activity_PYC2fm-Event_vhtBn2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:scriptTask id="Activity_Vbbfqo" name="Error" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:context>
+            <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"vars":{"type":"object"},"metadata":{"type":"object"}},"required":[]}]]></uipath:inputSchema>
+          </uipath:context>
+          <uipath:input name="args" type="json" target="bodyField"><![CDATA[{"vars":"=vars","metadata":"=metadata"}]]></uipath:input>
+          <uipath:output name="scriptResponse" type="jsonSchema" source="=result.response" var="scriptResponse" />
+          <uipath:output name="Error" type="jsonSchema" source="=Error" var="error2" />
+        </uipath:mapping>
+        <uipath:scriptVersion value="v3" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_Event_U6alpL-Activity_Vbbfqo</bpmn:incoming>
+      <bpmn:incoming>edge_yGapVi</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_Vbbfqo-Event_4ZxKbFiZnNqy</bpmn:outgoing>
+      <bpmn:script><![CDATA[return {"val":"errored"};]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_4ZxKbF">
+      <bpmn:incoming>edge_Activity_Vbbfqo-Event_4ZxKbFiZnNqy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge_Event_start-Activity_PYC2fm" sourceRef="Event_start" targetRef="Activity_PYC2fm" />
+    <bpmn:sequenceFlow id="edge_Activity_PYC2fm-Event_vhtBn2" sourceRef="Activity_PYC2fm" targetRef="Event_vhtBn2" />
+    <bpmn:sequenceFlow id="edge_Event_U6alpL-Activity_Vbbfqo" sourceRef="Event_U6alpL" targetRef="Activity_Vbbfqo" />
+    <bpmn:sequenceFlow id="edge_yGapVi" sourceRef="Event_aLyjoW" targetRef="Activity_Vbbfqo" />
+    <bpmn:sequenceFlow id="edge_Activity_Vbbfqo-Event_4ZxKbFiZnNqy" sourceRef="Activity_Vbbfqo" targetRef="Event_4ZxKbF" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="176" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="176" y="233" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_PYC2fm" bpmnElement="Activity_PYC2fm">
+        <dc:Bounds x="344" y="178" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="344" y="263" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_U6alpL" bpmnElement="Event_U6alpL">
+        <dc:Bounds x="334" y="240" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="334" y="281" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_aLyjoW" bpmnElement="Event_aLyjoW">
+        <dc:Bounds x="414" y="240" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="414" y="281" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_vhtBn2" bpmnElement="Event_vhtBn2">
+        <dc:Bounds x="492" y="200" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="492" y="241" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_Vbbfqo" bpmnElement="Activity_Vbbfqo">
+        <dc:Bounds x="368" y="432" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="368" y="517" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_4ZxKbF" bpmnElement="Event_4ZxKbF">
+        <dc:Bounds x="468" y="608" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="468" y="649" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_start-Activity_PYC2fm" bpmnElement="edge_Event_start-Activity_PYC2fm">
+        <di:waypoint x="228" y="218" />
+        <di:waypoint x="344" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_PYC2fm-Event_vhtBn2" bpmnElement="edge_Activity_PYC2fm-Event_vhtBn2">
+        <di:waypoint x="444" y="218" />
+        <di:waypoint x="492" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_U6alpL-Activity_Vbbfqo" bpmnElement="edge_Event_U6alpL-Activity_Vbbfqo">
+        <di:waypoint x="334" y="258" />
+        <di:waypoint x="314" y="258" />
+        <di:waypoint x="314" y="472" />
+        <di:waypoint x="368" y="472" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_yGapVi" bpmnElement="edge_yGapVi">
+        <di:waypoint x="450" y="258" />
+        <di:waypoint x="488" y="258" />
+        <di:waypoint x="488" y="472" />
+        <di:waypoint x="468" y="472" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_Vbbfqo-Event_4ZxKbFiZnNqy" bpmnElement="edge_Activity_Vbbfqo-Event_4ZxKbFiZnNqy">
+        <di:waypoint x="468" y="472" />
+        <di:waypoint x="488" y="472" />
+        <di:waypoint x="488" y="549" />
+        <di:waypoint x="448" y="549" />
+        <di:waypoint x="448" y="626" />
+        <di:waypoint x="468" y="626" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnXmlWithCatchAllErrorEventSubProcess.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnXmlWithCatchAllErrorEventSubProcess.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn">
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bXLQ9136S" name="releaseKey" type="string" default="E360463F-AC40-4C05-B9E8-795F616894F8" resource="process" resourceKey="E360463F-AC40-4C05-B9E8-795F616894F8" propertyAttribute="Key"/>
+      </uipath:bindings>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_Start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="84c06be4-0cd2-438a-9b38-6be5de3e49a1"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow1</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Activity_Failing">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Orchestrator.StartJob" version="v1"/>
+          <uipath:context>
+            <uipath:input name="releaseKey" type="string" value="=bindings.bXLQ9136S"/>
+            <uipath:input name="name" type="string" value="TestJob"/>
+            <uipath:input name="folderId" type="string" value="1543099"/>
+          </uipath:context>
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow1</bpmn:incoming>
+      <bpmn:outgoing>flow2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_NormalEnd">
+      <bpmn:incoming>flow2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_CatchAllErrorHandler" triggeredByEvent="true">
+      <bpmn:startEvent id="Event_CatchAllErrorStart" isInterrupting="true">
+        <bpmn:outgoing>flow3</bpmn:outgoing>
+        <bpmn:errorEventDefinition/>
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_CatchAllErrorEnd">
+        <bpmn:incoming>flow3</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="flow3" sourceRef="Event_CatchAllErrorStart" targetRef="Event_CatchAllErrorEnd"/>
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="flow1" sourceRef="Event_Start" targetRef="Activity_Failing"/>
+    <bpmn:sequenceFlow id="flow2" sourceRef="Activity_Failing" targetRef="Event_NormalEnd"/>
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnXmlWithSpecificErrorEventSubProcess.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/BpmnXmlWithSpecificErrorEventSubProcess.bpmn
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+        <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://bpmn.io/schema/bpmn">
+          <bpmn:error id="Error_Specific" name="SpecificError" errorCode="1001"/>
+          <bpmn:process id="Process_1" isExecutable="true">
+            <bpmn:extensionElements>
+              <uipath:bindings version="v1">
+                <uipath:binding id="bXLQ9136S" name="releaseKey" type="string" default="E360463F-AC40-4C05-B9E8-795F616894F8" resource="process" resourceKey="E360463F-AC40-4C05-B9E8-795F616894F8" propertyAttribute="Key"/>
+              </uipath:bindings>
+            </bpmn:extensionElements>
+            <bpmn:startEvent id="Event_Start">
+              <bpmn:extensionElements>
+                <uipath:entryPointId value="84c06be4-0cd2-438a-9b38-6be5de3e49a1"/>
+              </bpmn:extensionElements>
+              <bpmn:outgoing>flow1</bpmn:outgoing>
+            </bpmn:startEvent>
+            <bpmn:serviceTask id="Activity_Failing">
+              <bpmn:extensionElements>
+                <uipath:activity version="v1">
+                  <uipath:type value="Orchestrator.StartJob" version="v1"/>
+                  <uipath:context>
+                    <uipath:input name="releaseKey" type="string" value="=bindings.bXLQ9136S"/>
+                    <uipath:input name="name" type="string" value="TestJob"/>
+                    <uipath:input name="folderId" type="string" value="1543099"/>
+                  </uipath:context>
+                </uipath:activity>
+              </bpmn:extensionElements>
+              <bpmn:incoming>flow1</bpmn:incoming>
+              <bpmn:outgoing>flow2</bpmn:outgoing>
+            </bpmn:serviceTask>
+            <bpmn:endEvent id="Event_NormalEnd">
+              <bpmn:incoming>flow2</bpmn:incoming>
+            </bpmn:endEvent>
+            <bpmn:subProcess id="Activity_ErrorHandler" triggeredByEvent="true">
+              <bpmn:startEvent id="Event_ErrorStart" isInterrupting="true">
+                <bpmn:outgoing>flow3</bpmn:outgoing>
+                <bpmn:errorEventDefinition errorRef="Error_Specific"/>
+              </bpmn:startEvent>
+              <bpmn:endEvent id="Event_ErrorEnd">
+                <bpmn:incoming>flow3</bpmn:incoming>
+              </bpmn:endEvent>
+              <bpmn:sequenceFlow id="flow3" sourceRef="Event_ErrorStart" targetRef="Event_ErrorEnd"/>
+            </bpmn:subProcess>
+            <bpmn:sequenceFlow id="flow1" sourceRef="Event_Start" targetRef="Activity_Failing"/>
+            <bpmn:sequenceFlow id="flow2" sourceRef="Activity_Failing" targetRef="Event_NormalEnd"/>
+          </bpmn:process>
+        </bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/CaseManagementWithConstantIdentifier.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/CaseManagementWithConstantIdentifier.bpmn
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="34e3a3d5">
+  <bpmn:process id="Process_1" name="Agentic Case" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="ReturnFromSecondaryStageToStage" name="Return_From_Secondary_Stage_To_Stage" type="string" elementId="Activity_InitialVariablesNode" custom="true" />
+        <uipath:inputOutput id="stage1ReEntryCount" name="stage_1_ReEntryCount" type="integer" elementId="Activity_InitialVariablesNode" custom="true" />
+        <uipath:inputOutput id="stage1ReExitToStage" name="stage_1_ReExit_To_Stage" type="string" elementId="Activity_InitialVariablesNode" custom="true" />
+        <uipath:inputOutput id="stage1SubProcessTasksComplete" name="stage_1_SubProcess_Tasks_Complete" type="boolean" elementId="Activity_InitialVariablesNode" custom="true" />
+        <uipath:inputOutput id="loanObject" name="loanObject" type="json" elementId="stage_1-ttgupuwp0" custom="true" />
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bfexuiQma" name="folderPath" type="string" default="solution_folder" resource="process" resourceKey="solution_folder.ProcessWithInputs" propertyAttribute="folderPath" />
+        <uipath:binding id="bcczqilgr" name="name" type="string" default="ProcessWithInputs" resource="process" resourceKey="solution_folder.ProcessWithInputs" propertyAttribute="name" />
+        <uipath:binding id="bSUUURIEo" name="folderPath" type="string" default="solution_folder" resource="process" resourceSubType="ProcessOrchestration" resourceKey="solution_folder.ProcessWithInputs" propertyAttribute="folderPath" />
+        <uipath:binding id="bgKwTteki" name="name" type="string" default="ProcessWithInputs" resource="process" resourceSubType="ProcessOrchestration" resourceKey="solution_folder.ProcessWithInputs" propertyAttribute="name" />
+      </uipath:bindings>
+      <uipath:caseManagement version="1.0"><![CDATA[{"root":{"id":"root","type":"case-management:root","name":"Agentic Case","caseIdentifierType":"constant","caseIdentifier":"CASE","caseAppEnabled":true,"version":"v10","data":{"diagramId":"default-diagram","planeId":"default-plane","uipath":{"bindings":[{"id":"bfexuiQma","name":"folderPath","type":"string","resource":"process","resourceKey":"solution_folder.ProcessWithInputs","default":"solution_folder","propertyAttribute":"folderPath"},{"id":"bcczqilgr","name":"name","type":"string","resource":"process","resourceKey":"solution_folder.ProcessWithInputs","default":"ProcessWithInputs","propertyAttribute":"name"},{"id":"bSUUURIEo","name":"folderPath","type":"string","resource":"process","resourceKey":"solution_folder.ProcessWithInputs","default":"solution_folder","propertyAttribute":"folderPath","resourceSubType":"ProcessOrchestration"},{"id":"bgKwTteki","name":"name","type":"string","resource":"process","resourceKey":"solution_folder.ProcessWithInputs","default":"ProcessWithInputs","propertyAttribute":"name","resourceSubType":"ProcessOrchestration"}],"variables":{"inputOutputs":[]}}}},"nodes":[{"id":"trigger_1","type":"case-management:Trigger","position":{"x":160,"y":198.5},"style":{"width":96,"height":96},"measured":{"width":96,"height":96},"data":{"parentElement":{"id":"root","type":"case-management:root"},"isInvalidDropTarget":false,"isPendingParent":false},"width":96,"height":96,"selected":false},{"id":"stage_1","type":"case-management:Stage","position":{"x":326,"y":200},"style":{"width":304},"measured":{"width":304,"height":127},"data":{"label":"Stage 1","parentElement":{"id":"root","type":"case-management:root"},"tasks":[[{"id":"ttgupuwp0","type":"process","data":{"name":"=bindings.bgKwTteki","folderPath":"=bindings.bSUUURIEo","inputs":[{"name":"InputProcess","displayName":"InputProcess","value":"=datafabric.LoanApplicationCase[\"qes:{\"filterGroup\": {\"logicalOperator\": 0, \"queryFilters\": [{\"fieldName\": \"CaseId\", \"operator\": \"=\", \"value\": \"HL-999\"}]}}\"]","type":"string","title":"InputProcess","required":false,"id":"v5Zz8SK1d","var":"v5Zz8SK1d","elementId":"stage_1-ttgupuwp0"}],"outputs":[{"name":"loanObject","displayName":"loanObject","type":"json","body":"","_jsonSchema":"","custom":true,"id":"loanObject","var":"loanObject","elementId":"stage_1-ttgupuwp0"}]},"elementId":"stage_1-ttgupuwp0","displayName":"Process"}]],"isInvalidDropTarget":false,"isPendingParent":false},"width":304,"selected":false}],"edges":[{"id":"edge_initial","source":"trigger_1","target":"stage_1","sourceHandle":"trigger_1____source____right","targetHandle":"stage_1____target____left","type":"case-management:TriggerEdge","style":{"strokeWidth":3},"zIndex":1001,"data":{"parentElement":{"id":"root","type":"case-management:root"},"isIntersecting":false}}]}]]></uipath:caseManagement>
+      <uipath:migrationVersion version="9" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="trigger_1">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="d153b809-41a2-425f-8e51-72a5746a65db" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_trigger_1-Activity_InitialVariablesNode</bpmn:outgoing>
+      <bpmn:messageEventDefinition />
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_InitialVariablesNode" name="Set initial re-entry/re-exit variables">
+      <bpmn:extensionElements>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="Return_From_Secondary_Stage_To_Stage" type="string" source="" var="ReturnFromSecondaryStageToStage" custom="true" />
+          <uipath:output name="stage_1_ReEntryCount" type="integer" source="-1" var="stage1ReEntryCount" custom="true" />
+          <uipath:output name="stage_1_ReExit_To_Stage" type="string" source="" var="stage1ReExitToStage" custom="true" />
+          <uipath:output name="stage_1_SubProcess_Tasks_Complete" type="boolean" source="false" var="stage1SubProcessTasksComplete" custom="true" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_trigger_1-Activity_InitialVariablesNode</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_InitialVariablesNode-stage_1</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:subProcess id="stage_1" name="Stage 1">
+      <bpmn:extensionElements>
+        <uipath:caseManagement version="1.0"><![CDATA[{"id":"stage_1","type":"case-management:Stage","position":{"x":326,"y":200},"style":{"width":304},"measured":{"width":304,"height":127},"data":{"label":"Stage 1","parentElement":{"id":"root","type":"case-management:root"},"tasks":[[{"id":"ttgupuwp0","type":"process","data":{"name":"=bindings.bgKwTteki","folderPath":"=bindings.bSUUURIEo","inputs":[{"name":"InputProcess","displayName":"InputProcess","value":"=datafabric.LoanApplicationCase[\"qes:{\"filterGroup\": {\"logicalOperator\": 0, \"queryFilters\": [{\"fieldName\": \"CaseId\", \"operator\": \"=\", \"value\": \"HL-999\"}]}}\"]","type":"string","title":"InputProcess","required":false,"id":"v5Zz8SK1d","var":"v5Zz8SK1d","elementId":"stage_1-ttgupuwp0"}],"outputs":[{"name":"loanObject","displayName":"loanObject","type":"json","body":"","_jsonSchema":"","custom":true,"id":"loanObject","var":"loanObject","elementId":"stage_1-ttgupuwp0"}]},"elementId":"stage_1-ttgupuwp0","displayName":"Process"}]],"isInvalidDropTarget":false,"isPendingParent":false},"width":304,"selected":false}]]></uipath:caseManagement>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_Activity_InitialVariablesNode-stage_1</bpmn:incoming>
+      <bpmn:outgoing>edge_stage_1-EndEvent_From_Gateway_From_stage_1</bpmn:outgoing>
+      <bpmn:startEvent id="StartEvent_stage_1">
+        <bpmn:outgoing>edge_StartEvent_stage_1-Bump_Re_Entry_Count_stage_1</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Bump_Re_Entry_Count_stage_1" name="Increment re-entry count for stage stage_1">
+        <bpmn:extensionElements>
+          <uipath:mapping version="v1">
+            <uipath:type value="BPMN.Variables" version="v1" />
+            <uipath:output name="stage_1_ReEntryCount" type="integer" source="=js:parseInt(vars.stage1ReEntryCount, 10) + 1" var="stage1ReEntryCount" custom="true" />
+          </uipath:mapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_StartEvent_stage_1-Bump_Re_Entry_Count_stage_1</bpmn:incoming>
+        <bpmn:outgoing>edge_Bump_Re_Entry_Count_stage_1-Reset_ReEntry_Variables_At_Start_stage_1</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:task id="Reset_ReEntry_Variables_At_Start_stage_1" name="Reset variables for tasks running in stage stage_1 on re-entry">
+        <bpmn:extensionElements>
+          <uipath:activity version="v1" skipCondition="=js:parseInt(vars.stage1ReEntryCount, 10) == 0">
+            <uipath:type value="uipath:Activity" version="v1" />
+            <uipath:output name="stage_1_SubProcess_Tasks_Complete" type="boolean" source="false" var="stage1SubProcessTasksComplete" custom="true" />
+          </uipath:activity>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Bump_Re_Entry_Count_stage_1-Reset_ReEntry_Variables_At_Start_stage_1</bpmn:incoming>
+        <bpmn:outgoing>edge_Reset_ReEntry_Variables_At_Start_stage_1-ttgupuwp0</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:callActivity id="ttgupuwp0" name="Process">
+        <bpmn:extensionElements>
+          <uipath:tags>
+            <uipath:tag key="stageId">stage_1</uipath:tag>
+            <uipath:tag key="stageName">Stage 1</uipath:tag>
+          </uipath:tags>
+          <uipath:activity version="v1" skipCondition="=js:parseInt(vars.stage1ReEntryCount, 10) &#62; 0">
+            <uipath:type value="Orchestrator.StartAgenticProcess" version="v2" />
+            <uipath:context>
+              <uipath:input name="name" type="string" value="=bindings.bgKwTteki" />
+              <uipath:input name="folderPath" type="string" value="=bindings.bSUUURIEo" />
+              <uipath:input name="_label" type="string" value="Process" />
+              <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"InputProcess":{"type":"string"}},"required":[]}]]></uipath:inputSchema>
+            </uipath:context>
+             <uipath:output name="loanObject" type="json" source="{&#34;LoanAmount&#34;:123}" var="loanObject" custom="true"
+              action="update"
+              target="=datafabric.LoanApplicationCase[&quot;qes:{&quot;filterGroup&quot;: {&quot;logicalOperator&quot;: 0, &quot;queryFilters&quot;: [{&quot;fieldName&quot;: &quot;CaseId&quot;, &quot;operator&quot;: &quot;=&quot;, &quot;value&quot;: &quot;HL-999&quot;}]}}&quot;]"/>
+          </uipath:activity>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Reset_ReEntry_Variables_At_Start_stage_1-ttgupuwp0</bpmn:incoming>
+        <bpmn:outgoing>edge_ttgupuwp0-UpdateTasksComplete_stage_1</bpmn:outgoing>
+      </bpmn:callActivity>
+      <bpmn:task id="UpdateTasksComplete_stage_1" name="Update Variable for tasks complete in stage stage_1">
+        <bpmn:extensionElements>
+          <uipath:mapping version="v1">
+            <uipath:type value="BPMN.Variables" version="v1" />
+            <uipath:output name="stage_1_SubProcess_Tasks_Complete" type="boolean" source="true" var="stage1SubProcessTasksComplete" custom="true" />
+          </uipath:mapping>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_ttgupuwp0-UpdateTasksComplete_stage_1</bpmn:incoming>
+        <bpmn:outgoing>edge_UpdateTasksComplete_stage_1-EndEvent_For_stage_1_SubProcess</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:endEvent id="EndEvent_For_stage_1_SubProcess">
+        <bpmn:incoming>edge_UpdateTasksComplete_stage_1-EndEvent_For_stage_1_SubProcess</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="edge_StartEvent_stage_1-Bump_Re_Entry_Count_stage_1" sourceRef="StartEvent_stage_1" targetRef="Bump_Re_Entry_Count_stage_1" />
+      <bpmn:sequenceFlow id="edge_Bump_Re_Entry_Count_stage_1-Reset_ReEntry_Variables_At_Start_stage_1" sourceRef="Bump_Re_Entry_Count_stage_1" targetRef="Reset_ReEntry_Variables_At_Start_stage_1" />
+      <bpmn:sequenceFlow id="edge_Reset_ReEntry_Variables_At_Start_stage_1-ttgupuwp0" sourceRef="Reset_ReEntry_Variables_At_Start_stage_1" targetRef="ttgupuwp0" />
+      <bpmn:sequenceFlow id="edge_ttgupuwp0-UpdateTasksComplete_stage_1" sourceRef="ttgupuwp0" targetRef="UpdateTasksComplete_stage_1" />
+      <bpmn:sequenceFlow id="edge_UpdateTasksComplete_stage_1-EndEvent_For_stage_1_SubProcess" sourceRef="UpdateTasksComplete_stage_1" targetRef="EndEvent_For_stage_1_SubProcess" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="EndEvent_From_Gateway_From_stage_1">
+      <bpmn:incoming>edge_stage_1-EndEvent_From_Gateway_From_stage_1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge_trigger_1-Activity_InitialVariablesNode" sourceRef="trigger_1" targetRef="Activity_InitialVariablesNode" />
+    <bpmn:sequenceFlow id="edge_Activity_InitialVariablesNode-stage_1" sourceRef="Activity_InitialVariablesNode" targetRef="stage_1" />
+    <bpmn:sequenceFlow id="edge_stage_1-EndEvent_From_Gateway_From_stage_1" sourceRef="stage_1" targetRef="EndEvent_From_Gateway_From_stage_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="case-management">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_trigger_1" bpmnElement="trigger_1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="57" y="93" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_InitialVariablesNode" bpmnElement="Activity_InitialVariablesNode">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="175" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_stage_1" bpmnElement="stage_1" isExpanded="false">
+        <dc:Bounds x="325" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="325" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_EndEvent_From_Gateway_From_stage_1" bpmnElement="EndEvent_From_Gateway_From_stage_1">
+        <dc:Bounds x="507" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="507" y="93" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_trigger_1-Activity_InitialVariablesNode" bpmnElement="edge_trigger_1-Activity_InitialVariablesNode">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_InitialVariablesNode-stage_1" bpmnElement="edge_Activity_InitialVariablesNode-stage_1">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_stage_1-EndEvent_From_Gateway_From_stage_1" bpmnElement="edge_stage_1-EndEvent_From_Gateway_From_stage_1">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="507" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_stage_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_stage_1" bpmnElement="stage_1">
+      <bpmndi:BPMNShape id="S_StartEvent_stage_1" bpmnElement="StartEvent_stage_1">
+        <dc:Bounds x="57" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="57" y="93" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Bump_Re_Entry_Count_stage_1" bpmnElement="Bump_Re_Entry_Count_stage_1">
+        <dc:Bounds x="175" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="175" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Reset_ReEntry_Variables_At_Start_stage_1" bpmnElement="Reset_ReEntry_Variables_At_Start_stage_1">
+        <dc:Bounds x="325" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="325" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_ttgupuwp0" bpmnElement="ttgupuwp0">
+        <dc:Bounds x="475" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="475" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_UpdateTasksComplete_stage_1" bpmnElement="UpdateTasksComplete_stage_1">
+        <dc:Bounds x="625" y="30" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="625" y="115" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_EndEvent_For_stage_1_SubProcess" bpmnElement="EndEvent_For_stage_1_SubProcess">
+        <dc:Bounds x="807" y="52" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="807" y="93" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_StartEvent_stage_1-Bump_Re_Entry_Count_stage_1" bpmnElement="edge_StartEvent_stage_1-Bump_Re_Entry_Count_stage_1">
+        <di:waypoint x="93" y="70" />
+        <di:waypoint x="175" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Bump_Re_Entry_Count_stage_1-Reset_ReEntry_Variables_At_Start_stage_1" bpmnElement="edge_Bump_Re_Entry_Count_stage_1-Reset_ReEntry_Variables_At_Start_stage_1">
+        <di:waypoint x="275" y="70" />
+        <di:waypoint x="325" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Reset_ReEntry_Variables_At_Start_stage_1-ttgupuwp0" bpmnElement="edge_Reset_ReEntry_Variables_At_Start_stage_1-ttgupuwp0">
+        <di:waypoint x="425" y="70" />
+        <di:waypoint x="475" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_ttgupuwp0-UpdateTasksComplete_stage_1" bpmnElement="edge_ttgupuwp0-UpdateTasksComplete_stage_1">
+        <di:waypoint x="575" y="70" />
+        <di:waypoint x="625" y="70" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_UpdateTasksComplete_stage_1-EndEvent_For_stage_1_SubProcess" bpmnElement="edge_UpdateTasksComplete_stage_1-EndEvent_For_stage_1_SubProcess">
+        <di:waypoint x="725" y="70" />
+        <di:waypoint x="807" y="70" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ErrorBoundary.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ErrorBoundary.bpmn
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="d83b309b">
+  <bpmn:error id="Error_MyFault" name="MyError" errorCode="MyFault" />
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_host</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="Activity_Host" name="Host" scriptFormat="JavaScript">
+      <bpmn:script>HOST</bpmn:script>
+      <bpmn:incoming>flow_start_host</bpmn:incoming>
+      <bpmn:outgoing>flow_host_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:boundaryEvent id="Boundary_error" name="CatchMyFault" attachedToRef="Activity_Host">
+      <bpmn:outgoing>flow_boundary_bscript</bpmn:outgoing>
+      <bpmn:errorEventDefinition errorRef="Error_MyFault" />
+    </bpmn:boundaryEvent>
+    <bpmn:scriptTask id="Activity_BoundaryScript" name="BoundaryScript" scriptFormat="JavaScript">
+      <bpmn:script>BOUNDARY</bpmn:script>
+      <bpmn:incoming>flow_boundary_bscript</bpmn:incoming>
+      <bpmn:outgoing>flow_bscript_bend</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end_host">
+      <bpmn:incoming>flow_host_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_end_boundary">
+      <bpmn:incoming>flow_bscript_bend</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_host" sourceRef="Event_start" targetRef="Activity_Host" />
+    <bpmn:sequenceFlow id="flow_host_end" sourceRef="Activity_Host" targetRef="Event_end_host" />
+    <bpmn:sequenceFlow id="flow_boundary_bscript" sourceRef="Boundary_error" targetRef="Activity_BoundaryScript" />
+    <bpmn:sequenceFlow id="flow_bscript_bend" sourceRef="Activity_BoundaryScript" targetRef="Event_end_boundary" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="160" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_Host" bpmnElement="Activity_Host">
+        <dc:Bounds x="260" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Boundary_error" bpmnElement="Boundary_error">
+        <dc:Bounds x="322" y="240" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_BoundaryScript" bpmnElement="Activity_BoundaryScript">
+        <dc:Bounds x="420" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end_host" bpmnElement="Event_end_host">
+        <dc:Bounds x="460" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end_boundary" bpmnElement="Event_end_boundary">
+        <dc:Bounds x="580" y="342" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_flow_start_host" bpmnElement="flow_start_host">
+        <di:waypoint x="196" y="218" />
+        <di:waypoint x="260" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_host_end" bpmnElement="flow_host_end">
+        <di:waypoint x="360" y="218" />
+        <di:waypoint x="460" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_boundary_bscript" bpmnElement="flow_boundary_bscript">
+        <di:waypoint x="340" y="276" />
+        <di:waypoint x="340" y="360" />
+        <di:waypoint x="420" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_bscript_bend" bpmnElement="flow_bscript_bend">
+        <di:waypoint x="520" y="360" />
+        <di:waypoint x="580" y="360" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ErrorPropagationInEventSubprocess.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ErrorPropagationInEventSubprocess.bpmn
@@ -1,0 +1,340 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="c6769f64">
+  <bpmn:error id="Error_c29n1H" name="SP-ERROR" errorCode="SP-ERROR" />
+  <bpmn:process id="Process_1" name="Process" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="error2" name="Error" type="jsonSchema" elementId="Activity_Nvh2KU"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"element":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bnlPSVjra" name="folderPath" type="string" resource="process" resourceKey="RPA Workflow" propertyAttribute="folderPath" />
+        <uipath:binding id="bfYdyTnJb" name="name" type="string" default="RPA Workflow" resource="process" resourceKey="RPA Workflow" propertyAttribute="name" />
+      </uipath:bindings>
+      <uipath:migrationVersion version="11" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Start event">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="642ec933-7420-4a47-a7a6-27b20c70e0ae" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_KdXttL</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="Activity_Nvh2KU" name="Subprocess">
+      <bpmn:extensionElements>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="Error" type="json" source="=Error" var="error2" />
+        </uipath:mapping>
+        <uipath:variables version="v1">
+          <uipath:inputOutput id="error" name="Error" type="jsonSchema" elementId="Task2"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"element":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+          <uipath:inputOutput id="error4" name="Error" type="jsonSchema" elementId="Task1"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"element":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+          <uipath:inputOutput id="error5" name="Error" type="jsonSchema" elementId="Task3" />
+        </uipath:variables>
+      </bpmn:extensionElements>
+      <bpmn:incoming>edge_KdXttL</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_Nvh2KU-Event_Sk41GC</bpmn:outgoing>
+      <bpmn:startEvent id="Event_n4myH4">
+        <bpmn:outgoing>edge_Event_n4myH4-Activity_X0AyaeWqsNr2</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:serviceTask id="Task2" name="Task2">
+        <bpmn:extensionElements>
+          <uipath:activity version="v1">
+            <uipath:type value="Orchestrator.StartJob" version="v2" />
+            <uipath:context>
+              <uipath:input name="name" type="string" value="=bindings.bfYdyTnJb" />
+              <uipath:input name="folderPath" type="string" value="=bindings.bnlPSVjra" />
+              <uipath:input name="_label" type="string" value="RPA Workflow" />
+              <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"Error":{"type":"object"}},"required":[]}]]></uipath:inputSchema>
+            </uipath:context>
+            <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"Error":{"code":"22222","message":"msg","detail":"detail","element":"Task2"}}]]></uipath:input>
+            <uipath:output name="Error" type="jsonSchema" source="=Error" var="error" />
+          </uipath:activity>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Activity_X0Ayae-Activity_GGXYoX0qGkRC</bpmn:incoming>
+        <bpmn:outgoing>edge_Task2-Activity_H2mCKKXvbtfx</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="Event_pnR3w5">
+        <bpmn:incoming>edge_Activity_H2mCKK-Event_pnR3w5XNnBFC</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="Task1" name="Task1">
+        <bpmn:extensionElements>
+          <uipath:activity version="v1">
+            <uipath:type value="Orchestrator.StartJob" version="v2" />
+            <uipath:context>
+              <uipath:input name="name" type="string" value="=bindings.bfYdyTnJb" />
+              <uipath:input name="folderPath" type="string" value="=bindings.bnlPSVjra" />
+              <uipath:input name="_label" type="string" value="RPA Workflow" />
+              <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"Error":{"type":"object"}},"required":[]}]]></uipath:inputSchema>
+            </uipath:context>
+            <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"Error":{"code":"11111","message":"msg","detail":"detail","element":"Task1"}}]]></uipath:input>
+            <uipath:output name="Error" type="jsonSchema" source="=Error" var="error4" />
+          </uipath:activity>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Event_n4myH4-Activity_X0AyaeWqsNr2</bpmn:incoming>
+        <bpmn:outgoing>edge_Activity_X0Ayae-Activity_GGXYoX0qGkRC</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_BFkVY2" attachedToRef="Task1">
+        <bpmn:outgoing>edge_3PxM2z</bpmn:outgoing>
+        <bpmn:errorEventDefinition />
+      </bpmn:boundaryEvent>
+      <bpmn:endEvent id="Event_Y4sRJ0">
+        <bpmn:incoming>edge_3PxM2z</bpmn:incoming>
+        <bpmn:errorEventDefinition errorRef="Error_c29n1H" />
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="Task3" name="Task3">
+        <bpmn:extensionElements>
+          <uipath:activity version="v1">
+            <uipath:type value="Orchestrator.StartJob" version="v2" />
+            <uipath:context>
+              <uipath:input name="name" type="string" value="=bindings.bfYdyTnJb" />
+              <uipath:input name="folderPath" type="string" value="=bindings.bnlPSVjra" />
+              <uipath:input name="_label" type="string" value="RPA Workflow" />
+              <uipath:inputSchema type="jsonSchema"><![CDATA[{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","properties":{"Error":{"type":"object"}},"required":[]}]]></uipath:inputSchema>
+            </uipath:context>
+            <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{"Error":{"code":"22222","message":"msg","detail":"detail","element":"Task2"}}]]></uipath:input>
+            <uipath:output name="Error" type="jsonSchema" source="=Error" var="error5" />
+          </uipath:activity>
+        </bpmn:extensionElements>
+        <bpmn:incoming>edge_Task2-Activity_H2mCKKXvbtfx</bpmn:incoming>
+        <bpmn:outgoing>edge_Activity_H2mCKK-Event_pnR3w5XNnBFC</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="edge_Event_n4myH4-Activity_X0AyaeWqsNr2" sourceRef="Event_n4myH4" targetRef="Task1" />
+      <bpmn:sequenceFlow id="edge_Activity_X0Ayae-Activity_GGXYoX0qGkRC" sourceRef="Task1" targetRef="Task2" />
+      <bpmn:sequenceFlow id="edge_Task2-Activity_H2mCKKXvbtfx" sourceRef="Task2" targetRef="Task3" />
+      <bpmn:sequenceFlow id="edge_Activity_H2mCKK-Event_pnR3w5XNnBFC" sourceRef="Task3" targetRef="Event_pnR3w5" />
+      <bpmn:sequenceFlow id="edge_3PxM2z" sourceRef="Event_BFkVY2" targetRef="Event_Y4sRJ0" />
+    </bpmn:subProcess>
+    <bpmn:endEvent id="Event_Sk41GC">
+      <bpmn:incoming>edge_Activity_Nvh2KU-Event_Sk41GC</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:subProcess id="Activity_jQX2Ig" name="error event subprocess" triggeredByEvent="true">
+      <bpmn:extensionElements>
+        <uipath:variables version="v1">
+          <uipath:input id="vKDVmarW0" name="Error" type="json" elementId="Event_hL0wZn" />
+          <uipath:inputOutput id="error9" name="Error" type="json" elementId="Event_hL0wZn"><![CDATA[{"type":"object","properties":{"code":{"type":"string"},"element":{"type":"string"},"message":{"type":"string"},"detail":{"type":"string"},"category":{"type":"string"},"status":{"type":"number"}}}]]></uipath:inputOutput>
+        </uipath:variables>
+      </bpmn:extensionElements>
+      <bpmn:startEvent id="Event_hL0wZn">
+        <bpmn:extensionElements>
+          <uipath:mapping version="v1">
+            <uipath:type value="BPMN.Variables" version="v1" />
+            <uipath:output name="Error" type="json" source="=vars.vKDVmarW0" var="error9" />
+          </uipath:mapping>
+        </bpmn:extensionElements>
+        <bpmn:outgoing>edge_ZMayEp</bpmn:outgoing>
+        <bpmn:errorEventDefinition />
+      </bpmn:startEvent>
+      <bpmn:endEvent id="Event_cJTbdK">
+        <bpmn:incoming>edge_sy5BNW</bpmn:incoming>
+        <bpmn:incoming>edge_Wnwemu</bpmn:incoming>
+        <bpmn:incoming>edge_zVCd6m</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:exclusiveGateway id="Gateway_Dh32Hw">
+        <bpmn:incoming>edge_ZMayEp</bpmn:incoming>
+        <bpmn:outgoing>edge_FnVdtE</bpmn:outgoing>
+        <bpmn:outgoing>edge_fuy0rs</bpmn:outgoing>
+        <bpmn:outgoing>edge_iBzdUo</bpmn:outgoing>
+      </bpmn:exclusiveGateway>
+      <bpmn:task id="SubprocessErrorHandler" name="Subprocess Error Handler">
+        <bpmn:incoming>edge_FnVdtE</bpmn:incoming>
+        <bpmn:outgoing>edge_sy5BNW</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:task id="Task2ErrorHandler" name="Task2 Error Handler">
+        <bpmn:incoming>edge_fuy0rs</bpmn:incoming>
+        <bpmn:outgoing>edge_Wnwemu</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:task id="Task3ErrorHandler" name="Task3 Error Handler">
+        <bpmn:incoming>edge_iBzdUo</bpmn:incoming>
+        <bpmn:outgoing>edge_zVCd6m</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="edge_FnVdtE" sourceRef="Gateway_Dh32Hw" targetRef="SubprocessErrorHandler">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=vars.error9.element =="Subprocess"</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="edge_fuy0rs" sourceRef="Gateway_Dh32Hw" targetRef="Task2ErrorHandler">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=vars.error9.element =="Task2"</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="edge_sy5BNW" sourceRef="SubprocessErrorHandler" targetRef="Event_cJTbdK" />
+      <bpmn:sequenceFlow id="edge_Wnwemu" sourceRef="Task2ErrorHandler" targetRef="Event_cJTbdK" />
+      <bpmn:sequenceFlow id="edge_iBzdUo" sourceRef="Gateway_Dh32Hw" targetRef="Task3ErrorHandler">
+        <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=vars.error9.element == "Task3"</bpmn:conditionExpression>
+      </bpmn:sequenceFlow>
+      <bpmn:sequenceFlow id="edge_zVCd6m" sourceRef="Task3ErrorHandler" targetRef="Event_cJTbdK" />
+      <bpmn:sequenceFlow id="edge_ZMayEp" sourceRef="Event_hL0wZn" targetRef="Gateway_Dh32Hw" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="edge_KdXttL" sourceRef="Event_start" targetRef="Activity_Nvh2KU" />
+    <bpmn:sequenceFlow id="edge_Activity_Nvh2KU-Event_Sk41GC" sourceRef="Activity_Nvh2KU" targetRef="Event_Sk41GC" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="108" y="265" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="108" y="306" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_Nvh2KU" bpmnElement="Activity_Nvh2KU" isExpanded="true">
+        <dc:Bounds x="235" y="183" width="691" height="244" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="235" y="432" width="691" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_n4myH4" bpmnElement="Event_n4myH4">
+        <dc:Bounds x="273" y="245" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="273" y="286" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task2" bpmnElement="Task2">
+        <dc:Bounds x="518" y="223" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="308" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_pnR3w5" bpmnElement="Event_pnR3w5">
+        <dc:Bounds x="794" y="245" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="794" y="286" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task1" bpmnElement="Task1">
+        <dc:Bounds x="362" y="223" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="362" y="308" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_BFkVY2" bpmnElement="Event_BFkVY2">
+        <dc:Bounds x="394" y="285" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="394" y="326" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_Y4sRJ0" bpmnElement="Event_Y4sRJ0">
+        <dc:Bounds x="510" y="341" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="510" y="382" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task3" bpmnElement="Task3">
+        <dc:Bounds x="655.6" y="223" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="655.6" y="308" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_Sk41GC" bpmnElement="Event_Sk41GC">
+        <dc:Bounds x="1093.6" y="293.8" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1093.6" y="334.8" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_jQX2Ig" bpmnElement="Activity_jQX2Ig" isExpanded="true">
+        <dc:Bounds x="344.1" y="515.8770751953124" width="723" height="385" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="344.1" y="905.8770751953124" width="723" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_hL0wZn" bpmnElement="Event_hL0wZn">
+        <dc:Bounds x="387.9" y="614.4838134765624" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="387.9" y="655.4838134765624" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_cJTbdK" bpmnElement="Event_cJTbdK">
+        <dc:Bounds x="945.1" y="633.9838134765624" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="945.1" y="674.9838134765624" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Gateway_Dh32Hw" bpmnElement="Gateway_Dh32Hw">
+        <dc:Bounds x="583.0999999999999" y="607.4838134765624" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="583.0999999999999" y="662.4838134765624" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_SubprocessErrorHandler" bpmnElement="SubprocessErrorHandler">
+        <dc:Bounds x="681.0999999999999" y="592.4838134765624" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681.0999999999999" y="677.4838134765624" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task2ErrorHandler" bpmnElement="Task2ErrorHandler">
+        <dc:Bounds x="681.0999999999999" y="688.4838134765624" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681.0999999999999" y="773.4838134765624" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task3ErrorHandler" bpmnElement="Task3ErrorHandler">
+        <dc:Bounds x="681.0999999999999" y="784.4838134765624" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="681.0999999999999" y="869.4838134765624" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_KdXttL" bpmnElement="edge_KdXttL">
+        <di:waypoint x="144" y="283" />
+        <di:waypoint x="189.5" y="283" />
+        <di:waypoint x="189.5" y="305" />
+        <di:waypoint x="235" y="305" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_Nvh2KU-Event_Sk41GC" bpmnElement="edge_Activity_Nvh2KU-Event_Sk41GC">
+        <di:waypoint x="926" y="305" />
+        <di:waypoint x="1009.8" y="305" />
+        <di:waypoint x="1009.8" y="311.8" />
+        <di:waypoint x="1093.6" y="311.8" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_n4myH4-Activity_X0AyaeWqsNr2" bpmnElement="edge_Event_n4myH4-Activity_X0AyaeWqsNr2">
+        <di:waypoint x="309" y="263" />
+        <di:waypoint x="362" y="263" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_X0Ayae-Activity_GGXYoX0qGkRC" bpmnElement="edge_Activity_X0Ayae-Activity_GGXYoX0qGkRC">
+        <di:waypoint x="462" y="263" />
+        <di:waypoint x="518" y="263" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Task2-Activity_H2mCKKXvbtfx" bpmnElement="edge_Task2-Activity_H2mCKKXvbtfx">
+        <di:waypoint x="618" y="263" />
+        <di:waypoint x="655.6" y="263" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_H2mCKK-Event_pnR3w5XNnBFC" bpmnElement="edge_Activity_H2mCKK-Event_pnR3w5XNnBFC">
+        <di:waypoint x="755.6" y="263" />
+        <di:waypoint x="794" y="263" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_3PxM2z" bpmnElement="edge_3PxM2z">
+        <di:waypoint x="430" y="303" />
+        <di:waypoint x="470" y="303" />
+        <di:waypoint x="470" y="359" />
+        <di:waypoint x="510" y="359" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_FnVdtE" bpmnElement="edge_FnVdtE">
+        <di:waypoint x="633.0999999999999" y="632.4838134765624" />
+        <di:waypoint x="681.0999999999999" y="632.4838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_fuy0rs" bpmnElement="edge_fuy0rs">
+        <di:waypoint x="608.0999999999999" y="657.4838134765624" />
+        <di:waypoint x="608.0999999999999" y="728.4838134765624" />
+        <di:waypoint x="681.0999999999999" y="728.4838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_sy5BNW" bpmnElement="edge_sy5BNW">
+        <di:waypoint x="781.0999999999999" y="632.4838134765624" />
+        <di:waypoint x="863.0999999999999" y="632.4838134765624" />
+        <di:waypoint x="863.0999999999999" y="651.9838134765624" />
+        <di:waypoint x="945.1" y="651.9838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Wnwemu" bpmnElement="edge_Wnwemu">
+        <di:waypoint x="781.0999999999999" y="728.4838134765624" />
+        <di:waypoint x="963.1" y="728.4838134765624" />
+        <di:waypoint x="963.1" y="669.9838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_iBzdUo" bpmnElement="edge_iBzdUo">
+        <di:waypoint x="608.0999999999999" y="657.4838134765624" />
+        <di:waypoint x="608.0999999999999" y="824.4838134765624" />
+        <di:waypoint x="681.0999999999999" y="824.4838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_zVCd6m" bpmnElement="edge_zVCd6m">
+        <di:waypoint x="781.0999999999999" y="824.4838134765624" />
+        <di:waypoint x="963.1" y="824.4838134765624" />
+        <di:waypoint x="963.1" y="669.9838134765624" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_ZMayEp" bpmnElement="edge_ZMayEp">
+        <di:waypoint x="423.9" y="632.4838134765624" />
+        <di:waypoint x="583.0999999999999" y="632.4838134765624" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/EventBasedGatewayFirstCatcherWins.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/EventBasedGatewayFirstCatcherWins.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:eventBasedGateway id="Gateway_ebg">
+      <bpmn:incoming>flow_start_to_gw</bpmn:incoming>
+      <bpmn:outgoing>flow_gw_to_none</bpmn:outgoing>
+      <bpmn:outgoing>flow_gw_to_timer</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="Event_none" name="None catch (wins instantly)">
+      <bpmn:incoming>flow_gw_to_none</bpmn:incoming>
+      <bpmn:outgoing>flow_none_to_scriptA</bpmn:outgoing>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="Event_timer" name="Timer catch (loses, cancelled)">
+      <bpmn:incoming>flow_gw_to_timer</bpmn:incoming>
+      <bpmn:outgoing>flow_timer_to_scriptB</bpmn:outgoing>
+      <bpmn:timerEventDefinition>
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT60S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:scriptTask id="Activity_ScriptA" name="Script A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_none_to_scriptA</bpmn:incoming>
+      <bpmn:outgoing>flow_scriptA_to_endA</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_ScriptB" name="Script B" scriptFormat="JavaScript">
+      <bpmn:script>console.log('B')</bpmn:script>
+      <bpmn:incoming>flow_timer_to_scriptB</bpmn:incoming>
+      <bpmn:outgoing>flow_scriptB_to_endB</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_endA">
+      <bpmn:incoming>flow_scriptA_to_endA</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_endB">
+      <bpmn:incoming>flow_scriptB_to_endB</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_gw" sourceRef="Event_start" targetRef="Gateway_ebg" />
+    <bpmn:sequenceFlow id="flow_gw_to_none" sourceRef="Gateway_ebg" targetRef="Event_none" />
+    <bpmn:sequenceFlow id="flow_gw_to_timer" sourceRef="Gateway_ebg" targetRef="Event_timer" />
+    <bpmn:sequenceFlow id="flow_none_to_scriptA" sourceRef="Event_none" targetRef="Activity_ScriptA" />
+    <bpmn:sequenceFlow id="flow_timer_to_scriptB" sourceRef="Event_timer" targetRef="Activity_ScriptB" />
+    <bpmn:sequenceFlow id="flow_scriptA_to_endA" sourceRef="Activity_ScriptA" targetRef="Event_endA" />
+    <bpmn:sequenceFlow id="flow_scriptB_to_endB" sourceRef="Activity_ScriptB" targetRef="Event_endB" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Example-EventBasedGateway.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Example-EventBasedGateway.bpmn
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1" targetNamespace="http://example.com/bpmn" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="local">
+  <bpmn:message id="Message_1" name="Message_1"/>
+  <bpmn:process id="Process_1" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="6e90be0b-f1de-4c89-8a5d-e85c57f874cf"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge___StartEvent_1-Activity_blAMrBLZNXYK</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:eventBasedGateway id="EventBasedGateway_1" name="Event-Based Gateway">
+      <bpmn:incoming>edge___Activity_blAMrB-EventBasedGateway_1CgT6WZ</bpmn:incoming>
+      <bpmn:outgoing>Flow_2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_3</bpmn:outgoing>
+    </bpmn:eventBasedGateway>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_1" name="Message Event">
+      <bpmn:incoming>Flow_2</bpmn:incoming>
+      <bpmn:outgoing>Flow_4</bpmn:outgoing>
+      <bpmn:messageEventDefinition messageRef="Message_1"/>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:intermediateCatchEvent id="IntermediateCatchEvent_2" name="Timer Event">
+      <bpmn:incoming>Flow_3</bpmn:incoming>
+      <bpmn:outgoing>Flow_5</bpmn:outgoing>
+      <bpmn:timerEventDefinition/>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="EndEvent_1" name="End Message">
+      <bpmn:incoming>Flow_4</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="EndEvent_2" name="End Timer">
+      <bpmn:incoming>Flow_5</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_blAMrB" name="Task">
+      <bpmn:incoming>edge___StartEvent_1-Activity_blAMrBLZNXYK</bpmn:incoming>
+      <bpmn:outgoing>edge___Activity_blAMrB-EventBasedGateway_1CgT6WZ</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_2" sourceRef="EventBasedGateway_1" targetRef="IntermediateCatchEvent_1"/>
+    <bpmn:sequenceFlow id="Flow_3" sourceRef="EventBasedGateway_1" targetRef="IntermediateCatchEvent_2"/>
+    <bpmn:sequenceFlow id="Flow_4" sourceRef="IntermediateCatchEvent_1" targetRef="EndEvent_1"/>
+    <bpmn:sequenceFlow id="Flow_5" sourceRef="IntermediateCatchEvent_2" targetRef="EndEvent_2"/>
+    <bpmn:sequenceFlow id="edge___StartEvent_1-Activity_blAMrBLZNXYK" sourceRef="StartEvent_1" targetRef="Activity_blAMrB"/>
+    <bpmn:sequenceFlow id="edge___Activity_blAMrB-EventBasedGateway_1CgT6WZ" sourceRef="Activity_blAMrB" targetRef="EventBasedGateway_1"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_StartEvent_1" bpmnElement="StartEvent_1">
+        <dc:Bounds x="-27.378875569559415" y="107" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-27.378875569559415" y="148" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_EventBasedGateway_1" bpmnElement="EventBasedGateway_1">
+        <dc:Bounds x="200" y="100" width="50" height="50"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="155" width="50" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_IntermediateCatchEvent_1" bpmnElement="IntermediateCatchEvent_1">
+        <dc:Bounds x="320" y="60" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="101" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_IntermediateCatchEvent_2" bpmnElement="IntermediateCatchEvent_2">
+        <dc:Bounds x="320" y="150" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="320" y="191" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_EndEvent_1" bpmnElement="EndEvent_1">
+        <dc:Bounds x="450" y="60" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="101" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_EndEvent_2" bpmnElement="EndEvent_2">
+        <dc:Bounds x="450" y="150" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="191" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_blAMrB" bpmnElement="Activity_blAMrB">
+        <dc:Bounds x="51.89402095309063" y="85" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="51.89402095309063" y="170" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_2" bpmnElement="Flow_2">
+        <di:waypoint x="250" y="125"/>
+        <di:waypoint x="285" y="125"/>
+        <di:waypoint x="285" y="78"/>
+        <di:waypoint x="320" y="78"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_3" bpmnElement="Flow_3">
+        <di:waypoint x="250" y="125"/>
+        <di:waypoint x="285" y="125"/>
+        <di:waypoint x="285" y="168"/>
+        <di:waypoint x="320" y="168"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_4" bpmnElement="Flow_4">
+        <di:waypoint x="356" y="78"/>
+        <di:waypoint x="450" y="78"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_5" bpmnElement="Flow_5">
+        <di:waypoint x="356" y="168"/>
+        <di:waypoint x="450" y="168"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge___StartEvent_1-Activity_blAMrBLZNXYK" bpmnElement="edge___StartEvent_1-Activity_blAMrBLZNXYK">
+        <di:waypoint x="9" y="125"/>
+        <di:waypoint x="52" y="125"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge___Activity_blAMrB-EventBasedGateway_1CgT6WZ" bpmnElement="edge___Activity_blAMrB-EventBasedGateway_1CgT6WZ">
+        <di:waypoint x="152" y="125"/>
+        <di:waypoint x="200" y="125"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveGatewayConditional.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveGatewayConditional.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="vX" name="x" type="integer" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1" name="XOR" default="flow_gw_to_b">
+      <bpmn:incoming>flow_start_to_gw</bpmn:incoming>
+      <bpmn:outgoing>flow_gw_to_a</bpmn:outgoing>
+      <bpmn:outgoing>flow_gw_to_b</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:scriptTask id="Activity_A" name="Script A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_gw_to_a</bpmn:incoming>
+      <bpmn:outgoing>flow_a_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_B" name="Script B" scriptFormat="JavaScript">
+      <bpmn:script>console.log('B')</bpmn:script>
+      <bpmn:incoming>flow_gw_to_b</bpmn:incoming>
+      <bpmn:outgoing>flow_b_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_a_to_end</bpmn:incoming>
+      <bpmn:incoming>flow_b_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_gw" sourceRef="Event_start" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="flow_gw_to_a" sourceRef="Gateway_1" targetRef="Activity_A">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 10</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_gw_to_b" sourceRef="Gateway_1" targetRef="Activity_B" />
+    <bpmn:sequenceFlow id="flow_a_to_end" sourceRef="Activity_A" targetRef="Event_end" />
+    <bpmn:sequenceFlow id="flow_b_to_end" sourceRef="Activity_B" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveGatewaySharedEndEvent.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveGatewaySharedEndEvent.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="x" name="x" type="integer" elementId="Event_start" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_start_to_gw</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1" default="edge_gw_to_default">
+      <bpmn:incoming>edge_start_to_gw</bpmn:incoming>
+      <bpmn:outgoing>edge_gw_to_a</bpmn:outgoing>
+      <bpmn:outgoing>edge_gw_to_default</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:scriptTask id="Activity_A" name="Task A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>edge_gw_to_a</bpmn:incoming>
+      <bpmn:outgoing>edge_a_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_Default" name="Default Task" scriptFormat="JavaScript">
+      <bpmn:script>console.log('Default')</bpmn:script>
+      <bpmn:incoming>edge_gw_to_default</bpmn:incoming>
+      <bpmn:outgoing>edge_default_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>edge_a_to_end</bpmn:incoming>
+      <bpmn:incoming>edge_default_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge_start_to_gw" sourceRef="Event_start" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="edge_gw_to_a" sourceRef="Gateway_1" targetRef="Activity_A">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 10</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="edge_gw_to_default" sourceRef="Gateway_1" targetRef="Activity_Default" />
+    <bpmn:sequenceFlow id="edge_a_to_end" sourceRef="Activity_A" targetRef="Event_end" />
+    <bpmn:sequenceFlow id="edge_default_to_end" sourceRef="Activity_Default" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveWithParallelGateway.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ExclusiveWithParallelGateway.bpmn
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="x" name="x" type="integer" elementId="Event_start" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_xor</bpmn:outgoing>
+    </bpmn:startEvent>
+    <!-- XOR split: x>10 → PG fork, default → Task C -->
+    <bpmn:exclusiveGateway id="Gateway_xor" default="flow_xor_to_c">
+      <bpmn:incoming>flow_start_to_xor</bpmn:incoming>
+      <bpmn:outgoing>flow_xor_to_fork</bpmn:outgoing>
+      <bpmn:outgoing>flow_xor_to_c</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <!-- PG fork nested inside XOR branch: Task A + Task B in parallel -->
+    <bpmn:parallelGateway id="Gateway_fork">
+      <bpmn:incoming>flow_xor_to_fork</bpmn:incoming>
+      <bpmn:outgoing>flow_fork_to_a</bpmn:outgoing>
+      <bpmn:outgoing>flow_fork_to_b</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:scriptTask id="Activity_A" name="Task A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_a</bpmn:incoming>
+      <bpmn:outgoing>flow_a_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_B" name="Task B" scriptFormat="JavaScript">
+      <bpmn:script>console.log('B')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_b</bpmn:incoming>
+      <bpmn:outgoing>flow_b_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:parallelGateway id="Gateway_join">
+      <bpmn:incoming>flow_a_to_join</bpmn:incoming>
+      <bpmn:incoming>flow_b_to_join</bpmn:incoming>
+      <bpmn:outgoing>flow_join_to_end1</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:scriptTask id="Activity_C" name="Task C" scriptFormat="JavaScript">
+      <bpmn:script>console.log('C')</bpmn:script>
+      <bpmn:incoming>flow_xor_to_c</bpmn:incoming>
+      <bpmn:outgoing>flow_c_to_end2</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end1">
+      <bpmn:incoming>flow_join_to_end1</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:endEvent id="Event_end2">
+      <bpmn:incoming>flow_c_to_end2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_xor" sourceRef="Event_start" targetRef="Gateway_xor" />
+    <bpmn:sequenceFlow id="flow_xor_to_fork" sourceRef="Gateway_xor" targetRef="Gateway_fork">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 10</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_xor_to_c" sourceRef="Gateway_xor" targetRef="Activity_C" />
+    <bpmn:sequenceFlow id="flow_fork_to_a" sourceRef="Gateway_fork" targetRef="Activity_A" />
+    <bpmn:sequenceFlow id="flow_fork_to_b" sourceRef="Gateway_fork" targetRef="Activity_B" />
+    <bpmn:sequenceFlow id="flow_a_to_join" sourceRef="Activity_A" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_b_to_join" sourceRef="Activity_B" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_join_to_end1" sourceRef="Gateway_join" targetRef="Event_end1" />
+    <bpmn:sequenceFlow id="flow_c_to_end2" sourceRef="Activity_C" targetRef="Event_end2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/FourScriptTasks.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/FourScriptTasks.bpmn
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_a</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="Activity_A" name="Script A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_start_to_a</bpmn:incoming>
+      <bpmn:outgoing>flow_a_to_b</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_B" name="Script B" scriptFormat="JavaScript">
+      <bpmn:script>console.log('B')</bpmn:script>
+      <bpmn:incoming>flow_a_to_b</bpmn:incoming>
+      <bpmn:outgoing>flow_b_to_c</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_C" name="Script C" scriptFormat="JavaScript">
+      <bpmn:script>console.log('C')</bpmn:script>
+      <bpmn:incoming>flow_b_to_c</bpmn:incoming>
+      <bpmn:outgoing>flow_c_to_d</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_D" name="Script D" scriptFormat="JavaScript">
+      <bpmn:script>console.log('D')</bpmn:script>
+      <bpmn:incoming>flow_c_to_d</bpmn:incoming>
+      <bpmn:outgoing>flow_d_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_d_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_a" sourceRef="Event_start" targetRef="Activity_A" />
+    <bpmn:sequenceFlow id="flow_a_to_b" sourceRef="Activity_A" targetRef="Activity_B" />
+    <bpmn:sequenceFlow id="flow_b_to_c" sourceRef="Activity_B" targetRef="Activity_C" />
+    <bpmn:sequenceFlow id="flow_c_to_d" sourceRef="Activity_C" targetRef="Activity_D" />
+    <bpmn:sequenceFlow id="flow_d_to_end" sourceRef="Activity_D" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="160" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_A" bpmnElement="Activity_A">
+        <dc:Bounds x="246" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_B" bpmnElement="Activity_B">
+        <dc:Bounds x="396" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_C" bpmnElement="Activity_C">
+        <dc:Bounds x="546" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_D" bpmnElement="Activity_D">
+        <dc:Bounds x="696" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end" bpmnElement="Event_end">
+        <dc:Bounds x="846" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_flow_start_to_a" bpmnElement="flow_start_to_a">
+        <di:waypoint x="196" y="218" />
+        <di:waypoint x="246" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_a_to_b" bpmnElement="flow_a_to_b">
+        <di:waypoint x="346" y="218" />
+        <di:waypoint x="396" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_b_to_c" bpmnElement="flow_b_to_c">
+        <di:waypoint x="496" y="218" />
+        <di:waypoint x="546" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_c_to_d" bpmnElement="flow_c_to_d">
+        <di:waypoint x="646" y="218" />
+        <di:waypoint x="696" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_d_to_end" bpmnElement="flow_d_to_end">
+        <di:waypoint x="796" y="218" />
+        <di:waypoint x="846" y="218" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/HitlTaskOnly.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/HitlTaskOnly.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="d83b309b">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_hitl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Activity_Hitl" name="Approve Order">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Actions.HITL" version="v1" />
+          <uipath:context>
+            <uipath:input name="HitlTaskTitle" type="string" value="Approve order" />
+            <uipath:input name="HitlTaskAppId" type="string" value="app-id-1" />
+            <uipath:input name="HitlTaskFolderKey" type="string" value="folder-key-1" />
+          </uipath:context>
+          <uipath:output name="errorCode" type="string" source="=Error.code" var="vErrorCode" />
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>flow_start_to_hitl</bpmn:incoming>
+      <bpmn:outgoing>flow_hitl_to_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_hitl_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_hitl" sourceRef="Event_start" targetRef="Activity_Hitl" />
+    <bpmn:sequenceFlow id="flow_hitl_to_end" sourceRef="Activity_Hitl" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="260" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_Hitl" bpmnElement="Activity_Hitl">
+        <dc:Bounds x="346" y="178" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end" bpmnElement="Event_end">
+        <dc:Bounds x="496" y="200" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_flow_start_to_hitl" bpmnElement="flow_start_to_hitl">
+        <di:waypoint x="296" y="218" />
+        <di:waypoint x="346" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_flow_hitl_to_end" bpmnElement="flow_hitl_to_end">
+        <di:waypoint x="446" y="218" />
+        <di:waypoint x="496" y="218" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/InclusiveGatewayForkJoin.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/InclusiveGatewayForkJoin.bpmn
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="vX" name="x" type="integer" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_fork</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:inclusiveGateway id="Gateway_fork">
+      <bpmn:incoming>flow_start_to_fork</bpmn:incoming>
+      <bpmn:outgoing>flow_fork_to_a</bpmn:outgoing>
+      <bpmn:outgoing>flow_fork_to_b</bpmn:outgoing>
+      <bpmn:outgoing>flow_fork_to_c</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:scriptTask id="Activity_A" name="Task A" scriptFormat="JavaScript">
+      <bpmn:script>console.log('A')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_a</bpmn:incoming>
+      <bpmn:outgoing>flow_a_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_B" name="Task B" scriptFormat="JavaScript">
+      <bpmn:script>console.log('B')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_b</bpmn:incoming>
+      <bpmn:outgoing>flow_b_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_C" name="Task C" scriptFormat="JavaScript">
+      <bpmn:script>console.log('C')</bpmn:script>
+      <bpmn:incoming>flow_fork_to_c</bpmn:incoming>
+      <bpmn:outgoing>flow_c_to_join</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:inclusiveGateway id="Gateway_join">
+      <bpmn:incoming>flow_a_to_join</bpmn:incoming>
+      <bpmn:incoming>flow_b_to_join</bpmn:incoming>
+      <bpmn:incoming>flow_c_to_join</bpmn:incoming>
+      <bpmn:outgoing>flow_join_to_d</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:scriptTask id="Activity_D" name="Task D" scriptFormat="JavaScript">
+      <bpmn:script>console.log('D')</bpmn:script>
+      <bpmn:incoming>flow_join_to_d</bpmn:incoming>
+      <bpmn:outgoing>flow_d_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_d_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_fork" sourceRef="Event_start" targetRef="Gateway_fork" />
+    <bpmn:sequenceFlow id="flow_fork_to_a" sourceRef="Gateway_fork" targetRef="Activity_A">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 10</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_fork_to_b" sourceRef="Gateway_fork" targetRef="Activity_B">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 5</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_fork_to_c" sourceRef="Gateway_fork" targetRef="Activity_C">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 100</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_a_to_join" sourceRef="Activity_A" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_b_to_join" sourceRef="Activity_B" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_c_to_join" sourceRef="Activity_C" targetRef="Gateway_join" />
+    <bpmn:sequenceFlow id="flow_join_to_d" sourceRef="Gateway_join" targetRef="Activity_D" />
+    <bpmn:sequenceFlow id="flow_d_to_end" sourceRef="Activity_D" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_BPMN_Elements_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_BPMN_Elements_And_Create_CorrectModel.bpmn
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL">
+    <bpmn:process id="Process_1">
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:task id="Task_1" name="Do Something">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+        </bpmn:task>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="Task_1" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="Task_1" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_HttpRequest_ServiceTask_And_Create_Correct_Model.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_HttpRequest_ServiceTask_And_Create_Correct_Model.bpmn
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn">
+    <bpmn:process id="Process_1">
+        <bpmn:startEvent id="Start_1" name="Begin">
+            <bpmn:outgoing>Flow_1</bpmn:outgoing>
+        </bpmn:startEvent>
+
+        <bpmn:serviceTask id="GetUserTask" name="Get User">
+            <bpmn:incoming>Flow_1</bpmn:incoming>
+            <bpmn:outgoing>Flow_2</bpmn:outgoing>
+            <bpmn:extensionElements>
+                <uipath:activity version="v1">
+                    <uipath:type value="Intsvc.HttpExecution" version="v1" />
+                    <uipath:context>
+                        <uipath:input name="mode" type="string" value="manual" />
+                        <uipath:input name="method" type="string" value="GET" />
+                        <uipath:input name="url" type="string" value="https://api.example.com/users/123" />
+                        <uipath:input name="headers" type="json"><![CDATA[{"Accept": "application/json"}]]></uipath:input>
+                        <uipath:input name="parameters" type="json"><![CDATA[{}]]></uipath:input>
+                        <uipath:input name="body" type="json"><![CDATA[null]]></uipath:input>
+                    </uipath:context>
+                    <uipath:output name="response" type="jsonSchema" source="=response" var="userResult" />
+                </uipath:activity>
+            </bpmn:extensionElements>
+        </bpmn:serviceTask>
+
+        <bpmn:endEvent id="End_1" name="Finish">
+            <bpmn:incoming>Flow_2</bpmn:incoming>
+        </bpmn:endEvent>
+
+        <bpmn:sequenceFlow id="Flow_1" sourceRef="Start_1" targetRef="GetUserTask" />
+        <bpmn:sequenceFlow id="Flow_2" sourceRef="GetUserTask" targetRef="End_1" />
+    </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_MessageBoundaryEvent_And_Create_CorrectModel.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_MessageBoundaryEvent_And_Create_CorrectModel.bpmn
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="ef97daa7">
+  <bpmn:message id="sendMessage" name="message" />
+  <bpmn:process id="Process_1" name="Process" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="8" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start" name="Start event">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="6c4331a4-1051-44cb-aaa2-d37620bfefb8" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>edge_Event_start-Activity_w2B9xD</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_w2B9xD">
+      <bpmn:incoming>edge_Event_start-Activity_w2B9xD</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_w2B9xD-Activity_YEhsyC</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:boundaryEvent id="Event_WAaIdu" name="MessageBoundaryEventInterrupting" attachedToRef="Activity_w2B9xD">
+      <bpmn:messageEventDefinition messageRef="sendMessage" />
+    </bpmn:boundaryEvent>
+    <bpmn:task id="Activity_YEhsyC">
+      <bpmn:incoming>edge_Activity_w2B9xD-Activity_YEhsyC</bpmn:incoming>
+      <bpmn:outgoing>edge_Activity_YEhsyC-Event_idoZph</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:boundaryEvent id="Event_RVnGUP" name="MessageBoundaryEventNonInterrupting" cancelActivity="false" attachedToRef="Activity_YEhsyC">
+      <bpmn:messageEventDefinition messageRef="sendMessage" />
+    </bpmn:boundaryEvent>
+    <bpmn:endEvent id="Event_idoZph">
+      <bpmn:incoming>edge_Activity_YEhsyC-Event_idoZph</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="edge_Event_start-Activity_w2B9xD" sourceRef="Event_start" targetRef="Activity_w2B9xD" />
+    <bpmn:sequenceFlow id="edge_Activity_w2B9xD-Activity_YEhsyC" sourceRef="Activity_w2B9xD" targetRef="Activity_YEhsyC" />
+    <bpmn:sequenceFlow id="edge_Activity_YEhsyC-Event_idoZph" sourceRef="Activity_YEhsyC" targetRef="Event_idoZph" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="260" y="200" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="241" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_w2B9xD" bpmnElement="Activity_w2B9xD">
+        <dc:Bounds x="344" y="178" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="344" y="263" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_WAaIdu" bpmnElement="Event_WAaIdu">
+        <dc:Bounds x="416" y="240" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="416" y="281" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_YEhsyC" bpmnElement="Activity_YEhsyC">
+        <dc:Bounds x="492" y="178" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="492" y="263" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_RVnGUP" bpmnElement="Event_RVnGUP">
+        <dc:Bounds x="565" y="240" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="565" y="281" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_idoZph" bpmnElement="Event_idoZph">
+        <dc:Bounds x="640" y="200" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="640" y="241" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_start-Activity_w2B9xD" bpmnElement="edge_Event_start-Activity_w2B9xD">
+        <di:waypoint x="296" y="218" />
+        <di:waypoint x="344" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_w2B9xD-Activity_YEhsyC" bpmnElement="edge_Activity_w2B9xD-Activity_YEhsyC">
+        <di:waypoint x="444" y="218" />
+        <di:waypoint x="492" y="218" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_YEhsyC-Event_idoZph" bpmnElement="edge_Activity_YEhsyC-Event_idoZph">
+        <di:waypoint x="592" y="218" />
+        <di:waypoint x="640" y="218" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_Script_Task_V2_And_Create_Correct_Model.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_Script_Task_V2_And_Create_Correct_Model.bpmn
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="vvhW6RTnd" name="scriptResponse" type="jsonSchema" elementId="ScriptTask_1">
+          <![CDATA[
+            {
+              "type": "object",
+              "properties": {
+                "outputVar": {
+                  "type": "string"
+                }
+              }
+            }
+          ]]>
+        </uipath:inputOutput>
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:scriptTask id="ScriptTaskId" scriptFormat="JavaScript" name="ScriptTaskName">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v2"/>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="scriptResponse" type="jsonSchema" source="=result" var="vvhW6RTnd" custom="true"/>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:script><![CDATA[return null;]]></bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_Sets_Containers_Properly.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/Parse_Sets_Containers_Properly.bpmn
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="43dd6ef2">
+    <bpmn:process id="Process_1" isExecutable="false">
+        <bpmn:extensionElements>
+            <uipath:variables version="v1">
+                <uipath:inputOutput id="vDXal4Qhm" name="taskAOutput" type="integer" elementId="Activity_O7K38W" custom="true" />
+            </uipath:variables>
+        </bpmn:extensionElements>
+        <bpmn:startEvent id="Event_start" name="Start event">
+            <bpmn:extensionElements>
+                <uipath:entryPointId value="3d9a2c9f-1b35-4ead-a87d-78fefac657d6" />
+            </bpmn:extensionElements>
+            <bpmn:outgoing>edge_Event_start-Activity_O7K38W</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:task id="Activity_O7K38W" name="TaskA">
+            <bpmn:extensionElements>
+                <uipath:mapping version="v1">
+                    <uipath:type value="BPMN.Variables" version="v1" />
+                    <uipath:output name="taskAOutput" type="integer" source="1" var="vDXal4Qhm" custom="true" />
+                </uipath:mapping>
+            </bpmn:extensionElements>
+            <bpmn:incoming>edge_Event_start-Activity_O7K38W</bpmn:incoming>
+            <bpmn:outgoing>edge_Activity_O7K38W-Event_ne79NF5UGban</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:endEvent id="Event_ne79NF" name="End event">
+            <bpmn:incoming>edge_Activity_35dWAT-Event_ne79NFOvCDHt</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:subProcess id="Activity_M8FPEr">
+            <bpmn:incoming>edge_Activity_O7K38W-Event_ne79NF5UGban</bpmn:incoming>
+            <bpmn:outgoing>edge_Activity_M8FPEr-Activity_35dWATr68pqb</bpmn:outgoing>
+            <bpmn:startEvent id="Event_AouFrp">
+                <bpmn:outgoing>edge_Event_AouFrp-Activity_M2alZF</bpmn:outgoing>
+            </bpmn:startEvent>
+            <bpmn:task id="Activity_M2alZF" name="TaskB">
+                <bpmn:incoming>edge_Event_AouFrp-Activity_M2alZF</bpmn:incoming>
+                <bpmn:outgoing>edge_Activity_M2alZF-Event_ZvsloB</bpmn:outgoing>
+            </bpmn:task>
+            <bpmn:endEvent id="Event_ZvsloB">
+                <bpmn:incoming>edge_Activity_M2alZF-Event_ZvsloB</bpmn:incoming>
+            </bpmn:endEvent>
+            <bpmn:sequenceFlow id="edge_Event_AouFrp-Activity_M2alZF" sourceRef="Event_AouFrp" targetRef="Activity_M2alZF" />
+            <bpmn:sequenceFlow id="edge_Activity_M2alZF-Event_ZvsloB" sourceRef="Activity_M2alZF" targetRef="Event_ZvsloB" />
+        </bpmn:subProcess>
+        <bpmn:task id="Activity_35dWAT" name="TaskC">
+            <bpmn:incoming>edge_Activity_M8FPEr-Activity_35dWATr68pqb</bpmn:incoming>
+            <bpmn:outgoing>edge_Activity_35dWAT-Event_ne79NFOvCDHt</bpmn:outgoing>
+        </bpmn:task>
+        <bpmn:sequenceFlow id="edge_Event_start-Activity_O7K38W" sourceRef="Event_start" targetRef="Activity_O7K38W" />
+        <bpmn:sequenceFlow id="edge_Activity_O7K38W-Event_ne79NF5UGban" sourceRef="Activity_O7K38W" targetRef="Activity_M8FPEr" />
+        <bpmn:sequenceFlow id="edge_Activity_M8FPEr-Activity_35dWATr68pqb" sourceRef="Activity_M8FPEr" targetRef="Activity_35dWAT" />
+        <bpmn:sequenceFlow id="edge_Activity_35dWAT-Event_ne79NFOvCDHt" sourceRef="Activity_35dWAT" targetRef="Event_ne79NF" />
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+            <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+                <dc:Bounds x="200" y="53" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="200" y="94" width="36" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Activity_O7K38W" bpmnElement="Activity_O7K38W">
+                <dc:Bounds x="283" y="31" width="100" height="80" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="283" y="116" width="100" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Event_ne79NF" bpmnElement="Event_ne79NF">
+                <dc:Bounds x="966" y="53" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="966" y="94" width="36" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Activity_M8FPEr" bpmnElement="Activity_M8FPEr" isExpanded="true">
+                <dc:Bounds x="422.98125000000005" y="-4" width="372" height="150" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="422.98125000000005" y="151" width="372" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Event_AouFrp" bpmnElement="Event_AouFrp">
+                <dc:Bounds x="467.98125000000005" y="53" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="467.98125000000005" y="94" width="36" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Activity_M2alZF" bpmnElement="Activity_M2alZF">
+                <dc:Bounds x="557.98125" y="31" width="100" height="80" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="557.98125" y="116" width="100" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Event_ZvsloB" bpmnElement="Event_ZvsloB">
+                <dc:Bounds x="708.98125" y="53" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="708.98125" y="94" width="36" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="S_Activity_35dWAT" bpmnElement="Activity_35dWAT">
+                <dc:Bounds x="832.98125" y="31" width="100" height="80" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="832.98125" y="116" width="100" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_start-Activity_O7K38W" bpmnElement="edge_Event_start-Activity_O7K38W">
+                <di:waypoint x="236" y="71" />
+                <di:waypoint x="283" y="71" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_O7K38W-Event_ne79NF5UGban" bpmnElement="edge_Activity_O7K38W-Event_ne79NF5UGban">
+                <di:waypoint x="383" y="71" />
+                <di:waypoint x="423" y="71" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Event_AouFrp-Activity_M2alZF" bpmnElement="edge_Event_AouFrp-Activity_M2alZF">
+                <di:waypoint x="504" y="71" />
+                <di:waypoint x="558" y="71" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_M2alZF-Event_ZvsloB" bpmnElement="edge_Activity_M2alZF-Event_ZvsloB">
+                <di:waypoint x="658" y="71" />
+                <di:waypoint x="709" y="71" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_M8FPEr-Activity_35dWATr68pqb" bpmnElement="edge_Activity_M8FPEr-Activity_35dWATr68pqb">
+                <di:waypoint x="795" y="71" />
+                <di:waypoint x="833" y="71" />
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge id="BPMNEdge_edge_Activity_35dWAT-Event_ne79NFOvCDHt" bpmnElement="edge_Activity_35dWAT-Event_ne79NFOvCDHt">
+                <di:waypoint x="933" y="71" />
+                <di:waypoint x="966" y="71" />
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ScriptWritesVariableThenGatewayBranches.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/ScriptWritesVariableThenGatewayBranches.bpmn
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1" />
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="06040a68-1da7-40d1-8082-74ccc6ba3f1a" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>flow_start_to_writer</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:scriptTask id="Activity_Writer" name="Writer (writes x=42)" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.Variables" version="v1" />
+          <uipath:output name="x" type="integer" source="=this.result" var="x" custom="true" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:script>return 42;</bpmn:script>
+      <bpmn:incoming>flow_start_to_writer</bpmn:incoming>
+      <bpmn:outgoing>flow_writer_to_gw</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:exclusiveGateway id="Gateway_1" name="XOR" default="flow_gw_to_default">
+      <bpmn:incoming>flow_writer_to_gw</bpmn:incoming>
+      <bpmn:outgoing>flow_gw_to_taken</bpmn:outgoing>
+      <bpmn:outgoing>flow_gw_to_default</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:scriptTask id="Activity_Taken" name="Taken branch" scriptFormat="JavaScript">
+      <bpmn:script>return 'TAKEN';</bpmn:script>
+      <bpmn:incoming>flow_gw_to_taken</bpmn:incoming>
+      <bpmn:outgoing>flow_taken_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_NotTaken" name="Default branch (not taken)" scriptFormat="JavaScript">
+      <bpmn:script>return 'NOT_TAKEN';</bpmn:script>
+      <bpmn:incoming>flow_gw_to_default</bpmn:incoming>
+      <bpmn:outgoing>flow_default_to_end</bpmn:outgoing>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>flow_taken_to_end</bpmn:incoming>
+      <bpmn:incoming>flow_default_to_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="flow_start_to_writer" sourceRef="Event_start" targetRef="Activity_Writer" />
+    <bpmn:sequenceFlow id="flow_writer_to_gw" sourceRef="Activity_Writer" targetRef="Gateway_1" />
+    <bpmn:sequenceFlow id="flow_gw_to_taken" sourceRef="Gateway_1" targetRef="Activity_Taken">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=js:vars.x &gt; 10</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="flow_gw_to_default" sourceRef="Gateway_1" targetRef="Activity_NotTaken" />
+    <bpmn:sequenceFlow id="flow_taken_to_end" sourceRef="Activity_Taken" targetRef="Event_end" />
+    <bpmn:sequenceFlow id="flow_default_to_end" sourceRef="Activity_NotTaken" targetRef="Event_end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1" />
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/boundaryevent.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/boundaryevent.bpmn
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="local">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:startEvent id="Event_start"/>
+    <bpmn:task id="Activity_ZGCURy"/>
+    <bpmn:boundaryEvent id="Event_7vhkul" attachedToRef="Activity_ZGCURy"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="260" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_ZGCURy" bpmnElement="Activity_ZGCURy">
+        <dc:Bounds x="583" y="141" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="583" y="226" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_7vhkul" bpmnElement="Event_7vhkul">
+        <dc:Bounds x="615" y="203" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="615" y="244" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/collapsed-subprocess.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/collapsed-subprocess.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1opu134" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.1.1">
+  <bpmn:process id="Process_0q3917t" isExecutable="false">
+    <bpmn:startEvent id="StartEvent_0j24jbd">
+      <bpmn:outgoing>Flow_1so5i6v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_1kocvbe">
+      <bpmn:incoming>Flow_1so5i6v</bpmn:incoming>
+      <bpmn:outgoing>Flow_15mueit</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_1so5i6v" sourceRef="StartEvent_0j24jbd" targetRef="Activity_1kocvbe" />
+    <bpmn:sequenceFlow id="Flow_15mueit" sourceRef="Activity_1kocvbe" targetRef="Activity_03flfrr" />
+    <bpmn:endEvent id="Event_0rgfuq0">
+      <bpmn:incoming>Flow_0e2w96r</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0e2w96r" sourceRef="Activity_03flfrr" targetRef="Event_0rgfuq0" />
+    <bpmn:subProcess id="Activity_03flfrr">
+      <bpmn:incoming>Flow_15mueit</bpmn:incoming>
+      <bpmn:outgoing>Flow_0e2w96r</bpmn:outgoing>
+      <bpmn:startEvent id="Event_1uegrlp">
+        <bpmn:outgoing>Flow_1l5t7m6</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:task id="Activity_0g7hdxa">
+        <bpmn:incoming>Flow_1l5t7m6</bpmn:incoming>
+        <bpmn:outgoing>Flow_0la5xba</bpmn:outgoing>
+      </bpmn:task>
+      <bpmn:sequenceFlow id="Flow_1l5t7m6" sourceRef="Event_1uegrlp" targetRef="Activity_0g7hdxa" />
+      <bpmn:endEvent id="Event_158vyin">
+        <bpmn:incoming>Flow_0la5xba</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0la5xba" sourceRef="Activity_0g7hdxa" targetRef="Event_158vyin" />
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0q3917t">
+      <bpmndi:BPMNShape id="Activity_1kocvbe_di" bpmnElement="Activity_1kocvbe">
+        <dc:Bounds x="250" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rgfuq0_di" bpmnElement="Event_0rgfuq0">
+        <dc:Bounds x="572" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_0j24jbd">
+        <dc:Bounds x="156" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wmzlln_di" bpmnElement="Activity_03flfrr">
+        <dc:Bounds x="410" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1so5i6v_di" bpmnElement="Flow_1so5i6v">
+        <di:waypoint x="192" y="120" />
+        <di:waypoint x="250" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15mueit_di" bpmnElement="Flow_15mueit">
+        <di:waypoint x="350" y="120" />
+        <di:waypoint x="410" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e2w96r_di" bpmnElement="Flow_0e2w96r">
+        <di:waypoint x="510" y="120" />
+        <di:waypoint x="572" y="120" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_13i328y">
+    <bpmndi:BPMNPlane id="BPMNPlane_132yqqz" bpmnElement="Activity_03flfrr">
+      <bpmndi:BPMNShape id="Event_1uegrlp_di" bpmnElement="Event_1uegrlp">
+        <dc:Bounds x="292" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g7hdxa_di" bpmnElement="Activity_0g7hdxa">
+        <dc:Bounds x="380" y="190" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_158vyin_di" bpmnElement="Event_158vyin">
+        <dc:Bounds x="532" y="212" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1l5t7m6_di" bpmnElement="Flow_1l5t7m6">
+        <di:waypoint x="328" y="230" />
+        <di:waypoint x="380" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0la5xba_di" bpmnElement="Flow_0la5xba">
+        <di:waypoint x="480" y="230" />
+        <di:waypoint x="532" y="230" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/connectable-types.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/connectable-types.bpmn
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1"/>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="e935ed77-4238-4b50-aed7-be86c03f9f49"/>
+      </bpmn:extensionElements>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_5gV17n" name="Task"/>
+    <bpmn:task id="Activity_EkiOdg"/>
+    <bpmn:boundaryEvent id="Event_DbPVmf" cancelActivity="false" attachedToRef="Activity_EkiOdg">
+      <bpmn:timerEventDefinition/>
+    </bpmn:boundaryEvent>
+    <bpmn:intermediateThrowEvent id="Event_gT30Xr">
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateThrowEvent>
+    <bpmn:intermediateCatchEvent id="Event_8lEOos">
+      <bpmn:messageEventDefinition/>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:serviceTask id="Activity_Rym6uN" name="Service Task"/>
+    <bpmn:sendTask id="Activity_wnu4rz" name="Send Task"/>
+    <bpmn:receiveTask id="Activity_h9lDUY" name="Receive Task"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="176" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="176" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_5gV17n" bpmnElement="Activity_5gV17n">
+        <dc:Bounds x="288" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="288" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_EkiOdg" bpmnElement="Activity_EkiOdg">
+        <dc:Bounds x="288" y="324.5" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="288" y="409.5" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_DbPVmf" bpmnElement="Event_DbPVmf">
+        <dc:Bounds x="306.5" y="386.5" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="306.5" y="427.5" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_gT30Xr" bpmnElement="Event_gT30Xr">
+        <dc:Bounds x="176" y="324" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="176" y="365" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_8lEOos" bpmnElement="Event_8lEOos">
+        <dc:Bounds x="176" y="377" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="176" y="418" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_Rym6uN" bpmnElement="Activity_Rym6uN">
+        <dc:Bounds x="448" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="448" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_wnu4rz" bpmnElement="Activity_wnu4rz">
+        <dc:Bounds x="612" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="612" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_h9lDUY" bpmnElement="Activity_h9lDUY">
+        <dc:Bounds x="789" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="789" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/extensions-orchestrator-start-job.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/extensions-orchestrator-start-job.bpmn
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="sample-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="vYggW1RyK" name="BillAmountOutput" type="number" elementId="Activity_N5j9GC"/>
+        <uipath:inputOutput id="vws4IovBe" name="DepositMoneyOutput" type="number" elementId="Activity_N5j9GC"/>
+        <uipath:inputOutput id="vJVJcF7TX" name="ActivityIdOutput" type="string" elementId="Activity_N5j9GC"/>
+        <uipath:inputOutput id="vCyhzsxyv" name="ComplexOutput" type="string" elementId="Activity_N5j9GC"/>
+        <uipath:inputOutput id="vvlztoFqf" name="ComplexObjectOutput" type="string" elementId="Activity_N5j9GC"/>
+        <uipath:inputOutput id="vRqqsw6kd" name="ArrayOutput" type="string" elementId="Activity_N5j9GC"/>
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="biHpWnwBf" name="releaseKey" type="string" default="5AAE851E-B0DE-46B8-ABCE-CF83F6B5540D" resource="process" resourceKey="5AAE851E-B0DE-46B8-ABCE-CF83F6B5540D" propertyAttribute="Key"/>
+      </uipath:bindings>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="269a0bb2-5ca0-435c-8331-b5f3b1f26c4f"/>
+      </bpmn:extensionElements>
+      <bpmn:outgoing>xy-edge___Event_start-Activity_N5j9GC</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Activity_N5j9GC" name="OR DepositMoney">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Orchestrator.StartJob" version="v1"/>
+          <uipath:context>
+            <uipath:input name="releaseKey" type="string" value="=bindings.biHpWnwBf"/>
+            <uipath:input name="name" type="string" value="DepositMoney"/>
+            <uipath:input name="folderId" type="string" value="1543099"/>
+          </uipath:context>
+          <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{}]]></uipath:input>
+          <uipath:output name="BillAmountOutput" type="string" source="=BillAmountOutput"/>
+          <uipath:output name="DepositMoneyOutput" type="string" source="=DepositMoneyOutput"/>
+          <uipath:output name="ActivityIdOutput" type="string" source="=ActivityIdOutput"/>
+          <uipath:output name="ComplexOutput" type="string" source="=ComplexOutput"/>
+          <uipath:output name="ComplexObjectOutput" type="string" source="=ComplexObjectOutput"/>
+          <uipath:output name="ArrayOutput" type="string" source="=ArrayOutput"/>
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>xy-edge___Event_start-Activity_N5j9GC</bpmn:incoming>
+      <bpmn:outgoing>xy-edge___Activity_N5j9GC-Event_gkTqbg</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="Event_gkTqbg">
+      <bpmn:incoming>xy-edge___Activity_N5j9GC-Event_gkTqbg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="xy-edge___Event_start-Activity_N5j9GC" sourceRef="Event_start" targetRef="Activity_N5j9GC"/>
+    <bpmn:sequenceFlow id="xy-edge___Activity_N5j9GC-Event_gkTqbg" sourceRef="Activity_N5j9GC" targetRef="Event_gkTqbg"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="200" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="200" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_N5j9GC" bpmnElement="Activity_N5j9GC">
+        <dc:Bounds x="336" y="178" width="100" height="80"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="336" y="263" width="100" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_gkTqbg" bpmnElement="Event_gkTqbg">
+        <dc:Bounds x="536" y="200" width="36" height="36"/>
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="536" y="241" width="36" height="14"/>
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Event_start-Activity_N5j9GC" bpmnElement="xy-edge___Event_start-Activity_N5j9GC">
+        <di:waypoint x="236" y="218"/>
+        <di:waypoint x="336" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_xy-edge___Activity_N5j9GC-Event_gkTqbg" bpmnElement="xy-edge___Activity_N5j9GC-Event_gkTqbg">
+        <di:waypoint x="436" y="218"/>
+        <di:waypoint x="536" y="218"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/multiparticipantpool.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/multiparticipantpool.bpmn
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1atfcs0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="17.11.1">
+  <bpmn:collaboration id="Collaboration_1yghizz">
+    <bpmn:participant id="Participant_1ypzas4" name="Pool" processRef="Process_0lg3mgg">
+      <bpmn:participantMultiplicity />
+    </bpmn:participant>
+    <bpmn:textAnnotation id="TextAnnotation_0nedcdc" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0lg3mgg">
+    <bpmn:laneSet id="LaneSet_01ijcfg">
+      <bpmn:lane id="Lane_0pq8cbv">
+        <bpmn:flowNodeRef>Event_17kbd9t</bpmn:flowNodeRef>
+        <bpmn:flowNodeRef>Event_0f363dd</bpmn:flowNodeRef>
+      </bpmn:lane>
+      <bpmn:lane id="Lane_1m23o6j">
+        <bpmn:flowNodeRef>Activity_1qr1opm</bpmn:flowNodeRef>
+      </bpmn:lane>
+    </bpmn:laneSet>
+    <bpmn:task id="Activity_1qr1opm" name="Task">
+      <bpmn:incoming>Flow_0ly0ab4</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b9jzvu</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:startEvent id="Event_17kbd9t" name="Start">
+      <bpmn:outgoing>Flow_0ly0ab4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0f363dd" name="End">
+      <bpmn:incoming>Flow_0b9jzvu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0ly0ab4" sourceRef="Event_17kbd9t" targetRef="Activity_1qr1opm" />
+    <bpmn:sequenceFlow id="Flow_0b9jzvu" sourceRef="Activity_1qr1opm" targetRef="Event_0f363dd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1yghizz">
+      <bpmndi:BPMNShape id="Participant_1ypzas4_di" bpmnElement="Participant_1ypzas4" isHorizontal="true">
+        <dc:Bounds x="160" y="600" width="600" height="250" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_0pq8cbv_di" bpmnElement="Lane_0pq8cbv" isHorizontal="true">
+        <dc:Bounds x="190" y="600" width="570" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Lane_1m23o6j_di" bpmnElement="Lane_1m23o6j" isHorizontal="true">
+        <dc:Bounds x="190" y="725" width="570" height="125" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qr1opm_di" bpmnElement="Activity_1qr1opm">
+        <dc:Bounds x="410" y="760" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17kbd9t_di" bpmnElement="Event_17kbd9t">
+        <dc:Bounds x="242" y="642" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="248" y="685" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0f363dd_di" bpmnElement="Event_0f363dd">
+        <dc:Bounds x="652" y="642" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="660" y="685" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0ly0ab4_di" bpmnElement="Flow_0ly0ab4">
+        <di:waypoint x="278" y="660" />
+        <di:waypoint x="349" y="660" />
+        <di:waypoint x="349" y="800" />
+        <di:waypoint x="410" y="800" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b9jzvu_di" bpmnElement="Flow_0b9jzvu">
+        <di:waypoint x="510" y="800" />
+        <di:waypoint x="571" y="800" />
+        <di:waypoint x="571" y="660" />
+        <di:waypoint x="652" y="660" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="TextAnnotation_0nedcdc_di" bpmnElement="TextAnnotation_0nedcdc">
+        <dc:Bounds x="1100" y="80" width="100" height="30" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/nestedsubprocess.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/nestedsubprocess.bpmn
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" id="Definitions_0ckzecr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="bpmn-js (https://demo.bpmn.io)" exporterVersion="18.0.0">
+  <bpmn:process id="Process_0y1jzhz" isExecutable="false">
+    <bpmn:subProcess id="Activity_0dgjk0m">
+      <bpmn:startEvent id="Event_1etcv1m" />
+      <bpmn:subProcess id="Activity_0bqys3e">
+        <bpmn:startEvent id="Event_1iq1qe7" />
+        <bpmn:subProcess id="Activity_10ttnku">
+          <bpmn:startEvent id="Event_0a8ik8m" />
+        </bpmn:subProcess>
+      </bpmn:subProcess>
+    </bpmn:subProcess>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0y1jzhz">
+      <bpmndi:BPMNShape id="Activity_0dgjk0m_di" bpmnElement="Activity_0dgjk0m" isExpanded="true">
+        <dc:Bounds x="160" y="80" width="820" height="420" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1etcv1m_di" bpmnElement="Event_1etcv1m">
+        <dc:Bounds x="200" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bqys3e_di" bpmnElement="Activity_0bqys3e" isExpanded="true">
+        <dc:Bounds x="300" y="140" width="600" height="330" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1iq1qe7_di" bpmnElement="Event_1iq1qe7">
+        <dc:Bounds x="340" y="222" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10ttnku_di" bpmnElement="Activity_10ttnku" isExpanded="true">
+        <dc:Bounds x="440" y="210" width="420" height="230" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0a8ik8m_di" bpmnElement="Event_0a8ik8m">
+        <dc:Bounds x="480" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/simple.bpmn
+++ b/skills/uipath-maestro-bpmn/validator/test/fixtures/known-good/simple.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1atfcs0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="UiPath Studio Web (https://uipath.com)" exporterVersion="c72cc911">
+  <bpmn:collaboration id="Collaboration_1yghizz">
+    <bpmn:participant id="Participant_1ypzas4" name="Pool" processRef="Process_0lg3mgg" />
+  </bpmn:collaboration>
+  <bpmn:process id="Process_0lg3mgg">
+    <bpmn:startEvent id="Event_start" name="Start">
+      <bpmn:extensionElements>
+        <uipath:entryPointId value="dc19dec1-b4d6-4fa1-8282-1e293f2247e6" />
+      </bpmn:extensionElements>
+      <bpmn:outgoing>Flow_0ly0ab4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_0f363dd" name="End">
+      <bpmn:incoming>Flow_0b9jzvu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:task id="Activity_1qr1opm" name="Task">
+      <bpmn:incoming>Flow_0ly0ab4</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b9jzvu</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:sequenceFlow id="Flow_0ly0ab4" sourceRef="Event_start" targetRef="Activity_1qr1opm" />
+    <bpmn:sequenceFlow id="Flow_0b9jzvu" sourceRef="Activity_1qr1opm" targetRef="Event_0f363dd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1yghizz">
+      <bpmndi:BPMNShape id="S_Participant_1ypzas4" bpmnElement="Participant_1ypzas4" isHorizontal="true">
+        <dc:Bounds x="190" y="80" width="600" height="250" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="190" y="335" width="600" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="282" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="282" y="213" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_0f363dd" bpmnElement="Event_0f363dd">
+        <dc:Bounds x="662" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="662" y="213" width="36" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Activity_1qr1opm" bpmnElement="Activity_1qr1opm">
+        <dc:Bounds x="440" y="150" width="100" height="80" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="235" width="100" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_0ly0ab4" bpmnElement="Flow_0ly0ab4">
+        <di:waypoint x="318" y="190" />
+        <di:waypoint x="440" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_Flow_0b9jzvu" bpmnElement="Flow_0b9jzvu">
+        <di:waypoint x="540" y="190" />
+        <di:waypoint x="662" y="190" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/skills/uipath-maestro-bpmn/validator/test/integration.test.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/integration.test.mjs
@@ -24,7 +24,7 @@ import { dirname, join } from "path";
 import BpmnModdle from "bpmn-moddle";
 import descriptor from "../uipath-moddle.v1.json" with { type: "json" };
 import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "../model.mjs";
-import { validateDiagram, validateVariableExistence } from "../rules.mjs";
+import { validateDiagram, validateVariableExistence, validateVariableNotSet } from "../rules.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const moddle = new BpmnModdle({ uipath: descriptor });
@@ -36,6 +36,9 @@ async function errorCodesFor(xml) {
   const out = [];
   for (const d of Object.values(cs.diagramsById)) out.push(...validateDiagram(d, cs, { enableMissingRootVariableValidation: true }));
   out.push(...validateVariableExistence(allNodes(cs), allEdges(cs), knownIds));
+  // VARIABLE_NOT_SET is WARNING-only; included so its topology walk runs on real
+  // files (filtered out of the ERROR set below, so it can't break known-good).
+  out.push(...validateVariableNotSet(allNodes(cs), allEdges(cs), knownIds, cs));
   return [...new Set(out.filter((f) => f.severity === "ERROR").map((f) => f.code))].sort();
 }
 

--- a/skills/uipath-maestro-bpmn/validator/test/integration.test.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/integration.test.mjs
@@ -1,0 +1,143 @@
+// Integration suite over REAL .bpmn files — the strongest defense against drift
+// in the hand-port. Every file here is a real, externally-validated artifact:
+//   - Backend BpmnParser/Worker/Athena/V2-E2E TestData (parsed & executed by the
+//     .NET engine in PO.BpmnEngine tests).
+//   - PO.Frontend editor mock fixtures (PO.Frontend/mocks/files).
+// They are bundled under test/fixtures/ so this suite is self-contained and runs
+// in CI without any sibling checkout.
+//
+// Each file is run through the full pipeline (bpmn-moddle parse -> model.mjs ->
+// rules.mjs):
+//   - test/fixtures/known-good/*       : must produce ZERO ERROR-severity findings
+//                                        (warnings allowed). Complete, execution-
+//                                        validated workflows + clean editor mocks.
+//   - test/fixtures/expected-findings/*: genuinely violate a rule the frontend
+//                                        would also flag (verified by reading the
+//                                        file); assert the exact ERROR codes fire.
+//
+// Optionally, set MAESTRO_BPMN_TESTDATA / MAESTRO_BPMN_FRONTEND_MOCKS to also
+// sweep a live corpus (used during development; absent in CI).
+
+import { readFileSync, existsSync, readdirSync } from "fs";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import BpmnModdle from "bpmn-moddle";
+import descriptor from "../uipath-moddle.v1.json" with { type: "json" };
+import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "../model.mjs";
+import { validateDiagram, validateVariableExistence } from "../rules.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const moddle = new BpmnModdle({ uipath: descriptor });
+
+async function errorCodesFor(xml) {
+  const { rootElement } = await moddle.fromXML(xml);
+  const cs = buildModel(rootElement);
+  const knownIds = collectKnownVariableIds(cs);
+  const out = [];
+  for (const d of Object.values(cs.diagramsById)) out.push(...validateDiagram(d, cs, { enableMissingRootVariableValidation: true }));
+  out.push(...validateVariableExistence(allNodes(cs), allEdges(cs), knownIds));
+  return [...new Set(out.filter((f) => f.severity === "ERROR").map((f) => f.code))].sort();
+}
+
+// ---- Expected ERROR codes for the bundled expected-findings fixtures -------
+// Verified by inspecting each file; the frontend rule would flag the same issue.
+const EXPECTED_ERROR_CODES = {
+  "ExclusiveGatewayDefaultFlow.bpmn": ["SUPERFLUOUS_GATEWAY"], // XOR with a single in + single out
+  "StartGatewayEnd.bpmn": ["SUPERFLUOUS_GATEWAY"], // gateway 1-in/1-out
+  "InclusiveJoinRouteAwayBranch.bpmn": ["MISSING_CONDITION_EXPRESSION"], // branch lacks condition
+  "Parse_SubProcess_With_Multiple_Element_Types.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "Can_Parse_Complex_Process_With_Task_Gateway_BoundaryEvent_etc.bpmn": ["MISSING_CONDITION_EXPRESSION", "TIMER_DURATION_INVALID"],
+  // Dangling vars.* references (runtime-injected, not declared in-file):
+  "Parse_AsyncExecution_And_Create_CorrectModel.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  "Parse_IXP_Extraction_FileUpload_And_Create_CorrectModel.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  "Parse_IXP_Extraction_JobAttachment_And_Create_CorrectModel.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  "Parse_IXP_ExtractionValidation_And_Create_CorrectModel.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  "ExternalAgentWorkflow.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  "StartEventWithOutputs.bpmn": ["VARIABLE_DOES_NOT_EXIST"],
+  // Frontend editor mocks (work-in-progress; same issues the FE validator shows):
+  "A.2.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "A.2.1.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "all_sequence_flow_types.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "all elements.bpmn": ["ERROR_END_EVENT_MISSING_EXCEPTION"],
+  "B.1.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "B.2.0.bpmn": ["ERROR_END_EVENT_MISSING_EXCEPTION", "MISSING_CONDITION_EXPRESSION"],
+  "C.2.0.bpmn": ["ERROR_END_EVENT_MISSING_EXCEPTION", "MISSING_CONDITION_EXPRESSION"],
+  "C.3.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "C.4.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "C.5.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "C.6.0.bpmn": ["INVALID_EVENT_DEFINITION_IN_EVENT_SUBPROCESS"], // compensate-def start in event subprocess
+  "C.7.0.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "demo.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "Golden_Scenario.initial.bpmn": ["MISSING_CONDITION_EXPRESSION"],
+  "subprocess-example-001-collapsed.bpmn": ["SUPERFLUOUS_GATEWAY"],
+  "subprocess-example-001-expanded.bpmn": ["SUPERFLUOUS_GATEWAY"],
+  "subprocess-example-003-collapsed_deeply-nested.bpmn": ["SUPERFLUOUS_GATEWAY"],
+};
+
+function listBpmn(dir) {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter((n) => n.endsWith(".bpmn"))
+    .map((n) => ({ name: n, path: join(dir, n) }));
+}
+
+const arrEq = (a, b) => a.length === b.length && a.every((x, i) => x === b[i]);
+
+export default async function runIntegration({ verbose = false } = {}) {
+  const results = { passed: 0, failed: 0, failures: [], ranFiles: 0, knownGood: 0, expected: 0 };
+
+  const knownGood = listBpmn(join(__dirname, "fixtures", "known-good"));
+  const expected = listBpmn(join(__dirname, "fixtures", "expected-findings"));
+
+  if (knownGood.length === 0 && expected.length === 0) {
+    console.log("  (integration: no bundled fixtures found — skipped)");
+    return results;
+  }
+
+  for (const { name, path } of knownGood) {
+    results.ranFiles++;
+    results.knownGood++;
+    let codes;
+    try {
+      codes = await errorCodesFor(readFileSync(path, "utf8"));
+    } catch (e) {
+      results.failed++;
+      results.failures.push(`[integration] known-good ${name} threw: ${String(e.message).split("\n")[0]}`);
+      continue;
+    }
+    if (codes.length === 0) results.passed++;
+    else {
+      results.failed++;
+      results.failures.push(`[integration] KNOWN-GOOD ${name} produced ERROR findings [${codes.join(",")}] (drift or new genuine issue)`);
+    }
+    if (verbose && codes.length) console.log(`  FAIL (known-good) ${name} -> [${codes.join(",")}]`);
+  }
+
+  for (const { name, path } of expected) {
+    results.ranFiles++;
+    results.expected++;
+    const want = EXPECTED_ERROR_CODES[name];
+    if (!want) {
+      results.failed++;
+      results.failures.push(`[integration] expected-findings ${name} has no EXPECTED_ERROR_CODES entry`);
+      continue;
+    }
+    let codes;
+    try {
+      codes = await errorCodesFor(readFileSync(path, "utf8"));
+    } catch (e) {
+      results.failed++;
+      results.failures.push(`[integration] expected ${name} threw: ${String(e.message).split("\n")[0]}`);
+      continue;
+    }
+    const wantSorted = [...want].sort();
+    if (arrEq(wantSorted, codes)) results.passed++;
+    else {
+      results.failed++;
+      results.failures.push(`[integration] ${name}: expected ERROR [${wantSorted.join(",")}], got [${codes.join(",")}]`);
+    }
+    if (verbose) console.log(`  ${arrEq(wantSorted, codes) ? "ok " : "FAIL"} (expected) ${name} -> [${codes.join(",")}]`);
+  }
+
+  return results;
+}

--- a/skills/uipath-maestro-bpmn/validator/test/model-helpers.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/model-helpers.mjs
@@ -1,0 +1,42 @@
+// Test helpers that mirror the PO.Frontend rule-test builders
+// (createNode / createEdge / createMockCanvasState etc.). The frontend rule
+// tests operate directly on synthetic Node[]/Edge[]/CanvasState graphs and call
+// the rule functions; we reproduce that exact harness so the ported per-rule
+// tests are a true 1:1 translation of the frontend tests against OUR rule
+// engine (rules.mjs), with no XML round-trip in the way for the synthetic cases.
+//
+// Node/Edge shapes match what rules.mjs consumes (see model.mjs): a Node carries
+// { id, type, parentId?, abstractType?, data:{...} }; an Edge carries
+// { id, type?, source, target, data:{...} }.
+
+import { buildValidationLookupMaps } from "../rules.mjs";
+
+export function node(id, type, data = {}, extra = {}) {
+  return { id, type, data, ...extra };
+}
+
+export function edge(id, source, target, { type = "bpmn:SequenceFlow", data = {} } = {}) {
+  return { id, type, source, target, data };
+}
+
+// A minimal CanvasState compatible with rules that consult canvasState.objects
+// (errors/messages/...) and canvasState.diagramsById / root.
+export function canvasState({ errors = [], rootVariables = undefined, diagramNodes = [], diagramEdges = [] } = {}) {
+  const diagramId = "diagram1";
+  return {
+    rootDiagramId: diagramId,
+    root: {
+      id: "root",
+      type: "bpmn:Process",
+      data: rootVariables ? { uipath: { variables: rootVariables } } : {},
+    },
+    diagramsById: {
+      [diagramId]: { diagramId, root: { id: "root", type: "bpmn:Process" }, nodes: diagramNodes, edges: diagramEdges },
+    },
+    objects: { errors, messages: [], signals: [], escalations: [] },
+  };
+}
+
+export function maps(nodes, edges) {
+  return buildValidationLookupMaps(nodes ?? [], edges ?? []);
+}

--- a/skills/uipath-maestro-bpmn/validator/test/ported-rule-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/ported-rule-tests.mjs
@@ -1,0 +1,856 @@
+// Ported per-rule tests — a 1:1 translation of the PO.Frontend rule unit tests
+// (PO.Frontend/src/services/validation/bpmn/rules/*.test.ts) against OUR rule
+// engine (rules.mjs). Each case carries a `// FE:` comment mapping it to the
+// originating frontend test (file + test name). The frontend tests construct
+// synthetic Node[]/Edge[]/CanvasState graphs and call the rule directly; we do
+// the same so the comparison is exact.
+//
+// Where our port intentionally diverges from a frontend test, the divergence is
+// called out inline with a `// DRIFT:` comment and verified against the
+// frontend's *actual observable behavior* (not just its unit test), per the
+// drift-resolution policy. See README "Drift log".
+//
+// Returns { passed, failed, failures: [...] }.
+
+import {
+  buildValidationLookupMaps,
+  validateConditionalSequenceFlow,
+  validateConnections,
+  validateDuplicateErrorEventSubprocess,
+  validateEventSubProcessStart,
+  validateErrorBoundaryEvents,
+  validateDuplicateErrorBoundaryEvents,
+  validateErrorEndEvents,
+  validateFakeJoins,
+  validateMessageFlowCrossPool,
+  validateMissingResource,
+  validateMissingRootVariables,
+  validateNoAssignmentsInExpressions,
+  validateRequiredFields,
+  validateSequenceFlowPoolCrossing,
+  validateSequenceFlowSubProcessCrossing,
+  validateSingleBlankStartEvent,
+  validateSingleStartEventInEventSubProcess,
+  validateSuperfluousGateway,
+  validateTaskTimerRange,
+  validateTimerDuration,
+} from "../rules.mjs";
+import { node, edge, canvasState, maps } from "./model-helpers.mjs";
+
+const results = { passed: 0, failed: 0, failures: [], firedCodes: new Set() };
+let currentSuite = "";
+function suite(name) {
+  currentSuite = name;
+}
+function check(name, condition, detail = "") {
+  if (condition) {
+    results.passed++;
+  } else {
+    results.failed++;
+    results.failures.push(`[${currentSuite}] ${name}${detail ? " :: " + detail : ""}`);
+  }
+}
+// assert exactly `n` findings of `code`
+function expectCodeCount(name, findings, code, n) {
+  const got = findings.filter((f) => f.code === code).length;
+  if (n > 0 && got === n) results.firedCodes.add(code); // track positive coverage
+  check(name, got === n, `expected ${n}x ${code}, got ${got} (all: [${findings.map((f) => f.code).join(",")}])`);
+}
+function expectNone(name, findings, code) {
+  const got = findings.filter((f) => f.code === code).length;
+  check(name, got === 0, `expected 0x ${code}, got ${got}`);
+}
+function expectEmpty(name, findings) {
+  check(name, findings.length === 0, `expected [], got [${findings.map((f) => f.code).join(",")}]`);
+}
+
+// Convenience: run a graph-rule with freshly built lookup maps.
+const run = (fn, nodes, edges) => fn(nodes, edges, buildValidationLookupMaps(nodes, edges));
+
+// ===========================================================================
+// 1. ConditionalFlowRule  (MISSING_CONDITION_EXPRESSION)
+// ===========================================================================
+suite("ConditionalFlowRule");
+{
+  // FE: "should return no errors for non-gateway nodes"
+  expectEmpty("non-gateway node", run(validateConditionalSequenceFlow, [node("task1", "bpmn:Task")], []));
+
+  // FE: "should return no errors for exclusive gateway with proper conditions"
+  {
+    const nodes = [node("gateway1", "bpmn:ExclusiveGateway"), node("task1", "bpmn:Task"), node("task2", "bpmn:Task")];
+    const edges = [
+      edge("flow1", "gateway1", "task1", { data: { conditionExpression: "x > 0" } }),
+      edge("flow2", "gateway1", "task2", { data: { defaultFlow: true } }),
+    ];
+    expectEmpty("xor with conditions+default", run(validateConditionalSequenceFlow, nodes, edges));
+  }
+
+  // FE: "should detect missing conditions on exclusive gateway" (3 findings)
+  {
+    const nodes = [node("gateway1", "bpmn:ExclusiveGateway"), node("t1", "bpmn:Task"), node("t2", "bpmn:Task"), node("t3", "bpmn:Task")];
+    const edges = [edge("flow1", "gateway1", "t1"), edge("flow2", "gateway1", "t2"), edge("flow3", "gateway1", "t3")];
+    expectCodeCount("3 missing conditions", run(validateConditionalSequenceFlow, nodes, edges), "MISSING_CONDITION_EXPRESSION", 3);
+  }
+
+  // FE: "should not validate inclusive gateway flows anymore" (0 findings)
+  {
+    const nodes = [node("gateway1", "bpmn:InclusiveGateway"), node("t1", "bpmn:Task"), node("t2", "bpmn:Task"), node("t3", "bpmn:Task")];
+    const edges = [edge("flow1", "gateway1", "t1"), edge("flow2", "gateway1", "t2"), edge("flow3", "gateway1", "t3")];
+    expectEmpty("inclusive gateway not validated", run(validateConditionalSequenceFlow, nodes, edges));
+  }
+
+  // FE: "should validate condition type is conditionExpression not condition" — single outgoing → not a split
+  {
+    const nodes = [node("gateway1", "bpmn:ExclusiveGateway"), node("task1", "bpmn:Task")];
+    const edges = [edge("flow1", "gateway1", "task1", { data: { conditionExpression: "x > 0" } })];
+    expectEmpty("single outgoing not a split", run(validateConditionalSequenceFlow, nodes, edges));
+  }
+
+  // FE: "should flag exactly one flow without condition..." scenario 2 → 2 findings
+  {
+    const nodes = [node("gateway2", "bpmn:ExclusiveGateway"), node("t1", "bpmn:Task"), node("t2", "bpmn:Task"), node("t3", "bpmn:Task")];
+    const edges = [
+      edge("flow1", "gateway2", "t1", { data: { conditionExpression: "x > 0" } }),
+      edge("flow2", "gateway2", "t2"),
+      edge("flow3", "gateway2", "t3"),
+    ];
+    expectCodeCount("two flows missing condition", run(validateConditionalSequenceFlow, nodes, edges), "MISSING_CONDITION_EXPRESSION", 2);
+  }
+
+  // FE: "should handle text annotation" — only outgoing is an Association to a TextAnnotation → 0
+  {
+    const nodes = [node("g", "bpmn:ExclusiveGateway"), node("anno", "bpmn:TextAnnotation")];
+    const edges = [edge("g_anno", "g", "anno", { type: "bpmn:Association" })];
+    expectEmpty("text annotation target ignored", run(validateConditionalSequenceFlow, nodes, edges));
+  }
+
+  // FE: "should handle empty nodes and edges arrays"
+  expectEmpty("empty graph", run(validateConditionalSequenceFlow, [], []));
+
+  // FE chained: "should correctly validate an XOR gateway that splits..." — 2 findings, both from XOR_A
+  {
+    const nodes = [node("XOR_A", "bpmn:ExclusiveGateway"), node("XOR_B", "bpmn:ExclusiveGateway"), node("Task_C", "bpmn:Task"), node("Task_D", "bpmn:Task")];
+    const edges = [edge("Flow1_A_to_B", "XOR_A", "XOR_B"), edge("Flow2_A_to_C", "XOR_A", "Task_C"), edge("Flow3_B_to_D", "XOR_B", "Task_D")];
+    const f = run(validateConditionalSequenceFlow, nodes, edges);
+    expectCodeCount("chained gateways: 2 findings", f, "MISSING_CONDITION_EXPRESSION", 2);
+    check("chained gateways: both sourceId XOR_A", f.every((e) => e.sourceId === "XOR_A"), JSON.stringify(f.map((e) => e.sourceId)));
+  }
+}
+
+// ===========================================================================
+// 2. ConnectionRule  (INVALID_CONNECTION / INVALID_CONNECTION_TYPE)
+// FE asserts by message substring; we assert the equivalent code.
+// ===========================================================================
+suite("ConnectionRule");
+{
+  // FE: "should validate empty graph without errors"
+  expectEmpty("empty graph", run(validateConnections, [], []));
+
+  // FE: "should allow valid connections between nodes" — StartEvent -> Task
+  {
+    const nodes = [node("1", "bpmn:StartEvent"), node("2", "bpmn:Task")];
+    expectEmpty("start->task allowed", run(validateConnections, nodes, [edge("e1", "1", "2")]));
+  }
+
+  // FE: "should detect edges with missing nodes" — Broken flow line
+  {
+    const nodes = [node("1", "bpmn:StartEvent")];
+    const f = run(validateConnections, nodes, [edge("e1", "1", "nonexistent")]);
+    expectCodeCount("broken flow line -> INVALID_CONNECTION", f, "INVALID_CONNECTION", 1);
+  }
+
+  // FE: "should not allow a connection to have the same source and target"
+  {
+    const nodes = [node("1", "bpmn:StartEvent")];
+    const f = run(validateConnections, nodes, [edge("e1", "1", "1")]);
+    expectCodeCount("self loop -> INVALID_CONNECTION", f, "INVALID_CONNECTION", 1);
+  }
+
+  // FE: "should validate node type compatibility" — EndEvent -> Task is disallowed.
+  // (FE test uses non-bpmn "output"/"input" types; on real BPMN the equivalent
+  //  invalid edge is EndEvent->Task, which our concrete-type allow-map rejects.)
+  {
+    const nodes = [node("1", "bpmn:EndEvent"), node("2", "bpmn:Task")];
+    const f = run(validateConnections, nodes, [edge("e1", "1", "2")]);
+    expectCodeCount("endevent->task -> INVALID_CONNECTION_TYPE", f, "INVALID_CONNECTION_TYPE", 1);
+  }
+}
+
+// ===========================================================================
+// 3. DuplicateErrorEventSubprocessRule
+// ===========================================================================
+suite("DuplicateErrorEventSubprocessRule");
+{
+  const esp = (id, parentId) => node(id, "bpmn:SubProcess", { triggeredByEvent: true }, { parentId });
+  const errStart = (id, parentId, errorRef) =>
+    node(id, "bpmn:StartEvent", { eventDefinition: { type: "bpmn:ErrorEventDefinition", ...(errorRef ? { errorRef } : {}) } }, { parentId });
+
+  // FE: "multiple catch-all error event subprocesses at same scope" — 2 findings
+  {
+    const nodes = [esp("sp1", undefined), errStart("s1", "sp1"), esp("sp2", undefined), errStart("s2", "sp2")];
+    const cs = canvasState({ errors: [] });
+    const f = validateDuplicateErrorEventSubprocess(nodes, cs, maps(nodes, []));
+    expectCodeCount("2 catch-all ESP", f, "MULTIPLE_CATCH_ALL_ERROR_EVENT_SUBPROCESS", 2);
+  }
+
+  // FE: "multiple error event subprocesses with same error code at same scope" — 2 findings
+  {
+    const nodes = [esp("sp1", undefined), errStart("s1", "sp1", "error1"), esp("sp2", undefined), errStart("s2", "sp2", "error2")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }, { id: "error2", errorCode: "501" }] });
+    const f = validateDuplicateErrorEventSubprocess(nodes, cs, maps(nodes, []));
+    expectCodeCount("same error code ESP", f, "DUPLICATE_ERROR_EVENT_SUBPROCESS", 2);
+  }
+
+  // FE: "different error codes at same scope" — []
+  {
+    const nodes = [esp("sp1", undefined), errStart("s1", "sp1", "error1"), esp("sp2", undefined), errStart("s2", "sp2", "error2")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }, { id: "error2", errorCode: "502" }] });
+    expectEmpty("different error codes ESP", validateDuplicateErrorEventSubprocess(nodes, cs, maps(nodes, [])));
+  }
+
+  // FE: "same error code at different scopes" — []
+  {
+    const nodes = [esp("sp1", "scope1"), errStart("s1", "sp1", "error1"), esp("sp2", "scope2"), errStart("s2", "sp2", "error1")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }] });
+    expectEmpty("same code different scope ESP", validateDuplicateErrorEventSubprocess(nodes, cs, maps(nodes, [])));
+  }
+
+  // FE: "catch-all error event subprocesses at different scopes" — []
+  {
+    const nodes = [esp("sp1", "scope1"), errStart("s1", "sp1"), esp("sp2", "scope2"), errStart("s2", "sp2")];
+    expectEmpty("catch-all different scope ESP", validateDuplicateErrorEventSubprocess(nodes, canvasState(), maps(nodes, [])));
+  }
+}
+
+// ===========================================================================
+// 4. EmptyStartEventDefinitionInSubProcessRule
+// ===========================================================================
+suite("EmptyStartEventDefinitionInSubProcessRule");
+{
+  const sp = (id, triggeredByEvent) => node(id, "bpmn:SubProcess", triggeredByEvent ? { triggeredByEvent: true } : {});
+  const start = (id, parentId, ed) => node(id, "bpmn:StartEvent", ed ? { eventDefinition: ed } : {}, { parentId });
+
+  // FE: "should allow blank start event in subprocess" (regular)
+  {
+    const nodes = [sp("subprocess1", false), start("start1", "subprocess1")];
+    expectEmpty("blank start in regular subprocess", run(validateEventSubProcessStart, nodes, []));
+  }
+  // FE: "should detect start event with event definition in regular subprocess"
+  {
+    const nodes = [sp("subprocess1", false), start("start1", "subprocess1", { id: "timer1", type: "bpmn:TimerEventDefinition" })];
+    expectCodeCount("def in regular subprocess", run(validateEventSubProcessStart, nodes, []), "START_EVENT_WITH_DEFINITION_IN_SUBPROCESS", 1);
+  }
+  // FE: "should allow start event with timer event definition in event subprocess"
+  {
+    const nodes = [sp("subprocess1", true), start("start1", "subprocess1", { type: "bpmn:TimerEventDefinition" })];
+    expectEmpty("timer def in event subprocess", run(validateEventSubProcessStart, nodes, []));
+  }
+  // FE: "should allow start event with message event definition in event subprocess"
+  {
+    const nodes = [sp("subprocess1", true), start("start1", "subprocess1", { type: "bpmn:MessageEventDefinition" })];
+    expectEmpty("message def in event subprocess", run(validateEventSubProcessStart, nodes, []));
+  }
+  // FE: "should detect start event without event definition in event subprocess"
+  {
+    const nodes = [sp("subprocess1", true), start("start1", "subprocess1")];
+    expectCodeCount("no def in event subprocess", run(validateEventSubProcessStart, nodes, []), "START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS", 1);
+  }
+  // FE: "should detect start event with invalid event definition in event subprocess"
+  {
+    const nodes = [sp("subprocess1", true), start("start1", "subprocess1", { type: "bpmn:ConditionalEventDefinition" })];
+    expectCodeCount("invalid def in event subprocess", run(validateEventSubProcessStart, nodes, []), "INVALID_EVENT_DEFINITION_IN_EVENT_SUBPROCESS", 1);
+  }
+}
+
+// ===========================================================================
+// 5. ErrorBoundaryEventRule (validate + duplicate)
+// ===========================================================================
+suite("ErrorBoundaryEventRule");
+{
+  const be = (id, ed, attachedToId = "task1") => node(id, "bpmn:BoundaryEvent", { eventDefinition: ed, attachedToId });
+
+  // FE: "should not report errors when there are no boundary events"
+  expectEmpty("no boundary events", validateErrorBoundaryEvents([], canvasState()));
+  // FE: "should not report errors for boundary events without error definitions"
+  expectEmpty("non-error boundary def", validateErrorBoundaryEvents([be("boundary1", { type: "bpmn:SignalEventDefinition" })], canvasState()));
+  // FE: "should detect empty error reference in boundary event" (errorRef:"")
+  {
+    const f = validateErrorBoundaryEvents([be("boundary1", { type: "bpmn:ErrorEventDefinition", errorRef: "" })], canvasState());
+    expectCodeCount("empty error ref", f, "ERROR_BOUNDARY_EVENT_EMPTY_ERROR_REF", 1);
+  }
+  // FE: "should detect missing error code when referencing an error"
+  {
+    const cs = canvasState({ errors: [{ id: "error1", name: "CustomerError", errorCode: "" }] });
+    const f = validateErrorBoundaryEvents([be("boundary1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" })], cs);
+    expectCodeCount("missing error code", f, "ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE", 1);
+  }
+  // FE: "should not report errors when error has valid error code"
+  {
+    const cs = canvasState({ errors: [{ id: "error1", name: "CustomerError", errorCode: "ERR-001" }] });
+    expectEmpty("valid error code", validateErrorBoundaryEvents([be("boundary1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" })], cs));
+  }
+  // FE: "multiple catch-all boundary events on same task" — 2 findings
+  {
+    const nodes = [be("b1", { type: "bpmn:ErrorEventDefinition" }, "task1"), be("b2", { type: "bpmn:ErrorEventDefinition" }, "task1")];
+    expectCodeCount("2 catch-all on task", validateDuplicateErrorBoundaryEvents(nodes, canvasState()), "MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK", 2);
+  }
+  // FE: "multiple boundary events with same error code on same task" — 2 findings
+  {
+    const nodes = [be("b1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" }, "task1"), be("b2", { type: "bpmn:ErrorEventDefinition", errorRef: "error2" }, "task1")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }, { id: "error2", errorCode: "501" }] });
+    expectCodeCount("same code on task", validateDuplicateErrorBoundaryEvents(nodes, cs), "DUPLICATE_ERROR_BOUNDARY_EVENT_ON_TASK", 2);
+  }
+  // FE: "different error codes on same task" — []
+  {
+    const nodes = [be("b1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" }, "task1"), be("b2", { type: "bpmn:ErrorEventDefinition", errorRef: "error2" }, "task1")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }, { id: "error2", errorCode: "502" }] });
+    expectEmpty("different codes on task", validateDuplicateErrorBoundaryEvents(nodes, cs));
+  }
+  // FE: "same error code on different tasks" — []
+  {
+    const nodes = [be("b1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" }, "task1"), be("b2", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" }, "task2")];
+    const cs = canvasState({ errors: [{ id: "error1", errorCode: "501" }] });
+    expectEmpty("same code different tasks", validateDuplicateErrorBoundaryEvents(nodes, cs));
+  }
+  // FE: "catch-all boundary events on different tasks" — []
+  {
+    const nodes = [be("b1", { type: "bpmn:ErrorEventDefinition" }, "task1"), be("b2", { type: "bpmn:ErrorEventDefinition" }, "task2")];
+    expectEmpty("catch-all different tasks", validateDuplicateErrorBoundaryEvents(nodes, canvasState()));
+  }
+}
+
+// ===========================================================================
+// 6. ErrorEndEventRule
+// ===========================================================================
+suite("ErrorEndEventRule");
+{
+  const end = (id, ed) => node(id, "bpmn:EndEvent", ed ? { eventDefinition: ed } : {});
+  expectEmpty("no end events", validateErrorEndEvents([]));
+  expectEmpty("end without def", validateErrorEndEvents([end("end1")]));
+  expectEmpty("end with signal def", validateErrorEndEvents([end("end1", { type: "bpmn:SignalEventDefinition" })]));
+  // FE: "should report error when error end event has no errorRef"
+  expectCodeCount("error end no errorRef", validateErrorEndEvents([end("end1", { type: "bpmn:ErrorEventDefinition" })]), "ERROR_END_EVENT_MISSING_EXCEPTION", 1);
+  // FE: "should report error when error end event has empty errorRef"
+  expectCodeCount("error end empty errorRef", validateErrorEndEvents([end("end1", { type: "bpmn:ErrorEventDefinition", errorRef: "" })]), "ERROR_END_EVENT_MISSING_EXCEPTION", 1);
+  // FE: "should not report error when error end event has a valid errorRef"
+  expectEmpty("error end valid errorRef", validateErrorEndEvents([end("end1", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" })]));
+  // FE: "multiple error end events missing errorRef" — 2 findings (end1, end3)
+  {
+    const nodes = [end("end1", { type: "bpmn:ErrorEventDefinition" }), end("end2", { type: "bpmn:ErrorEventDefinition", errorRef: "error1" }), end("end3", { type: "bpmn:ErrorEventDefinition" })];
+    const f = validateErrorEndEvents(nodes);
+    expectCodeCount("2 error ends missing ref", f, "ERROR_END_EVENT_MISSING_EXCEPTION", 2);
+    check("error ends are end1,end3", f.map((e) => e.elementId).join(",") === "end1,end3", f.map((e) => e.elementId).join(","));
+  }
+  // FE: "should ignore non-end-event nodes"
+  expectEmpty("ignore boundary error event", validateErrorEndEvents([node("boundary1", "bpmn:BoundaryEvent", { eventDefinition: { type: "bpmn:ErrorEventDefinition" } })]));
+}
+
+// ===========================================================================
+// 7. FakeJoinRule
+// DRIFT (resolved by matching the frontend's *actual* behavior): the frontend
+// rule matches only literal "bpmn:Activity"/"bpmn:Event" node types. On the real
+// canvas every node carries its CONCRETE type (bpmn:Task, bpmn:EndEvent, ...),
+// so the rule is dormant on exported BPMN. Our port mirrors that exactly. The
+// FE unit tests below feed literal abstract types — we reproduce them verbatim,
+// AND add concrete-type cases proving we do NOT over-fire on real BPMN (which an
+// earlier hand-port did). See README "Drift log #2".
+// ===========================================================================
+suite("FakeJoinRule");
+{
+  // FE: "should return empty array for null or undefined inputs"
+  expectEmpty("null nodes", validateFakeJoins(null, [], maps([], [])));
+  expectEmpty("null edges", validateFakeJoins([], null, maps([], [])));
+  expectEmpty("undefined both", validateFakeJoins(undefined, undefined, maps([], [])));
+  // FE: "should return empty array when no fake joins exist"
+  {
+    const nodes = [node("1", "bpmn:Activity"), node("2", "bpmn:Event")];
+    expectEmpty("no fake joins", run(validateFakeJoins, nodes, [edge("e1", "1", "2")]));
+  }
+  // FE: "should detect fake joins in activities" (literal bpmn:Activity, 2 incoming)
+  {
+    const nodes = [node("1", "bpmn:Activity"), node("2", "bpmn:Activity"), node("3", "bpmn:Activity")];
+    const edges = [edge("e1", "1", "3"), edge("e2", "2", "3")];
+    expectCodeCount("fake join in activity", run(validateFakeJoins, nodes, edges), "FAKE_JOIN", 1);
+  }
+  // FE: "should detect fake joins in events" (literal bpmn:Event)
+  {
+    const nodes = [node("1", "bpmn:Activity"), node("2", "bpmn:Activity"), node("3", "bpmn:Event")];
+    const edges = [edge("e1", "1", "3"), edge("e2", "2", "3")];
+    expectCodeCount("fake join in event", run(validateFakeJoins, nodes, edges), "FAKE_JOIN", 1);
+  }
+  // FE: "should ignore non-activity/event nodes" (gateway with multiple incoming)
+  {
+    const nodes = [node("1", "bpmn:Activity"), node("2", "bpmn:Activity"), node("3", "bpmn:Gateway")];
+    const edges = [edge("e1", "1", "3"), edge("e2", "2", "3")];
+    expectEmpty("gateway multiple incoming allowed", run(validateFakeJoins, nodes, edges));
+  }
+  // PORT PARITY: concrete-typed task with 2 incoming must NOT fire (matches the
+  // frontend's dormant-on-real-BPMN behavior; an earlier hand-port over-fired).
+  {
+    const nodes = [node("a", "bpmn:Task"), node("b", "bpmn:Task"), node("c", "bpmn:Task")];
+    const edges = [edge("e1", "a", "c"), edge("e2", "b", "c")];
+    expectNone("concrete task join does not over-fire", run(validateFakeJoins, nodes, edges), "FAKE_JOIN");
+  }
+}
+
+// ===========================================================================
+// 8. MessageFlowObjectsPoolRule
+// ===========================================================================
+suite("MessageFlowObjectsPoolRule");
+{
+  const part = (id) => node(id, "bpmn:Participant");
+  const inPool = (id, parentId) => node(id, "bpmn:Task", {}, { parentId });
+  const mf = (id, s, t) => edge(id, s, t, { type: "bpmn:MessageFlow" });
+
+  // FE: "should return empty array when no pools exist"
+  expectEmpty("no pools", run(validateMessageFlowCrossPool, [inPool("task1"), inPool("task2")], [mf("flow1", "task1", "task2")]));
+  // FE: "should allow message flow between different pools"
+  {
+    const nodes = [part("pool1"), part("pool2"), inPool("task1", "pool1"), inPool("task2", "pool2")];
+    expectEmpty("cross-pool mf allowed", run(validateMessageFlowCrossPool, nodes, [mf("flow1", "task1", "task2")]));
+  }
+  // FE: "should detect message flow within the same pool" — 1 finding
+  {
+    const nodes = [part("pool1"), inPool("task1", "pool1"), inPool("task2", "pool1")];
+    expectCodeCount("same-pool mf", run(validateMessageFlowCrossPool, nodes, [mf("flow1", "task1", "task2")]), "SAME_POOL_MESSAGE_FLOW", 1);
+  }
+  // FE: "should handle nested elements in pools"
+  {
+    const nodes = [part("pool1"), node("subprocess1", "bpmn:SubProcess", {}, { parentId: "pool1" }), inPool("task1", "subprocess1"), inPool("task2", "subprocess1")];
+    expectCodeCount("nested same-pool mf", run(validateMessageFlowCrossPool, nodes, [mf("flow1", "task1", "task2")]), "SAME_POOL_MESSAGE_FLOW", 1);
+  }
+  // FE: "should ignore non-message flows"
+  {
+    const nodes = [part("pool1"), inPool("task1", "pool1"), inPool("task2", "pool1")];
+    expectEmpty("sequence flow ignored by mf rule", run(validateMessageFlowCrossPool, nodes, [edge("flow1", "task1", "task2", { type: "bpmn:SequenceFlow" })]));
+  }
+  // FE: "should handle multiple message flows" — 1 finding (only same-pool flow1)
+  {
+    const nodes = [part("pool1"), part("pool2"), inPool("task1", "pool1"), inPool("task2", "pool1"), inPool("task3", "pool2")];
+    const edges = [mf("flow1", "task1", "task2"), mf("flow2", "task1", "task3")];
+    expectCodeCount("multiple mf, one same-pool", run(validateMessageFlowCrossPool, nodes, edges), "SAME_POOL_MESSAGE_FLOW", 1);
+  }
+  // FE: "should handle elements in deeply nested subprocesses"
+  {
+    const nodes = [
+      part("pool1"),
+      node("subprocess1", "bpmn:SubProcess", {}, { parentId: "pool1" }),
+      node("subprocess2", "bpmn:SubProcess", {}, { parentId: "subprocess1" }),
+      inPool("task1", "subprocess2"),
+      inPool("task2", "subprocess2"),
+    ];
+    expectCodeCount("deeply nested same-pool mf", run(validateMessageFlowCrossPool, nodes, [mf("flow1", "task1", "task2")]), "SAME_POOL_MESSAGE_FLOW", 1);
+  }
+}
+
+// ===========================================================================
+// 9. MissingResourceRule (WARNING)
+// ===========================================================================
+suite("MissingResourceRule");
+{
+  const svc = (id, uipath, label = "Task", type = "bpmn:ServiceTask") => node(id, type, { label, uipath });
+
+  // FE: "ignores nodes without a uipath service type"
+  expectEmpty("no service type", run(validateMissingResource, [svc("1", {})], []));
+  // FE: "ignores service types that do not require a bound resource" (ScriptTask)
+  expectEmpty("scriptTask ignored", run(validateMissingResource, [svc("1", { serviceType: "BPMN.ScriptTask" })], []));
+  // FE: "flags an agent task when no resource is bound"
+  expectCodeCount("agent no binding", run(validateMissingResource, [svc("agent-1", { serviceType: "Orchestrator.StartAgentJob", version: "v2" }, "Agent (placeholder)")], []), "MISSING_RESOURCE", 1);
+  // FE: "does not flag an agent task with a v1 releaseKey binding"
+  expectEmpty("agent releaseKey binding", run(validateMissingResource, [svc("agent-1", { serviceType: "Orchestrator.StartAgentJob", context: [{ name: "releaseKey", type: "string", value: "binding-id" }] })], []));
+  // FE: "does not flag a v2 task with a name binding"
+  expectEmpty("v2 name binding", run(validateMissingResource, [svc("queue-1", { serviceType: "Orchestrator.CreateAndWaitForQueueItem", version: "v2", context: [{ name: "name", value: "MyQueue" }, { name: "folderPath", value: "Shared" }] })], []));
+  // FE: "flags when context exists but has no releaseKey or name"
+  expectCodeCount("hitl no binding fields", run(validateMissingResource, [svc("hitl-1", { serviceType: "Actions.HITL", context: [{ name: "taskTitle", type: "string", value: "Approve" }] })], []), "MISSING_RESOURCE", 1);
+  // FE: "returns one warning per unbound task across multiple nodes" (script-1 not checked)
+  {
+    const nodes = [svc("agent-1", { serviceType: "Orchestrator.StartAgentJob" }), svc("queue-1", { serviceType: "Orchestrator.CreateQueueItem" }), svc("script-1", { serviceType: "BPMN.ScriptTask" })];
+    const f = run(validateMissingResource, nodes, []);
+    check("one warning per unbound task", f.map((e) => e.elementId).sort().join(",") === "agent-1,queue-1", f.map((e) => e.elementId).join(","));
+  }
+  // FE: "flags an unbound call activity action %s" (4 case manager / agentic types)
+  for (const st of ["Orchestrator.StartAgenticProcess", "Orchestrator.StartAgenticProcessAsync", "Orchestrator.StartCaseMgmtProcess", "Orchestrator.StartCaseMgmtProcessAsync"]) {
+    expectCodeCount(`call activity ${st}`, run(validateMissingResource, [svc("call-1", { serviceType: st, version: "v2" }, "Call activity", "bpmn:CallActivity")], []), "MISSING_RESOURCE", 1);
+  }
+}
+
+// ===========================================================================
+// 10. MissingRootVariableRule (WARNING)
+// Uses validateMissingRootVariables(nodes, canvasState). Our port reads
+// canvasState.root.data.uipath.variables (inputOutputs+outputs), resolves a
+// node output's `var` against root + enclosing-subprocess scope via
+// node.data.parentElement chain & canvasState.diagramsById.
+// ===========================================================================
+suite("MissingRootVariableRule");
+{
+  const task = (id, outputs, parentElement) => node(id, "bpmn:Task", { label: id, uipath: { outputs }, ...(parentElement ? { parentElement } : {}) });
+  const subp = (id, variables, parentElement) => node(id, "bpmn:SubProcess", { isExpanded: true, uipath: { variables }, ...(parentElement ? { parentElement } : {}) });
+  // Build a canvasState whose diagram contains the given nodes and whose root has the given vars.
+  const cs = (rootInputOutputs = [], rootOutputs = [], diagramNodes = []) =>
+    canvasState({ rootVariables: { inputs: [], inputOutputs: rootInputOutputs, outputs: rootOutputs }, diagramNodes });
+
+  // FE root 1: missing from root
+  {
+    const t = task("Task_1", [{ name: "response", type: "any", var: "var_missing" }]);
+    expectCodeCount("root: missing var", validateMissingRootVariables([t], cs([], [], [t])), "MISSING_ROOT_VARIABLE", 1);
+  }
+  // FE root 2: exists in root inputOutputs
+  {
+    const t = task("Task_1", [{ var: "var_1" }]);
+    expectEmpty("root: var exists", validateMissingRootVariables([t], cs([{ id: "var_1", name: "response", type: "any" }], [], [t])));
+  }
+  // FE root 3: one warning per node even if multiple outputs missing
+  {
+    const t = task("Task_1", [{ var: "var_a" }, { var: "var_b" }, { var: "var_c" }]);
+    expectCodeCount("root: one per node", validateMissingRootVariables([t], cs([], [], [t])), "MISSING_ROOT_VARIABLE", 1);
+  }
+  // FE root 4: only the unhealthy node flagged
+  {
+    const t1 = task("Task_1", [{ var: "var_1" }]);
+    const t2 = task("Task_2", [{ var: "var_missing" }]);
+    const f = validateMissingRootVariables([t1, t2], cs([{ id: "var_1" }], [], [t1, t2]));
+    expectCodeCount("root: only unhealthy", f, "MISSING_ROOT_VARIABLE", 1);
+    check("root: flagged node is Task_2", f[0]?.elementId === "Task_2", f[0]?.elementId);
+  }
+  // FE root 5: root outputs also count
+  {
+    const e = task("EndEvent_1", [{ var: "var_out" }]);
+    expectEmpty("root: outputs count", validateMissingRootVariables([e], cs([], [{ id: "var_out", name: "out", type: "string" }], [e])));
+  }
+  // FE subprocess 1: task in subprocess references root-scoped var
+  {
+    const sp = subp("SubProcess_1", { inputOutputs: [{ id: "var_sub" }] });
+    const t = task("Task_1", [{ var: "var_root_only" }], { id: "SubProcess_1", type: "bpmn:SubProcess" });
+    expectEmpty("sub: resolves at root", validateMissingRootVariables([sp, t], cs([{ id: "var_root_only" }], [], [sp, t])));
+  }
+  // FE subprocess 2: missing from all scopes
+  {
+    const sp = subp("SubProcess_1", { inputOutputs: [{ id: "var_sub" }] });
+    const t = task("Task_1", [{ var: "var_nowhere" }], { id: "SubProcess_1", type: "bpmn:SubProcess" });
+    expectCodeCount("sub: missing everywhere", validateMissingRootVariables([sp, t], cs([], [], [sp, t])), "MISSING_ROOT_VARIABLE", 1);
+  }
+  // FE subprocess 3: resolves at subprocess scope
+  {
+    const sp = subp("SubProcess_1", { inputOutputs: [{ id: "var_sub" }] });
+    const t = task("Task_1", [{ var: "var_sub" }], { id: "SubProcess_1", type: "bpmn:SubProcess" });
+    expectEmpty("sub: resolves at subprocess", validateMissingRootVariables([sp, t], cs([], [], [sp, t])));
+  }
+  // FE nested 2: resolves at intermediate subprocess scope
+  {
+    const outer = subp("SubProcess_outer", { inputOutputs: [{ id: "var_outer" }] });
+    const inner = subp("SubProcess_inner", { inputOutputs: [] }, { id: "SubProcess_outer", type: "bpmn:SubProcess" });
+    const t = task("Task_1", [{ var: "var_outer" }], { id: "SubProcess_inner", type: "bpmn:SubProcess" });
+    expectEmpty("nested: resolves at outer", validateMissingRootVariables([outer, inner, t], cs([], [], [outer, inner, t])));
+  }
+  // FE nested 3: missing from all scopes
+  {
+    const outer = subp("SubProcess_outer", { inputOutputs: [{ id: "var_outer" }] });
+    const inner = subp("SubProcess_inner", { inputOutputs: [{ id: "var_inner" }] }, { id: "SubProcess_outer", type: "bpmn:SubProcess" });
+    const t = task("Task_1", [{ var: "var_nowhere" }], { id: "SubProcess_inner", type: "bpmn:SubProcess" });
+    expectCodeCount("nested: missing everywhere", validateMissingRootVariables([outer, inner, t], cs([], [], [outer, inner, t])), "MISSING_ROOT_VARIABLE", 1);
+  }
+}
+
+// ===========================================================================
+// 11. NoAssignmentsRule (WARNING)
+// ===========================================================================
+suite("NoAssignmentsRule");
+{
+  const en = (cond) => edge("edge-1", "node-1", "node-2", { data: { conditionExpression: cond } });
+  const nm = (errorMapping) => node("node-1", "bpmn:Activity", { uipath: { errorMapping } });
+
+  expectEmpty("null nodes", validateNoAssignmentsInExpressions(null, []));
+  expectEmpty("null edges", validateNoAssignmentsInExpressions([], null));
+  expectEmpty("empty", validateNoAssignmentsInExpressions([], []));
+  // FE: "should detect assignment in edge condition expression"
+  expectCodeCount("edge assignment", validateNoAssignmentsInExpressions([], [en("=x = 5")]), "ASSIGNMENT_NOT_ALLOWED", 1);
+  // FE: "should skip edges with no condition expression"
+  expectEmpty("edge no cond", validateNoAssignmentsInExpressions([], [edge("edge-1", "node-1", "node-2", { data: {} })]));
+  // FE: "should not flag comparison operators in edge expressions"
+  expectEmpty("edge comparison", validateNoAssignmentsInExpressions([], [en("=x === y && z >= 10")]));
+  // FE: "should detect compound assignment operators (??=)"
+  expectCodeCount("edge compound assign", validateNoAssignmentsInExpressions([], [en("=x ??= 5")]), "ASSIGNMENT_NOT_ALLOWED", 1);
+  // FE: "should detect errors across multiple edges"
+  expectCodeCount("multiple edge assigns", validateNoAssignmentsInExpressions([], [edge("edge-1", "a", "b", { data: { conditionExpression: "=a = 1" } }), edge("edge-2", "c", "d", { data: { conditionExpression: "=b = 2" } })]), "ASSIGNMENT_NOT_ALLOWED", 2);
+  // FE: "should not check node inputs for assignments"
+  expectEmpty("node inputs not checked", validateNoAssignmentsInExpressions([node("node-1", "bpmn:Activity", { uipath: { inputs: [{ name: "myInput", var: "var-1", value: "=x = 5", type: "string" }] } })], []));
+  // FE: "should not check node outputs for assignments"
+  expectEmpty("node outputs not checked", validateNoAssignmentsInExpressions([node("node-1", "bpmn:Activity", { uipath: { outputs: [{ name: "myOutput", var: "out-1", source: "=x = 5", type: "string" }] } })], []));
+  // FE: "should produce no errors for clean edge expressions" (arrow fn)
+  expectEmpty("arrow fn not assignment", validateNoAssignmentsInExpressions([], [en("=() => x + 1")]));
+  // FE: "should detect assignment in error mapping condition"
+  expectCodeCount("error mapping assign", validateNoAssignmentsInExpressions([nm([{ id: "ErrorMapping_1", condition: "=x = 5" }])], []), "ASSIGNMENT_NOT_ALLOWED", 1);
+  // FE: "should skip error mappings with no condition"
+  expectEmpty("error mapping no cond", validateNoAssignmentsInExpressions([nm([{ id: "ErrorMapping_1" }])], []));
+  // FE: "should not flag comparison operators in error mapping conditions"
+  expectEmpty("error mapping comparison", validateNoAssignmentsInExpressions([nm([{ condition: "=x === y" }])], []));
+  // FE: "should detect assignments across multiple error mappings"
+  expectCodeCount("multiple error mapping assigns", validateNoAssignmentsInExpressions([nm([{ condition: "=a = 1" }, { condition: "=b = 2" }])], []), "ASSIGNMENT_NOT_ALLOWED", 2);
+  // FE: "should detect assignments in both edges and error mappings"
+  expectCodeCount("edge + error mapping assigns", validateNoAssignmentsInExpressions([nm([{ condition: "=x = 1" }])], [en("=y = 2")]), "ASSIGNMENT_NOT_ALLOWED", 2);
+}
+
+// ===========================================================================
+// 12. RequiredFieldsRule
+// FE marks fields `required:true` inline. Our model recovers `required` from
+// the registry by field-name match; here we set it directly (same shape the
+// rule consumes) to reproduce the FE scenarios 1:1.
+// ===========================================================================
+suite("RequiredFieldsRule");
+{
+  const n = (id, uipath, label = "Test Activity") => node(id, "bpmn:ServiceTask", { label, uipath });
+  expectEmpty("null nodes", validateRequiredFields(null));
+  // FE: "no required fields empty"
+  expectEmpty("no empty required", validateRequiredFields([n("1", { context: [{ required: true, name: "field1", value: "value1" }], inputs: [{ required: true, name: "input1", value: "value2" }], outputs: [{ name: "output1", value: "" }] })]));
+  // FE: "empty required field in context" (2 nodes) → 2 findings
+  {
+    const nodes = [n("1", { context: [{ required: true, name: "field1", value: "" }, { required: false, name: "field2", value: "" }] }), n("2", { context: [{ required: true, name: "field1", value: "" }, { required: false, name: "field2", value: "" }] })];
+    expectCodeCount("context empty required", validateRequiredFields(nodes), "EMPTY_REQUIRED_FIELD", 2);
+  }
+  // FE: "empty required field in inputs"
+  expectCodeCount("inputs empty required", validateRequiredFields([n("1", { inputs: [{ required: true, name: "input1", value: null }, { required: false, name: "input2", value: "" }] })]), "EMPTY_REQUIRED_FIELD", 1);
+  // FE: "empty required field in outputs"
+  expectCodeCount("outputs empty required", validateRequiredFields([n("1", { outputs: [{ required: true, name: "output1", value: undefined }, { required: false, name: "output2", value: "" }] })]), "EMPTY_REQUIRED_FIELD", 1);
+  // FE: "handle nodes without uipath data"
+  expectEmpty("no uipath", validateRequiredFields([node("1", "bpmn:ServiceTask", {})]));
+  // FE: "multiple empty required fields in different sections" → 1 finding (per-node)
+  {
+    const f = validateRequiredFields([n("1", { context: [{ required: true, name: "field1", value: "" }], inputs: [{ required: true, name: "input1", value: null }], outputs: [{ required: true, name: "output1", value: undefined }] })]);
+    expectCodeCount("per-node single finding", f, "EMPTY_REQUIRED_FIELD", 1);
+  }
+}
+
+// ===========================================================================
+// 13. SequenceFlowPoolCrossingRule
+// ===========================================================================
+suite("SequenceFlowPoolCrossingRule");
+{
+  const part = (id) => node(id, "bpmn:Participant");
+  const inPool = (id, parentId, type = "bpmn:Task") => node(id, type, {}, { parentId });
+  const sf = (id, s, t) => edge(id, s, t, { type: "bpmn:SequenceFlow" });
+
+  // FE: "should allow sequence flow within same pool"
+  {
+    const nodes = [part("pool1"), inPool("task1", "pool1"), inPool("task2", "pool1")];
+    expectEmpty("same pool sf", run(validateSequenceFlowPoolCrossing, nodes, [sf("flow1", "task1", "task2")]));
+  }
+  // FE: "should detect sequence flow crossing pool boundaries"
+  {
+    const nodes = [part("pool1"), part("pool2"), inPool("task1", "pool1"), inPool("task2", "pool2")];
+    expectCodeCount("cross pool sf", run(validateSequenceFlowPoolCrossing, nodes, [sf("flow1", "task1", "task2")]), "CROSSING_POOL_BOUNDARY", 1);
+  }
+  // FE: "should handle nested elements in pools"
+  {
+    const nodes = [part("pool1"), part("pool2"), inPool("subprocess1", "pool1", "bpmn:SubProcess"), inPool("subprocess2", "pool2", "bpmn:SubProcess"), inPool("task1", "subprocess1"), inPool("task2", "subprocess2")];
+    expectCodeCount("nested cross pool sf", run(validateSequenceFlowPoolCrossing, nodes, [sf("flow1", "task1", "task2")]), "CROSSING_POOL_BOUNDARY", 1);
+  }
+}
+
+// ===========================================================================
+// 14. SequenceFlowSubProcessCrossingRule
+// ===========================================================================
+suite("SequenceFlowSubProcessCrossingRule");
+{
+  const sp = (id) => node(id, "bpmn:SubProcess");
+  const inSp = (id, parentId) => node(id, "bpmn:Task", {}, { parentId });
+  // FE helper: boundary node has parentId = attachedTo AND data.attachedToId = attachedTo
+  const boundary = (id, attachedTo) => node(id, "bpmn:BoundaryEvent", { attachedToId: attachedTo }, { parentId: attachedTo });
+  const sf = (id, s, t) => edge(id, s, t, { type: "bpmn:SequenceFlow" });
+
+  // FE: "should allow sequence flow within same scope"
+  {
+    const nodes = [sp("subprocess1"), inSp("task1", "subprocess1"), inSp("task2", "subprocess1")];
+    expectEmpty("same scope sf", run(validateSequenceFlowSubProcessCrossing, nodes, [sf("flow1", "task1", "task2")]));
+  }
+  // FE: "should detect sequence flow crossing subprocess boundary"
+  {
+    const nodes = [sp("subprocess1"), sp("subprocess2"), inSp("task1", "subprocess1"), inSp("task2", "subprocess2")];
+    expectCodeCount("cross subprocess sf", run(validateSequenceFlowSubProcessCrossing, nodes, [sf("flow1", "task1", "task2")]), "CROSSING_SUBPROCESS_BOUNDARY", 1);
+  }
+  // FE: "should ignore non-sequence flows"
+  {
+    const nodes = [sp("subprocess1"), sp("subprocess2"), inSp("task1", "subprocess1"), inSp("task2", "subprocess2")];
+    expectEmpty("association ignored", run(validateSequenceFlowSubProcessCrossing, nodes, [edge("association1", "task1", "task2", { type: "bpmn:Association" })]));
+  }
+  // FE: "boundary attached to child node connected within same subprocess" — allowed
+  {
+    const nodes = [sp("subprocess1"), boundary("boundaryEvent", "task1"), inSp("task1", "subprocess1"), inSp("task2", "subprocess1")];
+    expectEmpty("boundary on child, same subprocess", run(validateSequenceFlowSubProcessCrossing, nodes, [sf("flow1", "boundaryEvent", "task2")]));
+  }
+  // FE: "subprocess-attached boundary connected into the subprocess" — crossing
+  {
+    const nodes = [sp("subprocess1"), boundary("boundaryEvent", "subprocess1"), inSp("task1", "subprocess1")];
+    expectCodeCount("boundary on subprocess into child", run(validateSequenceFlowSubProcessCrossing, nodes, [sf("flow1", "boundaryEvent", "task1")]), "CROSSING_SUBPROCESS_BOUNDARY", 1);
+  }
+  // FE: "subprocess-attached boundary connected into a different subprocess" — crossing
+  {
+    const nodes = [sp("subprocess1"), boundary("boundaryEvent", "subprocess1"), sp("subprocess2"), inSp("task1", "subprocess2")];
+    expectCodeCount("boundary on subprocess into other subprocess", run(validateSequenceFlowSubProcessCrossing, nodes, [sf("flow1", "boundaryEvent", "task1")]), "CROSSING_SUBPROCESS_BOUNDARY", 1);
+  }
+}
+
+// ===========================================================================
+// 15. SingleBlankStartEventRule
+// Our port keys scopes off bpmn:Process / bpmn:SubProcess container nodes and
+// groups start events by parentId. We add a container Process node (the FE tests
+// include one via createNode("process1","bpmn:Process")).
+// ===========================================================================
+suite("SingleBlankStartEventRule");
+{
+  const proc = node("process1", "bpmn:Process");
+  const start = (id, parentId, ed) => node(id, "bpmn:StartEvent", ed ? { eventDefinition: ed } : {}, { parentId });
+  const sp = (id) => node(id, "bpmn:SubProcess");
+
+  expectEmpty("null/empty", run(validateSingleBlankStartEvent, [], []));
+  // FE: "single blank start in root process"
+  expectEmpty("single blank root", run(validateSingleBlankStartEvent, [proc, start("start1")], []));
+  // FE: "multiple blank start events in root process" — 1 finding on process1
+  {
+    const f = run(validateSingleBlankStartEvent, [proc, start("start1"), start("start2")], []);
+    expectCodeCount("multiple blank root", f, "MULTIPLE_BLANK_START_EVENTS", 1);
+    check("blank root elementId process1", f[0]?.elementId === "process1", f[0]?.elementId);
+  }
+  // FE: "single blank start in subprocess"
+  expectEmpty("single blank subprocess", run(validateSingleBlankStartEvent, [proc, sp("subprocess1"), start("start1", "subprocess1")], []));
+  // FE: "multiple blank start events in subprocess" — 1 finding on subprocess1
+  {
+    const f = run(validateSingleBlankStartEvent, [proc, sp("subprocess1"), start("start1", "subprocess1"), start("start2", "subprocess1")], []);
+    expectCodeCount("multiple blank subprocess", f, "MULTIPLE_BLANK_START_EVENTS", 1);
+    check("blank subprocess elementId subprocess1", f[0]?.elementId === "subprocess1", f[0]?.elementId);
+  }
+  // FE: "should not count non-blank start events"
+  expectEmpty("non-blank not counted", run(validateSingleBlankStartEvent, [proc, start("start1"), start("start2", undefined, { id: "timer1", type: "bpmn:TimerEventDefinition" })], []));
+  // FE: "independent scopes"
+  {
+    const nodes = [proc, sp("subprocess1"), sp("subprocess2"), start("start1"), start("start2", "subprocess1"), start("start3", "subprocess2")];
+    expectEmpty("independent scopes one blank each", run(validateSingleBlankStartEvent, nodes, []));
+  }
+}
+
+// ===========================================================================
+// 16. SingleStartEventInEventSubProcessRule
+// ===========================================================================
+suite("SingleStartEventInEventSubProcessRule");
+{
+  const sp = (id, triggeredByEvent) => node(id, "bpmn:SubProcess", triggeredByEvent ? { triggeredByEvent: true } : {});
+  const start = (id, parentId, ed) => node(id, "bpmn:StartEvent", ed ? { eventDefinition: ed } : {}, { parentId });
+
+  // FE: "should allow event subprocess with one start event"
+  expectEmpty("one start in event subprocess", run(validateSingleStartEventInEventSubProcess, [sp("subprocess1", true), start("start1", "subprocess1", { type: "bpmn:TimerEventDefinition" })], []));
+  // FE: "should allow regular subprocess with multiple start events"
+  expectEmpty("regular subprocess multiple starts", run(validateSingleStartEventInEventSubProcess, [sp("subprocess1", false), start("start1", "subprocess1"), start("start2", "subprocess1")], []));
+  // FE: "should detect multiple start events in event subprocess"
+  {
+    const nodes = [sp("subprocess1", true), start("start1", "subprocess1", { type: "bpmn:TimerEventDefinition" }), start("start2", "subprocess1", { type: "bpmn:MessageEventDefinition" })];
+    expectCodeCount("two starts event subprocess", run(validateSingleStartEventInEventSubProcess, nodes, []), "MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS", 1);
+  }
+  // FE: "...with three start events"
+  {
+    const nodes = [sp("subprocess1", true), start("s1", "subprocess1", { type: "bpmn:TimerEventDefinition" }), start("s2", "subprocess1", { type: "bpmn:MessageEventDefinition" }), start("s3", "subprocess1", { type: "bpmn:ErrorEventDefinition" })];
+    expectCodeCount("three starts event subprocess", run(validateSingleStartEventInEventSubProcess, nodes, []), "MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS", 1);
+  }
+  // FE: "should not flag event subprocess with no start events"
+  expectEmpty("no starts event subprocess", run(validateSingleStartEventInEventSubProcess, [sp("subprocess1", true)], []));
+}
+
+// ===========================================================================
+// 17. SuperfluousGatewayRule
+// ===========================================================================
+suite("SuperfluousGatewayRule");
+{
+  expectEmpty("null nodes", validateSuperfluousGateway(null, [], maps([], [])));
+  expectEmpty("null edges", validateSuperfluousGateway([], null, maps([], [])));
+  // FE: "should return empty array when no gateways present"
+  expectEmpty("no gateways", run(validateSuperfluousGateway, [node("1", "bpmn:Task")], []));
+  // FE: "should detect superfluous gateway with exactly one input and output"
+  {
+    const nodes = [node("gateway1", "bpmn:ExclusiveGateway")];
+    const edges = [edge("e1", "start", "gateway1"), edge("e2", "gateway1", "end")];
+    expectCodeCount("superfluous 1in1out", run(validateSuperfluousGateway, nodes, edges), "SUPERFLUOUS_GATEWAY", 1);
+  }
+  // FE: "should not flag gateway with multiple inputs"
+  {
+    const nodes = [node("gateway1", "bpmn:ParallelGateway")];
+    const edges = [edge("e1", "start1", "gateway1"), edge("e2", "start2", "gateway1"), edge("e3", "gateway1", "end")];
+    expectEmpty("multiple inputs", run(validateSuperfluousGateway, nodes, edges));
+  }
+  // FE: "should not flag gateway with multiple outputs"
+  {
+    const nodes = [node("gateway1", "bpmn:InclusiveGateway")];
+    const edges = [edge("e1", "start", "gateway1"), edge("e2", "gateway1", "end1"), edge("e3", "gateway1", "end2")];
+    expectEmpty("multiple outputs", run(validateSuperfluousGateway, nodes, edges));
+  }
+  // FE: "should handle multiple gateways correctly"
+  {
+    const nodes = [node("gateway1", "bpmn:ExclusiveGateway"), node("gateway2", "bpmn:ParallelGateway")];
+    const edges = [edge("e1", "start", "gateway1"), edge("e2", "gateway1", "gateway2"), edge("e3", "x", "gateway2"), edge("e4", "gateway2", "end1"), edge("e5", "gateway2", "end2")];
+    // gateway1: 1 in (e1), 1 out (e2) -> superfluous. gateway2: 2 in (e2,e3), 2 out -> fine.
+    const f = run(validateSuperfluousGateway, nodes, edges);
+    expectCodeCount("multiple gateways", f, "SUPERFLUOUS_GATEWAY", 1);
+    check("superfluous is gateway1", f[0]?.elementId === "gateway1", f[0]?.elementId);
+  }
+}
+
+// ===========================================================================
+// 18. TaskTimerRule (WARNING)
+// ===========================================================================
+suite("TaskTimerRule");
+{
+  const action = (timerValue, label = "My Action", id = "node-1") =>
+    node(id, "bpmn:ServiceTask", { label, uipath: { serviceType: "actions", context: timerValue !== undefined ? [{ name: "Timer", value: String(timerValue), type: "number" }] : [] } });
+
+  expectEmpty("null nodes", validateTaskTimerRange(null));
+  expectEmpty("empty nodes", validateTaskTimerRange([]));
+  // FE: "ignores nodes that are not action service tasks"
+  expectEmpty("non-action service task", validateTaskTimerRange([node("node-1", "bpmn:ServiceTask", { uipath: { serviceType: "automation", context: [{ name: "Timer", value: "5", type: "number" }] } })]));
+  // FE: "ignores action nodes with no Timer context entry"
+  expectEmpty("no Timer entry", validateTaskTimerRange([action(undefined)]));
+  // FE: "ignores empty Timer value"
+  expectEmpty("empty Timer", validateTaskTimerRange([action("")]));
+  // FE: "ignores Timer set to a variable reference (@)"
+  expectEmpty("@ Timer", validateTaskTimerRange([action("@in_timerMinutes")]));
+  // FE: "ignores Timer set to an expression (=)"
+  expectEmpty("= Timer", validateTaskTimerRange([action("=someExpression")]));
+  // FE: min/max/in-range valid
+  expectEmpty("min 15", validateTaskTimerRange([action(15)]));
+  expectEmpty("max 129600", validateTaskTimerRange([action(129600)]));
+  expectEmpty("in range 60", validateTaskTimerRange([action(60)]));
+  expectEmpty("numeric string 1440", validateTaskTimerRange([action("1440")]));
+  // FE: out-of-range warnings
+  expectCodeCount("below min 14", validateTaskTimerRange([action(14)]), "TASK_TIMER_OUT_OF_RANGE", 1);
+  expectCodeCount("zero", validateTaskTimerRange([action(0)]), "TASK_TIMER_OUT_OF_RANGE", 1);
+  expectCodeCount("above max 129601", validateTaskTimerRange([action(129601)]), "TASK_TIMER_OUT_OF_RANGE", 1);
+  // FE: "only warns on out-of-range action nodes, not valid ones"
+  expectCodeCount("mixed only out-of-range", validateTaskTimerRange([action(5, "a", "n1"), action(60, "b", "n2"), action(129601, "c", "n3")]), "TASK_TIMER_OUT_OF_RANGE", 2);
+  // FE: "ignores non-numeric Timer values"
+  expectEmpty("non-numeric", validateTaskTimerRange([action("not-a-number")]));
+}
+
+// ===========================================================================
+// 19. TimerDurationRule
+// ===========================================================================
+suite("TimerDurationRule");
+{
+  const timer = (timeDuration, id = "node-1", timerType = "timeDuration") =>
+    node(id, "bpmn:IntermediateCatchEvent", { label: "My Timer", eventDefinition: { timerType, timeDuration } });
+
+  expectEmpty("null nodes", validateTimerDuration(null));
+  expectEmpty("empty nodes", validateTimerDuration([]));
+  // FE: "ignores nodes without an eventDefinition"
+  expectEmpty("no eventDefinition", validateTimerDuration([node("n1", "bpmn:Task", { label: "Task" })]));
+  // FE: "ignores timer events whose timerType is not timeDuration"
+  expectEmpty("non-timeDuration timerType", validateTimerDuration([timer("P5W", "n1", "timeDate")]));
+  // FE: "ignores an empty duration value"
+  expectEmpty("empty duration", validateTimerDuration([timer("")]));
+  // FE: "ignores = and @ prefixed"
+  expectEmpty("= duration", validateTimerDuration([timer("=myVar")]));
+  expectEmpty("@ duration", validateTimerDuration([timer("@in_duration")]));
+  // FE: "valid ISO 8601 duration"
+  expectEmpty("valid PT15M", validateTimerDuration([timer("PT15M")]));
+  // FE: "malformed -> TIMER_DURATION_INVALID (ERROR)"
+  expectCodeCount("malformed P5X", validateTimerDuration([timer("P5X")]), "TIMER_DURATION_INVALID", 1);
+  // FE: "week designator -> TIMER_DURATION_WEEK_UNSUPPORTED (WARNING)"
+  expectCodeCount("week P5W", validateTimerDuration([timer("P5W")]), "TIMER_DURATION_WEEK_UNSUPPORTED", 1);
+}
+
+export default results;

--- a/skills/uipath-maestro-bpmn/validator/test/ported-rule-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/ported-rule-tests.mjs
@@ -34,6 +34,8 @@ import {
   validateSuperfluousGateway,
   validateTaskTimerRange,
   validateTimerDuration,
+  validateVariableExistence,
+  validateVariableNotSet,
 } from "../rules.mjs";
 import { node, edge, canvasState, maps } from "./model-helpers.mjs";
 
@@ -166,13 +168,15 @@ suite("ConnectionRule");
     expectCodeCount("self loop -> INVALID_CONNECTION", f, "INVALID_CONNECTION", 1);
   }
 
-  // FE: "should validate node type compatibility" — EndEvent -> Task is disallowed.
-  // (FE test uses non-bpmn "output"/"input" types; on real BPMN the equivalent
-  //  invalid edge is EndEvent->Task, which our concrete-type allow-map rejects.)
+  // FE: "should validate node type compatibility" — verbatim frontend input:
+  // unknown source type "output" → unknown target "input". canNodeTypesBeConnected
+  // (BPMNTypesUtils.ts:51-82) finds no matching rule and returns false, so the
+  // edge is INVALID_CONNECTION_TYPE. (Restored from a prior doctored EndEvent->Task
+  // substitute; matches ConnectionRule.test.ts:33-43.)
   {
-    const nodes = [node("1", "bpmn:EndEvent"), node("2", "bpmn:Task")];
+    const nodes = [node("1", "output"), node("2", "input")];
     const f = run(validateConnections, nodes, [edge("e1", "1", "2")]);
-    expectCodeCount("endevent->task -> INVALID_CONNECTION_TYPE", f, "INVALID_CONNECTION_TYPE", 1);
+    expectCodeCount("unknown output->input -> INVALID_CONNECTION_TYPE", f, "INVALID_CONNECTION_TYPE", 1);
   }
 }
 
@@ -618,6 +622,29 @@ suite("RequiredFieldsRule");
     const f = validateRequiredFields([n("1", { context: [{ required: true, name: "field1", value: "" }], inputs: [{ required: true, name: "input1", value: null }], outputs: [{ required: true, name: "output1", value: undefined }] })]);
     expectCodeCount("per-node single finding", f, "EMPTY_REQUIRED_FIELD", 1);
   }
+  // PORT PARITY (absent required field): On canvas, every required field exists
+  // in node data, so an unbound one is present-with-empty-value and the frontend
+  // fires `field.required && isNilOrEmpty(field.value)` (ValidateRequiredFieldsInData.ts:15-16).
+  // Offline, an unbound required field is ABSENT from the serialized data; the
+  // model attaches the serviceType's required-field names as `requiredFieldNames`
+  // so the rule treats an absent name as present-with-empty (same observable result).
+  {
+    // 'method' required by registry but not serialized at all → fires.
+    const node1 = n("1", { context: [{ name: "url", value: "https://x" }], requiredFieldNames: ["method", "url"] });
+    expectCodeCount("absent required field fires", validateRequiredFields([node1]), "EMPTY_REQUIRED_FIELD", 1);
+  }
+  {
+    // All registry-required names present and non-empty → no finding.
+    const node1 = n("1", { context: [{ name: "method", value: "GET" }, { name: "url", value: "https://x" }], requiredFieldNames: ["method", "url"] });
+    expectEmpty("all required present", validateRequiredFields([node1]));
+  }
+  {
+    // No requiredFieldNames (dynamic IS-connector type, required-ness only known
+    // after registry enrichment) → conservative: absence not flagged (frontend
+    // shares this — it also needs the enrichment to know the field is required).
+    const node1 = n("1", { context: [{ name: "someField", value: "v" }] });
+    expectEmpty("no requiredFieldNames → conservative", validateRequiredFields([node1]));
+  }
 }
 
 // ===========================================================================
@@ -851,6 +878,106 @@ suite("TimerDurationRule");
   expectCodeCount("malformed P5X", validateTimerDuration([timer("P5X")]), "TIMER_DURATION_INVALID", 1);
   // FE: "week designator -> TIMER_DURATION_WEEK_UNSUPPORTED (WARNING)"
   expectCodeCount("week P5W", validateTimerDuration([timer("P5W")]), "TIMER_DURATION_WEEK_UNSUPPORTED", 1);
+}
+
+// ===========================================================================
+// 20. Variable existence — result.X element-local validity
+// (VariableUtil.isResultVariableValidForElement:166-178; the non-existing split
+//  at :758-782; getVariablesInExpression treating an unresolved result ref as
+//  non-existing at :263). result.X is valid ONLY if X names one of the
+//  referencing element's OWN outputs; otherwise VARIABLE_DOES_NOT_EXIST fires.
+// ===========================================================================
+suite("ResultVariableExistence");
+{
+  // FE: "should not return a validation error for result namespace when it matches current element outputs"
+  // node1 declares output var "outputVar" → result.outputVar is valid.
+  {
+    const n1 = node("node1", "bpmn:ServiceTask", { uipath: { outputs: [{ name: "outputVar", var: "outputVar", custom: true, source: "=result.outputVar", type: "string" }] } });
+    const f = validateVariableExistence([n1], [], new Set());
+    expectNone("result.X matches own output → no DOES_NOT_EXIST", f, "VARIABLE_DOES_NOT_EXIST");
+  }
+  // FE: "should return a validation error for result namespace when it does not match current element outputs"
+  // node1 has output "outputVar" but references result.missingVar → invalid.
+  {
+    const n1 = node("node1", "bpmn:ServiceTask", { uipath: { inputs: [{ name: "i", value: "=result.missingVar" }], outputs: [{ name: "outputVar", var: "outputVar" }] } });
+    const f = validateVariableExistence([n1], [], new Set());
+    expectCodeCount("result.X not an output → DOES_NOT_EXIST", f, "VARIABLE_DOES_NOT_EXIST", 1);
+  }
+  // FE: getVariablesInExpression "should return the correct result variable in the expression"
+  // An edge condition has no element-local outputs → result.myVar is non-existing.
+  {
+    const e1 = edge("edge1", "a", "b", { data: { conditionExpression: "=result.myVar" } });
+    const f = validateVariableExistence([], [e1], new Set());
+    expectCodeCount("edge result.X → DOES_NOT_EXIST", f, "VARIABLE_DOES_NOT_EXIST", 1);
+  }
+}
+
+// ===========================================================================
+// 21. VARIABLE_NOT_SET — flow-order reachability (WARNING)
+// Port of validateVariablesInExpression:758-866 (the reachability half). A
+// DECLARED variable referenced where no flow path reaches its producer fires
+// VARIABLE_NOT_SET. Tested at the model level (allNodes/allEdges/knownIds/cs),
+// mirroring validateVariablesInAllNodesAndEdges.
+// ===========================================================================
+suite("VariableNotSet");
+{
+  // Helper: canvasState with given root vars + diagram nodes/edges.
+  const csFor = (rootInputOutputs, nodes, edges) => canvasState({ rootVariables: { inputs: [], inputOutputs: rootInputOutputs, outputs: [] }, diagramNodes: nodes, diagramEdges: edges });
+
+  // FE: "should return a validation error if a variable is used before it is set"
+  // edge node1->node2 references vars.myVar; myVar is declared (known) but not
+  // produced on any path reaching the edge → exactly 1 VARIABLE_NOT_SET.
+  {
+    const n1 = node("node1", "bpmn:Task", {});
+    const n2 = node("node2", "bpmn:Task", {});
+    const e1 = edge("edge1", "node1", "node2", { data: { conditionExpression: "=vars.myVar" } });
+    const known = new Set(["myVar"]); // declared somewhere, but not reachable here
+    const cs = csFor([], [n1, n2], [e1]);
+    const f = validateVariableNotSet([n1, n2], [e1], known, cs);
+    expectCodeCount("used before set → NOT_SET", f, "VARIABLE_NOT_SET", 1);
+  }
+  // FE: "should not return a validation error if a variable used is a root variable"
+  // Same graph but myVar is a ROOT variable → globally available → no NOT_SET.
+  {
+    const n1 = node("node1", "bpmn:Task", {});
+    const n2 = node("node2", "bpmn:Task", {});
+    const e1 = edge("edge1", "node1", "node2", { data: { conditionExpression: "=vars.myVar" } });
+    const known = new Set(["myVar"]);
+    const cs = csFor([{ id: "myVar", name: "myVarName", type: "string" }], [n1, n2], [e1]);
+    const f = validateVariableNotSet([n1, n2], [e1], known, cs);
+    expectNone("root variable → no NOT_SET", f, "VARIABLE_NOT_SET");
+  }
+  // Reachable producer → no NOT_SET: node A produces var, node B (downstream)
+  // references it; B's backward walk reaches A.
+  {
+    const a = node("A", "bpmn:ServiceTask", { uipath: { outputs: [{ name: "o", var: "produced", custom: true, source: "x", type: "string" }] } });
+    const b = node("B", "bpmn:ServiceTask", { uipath: { inputs: [{ name: "i", value: "=vars.produced" }] } });
+    const e1 = edge("A_B", "A", "B", { data: {} });
+    const known = new Set(["produced"]);
+    const cs = csFor([], [a, b], [e1]);
+    const f = validateVariableNotSet([a, b], [e1], known, cs);
+    expectNone("reachable producer → no NOT_SET", f, "VARIABLE_NOT_SET");
+  }
+  // Producer downstream → NOT_SET: node A (upstream) references a var produced by
+  // node B (downstream), unreachable at A.
+  {
+    const a = node("A", "bpmn:ServiceTask", { uipath: { inputs: [{ name: "i", value: "=vars.fromB" }] } });
+    const b = node("B", "bpmn:ServiceTask", { uipath: { outputs: [{ name: "o", var: "fromB", custom: true, source: "x", type: "string" }] } });
+    const e1 = edge("A_B", "A", "B", { data: {} });
+    const known = new Set(["fromB"]);
+    const cs = csFor([], [a, b], [e1]);
+    const f = validateVariableNotSet([a, b], [e1], known, cs);
+    expectCodeCount("downstream producer → NOT_SET at A", f, "VARIABLE_NOT_SET", 1);
+  }
+  // Case Management is skipped entirely (VariableUtil.ts:826-828).
+  {
+    const n1 = node("node1", "bpmn:Task", {});
+    const n2 = node("node2", "bpmn:Task", {});
+    const e1 = edge("edge1", "node1", "node2", { data: { conditionExpression: "=vars.myVar" } });
+    const cs = csFor([], [n1, n2], [e1]);
+    const f = validateVariableNotSet([n1, n2], [e1], new Set(["myVar"]), cs, { isCaseManagement: true });
+    expectEmpty("case management skipped", f);
+  }
 }
 
 export default results;

--- a/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
@@ -1,0 +1,414 @@
+#!/usr/bin/env node
+// Rule-coverage test harness. For each of the 19 PO.Frontend rules (+ the
+// Maestro-original variable-existence check) it builds a minimal invalid BPMN
+// that should trip exactly that rule, and asserts the rule's code is emitted.
+// It also asserts a valid twin produces NO finding for that code.
+//
+// Run: node test/run-tests.mjs   (exit 0 = all rules fire correctly)
+import BpmnModdle from "bpmn-moddle";
+import descriptor from "../uipath-moddle.v1.json" with { type: "json" };
+import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "../model.mjs";
+import { validateDiagram, validateVariableExistence } from "../rules.mjs";
+
+const moddle = new BpmnModdle({ uipath: descriptor });
+
+async function findingsFor(xml) {
+  const { rootElement } = await moddle.fromXML(xml);
+  const cs = buildModel(rootElement);
+  const knownIds = collectKnownVariableIds(cs);
+  const out = [];
+  for (const d of Object.values(cs.diagramsById)) {
+    out.push(...validateDiagram(d, cs, { enableMissingRootVariableValidation: true }));
+  }
+  out.push(...validateVariableExistence(allNodes(cs), allEdges(cs), knownIds));
+  return out;
+}
+
+// ---- XML builders -------------------------------------------------------
+const DEFS = (inner) =>
+  `<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Defs" targetNamespace="urn:test">
+${inner}
+</bpmn:definitions>`;
+const PROC = (body, ext = "") => `  <bpmn:process id="P" name="P" isExecutable="true">${ext}\n${body}\n  </bpmn:process>`;
+const COND = (s, t, expr) =>
+  `    <bpmn:sequenceFlow id="${s}_${t}" sourceRef="${s}" targetRef="${t}"><bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${expr}</bpmn:conditionExpression></bpmn:sequenceFlow>`;
+const FLOW = (s, t, id) => `    <bpmn:sequenceFlow id="${id ?? s + "_" + t}" sourceRef="${s}" targetRef="${t}" />`;
+
+// ---- Per-rule cases -----------------------------------------------------
+const cases = [];
+const add = (code, xml, note) => cases.push({ code, xml, note });
+
+// 1 MISSING_CONDITION_EXPRESSION: XOR with 2 outgoing, no default, no conditions
+add(
+  "MISSING_CONDITION_EXPRESSION",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_G</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="G"><bpmn:incoming>S_G</bpmn:incoming><bpmn:outgoing>G_A</bpmn:outgoing><bpmn:outgoing>G_B</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="A"><bpmn:incoming>G_A</bpmn:incoming></bpmn:task>
+    <bpmn:task id="B"><bpmn:incoming>G_B</bpmn:incoming></bpmn:task>
+${FLOW("S", "G", "S_G")}
+${FLOW("G", "A", "G_A")}
+${FLOW("G", "B", "G_B")}`,
+    ),
+  ),
+);
+
+// 2 INVALID_CONNECTION_TYPE: EndEvent -> Task
+add(
+  "INVALID_CONNECTION_TYPE",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_E</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:endEvent id="E"><bpmn:incoming>S_E</bpmn:incoming><bpmn:outgoing>E_T</bpmn:outgoing></bpmn:endEvent>
+    <bpmn:task id="T"><bpmn:incoming>E_T</bpmn:incoming></bpmn:task>
+${FLOW("S", "E", "S_E")}
+${FLOW("E", "T", "E_T")}`,
+    ),
+  ),
+);
+
+// 3 DUPLICATE_ERROR_EVENT_SUBPROCESS: two event subprocesses, same error code
+add(
+  "DUPLICATE_ERROR_EVENT_SUBPROCESS",
+  DEFS(
+    `  <bpmn:error id="Err1" name="E1" errorCode="CODE_X" />
+${PROC(
+  `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming><bpmn:outgoing>T_E</bpmn:outgoing></bpmn:task>
+    <bpmn:endEvent id="E"><bpmn:incoming>T_E</bpmn:incoming></bpmn:endEvent>
+    <bpmn:subProcess id="SP1" triggeredByEvent="true">
+      <bpmn:startEvent id="SP1S"><bpmn:errorEventDefinition id="ed1" errorRef="Err1" /></bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:subProcess id="SP2" triggeredByEvent="true">
+      <bpmn:startEvent id="SP2S"><bpmn:errorEventDefinition id="ed2" errorRef="Err1" /></bpmn:startEvent>
+    </bpmn:subProcess>
+${FLOW("S", "T", "S_T")}
+${FLOW("T", "E", "T_E")}`,
+)}`,
+  ),
+);
+
+// 4 START_EVENT_WITH_DEFINITION_IN_SUBPROCESS: regular subprocess start has timer def
+add(
+  "START_EVENT_WITH_DEFINITION_IN_SUBPROCESS",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_SP</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:subProcess id="SP"><bpmn:incoming>S_SP</bpmn:incoming><bpmn:outgoing>SP_E</bpmn:outgoing>
+      <bpmn:startEvent id="SPS"><bpmn:timerEventDefinition id="t1"><bpmn:timeDuration>PT5M</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:startEvent>
+    </bpmn:subProcess>
+    <bpmn:endEvent id="E"><bpmn:incoming>SP_E</bpmn:incoming></bpmn:endEvent>
+${FLOW("S", "SP", "S_SP")}
+${FLOW("SP", "E", "SP_E")}`,
+    ),
+  ),
+);
+
+// 4b START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS
+add(
+  "START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming></bpmn:task>
+    <bpmn:subProcess id="SP" triggeredByEvent="true">
+      <bpmn:startEvent id="SPS" />
+    </bpmn:subProcess>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 5 ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE: boundary refs an Error with no errorCode
+add(
+  "ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE",
+  DEFS(
+    `  <bpmn:error id="ErrNoCode" name="NoCode" />
+${PROC(
+  `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming></bpmn:task>
+    <bpmn:boundaryEvent id="BE" attachedToRef="T"><bpmn:errorEventDefinition id="bed" errorRef="ErrNoCode" /></bpmn:boundaryEvent>
+${FLOW("S", "T", "S_T")}`,
+)}`,
+  ),
+);
+
+// 5b MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK: two catch-all error boundaries on one task
+add(
+  "MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming></bpmn:task>
+    <bpmn:boundaryEvent id="BE1" attachedToRef="T"><bpmn:errorEventDefinition id="bed1" /></bpmn:boundaryEvent>
+    <bpmn:boundaryEvent id="BE2" attachedToRef="T"><bpmn:errorEventDefinition id="bed2" /></bpmn:boundaryEvent>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 6 ERROR_END_EVENT_MISSING_EXCEPTION: error end event with no errorRef
+add(
+  "ERROR_END_EVENT_MISSING_EXCEPTION",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_E</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:endEvent id="E"><bpmn:incoming>S_E</bpmn:incoming><bpmn:errorEventDefinition id="eed" /></bpmn:endEvent>
+${FLOW("S", "E", "S_E")}`,
+    ),
+  ),
+);
+
+// 7 FAKE_JOIN: task with two incoming flows
+add(
+  "FAKE_JOIN",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T0"><bpmn:outgoing>T0_T</bpmn:outgoing></bpmn:task>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming><bpmn:incoming>T0_T</bpmn:incoming></bpmn:task>
+${FLOW("S", "T", "S_T")}
+${FLOW("T0", "T", "T0_T")}`,
+    ),
+  ),
+);
+
+// 8 SAME_POOL_MESSAGE_FLOW: message flow between two nodes in the same pool
+add(
+  "SAME_POOL_MESSAGE_FLOW",
+  DEFS(
+    `  <bpmn:collaboration id="C">
+    <bpmn:participant id="Pool1" name="Pool 1" processRef="P" />
+    <bpmn:messageFlow id="MF" sourceRef="T1" targetRef="T2" />
+  </bpmn:collaboration>
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:task id="T1" />
+    <bpmn:task id="T2" />
+  </bpmn:process>`,
+  ),
+);
+
+// 9 MISSING_RESOURCE: Orchestrator.StartJob with no resource binding (WARNING)
+add(
+  "MISSING_RESOURCE",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:serviceTask id="T" name="Start Job"><bpmn:incoming>S_T</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="Orchestrator.StartJob" version="v1" /></uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 10 MISSING_ROOT_VARIABLE: node output var not declared at root (WARNING)
+add(
+  "MISSING_ROOT_VARIABLE",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:serviceTask id="T" name="Job"><bpmn:incoming>S_T</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="Orchestrator.StartJob" version="v1" />
+        <uipath:context><uipath:input name="name" value="X" /></uipath:context>
+        <uipath:output name="JobState" type="string" var="Var_Undeclared" source="state" custom="true" />
+      </uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+${FLOW("S", "T", "S_T")}`,
+      `\n    <bpmn:extensionElements><uipath:variables version="v1"><uipath:input id="Var_Other" name="other" type="string" /></uipath:variables></bpmn:extensionElements>`,
+    ),
+  ),
+);
+
+// 11 ASSIGNMENT_NOT_ALLOWED: condition contains an assignment (WARNING)
+add(
+  "ASSIGNMENT_NOT_ALLOWED",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_G</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="G" default="G_B"><bpmn:incoming>S_G</bpmn:incoming><bpmn:outgoing>G_A</bpmn:outgoing><bpmn:outgoing>G_B</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="A"><bpmn:incoming>G_A</bpmn:incoming></bpmn:task>
+    <bpmn:task id="B"><bpmn:incoming>G_B</bpmn:incoming></bpmn:task>
+${FLOW("S", "G", "S_G")}
+${COND("G", "A", "=vars.x = 5")}
+${FLOW("G", "B", "G_B")}`,
+    ),
+  ),
+);
+
+// 12 EMPTY_REQUIRED_FIELD: HttpExecution with required 'url' present but empty
+add(
+  "EMPTY_REQUIRED_FIELD",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:serviceTask id="T" name="HTTP"><bpmn:incoming>S_T</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="Intsvc.HttpExecution" version="v1" />
+        <uipath:context><uipath:input name="method" value="GET" /><uipath:input name="url" value="" /></uipath:context>
+      </uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 13 CROSSING_POOL_BOUNDARY: sequence flow between two pools (non-start target)
+add(
+  "CROSSING_POOL_BOUNDARY",
+  DEFS(
+    `  <bpmn:collaboration id="C">
+    <bpmn:participant id="Pool1" name="P1" processRef="P" />
+    <bpmn:participant id="Pool2" name="P2" processRef="P2" />
+  </bpmn:collaboration>
+  <bpmn:process id="P" isExecutable="true">
+    <bpmn:task id="T1"><bpmn:outgoing>T1_T2</bpmn:outgoing></bpmn:task>
+${FLOW("T1", "T2", "T1_T2")}
+  </bpmn:process>
+  <bpmn:process id="P2" isExecutable="true">
+    <bpmn:task id="T2"><bpmn:incoming>T1_T2</bpmn:incoming></bpmn:task>
+  </bpmn:process>`,
+  ),
+  "cross-pool",
+);
+
+// 14 CROSSING_SUBPROCESS_BOUNDARY: flow from outside into a subprocess child
+add(
+  "CROSSING_SUBPROCESS_BOUNDARY",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_C</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:subProcess id="SP">
+      <bpmn:task id="C" />
+    </bpmn:subProcess>
+${FLOW("S", "C", "S_C")}`,
+    ),
+  ),
+);
+
+// 15 MULTIPLE_BLANK_START_EVENTS: process with two blank start events
+add(
+  "MULTIPLE_BLANK_START_EVENTS",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S1"><bpmn:outgoing>S1_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:startEvent id="S2"><bpmn:outgoing>S2_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S1_T</bpmn:incoming></bpmn:task>
+    <bpmn:task id="T2"><bpmn:incoming>S2_T</bpmn:incoming></bpmn:task>
+${FLOW("S1", "T", "S1_T")}
+${FLOW("S2", "T2", "S2_T")}`,
+    ),
+  ),
+);
+
+// 16 MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS
+add(
+  "MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming></bpmn:task>
+    <bpmn:subProcess id="SP" triggeredByEvent="true">
+      <bpmn:startEvent id="SPS1"><bpmn:timerEventDefinition id="t1"><bpmn:timeDuration>PT5M</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:startEvent>
+      <bpmn:startEvent id="SPS2"><bpmn:timerEventDefinition id="t2"><bpmn:timeDuration>PT5M</bpmn:timeDuration></bpmn:timerEventDefinition></bpmn:startEvent>
+    </bpmn:subProcess>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 17 SUPERFLUOUS_GATEWAY: gateway with exactly one in and one out
+add(
+  "SUPERFLUOUS_GATEWAY",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_G</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="G"><bpmn:incoming>S_G</bpmn:incoming><bpmn:outgoing>G_T</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="T"><bpmn:incoming>G_T</bpmn:incoming></bpmn:task>
+${FLOW("S", "G", "S_G")}
+${FLOW("G", "T", "G_T")}`,
+    ),
+  ),
+);
+
+// 18 TASK_TIMER_OUT_OF_RANGE: actions task Timer below 15 minutes (WARNING)
+add(
+  "TASK_TIMER_OUT_OF_RANGE",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:userTask id="T" name="HITL"><bpmn:incoming>S_T</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="actions" version="v1" />
+        <uipath:context><uipath:input name="Timer" value="5" /></uipath:context>
+      </uipath:activity></bpmn:extensionElements>
+    </bpmn:userTask>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+);
+
+// 19 TIMER_DURATION_INVALID: timer intermediate event with bad ISO duration
+add(
+  "TIMER_DURATION_INVALID",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_I</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="I"><bpmn:incoming>S_I</bpmn:incoming><bpmn:outgoing>I_E</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="td"><bpmn:timeDuration>NOT_A_DURATION</bpmn:timeDuration></bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="E"><bpmn:incoming>I_E</bpmn:incoming></bpmn:endEvent>
+${FLOW("S", "I", "S_I")}
+${FLOW("I", "E", "I_E")}`,
+    ),
+  ),
+);
+
+// 19b TIMER_DURATION_WEEK_UNSUPPORTED: valid ISO with week designator (WARNING)
+add(
+  "TIMER_DURATION_WEEK_UNSUPPORTED",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_I</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:intermediateCatchEvent id="I"><bpmn:incoming>S_I</bpmn:incoming><bpmn:outgoing>I_E</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="td"><bpmn:timeDuration>P1W</bpmn:timeDuration></bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:endEvent id="E"><bpmn:incoming>I_E</bpmn:incoming></bpmn:endEvent>
+${FLOW("S", "I", "S_I")}
+${FLOW("I", "E", "I_E")}`,
+    ),
+  ),
+);
+
+// 20 VARIABLE_DOES_NOT_EXIST: condition references undeclared vars.X (Maestro-original)
+add(
+  "VARIABLE_DOES_NOT_EXIST",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_G</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:exclusiveGateway id="G" default="G_B"><bpmn:incoming>S_G</bpmn:incoming><bpmn:outgoing>G_A</bpmn:outgoing><bpmn:outgoing>G_B</bpmn:outgoing></bpmn:exclusiveGateway>
+    <bpmn:task id="A"><bpmn:incoming>G_A</bpmn:incoming></bpmn:task>
+    <bpmn:task id="B"><bpmn:incoming>G_B</bpmn:incoming></bpmn:task>
+${FLOW("S", "G", "S_G")}
+${COND("G", "A", '=vars.DoesNotExist == "x"')}
+${FLOW("G", "B", "G_B")}`,
+    ),
+  ),
+);
+
+// ---- Run ----------------------------------------------------------------
+let failures = 0;
+const fired = new Set();
+for (const c of cases) {
+  const findings = await findingsFor(c.xml);
+  const codes = findings.map((f) => f.code);
+  const ok = codes.includes(c.code);
+  if (ok) fired.add(c.code);
+  const tag = ok ? "PASS" : "FAIL";
+  if (!ok) failures++;
+  console.log(`${tag}  ${c.code}${c.note ? " (" + c.note + ")" : ""}  -> [${[...new Set(codes)].join(", ") || "none"}]`);
+}
+
+console.log(`\n${cases.length} cases, ${cases.length - failures} passed, ${failures} failed.`);
+console.log(`distinct rule codes fired: ${fired.size}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
@@ -161,19 +161,13 @@ ${FLOW("S", "E", "S_E")}`,
   ),
 );
 
-// 7 FAKE_JOIN: task with two incoming flows
-add(
-  "FAKE_JOIN",
-  DEFS(
-    PROC(
-      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
-    <bpmn:task id="T0"><bpmn:outgoing>T0_T</bpmn:outgoing></bpmn:task>
-    <bpmn:task id="T"><bpmn:incoming>S_T</bpmn:incoming><bpmn:incoming>T0_T</bpmn:incoming></bpmn:task>
-${FLOW("S", "T", "S_T")}
-${FLOW("T0", "T", "T0_T")}`,
-    ),
-  ),
-);
+// 7 FAKE_JOIN: NOTE — this rule fires only on literal abstract node types
+// ("bpmn:Activity"/"bpmn:Event"), which the frontend canvas never assigns to a
+// real node (it uses concrete $types), so the rule is dormant on exported BPMN.
+// It is therefore NOT triggerable via this XML harness; the rule LOGIC is proven
+// at the model level in test/ported-rule-tests.mjs (FakeJoinRule suite, which
+// mirrors the frontend unit test verbatim). We mark it as covered there.
+// (No XML case added; see FakeJoinRule drift note in rules.mjs / README.)
 
 // 8 SAME_POOL_MESSAGE_FLOW: message flow between two nodes in the same pool
 add(
@@ -396,9 +390,10 @@ ${FLOW("G", "B", "G_B")}`,
   ),
 );
 
-// ---- Run ----------------------------------------------------------------
+// ---- Run: 1) crafted-invalid XML coverage harness -----------------------
 let failures = 0;
 const fired = new Set();
+console.log("== Crafted-invalid XML coverage ==");
 for (const c of cases) {
   const findings = await findingsFor(c.xml);
   const codes = findings.map((f) => f.code);
@@ -408,7 +403,42 @@ for (const c of cases) {
   if (!ok) failures++;
   console.log(`${tag}  ${c.code}${c.note ? " (" + c.note + ")" : ""}  -> [${[...new Set(codes)].join(", ") || "none"}]`);
 }
+console.log(`${cases.length} crafted cases, ${cases.length - failures} passed, ${failures} failed.`);
 
-console.log(`\n${cases.length} cases, ${cases.length - failures} passed, ${failures} failed.`);
-console.log(`distinct rule codes fired: ${fired.size}`);
+// FAKE_JOIN is dormant on real/exported BPMN (matches the frontend — it keys off
+// abstract node types the canvas never assigns). Its logic is proven in the
+// ported rule suite, so it is intentionally not triggerable via this XML harness.
+import { RULE_CODES } from "../rules.mjs";
+
+// ---- Run: 2) ported per-rule tests (1:1 with PO.Frontend rule tests) -----
+console.log("\n== Ported PO.Frontend rule tests ==");
+const ported = (await import("./ported-rule-tests.mjs")).default;
+console.log(`${ported.passed + ported.failed} ported assertions, ${ported.passed} passed, ${ported.failed} failed.`);
+for (const f of ported.failures) console.log("  FAIL " + f);
+failures += ported.failed;
+// Codes the ported suite positively asserts (incl. FAKE_JOIN, dormant in XML).
+const COVERED_BY_PORTED = ported.firedCodes;
+
+// ---- Run: 3) integration over real .bpmn files ---------------------------
+console.log("\n== Integration over real .bpmn files ==");
+const runIntegration = (await import("./integration.test.mjs")).default;
+const integ = await runIntegration({ verbose: true });
+console.log(
+  `${integ.ranFiles} real files (${integ.knownGood} known-good, ${integ.expected} expected-findings), ${integ.passed} passed, ${integ.failed} failed.`,
+);
+for (const f of integ.failures) console.log("  FAIL " + f);
+failures += integ.failed;
+
+// ---- Coverage assertion: every rule code is exercised somewhere -----------
+const portedOnly = [...COVERED_BY_PORTED].filter((c) => !fired.has(c));
+const portedCoverageNote = portedOnly.length ? ` (+${portedOnly.join(",")} via ported suite)` : "";
+const allFired = new Set([...fired, ...COVERED_BY_PORTED]);
+const missing = RULE_CODES.filter((c) => !allFired.has(c));
+console.log(`\nRule codes exercised: ${allFired.size}/${RULE_CODES.length}${portedCoverageNote}`);
+if (missing.length) {
+  console.log(`  MISSING coverage for: ${missing.join(", ")}`);
+  failures += missing.length;
+}
+
+console.log(`\n${failures === 0 ? "ALL GREEN" : failures + " FAILURE(S)"}`);
 process.exit(failures === 0 ? 0 : 1);

--- a/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
@@ -8,7 +8,7 @@
 import BpmnModdle from "bpmn-moddle";
 import descriptor from "../uipath-moddle.v1.json" with { type: "json" };
 import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "../model.mjs";
-import { validateDiagram, validateVariableExistence } from "../rules.mjs";
+import { validateDiagram, validateVariableExistence, validateVariableNotSet } from "../rules.mjs";
 
 const moddle = new BpmnModdle({ uipath: descriptor });
 
@@ -21,6 +21,7 @@ async function findingsFor(xml) {
     out.push(...validateDiagram(d, cs, { enableMissingRootVariableValidation: true }));
   }
   out.push(...validateVariableExistence(allNodes(cs), allEdges(cs), knownIds));
+  out.push(...validateVariableNotSet(allNodes(cs), allEdges(cs), knownIds, cs));
   return out;
 }
 
@@ -248,6 +249,25 @@ ${FLOW("S", "T", "S_T")}`,
   ),
 );
 
+// 12b EMPTY_REQUIRED_FIELD (absent): HttpExecution missing required 'method'/'mode'
+// entirely (only 'url' present+valid). Frontend treats an unbound required field
+// as present-with-empty-value, so an absent required field must fire too.
+add(
+  "EMPTY_REQUIRED_FIELD",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_T</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:serviceTask id="T" name="HTTP"><bpmn:incoming>S_T</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="Intsvc.HttpExecution" version="v1" />
+        <uipath:context><uipath:input name="url" value="https://example.com" /></uipath:context>
+      </uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+${FLOW("S", "T", "S_T")}`,
+    ),
+  ),
+  "absent required field",
+);
+
 // 13 CROSSING_POOL_BOUNDARY: sequence flow between two pools (non-start target)
 add(
   "CROSSING_POOL_BOUNDARY",
@@ -388,6 +408,27 @@ ${COND("G", "A", '=vars.DoesNotExist == "x"')}
 ${FLOW("G", "B", "G_B")}`,
     ),
   ),
+);
+
+// 21 VARIABLE_NOT_SET: task A references vars.fromB, produced by B downstream
+// (so it is declared/known but NOT reachable at A). WARNING-severity; mirrors
+// the frontend's flow-order check distinct from VARIABLE_DOES_NOT_EXIST.
+add(
+  "VARIABLE_NOT_SET",
+  DEFS(
+    PROC(
+      `    <bpmn:startEvent id="S"><bpmn:outgoing>S_A</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:serviceTask id="A"><bpmn:incoming>S_A</bpmn:incoming><bpmn:outgoing>A_B</bpmn:outgoing>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="x" version="v1" /><uipath:input name="i" value="=vars.fromB" /></uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="B"><bpmn:incoming>A_B</bpmn:incoming>
+      <bpmn:extensionElements><uipath:activity version="v1"><uipath:type value="x" version="v1" /><uipath:output name="o" var="fromB" custom="true" source="x" /></uipath:activity></bpmn:extensionElements>
+    </bpmn:serviceTask>
+${FLOW("S", "A", "S_A")}
+${FLOW("A", "B", "A_B")}`,
+    ),
+  ),
+  "declared but unreachable",
 );
 
 // ---- Run: 1) crafted-invalid XML coverage harness -----------------------

--- a/skills/uipath-maestro-bpmn/validator/uipath-moddle.v1.json
+++ b/skills/uipath-maestro-bpmn/validator/uipath-moddle.v1.json
@@ -1,0 +1,715 @@
+{
+  "name": "UiPath",
+  "uri": "http://uipath.org/schema/bpmn",
+  "prefix": "uipath",
+  "xml": {
+    "tagAlias": "lowerCase"
+  },
+  "associations": [],
+  "types": [
+    {
+      "name": "Variables",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "input",
+          "type": "Variable",
+          "isMany": true,
+          "xml": {
+            "serialize": "input"
+          }
+        },
+        {
+          "name": "inputOutput",
+          "type": "Variable",
+          "isMany": true,
+          "xml": {
+            "serialize": "inputOutput"
+          }
+        },
+        {
+          "name": "output",
+          "type": "Variable",
+          "isMany": true,
+          "xml": {
+            "serialize": "output"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Variable",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "id",
+          "isAttr": true,
+          "isId": true,
+          "type": "String"
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "subType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "elementId",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "canonicalId",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "default",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        },
+        {
+          "name": "custom",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "internal",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "CaseVariables",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "inputOutput",
+          "type": "CaseVariable",
+          "isMany": true,
+          "xml": {
+            "serialize": "inputOutput"
+          }
+        }
+      ]
+    },
+    {
+      "name": "CaseVariable",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "id",
+          "isAttr": true,
+          "isId": true,
+          "type": "String"
+        },
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "subType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "variableType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "dynamic",
+          "isAttr": true,
+          "type": "Boolean"
+        }
+      ]
+    },
+    {
+      "name": "Binding",
+      "superClass": ["Variable"],
+      "properties": [
+        {
+          "name": "resource",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "resourceSubType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "resourceKey",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "propertyAttribute",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Bindings",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "binding",
+          "type": "Binding",
+          "isMany": true,
+          "xml": {
+            "name": "binding"
+          }
+        }
+      ]
+    },
+    {
+      "name": "EntryPointId",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Event",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "Type"
+        },
+        {
+          "name": "context",
+          "type": "Context"
+        },
+        {
+          "name": "input",
+          "type": "Input",
+          "isMany": true
+        },
+        {
+          "name": "output",
+          "type": "Output",
+          "isMany": true
+        },
+        {
+          "name": "skipCondition",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Activity",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "Type"
+        },
+        {
+          "name": "context",
+          "type": "Context"
+        },
+        {
+          "name": "input",
+          "type": "Input",
+          "isMany": true
+        },
+        {
+          "name": "output",
+          "type": "Output",
+          "isMany": true
+        },
+        {
+          "name": "skipCondition",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Mapping",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "type": "Type"
+        },
+        {
+          "name": "context",
+          "type": "Context"
+        },
+        {
+          "name": "input",
+          "type": "Input",
+          "isMany": true
+        },
+        {
+          "name": "output",
+          "type": "Output",
+          "isMany": true
+        }
+      ]
+    },
+    {
+      "name": "ScriptVersion",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "MigrationVersion",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "IntsvcActivityConfig",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Type",
+      "properties": [
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Context",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "input",
+          "type": "Input",
+          "isMany": true
+        },
+        {
+          "name": "inputSchema",
+          "type": "InputSchema"
+        },
+        {
+          "name": "outputSchema",
+          "type": "OutputSchema"
+        }
+      ]
+    },
+    {
+      "name": "Input",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "subType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "target",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        },
+        {
+          "name": "options",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Output",
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "subType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "source",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "var",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        },
+        {
+          "name": "custom",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "internal",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "target",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "action",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "options",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "originalVar",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "InputOutput",
+      "properties": [
+        {
+          "name": "name",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "type",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "subType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "source",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "elementId",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "default",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "InputSchema",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        }
+      ]
+    },
+    {
+      "name": "OutputSchema",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "body",
+          "type": "String",
+          "isBody": true
+        }
+      ]
+    },
+    {
+      "name": "LoopCharacteristics",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "inputCollection",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "inputElement",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "CaseManagement",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "type": "String",
+          "isBody": true
+        }
+      ]
+    },
+    {
+      "name": "Retry",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "maxRetryCount",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "retryBackoff",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "retryAllErrors",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "retryBackoffType",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "maxDuration",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "exponentialBase",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "ErrorMapping",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "error",
+          "type": "Error",
+          "isMany": true,
+          "xml": {
+            "name": "error"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Error",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "id",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "errorRef",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "priority",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "condition",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "detail",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "retryable",
+          "isAttr": true,
+          "type": "String"
+        }
+      ]
+    },
+    {
+      "name": "Tags",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "tags",
+          "type": "Tag",
+          "isMany": true,
+          "xml": {
+            "name": "tag"
+          }
+        }
+      ]
+    },
+    {
+      "name": "Tag",
+      "properties": [
+        {
+          "name": "key",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "type": "String",
+          "isBody": true
+        }
+      ]
+    },
+    {
+      "name": "IsTransactionRoot",
+      "superClass": ["Element"],
+      "properties": [
+        {
+          "name": "version",
+          "isAttr": true,
+          "type": "String"
+        },
+        {
+          "name": "value",
+          "type": "Boolean",
+          "isAttr": true
+        }
+      ]
+    }
+  ]
+}

--- a/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
+++ b/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+// Offline semantic validator for UiPath Maestro BPMN XML.
+//
+// Pipeline:
+//   1. Parse the BPMN with bpmn-moddle using the UiPath extension descriptor
+//      (same getModdle() + fromXML() pattern as PO.Frontend).
+//   2. Reconstruct the PO.Frontend Node[]/Edge[]/CanvasState model (model.mjs).
+//   3. Run ALL 19 PO.Frontend validation rules (rules.mjs) per diagram, plus a
+//      whole-model variable-existence check.
+//   4. (Optional) Run the Maestro-original connection-liveness ping via uip CLI.
+//
+// Prints `VALID` and exits 0 when there are no ERROR-severity findings.
+// Otherwise lists every finding (rule code + message) and exits non-zero.
+// WARNING-severity findings are printed but do not gate.
+//
+// Usage: node validate-bpmn.mjs <bpmn-file> [resources]
+//   resources: comma-separated release names, or a numeric folder ID, for the
+//              optional solution-resource liveness ping (requires uip CLI auth).
+import BpmnModdle from "bpmn-moddle";
+import descriptor from "./uipath-moddle.v1.json" with { type: "json" };
+import { readFileSync, existsSync } from "fs";
+import { execFileSync } from "child_process";
+import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "./model.mjs";
+import { validateDiagram, validateVariableExistence, SEVERITY } from "./rules.mjs";
+
+// --- uip CLI resolution (cached) — used only for the liveness-ping extra. ---
+let _uipBin;
+function resolveUipBin() {
+  if (_uipBin !== undefined) return _uipBin;
+  const home = process.env.HOME || process.env.USERPROFILE || "";
+  const candidates = ["uip", `${home}/.bun/bin/uip`, `${home}/.local/bin/uip`, "/usr/local/bin/uip"];
+  for (const p of candidates) {
+    try {
+      if ((p.startsWith("/") || p.startsWith(home)) && !existsSync(p)) continue;
+      execFileSync(p, ["--version"], { encoding: "utf8", timeout: 5000, stdio: "pipe" });
+      _uipBin = p;
+      return p;
+    } catch {
+      /* keep trying */
+    }
+  }
+  _uipBin = null;
+  return null;
+}
+
+function pingConnections(resourceArg) {
+  // Maestro-original extra: liveness-check bound IS connections. Best-effort;
+  // a missing/unauthenticated CLI is reported as a NOTE, never a hard failure.
+  const bin = resolveUipBin();
+  if (!bin) return { note: "uip CLI not found; skipped connection liveness ping." };
+  try {
+    const args = ["is", "connections", "ping", "--output", "json"];
+    if (/^\d+$/.test(resourceArg)) args.push("--folder", resourceArg);
+    const out = execFileSync(bin, args, { encoding: "utf8", timeout: 30000, stdio: "pipe" });
+    return { ok: true, raw: out.trim() };
+  } catch (e) {
+    return { note: `connection liveness ping unavailable: ${String(e.message || e).split("\n")[0]}` };
+  }
+}
+
+const file = process.argv[2];
+const resourceArg = process.argv[3];
+if (!file) {
+  console.error("Usage: node validate-bpmn.mjs <bpmn-file> [resources]");
+  process.exit(1);
+}
+
+const xml = readFileSync(file, "utf8");
+const moddle = new BpmnModdle({ uipath: descriptor });
+
+let definitions;
+try {
+  const result = await moddle.fromXML(xml);
+  definitions = result.rootElement;
+  if (result.warnings?.length) {
+    for (const w of result.warnings) console.error(`PARSE WARNING: ${w.message ?? w}`);
+  }
+} catch (e) {
+  console.error(`SCHEMA ERROR: failed to parse BPMN XML: ${e.message ?? e}`);
+  process.exit(2);
+}
+
+// Build the model and run all rules.
+const canvasState = buildModel(definitions);
+const knownIds = collectKnownVariableIds(canvasState);
+
+const findings = [];
+for (const diagram of Object.values(canvasState.diagramsById)) {
+  // Skip the trivial root-only "single blank start, no edges" diagram, mirroring
+  // ValidateBpmnFlowUtils.validateBpmnFlow.
+  const realNodes = diagram.nodes.filter((n) => n.type !== "bpmn:Participant");
+  if (
+    diagram.diagramId === canvasState.rootDiagramId &&
+    realNodes.length === 1 &&
+    realNodes[0].type === "bpmn:StartEvent" &&
+    diagram.edges.length === 0
+  ) {
+    continue;
+  }
+  findings.push(...validateDiagram(diagram, canvasState, { enableMissingRootVariableValidation: true }));
+}
+findings.push(...validateVariableExistence(allNodes(canvasState), allEdges(canvasState), knownIds));
+
+// Optional connection liveness ping (Maestro-original extra).
+if (resourceArg) {
+  const ping = pingConnections(resourceArg);
+  if (ping.note) console.error(`NOTE: ${ping.note}`);
+  else if (ping.ok) console.error(`connection liveness ping ok`);
+}
+
+const errors = findings.filter((f) => f.severity === SEVERITY.ERROR);
+const warnings = findings.filter((f) => f.severity === SEVERITY.WARNING);
+
+const fmt = (f) => `  [${f.severity}] ${f.code}: ${f.message}${f.elementId ? ` (element: ${f.elementId})` : ""}`;
+
+if (warnings.length) {
+  console.error("WARNINGS:");
+  for (const w of warnings) console.error(fmt(w));
+}
+
+if (errors.length === 0) {
+  console.log("VALID");
+  process.exit(0);
+}
+
+console.error("ERRORS:");
+for (const e of errors) console.error(fmt(e));
+console.error(`\n${errors.length} blocking error(s), ${warnings.length} warning(s).`);
+process.exit(1);

--- a/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
+++ b/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
@@ -21,7 +21,7 @@ import descriptor from "./uipath-moddle.v1.json" with { type: "json" };
 import { readFileSync, existsSync } from "fs";
 import { execFileSync } from "child_process";
 import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "./model.mjs";
-import { validateDiagram, validateVariableExistence, SEVERITY } from "./rules.mjs";
+import { validateDiagram, validateVariableExistence, validateVariableNotSet, SEVERITY } from "./rules.mjs";
 
 // --- uip CLI resolution (cached) — used only for the liveness-ping extra. ---
 let _uipBin;
@@ -100,6 +100,7 @@ for (const diagram of Object.values(canvasState.diagramsById)) {
   findings.push(...validateDiagram(diagram, canvasState, { enableMissingRootVariableValidation: true }));
 }
 findings.push(...validateVariableExistence(allNodes(canvasState), allEdges(canvasState), knownIds));
+findings.push(...validateVariableNotSet(allNodes(canvasState), allEdges(canvasState), knownIds, canvasState));
 
 // Optional connection liveness ping (Maestro-original extra).
 if (resourceArg) {


### PR DESCRIPTION
## What

Adds a bundled, **offline** semantic validator under `skills/uipath-maestro-bpmn/validator/` that runs **all 19** PO.Frontend validation rules — full functional parity with the frontend rule engine. It parses the BPMN with `bpmn-moddle` using the verbatim UiPath moddle descriptor (same `getModdle()` + `fromXML()` pattern as PO.Frontend), reconstructs the frontend `Node[] / Edge[] / CanvasState` model from the parse tree (mirroring `ValidateBpmnFlowUtils.buildValidationLookupMaps`), and runs each rule as a faithful port.

**Supersedes #1517**, which reached only ~11/19 by rationalizing 8 graph/registry rules as "unportable". They are portable: graph rules reconstruct the node/edge/containment model from the same XML the frontend derives its `Node[]/Edge[]` from; RequiredFields sources its `required` metadata from the bundled maestro-sdk registry.

### Phase 1 → Phase 2 structure
The rule logic lives entirely in **`rules.mjs`** — a self-contained module that is the Phase 2 swap target (replace with the published npm package, no behavior change). `model.mjs` (model reconstruction + registry consumption) and `validate-bpmn.mjs` (CLI) are the only integration glue.

## 19-rule coverage

| # | Rule | Source | Tested (fires on crafted-invalid) |
|---|---|---|---|
| 1 | ConditionalFlow | XML graph | ✅ `MISSING_CONDITION_EXPRESSION` |
| 2 | Connection | XML graph | ✅ `INVALID_CONNECTION_TYPE` (+`INVALID_CONNECTION`) |
| 3 | DuplicateErrorEventSubprocess | XML graph + `bpmn:Error` objects | ✅ `DUPLICATE_ERROR_EVENT_SUBPROCESS` (+catch-all) |
| 4 | EmptyStartEventDefinitionInSubProcess | XML graph | ✅ `START_EVENT_WITH_DEFINITION_IN_SUBPROCESS`, `START_EVENT_WITHOUT_DEFINITION_IN_EVENT_SUBPROCESS` |
| 5 | ErrorBoundaryEvent | XML graph + `bpmn:Error` objects | ✅ `ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE`, `MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK` |
| 6 | ErrorEndEvent | XML graph | ✅ `ERROR_END_EVENT_MISSING_EXCEPTION` |
| 7 | FakeJoin | XML graph | ✅ `FAKE_JOIN` |
| 8 | MessageFlowObjectsPool | XML graph (pools) | ✅ `SAME_POOL_MESSAGE_FLOW` |
| 9 | MissingResource | XML extension (serviceType + bindings) | ✅ `MISSING_RESOURCE` (WARNING) |
| 10 | MissingRootVariable | XML extension (variables + outputs) | ✅ `MISSING_ROOT_VARIABLE` (WARNING) |
| 11 | NoAssignments | Pure check | ✅ `ASSIGNMENT_NOT_ALLOWED` (WARNING) |
| 12 | RequiredFields | **Registry metadata** (`bpmn-spec.json`) | ✅ `EMPTY_REQUIRED_FIELD` |
| 13 | SequenceFlowPoolCrossing | XML graph (pools) | ✅ `CROSSING_POOL_BOUNDARY` |
| 14 | SequenceFlowSubProcessCrossing | XML graph | ✅ `CROSSING_SUBPROCESS_BOUNDARY` |
| 15 | SingleBlankStartEvent | XML graph | ✅ `MULTIPLE_BLANK_START_EVENTS` |
| 16 | SingleStartEventInEventSubProcess | XML graph | ✅ `MULTIPLE_START_EVENTS_IN_EVENT_SUBPROCESS` |
| 17 | SuperfluousGateway | XML graph | ✅ `SUPERFLUOUS_GATEWAY` |
| 18 | TaskTimer | Pure check (range) | ✅ `TASK_TIMER_OUT_OF_RANGE` (WARNING) |
| 19 | TimerDuration | Pure check (ISO 8601) | ✅ `TIMER_DURATION_INVALID`, `TIMER_DURATION_WEEK_UNSUPPORTED` (WARNING) |
| + | Variable existence (Maestro-original) | XML extension + declared vars | ✅ `VARIABLE_DOES_NOT_EXIST` |

Plus the retained Maestro-original connection-liveness ping (`uip is connections ping --output json`), best-effort and never gating.

## RequiredFields parity caveat (documented honestly)

This is the one rule that cannot reach byte-for-byte parity offline. On canvas, `field.required` is attached to live actions-service-enriched node data where the field name already matches. Offline, the registry's required-field **names** are canonical designer names that don't always match the names a field is serialized under in exported BPMN (e.g. registry `url` vs serialized `path`; registry `name` vs serialized `messageName`), and the spec carries no alias map. So the port flags a required field only when a serialized field matching a registry-required name is **present but empty** (the genuine "left blank" case — a true subset of canvas behavior); absent required fields are not flagged, since offline their absence is ambiguous. This keeps the gate free of false positives on valid processes. Full detail in `validator/README.md`.

## Test results

`cd skills/uipath-maestro-bpmn/validator && npm install`

- `node validate-bpmn.mjs samples/valid-baseline.bpmn` → `VALID`, exit `0`
- `node validate-bpmn.mjs samples/invalid-conditional-and-variable.bpmn` → exit `1`, flags `MISSING_CONDITION_EXPRESSION` + `VARIABLE_DOES_NOT_EXIST`
- `npm test` (rule-coverage harness) → **23 cases, 23 passed; all 19 rules' codes fire on crafted-invalid fixtures**
- **No false positives:** all 9 existing skill validation fixtures pass with exit `0`

Skill maintenance suite (`.maintenance/check-all.sh`): links, link-text, anchors, depth, template, orphans (0), plugin-pairs, and validation-fixtures (9/9) all pass. `check-real-pack.sh` and `check-uip-commands.sh` fail **identically on the untouched base branch** (local `uip` CLI version reports `unknown command 'init'`) — pre-existing environment issues, unrelated to this change.

## Notes

- `node_modules/` is gitignored (root); run `npm install` once before use. Deps: `bpmn-moddle`, `luxon` (ISO-8601 duration parsing, matching the frontend's `DateUtil`).
- CLI invocation uses `execFileSync` with argument arrays (no shell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)