### PR TITLE
Document get-default-xaml field resolution for IS activity types [ENGCE-58611] [PILOT-5698]

### DIFF
--- a/skills/uipath-rpa/references/is-connector-xaml-guide.md
+++ b/skills/uipath-rpa/references/is-connector-xaml-guide.md
@@ -36,6 +36,19 @@ Three ingredients:
 2. **`ConnectionId`** — the IS connection's GUID (from `uip is connections list`).
 3. **`Configuration`** — an opaque base64 + gzip JSON blob encoding connector/operation identity. **Never hand-edit.** Always take the value from `activities get-default-xaml`.
 
+## IS activity types & how fields resolve
+
+`get-default-xaml` produces all four IS activity shapes from a `typeId` (+ a live connection). What *unlocks* an activity's fields differs by type — hand the tool the right selector and it returns the resolved `FieldObjects`:
+
+| Activity | What it is | How to resolve its fields |
+|---|---|---|
+| `ConnectorActivity` | A connector operation (create / get / update …) | `typeId` + connection; criteria fields fed back via `--field-values` expand the rest (Step 4). |
+| `ConnectorTriggerActivity` | Fires when a connector event occurs | `typeId` already encodes the event; fields resolve from `typeId` + connection. |
+| `ConnectorPersistenceActivity` | Suspends the workflow until a connector event | `--event-operation <op>` selects the event and resolves its fields (Step 4). |
+| `ConnectorHttpActivity` | Generic HTTP-request escape hatch | Standard request fields (`method`, `url`, `headers`, `query`, `body`) — author them directly; they are the same for every connector. |
+
+Same principle throughout: **pass the selector the activity needs, get back its resolved schema.** A bare call (no selector) returns the correctly-typed activity with its baseline fields.
+
 ## Step-by-Step Flow
 
 ### Prereq: `uip login`
@@ -73,7 +86,7 @@ If `activityTypeId` is empty, the activity is a non-dynamic BAF/vendor activity 
 
 **`activities find` is not exhaustive — be ready to iterate.** Results vary by connector: some expose 6+ typed operations with rich descriptions (Slack); others expose only 1-2 (Outlook). Try several query phrasings (`"send email"`, `"<connector> send"`, the literal operation name from `uip is activities list`). If no typeId surfaces:
 
