### PR TITLE
fix(tests): move turn_timeout/max_turns to run_limits in agents conversational tasks

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/conversational/guardrail_agent_scope_rejected/guardrail_agent_scope_rejected.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/guardrail_agent_scope_rejected/guardrail_agent_scope_rejected.yaml
@@ -17,8 +17,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/lowcode/conversational/memory_unavailable/memory_unavailable.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/memory_unavailable/memory_unavailable.yaml
@@ -16,8 +16,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/lowcode/conversational/restrictions.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/restrictions.yaml
@@ -14,8 +14,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
@@ -13,8 +13,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/lowcode/conversational/with_builtin_tool/with_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/with_builtin_tool/with_builtin_tool.yaml
@@ -15,8 +15,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-agents/lowcode/conversational/with_context_grounding/with_context_grounding.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/with_context_grounding/with_context_grounding.yaml
@@ -16,8 +16,9 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep"]
-  turn_timeout: 1200
+run_limits:
   max_turns: 50
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Why

The **"Validate task schema (advisory)"** CI job has been failing on every PR (exit code 123, `Some tasks have errors`). It's a repo-wide check — it validates *all* task YAMLs against the pinned coder_eval `TaskDefinition` schema — so the failure surfaces on unrelated PRs (e.g. doc-only changes) even though those PRs touch no task files.

Root cause: six `uipath-agents/lowcode/conversational` tasks declare `turn_timeout` and `max_turns` **under the `agent:` block**, which the schema forbids:

```
✗ restrictions.yaml
  Error: Invalid task definition: 2 validation errors for TaskDefinition
agent.turn_timeout  Extra inputs are not permitted
agent.max_turns     Extra inputs are not permitted
```

These two fields belong under a top-level `run_limits:` block — that's where the task template and the passing HITL tasks (e.g. `quality_05_priority_and_timeout.yaml`) put them.

## What changed

For all six files, moved the two fields out of `agent:` into `run_limits:` (values unchanged):

```diff
 agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: [...]
-  turn_timeout: 1200
-  max_turns: 50
+
+run_limits:
+  max_turns: 50
+  turn_timeout: 1200
```

Files:
- `guardrail_agent_scope_rejected.yaml`
- `memory_unavailable.yaml`
- `restrictions.yaml`
- `scaffold.yaml`
- `with_builtin_tool.yaml`
- `with_context_grounding.yaml`

## Verification

All six parse cleanly and no longer carry the forbidden fields under `agent:`; both fields now resolve under `run_limits:` (`max_turns: 50`, `turn_timeout: 1200`). The schema validator itself runs against a pinned coder_eval wheel from a private feed (not installable locally), but the change directly removes the exact `extra_forbidden` fields the validator rejected and mirrors the placement used by tasks that already pass.

> Found while investigating why the advisory schema check was red on an unrelated `uipath-api-workflow` docs PR. The check is `continue-on-error: true` (non-blocking), but it should be green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)