### PR TITLE
docs(ixp): document mandatory -y/--yes on documents delete

### DIFF
--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -28,7 +28,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 | `uip ixp documents list <project-name> [-l <limit>] [--offset <n>] --output json` | List documents — returns `[{ DocumentId, AttachmentRef, Filename }]`. `Filename` is the original upload filename. Paginated: defaults to 50 items per page (max 10000). Pass `-l` for larger pages or `--offset` to skip ahead. |
 | `uip ixp documents download <project-name> <document-id> -o <path> --output json` | Download the original document file (PDF/PNG/JPG/etc.). The CLI auto-corrects the file extension to match the actual content; use the response `Path` field as the resolved location. |
 | `uip ixp documents upload <project-name> <file> --output json` | Upload a single document file to an existing project. See [Uploading documents](#uploading-documents-to-an-existing-project) below for validation, output shape, and the multi-file loop pattern. |
-| `uip ixp documents delete <project-name> <document-id> --output json` | Delete a document (and its labellings) from a project. Irreversible — triggers a retrain. |
+| `uip ixp documents delete <project-name> <document-id> -y --output json` | Delete a document (and its labellings) from a project. Irreversible — triggers a retrain. Requires `-y`/`--yes` to confirm the irreversible delete; the CLI never prompts, so the flag is mandatory (it does not use `--confirm-data-loss`). |
 
 ### Supported document files
 


### PR DESCRIPTION
## Summary

`uip ixp documents delete` requires `-y`/`--yes` to confirm the irreversible delete (the CLI never prompts), but `cli-reference.md` documented it without the flag. A skill-following agent would omit it and the command would error.

Adds the flag to the documents-delete row and notes it uses `-y`/`--yes` — **not** `--confirm-data-loss` (which is what `projects`/`groups`/`data-types` delete use; an inconsistency that will be fixed soon).