### PR TITLE
test(ixp): model-lifecycle smoke coverage — move tag + publish staging

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -2,8 +2,8 @@ task_id: skill-ixp-move-tag-smoke
 description: >
   Smoke: agent moves the `live` tag from one version to another by
   re-publishing the target with `--tag live`.
-  Trap: a tag is a single pointer — moving it does NOT require untag first,
-  and there is no retag command. The agent must not untag/retag.
+  Trap: a tag is a single pointer — moving it does NOT require untag first;
+  the agent must not untag.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -31,8 +31,8 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  # Trap: re-pointing a single-pointer tag needs only `publish --tag`; using
-  # untag (or inventing a retag flow) shows a misunderstanding of tag moves.
+  # The publish above already moves the tag; untagging the old version first
+  # is unnecessary and wrong.
   - type: command_not_executed
     description: "Agent did NOT untag (moving a tag does not require untag first)"
     tool_name: "Bash"

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -1,0 +1,50 @@
+task_id: skill-ixp-move-tag-smoke
+description: >
+  Smoke: agent moves the `live` tag from one version to another by
+  re-publishing the target with `--tag live`
+  (`uip ixp projects publish <Name> --model-version 16 --tag live`).
+  Trap: a tag is a single pointer — moving it does NOT require untag first,
+  and there is no retag command. The agent must not untag/retag.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project `my_invoices-f1afa9ef-ixp`, the `live` tag is currently
+  on model version 15. Make version 16 live instead.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent moved live to v16 via `projects publish <Name> --model-version 16 --tag live`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+publish\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*(--model-version|-m)\s+16\b)(?=.*--tag\s+["'']?live\b).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # Trap: re-pointing a single-pointer tag needs only `publish --tag`; using
+  # untag (or inventing a retag flow) shows a misunderstanding of tag moves.
+  - type: command_not_executed
+    description: "Agent did NOT untag (moving a tag does not require untag first)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+untag\b'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-move-tag-smoke
 description: >
   Smoke: agent moves the `live` tag from one version to another by
-  re-publishing the target with `--tag live`
-  (`uip ixp projects publish <Name> --model-version 16 --tag live`).
+  re-publishing the target with `--tag live`.
   Trap: a tag is a single pointer — moving it does NOT require untag first,
   and there is no retag command. The agent must not untag/retag.
 

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-publish-tag-staging-smoke
 description: >
-  Smoke: agent publishes a version and tags it staging with
-  `uip ixp projects publish <Name> --model-version 15 --tag staging`.
-  Pins the version and applies the staging tag (not live).
+  Smoke: agent publishes model version 15 and tags it staging — pins the
+  version and applies the staging tag (not live).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -1,0 +1,39 @@
+task_id: skill-ixp-publish-tag-staging-smoke
+description: >
+  Smoke: agent publishes a version and tags it staging with
+  `uip ixp projects publish <Name> --model-version 15 --tag staging`.
+  Pins the version and applies the staging tag (not live).
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project `my_invoices-f1afa9ef-ixp`, publish model version 15
+  and tag it as staging.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent published v15 with the staging tag via `projects publish <Name> --model-version 15 --tag staging`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+publish\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*(--model-version|-m)\s+15\b)(?=.*--tag\s+["'']?staging\b).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -1,7 +1,7 @@
 task_id: skill-ixp-publish-tag-staging-smoke
 description: >
   Smoke: agent publishes model version 15 and tags it staging — pins the
-  version and applies the staging tag (not live).
+  version and applies the staging tag.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.


### PR DESCRIPTION
## Summary

Completes the model-lifecycle smoke coverage for the `uipath-ixp` skill, building on the `publish_tag_live` / `unpublish` / `untag` tasks.

Adds two smoke tasks (grade command shape, unauthenticated):

- **`move_tag.yaml`** (`skill-ixp-move-tag-smoke`) — **ACTV-88719**: move the `live` tag to another version via `projects publish --model-version 16 --tag live`. Trap guard: a single-pointer tag moves by re-publishing the target — the agent must **not** untag first or invent a retag command.
- **`publish_tag_staging.yaml`** (`skill-ixp-publish-tag-staging-smoke`) — **ACTV-88718**: `projects publish --model-version 15 --tag staging` (pins + applies staging, not live).

Resolves **ACTV-88718**, **ACTV-88719**.