### PR TITLE
test(connector): data-grounded TM connector eval prototypes (CRUD + results)

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/check.py
+++ b/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/check.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Data-grounded check for the Test Manager connector CRUD task.
+
+Proves the agent did a REAL create->read round-trip (not just invoked the
+activity): the value retrieved by Get must equal the unique seeded value the
+agent created. A cheating/placeholder run can't satisfy this, because the Get
+response only carries the created name if the record was actually written.
+
+Reads:
+  seed.json   (pre_run) -> {"name": "<unique>", ...}
+  result.json (agent)   -> {"created_name", "retrieved_name", "id"}
+"""
+import json
+import sys
+
+
+def fail(msg):
+    print(f"FAIL: {msg}")
+    sys.exit(1)
+
+
+def main():
+    try:
+        seed = json.load(open("seed.json", encoding="utf-8"))
+    except OSError:
+        fail("seed.json missing (pre_run did not run)")
+    try:
+        res = json.load(open("result.json", encoding="utf-8"))
+    except OSError:
+        fail("result.json missing — agent did not record the create/get round-trip")
+
+    name = seed["name"]
+    if res.get("created_name") != name:
+        fail(f"created_name {res.get('created_name')!r} != seeded {name!r}")
+    if res.get("retrieved_name") != name:
+        fail(f"retrieved_name {res.get('retrieved_name')!r} != seeded {name!r} — value did not round-trip")
+    if not res.get("id"):
+        fail("no id captured from the create response")
+    print(f"OK: real round-trip verified — created & retrieved {name!r} (id {res['id']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/seed.py
+++ b/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/seed.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Seed a unique, deterministic Test Case name for the data-grounded CRUD task.
+Runs in pre_run; writes seed.json into the sandbox for the agent + checker to read.
+"""
+import json
+import os
+import uuid
+
+name = f"DataEval-TC-{uuid.uuid4().hex[:8]}"
+seed = {
+    "name": name,
+    # Project the test case is created under. Override via env for the eval tenant.
+    "project_key": os.environ.get("TM_EVAL_PROJECT_KEY", "HEALTH"),
+}
+with open("seed.json", "w", encoding="utf-8") as fh:
+    json.dump(seed, fh)
+print(f"seeded test case name: {name} (project {seed['project_key']})")

