### PR TITLE
fix(test): accept renamed Flow eval run envelope codes

### DIFF
--- a/skills/uipath-maestro-flow/references/evaluate/references/commands-reference.md
+++ b/skills/uipath-maestro-flow/references/evaluate/references/commands-reference.md
@@ -296,11 +296,11 @@ The CLI emits a `Code` field on every JSON response. Useful when filtering or sc
 | `eval set add` / `list` / `remove` | `FlowEvalSetAdd` / `FlowEvalSetList` / `FlowEvalSetRemove` |
 | `eval evaluator add` / `list` / `remove` | `FlowEvalEvaluatorAdd` / `FlowEvalEvaluatorList` / `FlowEvalEvaluatorRemove` |
 | `eval simulation add` / `list` / `remove` | `FlowEvalSimulationAdd` / `FlowEvalSimulationList` / `FlowEvalSimulationRemove` |
-| `eval run start` (no `--wait`) | `MaestroFlowEvalRunStarted` |
-| `eval run start --wait` (summary) | `MaestroFlowEvalRunCompleted` |
-| `eval run status` | `MaestroFlowEvalRunStatus` |
-| `eval run results` | `MaestroFlowEvalRunResults` |
-| `eval run list` | `MaestroFlowEvalRunList` |
-| `eval run compare` | `MaestroFlowEvalRunComparison` |
+| `eval run start` (no `--wait`) | `FlowEvalRunStarted` |
+| `eval run start --wait` (summary) | `FlowEvalRunCompleted` |
+| `eval run status` | `FlowEvalRunStatus` |
+| `eval run results` | `FlowEvalRunResults` |
+| `eval run list` | `FlowEvalRunList` |
+| `eval run compare` | `FlowEvalRunComparison` |
 
-If actual emitted codes diverge from the table above, trust the JSON output — file an issue.
+The `eval run *` codes dropped their `Maestro` prefix (e.g. `MaestroFlowEvalRunResults` → `FlowEvalRunResults`) to match the rest of the `eval` family. Older CLI versions emit the `Maestro`-prefixed names. If actual emitted codes diverge from the table above, trust the JSON output — file an issue.

