### PR TITLE
chore: Add eval for http fallback for non catalog connector (#ENGCE-58639)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""NonCatalogHttpFallback: verify the agent uses a managed HTTP-request node for
+a NON-catalog service that has no IS connector of its own (fixture: Spotify).
+
+Spotify is not a catalog connector — there is no ``uipath-spotify`` connector
+key. The only way to reach it through Integration Service's managed auth is the
+generic HTTP connector (``uipath-uipath-http``): a connection of that connector
+type holds the Spotify base URL + OAuth, and the flow issues a connector-mode
+HTTP request against it. The maestro-flow skill must therefore build a
+``core.action.http.v2`` node bound to the ``uipath-uipath-http`` connection,
+rather than searching for a native Spotify activity that does not exist.
+
+This is the non-catalog counterpart of the slack-http-fallback eval: there the
+fallback proxies a catalog connector (``targetConnector`` = the Slack key);
+here the connector key IS ``uipath-uipath-http`` because no catalog connector
+backs the service.
+
+One check (subcommand-dispatched, like the outlook_trigger_inbox checker):
+
+  check_fallback   Structural — the profile fetch is a connector-mode
+                   ``core.action.http.v2`` node whose connector key is
+                   ``uipath-uipath-http`` with a bound connection, and it
+                   targets Spotify's ``/me`` endpoint.
+
+``inputs.detail`` may be a dict (CLI-authored) or a ``=jsonString:``-prefixed
+JSON envelope (hand-authored). Both shapes are normalised before inspection.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import sys
+from typing import Any, NoReturn
+
+FLOW_GLOB = "**/SpotifyProfileTest*.flow"
+# The generic HTTP connector — the only managed path to a service with no
+# catalog connector of its own.
+HTTP_CONNECTOR_KEY = "uipath-uipath-http"
+# Spotify "Get Current User's Profile" endpoint.
+ME_ENDPOINT = "/me"
+_JSONSTRING_PREFIX = "=jsonString:"
+
+
+def _fail(message: str) -> NoReturn:
+    sys.exit(f"FAIL: {message}")
+
+
+def _read_flow() -> dict[str, Any]:
+    flows = sorted(glob.glob(FLOW_GLOB, recursive=True))
+    if not flows:
+        _fail(f"No flow file matching {FLOW_GLOB}")
+    if len(flows) > 1:
+        _fail(f"Multiple flows match {FLOW_GLOB}: {flows}")
+    with open(flows[0], encoding="utf-8") as f:
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            _fail(f"{flows[0]} is not valid JSON: {e}")
+
+
+def _normalise_detail(raw: Any) -> dict[str, Any]:
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw.startswith(_JSONSTRING_PREFIX):
+        try:
+            parsed = json.loads(raw[len(_JSONSTRING_PREFIX):])
+        except json.JSONDecodeError:
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _connection_bound(detail: dict[str, Any]) -> bool:
+    body = detail.get("bodyParameters") or {}
+    candidates = [
+        detail.get("connectionId"),
+        detail.get("connectionResourceId"),
+        body.get("connection") if isinstance(body, dict) else None,
+    ]
+    return any(
+        isinstance(v, str) and v.strip() and v != "ImplicitConnection"
+        for v in candidates
+    )
+
+
+def _is_http_connector_fallback(node: dict[str, Any]) -> bool:
+    """True when ``node`` is a connector-mode managed-HTTP node whose connector
+    key is the generic ``uipath-uipath-http`` (the non-catalog fallback shape)."""
+    node_type = str(node.get("type") or "").lower()
+    if "core.action.http" not in node_type:
+        return False
+    detail = _normalise_detail((node.get("inputs") or {}).get("detail"))
+    body = detail.get("bodyParameters") or {}
+    auth = str(body.get("authentication") or "").lower() if isinstance(body, dict) else ""
+    connector = str(detail.get("connector") or "").lower()
+    target = (
+        str(body.get("targetConnector") or body.get("connectorKey") or "").lower()
+        if isinstance(body, dict)
+        else ""
+    )
+    uses_http_connector = HTTP_CONNECTOR_KEY in (connector, target)
+    return auth == "connector" and uses_http_connector and _connection_bound(detail)
+
+
+def _targets_me_endpoint(node: dict[str, Any]) -> bool:
+    """True when the node's path/url is Spotify's ``/me`` endpoint. Matches the
+    explicit field value (not a blob substring) so '/me' cannot spuriously match
+    inside an unrelated path like '/members'."""
+    detail = _normalise_detail((node.get("inputs") or {}).get("detail"))
+    body = detail.get("bodyParameters") or {}
+    if not isinstance(body, dict):
+        return False
+    for key in ("path", "url"):
+        value = body.get(key)
+        if isinstance(value, str) and value.strip().rstrip("/").lower().endswith("/me"):
+            return True
+    return False
+
+
+# ── subcommand: check_fallback ──────────────────────────────────────────────
+def check_fallback() -> None:
+    flow = _read_flow()
+    if "nodes" not in flow or "edges" not in flow:
+        _fail("Flow missing 'nodes' or 'edges'")
+    nodes = flow["nodes"]
+    print(f"OK: {len(nodes)} nodes, {len(flow['edges'])} edges")
+
+    fallback_nodes = [n for n in nodes if _is_http_connector_fallback(n)]
+    if not fallback_nodes:
+        types = sorted({str(n.get("type") or "") for n in nodes})
+        _fail(
+            "No managed HTTP-request node using the generic "
+            f"{HTTP_CONNECTOR_KEY!r} connector found. Spotify is not a catalog "
+            "connector, so the flow must issue a connector-mode "
+            "core.action.http.v2 request bound to the uipath-uipath-http "
+            f"connection. Node types seen: {types}"
+        )
+    print(
+        f"OK: {len(fallback_nodes)} managed-HTTP node(s) bound to "
+        f"{HTTP_CONNECTOR_KEY!r} with a connection present"
+    )
+
+    if not any(_targets_me_endpoint(n) for n in fallback_nodes):
+        _fail(
+            f"No {HTTP_CONNECTOR_KEY!r} node targets the {ME_ENDPOINT!r} endpoint "
+            "(expected the Spotify '/me' path, which returns the current user's "
+            "profile)."
+        )
+    print(f"OK: fallback node targets Spotify's '{ME_ENDPOINT}' endpoint")
+    print("OK: all Spotify HTTP-fallback structural checks passed")
+
+
+DISPATCH = {
+    "check_fallback": check_fallback,
+}
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] not in DISPATCH:
+        _fail(f"usage: {os.path.basename(sys.argv[0])} {{{'|'.join(DISPATCH)}}}")
+    DISPATCH[sys.argv[1]]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
@@ -1,0 +1,49 @@
+task_id: skill-flow-non-catalog-http-fallback
+description: >
+  Integration test: a NON-catalog service (Spotify) has no IS connector of its
+  own — there is no `uipath-spotify` connector key. The only managed path is the
+  generic HTTP connector (`uipath-uipath-http`): a connection of that type holds
+  Spotify's base URL + OAuth, and the flow issues a connector-mode HTTP request
+  against it for the `/me` endpoint. The skill must build that managed-HTTP node.
+  Non-catalog counterpart of slack-http-fallback (there the proxy targets a
+  catalog connector; here the connector key IS uipath-uipath-http). Graded
+  structurally: validate plus a check on the fallback node shape. Runtime
+  `flow debug` is not graded here — correctness is verified by the node shape, so
+  the test does not depend on a live Spotify connection in the grading sandbox.
+tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:single-node, connector, uipath-uipath-http, feature:http, ipe]
+
+run_limits:
+  expected_turns: 32
+  task_timeout: 1500
+  max_turns: 100
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a new Flow project called "SpotifyProfileTest" with a manual trigger
+  that gets the current user's Spotify profile. Wire
+  the manual trigger to the node that fetches the profile.
+
+  Use the connection present in the `Shared/uipath-maestro-flow` folder.
+
+  Validate the final flow file.
+
+  Use `--output json` on every `uip` command whose output you parse.
+  Do NOT ask for approval, confirmation, or feedback — build and validate the
+  flow end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "uip maestro flow validate was called"
+    tool_name: "Bash"
+    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Profile fetch uses a managed HTTP node with the uipath-uipath-http connector key (non-catalog fallback) and targets the /me endpoint"
+    command: "python3 $TASK_DIR/check_non_catalog_http_fallback.py check_fallback"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds an integration coder-eval task that verifies the `uipath-maestro-flow` skill reaches a **non-catalog service** through a managed HTTP-request node. This is the non-catalog counterpart of the catalog-connector fallback test (#1553 / slack-http-fallback).

Spotify has no IS connector of its own — there is no `uipath-spotify` connector key. The only managed path is the generic HTTP connector (`uipath-uipath-http`): a connection of that type holds Spotify's base URL + OAuth, and the flow issues a connector-mode HTTP request against it for the `/me` endpoint (Get Current User's Profile). The skill must build that `core.action.http.v2` node bound to the `uipath-uipath-http` connection rather than searching for a native Spotify activity that does not exist.

