### PR TITLE
test(uipath-agents): guardrail validate task tests skill, not hand-fed steps [PRODEV-765]

### DIFF
--- a/tests/tasks/uipath-agents/coded/guardrails/_fixtures/MisplacedPromptAttacksAgent/graph.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/_fixtures/MisplacedPromptAttacksAgent/graph.py
@@ -1,0 +1,93 @@
+"""Customer support agent with a user-prompt-attacks guardrail.
+
+Answers questions about customer accounts using a tool to look up account info.
+A guardrail was added to block adversarial inputs, but its placement has not
+been verified against the guardrail catalog.
+"""
+
+from langchain.agents import create_agent
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.constants import END, START
+from langgraph.graph import StateGraph
+from pydantic import BaseModel
+
+from uipath_langchain.chat import UiPathChat
+from uipath_langchain.guardrails import (
+    guardrail,
+    BlockAction,
+    UserPromptAttacksValidator,
+    GuardrailExecutionStage,
+)
+
+
+class Input(BaseModel):
+    """Input schema for the support agent."""
+
+    question: str
+
+
+class Output(BaseModel):
+    """Output schema for the support agent."""
+
+    answer: str
+
+
+@guardrail(
+    validator=UserPromptAttacksValidator(),
+    action=BlockAction(reason="Adversarial input detected."),
+    name="Block prompt attacks",
+    stage=GuardrailExecutionStage.PRE,
+)
+@tool
+def lookup_account_info(customer_id: str) -> str:
+    """Look up account information for a customer.
+
+    Args:
+        customer_id: The unique identifier of the customer account.
+
+    Returns:
+        A string with the account details including name, status, and plan.
+    """
+    return f"Account {customer_id}: Active, Pro plan, member since 2022."
+
+
+SYSTEM_PROMPT = """You are a helpful customer support agent.
+Use the lookup_account_info tool to retrieve customer account details
+when the user provides their customer ID. Always be polite and concise."""
+
+
+def create_llm():
+    """Create the LLM instance."""
+    return UiPathChat(model="gpt-4o-2024-08-06", temperature=0.0)
+
+
+llm = create_llm()
+
+
+def create_support_agent():
+    """Create the support agent."""
+    return create_agent(
+        model=llm,
+        tools=[lookup_account_info],
+        system_prompt=SYSTEM_PROMPT,
+    )
+
+
+agent = create_support_agent()
+
+
+async def support_node(state: Input) -> Output:
+    """Convert question to messages, call agent, and extract answer."""
+    messages = [HumanMessage(content=state.question)]
+    result = await agent.ainvoke({"messages": messages})
+    answer = result["messages"][-1].content
+    return Output(answer=answer)
+
+
+builder = StateGraph(Input, input_schema=Input, output_schema=Output)
+builder.add_node("support", support_node)
+builder.add_edge(START, "support")
+builder.add_edge("support", END)
+
+graph = builder.compile()

--- a/tests/tasks/uipath-agents/coded/guardrails/_fixtures/MisplacedPromptAttacksAgent/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/guardrails/_fixtures/MisplacedPromptAttacksAgent/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "misplaced-prompt-attacks-agent"
+version = "0.0.1"
+description = "Coded agent with a misplaced user-prompt-attacks guardrail for diagnose-and-fix testing"
+authors = [{ name = "Test User", email = "test@example.com" }]
+requires-python = ">=3.11"
+dependencies = [
+    "uipath-langchain>=0.9.26",
+    "uipath>2.7.0",
+]
+
+[dependency-groups]
+dev = [
+    "uipath-dev",
+]

--- a/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
@@ -1,13 +1,14 @@
 task_id: skill-agent-guardrail-coded-validate
 description: >
-  Coded guardrail validation/fix flow. SimpleCodedAgent is seeded with no
-  guardrails. The user asks the skill to first add a deliberately misconfigured
-  user-prompt-attacks decorator (placed above @tool def lookup_account_info —
-  user_prompt_attacks is LLM-scope only), then validate, then fix the misuse
-  by moving the @guardrail above the create_llm() factory instead. Verifies
-  the catalog/list/SDK docs were consulted, the misuse is gone after the fix,
-  the user_prompt_attacks guardrail now decorates the LLM factory, and graph.py
-  still parses.
+  Coded guardrail diagnose-and-fix flow. The agent is handed a LangGraph
+  customer-support agent that already has a user-prompt-attacks guardrail
+  wired to the wrong place — @guardrail(UserPromptAttacksValidator()) sits
+  above @tool def lookup_account_info, but user_prompt_attacks is LLM-scope
+  only. The skill must lead the agent to recognise the misplacement (against
+  the catalog/SDK docs) and move the guardrail onto the LLM factory. Verifies
+  the catalog/list/SDK docs were consulted, the misuse is gone, the
+  user_prompt_attacks guardrail now decorates the LLM factory, and graph.py
+  still parses. Neither the diagnosis nor the fix is stated in the prompt.
 tags: [uipath-agents, e2e, coded, mode:build, guardrail]
 
 agent:
