### PR TITLE
fix(uipath-maestro-flow): correct eval run results envelope Code

### DIFF
--- a/skills/uipath-maestro-flow/references/evaluate/references/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/references/commands-reference.md
@@ -299,7 +299,7 @@ The CLI emits a `Code` field on every JSON response. Useful when filtering or sc
 | `eval run start` (no `--wait`) | `MaestroFlowEvalRunStarted` |
 | `eval run start --wait` (summary) | `MaestroFlowEvalRunCompleted` |
 | `eval run status` | `MaestroFlowEvalRunStatus` |
-| `eval run results` | `MaestroFlowEvalRunResults` |
+| `eval run results` | `FlowEvalRunResults` (no `Maestro` prefix — unlike its `eval run` siblings) |
 | `eval run list` | `MaestroFlowEvalRunList` |
 | `eval run compare` | `MaestroFlowEvalRunComparison` |
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
@@ -5,7 +5,8 @@ Reads `eval-results.json` (the JSON the agent saved from
 `uip maestro flow eval run results <run_id> --verbose --output json`) and
 asserts:
 
-  1. Top-level `Code` is `MaestroFlowEvalRunResults`.
+  1. Top-level `Code` is `FlowEvalRunResults` (the `eval run results`
+     envelope code; the prefixed `MaestroFlowEvalRunResults` is tolerated too).
   2. There is at least 1 per-data-point row.
   3. Every row has `Status == "Completed"`.
   4. No row has a non-empty `Error`.
@@ -110,9 +111,12 @@ def _extract_rows(doc: dict) -> list[dict]:
     minor key-name drift by walking common containers.
     """
     code = doc.get("Code")
-    if code != "MaestroFlowEvalRunResults":
+    # The CLI emits `FlowEvalRunResults` for `eval run results` (the only
+    # eval-run envelope code without the `Maestro` prefix its siblings carry).
+    # Tolerate the prefixed spelling too in case the CLI normalizes later.
+    if code not in ("FlowEvalRunResults", "MaestroFlowEvalRunResults"):
         _fail(
-            f'eval-results.json `Code` should be "MaestroFlowEvalRunResults", '
+            f'eval-results.json `Code` should be "FlowEvalRunResults", '
             f'got {code!r}'
         )
     data = doc.get("Data") or {}


### PR DESCRIPTION
## What

The `skill-flow-eval-run-e2e` checker hard-asserted the CLI envelope `Code` equals `MaestroFlowEvalRunResults`. The real CLI emits `FlowEvalRunResults` for `uip maestro flow eval run results` — **without** the `Maestro` prefix that its `eval run` siblings (`Started`, `Completed`, `Status`, `Comparison`, …) all carry.

Result: a fully successful, deterministic 1.0 run (all 12 prior criteria PASS) failed the final criterion:

```
FAIL: eval-results.json `Code` should be "MaestroFlowEvalRunResults", got 'FlowEvalRunResults'
```

## Changes

- **`tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py`** — accept the real code `FlowEvalRunResults`; still tolerate the prefixed `MaestroFlowEvalRunResults` in case the CLI normalizes later (consistent with the checker's existing "field names may evolve" tolerance). Docstring updated.
- **`skills/uipath-maestro-flow/references/evaluate/references/commands-reference.md`** — correct the `eval run results` → code mapping and note the missing prefix.

## Scope

Flow only. The `eval` CLI surface exists exclusively under `maestro flow` (confirmed against `assets/uip-catalog-snapshot.json`); there is no `maestro case eval` or `maestro bpmn eval`, so no equivalent fix applies there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)