### PR TITLE
docs(uipath-ixp): model-version --tag is live or staging only

### DIFF
--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -16,7 +16,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 | `uip ixp projects get-metrics <project-name> --output json` | Get validation metrics — `FieldGroups[]` (per-group) and `Fields[]` (per-field F1/Precision/Recall) |
 | `uip ixp projects configure-model <project-name> [options] --output json` | Configure extraction model. Options: `--model` (gemini_2_5_flash/gemini_2_5_pro/gpt_4o_2024_05_13) and `--preprocessing` (none/table_mini/table). |
 | `uip ixp projects list-models <project-name> --output json` | List all model versions and tags. Returns `Models[]` (Version, Pinned, TrainedTime) and `Tags[]` (Name, Version). |
-| `uip ixp projects publish <project-name> --output json` | Publish (pin) the latest model version. Options: `--model-version <N>` (specific version, default: latest), `--description "<text>"` (set description), `--tag <name>` (assign tag: "live", "staging", or custom). |
+| `uip ixp projects publish <project-name> --output json` | Publish (pin) the latest model version. Options: `--model-version <N>` (specific version, default: latest), `--description "<text>"` (set description), `--tag <live\|staging>` (tag the pinned version — only `live` or `staging` are accepted). |
 | `uip ixp projects delete <project-name> --confirm-data-loss --output json` | **Permanently** delete a project — its documents, taxonomy, and trained models. **Irreversible.** Requires `--confirm-data-loss`; the command refuses to run without it. |
 
 ## Documents


### PR DESCRIPTION
## Summary

The `projects publish` row in `cli-reference.md` said `--tag` accepts `"live"`, `"staging"`, **or custom**. That's wrong — the IXP platform accepts only **`live`** and **`staging`** (`USER_MODEL_TAGS` in `ixp-platform/backend/api/reinfer_api/shared.py`); any other value is rejected with `400 Unknown model tag`.

Corrected the row to state only `live`/`staging` are valid.

Pairs with the CLI fix [UiPath/cli#2584](https://github.com/UiPath/cli/pull/2584), which validates `--tag` up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)