### PR TITLE
fix(uipath-maestro-bpmn): strict XML well-formedness gate in the bundled validator

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -64,8 +64,9 @@ before writing. Read a reference only when you reach the structure it covers.
 
 1. **Discover.** `uip maestro bpmn registry pull` **once** (cached for the
    session — do not re-pull), then `list` / `search` to map intent to extension
-   types; `uip is connections list` for live connections. Confirm every
-   selection with the user (use AskUserQuestion). Never fabricate an identifier.
+   types; `uip is connections list --all-folders` for live connections (always
+   `--all-folders` — a folder-scoped list silently misses connections). Confirm
+   every selection with the user (use AskUserQuestion). Never fabricate an identifier.
    See [references/registry-workflow.md](references/registry-workflow.md).
 2. **Get templates.** `uip maestro bpmn registry get <type> --output json` for
    each chosen node. Enrich `Intsvc.*` connector nodes with

--- a/skills/uipath-maestro-bpmn/references/cli-conventions.md
+++ b/skills/uipath-maestro-bpmn/references/cli-conventions.md
@@ -17,7 +17,7 @@ All commands below are discovery/read-only. None mutate cloud state.
 | `uip maestro bpmn registry list [--limit <n\|-1>]` | List cached extension types (and discovered connectors/processes). Default 30; use `--limit -1` for all. |
 | `uip maestro bpmn registry search <keyword>` | Find entries by keyword across extension type, label, connector name, process name. |
 | `uip maestro bpmn registry get <extensionType> [--connection-id <id>] [--object-name <name>]` | Get the full spec for one extension type: `xmlTemplate`, `contextFields`, `bindingInfo`, input/output patterns. `--connection-id`/`--object-name` add live Integration Service field metadata for `Intsvc.*` connector types. |
-| `uip is connections list` | List live Integration Service connections (id + state). |
+| `uip is connections list --all-folders` | List live Integration Service connections (id + state) across all folders. Always pass `--all-folders`; a folder-scoped list silently misses connections. |
 
 These are the **only** commands the skill verifies against the CLI source
 (`packages/maestro-tool/src/commands/registry.ts`). Do not invent flags. In

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -10,12 +10,20 @@ into registry-backed XML.
 uip maestro bpmn registry pull            # sync + cache (login for connectors/processes)
 uip maestro bpmn registry list --limit -1 --output json   # all extension types
 uip maestro bpmn registry search <keyword> --output json  # find a type by intent
-uip is connections list --output json     # live Integration Service connections
+uip is connections list --all-folders --output json   # live IS connections (all folders)
 ```
 
 Map the user's intent to an extension type from the list. Confirm the choice
 with the user (and the specific connection / process / queue) before authoring.
 **Never fabricate an identifier** — see [cli-conventions.md](cli-conventions.md).
+
+**Connection discovery must be exhaustive.** Always pass `--all-folders` to
+`uip is connections list` — connections live in many folders and a folder-scoped
+listing silently misses them. An empty or unmatched result from a missing
+`--all-folders`, or from a connector key guessed from a brand name rather than
+found via `registry search`, is a **false negative** — never conclude "no
+connection exists" or ask the user to create one until you have searched the
+registry for the real connector key and listed across all folders.
 
 `registry list` returns three buckets in `Data`: `ExtensionTypes` (the OOTB
 extension types, always available), `Connectors` and `Processes` (only after
@@ -56,7 +64,7 @@ For connector types (`requiresDiscovery: Yes`, e.g.
 resolve a live connection and object, then enrich:
 
 ```bash
