### PR TITLE
test(uipath-maestro-case): execute case-management single-node test against published CaseTest

### DIFF
--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -1,15 +1,17 @@
 task_id: skill-case-single-case-management
 description: >
   Build a Case Management definition from an sdd.md whose only task is a
-  nested case (CASE_MANAGEMENT). The referenced sub-case will not be
-  published on the tenant, so the agent must emit a skeleton task per the
-  skill's unresolved-resource rules — `type: "case-management"` set, no
-  fabricated taskTypeId. Validates the resulting case file.
+  nested case (CASE_MANAGEMENT). Exercises the case-management plugin,
+  registry resolution via caseManagement-index.json, and direct caseplan.json
+  write of a `type: "case-management"` task that resolves to the published
+  CaseTest child case. Validates the resulting case file and runs
+  `uip maestro case debug` end-to-end, asserting the case finalStatus is
+  `Completed`.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:
-  expected_turns: 96
+  expected_turns: 131
   task_timeout: 1500
   max_turns: 120
   turn_timeout: 1500
@@ -22,7 +24,7 @@ initial_prompt: |
   ```
   # SDD — ParentCaseSingle
 
-  Single-stage, single-task case exercising the case-management (nested case) task plugin.
+  Single-stage, single-task case exercising the case-management (nested case) task plugin end-to-end.
 
   ## Section 1: Case Definition
 
@@ -30,7 +32,7 @@ initial_prompt: |
   | Property | Value |
   |---|---|
   | Case Name | ParentCaseSingle |
-  | Case Description | Single-node case that spawns a child ChildOnboardingCase as a nested case task. |
+  | Case Description | Single-node case that spawns the published CaseTest child case as a nested case task. |
   | Case Identifier | Prefix: PCS, Type: constant |
   | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
@@ -49,13 +51,13 @@ initial_prompt: |
   ### 1.5 Case Variables
   | Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
   |---|---|---|---|---|---|---|
-  | childCaseSpawned | Variable | boolean | | | false | ChildOnboardingCase spawn flag; populated by Delegate. |
+  | childCaseSpawned | Variable | boolean | | | false | CaseTest spawn flag; populated by Delegate. |
 
   ## Section 2: Stages & Tasks
 
   ### Stage 1: Delegate (`delegate`)
   **Type:** Stage
-  **Description:** Spawn the ChildOnboardingCase nested case.
+  **Description:** Spawn the CaseTest nested case.
   **Required for Case Completion:** Yes
 
   #### Stage Entry Conditions
@@ -71,12 +73,12 @@ initial_prompt: |
   #### Tasks
   | # | Task ID | Task Name | Type | Required | Run Only Once | Persona | SLA |
   |---|---------|-----------|------|----------|---------------|---------|-----|
-  | 1 | `delegate.spawnChildOnboardingCase` | Spawn ChildOnboardingCase | case-management | Yes | No | system | — |
+  | 1 | `delegate.spawnCaseTest` | Spawn CaseTest | case-management | Yes | No | system | — |
 
-  ##### Task 1.1: Spawn ChildOnboardingCase (`delegate.spawnChildOnboardingCase`)
+  ##### Task 1.1: Spawn CaseTest (`delegate.spawnCaseTest`)
 
   **Type:** case-management
-  **Description:** Spawn the ChildOnboardingCase as a nested case task.
+  **Description:** Spawn the CaseTest case as a nested case task.
 
   **Entry Condition**
 
@@ -86,17 +88,18 @@ initial_prompt: |
 
   | Field | Value |
   |---|---|
-  | Case Reference | Name "ChildOnboardingCase", Folder "Shared" |
+  | Case Reference | Name "CaseTest", Folder "Shared" |
   | Component Type | CASE_MANAGEMENT |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
   HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
-  debug`. Do NOT ask for approval, confirmation, or feedback. Build end-to-end
-  in a single pass. If the referenced sub-case isn't in the registry, leave
-  it as a skeleton task (`<UNRESOLVED>`) per the skill's rules — do NOT
-  fabricate a taskTypeId. Finish with `uip maestro case validate` passing
-  on the resulting caseplan.json.
+  debug` yourself — the test harness runs it. Do NOT ask for approval,
+  confirmation, or feedback. Build end-to-end in a single pass. CaseTest is
+  published on the tenant, so resolve it against caseManagement-index.json to
+  a real taskTypeId — do NOT leave it as a skeleton or fabricate an id.
+  Finish with `uip maestro case validate` passing on the resulting
+  caseplan.json.
 
 success_criteria:
   - type: run_command
@@ -108,9 +111,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan contains a task with type=\"case-management\""
+    description: "Caseplan has a resolved case-management task and debug completes successfully"
     command: "python3 $TASK_DIR/check_case_management_case.py"
-    timeout: 30
+    timeout: 720
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/check_case_management_case.py
@@ -1,19 +1,29 @@
 #!/usr/bin/env python3
-"""ParentCaseSingle: caseplan.json contains a task whose type is "case-management"."""
+"""ParentCaseSingle: a resolved case-management (nested case) task is wired and
+debug completes successfully."""
 
 import os
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.case_check import assert_task_type_present, task_is_skeleton  # noqa: E402
+from _shared.case_check import (  # noqa: E402
+    assert_task_type_present,
+    run_debug,
+    task_is_skeleton,
+)
 
 
 def main():
     task = assert_task_type_present("case-management")
-    skeleton = task_is_skeleton(task)
+    if task_is_skeleton(task):
+        sys.exit(
+            "FAIL: case-management task is a skeleton — debug requires a "
+            "resolved CaseTest registry entry with a real taskTypeId"
+        )
+    run_debug(timeout=540)
     print(
-        f"OK: case-management task present (displayName={task.get('displayName')!r}, "
-        f"skeleton={skeleton})"
+        f"OK: case-management task wired (displayName={task.get('displayName')!r}); "
+        f"debug finalStatus=Completed"
     )
 
 


### PR DESCRIPTION
## What

Convert the `case_management` single-node coder-eval task from a static skeleton check into a real end-to-end debug run, mirroring the `api_workflow` sibling.

Previously the task referenced an **unpublished** child case (`ChildOnboardingCase`), so the `case-management` task deliberately landed as a skeleton and the test only static-validated the caseplan. This change points it at the **published** `CaseTest` child case (folder `Shared`), so the task resolves to a real `taskTypeId` and the harness can drive it to completion.

## Changes

- **`case_management.yaml`**
  - SDD Case Reference → `CaseTest` (folder `Shared`, no inputs/outputs); task id `delegate.spawnCaseTest`.
  - Dropped the skeleton / `<UNRESOLVED>` / "don't fabricate taskTypeId" prompt guidance; prompt now states CaseTest is published and must resolve against `caseManagement-index.json`.
  - Defers `uip maestro case debug` to the harness (was "do NOT run debug").
  - Second criterion timeout `30 → 720`; `expected_turns 96 → 131`; description updated to the executing-test framing.
- **`check_case_management_case.py`** — fails on a skeleton task, then `run_debug(timeout=540)` asserting `finalStatus=Completed` (same pattern as `check_api_workflow_case.py`).

## Validation

- YAML + Python syntax OK.
- `/lint-task`: **OK** (0 issues). Not a near-duplicate of `api_workflow.yaml` — distinct plugin (`case-management`) and registry (`caseManagement-index.json`).
- CLI verb reachability: clean.

## Passing run

Ran end-to-end against a live tenant with `coder-eval` (`experiments/default.yaml`, `claude-sonnet-4-6`) — **2/2 criteria passed, weighted score 1.000, status SUCCESS** (≈16.6 min, 1 iteration).

| Criterion | Result |
|---|---|
| `uip maestro case validate` passes | ✅ 1.00 — `Status: Valid` |
| Resolved case-management task + debug completes | ✅ 1.00 — `OK: case-management task wired (displayName='Spawn CaseTest'); debug finalStatus=Completed` |

Confirms `CaseTest` resolved to a real `taskTypeId` (not a skeleton) and `uip maestro case debug` drove the parent case to `finalStatus=Completed`.

> **Note:** Requires `CaseTest` to be deployed in folder `Shared` on the tenant the e2e harness authenticates against; otherwise registry resolution fails and the skeleton guard trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