**Catalog vs non-catalog:** in slack-http-fallback the proxy node's `targetConnector` is a catalog key (`uipath-salesforce-slack`); here the connector key **is** `uipath-uipath-http` because no catalog connector backs the service. That distinction is exactly what `check_fallback` asserts.

## Files

- `tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml` — the task
- `tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py` — standalone structural checker

## Success criteria

| Criterion | Type | Weight | Validates |
|---|---|---|---|
| `flow validate` called | command_executed | 2.0 | agent validated |
| Non-catalog HTTP fallback | run_command (`check_fallback`) | 3.0 | connector-mode `core.action.http.v2` with connector key `uipath-uipath-http` + a bound connection, targeting the `/me` endpoint |

Integration tier — graded structurally (validate + fallback node shape). Runtime `flow debug` is intentionally not graded, so the test does not depend on a live Spotify connection in the grading sandbox; the `/me` match reads the explicit `path`/`url` field (not a blob substring) so it cannot spuriously match an unrelated path.

## Test run

| Run | Status | Criteria | Score | Duration |
|-----|---------|----------|-------|----------|
| 1 | SUCCESS | 2/2 | 1.000 | 309.9s |
| 2 | SUCCESS | 2/2 | 1.000 | 385.9s |
| 3 | SUCCESS | 2/2 | 1.000 | 538.2s |
| 4 | SUCCESS | 2/2 | 1.000 | 285.8s |
| 5 | SUCCESS | 2/2 | 1.000 | 285.8s |