-uip is connections list --output json     # pick a connection id + its connector
+uip is connections list --all-folders --output json   # pick a connection id + its connector (search all folders)
 uip maestro bpmn registry get Intsvc.ActivityExecution \
     --connection-id <id> --object-name <object> --output json
 ```

--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -18,9 +18,12 @@ node validate-bpmn.mjs <bpmn-file> [resources]
 - Prints `VALID` and exits `0` when there are no ERROR-severity findings.
 - Otherwise lists every finding (rule code + message) and exits `1`.
 - WARNING-severity findings are printed but do not gate.
-- A strict XML well-formedness gate runs **before** the parse and exits `2` on
-  malformed input (e.g. `--` inside a comment), which `bpmn-moddle`'s lenient SAX
-  parser would otherwise accept but the canvas import rejects.
+- A strict XML well-formedness gate (sax strict mode) runs **before** the
+  `bpmn-moddle` parse and exits `2` on malformed input — unescaped `&`/`<`, `--`
+  inside a comment, mismatched tags. `bpmn-moddle`'s SAX parser is lenient and
+  would accept these, but the Studio Web canvas import rejects them, so the
+  validator must too: a safety net that is more permissive than the real import
+  gives false confidence.
 - `resources` (optional): a numeric folder id (or comma-separated release names)
   for the connection-liveness ping via the `uip` CLI. Best-effort; a missing or
   unauthenticated CLI is reported as a NOTE, never a hard failure.

--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -18,6 +18,9 @@ node validate-bpmn.mjs <bpmn-file> [resources]
 - Prints `VALID` and exits `0` when there are no ERROR-severity findings.
 - Otherwise lists every finding (rule code + message) and exits `1`.
 - WARNING-severity findings are printed but do not gate.
+- A strict XML well-formedness gate runs **before** the parse and exits `2` on
+  malformed input (e.g. `--` inside a comment), which `bpmn-moddle`'s lenient SAX
+  parser would otherwise accept but the canvas import rejects.
 - `resources` (optional): a numeric folder id (or comma-separated release names)
   for the connection-liveness ping via the `uip` CLI. Best-effort; a missing or
   unauthenticated CLI is reported as a NOTE, never a hard failure.
@@ -28,7 +31,8 @@ npm test   # runs all three suites below; green = no drift from the frontend
 
 ## Test suites (`test/`)
 
-`npm test` runs three layers and asserts all 29 rule codes are exercised:
+`npm test` runs the layers below and asserts all 29 rule codes are exercised
+(plus a CLI well-formedness-gate check):
 
 1. **Crafted-invalid XML coverage** (`run-tests.mjs`): for each rule, a minimal
    BPMN that should trip exactly that rule's code, plus a check that valid twins

--- a/skills/uipath-maestro-bpmn/validator/package.json
+++ b/skills/uipath-maestro-bpmn/validator/package.json
@@ -3,10 +3,15 @@
   "private": true,
   "type": "module",
   "description": "Offline semantic validator for UiPath Maestro BPMN XML. Reconstructs the PO.Frontend Node/Edge/CanvasState model from the parsed BPMN and runs all 19 PO.Frontend validation rules.",
-  "bin": { "validate-bpmn": "./validate-bpmn.mjs" },
-  "scripts": { "test": "node test/run-tests.mjs" },
+  "bin": {
+    "validate-bpmn": "./validate-bpmn.mjs"
+  },
+  "scripts": {
+    "test": "node test/run-tests.mjs"
+  },
   "dependencies": {
     "bpmn-moddle": "^9.0.2",
-    "luxon": "^3.4.4"
+    "luxon": "^3.4.4",
+    "sax": "^1.6.0"
   }
 }

--- a/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
@@ -9,6 +9,11 @@ import BpmnModdle from "bpmn-moddle";
 import descriptor from "../uipath-moddle.v1.json" with { type: "json" };
 import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "../model.mjs";
 import { validateDiagram, validateVariableExistence, validateVariableNotSet } from "../rules.mjs";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+import { writeFileSync, mkdtempSync } from "fs";
+import { tmpdir } from "os";
 
 const moddle = new BpmnModdle({ uipath: descriptor });
 
@@ -469,6 +474,38 @@ console.log(
 );
 for (const f of integ.failures) console.log("  FAIL " + f);
 failures += integ.failed;
+
+// ---- Run: 4) CLI well-formedness gate ------------------------------------
+// bpmn-moddle's SAX parser is lenient and accepts "--" inside comments, which
+// strict parsers and the canvas import reject. The CLI applies a pre-parse
+// well-formedness gate; assert it fires (exit 2) and does not false-positive.
+console.log("\n== CLI well-formedness gate ==");
+{
+  const cli = join(dirname(fileURLToPath(import.meta.url)), "..", "validate-bpmn.mjs");
+  const tmp = mkdtempSync(join(tmpdir(), "wf-"));
+  const runExit = (xml) => {
+    const p = join(tmp, "case.bpmn");
+    writeFileSync(p, xml);
+    try {
+      execFileSync("node", [cli, p], { stdio: "pipe" });
+      return 0;
+    } catch (e) {
+      return e.status ?? 1;
+    }
+  };
+  const head = '<?xml version="1.0"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"';
+  const badComment = `${head}><!-- run uip foo --connection-id x --output json --><bpmn:process id="P"/></bpmn:definitions>`;
+  const okComment = `${head}><!-- run uip foo with connection id and json output --><bpmn:process id="P"/></bpmn:definitions>`;
+  const badExit = runExit(badComment);
+  const okExit = runExit(okComment);
+  // bad: must be rejected (non-zero); ok comment: must not be rejected for well-formedness (exit != 2)
+  const badOk = badExit !== 0;
+  const okOk = okExit !== 2;
+  console.log(`${badOk ? "PASS" : "FAIL"}  "--" inside comment rejected (exit ${badExit})`);
+  console.log(`${okOk ? "PASS" : "FAIL"}  clean comment not flagged for well-formedness (exit ${okExit})`);
+  if (!badOk) failures++;
+  if (!okOk) failures++;
+}
 
 // ---- Coverage assertion: every rule code is exercised somewhere -----------
 const portedOnly = [...COVERED_BY_PORTED].filter((c) => !fired.has(c));

--- a/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
+++ b/skills/uipath-maestro-bpmn/validator/test/run-tests.mjs
@@ -494,16 +494,24 @@ console.log("\n== CLI well-formedness gate ==");
     }
   };
   const head = '<?xml version="1.0"?><bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"';
-  const badComment = `${head}><!-- run uip foo --connection-id x --output json --><bpmn:process id="P"/></bpmn:definitions>`;
-  const okComment = `${head}><!-- run uip foo with connection id and json output --><bpmn:process id="P"/></bpmn:definitions>`;
-  const badExit = runExit(badComment);
+  // Each malformed case is well-formedness-invalid (strict parsers / canvas import
+  // reject it) but bpmn-moddle's lenient SAX parser would accept it.
+  const malformed = {
+    '"--" inside comment': `${head}><!-- uip foo --connection-id x --><bpmn:process id="P"/></bpmn:definitions>`,
+    "unescaped ampersand": `${head}><bpmn:process id="P" name="Tom & Jerry"/></bpmn:definitions>`,
+    "&& in text (not CDATA)": `${head}><bpmn:process id="P">a && b</bpmn:process></bpmn:definitions>`,
+    "stray <": `${head}><bpmn:process id="P">a < b</bpmn:process></bpmn:definitions>`,
+  };
+  for (const [name, xml] of Object.entries(malformed)) {
+    const exit = runExit(xml);
+    const ok = exit !== 0;
+    console.log(`${ok ? "PASS" : "FAIL"}  rejects ${name} (exit ${exit})`);
+    if (!ok) failures++;
+  }
+  const okComment = `${head}><!-- uip foo with connection id and json output --><bpmn:process id="P"/></bpmn:definitions>`;
   const okExit = runExit(okComment);
-  // bad: must be rejected (non-zero); ok comment: must not be rejected for well-formedness (exit != 2)
-  const badOk = badExit !== 0;
   const okOk = okExit !== 2;
-  console.log(`${badOk ? "PASS" : "FAIL"}  "--" inside comment rejected (exit ${badExit})`);
   console.log(`${okOk ? "PASS" : "FAIL"}  clean comment not flagged for well-formedness (exit ${okExit})`);
-  if (!badOk) failures++;
   if (!okOk) failures++;
 }
 

--- a/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
+++ b/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
@@ -66,6 +66,30 @@ if (!file) {
 }
 
 const xml = readFileSync(file, "utf8");
+
+// Strict XML well-formedness gate. bpmn-moddle's SAX parser (saxen) is lenient
+// and accepts constructs that strict parsers — and the Studio Web canvas import —
+// reject, most notably "--" (double-hyphen) inside a comment. Catch these before
+// the lenient parse so the validator never reports VALID for a file that will
+// fail to import.
+const wellFormedness = [];
+{
+  const commentRe = /<!--([\s\S]*?)-->/g;
+  let m;
+  while ((m = commentRe.exec(xml)) !== null) {
+    if (m[1].includes("--")) {
+      const line = xml.slice(0, m.index).split("\n").length;
+      wellFormedness.push(
+        `"--" (double-hyphen) inside an XML comment near line ${line}; XML comments cannot contain "--". Move CLI commands/flags out of the comment.`,
+      );
+    }
+  }
+}
+if (wellFormedness.length) {
+  for (const e of wellFormedness) console.error(`WELL-FORMEDNESS ERROR: ${e}`);
+  process.exit(2);
+}
+
 const moddle = new BpmnModdle({ uipath: descriptor });
 
 let definitions;

--- a/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
+++ b/skills/uipath-maestro-bpmn/validator/validate-bpmn.mjs
@@ -17,11 +17,31 @@
 //   resources: comma-separated release names, or a numeric folder ID, for the
 //              optional solution-resource liveness ping (requires uip CLI auth).
 import BpmnModdle from "bpmn-moddle";
+import sax from "sax";
 import descriptor from "./uipath-moddle.v1.json" with { type: "json" };
 import { readFileSync, existsSync } from "fs";
 import { execFileSync } from "child_process";
 import { buildModel, collectKnownVariableIds, allNodes, allEdges } from "./model.mjs";
 import { validateDiagram, validateVariableExistence, validateVariableNotSet, SEVERITY } from "./rules.mjs";
+
+// Strict XML well-formedness check via sax's strict mode. Returns the first
+// error message (with a line number) or null when the document is well-formed.
+function strictXmlError(xml) {
+  const parser = sax.parser(true, {});
+  let error = null;
+  parser.onerror = (e) => {
+    if (!error) {
+      const line = (parser.line ?? 0) + 1;
+      error = `${e.message.split("\n")[0]} (near line ${line})`;
+    }
+  };
+  try {
+    parser.write(xml).close();
+  } catch (e) {
+    if (!error) error = String(e.message ?? e).split("\n")[0];
+  }
+  return error;
+}
 
 // --- uip CLI resolution (cached) — used only for the liveness-ping extra. ---
 let _uipBin;
@@ -67,27 +87,17 @@ if (!file) {
 
 const xml = readFileSync(file, "utf8");
 
-// Strict XML well-formedness gate. bpmn-moddle's SAX parser (saxen) is lenient
-// and accepts constructs that strict parsers — and the Studio Web canvas import —
-// reject, most notably "--" (double-hyphen) inside a comment. Catch these before
-// the lenient parse so the validator never reports VALID for a file that will
-// fail to import.
-const wellFormedness = [];
+// Strict XML well-formedness gate. bpmn-moddle's SAX parser (saxen) is lenient:
+// it accepts unescaped `&`/`<`, `--` inside comments, and other malformed input
+// that strict parsers — and the Studio Web canvas import — reject. A validator
+// that is more permissive than the real import gives false confidence, so parse
+// strictly first and refuse anything the import would refuse.
 {
-  const commentRe = /<!--([\s\S]*?)-->/g;
-  let m;
-  while ((m = commentRe.exec(xml)) !== null) {
-    if (m[1].includes("--")) {
-      const line = xml.slice(0, m.index).split("\n").length;
-      wellFormedness.push(
-        `"--" (double-hyphen) inside an XML comment near line ${line}; XML comments cannot contain "--". Move CLI commands/flags out of the comment.`,
-      );
-    }
+  const err = strictXmlError(xml);
+  if (err) {
+    console.error(`WELL-FORMEDNESS ERROR: ${err}`);
+    process.exit(2);
   }
-}
-if (wellFormedness.length) {
-  for (const e of wellFormedness) console.error(`WELL-FORMEDNESS ERROR: ${e}`);
-  process.exit(2);
 }
 
 const moddle = new BpmnModdle({ uipath: descriptor });


### PR DESCRIPTION
Follow-up to #1519. The bundled validator parses with `bpmn-moddle`, whose SAX parser (`saxen`) is lenient and returns `VALID` for malformed XML — unescaped `&`/`<`, `--` inside a comment, mismatched tags. The frontend tolerates this (browser rendering resilience, machine-serialized input), but the Studio Web canvas/import path and the backend engine (`UiPath.PO.BpmnParser` → `XDocument`) are strict and reject it. A validator that is more permissive than the real import gives false confidence.

This adds a strict XML well-formedness gate (sax strict mode) that runs **before** the moddle parse and exits `2` on any well-formedness error, so the validator refuses what the engine would refuse.

- `validate-bpmn.mjs`: `strictXmlError()` pre-parse gate
- `package.json`: add `sax`
- `test/run-tests.mjs`: CLI gate test (rejects `--`-comment, unescaped `&`, `&&`, stray `<`; accepts clean comments)
- `README.md`: document the gate

All 31 known-good fixtures still parse; 59/59 fixtures and 29/29 rule codes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)