### PR TITLE
fix(test): make group_membership_update_smoke prescriptive to fix flakiness

### DIFF
--- a/tests/tasks/uipath-admin/identity_group_membership_update_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_group_membership_update_smoke.yaml
@@ -10,7 +10,13 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  Add user alice@example.com to the "Automation Users" group.
+  Add user alice@example.com to the "Automation Users" group. Run
+  these steps in order:
+  1. Resolve the user: `uip admin users list --search alice --output json`
+  2. Find the group: `uip admin groups list --output json`
+  3. Add the user: `uip admin groups members add <group-id> --user-ids <user-id> --output json`
+
+  If a command fails, move on to the next — use placeholder IDs.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be


### PR DESCRIPTION
## Summary

- Agent skipped `users list --search alice` in 2/3 coder eval runs, going straight to group operations
- Same root cause as the `role-assignment-grant-smoke` fix in #1578 — agent decides it doesn't need to resolve the user when the email is already in the prompt
- Makes prompt prescriptive with explicit 3-step sequence and placeholder ID fallback

## Evidence

Flakiness from 3 consecutive runs on main post-merge of #1578:
- Run 1: FAIL (score 0.667) — skipped user resolution
- Run 2: FAIL (score 0.667) — skipped user resolution  
- Run 3: PASS (score 1.000)

🤖 Generated with [Claude Code](https://claude.com/claude-code)