### PR TITLE
docs(uipath-rpa): dedicated Flowchart guide (un-bury flowchart rules from general XAML refs) [PILOT-5684]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -263,7 +263,8 @@ uip rpa activities find --query log --output json > /dev/null 2>&1 &
 | **Use execution templates** | XAML | [testing-guide.md § Execution Templates](references/testing-guide.md) |
 | **Create/edit XAML workflow** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) |
 | **Use a common activity** (`Sequence` / `If` / `Switch<T>` / `TryCatch` / `While` / `DoWhile` / `ForEach<T>` / `Assign` / `LogMessage` / `WriteLine` / `Delay` / `Throw` / `Rethrow`) | XAML | [common-activity-card.md](references/common-activity-card.md) |
-| **Create Flowchart/StateMachine** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
+| **Create/edit Flowchart** | XAML | [xaml/flowchart-guide.md](references/xaml/flowchart-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
+| **Create StateMachine** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
 | **Create/edit Long Running Workflow (ProcessDiagram)** | XAML | [xaml/long-running-workflow-guide.md](references/xaml/long-running-workflow-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |
 | **Write UI automation** | Both | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) |
 | **Build multi-screen UIA XAML workflow** | XAML | [ui-automation-guide.md](references/ui-automation-guide.md) → [uia-configure-target-workflows.md § Multi-Step UI Flows](references/uia-configure-target-workflows.md) |
@@ -388,6 +389,7 @@ The XAML file anatomy template (namespace declarations, root Activity element, b
 - [reframework-guide.md](references/reframework-guide.md) — REFramework execution modes, SetTransactionStatus queue-guard fix, Config.xlsx leftover trap
 - [xaml/csharp-activity-binding-guide.md](references/xaml/csharp-activity-binding-guide.md) — Canonical C# binding forms per common activity property (LogMessage, GetText, StartProcess, …) — flat lookup table + recipes
 - [xaml/csharp-expression-pitfalls.md](references/xaml/csharp-expression-pitfalls.md) — C#-specific expression failures (attribute-form VB JIT, ThrowIfNotInTree, OutArgument parse errors)
+- [xaml/flowchart-guide.md](references/xaml/flowchart-guide.md) — Flowchart node vocabulary, structure & wiring, node registration, forbidden nested-chain pattern, condition expressions
 - [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) — Flowchart, State Machine, and Long Running Workflow canvas layout with ViewState
 - [xaml/long-running-workflow-guide.md](references/xaml/long-running-workflow-guide.md) — LRW package dependency, node vocabulary, gateway patterns, suspend/resume persistence
 - [xaml/jit-custom-types-schema.md](references/xaml/jit-custom-types-schema.md) — JIT custom type discovery

--- a/skills/uipath-rpa/references/xaml/canvas-layout-guide.md
+++ b/skills/uipath-rpa/references/xaml/canvas-layout-guide.md
@@ -68,6 +68,8 @@ Every activity should have `sap:VirtualizedContainerService.HintSize` as an attr
 
 ## 3. Flowchart Layout
 
+Node vocabulary, structure & wiring, and node registration: [flowchart-guide.md](flowchart-guide.md). This section covers layout coordinates and ViewState only.
+
 ### What Counts as a Node
 
 A node is one `FlowStep` / `FlowDecision` / `FlowSwitch` on the canvas. A `FlowStep` wraps **exactly one** activity — which may be a container (`Sequence`, `NApplicationCard`, `NCheckState`, `TryCatch`). Activities **inside** a container are NOT separate nodes; they stay nested in their parent and never get their own `ShapeLocation`. Promote a step to its own node only when it is a top-level step in the process flow. Example: an `NCheckState`'s `Throw` belongs inside the `IfNotExists` branch — making it a sibling node would change when it runs.

--- a/skills/uipath-rpa/references/xaml/flowchart-guide.md
+++ b/skills/uipath-rpa/references/xaml/flowchart-guide.md
@@ -1,0 +1,113 @@
+# Flowchart Guide
+
+Node vocabulary, structure, and wiring for `<Flowchart>` workflows. Related references: XAML anatomy → [xaml-basics-and-rules.md](xaml-basics-and-rules.md); layout + ViewState → [canvas-layout-guide.md § 3](canvas-layout-guide.md#3-flowchart-layout); node registration full rules → [common-pitfalls.md § x:Reference](common-pitfalls.md#xreference--__referenceid-naming).
+
+## When to Use a Flowchart
+
+Branching logic with multiple decision points, loops, and back-edges. Best when the flow is a graph rather than a straight sequence. For straight-line steps use a `Sequence`; for state-driven processes use a State Machine; for BPMN-style event-driven long waits use a Long Running Workflow (ProcessDiagram).
+
+## Node Vocabulary
+
+| Node | Purpose | Successor wiring |
+|------|---------|------------------|
+| `FlowStep` | Wraps **exactly one** activity (which may be a container). The unit of work. | `FlowStep.Next` → one node |
+| `FlowDecision` | Boolean branch. `Condition` plus `True`/`False` targets. | `FlowDecision.True` / `.False` → one node each |
+| `FlowSwitch<T>` | Multi-way branch keyed by an expression. | `Default` plus one target per case |
+
+A `FlowStep` wraps one activity. If that activity is a container (`Sequence`, `NApplicationCard`, `TryCatch`), its children stay nested and are NOT separate nodes. See [canvas-layout-guide.md § What Counts as a Node](canvas-layout-guide.md#3-flowchart-layout).
+
+## Structure & Wiring
+
+**Rule:** every `FlowStep`/`FlowDecision`/`FlowSwitch` is a **direct child of `<Flowchart>`** with an `x:Name`. Links between nodes are made with `<x:Reference>__ReferenceIDn</x:Reference>` inside property elements (`Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True`/`.False`) — never by physically nesting one node inside another.
+
+```xml
+<Flowchart DisplayName="My Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+  <FlowStep x:Name="__ReferenceID0">
+    <ui:LogMessage DisplayName="Step 1" />
+    <FlowStep.Next>
+      <x:Reference>__ReferenceID1</x:Reference>
+    </FlowStep.Next>
+  </FlowStep>
+  <FlowDecision x:Name="__ReferenceID1">
+    <FlowDecision.Condition>
+      <CSharpValue x:TypeArguments="x:Boolean">condition</CSharpValue>
+    </FlowDecision.Condition>
+    <FlowDecision.True>
+      <x:Reference>__ReferenceID0</x:Reference>
+    </FlowDecision.True>
+    <!-- FlowDecision.False omitted = end of flow -->
+  </FlowDecision>
+</Flowchart>
+```
+
+`__ReferenceID` values must be unique across the whole file. When adding nodes, use a number higher than any existing one.
+
+## Node Registration
+
+Only nodes in the `Flowchart.Nodes` collection render — and that collection is built from the **direct children** of `<Flowchart>`. A node that is not a direct child is never registered, so the designer does not draw it, regardless of ViewState.
+
+Two cases:
+
+1. **Direct children** of `<Flowchart>` — already registered. Do NOT also add a trailing `<x:Reference>`.
+2. **Inline definitions** inside a property element (e.g., a `FlowStep` written inside `<FlowDecision.True>`) — MUST add a trailing `<x:Reference>` entry as a direct child of `<Flowchart>` to register them.
+
+Full correct/wrong examples for inline registration: [common-pitfalls.md § x:Reference](common-pitfalls.md#xreference--__referenceid-naming).
+
+### Forbidden — nested FlowStep chains
+
+Do NOT build the flow by physically nesting each `FlowStep` inside the previous one's `<FlowStep.Next>` (a deep chain with only the first node under `<Flowchart.StartNode>`). Nested-only steps never enter `Flowchart.Nodes`, so the designer renders almost nothing — invisible regardless of ViewState. Wire successors by reference and keep every step a direct child.
+
+**Correct** — each step a direct child, linked by reference:
+```xml
+<Flowchart sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+  <FlowStep x:Name="__ReferenceID0">
+    <ui:LogMessage DisplayName="Step 1" />
+    <FlowStep.Next>
+      <x:Reference>__ReferenceID1</x:Reference>
+    </FlowStep.Next>
+  </FlowStep>
+  <FlowStep x:Name="__ReferenceID1">          <!-- direct child — in Flowchart.Nodes -->
+    <ui:LogMessage DisplayName="Step 2" />
+  </FlowStep>
+</Flowchart>
+```
+
+**Wrong** — Step 2 nested inside Step 1's `.Next`; `Flowchart.Nodes` holds only Step 1, so Step 2 never renders:
+```xml
+<Flowchart sap2010:WorkflowViewState.IdRef="Flowchart_1">
+  <Flowchart.StartNode>
+    <x:Reference>__ReferenceID0</x:Reference>
+  </Flowchart.StartNode>
+  <FlowStep x:Name="__ReferenceID0">
+    <ui:LogMessage DisplayName="Step 1" />
+    <FlowStep.Next>
+      <FlowStep>                              <!-- WRONG — nested, not registered -->
+        <ui:LogMessage DisplayName="Step 2" />
+      </FlowStep>
+    </FlowStep.Next>
+  </FlowStep>
+</Flowchart>
+```
+
+### No Orphan Nodes
+
+Every node except the start must be reachable: referenced by `Flowchart.StartNode`, a `FlowStep.Next`, or a decision/switch branch. A `FlowStep` with no incoming reference and no `FlowStep.Next` is an orphan — it renders as a disconnected box and is almost always a leftover. Do not generate them.
+
+## Condition Expressions
+
+`FlowDecision.Condition` and `FlowSwitch` expressions follow the project's expression language:
+
+- **C# projects:** `<CSharpValue x:TypeArguments="x:Boolean">condition</CSharpValue>`
+- **VB projects:** `<mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="condition" />`
+
+## Layout & ViewState
+
+ViewState is **mandatory** for Flowcharts — without per-node `ShapeLocation`+`ShapeSize`, Studio stacks every node at (0,0) and they overlap into what looks like a single node (Studio does NOT auto-arrange on open). ViewState positions a node **only after** it is registered in `Flowchart.Nodes` — structure first, then coordinates.
+
+Coordinate system, node sizes, connector routing, and full ViewState recipes: [canvas-layout-guide.md § 3](canvas-layout-guide.md#3-flowchart-layout). See also SKILL.md Rule 20.

--- a/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
+++ b/skills/uipath-rpa/references/xaml/xaml-basics-and-rules.md
@@ -74,7 +74,7 @@ Linear, step-by-step execution. Best for straightforward processes.
 ### Flowchart
 Branching logic with decision nodes. Best for complex decision flows.
 
-**Key pattern:** All FlowStep/FlowDecision/FlowSwitch nodes are direct children of `<Flowchart>`. Use `<x:Reference>` inside property elements (`Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True/False`) to cross-reference nodes.
+**Key pattern:** All FlowStep/FlowDecision/FlowSwitch nodes are direct children of `<Flowchart>`; wire them via `<x:Reference>` inside property elements (`Flowchart.StartNode`, `FlowStep.Next`, `FlowDecision.True/False`). NEVER nest one `FlowStep` inside another's `<FlowStep.Next>` — nested-only steps are absent from `Flowchart.Nodes` and won't render.
 
 ```xml
 <Flowchart DisplayName="My Flowchart" sap2010:WorkflowViewState.IdRef="Flowchart_1">
@@ -99,48 +99,7 @@ Branching logic with decision nodes. Best for complex decision flows.
 </Flowchart>
 ```
 
-**Node registration:** If a node is defined inline within a property element (e.g., inside `FlowStep.Next`) instead of as a direct Flowchart child, it needs a trailing `<x:Reference>` entry as a direct child of `<Flowchart>`. See [common-pitfalls.md § x:Reference](common-pitfalls.md#xreference--__referenceid-naming) for details.
-
-**Forbidden — nested FlowStep chains.** Do NOT build the flow by physically nesting each `FlowStep` inside the previous one's `<FlowStep.Next>` (a deep chain with only the first node under `<Flowchart.StartNode>`). Only direct children of `<Flowchart>` are added to the `Flowchart.Nodes` collection — nested-only steps are absent from it, so the designer renders almost nothing, invisible regardless of ViewState. Every `FlowStep` MUST be a direct child of `<Flowchart>` with an `x:Name`; wire the sequence with `<FlowStep.Next><x:Reference>`.
-
-**Correct** — each step a direct child, linked by reference:
-```xml
-<Flowchart sap2010:WorkflowViewState.IdRef="Flowchart_1">
-  <Flowchart.StartNode>
-    <x:Reference>__ReferenceID0</x:Reference>
-  </Flowchart.StartNode>
-  <FlowStep x:Name="__ReferenceID0">
-    <ui:LogMessage DisplayName="Step 1" />
-    <FlowStep.Next>
-      <x:Reference>__ReferenceID1</x:Reference>
-    </FlowStep.Next>
-  </FlowStep>
-  <FlowStep x:Name="__ReferenceID1">          <!-- direct child — in Flowchart.Nodes -->
-    <ui:LogMessage DisplayName="Step 2" />
-  </FlowStep>
-</Flowchart>
-```
-
-**Wrong** — Step 2 nested inside Step 1's `.Next`; `Flowchart.Nodes` holds only Step 1, so Step 2 never renders:
-```xml
-<Flowchart sap2010:WorkflowViewState.IdRef="Flowchart_1">
-  <Flowchart.StartNode>
-    <x:Reference>__ReferenceID0</x:Reference>
-  </Flowchart.StartNode>
-  <FlowStep x:Name="__ReferenceID0">
-    <ui:LogMessage DisplayName="Step 1" />
-    <FlowStep.Next>
-      <FlowStep>                              <!-- WRONG — nested, not registered -->
-        <ui:LogMessage DisplayName="Step 2" />
-      </FlowStep>
-    </FlowStep.Next>
-  </FlowStep>
-</Flowchart>
-```
-
-**Expression language:** VB projects use `<mva:VisualBasicValue x:TypeArguments="x:Boolean" ExpressionText="condition" />` instead of `<CSharpValue>`.
-
-**ViewState is needed** for usable Flowchart layout. See [canvas-layout-guide.md § Flowchart Layout](canvas-layout-guide.md#3-flowchart-layout) for coordinate systems, sizes, and recipes.
+Node vocabulary, structure & wiring rules, the forbidden nested-chain pattern, node registration, condition expressions (VB/C#), and layout: [flowchart-guide.md](flowchart-guide.md). Layout coordinates and ViewState recipes: [canvas-layout-guide.md § Flowchart Layout](canvas-layout-guide.md#3-flowchart-layout).
 
 ### State Machine
 State-based workflow with transitions. Best for long-running processes with distinct states (e.g., REFramework).


### PR DESCRIPTION
## Why

Flowchart authoring rules were **buried inside general-purpose XAML references**, with no flowchart "home":

| Concern | Lived in |
|---------|----------|
| Node structure & wiring | `xaml-basics-and-rules.md § Flowchart` |
| Layout / ViewState | `canvas-layout-guide.md § 3` |
| `x:Reference` registration | `common-pitfalls.md § x:Reference` |

An agent generating a flowchart had to assemble the procedure from three files named for *XAML in general* — and that fragmentation is what let the nested-chain bug (PR #1565) slip through. Meanwhile **ProcessDiagram already has a dedicated `long-running-workflow-guide.md`**. Flowchart (and State Machine) did not — an inconsistency, not a deliberate design.

## What

Add `references/xaml/flowchart-guide.md` as the per-type Flowchart home, mirroring the LRW guide's shape (owns type-specific content, links out for shared mechanics):

**Owns:** node vocabulary (`FlowStep`/`FlowDecision`/`FlowSwitch`), structure & wiring, node registration incl. the **forbidden nested-FlowStep-chain** rule with correct/wrong examples, no-orphan-nodes, condition expressions (VB/C#).

**Links out (no duplication):** layout/ViewState → `canvas-layout-guide.md § 3`; registration detail → `common-pitfalls.md`; anatomy → `xaml-basics-and-rules.md`.

**Trim, don't copy:**
- `xaml-basics-and-rules.md § Flowchart` → reduced to a short anatomy stub + pointer (the detailed flat-vs-nested block from #1565 *moves* here, it is not duplicated).
- `canvas-layout-guide.md § 3` → reciprocal pointer for structure questions.
- `SKILL.md` → dedicated **Create/edit Flowchart** Task Navigation row + Reference Navigation entry, so agents land on the guide directly.

This is **extraction, not addition** — single source of truth, just relocated to a discoverable home, consistent with the existing per-type guide pattern.

## Scope notes

- **Stacked on #1565** (base is that branch) — it relocates the flat-vs-nested content that PR introduces. Merge #1565 first; GitHub will retarget this to \`main\`.
- **Flowchart only.** State Machine is in the identical situation and can get a matching \`state-machine-guide.md\` in a follow-up once this shape is reviewed.

Relates to PILOT-5684

🤖 Generated with [Claude Code](https://claude.com/claude-code)