### PR TITLE
fix(tests): match inline escalation node by registry prefix; demote inline index discovery gate

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -45,13 +45,17 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # Advisory, non-gating: inline agents can discover the index identity via the
+  # flow registry (uip maestro flow registry search/get) instead of solution
+  # resources list, so don't gate on it here. Standalone agents (context_index)
+  # have no flow registry and keep this gating.
   - type: command_executed
-    description: "Agent discovered the index identity with uip solution resources list"
+    description: "Advisory: agent discovered the index identity with uip solution resources list (informational, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+resources\s+list\b'
     min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
+    weight: 0.5
+    pass_threshold: 0.0
 
   - type: command_executed
     description: "Agent fetched the index configuration with uip solution resources get"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/check_inline_external_escalation.py
@@ -45,7 +45,7 @@ from _shared.inline_wiring import (  # noqa: E402
 )
 
 FLOW_PATH = Path(os.getcwd()) / "FraudFlowSol" / "FraudFlow" / "FraudFlow.flow"
-ESCALATION_NODE_TYPE = "uipath.agent.resource.escalation"
+ESCALATION_NODE_TYPE_PREFIX = "uipath.agent.resource.escalation."
 UUID_RE = re.compile(r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 
 EXPECTED_APP_NAME = "FraudEscalation"
@@ -55,7 +55,7 @@ EXPECTED_FOLDER_NAME = "Shared/uipath-agents/FraudEscalation"
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    escalation_node = find_resource_node(flow, node_type=ESCALATION_NODE_TYPE)
+    escalation_node = find_resource_node(flow, node_type_prefix=ESCALATION_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {escalation_node['type']} nodes")
 
     agent_source = (agent_node.get("inputs") or {}).get("source")

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/check_inline_solution_escalation.py
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/check_inline_solution_escalation.py
@@ -42,13 +42,13 @@ from _shared.inline_wiring import (  # noqa: E402
 )
 
 FLOW_PATH = Path(os.getcwd()) / "ReviewFlowSol" / "ReviewFlow" / "ReviewFlow.flow"
-ESCALATION_NODE_TYPE = "uipath.agent.resource.escalation"
+ESCALATION_NODE_TYPE_PREFIX = "uipath.agent.resource.escalation."
 
 
 def main() -> None:
     flow = load_json(FLOW_PATH)
     agent_node = find_autonomous_agent_node(flow)
-    escalation_node = find_resource_node(flow, node_type=ESCALATION_NODE_TYPE)
+    escalation_node = find_resource_node(flow, node_type_prefix=ESCALATION_NODE_TYPE_PREFIX)
     print(f"OK: flow has {agent_node['type']} and {escalation_node['type']} nodes")
 
     assert_edge(


### PR DESCRIPTION
## Summary

Three uipath-agents lowcode inline tests were failing or over-gating despite correct agent output. This fixes the grading, not the skill.

### 1. Inline escalation check scripts — exact-match never matched

`check_inline_external_escalation.py` and `check_inline_solution_escalation.py` exact-matched the node type `uipath.agent.resource.escalation`. But the flow registry's canonical node type is fully-qualified:

```
NodeType: uipath.agent.resource.escalation.coded-action-app   ("Action App Escalation")
```

The bare string is only a prefix and never matches a real flow node, so both checks failed for **any** correct output. Switched to `node_type_prefix` matching (the shared `find_resource_node` helper already supports it), mirroring the existing `inline_context_index` convention (`uipath.agent.resource.context.index.`).

### 2. `inline_context_index` — `solution resources list` demoted to advisory

The `uip solution resources list` criterion was gating (weight 1.5, threshold 1.0). Inline agents can discover the index identity via `uip maestro flow registry search/get` instead, so gating on `solution resources list` rejected a valid discovery path. Demoted to advisory (weight 0.5, threshold 0.0), matching the `inline_solution_*` sibling family. The standalone `context_index` test keeps it gating — standalone agents have no flow registry to fall back on.

## Verification

Re-ran all three under `experiments/default.yaml`:

| Test | Result |
|------|--------|
| `inline_context_index` | ✅ SUCCESS 13/13 |
| `inline_external_escalation` | ✅ SUCCESS 12/12 |
| `inline_solution_escalation` | ✅ SUCCESS 11/11 |

(`inline_solution_escalation` first hit a transient 1200s agent timeout under `-j 2`; passed cleanly on a solo re-run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)