### PR TITLE
test(ixp): integration test suite [ACTV-88563]

### DIFF
--- a/tests/tasks/uipath-ixp/integration/check_tags.py
+++ b/tests/tasks/uipath-ixp/integration/check_tags.py
@@ -1,0 +1,65 @@
+"""Verify the full publish/tag/unpublish lifecycle from saved list-models snapshots.
+
+ModelVersion numbers are dynamic (each retrain increments them), so we assert
+RELATIVE wire-effects, not fixed numbers. `list-models` Data carries:
+  - Tags[]:   {Name, Version}      — which version each named tag points to
+  - Models[]: {Version, Pinned}    — Pinned = currently published
+
+Each file may be the full CLI response (root has `Data`) or the unwrapped payload
+(root IS the data), so we accept either shape.
+
+Snapshots (saved by the agent after each step):
+  models_tagged.json           after: staging->v1, live->v2
+  models_after_move.json       after: live moved onto v1
+  models_after_untag.json      after: tags removed from v1 (still published)
+  models_after_unpublish.json  after: v2 unpublished (still trained/listed)
+"""
+import json
+import sys
+
+
+def load_snapshot(path):
+    d = json.load(open(path))
+    return d.get("Data", d)
+
+
+def get_tag_version(snapshot, tag_name):
+    hits = [t["Version"] for t in snapshot["Tags"] if t["Name"] == tag_name]
+    return hits[0] if hits else None
+
+
+def count_tags_on(snapshot, version):
+    return len([t for t in snapshot["Tags"] if t["Version"] == version])
+
+
+def is_published(snapshot, version):
+    return any(m["Version"] == version and m.get("Pinned") for m in snapshot["Models"])
+
+
+def is_listed(snapshot, version):
+    return any(m["Version"] == version for m in snapshot["Models"])
+
+
+tagged = load_snapshot("models_tagged.json")
+moved = load_snapshot("models_after_move.json")
+untagged = load_snapshot("models_after_untag.json")
+unpublished = load_snapshot("models_after_unpublish.json")
+
+v1 = get_tag_version(tagged, "staging")   # first version (staging)
+v2 = get_tag_version(tagged, "live")      # second version (live)
+
+checks = {
+    "tagging: staging and live point to two different versions":
+        v1 is not None and v2 is not None and v1 != v2,
+    "move: live now points to the staging version (v1)":
+        get_tag_version(moved, "live") == v1,
+    "untag: version 1 has exactly 0 tags left, and stays published":
+        count_tags_on(untagged, v1) == 0 and is_published(untagged, v1),
+    "unpublish: v2 is no longer published but still trained/listed":
+        (not is_published(unpublished, v2)) and is_listed(unpublished, v2),
+}
+
+for name, ok in checks.items():
+    print(("PASS" if ok else "FAIL"), "-", name)
+
+sys.exit(0 if all(checks.values()) else 1)

--- a/tests/tasks/uipath-ixp/integration/check_taxonomy_roundtrip.py
+++ b/tests/tasks/uipath-ixp/integration/check_taxonomy_roundtrip.py
@@ -15,13 +15,13 @@ import json
 import sys
 
 
-def dataset(path):
+def load_dataset(path):
     d = json.load(open(path))
     d = d.get("Data", d)        # full response -> Data; else unchanged
     return d.get("dataset", d)  # Data -> dataset; else already the dataset
 
 
-def structure(ds):
+def extract_structure(ds):
     groups = []
     for group in ds.get("label_groups", []):
         for ld in group.get("label_defs", []):
@@ -33,8 +33,8 @@ def structure(ds):
     return sorted(groups)
 
 
-initial = structure(dataset("taxonomy_initial.json"))
-final = structure(dataset("taxonomy_final.json"))
+initial = extract_structure(load_dataset("taxonomy_initial.json"))
+final = extract_structure(load_dataset("taxonomy_final.json"))
 
 if initial == final:
     print("PASS - taxonomy round-trip: final matches the initial auto-suggested taxonomy")

