### PR TITLE
docs(uipath-api-workflow): document Run Job / process-as-resource authoring

### DIFF
--- a/skills/uipath-api-workflow/references/cli-reference.md
+++ b/skills/uipath-api-workflow/references/cli-reference.md
@@ -132,6 +132,7 @@ uip api-workflow registry stub <activity-type-id> \
 | `--instance <n>` | no | Suffix for slot/export bucket key. Default `1`. `--instance 2` produces `<Name>_2` keys. |
 | `--slot-key <PascalCase>` | no | Override the auto-derived PascalCase slot key. The export bucket key always derives from `objectName + "_<n>"` (both Curated and Generic) and is not affected by this flag. |
 | `-i, --inputs <json>` | no | JSON object mapping field names to values. Field names match the IS schema (flat dotted keys — `"message.subject"`, not `{message:{subject:…}}`). Pass bare strings for literals; `${...}` for expression references. |
+| `--resource-key <field>=<key>` | no (repeatable) | Bind a Solution-resource picker field (listed in `Data.SolutionResourceFields`) to a solution resource **key**, so StudioWeb's picker renders the selection. The key is the `key` field of the matching file under the solution's `resources/` tree (e.g. `resources/solution_folder/process/process/<Name>.json`). The field's *value* (the resource name) still goes via `--inputs`. Requires a StudioWeb build with `savedResourceSelections` support; older builds ignore the entry (runtime unaffected). |
 
 Success output:
 ```json
@@ -152,7 +153,7 @@ Success output:
 }
 ```
 
