### PR TITLE
docs: allow runtime delegation to same-plugin sibling skills

### DIFF
--- a/.claude/rules/pr-review.md
+++ b/.claude/rules/pr-review.md
@@ -11,7 +11,7 @@ When reviewing or creating pull requests for this repository, enforce these rule
 - [ ] `name` field matches the folder name exactly
 - [ ] `description` has under 1024 characters and is concise
 - [ ] Critical Rules section exists with numbered rules
-- [ ] No cross-skill references (skill is fully self-contained)
+- [ ] No structural cross-skill dependencies (does not import or read another skill's files; runtime delegation to a same-plugin sibling that degrades gracefully is allowed)
 - [ ] Reference files use kebab-case naming
 - [ ] All relative links resolve to existing files
 - [ ] CODEOWNERS has been updated with the new skill path
@@ -21,7 +21,7 @@ When reviewing or creating pull requests for this repository, enforce these rule
 
 - [ ] SKILL.md frontmatter is still valid after changes
 - [ ] Critical Rules have not been removed without justification in the PR description
-- [ ] No new cross-skill dependencies introduced
+- [ ] No new structural cross-skill dependencies (runtime delegation to a same-plugin sibling that degrades gracefully is allowed)
 - [ ] Reference file naming conventions preserved
 - [ ] Changes are scoped to the skill being modified (no unrelated changes)
 

--- a/.claude/rules/skill-structure.md
+++ b/.claude/rules/skill-structure.md
@@ -79,7 +79,7 @@ python3 scripts/check-skill-status.py --write-readme
 
 ## Content Rules
 
-- Skills MUST be self-contained — no references to other skills
+- Skills MUST be self-contained — no importing, inlining, or reading another skill's files, and each MUST function when sibling skills are absent. Runtime delegation to a same-plugin sibling skill (e.g., spawning a subagent that delegates the edit to the artifact's owning domain skill) IS allowed when the delegating skill degrades gracefully without it
 - CLI commands MUST include `--output json` when output is parsed programmatically
 - All file links MUST use relative paths from the SKILL.md location
 - All file links MUST point to files that actually exist in the repo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This repository contains self-contained AI agent skills for UiPath automation de
 
 ## Architecture
 
-- **Skills are fully independent.** Each skill under `skills/` is self-contained. Skills cannot reference, import, or depend on other skills.
+- **Skills are self-contained.** Each skill under `skills/` must function on its own: it MUST NOT import, inline, or read another skill's files, and MUST still deliver its core value if sibling skills are absent. A skill MAY delegate a task to a sibling skill in this same plugin at runtime (e.g., spawn a subagent that hands an artifact edit to the artifact's owning domain skill) when that work is the sibling's domain — provided the delegation degrades gracefully (the skill still presents an actionable result when the sibling is unavailable).
 - **SKILL.md is the contract.** Every skill folder must have a `SKILL.md` with valid YAML frontmatter. This is the only file the plugin system reads to discover and activate skills.
 - **No build system.** This repo contains only markdown documentation and shell scripts. There is no compilation or packaging step.
 
@@ -16,7 +16,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide. Key rules:
 2. **SKILL.md frontmatter is required:** must include `name` (matching folder name) and `description` (with TRIGGER/DO NOT TRIGGER conditions)
 3. **References use kebab-case filenames** with `-guide.md` and `-template.md` suffixes
 4. **Update CODEOWNERS** when adding or modifying skill ownership
-5. **No cross-skill references** — each skill must work in isolation
+5. **No structural cross-skill dependencies** — a skill must work in isolation (never import or read another skill's files); runtime delegation to a same-plugin sibling skill is allowed when it degrades gracefully
 6. **No secrets or personal paths** in committed files
 7. **CLI commands must use `--output json`** when output is parsed programmatically
 


### PR DESCRIPTION
## What

Relaxes the repo's "skills must be fully self-contained" rule to **no *structural* cross-skill dependencies**: a skill still MUST NOT import, inline, or read another skill's files and MUST function when siblings are absent, but it MAY **delegate a task to a same-plugin sibling skill at runtime** (e.g. spawn a subagent that hands an artifact edit to the artifact's owning domain skill) — provided the delegation **degrades gracefully**.

The wording stays generic ("the artifact's owning domain skill") — no specific sibling skill is hardcoded in these repo-wide docs.

## Why

Policy prerequisite for the troubleshoot delegate-apply work (PR #1526, stacked on top). The troubleshooter is read-only and must hand confirmed artifact fixes to the owning domain skill rather than editing files itself; the old absolute "no cross-skill references" wording forbade that pattern.

## Files

- `CLAUDE.md` — Architecture + Contribution rule 5
- `.claude/rules/pr-review.md` — new/existing-skill review checklists
- `.claude/rules/skill-structure.md` — Content Rules

The troubleshoot contract that applies this policy (`SKILL.md` Critical Rule #7 + `presenter.md` §7 delegate-apply mechanics) lives in the stacked PR #1526.

## Stacking

PR #1526 is stacked on this branch. **Merge this first**, then #1526.