-- The operation may only be reachable via the generic `ConnectorHttpActivity` typeId (suffix `...httpRequest...`). Use it as a fallback — the field schema is still read from `uip is resources describe`, but the HTTP method/path live in the Configuration blob's `InstanceParameters`.
+- The operation may only be reachable via the generic `ConnectorHttpActivity` typeId (suffix `...httpRequest...`). Use it as a fallback — see [Typed Operation vs Generic HTTP](#typed-operation-vs-generic-http) for its standard, connector-independent request fields.
 - Different connectors that share a schema (e.g. a mock connector + its real counterpart) often share typeIds. The same `fbdeec58-...` "Send Email" typeId works for both `uipath-mock-outlook` and `uipath-microsoft-outlook365` — the `ConnectionId` at runtime determines which backend receives the call. Don't be surprised if the discovered typeId's description mentions a different connector than the one you're targeting.
 
 ### Step 3 — Get the connection ID
@@ -131,6 +144,17 @@ When you already know valid criteria values up front, the second call alone does
 **Field-name encoding.** Pass names **exactly as they appear in the returned `FieldObjects`** — copy them verbatim from the previous call's output. Don't hand-encode or invent names: the connector's encoding (nested paths, arrays — see § FieldObject Name Encoding Rules) is already applied in what it hands you. An unknown name fails fast with the list of available fields, so use that error as discovery rather than guessing.
 
 **Older CLI fallback:** if `--field-values` is not recognized, upgrade `uip`. Until then the expansion is not reachable headlessly — bind only fields present in the returned XAML and treat missing ones per § Hidden Secondary Fields.
+
+#### Resolve persistence event fields with `--event-operation`
+
+A `ConnectorPersistenceActivity` ("suspend until an event") exposes no event fields until an **event operation** is chosen — the headless equivalent of picking the event in the designer before its fields appear. Pass it explicitly:
+
+```bash
+uip rpa activities get-default-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN>" \
+    --event-operation "<eventOperation>" --project-dir "<P>" --output json
+```
+
+The returned `Configuration` carries the resolved event fields as `FieldObjects`. Without `--event-operation` you get the bare activity (correct default, no event fields). It is the persistence analogue of `--field-values` criteria — a selector that unlocks the schema — and needs a live connection (same cloud round-trip and silent-no-op caveat as above). Combine the two to also pre-bind values.
 
 ### Step 5 — Read the operation's field schema
 
@@ -236,7 +260,9 @@ If `HasErrors: true`, the `ErrorMessage` field carries the compile/runtime error
 
 ## Typed Operation vs Generic HTTP
 
-Every connector exposes a `ConnectorHttpActivity` with a typeId suffixed like `...httpRequest...` — a generic escape hatch for arbitrary HTTP calls. Prefer a **typed operation** (e.g. `send_message_to_channel_v2`) whenever one exists: it encodes the endpoint, method, and field schema for you. Only fall back to the HTTP activity when the connector lacks a modeled operation for what you need. For the generic one, the field names are NOT `method`/`path`/`body` — they're still connector-defined. Read the schema.
+Every connector exposes a `ConnectorHttpActivity` with a typeId suffixed like `...httpRequest...` — a generic escape hatch for arbitrary HTTP calls. Prefer a **typed operation** (e.g. `send_message_to_channel_v2`) whenever one exists: it encodes the endpoint, method, and field schema for you. Only fall back to the HTTP activity when the connector lacks a modeled operation for what you need.
+
+`get-default-xaml` for an HTTP typeId returns a correctly-typed `ConnectorHttpActivity` with a valid `Configuration`. Its fields are the **standard HTTP request fields** — `method`, `url`, `headers`, `query`, `body` (inputs), plus `out_body` / `out_headers` / `out_code` (outputs) — identical across connectors, so author the ones you need directly per Step 6 instead of reading a per-operation schema. The `ConnectionId` still scopes the call at runtime.
 
 ## Worked Example: Slack "Send Message to Channel"
 

--- a/skills/uipath-rpa/references/is-connector-xaml-guide.md
+++ b/skills/uipath-rpa/references/is-connector-xaml-guide.md
@@ -42,9 +42,9 @@ Three ingredients:
 
 | Activity | What it is | How to resolve its fields |
 |---|---|---|
-| `ConnectorActivity` | A connector operation (create / get / update …) | `typeId` + connection; criteria fields fed back via `--field-values` expand the rest (Step 4). |
-| `ConnectorTriggerActivity` | Fires when a connector event occurs | `typeId` already encodes the event; fields resolve from `typeId` + connection. |
-| `ConnectorPersistenceActivity` | Suspends the workflow until a connector event | Discover events with `uip is activities list <connector> --triggers`, then `--event-operation <op>` resolves the event's fields (Step 4). |
+| `ConnectorActivity` | A connector operation (create / get / update …) | `typeId` + connection. A **generic** operation needs `--object-name <obj>` (the record type); criteria fields fed back via `--field-values` expand the rest (Step 4). |
+| `ConnectorTriggerActivity` | Fires when a connector event occurs | Curated triggers resolve from `typeId` + connection; a **generic** trigger needs `--object-name <obj>` (the object whose changes it watches). |
+| `ConnectorPersistenceActivity` | Suspends the workflow until a connector event | Discover events with `uip is activities list <connector> --triggers`, then `--event-operation <op>` resolves the event's fields. A named event auto-resolves its single object; a generic/multi-object event also needs `--object-name <obj>` (Step 4). |
 | `ConnectorHttpActivity` | Generic HTTP-request escape hatch | Standard request fields (`method`, `url`, `headers`, `query`, `body`) — author them directly; they are the same for every connector. |
 
 Same principle throughout: **pass the selector the activity needs, get back its resolved schema.** A bare call (no selector) returns the correctly-typed activity with its baseline fields.
@@ -163,8 +163,8 @@ TICKET_UPDATED  Ticket Updated   tickets      Yes        ← named event: object
 CREATED         Record Created   N/A          No         ← generic op: choose an object too
 ```
 
-- **Named event** (`ObjectName` populated, e.g. `TICKET_UPDATED`) — pass its `Name` directly.
-- **Generic op** (`CREATED` / `UPDATED` / `DELETED`, `ObjectName` is `N/A`) — also pick the object it applies to:
+- **Named event** (`ObjectName` populated, e.g. `TICKET_UPDATED`) — pass its `Name` to `--event-operation`; its single object auto-resolves, so no `--object-name` is needed.
+- **Generic op** (`CREATED` / `UPDATED` / `DELETED`, `ObjectName` is `N/A`) — also pass `--object-name <obj>`. List the objects it applies to with:
   ```bash
   uip is triggers objects <connector-key> CREATED --output json
   ```
@@ -177,6 +177,22 @@ uip rpa activities get-default-xaml --activity-type-id "<TYPE_ID>" --connection-
 ```
 
 The returned `Configuration` carries the resolved event fields as `FieldObjects`. Without `--event-operation` you get the bare activity (correct default, no event fields). It is the persistence analogue of `--field-values` criteria — a selector that unlocks the schema — and the resolution needs a live connection (same cloud round-trip and silent-no-op caveat as above). Combine with `--field-values` to also pre-bind values.
+
+#### Select the object for generic activities with `--object-name`
+
+A **generic** `ConnectorActivity` (Insert / Get / Delete a record) or a generic event has no object baked into its `typeId`, so `get-default-xaml` returns it bare until you name the object — the headless equivalent of the designer's object dropdown. Pass `--object-name <obj>`:
+
+```bash
+uip rpa activities get-default-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN>" \
+    --object-name issue --project-dir "<P>" --output json
+```
+
+Discover valid object names (use the `Name` field, not the display name):
+
+- Generic activity → `uip is resources list <connector-key> --output json`
+- Generic event → `uip is triggers objects <connector-key> <EVENT> --output json`
+
+A named event auto-resolves its single object, so `--object-name` is only needed for generic operations and multi-object events. It is the same kind of selector as `--event-operation` (identity that unlocks the schema), needs a live connection, and combines with `--event-operation` and `--field-values`.
 
 ### Step 5 — Read the operation's field schema
 

--- a/skills/uipath-rpa/references/is-connector-xaml-guide.md
+++ b/skills/uipath-rpa/references/is-connector-xaml-guide.md
@@ -296,6 +296,12 @@ uip rpa run --file-path "<your-workflow>.xaml" --project-dir "<PROJECT_DIR>" --o
 
 If `HasErrors: true`, the `ErrorMessage` field carries the compile/runtime error.
 
+## Operation output is strongly typed
+
+The operation's result is exposed as an output FieldObject named `Jit_<operation>`, typed to a **generated record type** for that object — so downstream expressions that read its members (`record.id`, `records.First().name`) compile, and `uip rpa build` binds the consuming variable to the right type.
+
+That typed shape is generated from the **live connection's** schema while `get-default-xaml` resolves the activity; there is no flag for it — typing is automatic when resolution succeeds against a connection. If it cannot be generated — no usable connection at resolve time, or a connector schema that won't compile — the output **degrades to `System.Object`**: the activity stays valid, but typed member access no longer compiles. Re-resolve with a valid, enabled connection; treat a `System.Object` output as the signal that typing was skipped.
+
 ## Typed Operation vs Generic HTTP
 
 Every connector exposes a `ConnectorHttpActivity` with a typeId suffixed like `...httpRequest...` — a generic escape hatch for arbitrary HTTP calls. Prefer a **typed operation** (e.g. `send_message_to_channel_v2`) whenever one exists: it encodes the endpoint, method, and field schema for you. Only fall back to the HTTP activity when the connector lacks a modeled operation for what you need.

--- a/skills/uipath-rpa/references/is-connector-xaml-guide.md
+++ b/skills/uipath-rpa/references/is-connector-xaml-guide.md
@@ -44,7 +44,7 @@ Three ingredients:
 |---|---|---|
 | `ConnectorActivity` | A connector operation (create / get / update …) | `typeId` + connection; criteria fields fed back via `--field-values` expand the rest (Step 4). |
 | `ConnectorTriggerActivity` | Fires when a connector event occurs | `typeId` already encodes the event; fields resolve from `typeId` + connection. |
-| `ConnectorPersistenceActivity` | Suspends the workflow until a connector event | `--event-operation <op>` selects the event and resolves its fields (Step 4). |
+| `ConnectorPersistenceActivity` | Suspends the workflow until a connector event | Discover events with `uip is activities list <connector> --triggers`, then `--event-operation <op>` resolves the event's fields (Step 4). |
 | `ConnectorHttpActivity` | Generic HTTP-request escape hatch | Standard request fields (`method`, `url`, `headers`, `query`, `body`) — author them directly; they are the same for every connector. |
 
 Same principle throughout: **pass the selector the activity needs, get back its resolved schema.** A bare call (no selector) returns the correctly-typed activity with its baseline fields.
@@ -147,14 +147,36 @@ When you already know valid criteria values up front, the second call alone does
 
 #### Resolve persistence event fields with `--event-operation`
 
-A `ConnectorPersistenceActivity` ("suspend until an event") exposes no event fields until an **event operation** is chosen — the headless equivalent of picking the event in the designer before its fields appear. Pass it explicitly:
+A `ConnectorPersistenceActivity` ("suspend until an event") exposes no event fields until an **event operation** is chosen — the headless equivalent of picking the event in the designer before its fields appear. The event operation is a connector-specific value (e.g. `TICKET_UPDATED`, never the prose "ticket updated"), so **discover it — do not guess it.**
+
+**Step A — list the connector's events** (the same catalog the designer's dropdown uses; no connection needed):
+
+```bash
+uip is activities list <connector-key> --triggers --output json
+```
+
+Each entry's **`Name`** is the value for `--event-operation`; its **`ObjectName`** tells you the kind:
+
+```
+Name            DisplayName      ObjectName   IsCurated
+TICKET_UPDATED  Ticket Updated   tickets      Yes        ← named event: object is built in
+CREATED         Record Created   N/A          No         ← generic op: choose an object too
+```
+
+- **Named event** (`ObjectName` populated, e.g. `TICKET_UPDATED`) — pass its `Name` directly.
+- **Generic op** (`CREATED` / `UPDATED` / `DELETED`, `ObjectName` is `N/A`) — also pick the object it applies to:
+  ```bash
+  uip is triggers objects <connector-key> CREATED --output json
+  ```
+
+**Step B — resolve the activity** with the chosen operation:
 
 ```bash
 uip rpa activities get-default-xaml --activity-type-id "<TYPE_ID>" --connection-id "<CONN>" \
-    --event-operation "<eventOperation>" --project-dir "<P>" --output json
+    --event-operation "TICKET_UPDATED" --project-dir "<P>" --output json
 ```
 