-`Data.Activity` drops directly into the root sequence's `do` array. `Data.ExportBucketKey` is what `$context.outputs.<X>` reads as downstream — bind expressions against this, NOT against `Data.SlotKey`. `Data.Parameters` (query/path/multipart) and `Data.RequestFields` (body) list the operation's inputs with `required` flags; `Data.ResponseFields` lists the fields the IS schema says will be present on the activity output (under `.content.<field>` for IntSvc kind).
+`Data.Activity` drops directly into the root sequence's `do` array. `Data.ExportBucketKey` is what `$context.outputs.<X>` reads as downstream — bind expressions against this, NOT against `Data.SlotKey`. `Data.Parameters` (query/path/multipart) and `Data.RequestFields` (body) list the operation's inputs with `required` flags; `Data.ResponseFields` lists the fields the IS schema says will be present on the activity output (under `.content.<field>` for IntSvc kind). `Data.SolutionResourceFields` (when present) lists fields StudioWeb renders as Solution-resource pickers — see [Solution resources as activity fields](connector-activity-discovery.md#solution-resources-as-activity-fields-run-job-add-queue-item-) for the authoring recipe.
 
 `Data.Warnings` (when present):
 - `"IS Elements metadata could not be fetched…"` → IS schema lookup failed; stub uses fallback path `/<objectName>` and ships no `requestFields`. Endpoint may be wrong (no hub prefix, no multipart declaration).
@@ -207,7 +208,7 @@ See [connector-activity-discovery.md](connector-activity-discovery.md) for the f
 
 ## `uip api-workflow bindings sync`
 
-Walk a `Workflow.json`, extract IntSvc-kind connector activities, and emit the canonical `bindings_v2.json` file next to it. Pure-local transformation — no auth, no API calls. This mirrors what StudioWeb computes in-memory via `computeBindings$` when a workflow is opened in the designer, and what `solution pack` writes at pack time. The output is the **required input** to `uip solution resources refresh`, which is what actually writes the Solution catalogue file AND per-user debug overwrites (the two artefacts StudioWeb's properties panel reads to resolve `connectionId` on activity click).
+Walk a `Workflow.json`, extract IntSvc-kind connector activities, and emit the canonical `bindings_v2.json` file next to it. Connection bindings are derived locally; **Solution-resource bindings** (process/queue/asset fields like Run Job's `ReleaseName`) are derived by querying IS metadata for each activity's object — when IS is unreachable, generation is skipped and any pre-existing entries of those kinds are preserved rather than dropped. This mirrors what StudioWeb computes in-memory via `computeBindings$` when a workflow is opened in the designer, and what `solution pack` writes at pack time. The output is the **required input** to `uip solution resources refresh`, which is what actually writes the Solution catalogue file AND per-user debug overwrites (the two artefacts StudioWeb's properties panel reads to resolve `connectionId` on activity click).
 
 **When to run.** After every `registry stub --connection-id <uuid>` that adds an IntSvc activity to a workflow inside a `Solution/` tree. Always paired with `uip solution resources refresh` (the next step in the typical sequence).
 
@@ -232,15 +233,17 @@ Success output:
   "Code": "BindingsSync",
   "Data": {
     "BindingsPath": "<dir>/bindings_v2.json",
-    "ResourceCount": 1,
+    "ResourceCount": 2,
     "ActivitiesVisited": 1,
     "IntSvcActivities": 1,
-    "DuplicatesCollapsed": 0
+    "DuplicatesCollapsed": 0,
+    "ResourceBindings": 1,
+    "PreservedResources": 0
   }
 }
 ```
 
-`ResourceCount` is the number of unique connections in the output (one binding per unique UUID). `DuplicatesCollapsed` reports activities that shared a connection — two Outlook activities reading the same mailbox count as 1 binding, with `DuplicatesCollapsed: 1`.
+`ResourceCount` is the total entries written (connections + resource bindings + preserved). `DuplicatesCollapsed` reports activities that shared a connection — two Outlook activities reading the same mailbox count as 1 binding, with `DuplicatesCollapsed: 1`. `ResourceBindings` counts Solution-resource entries generated from IS metadata (e.g. `process | RPA Workflow` for a Run Job activity); `PreservedResources` counts pre-existing non-connection entries carried over because this run did not regenerate them.
 
 Failure modes:
 - `"Workflow file not found: <path>"` — `--workflow` does not exist. Pass an existing path.

--- a/skills/uipath-api-workflow/references/connector-activity-discovery.md
+++ b/skills/uipath-api-workflow/references/connector-activity-discovery.md
@@ -289,7 +289,7 @@ uip api-workflow bindings sync --workflow Solution/<ProjectName>/Workflow.json -
 uip solution resources refresh --solution-folder Solution --output json
 ```
 
-`bindings sync` is pure-local (no auth, no API calls) — it walks `Workflow.json`, extracts IntSvc connector activities, and writes the canonical `bindings_v2.json` next to the workflow (one binding per unique connection UUID — two activities sharing a connection collapse to one entry). This file is what StudioWeb computes in-memory on workflow open; emitting it offline avoids the "open in StudioWeb once first" detour.
+`bindings sync` walks `Workflow.json` and extracts IntSvc connector activities into the canonical `bindings_v2.json` next to the workflow. **Connection** bindings are derived locally (one binding per unique connection UUID — two activities sharing a connection collapse to one entry). **Solution-resource** bindings (process/queue/asset picker fields like Run Job's `ReleaseName`) are derived by querying IS metadata for each activity's object, so this step reaches the network when such fields are present; when IS is unreachable, resource-binding generation is skipped and any pre-existing entries of those kinds are preserved rather than dropped. This mirrors what StudioWeb computes in-memory on workflow open; emitting it offline avoids the "open in StudioWeb once first" detour.
 
 `solution resources refresh` then reads every project's `bindings_v2.json`, calls `@uipath/resource-builder-sdk`'s `addOrUpdateResourceToSolutionAsync` to write the catalogue files, and `editOverwritesAsync` to write the per-user debug overwrites. Requires `uip login` (the SDK looks up folder keys via Resource Catalog Service). Idempotent — re-runs only import new resources.
 
@@ -435,6 +435,35 @@ Generic-specific behavior to know:
 - **Slot key carries the operation; export bucket does not**: slot `ListUserRepos_1`, export bucket `user_repos_1` (objectName-based, like every Curated example). The bucket intentionally matches the platform's own derivation — solution reconcile (`resource refresh`) regenerates `Workflow.json` and recomputes export buckets from the object name, so a divergent bucket would be renamed on regeneration. As always, copy `Data.ExportBucketKey` verbatim; and after ANY external rewrite of `Workflow.json` (reconcile, designer save), re-check that downstream `$context.outputs.<X>` reads still match the on-disk `export.as` keys — `validate` cannot catch dangling output references; they surface only at run time as `undefined`.
 - **Path-parameter value formats are connector-specific.** `Retrieve`/`Update`/`Delete` endpoints take an id path param (e.g. `/repos/{repo}`) and the expected value format (name vs full name vs numeric id) varies and is sometimes wrong in the connector's own metadata — `uip is resources describe` shows the parameter's description and lookup hints. If the run 404s, cross-check by executing the same operation via `uip is resources run get <connector-key> <object-name> --connection-id <uuid> --query <param>=<value>`; if that also 404s, the connector's auto-generated metadata is broken upstream — pick a Curated activity or the Http kind instead.
 - **Quality varies by connector.** Generic operations are auto-generated from vendor API specs and are not hand-verified the way Curated ones are. Prefer a Curated activity when one exists for the job.
+
+### Solution resources as activity fields (Run Job, Add Queue Item, …)
+
+Some activity fields don't take free text — their value names another **Solution resource** (a process, queue, asset…). Orchestrator's Run Job is the canonical case: its `ReleaseName` field is the process to start. The stub flags these in `Data.SolutionResourceFields` (`{ name, kind, location }`). Authoring recipe:
+
+```bash
+# 1. Get the resource's NAME and KEY from the solution tree (no API call):
+#    resources/solution_folder/process/process/<Name>.json → spec.name + key
+# 2. Stub: name as the value, key as the picker binding
+uip api-workflow registry stub <run-job-guid> \
+  --connection-id <orchestrator-conn-uuid> \
+  --inputs '{"ReleaseName":"RPA Workflow"}' \
+  --resource-key 'ReleaseName=87ec3255-8ea6-446e-8237-8ff429d86032' \
+  --output json
+```
+
+What each layer gets, and from where:
+
+| Layer | Carried by | Authored via |
+|--|--|--|
+| Runtime (which process starts) | `bodyParameters.ReleaseName` = resource **name** | `--inputs` |
+| Job-result waiting | `with.executionType: "async"` + callback header | automatic (mirrored from IS metadata) |
+| Deployment rewiring | `bindings_v2.json` process entry (`NameFieldPath`) | automatic (`bindings sync`) |
+| StudioWeb picker display | `savedResourceSelections` in `metadata.configuration` | `--resource-key` |
+
+Notes:
+- The activity only starts successfully once a process with that name is deployed and visible to the connection (pack/publish/deploy first, or pre-existing).
+- The picker display requires a StudioWeb build with `savedResourceSelections` support; on older builds the entry is ignored — the picker shows empty until selected once manually, while runtime and deployment remain correct.
+- Do NOT put the resource **key** in `--inputs` (runtime would send a GUID where the API expects a name) and do NOT put the **name** in `--resource-key` (the picker resolves by key).
 
 ## Vendor curated activity response shape — `content.X`, not `X`
 

--- a/skills/uipath-api-workflow/references/troubleshooting.md
+++ b/skills/uipath-api-workflow/references/troubleshooting.md
@@ -437,7 +437,7 @@ These are issues that surface only when a workflow is opened or run in **StudioW
   Also check that `bindings_v2.json`'s `"key"` matches `Workflow.json`'s `connectionId` matches the missing resource file's intended `"key"` — same UUID across all three.
 - **Fix (preferred — two CLI commands):**
   ```bash
-  # 1. Generate bindings_v2.json from Workflow.json (pure local; no auth needed):
+  # 1. Generate bindings_v2.json from Workflow.json (local for connections; queries IS for resource picker fields):
   uip api-workflow bindings sync --workflow <path-to-Workflow.json> --output json
 
   # 2. Sync catalogue + debug overwrites via @uipath/resource-builder-sdk (requires uip login):


### PR DESCRIPTION
> **Draft — do not merge before [UiPath/cli#2529](https://github.com/UiPath/cli/pull/2529) is merged and released.** This documents CLI behaviour not yet in the released `@uipath/cli`. Merging early would describe a CLI users don't have.

## What / Why

The `uipath-api-workflow` skill currently documents `bindings sync` as *"pure-local (no auth, no API calls)… one binding per unique connection UUID"* and has no Run Job / resource-picker guidance. Once cli#2529 ships, that becomes wrong: `bindings sync` queries Integration Service to generate Solution-resource bindings (process/queue/asset/bucket) and preserves existing ones, plus there's a new `--resource-key` option.

This PR updates the skill to match the post-#2529 CLI:
- **`registry stub`** — documents `--resource-key <field>=<key>` and `Data.SolutionResourceFields`.
- **Run Job / process-as-resource** — authoring recipe + the four-layer (name vs key) model and the "never swap name and key" rule.
- **`bindings sync`** — corrects the stale "pure-local / no API calls / connection-only" claims in `cli-reference.md`, `connector-activity-discovery.md`, and `troubleshooting.md`; documents `ResourceBindings`/`PreservedResources` output.
- **StudioWeb note** — picker render requires `savedResourceSelections` support ([UiPath/StudioWeb#19127](https://github.com/UiPath/StudioWeb/pull/19127)); older builds ignore it, runtime unaffected.

## Why a skill update is needed (and only here)

Of the three STUD-80453 PRs, only **cli#2529** changes documented CLI surface, so only it needs a skill doc change:
- **cli#2514** (packager resolution) — silent internal pack-time fix; no documented workflow changes → no skill update.
- **cli#2529** (binding generation, `--resource-key`) — changes `bindings sync` behaviour + adds CLI options → **this PR**.
- **StudioWeb#19127** (picker render) — covered by the one-line StudioWeb-version note here.

## How this branch was produced

The docs were pre-drafted on the parked `docs/api-workflow-run-job-resources` branch (the doc counterpart to the CLI's parked work). Its predecessor commits — "Generic connector activities" — already landed on `main` via #1226, so this branch is **just the Run Job / resource-binding doc commit cherry-picked onto current `main`**. One conflict resolved: kept the new resource-binding description but preserved main's `uip solution resources refresh` (the singular `resource` verb was retired at uip 1.196.0).

## Validation note

Mirrors the CLI PR: the binding-generation surface is documented generically (process/queue/asset/bucket) but was only **live-validated for the process / Run Job case**. Asset/queue/bucket guidance is by-analogy until an end-to-end pack validation is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)