### PR TITLE
fix(tests): harden coded guardrail eval graders + fix skill routing

### DIFF
--- a/tests/tasks/uipath-agents/_shared/guardrail_middleware.py
+++ b/tests/tasks/uipath-agents/_shared/guardrail_middleware.py
@@ -1,0 +1,53 @@
+"""Shared AST helpers for coded-guardrail check scripts.
+
+Detects UiPath ``…Middleware`` classes spread (``*``) into a
+``create_agent(middleware=[...])`` list, accepting BOTH valid forms:
+
+  - inline:   ``middleware=[*UiPathPIIDetectionMiddleware(...)]``
+  - variable: ``m = UiPathPIIDetectionMiddleware(...); middleware=[*m]``
+
+A middleware instance is iterable, so ``[*var]`` and ``[*Class(...)]`` are
+equivalent. The original checks matched only the inline form via regex and
+wrongly rejected the (equally valid) variable form.
+"""
+
+from __future__ import annotations
+
+import ast
+
+
+def call_name(call: ast.Call) -> str | None:
+    """Callee name of a Call node — ``Foo(...)`` -> ``"Foo"``, ``mod.Foo(...)`` -> ``"Foo"``."""
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+def _var_to_call(tree: ast.AST) -> dict:
+    """Map each variable name to the Call it was last assigned (resolves ``*name`` spreads)."""
+    mapping: dict = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    mapping[target.id] = node.value
+    return mapping
+
+
+def spread_middleware_calls(tree: ast.AST) -> list:
+    """Every Call spread with ``*`` into a list — directly (``[*Foo(...)]``) or via a
+    one-level variable (``m = Foo(...); [*m]``). Returns the underlying Call nodes
+    (the same node objects produced by ``ast.walk``, so callers may key on ``id()``)."""
+    var_to_call = _var_to_call(tree)
+    calls: list = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Starred):
+            value = node.value
+            if isinstance(value, ast.Call):
+                calls.append(value)
+            elif isinstance(value, ast.Name) and value.id in var_to_call:
+                calls.append(var_to_call[value.id])
+    return calls

--- a/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/check_pii_middleware.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/check_pii_middleware.py
@@ -11,9 +11,16 @@ Validates:
 - PIIDetectionEntityType.EMAIL and PIIDetectionEntityType.PHONE_NUMBER are referenced
 """
 
-import re
+import ast
+import os
 import sys
 from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import call_name, spread_middleware_calls  # noqa: E402
 
 GRAPH = Path("graph.py")
 
@@ -31,6 +38,10 @@ def check(condition: bool, msg: str) -> None:
 
 def main() -> None:
     src = read()
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph.py no longer parses as Python: {exc}")
 
     check(
         "UiPathPIIDetectionMiddleware" in src,
@@ -44,12 +55,15 @@ def main() -> None:
     )
     print("OK: GuardrailScope referenced")
 
-    # Spread pattern: *UiPathPIIDetectionMiddleware(
+    # Spread pattern — accept inline `[*UiPathPIIDetectionMiddleware(...)]` OR the
+    # equivalent variable form `m = UiPathPIIDetectionMiddleware(...); middleware=[*m]`.
     check(
-        bool(re.search(r"\*UiPathPIIDetectionMiddleware\s*\(", src)),
-        "UiPathPIIDetectionMiddleware not spread with * into middleware list",
+        any(call_name(c) == "UiPathPIIDetectionMiddleware" for c in spread_middleware_calls(tree)),
+        "UiPathPIIDetectionMiddleware not spread with * into the middleware list "
+        "(accepts inline `[*UiPathPIIDetectionMiddleware(...)]` or a variable "
+        "`m = UiPathPIIDetectionMiddleware(...); middleware=[*m]`)",
     )
-    print("OK: *UiPathPIIDetectionMiddleware(...) spread pattern found")
+    print("OK: UiPathPIIDetectionMiddleware spread with * into middleware list")
 
     check(
         "middleware=" in src,

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_all/check_recommend_all.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_all/check_recommend_all.py
@@ -15,9 +15,16 @@ produces:
 """
 
 import ast
+import os
 import re
 import sys
 from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import call_name, spread_middleware_calls  # noqa: E402
 
 GRAPH = Path("graph.py")
 
@@ -60,42 +67,64 @@ def main() -> None:
 
     # 1. Syntactic — graph.py still parses
     try:
-        ast.parse(src)
+        tree = ast.parse(src)
     except SyntaxError as e:
         sys.exit(f"FAIL: graph.py no longer parses as Python: {e}")
     print("OK: graph.py parses as valid Python")
 
