### PR TITLE
test(ixp): predictions & metrics smoke coverage

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -1,8 +1,8 @@
 task_id: skill-ixp-confirm-all-predictions-smoke
 description: >
-  Smoke: agent confirms every prediction as ground truth via
-  `uip ixp labellings confirm <Name> <document-id>` without `--fields`
-  (bulk-confirms all predicted fields). Project-wide means looping documents.
+  Smoke: agent confirms all predictions on a document as ground truth via
+  `labellings confirm <Name> <document-id>` with no `--fields` (the no-field
+  form bulk-confirms every predicted field in that document).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -12,8 +12,8 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  In the IXP project my_invoices-f1afa9ef-ixp, confirm every prediction as
-  ground truth.
+  In the IXP project my_invoices-f1afa9ef-ixp, confirm all predictions on
+  document doc-abc-123 as ground truth.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -23,9 +23,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent bulk-confirmed predictions via `labellings confirm`"
+    description: "Agent bulk-confirmed all predictions on doc-abc-123 via `labellings confirm` (no --fields)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp).*'
+    command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*doc-abc-123).*'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -1,0 +1,39 @@
+task_id: skill-ixp-confirm-all-predictions-smoke
+description: >
+  Smoke: agent confirms every prediction as ground truth via
+  `uip ixp labellings confirm <Name> <document-id>` without `--fields`
+  (bulk-confirms all predicted fields). Project-wide means looping documents.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, confirm every prediction as
+  ground truth.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent bulk-confirmed predictions via `labellings confirm`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -29,6 +29,15 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
+  # "Confirm all" = the no-field form. Scoping with --fields would confirm
+  # only specific fields, not every prediction — so it must NOT appear.
+  - type: command_not_executed
+    description: "Agent did NOT scope the confirm with --fields (bulk-confirms all predicted fields)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b.*--fields'
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent used --output json on a uip ixp command"
     tool_name: "Bash"

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-confirm-all-predictions-smoke
 description: >
-  Smoke: agent confirms all predictions on a document as ground truth via
-  `labellings confirm <Name> <document-id>` with no `--fields` (the no-field
-  form bulk-confirms every predicted field in that document).
+  Smoke: agent confirms all predictions on a document as ground truth — the
+  no-`--fields` form bulk-confirms every predicted field in that document.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -22,7 +22,7 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent bulk-confirmed all predictions on doc-abc-123 via `labellings confirm` (no --fields)"
+    description: "Agent confirmed predictions on doc-abc-123 via `labellings confirm`"
     tool_name: "Bash"
     command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*doc-abc-123).*'
     min_count: 1

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-metrics-for-version-smoke
 description: >
   Smoke: agent fetches validation metrics scoped to one model version
-  (`get-metrics --model-version 14`) — that version's per-field/per-group
-  scores, not the latest.
+  (version 14) — that version's per-field/per-group scores, not the latest.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -1,8 +1,8 @@
 task_id: skill-ixp-metrics-for-version-smoke
 description: >
-  Smoke: agent fetches validation metrics scoped to one model version with
-  `uip ixp projects get-metrics <Name> --model-version 14`. Returns that
-  version's per-field/per-group scores, not the latest.
+  Smoke: agent fetches validation metrics scoped to one model version
+  (`get-metrics --model-version 14`) — that version's per-field/per-group
+  scores, not the latest.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -1,0 +1,38 @@
+task_id: skill-ixp-metrics-for-version-smoke
+description: >
+  Smoke: agent fetches validation metrics scoped to one model version with
+  `uip ixp projects get-metrics <Name> --model-version 14`. Returns that
+  version's per-field/per-group scores, not the latest.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, get the metrics for version 14.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched version-scoped metrics via `get-metrics … --model-version 14`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+get-metrics\b(?=.*(--model-version|-m)\s+14\b).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -1,0 +1,40 @@
+task_id: skill-ixp-pick-capable-model-smoke
+description: >
+  Smoke: faced with long, inference-heavy documents and low Flash F1, the agent
+  switches to a more capable model via
+  `uip ixp projects configure-model <Name> --model gemini_2_5_pro`.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, the documents are 150-page
+  filings with many inferred fields, and the current Flash model's F1 is low.
+  Switch to a more capable model.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent switched to a more capable model via `configure-model --model gemini_2_5_pro`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+configure-model\b(?=.*--model\s+gemini_2_5_pro\b).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -1,8 +1,8 @@
 task_id: skill-ixp-pick-capable-model-smoke
 description: >
