### PR TITLE
test(uipath-maestro-flow): add simulation CRUD coverage for eval skill

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Verify simulation CRUD produced real artifacts on disk.
+
+Beyond the `command_executed` matchers (which only prove the agent ran the
+right shell command), confirm the simulations landed in the eval-set JSON and
+that the remove actually mutated the file:
+
+  1. An eval-set JSON exists under SimEval/ with name == "Sim Set" carrying a
+     data point named "hello" in `evaluations[]`.
+  2. That data point has a non-empty `simulations` array.
+  3. The Llm simulation targeting `agent-lookup` is still present (add worked).
+  4. The Static simulation targeting `connector-send-email` is gone (the
+     `simulation remove` actually wrote back to disk, not just printed OK).
+
+Fails if the agent ran the commands but they errored, or fabricated stdout
+without producing/mutating real files.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+PROJECT = Path("SimEval")
+KEPT = "agent-lookup"
+REMOVED = "connector-send-email"
+
+
+def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
+    out: list[tuple[Path, dict]] = []
+    for p in root.rglob("*.json"):
+        try:
+            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def _component_ids(sim: dict) -> list[str]:
+    """Collect any string field that could carry the targeted component id,
+    tolerant of casing/key drift in the CLI's serialized shape."""
+    keys = ("componentId", "component_id", "id", "componentID")
+    return [str(sim[k]) for k in keys if isinstance(sim.get(k), str)]
+
+
+def main() -> None:
+    if not PROJECT.is_dir():
+        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
+
+    docs = _load_jsons(PROJECT)
+    if not docs:
+        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
+
+    set_match = next(
+        (
+            (p, d)
+            for p, d in docs
+            if isinstance(d, dict)
+            and d.get("name") == "Sim Set"
+            and isinstance(d.get("evaluations"), list)
+        ),
+        None,
+    )
+    if not set_match:
+        sys.exit('FAIL: no eval-set JSON under SimEval/ has name="Sim Set"')
+
+    cases = set_match[1].get("evaluations") or []
+    hello = next(
+        (c for c in cases if isinstance(c, dict) and c.get("name") == "hello"),
+        None,
+    )
+    if not hello:
+        sys.exit(
+            f'FAIL: eval set "Sim Set" ({set_match[0]}) has no data point named '
+            f'"hello". Got: {[c.get("name") for c in cases if isinstance(c, dict)]}'
+        )
+
+    sims = hello.get("simulations")
+    if not isinstance(sims, list) or not sims:
+        sys.exit(
+            f'FAIL: data point "hello" ({set_match[0]}) has no non-empty '
+            f'"simulations" array. Got: {sims!r}'
+        )
+
+    ids: list[str] = []
+    for s in sims:
+        if isinstance(s, dict):
+            ids.extend(_component_ids(s))
+
+    if KEPT not in ids:
+        sys.exit(
+            f'FAIL: Llm simulation "{KEPT}" not found in data point "hello" '
+            f'simulations (add did not persist). Component ids present: {ids}'
+        )
+    if REMOVED in ids:
+        sys.exit(
+            f'FAIL: Static simulation "{REMOVED}" is still present — '
+            f'`simulation remove` did not mutate the eval-set JSON. '
+            f'Component ids present: {ids}'
+        )
+
+    print(
+        f"OK: eval set {set_match[0]} data point 'hello' keeps '{KEPT}' and "
+        f"dropped '{REMOVED}' (simulation add + remove persisted)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -1,0 +1,144 @@
+task_id: skill-flow-eval-simulation-crud
+description: >
+  Skill-guided simulation CRUD: agent uses the uipath-maestro-flow skill's
+  evaluate capability to scaffold a Flow project, build an eval set + data
+  point, then add, list, and remove node simulations on that data point via
+  `uip maestro flow eval simulation add/list/remove`. Covers both strategies —
+  `Static` (`--mock-value`) and `Llm` (explicit `--output-schema`, so the
+  auto-resolution-from-.flow path is not exercised). Purely local, no login,
+  no upload, no run. Tests whether the skill teaches the simulation command
+  surface (required flags, strategy selection) and `--output json` discipline,
+  and verifies the simulation actually persists into the eval-set JSON.
+tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 60
+
+initial_prompt: |
+  Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a Flow
+  project, build an eval set with one data point, then add, list, and remove
+  node simulations on that data point — purely local, no Studio Web round-trip.
+
+  Steps:
+  1. Create a solution `SimEval` and a Flow project `SimEval`. The flow file
+     MUST live at `SimEval/SimEval/SimEval.flow` (double-nested layout) and be
+     linked via `uip solution project add`.
+
+  2. Declare a string input variable named `name` on
+     `SimEval/SimEval/SimEval.flow` before adding the data point.
+
+  3. Create an eval set named `Sim Set` in the Flow project at
+     `SimEval/SimEval`. (No `--entry-point`, no `--evaluators` — defaults are
+     fine.)
+
+  4. Add one data point named `hello` to that eval set with inputs
+     `{"name":"Alice"}` and expected `{"greeting":"Hello, Alice!"}`.
+
+  5. Add a `Static` simulation on the `hello` data point targeting component id
+     `connector-send-email`. Use `--component-type connector` and a fixed
+     `--mock-value '{"status":"ok","messageId":"abc123"}'`.
+
+  6. Add an `Llm` simulation on the `hello` data point targeting component id
+     `agent-lookup`. Use `--component-type agent`, supply
+     `--simulation-instructions "Return a plausible lookup result."`, and pass
+     `--output-schema '{"type":"object","properties":{"result":{"type":"string"}}}'`
+     explicitly (do NOT rely on auto-resolution from the .flow file).
+
+  7. List the simulations on the `hello` data point to confirm both are present.
+
+  8. Remove the `connector-send-email` simulation from the `hello` data point.
+
+  Important:
+  - Use `--output json` on every `uip maestro flow eval ...` command.
+  - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
+    `uip maestro flow eval run *` — this task tests local CRUD only.
+  - Do NOT run `uip maestro flow debug` or `uip maestro flow validate` — this
+    is not a flow-authoring test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a solution"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+solution\s+(new|init)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent initialized a Flow project"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Flow file was created at the double-nested path"
+    path: "SimEval/SimEval/SimEval.flow"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created an eval set"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a data point with --inputs and --expected"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a Static simulation with --strategy Static and --mock-value"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--strategy\s+Static\b.*--mock-value'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added an Llm simulation with --strategy Llm and explicit --output-schema"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--strategy\s+Llm\b.*--output-schema'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed simulations on the data point"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent removed the connector-send-email simulation"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+remove\s+.*connector-send-email'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on every eval command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+.*--output\s+json'
+    min_count: 5
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Eval-set JSON shows the Llm simulation persisted and the removed one is gone"
+    command: "python3 $TASK_DIR/check_simulation_crud.py"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Adds coder_eval coverage for the `uip maestro flow eval simulation add/list/remove` commands documented in #912 — which merged with **zero test coverage**.

New smoke task + disk-check script under a dedicated leaf directory:

- `tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml` — tagged `[uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval]`. Modeled on the sibling `local_crud.yaml`: scaffolds a double-nested Flow project, builds an eval set + data point, then exercises all three new commands:
  - `simulation add` with `--strategy Static --mock-value`
  - `simulation add` with `--strategy Llm` + **explicit** `--output-schema`
  - `simulation list`
  - `simulation remove`
  - `--output json` discipline on every eval command
- `tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py` — reads the CLI-produced eval-set JSON and asserts the kept Llm sim (`agent-lookup`) persisted **and** the removed Static sim (`connector-send-email`) is gone, so add + remove must both actually mutate the file. Not gameable by self-report.

## Scope notes

- **Local CRUD only** — no `uip login`, `solution upload`, or `eval run *`. Simulations are stored inline in the data point's `simulations` array, like the other local-CRUD eval tasks.
- The Llm path passes `--output-schema` explicitly so the **auto-resolution-from-`.flow`** behavior is *not* exercised — that needs a real connector/agent node with declared outputs (flow authoring + likely a live tenant) and belongs in a follow-up integration/e2e task.

## Validation

- YAML + Python parse clean.
- `/lint-task` verdict: **Low** (single carve-out-justified prompt note; consistent with sibling `local_crud.yaml`).
- `scripts/check-cli-verbs.py` exits 0 — all four `maestro flow eval simulation*` verbs present in the catalog snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)