### PR TITLE
chore: refresh uip CLI catalog (1.197.0-alpha.20260616.7543)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-16T05:55:50Z",
-  "cli_version": "1.197.0-alpha.20260615.7527",
+  "generated_at": "2026-06-17T05:43:05Z",
+  "cli_version": "1.197.0-alpha.20260616.7543",
   "verbs": [
     "admin",
     "admin audit",
@@ -1101,6 +1101,7 @@
     "solution resources list",
     "solution resources refresh",
     "solution resources remove",
+    "solution restore",
     "solution upload",
     "tasks",
     "tasks assign",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.197.0-alpha.20260616.7543`. The catalog has 1220 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.