### PR TITLE
test(uipath-troubleshoot): grade results via llm_judge only — drop command-path validation

### DIFF
--- a/tests/tasks/uipath-troubleshoot/healing-agent-invalid-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-invalid-license/task.yaml
@@ -48,30 +48,6 @@ success_criteria:
     path: .local/investigations/state.json
     weight: 0.5
 
-  - type: command_executed
-    description: "Agent fetched the faulted job to confirm Autopilot/Healing flags and RuntimeType (playbook step 2)"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+get\s+["\x27]?d2c90d73'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent fetched Error-level robot logs to find the 'No available license' line (playbook step 1)"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+logs\s+["\x27]?d2c90d73'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent read tenant license info to discriminate the playbook cause (#1 missing entitlement vs #7 exhausted) — playbook step 5"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+licenses\s+info'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: llm_judge
     description: "Agent matched healing-agent-no-license.md AND identified cause #1 (missing entitlement) as the root cause"
     weight: 3.0

--- a/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/healing-agent-no-license/task.yaml
@@ -74,38 +74,6 @@ success_criteria:
       - "package corruption"
     weight: 1.0
 
-  - type: command_executed
-    description: "Agent listed Faulted jobs in the Shared folder to discover the failing job key (no key was given in the prompt)"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+list\b[^|;&]*--state\s+Faulted'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent fetched the faulted job to confirm Autopilot/Healing flags and RuntimeType (playbook step 2)"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+get\s+["\x27]?cedeff5a'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent fetched Error-level robot logs to find the 'No available license' line (playbook step 1)"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+logs\s+["\x27]?cedeff5a'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent read tenant license info to discriminate the playbook cause (#1 missing entitlement vs #7 exhausted) — playbook step 5"
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+licenses\s+info'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: llm_judge
     description: "Agent matched healing-agent-no-license.md AND identified cause #1 (missing entitlement) as the root cause"
     weight: 3.0

--- a/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-alter-if-disabled/task.yaml
@@ -44,14 +44,6 @@ success_criteria:
     path: .local/investigations/state.json
     weight: 0.5
 
-  - type: command_executed
-    description: "Agent interrogated the faulted job via the uip CLI (uip or jobs get on the job key). Enforced here — not in the judge — so it stays robust across iterations and sub-agents."
-    tool_name: "Bash"
-    command_pattern: '(?<![\./\w])uip\s+or\s+jobs\s+get\s+["\x27]?49655b57'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
   - type: llm_judge
     description: "Agent matched the correct playbook AND reached the same conclusion as RESOLUTION.md"
     weight: 3.0
@@ -93,9 +85,9 @@ success_criteria:
         (disabled-element.md) in state.json's `matched_playbooks`.
         Acceptable: the agent also Reads neighboring playbooks during
         exploration.
-        (Orchestrator CLI interrogation is verified separately by a
-        command_executed criterion — do NOT grade it here, and do not
-        penalize based on which tool calls are or aren't visible.)
+        (Do NOT grade which tool calls are or aren't visible, and do not
+        penalize based on the investigation path taken — grade only the
+        playbook match, the root cause, and the fix.)
 
       DIMENSION B -- Correct fix per playbook branch (D)
         The reference fix names ALL of:

--- a/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-ambiguous-node-test/task.yaml
@@ -93,7 +93,7 @@ success_criteria:
 
       You must grade THREE dimensions in a single score:
 
-      DIMENSION A -- Correct playbook + actual CLI work
+      DIMENSION A -- Correct playbook
         The agent must match the UI-automation ambiguous-selector
         playbook (ambiguous-selector.md). It is acceptable for the
         agent to also Read neighboring playbooks (the selector-failure-*
@@ -105,14 +105,6 @@ success_criteria:
         `NodeNotFoundException` / `SelectorNotFoundException` — the
         zero-match cases. `NodeAmbiguousException` is the multiple-match
         case and has its own playbook.
-
-        Independently, the agent's tool-call history must show real
-        Orchestrator interrogation via the uip CLI — at minimum
-        `uip or jobs get <key>` on the faulted job, plus an inspection
-        of the workflow source (read Amb.xaml or equivalent). If the
-        agent reached a conclusion without invoking uip on the faulted
-        job AND without reading the workflow XAML, the playbook
-        dimension is failed regardless of which playbook was named.
 
       DIMENSION B -- Correct fix per playbook branch (B)
         The reference fix names ALL of:

--- a/tests/tasks/uipath-troubleshoot/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-node-not-found/task.yaml
@@ -73,17 +73,10 @@ success_criteria:
 
       You must grade BOTH dimensions in a single score:
 
-      DIMENSION A -- Correct playbook + actual CLI work
+      DIMENSION A -- Correct playbook
         The agent must match a UI-automation selector-failure playbook
         (selector-failure-healing-disabled.md OR selector-failure-manual.md
         OR no-recovery-data.md) in state.json's `matched_playbooks`.
-
-        Independently, the agent's tool-call history must show real
-        Orchestrator interrogation via the uip CLI — at minimum
-        `uip or jobs get <key>` on the faulted job. If the agent
-        reached a conclusion without invoking uip on the faulted job,
-        the playbook dimension is failed regardless of which playbook
-        was named.
 
       DIMENSION B -- Same root cause as RESOLUTION.md
         The reference root cause names ALL of:

--- a/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/uia-verify-execution-failure/task.yaml
@@ -92,21 +92,13 @@ success_criteria:
 
       You must grade THREE dimensions in a single score:
 
-      DIMENSION A -- Correct playbook + actual CLI work
+      DIMENSION A -- Correct playbook
         The agent must match the UI-automation verify-execution-failure
         playbook (verify-execution-failure.md). It is acceptable for
         the agent to also Read neighboring playbooks (e.g., the
         selector-failure-* family, timeout-issue, disabled-element)
         during exploration, but the conclusion must rest on
         verify-execution-failure.md.
-
-        Independently, the agent's tool-call history must show real
-        Orchestrator interrogation via the uip CLI — at minimum
-        `uip or jobs get <key>` on the faulted job, plus an inspection
-        of the workflow source (read ClickCase.xaml or equivalent).
-        If the agent reached a conclusion without invoking uip on the
-        faulted job AND without reading the workflow XAML, the playbook
-        dimension is failed regardless of which playbook was named.
 
       DIMENSION B -- Correct fix per playbook branch (D)
         The reference fix names ALL of:


### PR DESCRIPTION
Removes command-path validation from 6 `uipath-troubleshoot` scenarios so grading rests on the LLM judge's assessment of the **result**, not which `uip` commands the agent ran.

- **Layer 1** — deleted 8 `command_executed` criteria (`healing-agent-invalid-license`, `healing-agent-no-license`, `uia-alter-if-disabled`).
- **Layer 2** — dropped the DIMENSION A "actual CLI work / must invoke `uip or jobs get`" gate from the `uia-verify-execution-failure`, `uia-ambiguous-node-test`, and `uia-node-not-found` judges; reworded a now-dangling judge reference in `uia-alter-if-disabled`.

Self-edit / approval-gate and anti-`VerifyOptions` dimensions are untouched. Aligns with the directory's own `tests/tasks/uipath-troubleshoot/CLAUDE.md` guidance — command/file criteria "encode one specific path … and turn legitimate alternative solutions into false failures."

Re-validated locally (sonnet-4-6): **6/6 SUCCESS** (4 at 1.0; ambiguous 0.925 and node-not-found 0.933 — both sub-1.0s are DIMENSION B/C fix-quality variance with the playbook match confirmed correct, unrelated to this change).
