### PR TITLE
docs(ixp): document projects list pagination (-l/--offset)

### DIFF
--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -6,7 +6,7 @@ All commands use `uip ixp` prefix. Always append `--output json` when parsing ou
 
 | Command | Description |
 |---------|-------------|
-| `uip ixp projects list --output json` | List all IXP projects |
+| `uip ixp projects list [-l <limit>] [--offset <n>] --output json` | List all IXP projects. Paginated: defaults to 50 per page (max 10000). Pass `-l` for a larger page or `--offset` to skip ahead. |
 | `uip ixp projects get <project-name> --output json` | Get a project |
 | `uip ixp projects create "<name>" <folder-path> [-d "<description>"] [--skip-taxonomy] --output json` | Create project and upload supported docs in `<folder-path>` (top-level only — sub-folders are not scanned; see [Supported document files](#supported-document-files)). By default suggests+imports taxonomy. `-d` provides context for better taxonomy suggestion. Use `--skip-taxonomy` to create a blank project (import taxonomy separately). Use `ProjectName` from output. |
 | `uip ixp projects import-taxonomy <project-name> <file> --output json` | Import taxonomy from a local JSON file. Accepts `{ field_types, label_group }` or `{ entity_defs, label_groups }` format. |


### PR DESCRIPTION
## What

`projects list` gains pagination in the Design-Time migration (`feat/ixp-designtime-services-base`): `-l, --limit <number>` (1–10000, default 50) and `--offset <number>` (0–1000000, default 0) — same shape `documents list` already has. Updated the `projects list` row in `cli-reference.md` to document it.

## How this was scoped

I diffed every `uip ixp` command's argument surface (options **and** positional args) between `origin/main` and `origin/feat/ixp-designtime-services-base`:

- **Only change:** `projects list` += `-l/--limit`, `--offset`.
- Every other command (projects/documents/data-types/groups/fields/labellings/deployments) — flag sets and positional args **byte-identical**. The migration is otherwise an internal refactor (per-domain services + route change), no CLI-surface argument changes.

So this one row is the complete skill update needed for the new arguments.

## Sequencing

This describes behavior on the migration branch; it should land **with** that migration shipping (on today's published CLI, `projects list` has no pagination yet). Same pairing situation as the get-metrics shape work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)