### PR TITLE
test(uipath-troubleshoot): de-flake UIA replay tests (CLI via command_executed, simulator declines source edits)

### DIFF
--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -162,8 +162,9 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
     # The llm_judge sees only the final turn. If the simulator approves applying
-    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
-    # out of the graded turn. Decline source-file edits so the agent closes
-    # recommendation-only.
+    # the fix OR deleting .local/investigations/, that confirmation lands in the
+    # last turn and pushes the diagnosis out of the graded turn. Decline both so
+    # the agent closes with the diagnosis summary.
     - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
+    - "If the agent offers to clean up, delete, or remove `.local/investigations/` (or its evidence / raw / state files), DECLINE: tell it to leave those files in place and give you its final diagnosis summary -- the root cause and the exact change to make. Never approve deleting the investigation folder."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -39,11 +39,6 @@ success_criteria:
     expected_skill: "uipath-troubleshoot"
     weight: 1.0
 
-  - type: file_exists
-    description: "Agent wrote investigation state under .local/investigations/"
-    path: .local/investigations/state.json
-    weight: 0.5
-
   - type: command_executed
     description: "Agent interrogated the faulted job via the uip CLI (uip or jobs get on the job key). Enforced here — not in the judge — so it stays robust across iterations and sub-agents."
     tool_name: "Bash"
@@ -59,9 +54,6 @@ success_criteria:
     include_reference: true
     include_agent_output: true
     include_tool_calls: false
-    files:
-      - .local/investigations/state.json
-      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome (the attached RESOLUTION.md).
@@ -90,9 +82,8 @@ success_criteria:
 
       DIMENSION A -- Correct playbook
         The agent must match the UI-automation disabled-element playbook