--- a/skills/uipath-maestro-flow/references/evaluate/references/running-guide.md
+++ b/skills/uipath-maestro-flow/references/evaluate/references/running-guide.md
@@ -46,7 +46,7 @@ Polling cadence is not part of the public CLI contract — do not depend on a sp
 
 ```json
 {
-  "Code": "MaestroFlowEvalRunStarted",
+  "Code": "FlowEvalRunStarted",
   "Data": {
     "EvalSetRunId": "a1b2c3d4-...",
     "EvalSetName": "Smoke Tests",
@@ -71,7 +71,7 @@ uip maestro flow eval run status <eval_set_run_id> \
 
 ```json
 {
-  "Code": "MaestroFlowEvalRunStatus",
+  "Code": "FlowEvalRunStatus",
   "Data": {
     "EvalSetRunId": "a1b2c3d4-...",
     "Status": "Completed",
@@ -150,7 +150,7 @@ Output:
 
 ```json
 {
-  "Code": "MaestroFlowEvalRunComparison",
+  "Code": "FlowEvalRunComparison",
   "Data": {
     "RunA": { "Id": "...", "Score": 0.86, "Status": "Completed" },
     "RunB": { "Id": "...", "Score": 0.80, "Status": "Completed" },

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
@@ -112,8 +112,9 @@ def _status_summary(doc: dict) -> str:
 
 
 def _extract_rows(doc: dict) -> list[dict]:
-    """The CLI envelope is `{ Code, Data: { Results: [...] } }`. Tolerate
-    minor key-name drift by walking common containers.
+    """The results envelope is `{ Code, Data: ... }`. The current CLI returns
+    `Data` as a flat list of per-data-point row objects; older shapes nested
+    the rows under `Data.Results` / `DataPoints` / `Rows`. Tolerate both.
     """
     code = doc.get("Code")
     if code not in RESULTS_CODES:
@@ -121,14 +122,21 @@ def _extract_rows(doc: dict) -> list[dict]:
             f'eval-results.json `Code` should be one of {RESULTS_CODES}, '
             f'got {code!r}'
         )
-    data = doc.get("Data") or {}
-    for key in ("Results", "DataPoints", "Rows"):
-        rows = data.get(key)
-        if isinstance(rows, list) and rows:
-            return rows
+    data = doc.get("Data")
+    if isinstance(data, list) and data:
+        return data
+    if isinstance(data, dict):
+        for key in ("Results", "DataPoints", "Rows"):
+            rows = data.get(key)
+            if isinstance(rows, list) and rows:
+                return rows
+        _fail(
+            f'eval-results.json has no Results/DataPoints/Rows list under Data. '
+            f'Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}'
+        )
     _fail(
-        f'eval-results.json has no Results/DataPoints/Rows list under Data. '
-        f'Top-level keys: {list(doc.keys())}, Data keys: {list(data.keys())}'
+        f'eval-results.json Data is empty or an unexpected type '
+        f'({type(data).__name__}); top-level keys: {list(doc.keys())}'
     )
     return []  # unreachable
 

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/check_eval_run.py
@@ -5,7 +5,10 @@ Reads `eval-results.json` (the JSON the agent saved from
 `uip maestro flow eval run results <run_id> --verbose --output json`) and
 asserts:
 
-  1. Top-level `Code` is `MaestroFlowEvalRunResults`.
+  1. Top-level `Code` is the eval-run-results envelope code. Accept both the
+     current `FlowEvalRunResults` and the legacy `MaestroFlowEvalRunResults`
+     the CLI emitted before the `eval run *` codes dropped the `Maestro`
+     prefix.
   2. There is at least 1 per-data-point row.
   3. Every row has `Status == "Completed"`.
   4. No row has a non-empty `Error`.
@@ -30,6 +33,9 @@ from pathlib import Path
 RESULTS_PATH = Path("eval-results.json")
 STATUS_PATH = Path("eval-run-status.json")
 EXPECTED_DATA_POINTS = 1
+# Current CLI emits `FlowEvalRunResults`; older versions emitted the
+# `Maestro`-prefixed code. Accept both so the checker survives the rename.
+RESULTS_CODES = ("FlowEvalRunResults", "MaestroFlowEvalRunResults")
 
 
 def _fail(msg: str) -> None:
@@ -110,9 +116,9 @@ def _extract_rows(doc: dict) -> list[dict]:
     minor key-name drift by walking common containers.
     """
     code = doc.get("Code")
-    if code != "MaestroFlowEvalRunResults":
+    if code not in RESULTS_CODES:
         _fail(
-            f'eval-results.json `Code` should be "MaestroFlowEvalRunResults", '
+            f'eval-results.json `Code` should be one of {RESULTS_CODES}, '
             f'got {code!r}'
         )
     data = doc.get("Data") or {}


### PR DESCRIPTION
## Problem

The `uipath-maestro-flow` **Eval run e2e** task kept failing on its final assert:

```
FAIL: eval-results.json `Code` should be "MaestroFlowEvalRunResults", got 'FlowEvalRunResults'
```

The eval run itself was clean — the checker was asserting a **stale envelope code**. The `uip` CLI renamed the `eval run *` JSON `Code` values, dropping the `Maestro` prefix to match the rest of the `eval` family (`FlowEvalAdd`, `FlowEvalSetList`, …). So `MaestroFlowEvalRunResults` → `FlowEvalRunResults`. The check script and skill docs were never updated.

While confirming the codes live, a **second latent bug** surfaced in the same checker (see below).

## Fixes

**1. Stale envelope code (the failing assert)**
- **`check_eval_run.py`** — accept both current and legacy codes (`RESULTS_CODES = ("FlowEvalRunResults", "MaestroFlowEvalRunResults")`); passes on new and old CLI, still rejects anything else.
- **`commands-reference.md`** — six `eval run *` output-code rows updated to the current `Flow…` codes, with a note that older CLI versions emit the `Maestro`-prefixed names.
- **`running-guide.md`** — three sample JSON `Code` values updated.

**2. Wrong `Data` shape in the checker (latent crash)**
- The current CLI returns `eval run results` `Data` as a **flat list** of row objects (both with and without `--verbose`), but `_extract_rows()` assumed `Data.Results`/`DataPoints`/`Rows` and called `.get()` on `Data` — an `AttributeError` crash against the real list shape. Now handles `Data` as a list directly, keeps the legacy nested-dict shapes, and fails gracefully on empty/unexpected `Data`.

## Verification

Confirmed live against **`uip` 1.195.0** on a real Studio Web eval run (alpha tenant), capturing the actual envelope `Code` from each command:

| Command | Confirmed `Code` |
|---|---|
| `eval run start` (no `--wait`) | `FlowEvalRunStarted` ✓ |
| `eval run status` | `FlowEvalRunStatus` ✓ |
| `eval run results` | `FlowEvalRunResults` ✓ |
| `eval run list` | `FlowEvalRunList` ✓ |
| `eval run compare` | `FlowEvalRunComparison` ✓ |
| `eval run start --wait` (summary) | `FlowEvalRunCompleted` (inferred — same prefix pattern; the live run reached `workloadFailed` server-side so the completion summary wasn't emitted) |

Checker behavior verified across shapes: flat-list passing (exit 0), legacy nested dict (exit 0), real `workloadFailed` run (clean FAIL, no crash), empty list (clean FAIL); and across codes: `FlowEvalRunResults` (pass), legacy `MaestroFlowEvalRunResults` (pass), other (fail).

## Related findings (NOT in this PR)

Surfaced while reproducing the test against `uip` 1.195.0; flagging for follow-up:
- `.claude/rules/cli-renames.md` claims `solution new` → `solution init` (1.2.0), but v1.195.0 only has `solution new` (`init` is rejected).
- `solution resources refresh` / `solution resource refresh` no longer exist (resource sync now happens on `pack`/`upload`). The `eval_run.yaml` prompt still instructs that command and has a success criterion requiring it — that criterion will fail against the current CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)