### PR TITLE
chore: Add eval for http webhook connector (#ENGCE-58639)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""WebhookSelfTest: structural + runtime check for a two-branch self-testing flow.
+
+The flow must be:
+
+  manual start trigger
+    ├─ branch 1: Wait-for-event node (HTTP Webhook, uipath-http-webhook) -> End
+    └─ branch 2: Managed HTTP Request (core.action.http.v2, manual GET to the
+                 HTTP Webhook connection's webhook URL, no headers / no query) -> End
+
+Branch 2's GET hits the webhook URL, which delivers the event that completes
+branch 1's wait — so the flow self-triggers at runtime. This checker validates
+the static two-branch shape only; it does not run `flow debug`.
+
+Static assertions (read from the `.flow` source):
+  1. The start trigger is preserved (`core.trigger.*`) and fans out to >=2
+     branches (the event wait and the HTTP request).
+  2. A Wait-for-event node of the HTTP Webhook connector event exists
+     (`uipath.connector.event.uipath-http-webhook.http-webhook`).
+  3. A `core.action.http.v2` node is a MANUAL `GET` whose `url` is the webhook
+     URL, with NOTHING in headers or query (per the prompt).
+  4. Both branch tails reach an End node (`core.control.end`).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import sys
+
+FLOW_GLOB = "**/WebhookSelfTest*.flow"
+EVENT_MARKERS = ("uipath.connector.event", "uipath-http-webhook")
+HTTP_TYPE = "core.action.http.v2"
+END_TYPE = "core.control.end"
+TRIGGER_PREFIX = "core.trigger."
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_flow() -> dict:
+    flows = glob.glob(FLOW_GLOB, recursive=True)
+    if not flows:
+        _fail(f"no flow file matching {FLOW_GLOB} under cwd")
+    with open(flows[0], encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _reachable(start_id: str, edges: list) -> set:
+    """Node ids reachable from start_id following edges (sourceNodeId -> targetNodeId)."""
+    adj: dict[str, list[str]] = {}
+    for e in edges:
+        adj.setdefault(e.get("sourceNodeId"), []).append(e.get("targetNodeId"))
+    seen, stack = set(), [start_id]
+    while stack:
+        n = stack.pop()
+        for t in adj.get(n, []):
+            if t and t not in seen:
+                seen.add(t)
+                stack.append(t)
+    return seen
+
+
+def main() -> None:
+    flow = _read_flow()
+    nodes = flow.get("nodes") or []
+    edges = flow.get("edges") or []
+    types_seen = sorted({str(n.get("type", "")) for n in nodes})
+
+    # 1. Start trigger preserved + fans out into >=2 branches.
+    triggers = [n for n in nodes if str(n.get("type", "")).startswith(TRIGGER_PREFIX)]
+    if not triggers:
+        _fail(f"no start trigger (core.trigger.*). Types seen: {types_seen}")
+    start_id = triggers[0].get("id")
+    out_edges = [e for e in edges if e.get("sourceNodeId") == start_id]
+    if len(out_edges) < 2:
+        _fail(
+            f"start trigger {start_id!r} must fan out into >=2 branches; "
+            f"found {len(out_edges)} outgoing edge(s)"
+        )
+    print(f"OK: start trigger {start_id!r} fans out into {len(out_edges)} branches")
+
+    # 2. HTTP Webhook Wait-for-event node present.
+    event_nodes = [
+        n for n in nodes
+        if all(m in str(n.get("type", "")).lower() for m in EVENT_MARKERS)
+    ]
+    if not event_nodes:
+        _fail(
+            "no HTTP Webhook Wait-for-event node (type containing "
+            f"{' + '.join(EVENT_MARKERS)}). Types seen: {types_seen}"
+        )
+    print("OK: HTTP Webhook wait-for-event node present")
+
+    # 3. Manual GET HTTP node to the webhook URL, no headers / no query.
+    http_nodes = [n for n in nodes if str(n.get("type", "")) == HTTP_TYPE]
+    if not http_nodes:
+        _fail(f"no {HTTP_TYPE} node. Types seen: {types_seen}")
+
+    good_http = None
+    for n in http_nodes:
+        body = ((n.get("inputs") or {}).get("detail") or {}).get("bodyParameters") or {}
+        if not isinstance(body, dict):
+            continue
+        auth = str(body.get("authentication", "")).lower()
+        method = str(body.get("method", "")).lower()
+        url = str(body.get("url", ""))
+        headers = body.get("headers")
+        query = body.get("query") or body.get("queryParameters")
+        if auth != "manual" or method != "get":
+            continue
+        if "webhook" not in url.lower():
+            continue
+        if headers:  # any non-empty headers fails the "nothing in header" rule
+            _fail(f"HTTP node must not set headers; found: {headers}")
+        if query:  # any non-empty query fails the "nothing in query" rule
+            _fail(f"HTTP node must not set query parameters; found: {query}")
+        good_http = n
+        break
+
+    if good_http is None:
+        _fail(
+            "no core.action.http.v2 node configured as a manual GET to the "
+            "webhook URL (authentication=manual, method=GET, url contains 'webhook')"
+        )
+    print("OK: manual GET HTTP node to webhook URL, no headers / no query")
+
+    # 4. Both the event wait and the HTTP node reach an End node.
+    end_ids = {n.get("id") for n in nodes if str(n.get("type", "")) == END_TYPE}
+    if not end_ids:
+        _fail(f"no End node ({END_TYPE}). Types seen: {types_seen}")
+    for label, node in (("wait-for-event", event_nodes[0]), ("http-request", good_http)):
+        reach = _reachable(node.get("id"), edges)
+        if not (reach & end_ids):
+            _fail(f"{label} branch does not reach an End node")
+    print("OK: both branches terminate at an End node")
+
+    print("OK: all WebhookSelfTest checks passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
@@ -1,0 +1,91 @@
+task_id: skill-flow-webhook-waitfor-parallel
+description: >
+  E2E self-testing flow: a manual start trigger fans out into two parallel
+  branches. Branch 1 is a mid-flow Wait-for-event node bound to the HTTP Webhook
+  connector (`uipath.connector.event.uipath-http-webhook.http-webhook`). Branch 2
+  is a Managed HTTP Request (`core.action.http.v2`, manual GET) whose URL is the
+  webhook URL of that same HTTP Webhook connection, with nothing in headers or
+  query. The GET self-delivers the event that completes the wait at runtime.
+  Exercises the connector-trigger plugin's "Wait for events" variant, parallel
+  branch fan-out from the start trigger, manual-mode HTTP, and the CLI
+  webhook-URL retrieval path. Validates the static two-branch shape.
+tags:
+  [
+    uipath-maestro-flow,
+    integration,
+    mode:build,
+    lifecycle:generate,
+    shape:multi-node,
+    connector,
+    feature:trigger,
+    feature:http,
+    wait-for-event,
+    uipath-http-webhook,
+    ipe,
+  ]
+
+run_limits:
+  expected_turns: 35
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath Flow named "WebhookSelfTest" with a manual trigger.
+
+  The start trigger must fan out into TWO parallel branches:
+
+    - Branch 1: a mid-flow node that waits for an HTTP Webhook
+      event (the HTTP Webhook connector). For its connection, use the HTTP
+      Webhook connection in the `Shared/uipath-maestro-flow` folder. Then End
+      this branch.
+
+    - Branch 2: an HTTP Request node configured as a GET request
+      whose URL is the webhook URL of that same HTTP Webhook connection. 
+      Do NOT put anything in the headers or the query parameters — just the GET to 
+      the webhook URL. Then End this branch.
+
+  After building, validate the flow.
+
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and 
+  implementation. Build the complete flow end-to-end in a single pass. 
+  Use `--output json` on `uip` commands.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a solution"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+solution\s+(new|init)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent initialized a Flow project"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved the webhook URL"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+is\s+webhooks\s+config'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Two-branch structure: wait-for-event + manual-GET-to-webhook-URL (no headers/query), both reaching End"
+    command: "python3 $TASK_DIR/check_webhook_waitfor_parallel.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -3,7 +3,7 @@ description: >
   Loop over 3 cities, fetch weather from open-meteo for each, classify warm/cold
   with a script, collect results. Exercises Loop → HTTP → Script chaining with
   data flowing between nodes across iterations.
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop, feature:http, ipe]
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:loop, feature:http]
 
 run_limits:
   expected_turns: 43


### PR DESCRIPTION
## What

Adds an integration coder-eval task that verifies the `uipath-maestro-flow` skill can build a **self-testing HTTP Webhook flow** — a wait-for-event trigger paired with a parallel HTTP call that self-delivers the event at runtime.

The flow `WebhookSelfTest` fans the manual start trigger out into two parallel branches:

- **Branch 1** — a mid-flow Wait-for-event node bound to the HTTP Webhook connector (`uipath.connector.event.uipath-http-webhook.http-webhook`), using the HTTP Webhook connection in `Shared/uipath-maestro-flow`, then End.
- **Branch 2** — a Managed HTTP Request (`core.action.http.v2`, manual-mode GET) whose URL is the webhook URL of that same connection, with nothing in headers or query, then End.

The GET self-delivers the event that completes the wait. Exercises the connector-trigger plugin's "Wait for events" variant, parallel branch fan-out from the start trigger, manual-mode HTTP, and the CLI webhook-URL retrieval path (`uip is webhooks config`).

## Files

- `tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml` — the task
- `tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py` — structural checker (validates the static two-branch shape; does not run `flow debug`)

## Success criteria

| Criterion | Type | Weight | Validates |
|---|---|---|---|
| Created a solution | command_executed | 1.0 | `uip solution new/init` |
| Initialized a Flow project | command_executed | 1.0 | `uip ... flow init` |
| Retrieved the webhook URL | command_executed | 1.0 | `uip is webhooks config` |
| Validated the flow | command_executed | 1.5 | `uip ... flow validate` |
| Two-branch structure | run_command (`check_webhook_waitfor_parallel.py`) | 3.0 | wait-for-event + manual GET to webhook URL (no headers/query), both branches reaching End |

Integration tier — graded structurally (validate + two-branch node shape). Runtime `flow debug` is not graded, so the test does not depend on live event delivery in the grading sandbox.


---

## Prompt-quality review — `webhook_waitfor_parallel`

Reviewed the `initial_prompt` against the coder-eval realism/leakage rubric (does the prompt test *skill use*, or can the agent pass by transcription?).

**Verdict: Low — fit for purpose.**

The prompt states the build outcome in natural language and leaves all the hard work to the skill. It does not leak any of the following:

| Could the agent pass by transcription? | |
|---|---|
| `uip` command sequence + flags | **No** — none given |
| Node `type` strings (`core.action.http.v2`, `uipath.connector.event.uipath-http-webhook.*`) | **No** |
| JSON keys / artifact shapes | **No** |
| "Shape A vs B" answer / diagnosis | **No** |
| How to retrieve the webhook URL | **No** — pure discovery; the checker still requires `uip is webhooks config` |
| Product-internal node vocabulary | **None** — "a node that waits for an HTTP Webhook event" and "an HTTP Request node configured as a GET" read as plain outcomes |

The only prescriptive element is the two-branch topology itself, which is the legitimate requirement of a build-this-exact-flow E2E — not a leak. The agent must use the skill to author the wait-for-event node and the parallel fan-out in the `.flow` JSON, configure the HTTP node shape, and discover the webhook-URL retrieval command.

**Recommendation:** no changes needed.