-        (disabled-element.md) in state.json's `matched_playbooks`.
-        Acceptable: the agent also Reads neighboring playbooks during
-        exploration.
+        (disabled-element.md) in its presented diagnosis. Acceptable:
+        the agent also Reads neighboring playbooks during exploration.
         (Orchestrator CLI interrogation is verified separately by a
         command_executed criterion — do NOT grade it here, and do not
         penalize based on which tool calls are or aren't visible.)
@@ -136,7 +127,9 @@ success_criteria:
 
       Be substance-focused, not schema-focused. Intermediate file shapes
       may vary between runs — look at the meaning of what the agent
-      recorded.
+      presented to the user. Grade on the agent's final response and the
+      diagnosis it presents, NOT on the contents of
+      `.local/investigations/state.json` or `hypotheses.json`.
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook match and fix recommendation>"}
 
@@ -158,6 +151,9 @@ simulation:
     Let the agent complete its troubleshooting flow without imposing
     constraints. Approve every scope expansion or clarification the
     agent requests so the investigation reaches the final resolution.
+    Approve scope expansions so it reaches a root cause, but do NOT
+    authorize it to modify any project source files -- you will apply any
+    recommended fix yourself in Studio.
   constraints:
     - "If the agent asks whether to expand investigation scope (any new product domain such as ui-automation, integration-service, maestro, orchestrator), always answer Yes — pick the recommended / first / affirmative option."
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings using the evidence already gathered."
@@ -165,4 +161,9 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    # The llm_judge sees only the final turn. If the simulator approves applying
+    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
+    # out of the graded turn. Decline source-file edits so the agent closes
+    # recommendation-only.
+    - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -59,6 +59,9 @@ success_criteria:
     include_reference: true
     include_agent_output: true
     include_tool_calls: false
+    files:
+      - .local/investigations/state.json
+      - .local/investigations/hypotheses.json
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome (the attached RESOLUTION.md).
@@ -87,8 +90,9 @@ success_criteria:
 
       DIMENSION A -- Correct playbook
         The agent must match the UI-automation disabled-element playbook
-        (disabled-element.md) in its presented diagnosis. Acceptable:
-        the agent also Reads neighboring playbooks during exploration.
+        (disabled-element.md) in state.json's `matched_playbooks`.
+        Acceptable: the agent also Reads neighboring playbooks during
+        exploration.
         (Orchestrator CLI interrogation is verified separately by a
         command_executed criterion — do NOT grade it here, and do not
         penalize based on which tool calls are or aren't visible.)
@@ -132,9 +136,7 @@ success_criteria:
 
       Be substance-focused, not schema-focused. Intermediate file shapes
       may vary between runs — look at the meaning of what the agent
-      presented to the user. Grade on the agent's final response and the
-      diagnosis it presents, NOT on the contents of
-      `.local/investigations/state.json` or `hypotheses.json`.
+      recorded.
 
       Return JSON: {"score": <float>, "rationale": "<one sentence covering both playbook match and fix recommendation>"}
 

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -39,6 +39,11 @@ success_criteria:
     expected_skill: "uipath-troubleshoot"
     weight: 1.0
 
+  - type: file_exists
+    description: "Agent wrote investigation state under .local/investigations/"
+    path: .local/investigations/state.json
+    weight: 0.5
+
   - type: command_executed
     description: "Agent interrogated the faulted job via the uip CLI (uip or jobs get on the job key). Enforced here — not in the judge — so it stays robust across iterations and sub-agents."
     tool_name: "Bash"

--- a/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
@@ -49,13 +49,21 @@ success_criteria:
     expected_skill: "uipath-troubleshoot"
     weight: 1.0
 
+  - type: command_executed
+    description: "Agent interrogated the faulted job via the uip CLI (uip or jobs get on the job key). Enforced here — not in the judge — so it stays robust across iterations and sub-agents."
+    tool_name: "Bash"
+    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+get\s+["\x27]?79e6d2c6'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: llm_judge
     description: "Agent matched the ambiguous-selector playbook AND reached the same conclusion as RESOLUTION.md AND did not recommend any anti-pattern fix"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
-    include_tool_calls: true
+    include_tool_calls: false
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome (the attached RESOLUTION.md).
@@ -93,12 +101,13 @@ success_criteria:
 
       You must grade THREE dimensions in a single score:
 
-      DIMENSION A -- Correct playbook + actual CLI work
+      DIMENSION A -- Correct playbook
         The agent must match the UI-automation ambiguous-selector
-        playbook (ambiguous-selector.md). It is acceptable for the
-        agent to also Read neighboring playbooks (the selector-failure-*
-        family, timeout-issue, no-recovery-data) during exploration,
-        but the conclusion must rest on ambiguous-selector.md.
+        playbook (ambiguous-selector.md) in its presented diagnosis. It
+        is acceptable for the agent to also Read neighboring playbooks
+        (the selector-failure-* family, timeout-issue, no-recovery-data)
+        during exploration, but the conclusion must rest on
+        ambiguous-selector.md.
 
         Matching one of the selector-failure-*.md playbooks instead of
         ambiguous-selector.md is INCORRECT. Those playbooks target
@@ -106,13 +115,11 @@ success_criteria:
         zero-match cases. `NodeAmbiguousException` is the multiple-match
         case and has its own playbook.
 
-        Independently, the agent's tool-call history must show real
-        Orchestrator interrogation via the uip CLI — at minimum
-        `uip or jobs get <key>` on the faulted job, plus an inspection
-        of the workflow source (read Amb.xaml or equivalent). If the
-        agent reached a conclusion without invoking uip on the faulted
-        job AND without reading the workflow XAML, the playbook
-        dimension is failed regardless of which playbook was named.
+        (Orchestrator CLI interrogation is verified separately by a
+        command_executed criterion — do NOT grade it here, and do not
+        penalize based on which tool calls are or aren't visible. The
+        skill runs `uip or jobs get` inside sub-agents whose calls do
+        not surface to this judge.)
 
       DIMENSION B -- Correct fix per playbook branch (B)
         The reference fix names ALL of:
@@ -224,6 +231,9 @@ simulation:
     Let the agent complete its troubleshooting flow without imposing
     constraints. Approve every scope expansion or clarification the
     agent requests so the investigation reaches the final resolution.
+    Approve scope expansions so it reaches a root cause, but do NOT
+    authorize it to modify any project source files -- you will apply any
+    recommended fix yourself in Studio.
   constraints:
     - "If the agent asks whether to expand investigation scope (any new product domain such as ui-automation, integration-service, maestro, orchestrator), always answer Yes — pick the recommended / first / affirmative option."
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings using the evidence already gathered."
@@ -231,4 +241,9 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    # The llm_judge sees only the final turn. If the simulator approves applying
+    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
+    # out of the graded turn. Decline source-file edits so the agent closes
+    # recommendation-only.
+    - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
@@ -242,8 +242,9 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
     # The llm_judge sees only the final turn. If the simulator approves applying
-    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
-    # out of the graded turn. Decline source-file edits so the agent closes
-    # recommendation-only.
+    # the fix OR deleting .local/investigations/, that confirmation lands in the
+    # last turn and pushes the diagnosis out of the graded turn. Decline both so
+    # the agent closes with the diagnosis summary.
     - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
+    - "If the agent offers to clean up, delete, or remove `.local/investigations/` (or its evidence / raw / state files), DECLINE: tell it to leave those files in place and give you its final diagnosis summary -- the root cause and the exact change to make. Never approve deleting the investigation folder."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
@@ -203,8 +203,9 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
     # The llm_judge sees only the final turn. If the simulator approves applying
-    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
-    # out of the graded turn. Decline source-file edits so the agent closes
-    # recommendation-only.
+    # the fix OR deleting .local/investigations/, that confirmation lands in the
+    # last turn and pushes the diagnosis out of the graded turn. Decline both so
+    # the agent closes with the diagnosis summary.
     - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
+    - "If the agent offers to clean up, delete, or remove `.local/investigations/` (or its evidence / raw / state files), DECLINE: tell it to leave those files in place and give you its final diagnosis summary -- the root cause and the exact change to make. Never approve deleting the investigation folder."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
@@ -44,13 +44,21 @@ success_criteria:
     expected_skill: "uipath-troubleshoot"
     weight: 1.0
 
+  - type: command_executed
+    description: "Agent interrogated the faulted job via the uip CLI (uip or jobs get on the job key). Enforced here — not in the judge — so it stays robust across iterations and sub-agents."
+    tool_name: "Bash"
+    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+get\s+["\x27]?61f7af05'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: llm_judge
     description: "Agent matched the verify-execution-failure playbook AND reached the same conclusion as RESOLUTION.md AND did not recommend removing VerifyOptions"
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
     include_agent_output: true
-    include_tool_calls: true
+    include_tool_calls: false
     prompt: |
       You are grading a UiPath troubleshooting agent against a known-correct
       reference outcome (the attached RESOLUTION.md).
@@ -92,21 +100,18 @@ success_criteria:
 
       You must grade THREE dimensions in a single score:
 
-      DIMENSION A -- Correct playbook + actual CLI work
+      DIMENSION A -- Correct playbook
         The agent must match the UI-automation verify-execution-failure
-        playbook (verify-execution-failure.md). It is acceptable for
-        the agent to also Read neighboring playbooks (e.g., the
-        selector-failure-* family, timeout-issue, disabled-element)
-        during exploration, but the conclusion must rest on
-        verify-execution-failure.md.
-
-        Independently, the agent's tool-call history must show real
-        Orchestrator interrogation via the uip CLI — at minimum
-        `uip or jobs get <key>` on the faulted job, plus an inspection
-        of the workflow source (read ClickCase.xaml or equivalent).
-        If the agent reached a conclusion without invoking uip on the
-        faulted job AND without reading the workflow XAML, the playbook
-        dimension is failed regardless of which playbook was named.
+        playbook (verify-execution-failure.md) in its presented
+        diagnosis. It is acceptable for the agent to also Read
+        neighboring playbooks (e.g., the selector-failure-* family,
+        timeout-issue, disabled-element) during exploration, but the
+        conclusion must rest on verify-execution-failure.md.
+        (Orchestrator CLI interrogation is verified separately by a
+        command_executed criterion — do NOT grade it here, and do not
+        penalize based on which tool calls are or aren't visible. The
+        skill runs `uip or jobs get` inside sub-agents whose calls do
+        not surface to this judge.)
 
       DIMENSION B -- Correct fix per playbook branch (D)
         The reference fix names ALL of:
@@ -187,6 +192,9 @@ simulation:
     Let the agent complete its troubleshooting flow without imposing
     constraints. Approve every scope expansion or clarification the
     agent requests so the investigation reaches the final resolution.
+    Approve scope expansions so it reaches a root cause, but do NOT
+    authorize it to modify any project source files -- you will apply any
+    recommended fix yourself in Studio.
   constraints:
     - "If the agent asks whether to expand investigation scope (any new product domain such as ui-automation, integration-service, maestro, orchestrator), always answer Yes — pick the recommended / first / affirmative option."
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings using the evidence already gathered."
@@ -194,4 +202,9 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    # The llm_judge sees only the final turn. If the simulator approves applying
+    # the fix, the agent's edit lands in the last turn and pushes the diagnosis
+    # out of the graded turn. Decline source-file edits so the agent closes
+    # recommendation-only.
+    - "If the agent asks whether to apply, edit, or write the fix to a project source file (e.g. 'shall I apply the corrected selector / property to <file>?'), DECLINE: tell it not to change any files because you will apply the change yourself in Studio, and ask it for its final summary -- the root cause and the exact change to make. Never approve a source-file edit."
   max_turns: 6


### PR DESCRIPTION
## Problem

The three UIA faithful-replay troubleshoot tests failed in the **2026-06-18 nightly** (`2026-06-18_04-06-29`) — all three at once, with intermittent single failures on 06-12 and 06-15. The skill diagnosed every case **correctly in turn 1**; the failures are test-harness flakiness, not a skill regression:

1. **Judge blindness.** The `llm_judge` grades only the final agent turn and only the *main* agent's tool calls. The skill runs `uip or jobs get` inside sub-agents, invisible to the judge — so a Dimension A "must show CLI interrogation in tool calls" requirement mis-fired and capped correct runs at ~0.2. (Proven: `uia-alter-if-disabled`'s separate `command_executed` check scored 1.0 on the same run where the main-agent `uip` count was 0.)
2. **Simulator approved the source edit.** The simulator approved the agent's offer to apply the fix to the workflow `.xaml`, then approved deleting `.local/investigations/`. The agent's final graded turn became a file-edit / cleanup message instead of the diagnosis → judge 0.0.
3. `uia-alter-if-disabled` also graded a `file_exists state.json` criterion and read `state.json` in the judge — bookkeeping the agent legitimately deletes at session end.

## Fix (test-only — no skill changes)

- Verify CLI interrogation via a `command_executed` criterion on `uip or jobs get <job-key>` (the harness command checker sees sub-agent calls). Set judge `include_tool_calls: false` and reword Dimension A to grade the presented diagnosis.
- Simulator now **declines source-file edits** (applies the fix in Studio itself), so the agent closes recommendation-only and the diagnosis stays in the graded turn.
- Drop the brittle `file_exists state.json` criterion and the `state.json` / `hypotheses.json` judge attachment from `uia-alter-if-disabled`.

This aligns all three with `tests/CLAUDE.md` ("grade on presentation, not internal investigation state") and with the pattern `uia-alter-if-disabled` already used for the CLI check.