### PR TITLE
fix(tests): raise task_timeout on planner SDD e2e/integration tasks

### DIFF
--- a/tests/tasks/uipath-planner/constraint_gate/constraint_gate.yaml
+++ b/tests/tasks/uipath-planner/constraint_gate/constraint_gate.yaml
@@ -12,8 +12,12 @@ tags: [uipath-planner, integration, mode:build]
 run_limits:
   expected_turns: 16
   # Full Phase D SDD authoring runs in one unbroken autonomous turn (read PDD +
-  # guides, select scope, generate §1–§18). 1200s is too tight and times out
-  # before the SDD lands. See fix/planner-sdd-turn-timeout.
+  # guides, select scope, generate §1–§18). The experiment default caps the
+  # whole task at task_timeout: 1200s — that fires before the SDD lands no
+  # matter how high turn_timeout is. Raise BOTH: task_timeout for the
+  # end-to-end wall clock, turn_timeout for the long authoring turn.
+  # See fix/planner-sdd-turn-timeout.
+  task_timeout: 2700
   turn_timeout: 1800
 
 initial_prompt: |

--- a/tests/tasks/uipath-planner/e2e_rpa_sdd/e2e_rpa_sdd.yaml
+++ b/tests/tasks/uipath-planner/e2e_rpa_sdd/e2e_rpa_sdd.yaml
@@ -10,8 +10,12 @@ max_iterations: 1
 run_limits:
   expected_turns: 16
   # Full Phase D SDD authoring runs in one unbroken autonomous turn (read PDD +
-  # guides, select scope, generate §1–§18). 1200s is too tight and times out
-  # before the SDD lands. See fix/planner-sdd-turn-timeout.
+  # guides, select scope, generate §1–§18). The experiment default caps the
+  # whole task at task_timeout: 1200s — that fires before the SDD lands no
+  # matter how high turn_timeout is. Raise BOTH: task_timeout for the
+  # end-to-end wall clock, turn_timeout for the long authoring turn.
+  # See fix/planner-sdd-turn-timeout.
+  task_timeout: 2700
   turn_timeout: 1800
 
 initial_prompt: |


### PR DESCRIPTION
Both skill-sdd-e2e-rpa-process and skill-sdd-integration-constraint-gate overrode turn_timeout: 1800 but left task_timeout unset, so it inherited the experiment default of 1200s. The whole-task wall-clock cap fired before the SDD landed regardless of the per-turn budget. Set task_timeout: 2700 on both so the end-to-end run has headroom across setup turns and grading.