### PR TITLE
MST-11485:  add code eval tests for edit in coding agent

### DIFF
--- a/tests/tasks/uipath-maestro-case/edit/insert_stage/check_insert_stage.py
+++ b/tests/tasks/uipath-maestro-case/edit/insert_stage/check_insert_stage.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Insert-stage edit check.
+
+The starting fixture chains three stages: Intake → Review → Decision. The
+agent must insert a new "Approval" stage (carrying one wait-for-timer task)
+between Review and Decision, rewiring the condition-driven chain so Approval
+runs after Review and Decision runs after Approval. Verifies the insert
+happened AND the old Review → Decision hand-off was removed (a true insert,
+not an append).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import (  # noqa: E402
+    _get_ci,
+    find_caseplan,
+    find_node_by_label,
+    find_stages,
+    find_transitions,
+    first_rule_of_condition,
+    read_caseplan,
+    start_debug,
+)
+
+
+def main():
+    caseplan_path = find_caseplan()
+    plan = read_caseplan(caseplan_path)
+
+    stages = find_stages(plan, include_exception=False)
+    if len(stages) != 4:
+        labels = [(s.get("data") or {}).get("label") for s in stages]
+        sys.exit(
+            f"FAIL: expected 4 regular stages after inserting Approval "
+            f"(Intake, Review, Approval, Decision); got {len(stages)}: {labels}"
+        )
+
+    approval = find_node_by_label(plan, "Approval")
+    review = find_node_by_label(plan, "Review")
+    decision = find_node_by_label(plan, "Decision")
+
+    # Approval must carry at least one wait-for-timer task with a
+    # current-stage-entered task-entry condition.
+    approval_lanes = (approval.get("data") or {}).get("tasks") or []
+    approval_tasks = [t for lane in approval_lanes for t in (lane or [])]
+    if not approval_tasks:
+        sys.exit("FAIL: Approval stage has no tasks; expected one wait-for-timer task")
+    timers = [t for t in approval_tasks if t.get("type") == "wait-for-timer"]
+    if not timers:
+        types_seen = sorted({t.get("type", "?") for t in approval_tasks})
+        sys.exit(
+            f"FAIL: Approval stage has no wait-for-timer task; task types seen: {types_seen}"
+        )
+    timer = timers[0]
+    conds = timer.get("entryConditions") or []
+    rule = first_rule_of_condition(conds[0]) if conds else None
+    if not rule or rule.get("rule") != "current-stage-entered":
+        sys.exit(
+            f"FAIL: Approval's wait-for-timer task-entry rule should be "
+            f"'current-stage-entered'; got {rule and rule.get('rule')!r}"
+        )
+
+    # Reachability is condition-driven (edges retired): the chain must now run
+    # Review → Approval → Decision.
+    if not find_transitions(plan, source=review["id"], target=approval["id"]):
+        sys.exit(
+            "FAIL: no Review → Approval transition; Approval's entry condition must "
+            "name Review (selected-stage-completed/-exited selectedStageId=Review)"
+        )
+    if not find_transitions(plan, source=approval["id"], target=decision["id"]):
+        sys.exit(
+            "FAIL: no Approval → Decision transition; Decision's entry condition must "
+            "name Approval (selected-stage-completed/-exited selectedStageId=Approval)"
+        )
+
+    # True insert, not append: the old direct Review → Decision hand-off must
+    # be gone — Decision is rewired to follow Approval.
+    if find_transitions(plan, source=review["id"], target=decision["id"]):
+        sys.exit(
+            "FAIL: a direct Review → Decision transition still exists; Approval was "
+            "appended in parallel rather than inserted into the chain. Decision's "
+            "entry condition must reference Approval, not Review."
+        )
+
+    # e2e: the edited case must launch and run in the Studio Web debug runtime.
+    # Every task is a built-in wait-for-timer (no registry resources), but the
+    # case runtime suspends on wait-for-timer tasks, so the case won't
+    # necessarily reach Completed in one debug pass — start_debug refreshes
+    # solution resources, launches debug, and asserts it ran (tolerating a
+    # non-Completed finalStatus), exactly as the sibling linear_three_stages
+    # e2e check does for this same case shape.
+    payload = start_debug(timeout=540)
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
+
+    print(
+        "OK: Approval stage inserted between Review and Decision (4 stages total); "
+        "Approval carries a wait-for-timer task ('Approval Hold') with "
+        "current-stage-entered task-entry; chain rewired Review → Approval → "
+        "Decision with the old Review → Decision hand-off removed; "
+        f"edited case launched in debug runtime (status={status})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/edit/insert_stage/insert_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/insert_stage/insert_stage.yaml
@@ -1,0 +1,67 @@
+task_id: skill-case-edit-insert-stage
+description: >
+  Insert a new "Approval" stage carrying one wait-for-timer task into the
+  middle of an existing LinearThreeStages case, between the Review and
+  Decision stages. Exercises editing an existing caseplan.json: adding a
+  Stage node, adding a task in its data.tasks lane, and rewiring the
+  condition-driven chain so Approval runs after Review and Decision now
+  runs after Approval (the case analog of inserting a node into an edge).
+tags: [uipath-maestro-case, e2e, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+max_iterations: 1
+
+run_limits:
+  task_timeout: 1200
+  max_turns: 60
+  turn_timeout: 1200
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../templates
+
+initial_prompt: |
+  The LinearThreeStages case solution already exists on disk under
+  LinearThreeStages/. Its case definition (LinearThreeStages/LinearThreeStages/caseplan.json)
+  chains three stages linearly: Intake → Review → Decision.
+
+  Insert a NEW regular stage named "Approval" between Review and Decision.
+  Approval must:
+    - run after Review completes (its stage-entry condition references the
+      Review stage), and
+    - hand off to Decision — rewire Decision so it now runs after Approval
+      completes instead of after Review. After the edit there must be NO
+      direct Review → Decision hand-off.
+    - contain ONE built-in wait-for-timer task named "Approval Hold" with a
+      current-stage-entered task-entry condition and a short time duration
+      (e.g. 5s).
+
+  Leave Intake and Review otherwise unchanged.
+
+  Do NOT run `uip maestro case debug` — the test harness handles execution.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Make the edit end-to-end in a single pass and
+  finish with `uip maestro case validate` passing on the resulting
+  caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the edited caseplan.json"
+    command: "uip maestro case validate LinearThreeStages/LinearThreeStages/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Approval stage inserted between Review and Decision: 4 stages total, Approval carries a wait-for-timer task with current-stage-entered entry, Review → Approval and Approval → Decision transitions exist, the old Review → Decision transition is gone, and the edited case launches in the Studio Web debug runtime"
+    command: "python3 $TASK_DIR/check_insert_stage.py"
+    timeout: 720
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/edit/insert_stage/insert_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/insert_stage/insert_stage.yaml
@@ -6,7 +6,7 @@ description: >
   Stage node, adding a task in its data.tasks lane, and rewiring the
   condition-driven chain so Approval runs after Review and Decision now
   runs after Approval (the case analog of inserting a node into an edge).
-tags: [uipath-maestro-case, e2e, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/edit/remove_stage/check_remove_stage.py
+++ b/tests/tasks/uipath-maestro-case/edit/remove_stage/check_remove_stage.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Remove-stage edit check.
+
+The starting fixture chains three stages linearly: Intake → Review → Decision,
+wired through condition-driven stage-entry rules. The agent must delete the
+MIDDLE "Review" stage (its node and all of its tasks) and rewire Decision to
+enter after Intake, leaving no reference to the removed stage anywhere.
+Verifies the whole stage is gone (not just relabeled), the chain was rejoined
+into a direct Intake → Decision hand-off with no dangling condition reference,
+Intake was left intact, and the edited case still launches (a true delete-and-
+reconnect, not a rebuild). Distinct from remove_task, which drops a leaf task.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import (  # noqa: E402
+    _get_ci,
+    find_caseplan,
+    find_node_by_label,
+    find_stages,
+    find_transitions,
+    iter_stage_entry_conditions,
+    iter_stage_exit_conditions,
+    iter_tasks,
+    read_caseplan,
+    start_debug,
+)
+
+
+def _stage_tasks(node):
+    lanes = (node.get("data") or {}).get("tasks") or []
+    return [t for lane in lanes for t in (lane or [])]
+
+
+def _dangling_stage_refs(plan):
+    """Return (label, referenced_id) for every condition that points at a
+    stage id no node in the plan carries — i.e. a leftover reference to a
+    deleted stage."""
+    node_ids = {n.get("id") for n in plan.get("nodes") or []}
+    dangling = []
+    for node in plan.get("nodes") or []:
+        if "Stage" not in (node.get("type") or ""):
+            continue
+        label = (node.get("data") or {}).get("label") or node.get("id")
+        for cond in iter_stage_entry_conditions(node):
+            for group in cond.get("rules") or []:
+                for rule in group or []:
+                    sid = (rule or {}).get("selectedStageId")
+                    if sid and sid not in node_ids:
+                        dangling.append((label, sid))
+        for cond in iter_stage_exit_conditions(node):
+            dst = cond.get("exitToStageId")
+            if dst and dst not in node_ids:
+                dangling.append((label, dst))
+    return dangling
+
+
+def main():
+    caseplan_path = find_caseplan()
+    plan = read_caseplan(caseplan_path)
+
+    # Exactly two regular stages must remain: Intake and Decision.
+    stages = find_stages(plan, include_exception=False)
+    labels = sorted((s.get("data") or {}).get("label") for s in stages)
+    if labels != ["Decision", "Intake"]:
+        sys.exit(
+            f"FAIL: after removing Review the case must carry exactly the two "
+            f"stages Intake and Decision; got {labels}"
+        )
+
+    # The Review stage and its tasks must be gone from the ENTIRE case, not
+    # merely relabeled — no residual "Review" node, and its two tasks removed.
+    if any((s.get("data") or {}).get("label") == "Review" for s in stages):
+        sys.exit("FAIL: a stage still labeled 'Review' exists; the stage must be removed")
+    leftover_tasks = [
+        t.get("displayName")
+        for t in iter_tasks(plan)
+        if t.get("displayName") in {"Hold For 1 Hour", "Notify Reviewer"}
+    ]
+    if leftover_tasks:
+        sys.exit(
+            f"FAIL: tasks from the removed Review stage still exist in the case: "
+            f"{leftover_tasks}; deleting the stage must delete its tasks too"
+        )
+
+    # No condition may point at a stage id that no longer exists (a leftover
+    # reference to the deleted Review stage).
+    dangling = _dangling_stage_refs(plan)
+    if dangling:
+        sys.exit(
+            f"FAIL: dangling stage reference(s) to a deleted stage remain in "
+            f"conditions (stage → referenced id): {dangling}; rewire the chain "
+            f"so no condition references the removed Review stage"
+        )
+
+    intake = find_node_by_label(plan, "Intake")
+    decision = find_node_by_label(plan, "Decision")
+
+    # The chain must be rejoined: Decision now enters after Intake completes.
+    if not find_transitions(plan, source=intake["id"], target=decision["id"]):
+        sys.exit(
+            "FAIL: no Intake → Decision transition; Decision's stage-entry "
+            "condition must be rewired to reference the Intake stage after "
+            "Review's removal"
+        )
+
+    # Intake must be left intact: still carries its task and its case-entered
+    # entry rule.
+    intake_tasks = _stage_tasks(intake)
+    if not intake_tasks:
+        sys.exit("FAIL: Intake lost its task(s); the edit must leave Intake unchanged")
+    intake_rule = None
+    conds = list(iter_stage_entry_conditions(intake))
+    if conds:
+        groups = conds[0].get("rules") or []
+        if groups and groups[0]:
+            intake_rule = groups[0][0]
+    if not intake_rule or intake_rule.get("rule") != "case-entered":
+        sys.exit(
+            f"FAIL: Intake's case-entered entry rule was disturbed; got "
+            f"{intake_rule and intake_rule.get('rule')!r}"
+        )
+
+    # e2e: the edited case must launch and run in the Studio Web debug runtime.
+    # Every task is a built-in wait-for-timer (no registry resources), but the
+    # case runtime suspends on wait-for-timer tasks, so the case won't
+    # necessarily reach Completed in one debug pass — start_debug refreshes
+    # solution resources, launches debug, and asserts it ran (tolerating a
+    # non-Completed finalStatus), exactly as the sibling edit e2e checks do for
+    # this same case shape.
+    payload = start_debug(timeout=540)
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
+
+    print(
+        "OK: Review stage removed (node + tasks gone from the whole case); "
+        "exactly two stages remain (Intake, Decision); no dangling condition "
+        "reference to the deleted stage; chain rejoined into a direct Intake → "
+        "Decision hand-off; Intake left intact (task + case-entered entry "
+        f"preserved); edited case launched in debug runtime (status={status})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/edit/remove_stage/remove_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/remove_stage/remove_stage.yaml
@@ -8,7 +8,7 @@ description: >
   stage anywhere. Exercises deleting a whole node and reconnecting the chain
   (the case analog of removing a node from a flow and rejoining its edges) —
   distinct from remove_task, which deletes a leaf task inside a stage.
-tags: [uipath-maestro-case1, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/edit/remove_stage/remove_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/remove_stage/remove_stage.yaml
@@ -1,0 +1,70 @@
+task_id: skill-case-edit-remove-stage
+description: >
+  Remove an entire regular stage from a LinearThreeStages case and rewire the
+  chain around the gap. The case chains three stages linearly: Intake → Review
+  → Decision, wired through condition-driven stage-entry rules. The agent must
+  delete the middle "Review" stage (node and all its tasks) and rewire Decision
+  so it now enters after Intake completes, leaving NO reference to the removed
+  stage anywhere. Exercises deleting a whole node and reconnecting the chain
+  (the case analog of removing a node from a flow and rejoining its edges) —
+  distinct from remove_task, which deletes a leaf task inside a stage.
+tags: [uipath-maestro-case1, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+max_iterations: 1
+
+run_limits:
+  task_timeout: 1200
+  max_turns: 60
+  turn_timeout: 1200
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../templates
+
+initial_prompt: |
+  The LinearThreeStages case solution already exists on disk under
+  LinearThreeStages/. Its case definition (LinearThreeStages/LinearThreeStages/caseplan.json)
+  chains three stages linearly: Intake → Review → Decision. Each stage enters
+  via a condition on the previous stage completing.
+
+  Remove the middle "Review" stage entirely and rewire the chain so the case
+  runs Intake → Decision. After the edit:
+    - The Review stage node and all of its tasks must be gone from the entire
+      case definition — no stage named "Review", and no leftover reference to
+      the removed stage's id in any condition.
+    - Decision must now enter after Intake completes — rewire Decision's
+      stage-entry condition so it references the Intake stage instead of
+      Review. After the edit there must be a direct Intake → Decision hand-off
+      and NO dangling reference to the deleted Review stage.
+    - Leave Intake and Decision otherwise unchanged (their tasks, other
+      conditions), and leave the trigger, variables, and the case exit rule
+      (metadata.caseExitRules) unchanged.
+
+  Do NOT run `uip maestro case debug` — the test harness handles execution.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Make the edit end-to-end in a single pass and
+  finish with `uip maestro case validate` passing on the resulting
+  caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the edited caseplan.json"
+    command: "uip maestro case validate LinearThreeStages/LinearThreeStages/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Review stage removed and chain rejoined: exactly 2 stages (Intake, Decision), Review and its tasks gone from the whole case, no dangling reference to the removed stage in any condition, a direct Intake → Decision transition exists, Intake left intact, and the edited case launches in the Studio Web debug runtime"
+    command: "python3 $TASK_DIR/check_remove_stage.py"
+    timeout: 720
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/edit/remove_task/check_remove_task.py
+++ b/tests/tasks/uipath-maestro-case/edit/remove_task/check_remove_task.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Remove-task edit check.
+
+The starting fixture chains three stages: Intake → Review → Decision. The
+Review stage runs TWO parallel wait-for-timer tasks in distinct data.tasks
+lanes: "Hold For 1 Hour" (required) and "Notify Reviewer" (optional). The
+agent must remove the REQUIRED "Hold For 1 Hour" task, leaving Review with
+exactly one task ("Notify Reviewer") otherwise unchanged, while keeping
+Review's required-tasks-completed exit condition intact. Verifies the removal
+happened, the exit condition still holds, the surviving task and the stage
+chain are intact (a true delete, not a rebuild), and the edited case launches.
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import (  # noqa: E402
+    _get_ci,
+    find_caseplan,
+    find_node_by_label,
+    find_stages,
+    find_transitions,
+    iter_stage_exit_conditions,
+    iter_tasks,
+    read_caseplan,
+    start_debug,
+)
+
+
+def _stage_tasks(node):
+    lanes = (node.get("data") or {}).get("tasks") or []
+    return [t for lane in lanes for t in (lane or [])]
+
+
+def _has_required_tasks_completed_exit(node):
+    """True when the stage keeps a marksStageComplete exit rule whose rule is
+    'required-tasks-completed'."""
+    for cond in iter_stage_exit_conditions(node):
+        if not cond.get("marksStageComplete"):
+            continue
+        for group in cond.get("rules") or []:
+            for rule in group or []:
+                if (rule or {}).get("rule") == "required-tasks-completed":
+                    return True
+    return False
+
+
+def main():
+    caseplan_path = find_caseplan()
+    plan = read_caseplan(caseplan_path)
+
+    # Stage chain must be untouched: still 3 regular stages.
+    stages = find_stages(plan, include_exception=False)
+    if len(stages) != 3:
+        labels = [(s.get("data") or {}).get("label") for s in stages]
+        sys.exit(
+            f"FAIL: expected the 3 original stages (Intake, Review, Decision) "
+            f"to be unchanged; got {len(stages)}: {labels}"
+        )
+
+    intake = find_node_by_label(plan, "Intake")
+    review = find_node_by_label(plan, "Review")
+    decision = find_node_by_label(plan, "Decision")
+
+    # "Hold For 1 Hour" must be gone from the ENTIRE case, not just Review.
+    if any(t.get("displayName") == "Hold For 1 Hour" for t in iter_tasks(plan)):
+        sys.exit(
+            "FAIL: a task named 'Hold For 1 Hour' still exists in the case; "
+            "the required task must be removed entirely"
+        )
+
+    # Review must carry exactly ONE task, the surviving "Notify Reviewer".
+    review_tasks = _stage_tasks(review)
+    if len(review_tasks) != 1:
+        names = [t.get("displayName") for t in review_tasks]
+        sys.exit(
+            f"FAIL: Review must carry exactly one task after removal "
+            f"('Notify Reviewer'); got {len(review_tasks)}: {names}"
+        )
+
+    survivor = review_tasks[0]
+    if survivor.get("displayName") != "Notify Reviewer":
+        sys.exit(
+            f"FAIL: the surviving Review task should be 'Notify Reviewer'; "
+            f"got {survivor.get('displayName')!r} — the wrong task was removed"
+        )
+
+    # The survivor must be left intact: still a wait-for-timer with its
+    # current-stage-entered task-entry condition.
+    if survivor.get("type") != "wait-for-timer":
+        sys.exit(
+            f"FAIL: 'Notify Reviewer' should stay a wait-for-timer task; "
+            f"got type={survivor.get('type')!r}"
+        )
+    conds = survivor.get("entryConditions") or []
+    rule = None
+    if conds:
+        groups = conds[0].get("rules") or []
+        if groups and groups[0]:
+            rule = groups[0][0]
+    if not rule or rule.get("rule") != "current-stage-entered":
+        sys.exit(
+            f"FAIL: 'Notify Reviewer' task-entry rule should be "
+            f"'current-stage-entered'; got {rule and rule.get('rule')!r}"
+        )
+
+    # Review's exit condition must still hold: the required-tasks-completed
+    # marksStageComplete rule must survive the delete unrewritten. Removing the
+    # only required task must NOT have torn out or weakened the exit rule.
+    if not _has_required_tasks_completed_exit(review):
+        sys.exit(
+            "FAIL: Review's required-tasks-completed exit condition is gone or "
+            "was rewritten; deleting the required task must leave the stage's "
+            "marksStageComplete exit rule intact"
+        )
+
+    # The linear chain must be intact: Intake → Review → Decision.
+    if not find_transitions(plan, source=intake["id"], target=review["id"]):
+        sys.exit("FAIL: the Intake → Review transition was disturbed by the edit")
+    if not find_transitions(plan, source=review["id"], target=decision["id"]):
+        sys.exit("FAIL: the Review → Decision transition was disturbed by the edit")
+
+    # e2e: the edited case must launch and run in the Studio Web debug runtime.
+    # Every task is a built-in wait-for-timer (no registry resources), but the
+    # case runtime suspends on wait-for-timer tasks, so the case won't
+    # necessarily reach Completed in one debug pass — start_debug refreshes
+    # solution resources, launches debug, and asserts it ran (tolerating a
+    # non-Completed finalStatus), exactly as the sibling insert_stage e2e check
+    # does for this same case shape.
+    payload = start_debug(timeout=540)
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
+
+    print(
+        "OK: required 'Hold For 1 Hour' removed from Review (3 stages unchanged); "
+        "Review now carries exactly one task ('Notify Reviewer') left intact "
+        "(type + current-stage-entered entry preserved); Review's "
+        "required-tasks-completed exit condition still holds; Intake → Review → "
+        f"Decision chain unchanged; edited case launched in debug runtime "
+        f"(status={status})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
@@ -1,0 +1,71 @@
+task_id: skill-case-edit-remove-task
+description: >
+  Remove the required "Hold For 1 Hour" wait-for-timer task from the Review
+  stage of an existing LinearThreeStages case. Review starts with two parallel
+  tasks in distinct data.tasks lanes ("Hold For 1 Hour" required, "Notify
+  Reviewer" optional); after the edit Review must carry only "Notify Reviewer".
+  Exercises editing an existing caseplan.json: deleting a task from a stage's
+  data.tasks lanes while leaving the stage's required-tasks-completed exit
+  condition intact (it still holds — the agent must not rewrite or break it),
+  the surviving task undisturbed, and the linear stage chain unchanged.
+tags: [uipath-maestro-case, e2e, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+max_iterations: 1
+
+run_limits:
+  task_timeout: 1200
+  max_turns: 60
+  turn_timeout: 1200
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../templates
+
+initial_prompt: |
+  The LinearThreeStages case solution already exists on disk under
+  LinearThreeStages/. Its case definition (LinearThreeStages/LinearThreeStages/caseplan.json)
+  chains three stages linearly: Intake → Review → Decision. The Review stage
+  runs TWO parallel wait-for-timer tasks in distinct data.tasks lanes:
+  "Hold For 1 Hour" (required) and "Notify Reviewer" (optional). Review's exit
+  condition completes the stage on required-tasks-completed.
+
+  Remove the "Hold For 1 Hour" task from the Review stage. After the edit:
+    - Review must carry exactly ONE task, "Notify Reviewer", and "Hold For 1
+      Hour" must be gone from the entire case definition.
+    - Review's exit condition must still hold: leave the
+      required-tasks-completed exit rule (marksStageComplete) in place,
+      unchanged. Do NOT rewrite, weaken, or delete it.
+    - "Notify Reviewer" must be left otherwise unchanged (same type and
+      task-entry condition).
+    - The three stages and the Intake → Review → Decision chain must be
+      unchanged — do NOT touch Intake, Decision, the stage-entry conditions, or
+      any other stage's tasks.
+
+  Do NOT run `uip maestro case debug` — the test harness handles execution.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Make the edit end-to-end in a single pass and
+  finish with `uip maestro case validate` passing on the resulting
+  caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the edited caseplan.json"
+    command: "uip maestro case validate LinearThreeStages/LinearThreeStages/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Hold For 1 Hour task removed from Review: 3 stages unchanged, Review carries exactly one task ('Notify Reviewer') left intact, 'Hold For 1 Hour' is gone from the whole case, Review's required-tasks-completed exit condition still holds, the linear chain is unchanged, and the edited case launches in the Studio Web debug runtime"
+    command: "python3 $TASK_DIR/check_remove_task.py"
+    timeout: 720
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
@@ -8,7 +8,7 @@ description: >
   data.tasks lanes while leaving the stage's required-tasks-completed exit
   condition intact (it still holds — the agent must not rewrite or break it),
   the surviving task undisturbed, and the linear stage chain unchanged.
-tags: [uipath-maestro-case, e2e, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages.uipx
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages.uipx
@@ -1,0 +1,12 @@
+{
+    "DocVersion": "1.0.0",
+    "StudioMinVersion": "2025.10.0",
+    "SolutionId": "d8a87528-2dd7-4ae4-a88d-08dec8c34f7c",
+    "Projects": [
+        {
+            "Type": "CaseManagement",
+            "ProjectRelativePath": "LinearThreeStages/project.uiproj",
+            "Id": "08b4ee08-6a88-4cc0-96ef-a955406c502d"
+        }
+    ]
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/bindings_v2.json
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/bindings_v2.json
@@ -1,0 +1,4 @@
+{
+    "version": "2.0",
+    "resources": []
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/caseplan.json
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/caseplan.json
@@ -1,0 +1,382 @@
+{
+    "id": "case-Lx7Rq2mPnK",
+    "version": "23.0.0",
+    "name": "LinearThreeStages",
+    "description": "Three regular stages chained linearly behind a manual trigger; exercises stage-entry conditions, parallel wait-for-timer tasks, and the full Variable / In / Out argument trio.",
+    "metadata": {
+        "caseIdentifier": "LTS",
+        "caseIdentifierType": "constant",
+        "caseAppEnabled": false,
+        "publishVersion": 2,
+        "caseUnifiedSchemaEnabled": true,
+        "caseDirectlyPassTaskOutputs": true,
+        "intsvcActivityConfig": "v2",
+        "caseExitRules": [
+            {
+                "id": "Condition_Zt3mKb",
+                "displayName": "Complete Rule 1",
+                "marksCaseComplete": true,
+                "rules": [
+                    [
+                        {
+                            "id": "Rule_Np5wGx",
+                            "rule": "required-stages-completed"
+                        }
+                    ]
+                ]
+            }
+        ]
+    },
+    "bindings": [],
+    "variables": {
+        "inputs": [
+            {
+                "id": "pQr7Ks2Wm",
+                "name": "caseRef",
+                "type": "string",
+                "default": "",
+                "elementId": "trigger_1"
+            }
+        ],
+        "outputs": [
+            {
+                "id": "nBt4Xh9Vc",
+                "name": "finalDecision",
+                "type": "string",
+                "var": "finalDecision"
+            }
+        ],
+        "inputOutputs": [
+            {
+                "id": "skipReview",
+                "name": "skipReview",
+                "type": "boolean",
+                "default": false,
+                "custom": true,
+                "elementId": "root"
+            },
+            {
+                "id": "caseRef",
+                "name": "caseRef",
+                "type": "string",
+                "elementId": "trigger_1"
+            },
+            {
+                "id": "finalDecision",
+                "name": "finalDecision",
+                "type": "string",
+                "default": "",
+                "elementId": "root"
+            },
+            {
+                "id": "dueDate",
+                "name": "dueDate",
+                "type": "date",
+                "custom": true,
+                "elementId": "root"
+            },
+            {
+                "id": "caseMetadata",
+                "name": "caseMetadata",
+                "type": "jsonSchema",
+                "body": { "type": "object" },
+                "_jsonSchema": { "type": "object" },
+                "custom": true,
+                "elementId": "root"
+            },
+            {
+                "id": "attachments",
+                "name": "attachments",
+                "type": "jsonSchema",
+                "body": { "type": "array", "items": {} },
+                "_jsonSchema": { "type": "array", "items": {} },
+                "custom": true,
+                "elementId": "root"
+            },
+            {
+                "id": "caseSchema",
+                "name": "caseSchema",
+                "type": "jsonSchema",
+                "body": { "type": "object", "properties": { "caseId": { "type": "string" } } },
+                "_jsonSchema": { "type": "object", "properties": { "caseId": { "type": "string" } } },
+                "custom": true,
+                "elementId": "root"
+            }
+        ]
+    },
+    "nodes": [
+        {
+            "id": "Stage_Kp3mRx",
+            "type": "case-management:Stage",
+            "data": {
+                "label": "Intake",
+                "description": "Receives the case after the manual trigger.",
+                "isRequired": true,
+                "parentElement": { "id": "root", "type": "case-management:root" },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "entryConditions": [
+                    {
+                        "id": "Condition_En8kPr",
+                        "displayName": "On case entered",
+                        "isInterrupting": false,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Lm4nQx",
+                                    "rule": "case-entered"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "exitConditions": [
+                    {
+                        "id": "Condition_Fy9pWb",
+                        "displayName": "Complete Rule 1",
+                        "type": "exit-only",
+                        "marksStageComplete": true,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Jv7kLt",
+                                    "rule": "required-tasks-completed"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "tasks": [
+                    [
+                        {
+                            "id": "t8Kp3mRxN2",
+                            "type": "wait-for-timer",
+                            "displayName": "Intake Placeholder",
+                            "elementId": "Stage_Kp3mRx-t8Kp3mRxN2",
+                            "isRequired": true,
+                            "shouldRunOnlyOnce": false,
+                            "entryConditions": [
+                                {
+                                    "id": "cFm3Rp7Kn2",
+                                    "displayName": "Entry Rule 1",
+                                    "rules": [
+                                        [
+                                            {
+                                                "id": "rBx4Qz8Lm1",
+                                                "rule": "current-stage-entered"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "data": {
+                                "timerType": "timeDuration",
+                                "timeDuration": "PT5S"
+                            }
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "id": "Stage_Qn7tBz",
+            "type": "case-management:Stage",
+            "data": {
+                "label": "Review",
+                "description": "Follows Intake; runs two parallel wait-for-timer tasks sharing the same current-stage-entered task-entry condition.",
+                "isRequired": true,
+                "parentElement": { "id": "root", "type": "case-management:root" },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "entryConditions": [
+                    {
+                        "id": "Condition_Bx5rNm",
+                        "displayName": "Entry Rule 1",
+                        "isInterrupting": false,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Gw3kPj",
+                                    "rule": "selected-stage-completed",
+                                    "selectedStageId": "Stage_Kp3mRx"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "exitConditions": [
+                    {
+                        "id": "Condition_Hc6xTq",
+                        "displayName": "Complete Rule 1",
+                        "type": "exit-only",
+                        "marksStageComplete": true,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Dm8nVf",
+                                    "rule": "required-tasks-completed"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "tasks": [
+                    [
+                        {
+                            "id": "tQn7tBz4Wm",
+                            "type": "wait-for-timer",
+                            "displayName": "Hold For 1 Hour",
+                            "elementId": "Stage_Qn7tBz-tQn7tBz4Wm",
+                            "isRequired": true,
+                            "shouldRunOnlyOnce": true,
+                            "skipCondition": "=vars.skipReview",
+                            "entryConditions": [
+                                {
+                                    "id": "cNv6Wk3Tp8",
+                                    "displayName": "Entry Rule 1",
+                                    "rules": [
+                                        [
+                                            {
+                                                "id": "rJm9Yz4Bn5",
+                                                "rule": "current-stage-entered"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "data": {
+                                "timerType": "timeDuration",
+                                "timeDuration": "PT10S"
+                            }
+                        }
+                    ],
+                    [
+                        {
+                            "id": "tVw2hJcR5b",
+                            "type": "wait-for-timer",
+                            "displayName": "Notify Reviewer",
+                            "elementId": "Stage_Qn7tBz-tVw2hJcR5b",
+                            "isRequired": false,
+                            "shouldRunOnlyOnce": false,
+                            "entryConditions": [
+                                {
+                                    "id": "cPk2Xh8Qr4",
+                                    "displayName": "Entry Rule 1",
+                                    "rules": [
+                                        [
+                                            {
+                                                "id": "rDw7Mb3Vn6",
+                                                "rule": "current-stage-entered"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "data": {
+                                "timerType": "timeDuration",
+                                "timeDuration": "PT5S"
+                            }
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "id": "Stage_Vw2hJc",
+            "type": "case-management:Stage",
+            "data": {
+                "label": "Decision",
+                "description": "Follows Review and ends the linear flow.",
+                "isRequired": true,
+                "parentElement": { "id": "root", "type": "case-management:root" },
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "entryConditions": [
+                    {
+                        "id": "Condition_Rk2mTs",
+                        "displayName": "Entry Rule 1",
+                        "isInterrupting": false,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Xz4pQw",
+                                    "rule": "selected-stage-completed",
+                                    "selectedStageId": "Stage_Qn7tBz"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "exitConditions": [
+                    {
+                        "id": "Condition_Mv8nBj",
+                        "displayName": "Complete Rule 1",
+                        "type": "exit-only",
+                        "marksStageComplete": true,
+                        "rules": [
+                            [
+                                {
+                                    "id": "Rule_Yw6kHp",
+                                    "rule": "required-tasks-completed"
+                                }
+                            ]
+                        ]
+                    }
+                ],
+                "tasks": [
+                    [
+                        {
+                            "id": "tXp9Kq3Lsm",
+                            "type": "wait-for-timer",
+                            "displayName": "Decision Placeholder",
+                            "elementId": "Stage_Vw2hJc-tXp9Kq3Lsm",
+                            "isRequired": true,
+                            "shouldRunOnlyOnce": false,
+                            "entryConditions": [
+                                {
+                                    "id": "cHs5Tn7Wq9",
+                                    "displayName": "Entry Rule 1",
+                                    "rules": [
+                                        [
+                                            {
+                                                "id": "rLg4Uf8Kp2",
+                                                "rule": "current-stage-entered"
+                                            }
+                                        ]
+                                    ]
+                                }
+                            ],
+                            "data": {
+                                "timerType": "timeDuration",
+                                "timeDuration": "PT5S"
+                            }
+                        }
+                    ]
+                ]
+            }
+        },
+        {
+            "id": "trigger_1",
+            "type": "case-management:Trigger",
+            "data": {
+                "parentElement": { "id": "root", "type": "case-management:root" },
+                "label": "Start Manually",
+                "description": "User-initiated trigger that starts the LinearThreeStages case from the portal",
+                "isInvalidDropTarget": false,
+                "isPendingParent": false,
+                "uipath": {
+                    "outputs": [
+                        {
+                            "name": "caseRef",
+                            "type": "string",
+                            "source": "=vars.pQr7Ks2Wm",
+                            "var": "caseRef"
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "edges": [],
+    "layout": {}
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/entry-points.json
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/entry-points.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+    "$id": "entry-points.json",
+    "entryPoints": [
+        {
+            "filePath": "/content/caseplan.json.bpmn#trigger_1",
+            "uniqueId": "d48f410c-d60d-4ff6-aefd-7c29bee96d39",
+            "type": "CaseManagement",
+            "input": { "type": "object", "properties": {} },
+            "output": { "type": "object", "properties": {} },
+            "displayName": "Start Manually"
+        }
+    ]
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/project.uiproj
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/LinearThreeStages/project.uiproj
@@ -1,0 +1,4 @@
+{
+    "Name": "LinearThreeStages",
+    "ProjectType": "CaseManagement"
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/resources/solution_folder/package/LinearThreeStages.json
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/resources/solution_folder/package/LinearThreeStages.json
@@ -1,0 +1,22 @@
+{
+  "docVersion": "1.0.0",
+  "resource": {
+    "name": "LinearThreeStages",
+    "kind": "package",
+    "apiVersion": "orchestrator.uipath.com/v1",
+    "projectKey": "08b4ee08-6a88-4cc0-96ef-a955406c502d",
+    "dependencies": [],
+    "runtimeDependencies": [],
+    "folders": [
+      {
+        "fullyQualifiedName": "solution_folder"
+      }
+    ],
+    "spec": {
+      "name": "LinearThreeStages"
+    },
+    "locks": [],
+    "key": "e2fd673a-ff0d-472f-9b7f-7cadcfb8aa5d",
+    "files": []
+  }
+}

--- a/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/resources/solution_folder/process/caseManagement/LinearThreeStages.json
+++ b/tests/tasks/uipath-maestro-case/edit/templates/LinearThreeStages/resources/solution_folder/process/caseManagement/LinearThreeStages.json
@@ -1,0 +1,37 @@
+{
+  "docVersion": "1.0.0",
+  "resource": {
+    "name": "LinearThreeStages",
+    "kind": "process",
+    "type": "caseManagement",
+    "apiVersion": "orchestrator.uipath.com/v1",
+    "projectKey": "08b4ee08-6a88-4cc0-96ef-a955406c502d",
+    "dependencies": [
+      {
+        "kind": "package",
+        "name": "LinearThreeStages"
+      }
+    ],
+    "runtimeDependencies": [],
+    "folders": [
+      {
+        "fullyQualifiedName": "solution_folder"
+      }
+    ],
+    "spec": {
+      "type": "CaseManagement",
+      "name": "LinearThreeStages",
+      "package": {
+        "key": "e2fd673a-ff0d-472f-9b7f-7cadcfb8aa5d"
+      },
+      "targetFrameworkValue": "Portable",
+      "retentionAction": "Delete",
+      "retentionPeriod": 30,
+      "staleRetentionAction": "Delete",
+      "staleRetentionPeriod": 180
+    },
+    "locks": [],
+    "key": "5eeaedeb-a8a9-4845-a16a-efbd76c9d858",
+    "files": []
+  }
+}

--- a/tests/tasks/uipath-maestro-case/edit/update_task/check_update_task.py
+++ b/tests/tasks/uipath-maestro-case/edit/update_task/check_update_task.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Update-task edit check.
+
+The starting fixture chains three stages: Intake → Review → Decision. The
+Review stage runs TWO parallel wait-for-timer tasks in distinct data.tasks
+lanes: "Hold For 1 Hour" (required) and "Notify Reviewer" (optional). The
+agent must flip "Notify Reviewer" to required (isRequired true) in place,
+leaving everything else — both tasks, the surviving properties of the edited
+task, the sibling task, the stage chain — untouched. Verifies the single
+property changed, the task was not otherwise rewritten or duplicated, and the
+edited case launches (an in-place update, not a rebuild).
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.case_check import (  # noqa: E402
+    _get_ci,
+    find_caseplan,
+    find_node_by_label,
+    find_stages,
+    find_transitions,
+    read_caseplan,
+    start_debug,
+)
+
+
+def _stage_tasks(node):
+    lanes = (node.get("data") or {}).get("tasks") or []
+    return [t for lane in lanes for t in (lane or [])]
+
+
+def _entry_rule(task):
+    conds = task.get("entryConditions") or []
+    if not conds:
+        return None
+    groups = conds[0].get("rules") or []
+    if groups and groups[0]:
+        return groups[0][0]
+    return None
+
+
+def main():
+    caseplan_path = find_caseplan()
+    plan = read_caseplan(caseplan_path)
+
+    # Stage chain must be untouched: still 3 regular stages.
+    stages = find_stages(plan, include_exception=False)
+    if len(stages) != 3:
+        labels = [(s.get("data") or {}).get("label") for s in stages]
+        sys.exit(
+            f"FAIL: expected the 3 original stages (Intake, Review, Decision) "
+            f"to be unchanged; got {len(stages)}: {labels}"
+        )
+
+    intake = find_node_by_label(plan, "Intake")
+    review = find_node_by_label(plan, "Review")
+    decision = find_node_by_label(plan, "Decision")
+
+    # Review must still carry exactly its two tasks — no add, no remove.
+    review_tasks = _stage_tasks(review)
+    names = sorted(t.get("displayName") for t in review_tasks)
+    if names != ["Hold For 1 Hour", "Notify Reviewer"]:
+        sys.exit(
+            f"FAIL: Review must still carry exactly its two tasks "
+            f"('Hold For 1 Hour', 'Notify Reviewer'); got {names} — no task "
+            f"should be added or removed by an in-place update"
+        )
+
+    # Both tasks must remain in DISTINCT lanes (parallel), as in the fixture.
+    lanes = (review.get("data") or {}).get("tasks") or []
+    if len([lane for lane in lanes if lane]) != 2:
+        sys.exit(
+            f"FAIL: Review's two tasks must stay in two distinct data.tasks "
+            f"lanes; got lane layout {[len(lane or []) for lane in lanes]}"
+        )
+
+    notify = next(t for t in review_tasks if t.get("displayName") == "Notify Reviewer")
+    hold = next(t for t in review_tasks if t.get("displayName") == "Hold For 1 Hour")
+
+    # The one intended change: "Notify Reviewer" is now required.
+    if notify.get("isRequired") is not True:
+        sys.exit(
+            f"FAIL: 'Notify Reviewer' must be flipped to required "
+            f"(isRequired=true); got isRequired={notify.get('isRequired')!r}"
+        )
+
+    # "Notify Reviewer" must be otherwise unchanged: still a wait-for-timer
+    # with its current-stage-entered task-entry condition.
+    if notify.get("type") != "wait-for-timer":
+        sys.exit(
+            f"FAIL: 'Notify Reviewer' should stay a wait-for-timer task; "
+            f"got type={notify.get('type')!r}"
+        )
+    rule = _entry_rule(notify)
+    if not rule or rule.get("rule") != "current-stage-entered":
+        sys.exit(
+            f"FAIL: 'Notify Reviewer' task-entry rule should be "
+            f"'current-stage-entered'; got {rule and rule.get('rule')!r}"
+        )
+
+    # The sibling task must be left required and unchanged — only "Notify
+    # Reviewer" should have changed.
+    if hold.get("isRequired") is not True:
+        sys.exit(
+            f"FAIL: 'Hold For 1 Hour' should stay required (isRequired=true); "
+            f"got isRequired={hold.get('isRequired')!r} — only 'Notify "
+            f"Reviewer' should change"
+        )
+
+    # The linear chain must be intact: Intake → Review → Decision.
+    if not find_transitions(plan, source=intake["id"], target=review["id"]):
+        sys.exit("FAIL: the Intake → Review transition was disturbed by the edit")
+    if not find_transitions(plan, source=review["id"], target=decision["id"]):
+        sys.exit("FAIL: the Review → Decision transition was disturbed by the edit")
+
+    # e2e: the edited case must launch and run in the Studio Web debug runtime.
+    # Every task is a built-in wait-for-timer (no registry resources), but the
+    # case runtime suspends on wait-for-timer tasks, so the case won't
+    # necessarily reach Completed in one debug pass — start_debug refreshes
+    # solution resources, launches debug, and asserts it ran (tolerating a
+    # non-Completed finalStatus), exactly as the sibling edit e2e checks do for
+    # this same case shape.
+    payload = start_debug(timeout=540)
+    status = _get_ci(payload, "finalStatus", "FinalStatus", "status", "Status")
+
+    print(
+        "OK: 'Notify Reviewer' flipped to required in Review (3 stages "
+        "unchanged); Review still carries both tasks in two distinct lanes; "
+        "'Notify Reviewer' otherwise intact (type + current-stage-entered "
+        "entry preserved); 'Hold For 1 Hour' left required and unchanged; "
+        "Intake → Review → Decision chain unchanged; edited case launched in "
+        f"debug runtime (status={status})"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/edit/update_task/update_task.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/update_task/update_task.yaml
@@ -8,7 +8,7 @@ description: >
   restructuring: no stage added or removed, no task added or removed, the stage
   chain and every other node left untouched (the case analog of updating a
   node's properties in place).
-tags: [uipath-maestro-case1, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
 max_iterations: 1
 
 run_limits:

--- a/tests/tasks/uipath-maestro-case/edit/update_task/update_task.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/update_task/update_task.yaml
@@ -1,0 +1,70 @@
+task_id: skill-case-edit-update-task
+description: >
+  Update an existing task in place in the Review stage of a LinearThreeStages
+  case: flip the optional "Notify Reviewer" wait-for-timer task to required
+  (isRequired false → true). Review runs two parallel tasks in distinct
+  data.tasks lanes — "Hold For 1 Hour" (required) and "Notify Reviewer"
+  (optional). Exercises editing a single property on an existing task without
+  restructuring: no stage added or removed, no task added or removed, the stage
+  chain and every other node left untouched (the case analog of updating a
+  node's properties in place).
+tags: [uipath-maestro-case1, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
+max_iterations: 1
+
+run_limits:
+  task_timeout: 1200
+  max_turns: 60
+  turn_timeout: 1200
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../templates
+
+initial_prompt: |
+  The LinearThreeStages case solution already exists on disk under
+  LinearThreeStages/. Its case definition (LinearThreeStages/LinearThreeStages/caseplan.json)
+  chains three stages linearly: Intake → Review → Decision. The Review stage
+  runs TWO parallel wait-for-timer tasks in distinct data.tasks lanes:
+  "Hold For 1 Hour" (required) and "Notify Reviewer" (optional).
+
+  Make the "Notify Reviewer" task REQUIRED so Review no longer completes until
+  both of its tasks finish. After the edit:
+    - "Notify Reviewer" must be marked required (isRequired true), and must be
+      left otherwise unchanged — same displayName, same wait-for-timer type,
+      same current-stage-entered task-entry condition.
+    - Review must still carry exactly its two tasks in distinct lanes. Do NOT
+      add or remove any task, and leave "Hold For 1 Hour" required and
+      unchanged.
+    - The three stages and the Intake → Review → Decision chain must be
+      unchanged — do NOT touch Intake, Decision, any stage-entry condition,
+      Review's exit condition, or any other stage's tasks.
+
+  Do NOT run `uip maestro case debug` — the test harness handles execution.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Make the edit end-to-end in a single pass and
+  finish with `uip maestro case validate` passing on the resulting
+  caseplan.json.
+  Before starting, load the uipath-maestro-case skill. Read and follow its
+  workflow steps exactly.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the edited caseplan.json"
+    command: "uip maestro case validate LinearThreeStages/LinearThreeStages/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "'Notify Reviewer' flipped to required in Review: 3 stages unchanged, Review still carries both tasks in distinct lanes, 'Notify Reviewer' is now isRequired=true and otherwise intact (type + current-stage-entered entry preserved), 'Hold For 1 Hour' left required and unchanged, the linear chain is unchanged, and the edited case launches in the Studio Web debug runtime"
+    command: "python3 $TASK_DIR/check_update_task.py"
+    timeout: 720
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120


### PR DESCRIPTION
Add edit tests for uipath-maestro-case

Introduce an edit/ task suite that exercises editing an existing
caseplan.json, complementing the build-from-scratch coverage. Both tasks
share a LinearThreeStages template fixture (Intake → Review → Decision,
with two parallel wait-for-timer tasks in Review) so the agent starts
from a real on-disk case rather than a blank slate:

- insert_stage: insert an Approval stage between Review and Decision and
  rewire the condition-driven chain (a true insert — the old Review →
  Decision hand-off must be gone).
- remove_task: delete the required "Hold For 1 Hour" task from Review and
  verify the stage's required-tasks-completed exit condition still holds
  (the agent must not strip or rewrite the now-orphaned exit rule).

Each task validates the edited caseplan, asserts the structural delta via
a check script using the _shared/case_check helpers, and launches the
case in the Studio Web debug runtime.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
