### PR TITLE
chore(tests): add mode/lifecycle tags to Integration Service smoke tasks

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   trigger activities for a connector. Tests that the skill teaches the correct
   activity discovery workflow and the distinction between activities, triggers,
   and resources.
-tags: [uipath-platform, smoke, integration-service, activities]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, connector, feature:activities]
 
 run_limits:
   expected_turns: 9

--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   trigger activities for a connector. Tests that the skill teaches the correct
   activity discovery workflow and the distinction between activities, triggers,
   and resources.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, connector, feature:activities]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:activities]
 
 run_limits:
   expected_turns: 9

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -5,7 +5,7 @@ description: >
   teaches the correct connection workflow (list, present options, ping) and
   that the agent knows the create/edit recovery paths without executing them
   (both require browser interaction).
-tags: [uipath-platform, smoke, integration-service, connections]
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup, connector, feature:connections]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -5,7 +5,7 @@ description: >
   teaches the correct connection workflow (list, present options, ping) and
   that the agent knows the create/edit recovery paths without executing them
   (both require browser interaction).
-tags: [uipath-platform, smoke, mode:build, lifecycle:setup, connector, feature:connections]
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup, integration-service, connector, feature:connections]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -5,7 +5,7 @@ description: >
   teaches the correct connection workflow (list, present options, ping) and
   that the agent knows the create/edit recovery paths without executing them
   (both require browser interaction).
-tags: [uipath-platform, smoke, mode:build, lifecycle:setup, integration-service, connector, feature:connections]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:connections]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
@@ -1,0 +1,66 @@
+task_id: skill-platform-is-connection-setup-smoke
+description: >
+  Smoke test: agent uses the uipath-platform skill to set up a new
+  Integration Service connection via `uip is connections create` and
+  verify it with `connections ping`. Covers the lifecycle:setup path
+  on the IS axis, complementing the read-only connection_lifecycle
+  task that exercises list/ping/recovery paths only.
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup, integration-service, connector, feature:connections]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  I want to set up a new UiPath Integration Service connection for the
+  "uipath-hubspot-hubspotcrm" connector. Drive the create flow through
+  the `uip` CLI (not the browser portal) and then verify the resulting
+  connection with a ping.
+
+  1. Invoke the connection-create command for the HubSpot CRM connector,
+     suppressing the browser auto-open so it works in this headless
+     environment.
+  2. After create, ping the new connection to confirm health.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in
+    this environment. Commands WILL fail with auth errors — that is
+    expected. You MUST still run every command listed above.
+    Do NOT skip a command just because a previous one failed.
+    Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - If the create step does not return a real connection id, use a
+    placeholder like "placeholder-conn-id" to still run the ping command
+    with correct syntax.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invoked connections create — exercises the lifecycle:setup path"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+create'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent suppressed browser auto-open on create (headless-safe shape)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+create.*--no-browser'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent pinged the connection to verify setup"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+ping'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on connection commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   Service connectors by vendor name. Tests that the skill teaches the correct
   connector search workflow (list with --filter, --output json) and the HTTP
   fallback strategy when no native connector exists.
-tags: [uipath-platform, smoke, integration-service, connectors]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   Service connectors by vendor name. Tests that the skill teaches the correct
   connector search workflow (list with --filter, --output json) and the HTTP
   fallback strategy when no native connector exists.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
@@ -1,0 +1,78 @@
+task_id: skill-platform-is-record-crud-e2e
+description: >
+  E2E test: agent uses the uipath-platform skill to walk the full record CRUD
+  lifecycle on the Salesforce Contact resource via Integration Service —
+  create, get, partial update, full replace, then delete. Anchors the four
+  currently-uncovered `uip is resources run` verbs (get, update, replace,
+  delete) plus the already-covered create in one lifecycle walk.
+tags: [uipath-platform, e2e, mode:build, lifecycle:setup, integration-service, connector]
+
+run_limits:
+  expected_turns: 18
+
+sandbox:
+  driver: tempdir
+  python: {}
+  node: {}
+
+initial_prompt: |
+  Walk the full record-CRUD lifecycle on the Salesforce Contact resource via
+  UiPath Integration Service. Create a Contact, read it back, partial-update,
+  full-replace, then delete it.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - If an earlier step does not return a real record id, substitute a
+    placeholder id and continue the walk so each CRUD verb is exercised.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a Contact with --body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+create[\s\S]*--body'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent read the Contact back with run get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+get'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent partial-updated the Contact with --body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+update[\s\S]*--body'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent full-replaced the Contact with --body"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+replace[\s\S]*--body'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deleted the Contact"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+resources\s+run\s+delete'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json consistently across the CRUD walk"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+.*--output\s+json'
+    min_count: 4
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -4,7 +4,7 @@ description: >
   resources for a connector. Tests that the skill teaches the correct resource
   discovery workflow — listing with --operation, describing with --operation
   for field-level detail, and always passing --connection-id.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, connector]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -4,7 +4,7 @@ description: >
   resources for a connector. Tests that the skill teaches the correct resource
   discovery workflow — listing with --operation, describing with --operation
   for field-level detail, and always passing --connection-id.