-    # 1b. Adapter-registration import: guardrail symbols must come from
-    #     uipath_langchain.guardrails (registers the LangChain adapter as an import
-    #     side effect). Importing from uipath.platform.guardrails type-checks and runs
-    #     but makes every guardrail silently no-op.
+    # 1b. Adapter-registration import. The guardrail WRAPPING symbols — the
+    #     `guardrail` decorator and the *Middleware classes — must come from
+    #     uipath_langchain.guardrails, whose import registers the LangChain adapter as a
+    #     side effect. A wrapping symbol imported from uipath.platform.guardrails bypasses
+    #     that registration and the guardrail silently no-ops. Bare validators
+    #     (CustomValidator, PIIValidator, …), action classes, entity enums, and
+    #     GuardrailScope carry no adapter dependency and are re-exports of the same
+    #     objects, so they may be imported from either module.
     if "uipath_langchain.guardrails" not in src:
         sys.exit(
             "FAIL: graph.py never imports from uipath_langchain.guardrails. Without it the "
             "LangChain guardrail adapter is not registered and every guardrail silently "
-            "no-ops. Import guardrail/validators from uipath_langchain.guardrails."
+            "no-ops. Import the guardrail decorator / middleware from uipath_langchain.guardrails."
         )
-    if re.search(r"from\s+uipath\.platform\.guardrails\s+import", src):
+    platform_wrapping = sorted(
+        {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "uipath.platform.guardrails"
+            for alias in node.names
+            if alias.name == "guardrail"
+            or alias.name.endswith("Middleware")
+            or alias.name == "*"
+        }
+    )
+    if platform_wrapping:
         sys.exit(
-            "FAIL: graph.py imports guardrail symbols from uipath.platform.guardrails. Use "
-            "uipath_langchain.guardrails instead — the platform module exposes identical "
-            "names but does not register the adapter, so guardrails silently no-op."
+            f"FAIL: graph.py imports guardrail wrapping symbol(s) {platform_wrapping} from "
+            "uipath.platform.guardrails. The `guardrail` decorator and *Middleware classes "
+            "must come from uipath_langchain.guardrails — only that import registers the "
+            "LangChain adapter, without which the decorator/middleware never wraps the "
+            "LLM/tool/agent and the guardrail silently no-ops. (Validators, actions, and "
+            "enums may be imported from either module.)"
         )
-    print("OK: guardrail symbols imported from uipath_langchain.guardrails (adapter registers)")
+    print("OK: guardrail wrapping symbols imported from uipath_langchain.guardrails (adapter registers)")
 
-    # 2. Count distinct guardrails added.
+    # 2. Count distinct guardrails added. Middleware may be spread inline
+    #    (`[*Foo(...)]`) or via a variable (`m = Foo(...); [*m]`) — count both.
     decorator_matches = re.findall(r"@guardrail\s*\(", src)
-    middleware_matches = re.findall(r"\*([A-Za-z_][A-Za-z0-9_]*Middleware)\s*\(", src)
-    total = len(decorator_matches) + len(middleware_matches)
+    middleware_spreads = [
+        c for c in spread_middleware_calls(tree) if (call_name(c) or "").endswith("Middleware")
+    ]
+    total = len(decorator_matches) + len(middleware_spreads)
     if total < 2:
         sys.exit(
             f"FAIL: expected >= 2 guardrails, found {total} "
             f"(@guardrail decorators: {len(decorator_matches)}, "
-            f"*Middleware spreads: {len(middleware_matches)})"
+            f"*Middleware spreads: {len(middleware_spreads)})"
         )
     print(
         f"OK: {total} guardrail(s) added "
-        f"(@guardrail x{len(decorator_matches)}, *Middleware x{len(middleware_matches)})"
+        f"(@guardrail x{len(decorator_matches)}, *Middleware x{len(middleware_spreads)})"
     )
 
     # 3. LLM-scoped adversarial-input guardrail
@@ -129,10 +158,18 @@ def main() -> None:
     print(f"OK: content-safety guardrail(s) present: {sorted(content_hits)}")
 
     # 5. Every middleware class must be spread with `*` — no bare middleware object
