### PR TITLE
fix(test): raise e2e_01 invoice-extraction task_timeout to stop flaky 900s kills [RE-12529]

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -93,6 +93,10 @@ success_criteria:
     pass_threshold: 1.0
 
 run_limits:
-  max_turns: 80
+  # Heavy multi-connector e2e: the one completed run used 882s / 71 turns. On the slow
+  # eu.anthropic Bedrock path it tips over a 900s cap, so the run is wall-clock-killed
+  # before finishing. 1500 is the modal connector/e2e budget (~600s headroom over the
+  # 882s fast baseline); max_turns 120 keeps margin over the observed 71. RE-12529.
+  max_turns: 120
   turn_timeout: 1200
-  task_timeout: 900
+  task_timeout: 1500


### PR DESCRIPTION
`e2e_01_invoice_extraction_greenfield` flakes on ~80% of run-days with a hard
`Task timed out after 900s` (score 0.0, 0 turns recorded). Its `task_timeout`
(900s) sits below its own ~880–905s runtime, so on the slow `eu.anthropic`
Bedrock path the run is wall-clock-killed before it can finish. 900 is an
outlier: the repo default is 1200, the modal connector/e2e budget is 1500, and
the lighter sibling `e2e_02` already inherits the 1200 default.

This widens the budget to bring the task in line with its peers — no change to
what it verifies:
- `task_timeout` 900 → 1500 (~600s headroom over the 882s fast baseline)
- `max_turns` 80 → 120 (the one completed run used 71/80)
- `turn_timeout` unchanged; `task_timeout ≥ turn_timeout` preserved

The change only widens caps, so it cannot make the test fail more often.
Verified via `run-coder-eval` on this branch: SUCCESS, 8/8 criteria, 452s / 57
turns — though on the `us-east-2` `us.anthropic` profile, since the Action
can't reach the slow `eu.anthropic` path. Slow-path confirmation will come from
the post-merge nightly (eu) flipping e2e_01 to green with duration < 1500s.

RE-12529: https://uipath.atlassian.net/browse/RE-12529
