### PR TITLE
chore: refresh uip CLI catalog (1.197.0-alpha.20260622.7610)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-06-22T05:52:28Z",
-  "cli_version": "1.197.0-alpha.20260619.7595",
+  "generated_at": "2026-06-23T05:25:02Z",
+  "cli_version": "1.197.0-alpha.20260622.7610",
   "verbs": [
     "admin",
     "admin audit",
@@ -1188,6 +1188,13 @@
     "tm testcases list-testsets",
     "tm testcases remove",
     "tm testcases run",
+    "tm testcases steps",
+    "tm testcases steps add",
+    "tm testcases steps delete",
+    "tm testcases steps get",
+    "tm testcases steps list",
+    "tm testcases steps move",
+    "tm testcases steps update",
     "tm testcases unlink-automation",
     "tm testcases update",
     "tm testsets",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.197.0-alpha.20260622.7610`. The catalog has 1230 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.