### PR TITLE
fix(test): improve apms_get_my_ip_smoke prompt to trigger correct skill

### DIFF
--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -13,7 +13,9 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  What public IP does my UiPath organization see for me right now?
+  I need to check what public IP the UiPath platform sees for my
+  machine before I add it to our IP restriction allowlist. What's my
+  current outbound IP?
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be


### PR DESCRIPTION
## Summary

- Agent triggered `uipath-platform` instead of `uipath-admin` and guessed `uip admin apms get-my-ip` from the task directory name (APMS is the internal name; user-facing is "IP Restriction")
- Rephrased prompt to mention "IP restriction allowlist" context, which naturally activates the correct skill and guides toward `uip admin ip-restriction my-ip`
- Not a prescriptive fix — the prompt still asks a natural question, just with the right domain context

## Evidence

Failed in nightly eval run 2026-06-19 04:05:24 (score 0.00, 3 turns, 38s). Agent ran `uip admin apms get-my-ip` instead of `uip admin ip-restriction my-ip`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)