### PR TITLE
fix(test): rephrase apms_get_my_ip_smoke prompt to activate uipath-admin

### DIFF
--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -13,7 +13,7 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  What public IP does the UiPath platform see for me right now?
+  What public IP does my UiPath organization see for me right now?
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be


### PR DESCRIPTION
## Summary
- The `apms_get_my_ip_smoke` test was failing because the prompt phrase "UiPath platform" triggered `uipath-platform` instead of `uipath-admin`, causing the agent to guess the wrong CLI verb (`apms get-my-ip` instead of `ip-restriction my-ip`).
- Changed prompt wording from "UiPath platform" to "my UiPath organization" to match the phrasing used by the other passing APMS smoke tests (`apms_list_ip_ranges_smoke`, `apms_get_enforcement_smoke`).

## Test plan
- [x] Ran `apms_get_my_ip_smoke` locally — score 1.000, status SUCCESS
- [x] Verified `command_executed` criterion matched `uip admin ip-restriction my-ip ... --output json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)