--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -1,0 +1,160 @@
+task_id: skill-ixp-integration-labelling-correctness
+description: >
+  Integration: labelling correctness on a live trained project with a repeatable
+  field group (Line Items). Verifies per-occurrence confirm targeting (only the
+  chosen occurrences are confirmed), OCR-correction forwarding across occurrences
+  under `--group`, unconfirm rollback, and mark-missing — each checked by
+  re-reading `get-predictions`. These are CLI payload-construction behaviors, not
+  backend semantics.
+tags: [uipath-ixp, integration, mode:operate]
+
+run_limits:
+  max_turns: 68
+  task_timeout: 2400
+  turn_timeout: 900
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: ../_shared/fixtures
+
+initial_prompt: |
+  Set up a trained invoice project. Use the tenant I'm already signed into
+  (check I'm logged in; don't re-authenticate): create a blank project and upload
+  `./fixtures/csi_tower_invoice.png`. Then set up the taxonomy yourself — add a
+  "Line Items" field group with three fields: "Description" (text), "Amount"
+  (monetary), and "Tax" (monetary). Give it time to train, then look at the
+  predictions.
+
+  Then, on that invoice's line items:
+  - Confirm only the first line item — the other rows look wrong, leave them.
+  - The OCR mangled the "Amount" on the first two line items — confirm both of them
+    in one call, correcting the first's Amount to `1,234.56` and the second's to
+    `2,500.00`. Save that command's response to `confirm_result.json`.
+  - Actually, scrap that — roll back everything you just confirmed on this document,
+    and save that command's response to `unconfirm_result.json`.
+  - These line items have no tax column, so "Tax" doesn't apply here — mark it
+    missing, and save that response to `mark_missing_result.json`.
+
+  Clean up by deleting the project when you're done.
+
+success_criteria:
+  - type: command_executed
+    description: "Built the Line Items field group by hand"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+groups\s+add\b(?=.*Line Items)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Fetched predictions to resolve occurrences and field ids before mutating"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+labellings\s+get-predictions'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Confirmed the first occurrence via --group + --occurrence 0"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b(?=.*--group)(?=.*--occurrence(?:\s+|=)0\b)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Batched confirm with --updates carrying a corrections entry across occurrences"
+    tool_name: "Bash"
+    command_pattern: '(?s)(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b.*--group.*--updates.*corrections'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Rolled back with unconfirm"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+labellings\s+unconfirm'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Marked a genuinely-absent field missing"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+labellings\s+mark-missing\b.*--fields'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Deleted the project as cleanup"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # --- Outcome verification ---
+  # TODO: add a CLI command to read annotation state back, so we can validate the
+  # ACTUAL confirmed/corrected/missing values on the document — true outcome
+  # verification. No such command exists today, so for now we assert on the write
+  # response instead: the operation `Code`, a count of items affected, and
+  # `Unmatched == []` (the targeted field/occurrence existed and was hit, not
+  # silently skipped). (Result/Code are root-level, present because the agent
+  # saves the full CLI response.)
+  - type: json_check
+    description: "Batched correction confirm ran (right Code) and confirmed predictions"
+    path: "confirm_result.json"
+    assertions:
+      - expression: "Result"
+        operator: equals
+        expected: "Success"
+      - expression: "Code"
+        operator: equals
+        expected: "IxpLabellingsConfirm"
+      - expression: "Data.PredictionsConfirmed"
+        operator: gte
+        expected: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "unconfirm rolled back real annotations (count >= 1, nothing unmatched)"
+    path: "unconfirm_result.json"
+    assertions:
+      - expression: "Result"
+        operator: equals
+        expected: "Success"
+      - expression: "Code"
+        operator: equals
+        expected: "IxpLabellingsUnconfirm"
+      - expression: "Data.FieldsUnconfirmed"
+        operator: gte
+        expected: 1
+      - expression: "length(Data.Unmatched)"
+        operator: equals
+        expected: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "mark-missing hit the real Tax field (>=1 marked, none unmatched)"
+    path: "mark_missing_result.json"
+    assertions:
+      - expression: "Result"
+        operator: equals
+        expected: "Success"
+      - expression: "Code"
+        operator: equals
+        expected: "IxpLabellingsMarkMissing"
+      - expression: "Data.FieldsMarked"
+        operator: gte
+        expected: 1
+      - expression: "length(Data.Unmatched)"
+        operator: equals
+        expected: 0
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -1,0 +1,98 @@
+task_id: skill-ixp-integration-name-resolution
+description: >
+  Integration: name/title resolution on a live tenant. The agent must resolve
+  user-facing references to the ids the CLI needs — a document by FILENAME →
+  DocumentId via `documents list`, and a project by its TITLE → Name via
+  `projects list` — rather than passing the human label straight through. The
+  resolution step is the integration part; smokes pass the id in the prompt.
+tags: [uipath-ixp, integration, mode:operate]
+
+run_limits:
+  max_turns: 48
+  task_timeout: 1800
+  turn_timeout: 600
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: ../_shared/fixtures
+
+initial_prompt: |
+  Use the tenant I'm already signed into (check I'm logged in; don't
+  re-authenticate). Set up an invoice project from the files in `./fixtures/` —
+  import the taxonomy and upload the three invoices — and title it
+  "IxP Int Resolve".
+
+  Then:
+  - Delete the file `york_solutions_invoice.png`, then save the remaining document
+    list to `documents_after.json`.
+  - Rename the "IxP Int Resolve" project to "IxP Int Resolve Renamed", then save
+    the project's details to `project_after.json`.
+
+  Clean up by deleting the project at the end.
+
+success_criteria:
+  - type: command_executed
+    description: "Listed documents to resolve the filename → DocumentId, then re-read to save the remaining list"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+documents\s+list'
+    min_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Deleted the named document by resolved id (with -y)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+documents\s+delete\b.*(-y|--yes)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Listed projects to resolve Title → Name"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Renamed the project via update-title"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+update-title'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Did NOT pass the raw filename through as a document id to delete"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+documents\s+delete\s+\S+\s+york_solutions_invoice\.png'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Deleted the project as cleanup"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # --- Outcome verification: resolution actually deleted the named doc + renamed the project ---
+  - type: file_contains
+    description: "york is gone from the list; the other two documents remain"
+    path: "documents_after.json"
+    includes: ["csi_tower_invoice.png", "hp_tax_invoice.png"]
+    excludes: ["york_solutions_invoice.png"]
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "The project was renamed to the new title"
+    path: "project_after.json"
+    includes: ["IxP Int Resolve Renamed"]
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -1,0 +1,87 @@
+task_id: skill-ixp-integration-publish-lifecycle
+description: >
+  Integration: model publish/tag lifecycle on a live project, verified by
+  re-reading `list-models` after each transition. Covers publish, tag
+  staging/live, moving a tag to another version, unpublish, and untag — asserting
+  the published flag / tag pointer actually moved (wire-effect), not just command
+  shape.
+tags: [uipath-ixp, integration, mode:operate]
+
+run_limits:
+  max_turns: 68
+  task_timeout: 3000
+  turn_timeout: 1800
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: ../_shared/fixtures
+
+initial_prompt: |
+  I need to manage releases on an invoice project. Use the tenant I'm already
+  signed into (check I'm logged in; don't re-authenticate): start a project from
+  the files in `./fixtures/` — import the taxonomy, upload one of the invoices —
+  and let it train. I want two trained versions to tag, so once the first has
+  trained, tweak the "Total Amount" field's instruction to retrain a second.
+
+  Then, saving the model list after each step so I can see the state move:
+  - Put the first trained version on staging and the second on live → save to
+    `models_tagged.json`.
+  - Move the live tag over to the first version → save to `models_after_move.json`.
+  - Take the tags off the first version → save to `models_after_untag.json`.
+  - Unpublish the second version → save to `models_after_unpublish.json`.
+
+  Delete the project when you're done.
+
+success_criteria:
+  - type: command_executed
+    description: "Published with a tag (staging/live)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+publish\b.*--tag\s+(live|staging)'
+    min_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Untagged a version"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+untag\b.*--model-version'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Unpublished a version"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+unpublish\b.*--model-version'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Re-read list-models after each step (one snapshot per transition)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+list-models'
+    min_count: 4
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Deleted the project as cleanup"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # --- Outcome verification: full tag/publish lifecycle (see check_tags.py) ---
+  # Version numbers are dynamic, so it checks relative wire-effects, not fixed values.
+  - type: run_command
+    description: "Tag + publish lifecycle landed: tag -> move -> untag -> unpublish all verified across snapshots"
+    command: "python3 $TASK_DIR/check_tags.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
@@ -159,6 +159,12 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  - type: file_exists
+    description: "Captured the final taxonomy"
+    path: "taxonomy_final.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
   # Round-trip: every edit was confined to the added "Adjustments" group, so after
   # deleting it the taxonomy must structurally match the initial suggested one
   # (group/field names, kinds, instructions — ignoring ids/timestamps). This also

--- a/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
@@ -40,8 +40,7 @@ initial_prompt: |
   - Delete the "Surcharge" field.
   - Save the taxonomy to `taxonomy_before_delete.json`, then delete the
     "Adjustments" group.
-  - Save the taxonomy again to `taxonomy_final.json` — it should now match the
-    taxonomy you started with.
+  - Save the taxonomy again to `taxonomy_final.json`.
 
   When you're done, delete the project.
 


### PR DESCRIPTION
## What

The three IXP integration tests still awaiting live end-to-end validation:

- `labelling_correctness.yaml`
- `name_resolution.yaml`
- `publish_lifecycle.yaml`

## Stacked on #1663

This PR is **based on `test/ixp-integration-taxonomy-versions` (#1663)**, which carries the two already-validated tests (`taxonomy_lifecycle`, `versions_and_metrics`) plus the shared fixtures move. Merge #1663 first; this PR's diff is just the three tests above.

These three already include the suite-wide fixes (canonical `--yes`/`-y`, `(Data || @)` json_checks, no redundant login criterion), but have not yet been run green on a live tenant — keep as draft until each passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
