### PR TITLE
fix(test): rewrite 8 uipath-admin e2e prompts to customer-voice

### DIFF
--- a/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
@@ -30,9 +30,10 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
 initial_prompt: |
-  Export tenant audit events for the 3-day window ending 2 days ago
-  (UTC, whole days) as a single merged CSV to the ./audit-window base
-  directory in the current working directory. Resolve the dates with
+  Export tenant audit events for the 3-day window from 5 days ago
+  through 2 days ago (UTC, whole days) into the ./audit-window base
+  directory in the current working directory, as a single merged CSV
+  (not the default per-day JSON folder). Resolve the dates with
   `date -u -d '5 days ago' +%Y-%m-%d` and
   `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the
   run date.

--- a/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_csv_verify_e2e.yaml
@@ -30,24 +30,17 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
 initial_prompt: |
-  Export tenant audit events for the 3-day window from 5 days ago
-  through 2 days ago (UTC, whole days) into the ./audit-window base
-  directory in the current working directory, as a single merged CSV
-  (not the default per-day JSON folder) — the CLI creates a uniquely-named
-  `.csv` inside the base directory.
-  Resolve the dates with `date -u -d '5 days ago' +%Y-%m-%d` and
-  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the run
-  date.
+  Export tenant audit events for the 3-day window ending 2 days ago
+  (UTC, whole days) as a single merged CSV to the ./audit-window base
+  directory in the current working directory. Resolve the dates with
+  `date -u -d '5 days ago' +%Y-%m-%d` and
+  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the
+  run date.
 
   Important:
   - The `uip` CLI is available and connected via env-var auth to a real
-    tenant. The export should produce a real CSV file inside the
-    ./audit-window base directory.
-  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
-    bounds (no inline `T00:00:00Z` for these flags — the CLI treats them
-    as whole-day boundaries) and select the single-file CSV shape with
-    `--file-format csv`.
-  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer.
+    tenant. The export should produce a real CSV file at the requested
+    path.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
@@ -27,16 +27,17 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
 initial_prompt: |
-  Export tenant audit events for the 3-day window ending 2 days ago
-  (UTC, whole days) to the ./audit-window base directory in the current
-  working directory. Resolve the dates with
-  `date -u -d '5 days ago' +%Y-%m-%d` and
+  Export tenant audit events for the 3-day window from 5 days ago
+  through 2 days ago (UTC, whole days) as day-wise JSON files under the
+  ./audit-window base directory in the current working directory.
+  Resolve the dates with `date -u -d '5 days ago' +%Y-%m-%d` and
   `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the
   run date.
 
   Important:
   - The `uip` CLI is available and connected via env-var auth to a real
-    tenant. The export should produce real files at the requested path.
+    tenant. The export should produce a real folder of JSON files at the
+    requested path.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_verify_e2e.yaml
@@ -27,24 +27,16 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, real-artifact]
 
 initial_prompt: |
-  Export tenant audit events for the 3-day window from 5 days ago
-  through 2 days ago (UTC, whole days) as day-wise JSON files under the
-  ./audit-window base directory in the current working directory (the CLI
-  creates a uniquely-named subfolder inside it). Resolve the
-  dates with `date -u -d '5 days ago' +%Y-%m-%d` and
-  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the run
-  date.
+  Export tenant audit events for the 3-day window ending 2 days ago
+  (UTC, whole days) to the ./audit-window base directory in the current
+  working directory. Resolve the dates with
+  `date -u -d '5 days ago' +%Y-%m-%d` and
+  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the
+  run date.
 
   Important:
   - The `uip` CLI is available and connected via env-var auth to a real
-    tenant. The export should produce a real folder of JSON files at the
-    requested path.
-  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
-    bounds (no inline `T00:00:00Z` for these flags — the CLI treats them
-    as whole-day boundaries). json is the default format; `--output-path`
-    is a base directory — the CLI creates a uniquely-named
-    `audit_<from>_<to>_<generated-at>` subfolder inside it.
-  - The 2-days-ago upper bound preserves the >48h LTS-lag buffer.
+    tenant. The export should produce real files at the requested path.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
@@ -36,16 +36,18 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, scope-org, real-artifact]
 
 initial_prompt: |
-  Export the previous-full-day of organization-level audit events
-  (memberships, license changes, tenant lifecycle) to the
-  ./audit-org-window base directory in the current working directory.
-  Pin the day to 2 days ago (UTC) with
-  `date -u -d '2 days ago' +%Y-%m-%d` so it slides with the run —
-  use the same resolved value for the start and end of the window.
+  Export organization-level audit events (memberships, license changes,
+  tenant lifecycle) for the single UTC day 2 days ago as day-wise JSON
+  files under the ./audit-org-window base directory in the current
+  working directory. Resolve the date with
+  `date -u -d '2 days ago' +%Y-%m-%d` so the window slides with the
+  run date — use the same resolved value for both the start and end of
+  the window.
 
   Important:
   - The `uip` CLI is available and connected via env-var auth to a real
