### PR TITLE
test(ixp): assert e2e confirm succeeds, not just that it ran

### DIFF
--- a/tests/tasks/uipath-ixp/e2e/check_full_lifecycle.py
+++ b/tests/tasks/uipath-ixp/e2e/check_full_lifecycle.py
@@ -72,7 +72,29 @@ def read_f1(field: dict) -> float | None:
         return None
 
 
+def check_confirm_succeeded() -> None:
+    """Fail fast if the labelling confirm did not actually succeed.
+
+    `command_executed` only proves the confirm command was *invoked*; a
+    write-path failure (e.g. a 502 on the confirm endpoint) still emits
+    `Result: Failure` to stdout with --output json. Assert the captured
+    response is a success so the e2e fails on a broken confirm instead of
+    grading invocation alone."""
+    confirm = load_json("confirm_result.json")
+    result = confirm.get("Result")
+    if result != "Success":
+        log_fail(
+            f"labellings confirm did not succeed (Result={result!r}, "
+            f"Code={confirm.get('Code')!r}): {confirm.get('Instructions') or confirm.get('Message')}"
+        )
+    log_info("labelling confirm succeeded (Result == Success)")
+
+
 def main() -> int:
+    # Validate the mutating step first so a broken confirm fails fast,
+    # before any metrics comparison.
+    check_confirm_succeeded()
+
     target = load_json("target_field.json")
     field_id = target.get("field_id")
     if not field_id or not isinstance(field_id, str):

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -38,6 +38,10 @@ initial_prompt: |
   improve-prompts iteration.
 
   Capture these artifacts in the current working directory:
+  - `confirm_result.json` — the raw JSON response from your
+    `labellings confirm` step (`--output json`). Save it even if the
+    call reports an error, and if you confirm more than once, save the
+    response of the last confirm call.
   - `baseline_metrics.json` — full metrics response before the
     improvement.
   - `target_field.json` — the field you chose to improve, exactly:
@@ -96,6 +100,22 @@ success_criteria:
     command_pattern: '(uip|\$UIP)\s+ixp\s+labellings\s+confirm'
     min_count: 1
     weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Confirm response captured"
+    path: "confirm_result.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "labellings confirm actually succeeded (Result == Success, not a 5xx/error) — guards against grading invocation alone"
+    path: "confirm_result.json"
+    assertions:
+      - expression: "Result"
+        operator: equals
+        expected: "Success"
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed


### PR DESCRIPTION
## Problem

The full-lifecycle e2e ([`tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml`](tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml)) graded `labellings confirm` with a single `command_executed` criterion. That asserts the command was **invoked**, not that it **succeeded** — so a write-path failure (e.g. a 502 on the confirm endpoint) would still pass the e2e green.

Surfaced during the Design-Time migration QA (ACTV-88813): on the new `designtimeapi` route, `labellings confirm` 502s deterministically, yet the e2e's `confirm` assertion would have stayed green because it only checks invocation. `command_executed` exposes no exit code or output, so it structurally cannot tell a 200 from a 502 — the result has to be captured to a file the grader can read.

## Fix — two layers on the captured `confirm_result.json`

The agent saves the `labellings confirm` response (`--output json`) to `confirm_result.json` (the CLI writes `Result: Failure` to stdout on a 5xx even with `--output json`, so a 502 is captured).

1. **YAML** — `file_exists` (artifact captured) + `json_check` asserting `Result == "Success"` (named, visible signal in the report).
2. **`check_full_lifecycle.py`** (the weight-5 gate) — also asserts `confirm_result.json` is `Result == Success`, **first**, before any metrics comparison, so the single authoritative script fails fast on a broken confirm and can't be sidestepped.

Verified: the script exits 0 on a success response and exits 1 (`FAIL`) on a 502-shaped `Result: Failure` response.

## Scope / notes

- `confirm` is the only mutating labelling this e2e exercises (its improve step is `fields update-prompts`). Same pattern should extend to `unconfirm`/`mark-missing` if future steps add them.
- There is no native mid-run "fail fast" in coder_eval — criteria are graded post-hoc. This is as close as the framework allows: the weight-5 script validates confirm first and exits non-zero.
- **Merge note:** PR #1603 also edits `check_full_lifecycle.py` (Design-Time metrics shape). The two changes are in different parts of the file but expect a small merge; whichever lands second should keep `check_confirm_succeeded()` called first in `main()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)