### PR TITLE
chore(tests): set 30-min turn_timeout on remaining planner tests

### DIFF
--- a/tests/tasks/uipath-planner/bpmn_vs_case_management/bpmn_vs_case_management.yaml
+++ b/tests/tasks/uipath-planner/bpmn_vs_case_management/bpmn_vs_case_management.yaml
@@ -6,6 +6,7 @@ skip: true
 
 run_limits:
   max_turns: 5
+  turn_timeout: 1800  # 30-min per-turn cap
 
 dataset:
   paths: ["bpmn_vs_case_management.jsonl"]

--- a/tests/tasks/uipath-planner/smoke_file_reading.yaml
+++ b/tests/tasks/uipath-planner/smoke_file_reading.yaml
@@ -8,6 +8,7 @@ tags: [uipath-planner, smoke, lifecycle:generate]
 
 run_limits:
   expected_turns: 6
+  turn_timeout: 1800  # 30-min per-turn cap
 
 initial_prompt: |
   Step 1 — Write the following content to `pdd.md` using the Write tool.

--- a/tests/tasks/uipath-planner/smoke_pdd_activation.yaml
+++ b/tests/tasks/uipath-planner/smoke_pdd_activation.yaml
@@ -9,6 +9,7 @@ tags: [uipath-planner, smoke, lifecycle:generate]
 
 run_limits:
   expected_turns: 4
+  turn_timeout: 1800  # 30-min per-turn cap
 
 initial_prompt: |
   I have a Process Design Document I want to turn into a UiPath solution

--- a/tests/tasks/uipath-planner/smoke_skill_activation.yaml
+++ b/tests/tasks/uipath-planner/smoke_skill_activation.yaml
@@ -9,6 +9,7 @@ tags: [uipath-planner, smoke, lifecycle:plan]
 
 run_limits:
   expected_turns: 4
+  turn_timeout: 1800  # 30-min per-turn cap
 
 initial_prompt: |
   Help me plan a UiPath solution from scratch — a multi-step process that


### PR DESCRIPTION
## What

Pins `turn_timeout: 1800` (30 minutes) on the 4 planner tests that were still inheriting the 900s experiment default:

- `tests/tasks/uipath-planner/smoke_file_reading.yaml`
- `tests/tasks/uipath-planner/smoke_pdd_activation.yaml`
- `tests/tasks/uipath-planner/smoke_skill_activation.yaml`
- `tests/tasks/uipath-planner/bpmn_vs_case_management/bpmn_vs_case_management.yaml` (`skip: true`)

## Why

The other 5 planner tests (`constraint_gate`, `gap_detection`, `e2e_rpa_sdd`, `pdd_to_sdd`, `product_selection`) already pin `turn_timeout: 1800`. This brings every planner test to a uniform 30-minute per-turn cap.

`turn_timeout` is in seconds; the experiment default is 900s. The cap is a ceiling, not a target — the quick activation smoke tests (4–6 turns) are unaffected in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)