--- a/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/testmanager_crud_grounded.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/testmanager_crud_grounded.yaml
@@ -1,0 +1,70 @@
+# PROTOTYPE — data-grounded CRUD pattern (vs invocation-only). skip:true, tenant-gated.
+# Self-seeding + self-cleaning: no maintained fixture needed. Needs a TM connection
+# (codereval has one) and a project to create under (set TM_EVAL_PROJECT_KEY).
+# The grading verifies the RETRIEVED value equals the CREATED value — provable only
+# by a real create->read round-trip, not by merely invoking the activity.
+task_id: skill-platform-is-testmanager-crud-grounded
+description: >
+  Data-grounded coverage: agent creates a Test Case via the
+  uipath-uipath-testmanager connector with a unique seeded name, reads it back by
+  id, and records the round-trip. Graded on the agent invoking create+get AND on
+  the retrieved name matching the created (seeded) name — i.e. the connector
+  actually round-tripped the data, not just that the activity was called.
+tags: [uipath-platform, integration, integration-service, resources, execute]
+skip: true
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+run_limits:
+  expected_turns: 14
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/integration-service/testmanager_crud_grounded/seed.py"
+    timeout: 30
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Read seed.json — it has a unique `name` and a `project_key`. Using the UiPath
+  Test Manager Integration Service connector (`uipath-uipath-testmanager`):
+
+  1. Create a Test Case named exactly that `name` under that project
+     (`uip is resources run create uipath-uipath-testmanager TestCase ...`).
+     Capture the new test case `Id` from the response.
+  2. Get that test case back by its `Id`
+     (`uip is resources run get uipath-uipath-testmanager TestCase ...`).
+  3. Write `result.json` with: `created_name` (the name you sent), `retrieved_name`
+     (the name field returned by Get), and `id` (the captured Id).
+  4. Then delete the test case to clean up.
+
+  Use `--output json` and `--connection-id` on every resource command.
+
+  Do NOT ask for approval. Do NOT pause between planning and implementation.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the test case (`uip is resources run create uipath-uipath-testmanager TestCase`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+create\s+["\x27]?uipath-uipath-testmanager["\x27]?\s+["\x27]?TestCase'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent read the test case back (`uip is resources run get uipath-uipath-testmanager TestCase`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+get\s+["\x27]?uipath-uipath-testmanager["\x27]?\s+["\x27]?TestCase'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Data-grounded: retrieved name == created (seeded) name — the value round-tripped through the connector"
+    command: "python3 $TASK_DIR/check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/testmanager_results_grounded/check.py
+++ b/tests/tasks/uipath-platform/integration-service/testmanager_results_grounded/check.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Data-grounded check for the Test Manager 'Get Assertions' results activity.
+
+Proves the agent actually RETRIEVED the assertions for a known seeded execution —
+not just that it called the activity. Asserts the returned assertion count meets
+the fixture's expected minimum.
+
+Reads:
+  result.json (agent) -> {"execution_id": "<id>", "assertions": [ ... ]}
+
+EXPECTED_MIN is the fixture's known assertion count. TODO: set it (and the
+execution id in the task prompt) to a maintained seeded execution in the eval
+tenant — e.g. discover via `uip tm executions list` + `uip is resources run list
+uipath-uipath-testmanager GetAssertions` and pin a stable one.
+"""
+import json
+import sys
+
+EXPECTED_MIN = 1  # TODO: pin to the seeded fixture execution's real assertion count
+
+
+def main():
+    try:
+        res = json.load(open("result.json", encoding="utf-8"))
+    except OSError:
+        print("FAIL: result.json missing — agent did not record fetched assertions")
+        sys.exit(1)
+    assertions = res.get("assertions")
+    if not isinstance(assertions, list):
+        print("FAIL: result.json has no 'assertions' list")
+        sys.exit(1)
+    if len(assertions) < EXPECTED_MIN:
+        print(f"FAIL: got {len(assertions)} assertions, expected >= {EXPECTED_MIN}")
+        sys.exit(1)
+    print(f"OK: retrieved {len(assertions)} assertions for execution "
+          f"{res.get('execution_id')!r} (>= {EXPECTED_MIN} expected)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-platform/integration-service/testmanager_results_grounded/testmanager_results_grounded.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager_results_grounded/testmanager_results_grounded.yaml
@@ -1,0 +1,60 @@
+# PROTOTYPE — data-grounded RESULTS pattern (vs invocation-only). skip:true.
+# Unlike CRUD, results activities (Get Assertions / Robot Logs / Test Steps /
+# Test Case Logs) can't self-seed — they read byproducts of a prior test
+# EXECUTION. So this needs a MAINTAINED FIXTURE: a stable, completed test
+# execution with known assertions in the eval tenant.
+# TODO before un-skipping:
+#   1. Pick a stable finished execution in the eval tenant (uip tm executions list)
+#      that has assertions; put its ExecutionId in <FIXTURE_EXECUTION_ID> below.
+#   2. Set EXPECTED_MIN in check.py to that execution's real assertion count.
+# This is the reusable pattern for Get Assertions / Download Assertion / Get Robot
+# Logs / Get Test Steps / Get Test Step Logs / Get Test Case Logs — swap the object
+# + the expected fixture value.
+task_id: skill-platform-is-testmanager-results-grounded
+description: >
+  Data-grounded coverage: agent retrieves the assertions for a known seeded test
+  execution via the uipath-uipath-testmanager connector and records them. Graded
+  on the agent invoking Get Assertions AND on the returned assertion count meeting
+  the fixture's expected minimum — i.e. it fetched real results, not just called
+  the activity. Reusable pattern for the read/results activities (assertions,
+  robot logs, test steps, test case logs).
+tags: [uipath-platform, integration, integration-service, resources, execute]
+skip: true
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  Before starting, load the uipath-platform skill and follow its workflow.
+
+  Using the UiPath Test Manager Integration Service connector
+  (`uipath-uipath-testmanager`), retrieve the assertions for test execution
+  `<FIXTURE_EXECUTION_ID>` (`uip is resources run list uipath-uipath-testmanager
+  GetAssertions ...`). Then write `result.json` with `execution_id` and an
+  `assertions` array containing the assertions returned by the connector.
+
+  Use `--output json` and `--connection-id` on every resource command.
+
+  Do NOT ask for approval. Do NOT pause between planning and implementation.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent retrieved assertions (`uip is resources run list uipath-uipath-testmanager GetAssertions`)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+uipath-uipath-testmanager\s+GetAssertions'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Data-grounded: returned assertion count meets the fixture's expected minimum (real results fetched)"
+    command: "python3 $TASK_DIR/check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Data-grounded TM connector eval — prototype (proposal)

Today's connector coverage tasks grade **invocation/authoring** (did the agent call/wire the activity). This proposes grading **behavior** — that the connector actually returned the right data. Two reusable patterns:

### 1. Self-seeding CRUD (no fixture) — ✅ validated SUCCESS 1.000 on codereval
`testmanager_crud_grounded/` (`seed.py` + task + `check.py`)
- `seed.py` generates a unique name; agent creates the TestCase via the connector, reads it back, writes `result.json`; `check.py` asserts **`retrieved_name == created (seeded) name`** — only passable by a real create→read round-trip. Self-cleaning.
- Validated end-to-end against codereval (HEALTH): agent ran `uip is resources run create/get "uipath-uipath-testmanager" "TestCase"`, round-trip verified, 3/3.

### 2. Results activity (needs a fixture) — pattern, `skip:true`
`testmanager_results_grounded/` (task + `check.py`)
- Agent fetches **Get Assertions** for a known execution; `check.py` asserts returned count ≥ the fixture's expected minimum.
- Results activities can't self-seed (they read byproducts of a prior execution), so this needs a **maintained seeded execution** (TODO: pin `ExecutionId` + `EXPECTED_MIN`). Reusable for robot logs / test steps / test case logs.

### Finding
`command_executed` patterns are brittle — the agent quotes args (`create "uipath-uipath-testmanager" "TestCase"`), so patterns must allow optional quotes. The data-grounded `check.py` passed regardless of quoting — **behavior checks are more robust than command-shape checks.** (Same quote-tolerance fix likely makes the #1445 IS tasks reliably green.)

### Proposed rollout
- CRUD groups → self-seeding grounded (cheap, no fixture).
- Results/read groups → fixture-backed grounded (needs one seeded execution + an owner).

Separate from #1445 (which is the invocation/authoring coverage). Draft for discussion.
