### PR TITLE
chore: refresh uip CLI catalog (1.197.0-alpha.20260618.7591)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-18T05:40:43Z",
-  "cli_version": "1.197.0-alpha.20260617.7564",
+  "generated_at": "2026-06-19T05:47:39Z",
+  "cli_version": "1.197.0-alpha.20260618.7591",
   "verbs": [
     "admin",
     "admin audit",
@@ -298,6 +298,7 @@
     "api-workflow bindings",
     "api-workflow bindings sync",
     "api-workflow build",
+    "api-workflow init",
     "api-workflow pack",
     "api-workflow registry",
     "api-workflow registry resolve",
@@ -535,6 +536,8 @@
     "ixp projects list",
     "ixp projects list-models",
     "ixp projects publish",
+    "ixp projects unpublish",
+    "ixp projects untag",
     "ixp projects update-prompt",
     "ixp projects update-title",
     "llm-configuration",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.197.0-alpha.20260618.7591`. The catalog has 1223 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.