-tags: [uipath-platform, smoke, integration-service, resources, describe]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, connector]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -15,8 +15,12 @@ sandbox:
   node: {}
 
 initial_prompt: |
-  Walk me through creating a Contact in Salesforce via UiPath Integration
-  Service. Follow the full Integration Service workflow.
+  Walk me through creating a Contact in Salesforce via the UiPath Integration
+  Service connector surface — discover the connector, find a connection, ping
+  it, describe the Contact resource for the Create operation, and execute the
+  create directly through `uip is resources`. Do NOT author an API workflow
+  JSON or use `uip api-workflow` — this is the raw IS resource execute path,
+  one command per step.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live tenant in this

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -4,7 +4,7 @@ description: >
   Integration Service workflow — connector, connection, ping, discover,
   describe, and execute a create operation. Tests that the skill teaches the
   complete 6-step workflow and correct `resources run create` syntax with --body.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:setup, connector]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:setup, integration-service, connector]
 
 run_limits:
   expected_turns: 15

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -4,7 +4,7 @@ description: >
   Integration Service workflow — connector, connection, ping, discover,
   describe, and execute a create operation. Tests that the skill teaches the
   complete 6-step workflow and correct `resources run create` syntax with --body.
-tags: [uipath-platform, smoke, integration-service, resources, execute]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:setup, connector]
 
 run_limits:
   expected_turns: 15

--- a/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
@@ -1,0 +1,64 @@
+task_id: skill-platform-is-trigger-diagnose-smoke
+description: >
+  Smoke test (mode:diagnose): agent uses the uipath-platform skill to diagnose
+  a non-firing Integration Service trigger by inspecting the trigger object's
+  payload schema (`uip is triggers describe`) and the webhook configuration
+  (`uip is webhooks config`). First diagnose-mode test on the IS axis.
+tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, integration-service, connector]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  An Outlook365 EMAIL_RECEIVED trigger is not firing. Diagnose by inspecting
+  the trigger object's payload shape and the webhook configuration so I can
+  verify the upstream system is wired correctly.
+
+  Connector: uipath-microsoft-outlook365
+  Trigger object: EMAIL_RECEIVED
+
+  Use `uip` to (a) describe the trigger payload schema and (b) fetch the
+  webhook configuration (URL + secret hint).
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live tenant in this
+    environment. Commands WILL fail with auth errors — that is expected.
+    You MUST still run both commands (triggers describe and webhooks config).
+    Do NOT skip a command just because a previous one failed.
+    Do NOT retry or attempt to login.
+  - Use `--output json` on every uip command.
+  - Use placeholders like "placeholder-connection-id" / "placeholder-instance-id"
+    for IDs you cannot obtain from a live tenant.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent described the trigger payload schema"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+triggers\s+describe'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent described the EMAIL_RECEIVED trigger object specifically"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+triggers\s+describe.*EMAIL_RECEIVED'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the webhook configuration"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+webhooks\s+config'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on diagnose commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+(triggers|webhooks)\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Adds the required mode:* and lifecycle:* tags to the 5 IS smoke tasks so the Coding Agents Scorecard B/O/T automation can classify them (removes the asterisk on the IS row of the scorecard). Mode/lifecycle values match what tests/reports/uipath-platform.md already inferred per row.

Also drops the invented leaf tags (integration-service, activities, connections, connectors, resources, describe, execute) — these duplicate the file path or fall outside the closed tag vocabulary in tests/README.md §Tag Taxonomy. Promotes connections/activities to the proper feature: namespace and adds the flat connector marker where the task exercises a connector.