-    #    in middleware=[...]. Look for "<ClassName>Middleware(" not preceded by "*".
-    bare_middleware = re.findall(r"(?<!\*)\b([A-Za-z_][A-Za-z0-9_]*Middleware)\s*\(", src)
-    # Filter to only those that are actually used (also appear in middleware spread or as bare)
-    # — but the regex above already finds the bare uses. Any hit is a violation.
+    #    in middleware=[...]. A `…Middleware(...)` call is bare iff it is never spread,
+    #    whether inline (`[*Foo(...)]`) or via a variable (`m = Foo(...); [*m]`).
+    spread_ids = {id(c) for c in spread_middleware_calls(tree)}
+    bare_middleware = sorted(
+        {
+            call_name(node)
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and (call_name(node) or "").endswith("Middleware")
+            and id(node) not in spread_ids
+        }
+    )
     if bare_middleware:
         sys.exit(
             f"FAIL: middleware class(es) not spread with `*`: {bare_middleware}. "

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/check_recommend_scoped.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/check_recommend_scoped.py
@@ -12,9 +12,15 @@ Validates:
 """
 
 import ast
-import re
+import os
 import sys
 from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import spread_middleware_calls  # noqa: E402
 
 GRAPH = Path("graph.py")
 TARGET_TOOL = "lookup_account_info"
@@ -66,18 +72,13 @@ def attr_chain(node: ast.expr) -> str | None:
 def find_middleware_with_target_tool(tree: ast.AST) -> list[str]:
     """Find *<X>Middleware(...) spread calls whose kwargs include
     scopes containing GuardrailScope.TOOL and tools containing the bare identifier
-    TARGET_TOOL.
+    TARGET_TOOL. Accepts inline (`[*Foo(...)]`) and variable
+    (`m = Foo(...); middleware=[*m]`) spreads.
 
     Returns matching middleware class names (or [] if none).
     """
     hits: list[str] = []
-    for node in ast.walk(tree):
-        # `*Foo(...)` inside a list/call appears as ast.Starred(value=ast.Call(...))
-        if not isinstance(node, ast.Starred):
-            continue
-        call = node.value
-        if not isinstance(call, ast.Call):
-            continue
+    for call in spread_middleware_calls(tree):
         name = deco_name(call)
         if not name or not name.endswith("Middleware"):
             continue
@@ -111,22 +112,42 @@ def main() -> None:
         sys.exit(f"FAIL: graph.py no longer parses as Python: {e}")
     print("OK: graph.py parses as valid Python")
 
-    # 1b. Adapter-registration import: guardrail symbols must come from
-    #     uipath_langchain.guardrails (registers the LangChain adapter as an import
-    #     side effect). Importing from uipath.platform.guardrails makes guardrails no-op.
+    # 1b. Adapter-registration import. The guardrail WRAPPING symbols — the
+    #     `guardrail` decorator and the *Middleware classes — must come from
+    #     uipath_langchain.guardrails, whose import registers the LangChain adapter as a
+    #     side effect. A wrapping symbol imported from uipath.platform.guardrails bypasses
+    #     that registration and the guardrail silently no-ops. Bare validators
+    #     (CustomValidator, PIIValidator, …), action classes, entity enums, and
+    #     GuardrailScope carry no adapter dependency and are re-exports of the same
+    #     objects, so they may be imported from either module.
     if "uipath_langchain.guardrails" not in src:
         sys.exit(
             "FAIL: graph.py never imports from uipath_langchain.guardrails. Without it the "
-            "LangChain guardrail adapter is not registered and the guardrail silently "
-            "no-ops. Import guardrail/validators from uipath_langchain.guardrails."
+            "LangChain guardrail adapter is not registered and every guardrail silently "
+            "no-ops. Import the guardrail decorator / middleware from uipath_langchain.guardrails."
         )
-    if re.search(r"from\s+uipath\.platform\.guardrails\s+import", src):
+    platform_wrapping = sorted(
+        {
+            alias.name
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ImportFrom)
+            and node.module == "uipath.platform.guardrails"
+            for alias in node.names
+            if alias.name == "guardrail"
+            or alias.name.endswith("Middleware")
+            or alias.name == "*"
+        }
+    )
+    if platform_wrapping:
         sys.exit(
-            "FAIL: graph.py imports guardrail symbols from uipath.platform.guardrails. Use "
-            "uipath_langchain.guardrails instead — the platform module exposes identical "
-            "names but does not register the adapter, so the guardrail silently no-ops."
+            f"FAIL: graph.py imports guardrail wrapping symbol(s) {platform_wrapping} from "
+            "uipath.platform.guardrails. The `guardrail` decorator and *Middleware classes "
+            "must come from uipath_langchain.guardrails — only that import registers the "
+            "LangChain adapter, without which the decorator/middleware never wraps the "
+            "LLM/tool/agent and the guardrail silently no-ops. (Validators, actions, and "
+            "enums may be imported from either module.)"
         )
-    print("OK: guardrail symbols imported from uipath_langchain.guardrails (adapter registers)")
+    print("OK: guardrail wrapping symbols imported from uipath_langchain.guardrails (adapter registers)")
 
     # 2. lookup_account_info must still be the tool (sanity — the fixture defines it).
     has_target = any(

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
@@ -24,9 +24,9 @@ sandbox:
       path: ../_fixtures/SimpleCodedAgent
 
 initial_prompt: |
-  I have a coded LangGraph agent in graph.py. It handles customer support questions.
-  The LLM is created in a create_llm() factory function. I want to add a user prompt
-  attacks detection guardrail using the decorator style at LLM scope — adversarial
+  I have a coded UiPath LangGraph agent in graph.py. It handles customer support questions.
+  The LLM is created in a create_llm() factory function. I want to add a UiPath user prompt
+  attacks guardrail using the decorator style at LLM scope — adversarial
   inputs should be blocked before they reach the LLM.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or feedback.
@@ -34,6 +34,13 @@ initial_prompt: |
   end-to-end in a single pass.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: run_command
     description: "User prompt attacks decorator guardrail correctly added to graph.py"
     command: "python3 $TASK_DIR/check_user_prompt_attacks_decorator.py"


### PR DESCRIPTION
## What changed?

Fixes four coded-guardrail eval failures. In every case the **skill produced valid code** — the failures were grader/test bugs, not skill regressions. No skill content changed.

**1. Over-broad `uipath.platform.guardrails` import guard** (`check_recommend_all.py`, `check_recommend_scoped.py`)
Narrowed it to flag only the guardrail *wrapping* symbols (the `guardrail` decorator and `*Middleware` classes), not bare validators like `CustomValidator` — which `uipath_langchain.guardrails` re-exports. A valid mixed import no longer fails with a false "guardrails silently no-op" verdict.

**2. Inline-only middleware-spread assumption** (`check_pii_middleware.py`, `check_recommend_all.py`, `check_recommend_scoped.py`)
The graders matched only the inline form `middleware=[*Foo(...)]` and rejected the functionally-identical variable form `m = Foo(...); middleware=[*m]`. Replaced the brittle regexes with a shared AST helper (`_shared/guardrail_middleware.py`) that resolves `*`-spreads inline **and** through one level of variable indirection.

**3. Skill misrouting** (`user_prompt_attacks_decorator.yaml`)
The agent loaded the global `claude-api` skill instead of `uipath-agents` and hand-rolled an Anthropic-SDK guardrail. Anchored the prompt to UiPath and added a `skill_triggered` success criterion asserting `uipath-agents` was loaded.

Failing runs that motivated this:
- `recommend-all` — false platform-import failure
- `pii-middleware` — variable-spread rejected
- `user-prompt-attacks-decorator` — wrong skill loaded

## How has this been tested?

- **Graders, locally:** each modified check run against representative `graph.py` forms — inline ✅, variable-spread ✅, bare (no `*`) ❌-as-expected, missing ❌-as-expected; `recommend_scoped` decorator path still ✅; the original `recommend_all` artifact still passes (same "6 guardrails" count, now via AST). All four scripts `py_compile` clean.
- **`user_prompt_attacks_decorator`:** `/lint-task` verdict OK; the unchanged grader still passes a correct decorator-style artifact.
- **End-to-end — `run-coder-eval` dispatched twice on this branch over the 4 tasks (`parallelism=4`). 8/8 SUCCESS, score 1.0, all on `claude-sonnet-4-6`:**

  | Task | Run #1 | Run #2 |
  |------|:------:|:------:|
  | recommend-all | ✅ 1.0 | ✅ 1.0 |
  | recommend-scoped | ✅ 1.0 | ✅ 1.0 |
  | pii-middleware | ✅ 1.0 | ✅ 1.0 |
  | user-prompt-attacks-decorator | ✅ 1.0 | ✅ 1.0 |

  Confirms each fix end-to-end: pii-middleware's variable-then-spread form now passes (the original failure); the `skill_triggered` guard confirmed `uipath-agents` loaded (not `claude-api`) both times; recommend-all/scoped still pass with no regression. Runs: [27772637552](https://github.com/UiPath/skills/actions/runs/27772637552) · [27772644873](https://github.com/UiPath/skills/actions/runs/27772644873).

## Are there any breaking changes?

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)
