### PR TITLE
fix(tests): coded-agent eval fixes

### DIFF
--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
@@ -46,6 +46,26 @@ def find_call(tree: ast.Module, func_name: str) -> ast.Call | None:
     return None
 
 
+def module_str_constants(tree: ast.Module) -> dict[str, str]:
+    """Map module-level `NAME = "literal"` assignments to their string value."""
+    consts: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    consts[target.id] = node.value.value
+    return consts
+
+
+def resolve_str(node: ast.AST | None, consts: dict[str, str]) -> str | None:
+    """Resolve a string literal or a module-level string constant reference."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name) and node.id in consts:
+        return consts[node.id]
+    return None
+
+
 def imports_from(tree: ast.Module, module: str, name: str) -> bool:
     """True if `tree` contains `from <module> import <name>` — single- or multi-line."""
     for node in ast.walk(tree):
@@ -101,8 +121,9 @@ def main() -> None:
         fail("no `ContextGroundingQueryEngine(...)` call site found")
     kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
     name_node = kwargs.get("index_name")
-    if name_node is None or not (isinstance(name_node, ast.Constant) and name_node.value == "hr-policy"):
-        got = getattr(name_node, "value", name_node)
+    consts = module_str_constants(tree)
+    if resolve_str(name_node, consts) != "hr-policy":
+        got = resolve_str(name_node, consts) or getattr(name_node, "value", name_node)
         fail(
             f"`ContextGroundingQueryEngine(index_name=...)` resolves to {got!r}, "
             "expected 'hr-policy' (the index the user named in the prompt)"

--- a/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
+++ b/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
@@ -35,6 +35,13 @@ initial_prompt: |
   single pass.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent consulted the uipath-agents skill"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent regenerated the schema after editing main.py"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
+++ b/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
@@ -13,12 +13,14 @@ run_limits:
   expected_turns: 3
 
 initial_prompt: |
-  Build me a UiPath coded agent using OpenAI Agents. It takes an address and
-  breaks it down into its parts — street, city, postal code, and country.
+  I want to build a UiPath coded agent that takes an address and breaks it
+  down into its parts: street, city, postal code, and country.
 
   It'll be called by another automation that passes the address in a single
-  named input field called `address` — it's not a chatbot, there's no
-  conversation and no chat history.
+  named input field called `address`.
+
+  I'd like to use OpenAI Agents since that's the framework I know best. Is it
+  complicated?
 
 success_criteria:
   - type: skill_triggered


### PR DESCRIPTION
## Summary
- `llamaindex-rag` eval now passes when the agent stores the index name in a constant like `INDEX_NAME = "hr-policy"` and passes it by reference, instead of requiring a literal at the call site
-  check correct skill was loaded for `local-workspace-iterate`
- different phrasing in `strict-input-no-messages` so the agent doesn't try to use the AskUserQuestion tool which results in an error in a non-interactive env

## Why

these evals were penalizing valid agent behavior. the `rag check` only resolved a string literal, the `local-workspace task` made the agent author the whole seed tree (which is the framework's job), and the `strict-input task` relied on a clarifying question that errors in the harness and pushed the agent into scaffolding.