-  Smoke: faced with long, inference-heavy documents and low Flash F1, the agent
-  switches to a more capable model via
-  `uip ixp projects configure-model <Name> --model gemini_2_5_pro`.
+  Smoke: faced with long, inference-heavy documents and low Flash F1, the
+  agent switches to a more capable model via `configure-model --model
+  gemini_2_5_pro`.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -22,10 +22,8 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
-  # Deterministic answer is gemini_2_5_pro (not gpt_4o): the skill's
-  # project-setup-guide maps "very long documents (100+ pages)" to
-  # gemini_2_5_pro, and the prompt's 150-page filings trigger that rule.
-  # gpt_4o would be the wrong call for 150-page docs (smaller context).
+  # Deterministic: the skill maps 100+ page docs to gemini_2_5_pro, which the
+  # 150-page prompt triggers (so gpt_4o would be wrong here).
   - type: command_executed
     description: "Agent switched to a more capable model via `configure-model --model gemini_2_5_pro`"
     tool_name: "Bash"

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -1,8 +1,7 @@
 task_id: skill-ixp-pick-capable-model-smoke
 description: >
   Smoke: faced with long, inference-heavy documents and low Flash F1, the
-  agent switches to a more capable model via `configure-model --model
-  gemini_2_5_pro`.
+  agent switches to a more capable model (Gemini Pro).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -22,6 +22,10 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
+  # Deterministic answer is gemini_2_5_pro (not gpt_4o): the skill's
+  # project-setup-guide maps "very long documents (100+ pages)" to
+  # gemini_2_5_pro, and the prompt's 150-page filings trigger that rule.
+  # gpt_4o would be the wrong call for 150-page docs (smaller context).
   - type: command_executed
     description: "Agent switched to a more capable model via `configure-model --model gemini_2_5_pro`"
     tool_name: "Bash"

--- a/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
+++ b/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
@@ -1,0 +1,38 @@
+task_id: skill-ixp-refresh-prediction-smoke
+description: >
+  Smoke: agent fetches the model's prediction for one document with
+  `uip ixp labellings get-predictions <Name> doc-abc-123`.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, refresh the prediction for
+  document doc-abc-123.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched predictions via `labellings get-predictions … doc-abc-123`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+get-predictions\b(?=.*doc-abc-123).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on a uip ixp command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
+++ b/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
@@ -1,7 +1,7 @@
 task_id: skill-ixp-refresh-prediction-smoke
 description: >
-  Smoke: agent fetches the model's prediction for one document with
-  `uip ixp labellings get-predictions <Name> doc-abc-123`.
+  Smoke: agent fetches the model's prediction for one document via
+  `labellings get-predictions`.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
+++ b/tests/tasks/uipath-ixp/smoke/refresh_prediction.yaml
@@ -1,7 +1,6 @@
 task_id: skill-ixp-refresh-prediction-smoke
 description: >
-  Smoke: agent fetches the model's prediction for one document via
-  `labellings get-predictions`.
+  Smoke: agent fetches the model's prediction for one document.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.

--- a/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
@@ -1,6 +1,7 @@
-task_id: skill-ixp-refresh-prediction-smoke
+task_id: skill-ixp-show-predictions-smoke
 description: >
-  Smoke: agent fetches the model's prediction for one document.
+  Smoke: agent reads the model's predicted values for one document (the
+  prediction layer, via get-predictions — not by reading the file itself).
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -10,8 +11,8 @@ run_limits:
   expected_turns: 5
 
 initial_prompt: |
-  In the IXP project my_invoices-f1afa9ef-ixp, refresh the prediction for
-  document doc-abc-123.
+  In the IXP project my_invoices-f1afa9ef-ixp, show the values the model
+  predicted for document doc-abc-123.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in


### PR DESCRIPTION
## Summary

Smoke coverage for `uip ixp labellings` (predictions) and version-scoped metrics / model selection. All grade command shape, unauthenticated.

- **`refresh_prediction.yaml`** — **ACTV-88702**: `labellings get-predictions <doc>`.
- **`confirm_all_predictions.yaml`** — **ACTV-88712**: bulk `labellings confirm` (no `--fields`).
- **`metrics_for_version.yaml`** — **ACTV-88715**: `projects get-metrics --model-version 14`.
- **`pick_capable_model.yaml`** — **ACTV-88699**: `projects configure-model --model gemini_2_5_pro` for long/inference-heavy docs.

Resolves **ACTV-88699**, **ACTV-88702**, **ACTV-88712**, **ACTV-88715**.