### PR TITLE
fix(test): allow line continuations in authz delete command_pattern

### DIFF
--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
@@ -62,7 +62,7 @@ success_criteria:
   - type: command_executed
     description: "Agent cleaned up via `roles assignments delete <id>`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+(?:["'']?[a-f0-9-]{8,}|--file\s+\S+)'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+.*(?:["'']?[a-f0-9-]{8,}|--file\s+\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
@@ -69,7 +69,7 @@ success_criteria:
   - type: command_executed
     description: "Agent cleaned up via `roles assignments delete` (positional id or --file batch form)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+(?:["'']?[a-f0-9-]{8,}|--file\s+\S+)'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+delete\s+.*(?:["'']?[a-f0-9-]{8,}|--file\s+\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- The `assignments delete` criterion regex in authz lifecycle e2e tests failed when agents used shell line continuations (`\` + newline) or flag-based forms (`--assignment-id <UUID>`) between `delete` and the UUID argument.
- Added `.*` after `\s+` in the delete `command_pattern` to absorb intervening characters — matching the style already used by the `create` criterion in the same files.
- Fixed in both `authz_assignment_lifecycle_tenant_global_e2e` and `authz_assignment_lifecycle_org_e2e`.

Passed run: https://github.com/UiPath/skills/actions/runs/27706436088 

## Test plan
- [x] Verified regex change matches the failing command from CI: `uip admin authorization roles assignments delete --assignment-id 3c2cfaf2-... --output json`
- [x] Confirmed regex still matches the documented positional form: `delete <UUID> --output json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)