-The returned `Configuration` carries the resolved event fields as `FieldObjects`. Without `--event-operation` you get the bare activity (correct default, no event fields). It is the persistence analogue of `--field-values` criteria — a selector that unlocks the schema — and needs a live connection (same cloud round-trip and silent-no-op caveat as above). Combine the two to also pre-bind values.
+The returned `Configuration` carries the resolved event fields as `FieldObjects`. Without `--event-operation` you get the bare activity (correct default, no event fields). It is the persistence analogue of `--field-values` criteria — a selector that unlocks the schema — and the resolution needs a live connection (same cloud round-trip and silent-no-op caveat as above). Combine with `--field-values` to also pre-bind values.
 
 ### Step 5 — Read the operation's field schema
 


### PR DESCRIPTION
## What
Updates the `uipath-rpa` Integration Service connector guide for how `get-default-xaml` resolves fields across all four IS activity types:

- A field-resolution table — ConnectorActivity / Trigger / Persistence / HTTP — framed around one principle: **pass the selector the activity needs, get back its resolved schema**.
- `--event-operation` usage for persistence/trigger events (discover via `uip is activities list <connector> --triggers`).
- `--object-name` usage for **generic** `ConnectorActivity` operations and generic/multi-object events, with the verified object-discovery commands (`uip is resources list <connector>`, `uip is triggers objects <connector> <event>`). A named event auto-resolves its single object, so `--object-name` is only needed for the generic/multi-object cases.
- Corrected HTTP guidance: the activity resolves to `ConnectorHttpActivity` with standard request fields `method`/`url`/`headers`/`query`/`body`, authored directly, rather than a per-operation schema.

Kept general and distilled; scalar selector examples only (no inline-JSON, per the PS 5.1 rule). Pairs with UiPath/Studio#28422 and UiPath/IntegrationServiceActivities#1032.

---
**Related PRs** — the code this documents: UiPath/Studio#28422 (`--event-operation` / `--object-name`) · UiPath/IntegrationServiceActivities#1032 (headless field resolution).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
