### PR TITLE
test(uipath-maestro-flow): add eval task for inline agent node

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Verify the inline-agent eval scaffold produced real artifacts on disk.
+
+This task wires evaluation scaffolding against an INLINE agent node
+(`uipath.agent.autonomous`), whose output is non-deterministic LLM text — so
+the correct evaluator is an LLM judge, NOT the `exact-match` the deterministic
+script-node eval tasks use. Beyond the `command_executed` matchers (which only
+prove the agent ran the right shell command), assert the side effects:
+
+  1. An inline agent.json exists under TriageEval/TriageEval/<uuid>/agent.json
+     (the inline agent dir is a UUID, so glob it; skip generated
+     .agent-builder/). Proves the eval target is a real inline agent.
+  2. An evaluator JSON exists with evaluatorTypeId ==
+     "uipath-llm-judge-output-semantic-similarity" (the `llm-judge-output`
+     internal id) carrying a non-empty `model` — the right choice for a
+     non-deterministic agent output, and the model the LLM gateway requires.
+  3. An eval-set JSON exists with at least one data point in `evaluations[]`
+     carrying non-empty `inputs` and an expected-output field.
+
+These checks fail if the agent ran the commands but they errored, picked a
+deterministic evaluator for the non-deterministic agent, or fabricated stdout
+without producing real files. Reads only source files — no tenant calls.
+"""
+from __future__ import annotations
+
+import glob
+import json
+import sys
+from pathlib import Path
+
+PROJECT = Path("TriageEval")
+INLINE_AGENT_GLOB = "TriageEval/TriageEval/*/agent.json"
+LLM_JUDGE_TYPE_ID = "uipath-llm-judge-output-semantic-similarity"
+
+
+def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
+    out: list[tuple[Path, dict]] = []
+    for p in root.rglob("*.json"):
+        if "/.agent-builder/" in p.as_posix():
+            continue
+        try:
+            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return out
+
+
+def main() -> None:
+    if not PROJECT.is_dir():
+        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
+
+    # 1. Inline agent target exists.
+    agent_paths = [p for p in glob.glob(INLINE_AGENT_GLOB) if "/.agent-builder/" not in p]
+    if not agent_paths:
+        sys.exit(f"FAIL: no inline agent.json matched {INLINE_AGENT_GLOB!r}")
+    print(f"OK: inline agent at {sorted(agent_paths)[0]}")
+
+    docs = _load_jsons(PROJECT)
+    if not docs:
+        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
+
+    # 2. LLM-judge evaluator (not a deterministic type) with a model set.
+    evaluator = next(
+        (
+            (p, d)
+            for p, d in docs
+            if isinstance(d, dict) and d.get("evaluatorTypeId") == LLM_JUDGE_TYPE_ID
+        ),
+        None,
+    )
+    if not evaluator:
+        ids = sorted({d.get("evaluatorTypeId") for _, d in docs if isinstance(d, dict) and d.get("evaluatorTypeId")})
+        sys.exit(
+            f'FAIL: no evaluator JSON under {PROJECT}/ has '
+            f'evaluatorTypeId="{LLM_JUDGE_TYPE_ID}" (llm-judge-output). '
+            f"Found evaluator type ids: {ids}"
+        )
+    model = (evaluator[1].get("evaluatorConfig") or {}).get("model") or evaluator[1].get("model")
+    if not model:
+        sys.exit(f"FAIL: llm-judge evaluator {evaluator[0]} has no model set")
+    print(f"OK: llm-judge-output evaluator {evaluator[0]} with model={model!r}")
+
+    # 3. Eval set with at least one well-formed data point.
+    set_match = next(
+        (
+            (p, d)
+            for p, d in docs
+            if isinstance(d, dict) and isinstance(d.get("evaluations"), list) and d.get("evaluations")
+        ),
+        None,
+    )
+    if not set_match:
+        sys.exit(f"FAIL: no eval-set JSON under {PROJECT}/ has a non-empty evaluations[] list")
+
+    cases = set_match[1].get("evaluations") or []
+    good = next(
+        (
+            c
+            for c in cases
+            if isinstance(c, dict) and c.get("inputs") and (c.get("expectedOutput") or c.get("expected"))
+        ),
+        None,
+    )
+    if not good:
+        sys.exit(
+            f"FAIL: eval set {set_match[0]} has no data point with both non-empty "
+            f"inputs and an expectedOutput/expected field"
+        )
+    print(f"OK: eval set {set_match[0]} has data point {good.get('name')!r} with inputs + expected")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
@@ -1,0 +1,150 @@
+task_id: skill-flow-eval-inline-agent
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-flow skill to build a
+  Flow whose work is done by an INLINE agent node (uipath.agent.autonomous),
+  then wires eval scaffolding that targets it — an `llm-judge-output` evaluator
+  (the correct choice for a non-deterministic agent output, NOT the
+  `exact-match` the deterministic script-node eval tasks use), an eval set, and
+  one data point. Purely local CRUD: no login, no upload, no run. Guards the
+  Author(inline-agent) → Evaluate handoff and the evaluator-type decision.
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, node:inline-agent, feature:eval]
+
+run_limits:
+  expected_turns: 30
+  max_turns: 75
+
+initial_prompt: |
+  Build a UiPath Flow whose reasoning is done by an inline agent, then add
+  evaluation scaffolding for it — purely local, no Studio Web round-trip.
+  Use the `uipath-maestro-flow` skill — both the `author` and `evaluate`
+  capabilities apply.
+
+  Flow:
+  - Solution `TriageEval`, Flow project `TriageEval`. The flow file MUST live
+    at `TriageEval/TriageEval/TriageEval.flow` (double-nested layout) and be
+    linked via `uip solution project add`.
+  - One start trigger with a string input variable named `email`.
+  - One inline agent node (uipath.agent.autonomous) that classifies the
+    inbound `email` into a category and a priority. Scaffold it with
+    `uip agent init --inline-in-flow`. Configure it to a production bar:
+    pick a current model (not the scaffold default), write a real system
+    prompt for the classification task, and declare a typed outputSchema
+    with `category` and `priority` fields.
+  - One end node whose output is mapped from the inline agent's result.
+  - Validate the flow with `uip maestro flow validate` before adding eval
+    scaffolding.
+
+  Eval scaffolding (the agent output is non-deterministic LLM text — choose
+  the evaluator type accordingly):
+  - One evaluator named `triage-judge`. Pick the `--type` that scores
+    natural-language / semantic similarity of a non-deterministic output
+    against an expected value. Pass `--model gpt-4.1-2025-04-14`. Do NOT use
+    a deterministic evaluator type (`exact-match`/`contains`) — the agent's
+    wording will vary run to run.
+  - One eval set named `Triage Cases`. Create it after the evaluator and omit
+    `--evaluators` so the CLI links the current evaluators via generated file
+    refs. Do NOT pass the display name `triage-judge` to `--evaluators`.
+  - One data point named `password-reset` with inputs
+    `{"email":"Subject: Can't log in\n\nI forgot my password and the reset
+    link is broken. Please help ASAP."}` and an expected output describing
+    the classification, e.g. `{"category":"Account Access","priority":"High"}`.
+
+  Important:
+  - Use `--output json` on every `uip maestro flow eval ...` command.
+  - Local CRUD only. Do NOT call `uip login`. Do NOT call `uip solution
+    upload`. Do NOT call `uip maestro flow eval run *`. Do NOT run
+    `uip maestro flow debug`.
+  - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+    planning and implementation. Build it end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the inline agent with uip agent init --inline-in-flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+agent\s+init\s+.*--inline-in-flow'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Flow file was created at the double-nested path"
+    path: "TriageEval/TriageEval/TriageEval.flow"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Flow contains the inline agent node type"
+    path: "TriageEval/TriageEval/TriageEval.flow"
+    includes:
+      - '"uipath.agent.autonomous"'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added an llm-judge-output evaluator with a --model"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+llm-judge-output.*--model|(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--model.*--type\s+llm-judge-output'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT pick a deterministic evaluator for the non-deterministic agent output"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+(exact-match|contains)\b'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created an eval set"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not pass evaluator display name to eval set add"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add\s+.*--evaluators(=|\s+)["'']?(?:[^"''\s,]+,\s*)*triage-judge["'']?(?![-\w])'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a data point with --inputs and --expected"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Local CRUD only — agent did not start an eval run"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+run\s+start'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on eval commands"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+.*--output\s+json'
+    min_count: 3
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Inline agent + llm-judge evaluator + eval set with a data point all exist on disk"
+    command: 'python3 "$TASK_DIR/check_inline_agent_eval.py"'
+    timeout: 15
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds an integration coder-eval task — `skill-flow-eval-inline-agent` — that wires evaluation scaffolding against an **inline agent node** (`uipath.agent.autonomous`) in a UiPath Flow.

New files:
- `tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml`
- `tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py`

## Why

Closes a coverage gap in the `uipath-maestro-flow` evaluate capability. Existing eval tasks (`eval_run`, `local_crud`) target deterministic script nodes with `exact-match` evaluators. None exercised the **Author(inline-agent) → Evaluate** handoff or the evaluator-type decision for a non-deterministic agent output.

## What it guards

- Scaffolding an inline agent with `uip agent init --inline-in-flow` and authoring the `uipath.agent.autonomous` node.
- Picking an `llm-judge-output` evaluator for the non-deterministic agent output — **not** a deterministic `exact-match`/`contains` type (enforced via a `command_not_executed` guard). The prompt describes the output semantics but does not name the answer, so the agent must map semantics → type itself.
- Creating an eval set + data point without leaking the evaluator display name into `--evaluators`.

Local CRUD only — no login, upload, or eval run. The check script asserts real CLI-produced artifacts on disk (inline `agent.json`, an evaluator with `evaluatorTypeId: uipath-llm-judge-output-semantic-similarity` and a `model`, and an eval set with a well-formed data point) rather than agent self-reports.

## Validation

- `/lint-task`: clean — one documented-carve-out Low (validate-only at integration tier, deliberately local-only per the description; consistent with sibling local-CRUD eval tasks).
- CLI verb reachability: all verbs resolve (only Info-level dynamic-pattern findings).
- Tags conform to the closed taxonomy; `run_limits` top-level; no `@uipath/cli` in sandbox.

> **Note:** a `coder-eval` passing-run claim is not yet attached. Will add once the task is run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)