5/5 runs passed (2/2 criteria each).



---

## Prompt-quality review

Reviewed the `initial_prompt` against the coder-eval realism/leakage rubric (does the prompt test *skill use*, or can the agent pass by transcription?).

**Headline:** 1 task · **High 0 / Medium 0 / Low 1** · seed-paste 0

| Task | Severity | Why |
|------|----------|-----|
| `non_catalog_http_fallback` | **Low — fit for purpose** | Customer-voice intent; leaves the non-catalog→managed-HTTP fallback reasoning entirely to the skill |

**Assessment** — clean exemplar prompt. It leaks none of what `check_fallback` greps for:

- States the outcome in pure customer voice ("get the current user's Spotify profile") — no insider jargon.
- Never names the HTTP connector key, `core.action.http.v2`, the `/me` endpoint, or any `uip` command/flag/JSON shape.
- The one mildly-internal line ("use the connection present in `Shared/uipath-maestro-flow`") is legitimate sandbox scaffolding — a pre-staged connection stands in for a live Spotify OAuth, and it does *not* reveal that the connection is HTTP-type, so the non-catalog→fallback reasoning stays with the agent.
- The closing `--output json` / no-approval lines are standard harness control (excluded from judgment).

**Recommendation** — no changes needed. Use this as the style exemplar for connector-fallback tasks: name the service + outcome in customer voice and let the agent discover that no catalog connector exists and that the managed-HTTP node is the only path. The pre-staged-connection phrasing is also the canonical way to supply auth scaffolding without leaking the connector type.