@@ -16,34 +17,14 @@ agent:
 sandbox:
   template_sources:
     - type: template_dir
-      path: ../_fixtures/SimpleCodedAgent
+      path: ../_fixtures/MisplacedPromptAttacksAgent
 
 initial_prompt: |
-  I have a coded LangGraph agent in graph.py. I tried to add a user-prompt-
-  attacks guardrail but I'm not sure I placed it right. First add the snippet
-  below to graph.py exactly as-is (do not modify it yet) — it puts a
-  @guardrail decorator above @tool def lookup_account_info using
-  UserPromptAttacksValidator and BlockAction at GuardrailExecutionStage.PRE:
-
-      @guardrail(
-          validator=UserPromptAttacksValidator(),
-          action=BlockAction(reason="Adversarial input detected."),
-          name="Block prompt attacks",
-          stage=GuardrailExecutionStage.PRE,
-      )
-      @tool
-      def lookup_account_info(customer_id: str) -> str:
-          ...
-
-  Add the necessary imports for it. Then fetch the guardrail catalog with
-  `uip agent guardrails catalog`, the definitions with
-  `uip agent guardrails list`, and the SDK docs from
-  https://uipath.github.io/uipath-python/core/guardrails/ and
-  https://uipath.github.io/uipath-python/langchain/guardrails/ . Run a
-  validation pass against the snippet — `user_prompt_attacks` is LLM-scope
-  only, so decorating a `@tool` is wrong. Fix it by moving the @guardrail
-  above the existing create_llm() factory function instead, and remove it
-  from above @tool def lookup_account_info. Make sure graph.py still parses.
+  I have a coded LangGraph customer-support agent in graph.py. I added a
+  guardrail to block prompt-injection / adversarial user inputs, but I'm not
+  confident I attached it in the right place. Can you check whether it's
+  configured correctly and fix it if it isn't? Make sure graph.py still parses
+  when you're done.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or
   feedback. Do NOT pause between planning and implementation. Complete the


### PR DESCRIPTION
## What changed?

Rewrites the coded-guardrail **validate** task (`tests/tasks/uipath-agents/coded/guardrails/validate/`) so it tests whether the `uipath-agents` skill *guides* the agent, instead of testing instruction-following.

**Problem:** the old `initial_prompt` read like a runbook. It pasted the exact `@guardrail(...)` snippet, named the exact CLI verbs (`uip agent guardrails catalog` / `list`) and the literal SDK doc URLs, and spelled out both the diagnosis (*`user_prompt_attacks` is LLM-scope only*) and the fix (*move it onto `create_llm()`*). An agent could pass by following the recipe without ever invoking the skill.

**Fix:**
- New seeded fixture `_fixtures/MisplacedPromptAttacksAgent/` — the agent now receives a project where the `user_prompt_attacks` guardrail is *already* (wrongly) decorating `@tool def lookup_account_info`. (The shared `SimpleCodedAgent` fixture is left untouched — the four sibling guardrail tasks depend on it starting clean.)
- `validate.yaml` — `template_sources` repointed at the new fixture; `description` + `initial_prompt` rewritten to a genuine user request that states only the goal ("block adversarial inputs") and the success bar ("graph.py still parses"). No commands, URLs, diagnosis, or fix.
- Success criteria unchanged — they grade behavior (catalog/list/SDK-docs consulted + AST check that the guardrail moved off the tool onto the LLM factory), matching the sibling `recommend_scoped` task.

This aligns the task with the repo rule (`.claude/rules/test-writing.md` § Prompts: *"Minimal. State the goal and the success bar. Do not enumerate CLI flags"*) and the established `antipattern_*` seed-a-broken-fixture pattern.

## How has this been tested?

- `/lint-task` on the task: clean (0 issues); `check-cli-verbs.py` exit 0.
- `check_validate.py` fails on the seeded (misplaced) state and passes once the guardrail is moved to the factory — confirmed before the run.
- Real `uip agent guardrails list` confirms `user_prompt_attacks` → `AllowedScopes: ['Llm']` only, so the task's premise holds.
- **Live `coder-eval` run** (`experiments/default.yaml`, sonnet-4-6): **1/1 succeeded, weighted score 1.000 (4/4 criteria)**. From the minimal prompt the agent triggered the `uipath-agents` skill, ran the catalog/list commands and fetched the SDK docs on its own, and relocated the `@guardrail` from `@tool def lookup_account_info` onto `create_llm()`.

## Are there any breaking changes?

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W8vyFb36EsVNRmmuhVjRb7
