### PR TITLE
test(ixp): taxonomy groups & data-types smoke coverage

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -1,0 +1,44 @@
+task_id: skill-ixp-create-choice-type-smoke
+description: >
+  Smoke: agent creates a custom Choice data type with three options and
+  instructions — `uip ixp data-types add <Name> --name "clause presence"
+  --kind choice --choices '<json>' --instructions … --input-value inferred`.
+  --kind choice requires --choices.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, create a new Field Type named
+  "clause presence" of data type Choice with the display values: True, False,
+  not present. Instructions: output "not present" if the document has no
+  termination-by-counterparty clause; "True" if the clause is present and
+  obliges the parties to auto-renew; "False" if it is present but does not
+  oblige auto-renewal.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the choice type via `data-types add … --kind choice … --choices`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+data-types\s+add\b(?=.*clause presence)(?=.*--kind\s+choice)(?=.*--choices).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-create-choice-type-smoke
 description: >
   Smoke: agent creates a custom Choice data type with three options and
-  instructions (`data-types add --kind choice` with `--choices`; --kind
-  choice requires --choices).
+  instructions.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -28,7 +28,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created the choice type via `data-types add … --kind choice … --choices`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+data-types\s+add\b(?=.*clause presence)(?=.*--kind\s+choice)(?=.*--choices).*'
+    command_pattern: 'uip\s+ixp\s+data-types\s+add\b(?=.*clause presence)(?=.*--kind\s+choice)(?=.*--choices)(?=.*[Tt]rue)(?=.*[Ff]alse)(?=.*[Nn]ot[ _-]?[Pp]resent)(?=.*--instructions).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -28,7 +28,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created the choice type via `data-types add … --kind choice … --choices`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+data-types\s+add\b(?=.*clause presence)(?=.*--kind\s+choice)(?=.*--choices)(?=.*[Tt]rue)(?=.*[Ff]alse)(?=.*[Nn]ot[ _-]?[Pp]resent)(?=.*--instructions).*'
+    command_pattern: 'uip\s+ixp\s+data-types\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*clause presence)(?=.*--kind\s+choice)(?=.*--choices)(?=.*[Tt]rue)(?=.*[Ff]alse)(?=.*[Nn]ot[ _-]?[Pp]resent)(?=.*--instructions).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -1,9 +1,8 @@
 task_id: skill-ixp-create-choice-type-smoke
 description: >
   Smoke: agent creates a custom Choice data type with three options and
-  instructions — `uip ixp data-types add <Name> --name "clause presence"
-  --kind choice --choices '<json>' --instructions … --input-value inferred`.
-  --kind choice requires --choices.
+  instructions (`data-types add --kind choice` with `--choices`; --kind
+  choice requires --choices).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -1,8 +1,9 @@
 task_id: skill-ixp-create-field-group-smoke
 description: >
   Smoke: agent creates a field group with several fields in one call. The
-  user gives no field types, so the agent must default sensibly (or ask) and
-  supply instructions per field.
+  user gives no field types, so the agent must pick sensible default types
+  (the CLI requires a type per field) and supply instructions per field —
+  Critical Rule 2 says run automatically, don't stop to ask.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -1,9 +1,8 @@
 task_id: skill-ixp-create-field-group-smoke
 description: >
-  Smoke: agent creates a field group with several fields in one call. The
-  user gives no field types, so the agent must pick sensible default types
-  (the CLI requires a type per field) and supply instructions per field —
-  Critical Rule 2 says run automatically, don't stop to ask.
+  Smoke: agent creates a field group and all its fields in ONE batch call —
+  not one call per field. The user gives no field types, so the agent
+  defaults them and proceeds (it must not stop to ask).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -25,9 +24,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent created the group via `groups add … --name \"Subscriber information\" … --fields`"
+    description: "Agent created the group with multiple fields in one `groups add … --fields` call (batch)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)(?=.*--fields).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)(?=.*--fields)(?=.*surname)(?=.*address)(?=.*phone number).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -1,8 +1,8 @@
 task_id: skill-ixp-create-field-group-smoke
 description: >
-  Smoke: agent creates a field group with several fields in one call
-  (`groups add` with `--fields`). The user gives no field types, so the agent
-  must default sensibly (or ask) and supply instructions per field.
+  Smoke: agent creates a field group with several fields in one call. The
+  user gives no field types, so the agent must default sensibly (or ask) and
+  supply instructions per field.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -1,0 +1,41 @@
+task_id: skill-ixp-create-field-group-smoke
+description: >
+  Smoke: agent creates a field group with several fields in one call —
+  `uip ixp groups add <Name> --name "Subscriber information" --instructions …
+  --fields '<json with 6 fields>'`. The user gives no field types, so the
+  agent must default sensibly (or ask) and supply instructions per field.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
+  "Subscriber information" with fields: name, surname, address, bank account,
+  phone number, customer unique identifier.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the group via `groups add … --name \"Subscriber information\" … --fields`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*Subscriber information)(?=.*--fields).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -13,8 +13,8 @@ run_limits:
 
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
-  "Subscriber information" with fields: name, surname, address, bank account,
-  phone number, customer unique identifier.
+  "Subscriber information" with fields: surname, address, bank account, and
+  phone number.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -26,7 +26,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created the group with multiple fields in one `groups add … --fields` call (batch)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)(?=.*--fields)(?=.*surname)(?=.*address)(?=.*phone number).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)(?=.*--fields)(?=.*surname)(?=.*address)(?=.*bank account)(?=.*phone number).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -1,9 +1,8 @@
 task_id: skill-ixp-create-field-group-smoke
 description: >