-    tenant. The export should produce real files at the requested path.
+    tenant. The export should produce a real folder of JSON files at the
+    requested path.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_org_export_verify_e2e.yaml
@@ -36,26 +36,16 @@ description: >
 tags: [uipath-admin, e2e, mode:operate, audit, export, scope-org, real-artifact]
 
 initial_prompt: |
-  Export ORGANIZATION-level audit events (memberships, license changes,
-  tenant lifecycle) for the single UTC day **2 days ago** as day-wise
-  JSON files under the ./audit-org-window base directory in the current
-  working directory (the CLI creates a uniquely-named subfolder inside it).
-  Resolve the date with `date -u -d '2 days ago' +%Y-%m-%d`
-  so the window slides with the run date — use the same value for both
-  `--from-date` and `--to-date`.
+  Export the previous-full-day of organization-level audit events
+  (memberships, license changes, tenant lifecycle) to the
+  ./audit-org-window base directory in the current working directory.
+  Pin the day to 2 days ago (UTC) with
+  `date -u -d '2 days ago' +%Y-%m-%d` so it slides with the run —
+  use the same resolved value for the start and end of the window.
 
   Important:
-  - The `uip` CLI is available and connected via env-var auth to a
-    real tenant. The export should produce a real folder of JSON files
-    at the requested path.
-  - Use the canonical `--from-date YYYY-MM-DD` / `--to-date YYYY-MM-DD`
-    bounds (no inline `T00:00:00Z` for these flags — the CLI treats
-    them as whole-day boundaries). json is the default format;
-    `--output-path` is a base directory — the CLI creates a uniquely-named
-    `audit_<from>_<to>_<generated-at>` subfolder inside it.
-  - The 2-days-ago boundary preserves the >48h LTS-lag buffer.
-  - This is ORG scope, not tenant. Do NOT pass `--tenant-id` (org
-    silently ignores it).
+  - The `uip` CLI is available and connected via env-var auth to a real
+    tenant. The export should produce real files at the requested path.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_org_e2e.yaml
@@ -19,11 +19,9 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Grant my account organization-level access by assigning the built-in
-  organization-level role "Insights Dashboard Viewer". Exercise the create,
-  list, and delete commands: look the role up by name, create the
-  assignment, list my assignments to confirm it shows up, then delete the
-  assignment and list again to confirm it's gone.
+  Give my own account the built-in organization-level role "Insights
+  Dashboard Viewer", confirm it's actually assigned to me, then take it
+  back off again and confirm it's gone.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be

--- a/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_assignment_lifecycle_tenant_global_e2e.yaml
@@ -18,11 +18,10 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  My account needs the built-in global template role "Tenant Administrator",
-  which is available across every tenant in the organization. Exercise the
-  create, list, and delete commands: look the role up by name, create the
-  assignment, list my assignments to confirm it appears, then delete the
-  assignment and list again to confirm it's gone.
+  My account needs the built-in global template role "Tenant
+  Administrator", which is available across every tenant in the
+  organization. Assign it to me, confirm the assignment is there, then
+  remove it and confirm it's gone.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_org_e2e.yaml
@@ -17,18 +17,13 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  I need a read-only role at organization scope called "AccessPolicyViewer_clie2e" that
-  grants only read access to the organization's Access Policies (the
-  Conditional Access Policy "Read" permission).
+  I need an org-scope read-only role named "AccessPolicyViewer_clie2e"
+  that grants only read access to the organization's Access Policies
+  (the Conditional Access Policy "Read" permission).
 
-  Walk the full lifecycle, exercising the create, get, update, and delete
-  commands:
-    1. List the organization-scope permissions to find the Access Policy
-       read permission, confirm no role named "AccessPolicyViewer_clie2e" already exists,
-       then create the role including that permission.
-    2. Update it — change its description.
-    3. Get the role's contents so I can confirm the update.
-    4. Delete the role and confirm it's gone.
+  Create it, then change its description and confirm the change stuck,
+  and finally remove it again so we don't leave it behind — confirm
+  it's gone.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_e2e.yaml
@@ -26,24 +26,19 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Set up a read-only role called "AdminPageViewer_clie2e" that applies only
-  to the tenant I'm currently logged into — not the whole organization, not
-  other tenants. It should grant view-only access to the Administration page
-  (read-only admin-page access, nothing else).
+  Set up a read-only role called "AdminPageViewer_clie2e" that applies
+  only to the tenant I'm currently logged into — not the whole
+  organization, not other tenants. It should grant view-only access to
+  the Administration page (read-only admin-page access, nothing else).
 
-  Walk the full lifecycle, exercising the create, get, update, and delete
-  commands:
-    1. First confirm no role named "AdminPageViewer_clie2e" already exists,
-       then create it bound to my current tenant.
-    2. Update it — change its description to note it is read-only.
-    3. Get the role's details so I can confirm the update.
-    4. Delete the role and confirm it's gone.
+  Create it, then update its description to note it is read-only and
+  confirm the change, and finally remove it and confirm it's gone.
 
   Important:
