### PR TITLE
fix(ci): make the ixp e2e hit Design-Time in CI (pre-bake ixp-tool + driver:docker)

### DIFF
--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -43,6 +43,11 @@ RUN set -euo pipefail && \
     # to public npm (stable only) — stable lacks the alpha-only guardrail-format
     # review rules, which silently scores guardrail review tasks 0.
     uip tools install @uipath/agent-tool && \
+    # IXP command group (`uip ixp …`) ships as a separate plugin on the @alpha
+    # feed. Required so the live ixp e2e (full_lifecycle) can actually execute
+    # `uip ixp` — without it the command is unknown and the e2e thrashes to
+    # MAX_TURNS. (Smoke ixp tasks pass regardless, since they grade command shape.)
+    uip tools install @uipath/ixp-tool && \
     # AgentHub command group ships as a separate plugin (CLI fetches it lazily).
     # Pre-install from the same @alpha feed so live `uip agenthub …` MCP e2e
     # tasks don't hit a missing-plugin 401.

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -13,8 +13,14 @@ run_limits:
   task_timeout: 2400
   turn_timeout: 1800
 
+# driver: docker (NOT tempdir) is required. `uip ixp` ships as the separate
+# @uipath/ixp-tool plugin, pre-baked only into skills-image:latest (see
+# tests/docker/Dockerfile). tempdir runs the agent on the base coder-eval image,
+# which has no ixp plugin → every `uip ixp` is "unknown command", zero API calls,
+# and the run thrashes to MAX_TURNS. docker inherits the image + UIPATH_CLI_* auth
+# passthrough + ~/.uipath mount from the experiment default.
 sandbox:
-  driver: tempdir
+  driver: docker
   python: {}
   template_sources:
     - type: template_dir


### PR DESCRIPTION
## What
Make the live `uip ixp` **e2e** (`full_lifecycle`) actually exercise the migrated Design-Time CLI in CI, by running it in-container against a pre-baked migrated tool.

**Root cause:** under `driver: tempdir` the e2e runs on the BYOS host, where `uip ixp` resolves the host's **stale pre-migration `ixp-tool` (1.1.0)** → legacy `reinfer_` backend → zero Design-Time traffic (and a hollow "success").

## Changes
- **Pre-bake `@uipath/ixp-tool`** in the eval image (`tests/docker/Dockerfile`) so the migrated 1.197 tool is present in-image.
- **`driver: docker`** (not `tempdir`) for the e2e `full_lifecycle` task → `uip ixp` resolves the baked migrated tool → `du_/api/designtimeapi`.

## Validation
- Live `Run coder-eval` on this branch: `skill-ixp-e2e-full-lifecycle` = **SUCCESS** (fix confirmed).

## Scope
The **integration** tasks' `driver:docker` + turn-budget changes (which also depend on the Dockerfile pre-bake here) live in a separate PR (#1675) to keep this one focused on the shared docker infra + the e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mwj1Gyvj9GoEYWULV6eT98