-  Smoke: agent creates a field group with several fields in one call —
-  `uip ixp groups add <Name> --name "Subscriber information" --instructions …
-  --fields '<json with 6 fields>'`. The user gives no field types, so the
-  agent must default sensibly (or ask) and supply instructions per field.
+  Smoke: agent creates a field group with several fields in one call
+  (`groups add` with `--fields`). The user gives no field types, so the agent
+  must default sensibly (or ask) and supply instructions per field.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -27,7 +27,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created the group via `groups add … --name \"Subscriber information\" … --fields`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*Subscriber information)(?=.*--fields).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)(?=.*--fields).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent deleted the group via `groups delete … --confirm-data-loss`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+delete\b(?=.*--confirm-data-loss).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+delete\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*name group)(?=.*--confirm-data-loss).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent deleted the group via `groups delete … --confirm-data-loss`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+delete\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*name group)(?=.*--confirm-data-loss).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+delete\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--name\s+["'']?name group)(?=.*--confirm-data-loss).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -1,0 +1,40 @@
+task_id: skill-ixp-delete-field-group-smoke
+description: >
+  Smoke: agent deletes a field group with
+  `uip ixp groups delete <Name> --name "name group" --confirm-data-loss`.
+  Destructive cascade — deleting the group drops all annotations on all its
+  fields; the CLI refuses without --confirm-data-loss.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, delete the field group
+  "name group".
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent deleted the group via `groups delete … --confirm-data-loss`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+groups\s+delete\b(?=.*--confirm-data-loss).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -1,9 +1,8 @@
 task_id: skill-ixp-delete-field-group-smoke
 description: >
-  Smoke: agent deletes a field group with
-  `uip ixp groups delete <Name> --name "name group" --confirm-data-loss`.
-  Destructive cascade — deleting the group drops all annotations on all its
-  fields; the CLI refuses without --confirm-data-loss.
+  Smoke: agent deletes a field group — a destructive cascade that drops all
+  annotations on all its fields, so it must pass --confirm-data-loss (the CLI
+  refuses without it).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
@@ -1,9 +1,8 @@
 task_id: skill-ixp-group-instructions-smoke
 description: >
-  Smoke: agent updates a field group's instructions with
-  `uip ixp groups update-prompts <Name> --updates '[{"name":"Invoice Header",
-  "instructions":"…"}]'`. Updates the group (label_def) instructions only;
-  fields are untouched.
+  Smoke: agent updates a field group's instructions via
+  `groups update-prompts --updates`. Updates the group (label_def)
+  instructions only; fields are untouched.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
@@ -1,0 +1,41 @@
+task_id: skill-ixp-group-instructions-smoke
+description: >
+  Smoke: agent updates a field group's instructions with
+  `uip ixp groups update-prompts <Name> --updates '[{"name":"Invoice Header",
+  "instructions":"…"}]'`. Updates the group (label_def) instructions only;
+  fields are untouched.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, update the instructions for the
+  field group "Invoice Header" to: "Header section of the invoice — vendor,
+  invoice number, dates, and totals."
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent updated group instructions via `groups update-prompts … --updates`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*--updates).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent updated group instructions via `groups update-prompts … --updates`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*--updates).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Invoice Header)(?=.*--updates).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/group_instructions.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-group-instructions-smoke
 description: >
-  Smoke: agent updates a field group's instructions via
-  `groups update-prompts --updates`. Updates the group (label_def)
-  instructions only; fields are untouched.
+  Smoke: agent updates a field group's instructions only — its fields are
+  untouched.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -24,7 +24,7 @@ success_criteria:
   - type: command_executed
     description: "Agent renamed the group via `groups rename … --new-name \"Consumption\"`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+rename\b(?=.*Consumption).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+rename\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*rename me 2)(?=.*Consumption).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -1,0 +1,47 @@
+task_id: skill-ixp-rename-field-group-smoke
+description: >
+  Smoke: agent renames a field group with
+  `uip ixp groups rename <Name> --name "rename me 2" --new-name "Consumption"`.
+  Preserves the group's fields and annotations; the agent must NOT
+  delete/recreate.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, rename the field group
+  "rename me 2" to "Consumption".
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent renamed the group via `groups rename … --new-name \"Consumption\"`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+groups\s+rename\b(?=.*Consumption).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did NOT delete the group (rename must not destroy it)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+groups\s+delete\b'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -1,7 +1,7 @@
 task_id: skill-ixp-rename-field-group-smoke
 description: >