-  - If the `uip admin` subcommand is unavailable or a command fails, that
-    is acceptable — run each command exactly once and continue. Do NOT
-    retry, do NOT attempt to login, do NOT try to install tools, do NOT
-    troubleshoot errors.
+  - If the `uip admin` subcommand is unavailable or a command fails,
+    that is acceptable — run each command exactly once and continue. Do
+    NOT retry, do NOT attempt to login, do NOT try to install tools, do
+    NOT troubleshoot errors.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_role_lifecycle_tenant_global_e2e.yaml
@@ -24,24 +24,20 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  Set up a reusable read-only role template called "AdminPageViewerGlobal_clie2e"
-  that can be assigned in every tenant of our organization — a template
-  not bound to any single tenant. It should grant view-only access to the
-  Administration page (read-only admin-page access, nothing else).
+  Set up a reusable read-only role template called
+  "AdminPageViewerGlobal_clie2e" that can be assigned in every tenant of
+  our organization — a template not bound to any single tenant. It should
+  grant view-only access to the Administration page (read-only
+  admin-page access, nothing else).
 
-  Walk the full lifecycle, exercising the create, get, update, and delete
-  commands:
-    1. First confirm no role named "AdminPageViewerGlobal_clie2e" already
-       exists, then create it.
-    2. Update it — change its description to note it is read-only.
-    3. Get the role's details so I can confirm the update.
-    4. Delete the role and confirm it's gone.
+  Create it, then update its description to note it is read-only and
+  confirm the change, and finally remove it and confirm it's gone.
 
   Important:
-  - If the `uip admin` subcommand is unavailable or a command fails, that
-    is acceptable — run each command exactly once and continue. Do NOT
-    retry, do NOT attempt to login, do NOT try to install tools, do NOT
-    troubleshoot errors.
+  - If the `uip admin` subcommand is unavailable or a command fails,
+    that is acceptable — run each command exactly once and continue. Do
+    NOT retry, do NOT attempt to login, do NOT try to install tools, do
+    NOT troubleshoot errors.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:


### PR DESCRIPTION
## Summary
Rewrites 8 Medium-rated `uipath-admin` task prompts per the [Confluence prompt-fitness review](https://uipath.atlassian.net/wiki/spaces/CA/pages/90823262384). Strips CLI internals and command enumerations so the agent must derive CLI verbs from the skill, not the prompt.

**Authz lifecycle e2e (5 tasks):** Replace "exercise the create/get/update/delete commands" + numbered verb walkthroughs with outcome-oriented arcs ("create, confirm, modify, confirm, remove, confirm").

**Audit verify e2e (3 tasks):** Strip CLI flag-format hints (`--from-date YYYY-MM-DD`, `no inline T00:00:00Z`), whole-day boundary explanations, `>48h LTS-lag buffer` rationale, and `Do NOT pass --tenant-id` gotcha. Retain natural-language output-shape requirements (day-wise JSON files, single merged CSV, org-scope).

All `success_criteria` unchanged — agents must derive CLI verbs and flags from the skill, not the prompt.

## Coder-eval results

### Authz tasks (5/5) — 3 consecutive passes ✅

| Run | Link | Result |
|-----|------|--------|
| #1 | [27978422901](https://github.com/UiPath/skills/actions/runs/27978422901) | 5/5 PASS (all score=1.000) |
| #2 | [27979005372](https://github.com/UiPath/skills/actions/runs/27979005372) | 5/5 PASS (all score=1.000) |
| #3 | [27979611297](https://github.com/UiPath/skills/actions/runs/27979611297) | 5/5 PASS (all score=1.000) |

### Audit verify tasks (3) — blocked on CLI feature, not a regression

These 3 tasks (`audit_export_verify_e2e`, `audit_org_export_verify_e2e`, `audit_export_csv_verify_e2e`) have **never passed in CI on any branch**, including `main`. Their `description` field documents the blocker:

> Blocker: this task requires the base-directory + generated-name export behavior in the published `@uipath/cli` (UiPath/cli#2585 must ship + publish). Until then `--output-path` is treated as the exact output folder (no generated subfolder) and the `audit_*` glob finds nothing.

The prompt rewrites actually **improved** command construction — the agent now derives the correct `uip admin audit tenant export --from-date ... --to-date ... --output-path ...` from the skill (score 0.000 → 0.222). The `run_command` checkers fail because the CLI doesn't produce the expected output structure yet.

## Test plan
- [x] Coder-eval: 5 authz tasks pass 3x consecutively (score=1.000 each run)
- [x] Coder-eval: 3 audit verify tasks confirmed blocked on UiPath/cli#2585 (pre-existing, not a regression)
- [x] YAML validation: all 8 files parse correctly
- [x] No CLI flags, flag formats, or internal gotchas in rewritten prompts
- [x] All checker-required artifacts preserved (role names, output paths, date commands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)