### PR TITLE
fix(ci): disable uip CLI version-sync in skills eval workflows

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -133,6 +133,14 @@ jobs:
     # hiccups, etc.).
     timeout-minutes: 330
     name: Run coder-eval (Linux)
+    # Disable uip CLI version-sync for the whole job. A task's `uip login
+    # status` otherwise re-pins ~/.uipath/config.json to a stale CLI line;
+    # with nightly.yaml's shared `~/.uipath:/.uipath:rw` mount that downgrade
+    # leaks into every later task. The CLI honors this kill switch
+    # unconditionally; coder_eval forwards it into task containers via its
+    # default env_passthrough allowlist. Mirrors the nightly daily.sh fix.
+    env:
+      UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
       - uses: actions/checkout@v4
 
@@ -275,6 +283,13 @@ jobs:
     # mirrors smoke-rpa-skills.yml plus headroom for ad-hoc / e2e runs.
     timeout-minutes: 240
     name: Run coder-eval (Windows)
+    # Disable uip CLI version-sync for the whole job. Windows tasks run in
+    # tempdir mode (no container) and share one host ~/.uipath / global `uip`,
+    # so a `uip login status` re-pin downgrades the CLI for every later task.
+    # The CLI honors this kill switch unconditionally. Mirrors the nightly
+    # daily.sh fix.
+    env:
+      UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -133,12 +133,9 @@ jobs:
     # hiccups, etc.).
     timeout-minutes: 330
     name: Run coder-eval (Linux)
-    # Disable uip CLI version-sync for the whole job. A task's `uip login
-    # status` otherwise re-pins ~/.uipath/config.json to a stale CLI line;
-    # with nightly.yaml's shared `~/.uipath:/.uipath:rw` mount that downgrade
-    # leaks into every later task. The CLI honors this kill switch
-    # unconditionally; coder_eval forwards it into task containers via its
-    # default env_passthrough allowlist. Mirrors the nightly daily.sh fix.
+    # Disable uip CLI version-sync: a task's `uip login status` re-pins
+    # ~/.uipath/config.json to a stale line and, via nightly.yaml's shared
+    # ~/.uipath mount, downgrades the CLI for later tasks. Mirrors daily.sh.
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
@@ -283,11 +280,9 @@ jobs:
     # mirrors smoke-rpa-skills.yml plus headroom for ad-hoc / e2e runs.
     timeout-minutes: 240
     name: Run coder-eval (Windows)
-    # Disable uip CLI version-sync for the whole job. Windows tasks run in
-    # tempdir mode (no container) and share one host ~/.uipath / global `uip`,
-    # so a `uip login status` re-pin downgrades the CLI for every later task.
-    # The CLI honors this kill switch unconditionally. Mirrors the nightly
-    # daily.sh fix.
+    # Disable uip CLI version-sync: tempdir tasks share one host ~/.uipath /
+    # global uip, so a `uip login status` re-pin downgrades later tasks.
+    # Mirrors daily.sh.
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -87,12 +87,9 @@ jobs:
     # min; bump the ceiling so we don't cancel mid-task.
     timeout-minutes: 90
     name: Run RPA skill smoke tests (Windows)
-    # Disable uip CLI version-sync for the whole job. These tasks run in
-    # tempdir mode (no container), so the auth step and every task share one
-    # host ~/.uipath and one global `uip`; a `uip login status` otherwise
-    # re-pins config.json to a stale CLI line and downgrades the CLI for every
-    # later task. The CLI honors this kill switch unconditionally. Mirrors the
-    # nightly daily.sh fix.
+    # Disable uip CLI version-sync: tasks run in tempdir (no container) and
+    # share one host ~/.uipath / global uip, so a `uip login status` re-pin
+    # downgrades the CLI for later tasks. Mirrors daily.sh.
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -87,6 +87,14 @@ jobs:
     # min; bump the ceiling so we don't cancel mid-task.
     timeout-minutes: 90
     name: Run RPA skill smoke tests (Windows)
+    # Disable uip CLI version-sync for the whole job. These tasks run in
+    # tempdir mode (no container), so the auth step and every task share one
+    # host ~/.uipath and one global `uip`; a `uip login status` otherwise
+    # re-pins config.json to a stale CLI line and downgrades the CLI for every
+    # later task. The CLI honors this kill switch unconditionally. Mirrors the
+    # nightly daily.sh fix.
+    env:
+      UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -253,6 +253,16 @@ jobs:
     # masking real hangs.
     timeout-minutes: 120
     name: Run skill smoke tests
+    # Disable uip CLI version-sync for the whole job. A task's `uip login
+    # status` otherwise re-pins ~/.uipath/config.json to a stale CLI line;
+    # with smoke.yaml's shared `~/.uipath:/.uipath:rw` mount that downgrade
+    # leaks into every later task, so some run on the pinned @alpha CLI and
+    # some on the downgraded one (the inconsistency that fails tasks). The CLI
+    # honors this kill switch unconditionally (before its env-auth gate), and
+    # coder_eval forwards it into task containers via its default
+    # env_passthrough allowlist. Mirrors the nightly daily.sh fix.
+    env:
+      UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -253,14 +253,9 @@ jobs:
     # masking real hangs.
     timeout-minutes: 120
     name: Run skill smoke tests
-    # Disable uip CLI version-sync for the whole job. A task's `uip login
-    # status` otherwise re-pins ~/.uipath/config.json to a stale CLI line;
-    # with smoke.yaml's shared `~/.uipath:/.uipath:rw` mount that downgrade
-    # leaks into every later task, so some run on the pinned @alpha CLI and
-    # some on the downgraded one (the inconsistency that fails tasks). The CLI
-    # honors this kill switch unconditionally (before its env-auth gate), and
-    # coder_eval forwards it into task containers via its default
-    # env_passthrough allowlist. Mirrors the nightly daily.sh fix.
+    # Disable uip CLI version-sync: a task's `uip login status` re-pins
+    # ~/.uipath/config.json to a stale line and, via smoke.yaml's shared
+    # ~/.uipath mount, downgrades the CLI for later tasks. Mirrors daily.sh.
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:


### PR DESCRIPTION
## What

Disable the uip CLI's auto version-sync in the GitHub Actions workflows that run coder-eval tasks: the Linux smoke gate (`smoke-skills.yml`), the Windows RPA smoke gate (`smoke-rpa-skills.yml`), and the ad-hoc / nightly runner (`run-coder-eval.yml`).

## Why

A task that runs `uip login status` triggers the CLI's post-login version-sync, which re-pins the shared `~/.uipath/config.json` to a stale CLI line and silently downgrades the CLI. Because the eval containers share one `~/.uipath` (and the Windows runs share one host CLI), that downgrade then leaks into later tasks — so some tasks run on the pinned `@alpha` CLI and some on the downgraded one. That version split is what fails smoke tasks inconsistently.

Same root cause and same fix already shipped for the nightly run (`coder_eval_uipath` `daily.sh`). The CLI treats `UIPATH_CLI_DISABLE_VERSION_SYNC` as a hard kill switch, and coder_eval already forwards it into task containers via its default `env_passthrough` allowlist, so setting it per job closes the gap across all the skills-repo eval entry points.

Background — public thread on the `uip login` silent-downgrade issue: https://uipath-product.slack.com/archives/C0A3Z950TNW/p1781096211538789