-  Smoke: agent renames a field group via `groups rename`. Preserves the
-  group's fields and annotations; the agent must NOT delete/recreate.
+  Smoke: agent renames a field group. Preserves the group's fields and
+  annotations; the agent must NOT delete/recreate.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -12,7 +12,7 @@ run_limits:
 
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, rename the field group
-  "rename me 2" to "Consumption".
+  "Usage" to "Consumption".
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -24,7 +24,7 @@ success_criteria:
   - type: command_executed
     description: "Agent renamed the group via `groups rename … --new-name \"Consumption\"`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+rename\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*rename me 2)(?=.*Consumption).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+rename\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--name\s+["'']?Usage)(?=.*--new-name\s+["'']?Consumption).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -1,9 +1,7 @@
 task_id: skill-ixp-rename-field-group-smoke
 description: >
-  Smoke: agent renames a field group with
-  `uip ixp groups rename <Name> --name "rename me 2" --new-name "Consumption"`.
-  Preserves the group's fields and annotations; the agent must NOT
-  delete/recreate.
+  Smoke: agent renames a field group via `groups rename`. Preserves the
+  group's fields and annotations; the agent must NOT delete/recreate.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -22,11 +22,22 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent set the new instructions on \"Invoice Header\" via `groups update-prompts --updates`"
+    description: "Agent ran `groups update-prompts … --updates` on the project"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--updates)(?=.*Invoice Header)(?=.*Header section of the invoice).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--updates).*'
     min_count: 1
     weight: 3.0
+    pass_threshold: 1.0
+
+  # The skill builds --updates via a heredoc, so the group name + instruction
+  # text live in the `cat > …json` command, not on the update-prompts line.
+  # Verify the payload was constructed (matches the heredoc, or an inline JSON).
+  - type: command_executed
+    description: "Agent built the payload targeting \"Invoice Header\" with the new instructions"
+    tool_name: "Bash"
+    command_pattern: '(?=.*Invoice Header)(?=.*Header section of the invoice).*'
+    min_count: 1
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -22,9 +22,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent updated group instructions via `groups update-prompts … --updates`"
+    description: "Agent set the new instructions on \"Invoice Header\" via `groups update-prompts --updates`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*Invoice Header)(?=.*--updates).*'
+    command_pattern: 'uip\s+ixp\s+groups\s+update-prompts\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--updates)(?=.*Invoice Header)(?=.*Header section of the invoice).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -1,7 +1,6 @@
-task_id: skill-ixp-group-instructions-smoke
+task_id: skill-ixp-update-group-instructions-smoke
 description: >
-  Smoke: agent updates a field group's instructions only — its fields are
-  untouched.
+  Smoke: agent updates a field group's instructions.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.


### PR DESCRIPTION
## Summary

Smoke coverage for the `uip ixp groups` and `uip ixp data-types` command groups. All grade command shape, unauthenticated.

- **`create_field_group.yaml`** — **ACTV-88679**: batch create a group + multiple fields in one `groups add --fields` call (verifies several field names land together).
- **`delete_field_group.yaml`** — **ACTV-88685**: `groups delete … --confirm-data-loss` (destructive cascade).
- **`rename_field_group.yaml`** — **ACTV-88686**: `groups rename` (anchored on `--name`/`--new-name`); guards against delete.
- **`update_group_instructions.yaml`** — **ACTV-88705**: `groups update-prompts --updates`.
- **`create_choice_type.yaml`** — **ACTV-88691**: `data-types add --kind choice --choices` (verifies the three option values + instructions).

Sensible-default-field-type verification (when types are unspecified) is split out to the integration umbrella ACTV-88563.

## Note: heredoc workflow in `update_group_instructions`

The skill (Critical Rule 5) builds `--updates` through a heredoc file, so the agent runs **three** commands:

```bash
mkdir -p /tmp/ixp/<project>/{docs,taxonomies,prompts}

cat > /tmp/ixp/<project>/prompts/group_updates.json << 'HEREDOC'
[{"name":"Invoice Header","instructions":"Header section of the invoice — …"}]
HEREDOC

uip ixp groups update-prompts <project> --updates "$(cat /tmp/ixp/<project>/prompts/group_updates.json)" --output json
```

The group name + instruction text live in the **heredoc** (command 2), not on the `update-prompts` line (command 3, where `--updates` is just `"$(cat …)"`). So that task's criteria are split to match the command that actually carries each piece: a **shape** check (`groups update-prompts … --updates`) against the `uip` line, and a **content** check (`Invoice Header` + the instruction snippet) against the heredoc.

Resolves **ACTV-88679**, **ACTV-88685**, **ACTV-88686**, **ACTV-88705**, **ACTV-88691**.
