### PR TITLE
fix(skills): renumber legacy ids in uipath-rpa activation set

### DIFF
--- a/tests/tasks/activation/uipath-rpa.jsonl
+++ b/tests/tasks/activation/uipath-rpa.jsonl
@@ -50,54 +50,54 @@
 {"id": "uipath-rpa-050", "prompt": "Add a Get Asset activity to pull the OrchestratorUrl asset and use it in the HTTP Request", "expected_skill": "uipath-rpa"}
 {"id": "uipath-rpa-051", "prompt": "Edit my Main.xaml file", "expected_skill": "uipath-rpa"}
 {"id": "uipath-rpa-052", "prompt": "Write a coded workflow in C# that calls a REST API and parses JSON", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-001", "prompt": "Create a new Windows-Legacy UiPath project called InvoiceProcessing", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-002", "prompt": "Build a legacy XAML workflow that reads an Excel file and logs each row", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-003", "prompt": "My project.json has targetFramework Legacy, can you add a try-catch around the Outlook activities in Main.xaml?", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-004", "prompt": "Validate this Studio Desktop project with uip rpa-legacy", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-005", "prompt": "Add a Read Range classic activity to GetInvoices.xaml", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-006", "prompt": "Generate a REFramework-based legacy project for queue processing", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-007", "prompt": "Fix the validation errors in this .NET Framework 4.6.1 project", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-008", "prompt": "Convert these VB.NET expressions in my legacy XAML to use the right bracket syntax", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-009", "prompt": "Add a Flowchart with three decision branches to Process.xaml in my Windows-Legacy project", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-010", "prompt": "Set up a Dispatcher/Performer pair in a legacy UiPath project", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-011", "prompt": "Open Main.xaml and add a LogMessage at the start, project is Windows - Legacy", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-012", "prompt": "uip rpa-legacy validate is returning errors about missing namespace imports, please fix them", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-013", "prompt": "Create a XAML using classic UI Automation Click and Type Into activities", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-014", "prompt": "Build me a legacy library project with three reusable workflows", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-015", "prompt": "Add a Retry Scope around the SAP login sequence in my legacy workflow", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-016", "prompt": "I'm on Studio Desktop 24.10, build a XAML that downloads attachments from Outlook", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-017", "prompt": "Generate a StateMachine XAML with Init / Process / End states for my legacy project", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-018", "prompt": "Add an Invoke Code activity in VB.NET that parses a JSON string", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-019", "prompt": "Debug this legacy XAML, it crashes with NullReferenceException at runtime", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-020", "prompt": "Run the workflow with uip rpa-legacy debug and show me the output arguments", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-021", "prompt": "Add a Get Outlook Mail Messages activity (classic) and filter by subject", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-022", "prompt": "Package my Studio Desktop project into a .nupkg", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-023", "prompt": "Make a legacy Test Automation project with two test cases for the login flow", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-024", "prompt": "Add a For Each Row over dt_Invoices that writes each row to SAP", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-025", "prompt": "Fix the 'Cannot create unknown type' error in my Windows-Legacy XAML", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-026", "prompt": "Add Orchestrator queue Add Queue Item / Get Transaction Item activities to the dispatcher and performer", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-027", "prompt": "Build a workflow that uses Excel Application Scope to read Config.xlsx and load assets", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-028", "prompt": "In my Windows-Legacy project, create a full selector for a button in Notepad and add a classic Click activity", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-029", "prompt": "My XAML uses System.Private.CoreLib, switch the assembly references back to mscorlib", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-030", "prompt": "In my Windows-Legacy XAML, add a TryCatch around the entire Main sequence and log the exception", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-031", "prompt": "I have a Windows-Legacy project, add Send Outlook Mail Message at the end of Main.xaml", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-032", "prompt": "ViewState is missing on my Flowchart nodes \u2014 Studio is stacking them at 0,0. Fix it.", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-033", "prompt": "Find activities for HTTP Request in my legacy project and add one to call our API", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-034", "prompt": "Create a new XAML library that wraps our login flow as an InvokeWorkflow target", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-035", "prompt": "Add an Assign with a LINQ query that filters rows where Status = \"Open\"", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-036", "prompt": "Help me read a PDF with the classic Read PDF Text activity", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-037", "prompt": "Set the project's expressionLanguage to C# and update Main.xaml to use C# expressions", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-038", "prompt": "In my legacy XAML, add a While loop with a counter that retries the HTTP Request activity up to 3 times", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-039", "prompt": "In my Windows-Legacy REFramework project, add a Switch activity in Process.xaml with cases for each transaction type", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-040", "prompt": "Build the dispatcher that adds queue items from an Excel sheet", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-041", "prompt": "Generate a Document Understanding pipeline XAML for a legacy project", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-042", "prompt": "Add an in_FilePath argument to Main.xaml in my Windows-Legacy project and wire it through to the Excel Application Scope", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-043", "prompt": "Validate the whole project and tell me what errors come up", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-044", "prompt": "Open project in Studio Desktop, write a workflow that scrapes a table from a web page using classic UI Automation", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-045", "prompt": "Set ContinueOnError=True on a non-critical classic activity in my legacy XAML so the workflow doesn't fail", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-046", "prompt": "Create test data \u2014 an Excel file and a JSON config \u2014 for testing my legacy workflow", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-047", "prompt": "Refactor this monolithic Main.xaml into smaller InvokeWorkflowFile blocks", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-048", "prompt": "Add Get Asset and Get Credential activities to read Orchestrator assets", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-049", "prompt": "Fix the dependencies in project.json so packages resolve for a Windows-Legacy target", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-050", "prompt": "I want to add a Persistence (Wait For) pattern in my legacy workflow \u2014 is that possible? show how", "expected_skill": "uipath-rpa"}
-{"id": "uipath-rpa-legacy-051", "prompt": "Build a UiPath Studio Desktop project targeting .NET Framework 4.6.1 with a Main.xaml that prints Hello", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-053", "prompt": "Create a new Windows-Legacy UiPath project called InvoiceProcessing", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-054", "prompt": "Build a legacy XAML workflow that reads an Excel file and logs each row", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-055", "prompt": "My project.json has targetFramework Legacy, can you add a try-catch around the Outlook activities in Main.xaml?", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-056", "prompt": "Validate this Studio Desktop project with uip rpa-legacy", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-057", "prompt": "Add a Read Range classic activity to GetInvoices.xaml", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-058", "prompt": "Generate a REFramework-based legacy project for queue processing", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-059", "prompt": "Fix the validation errors in this .NET Framework 4.6.1 project", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-060", "prompt": "Convert these VB.NET expressions in my legacy XAML to use the right bracket syntax", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-061", "prompt": "Add a Flowchart with three decision branches to Process.xaml in my Windows-Legacy project", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-062", "prompt": "Set up a Dispatcher/Performer pair in a legacy UiPath project", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-063", "prompt": "Open Main.xaml and add a LogMessage at the start, project is Windows - Legacy", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-064", "prompt": "uip rpa-legacy validate is returning errors about missing namespace imports, please fix them", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-065", "prompt": "Create a XAML using classic UI Automation Click and Type Into activities", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-066", "prompt": "Build me a legacy library project with three reusable workflows", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-067", "prompt": "Add a Retry Scope around the SAP login sequence in my legacy workflow", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-068", "prompt": "I'm on Studio Desktop 24.10, build a XAML that downloads attachments from Outlook", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-069", "prompt": "Generate a StateMachine XAML with Init / Process / End states for my legacy project", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-070", "prompt": "Add an Invoke Code activity in VB.NET that parses a JSON string", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-071", "prompt": "Debug this legacy XAML, it crashes with NullReferenceException at runtime", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-072", "prompt": "Run the workflow with uip rpa-legacy debug and show me the output arguments", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-073", "prompt": "Add a Get Outlook Mail Messages activity (classic) and filter by subject", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-074", "prompt": "Package my Studio Desktop project into a .nupkg", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-075", "prompt": "Make a legacy Test Automation project with two test cases for the login flow", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-076", "prompt": "Add a For Each Row over dt_Invoices that writes each row to SAP", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-077", "prompt": "Fix the 'Cannot create unknown type' error in my Windows-Legacy XAML", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-078", "prompt": "Add Orchestrator queue Add Queue Item / Get Transaction Item activities to the dispatcher and performer", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-079", "prompt": "Build a workflow that uses Excel Application Scope to read Config.xlsx and load assets", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-080", "prompt": "In my Windows-Legacy project, create a full selector for a button in Notepad and add a classic Click activity", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-081", "prompt": "My XAML uses System.Private.CoreLib, switch the assembly references back to mscorlib", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-082", "prompt": "In my Windows-Legacy XAML, add a TryCatch around the entire Main sequence and log the exception", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-083", "prompt": "I have a Windows-Legacy project, add Send Outlook Mail Message at the end of Main.xaml", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-084", "prompt": "ViewState is missing on my Flowchart nodes \u2014 Studio is stacking them at 0,0. Fix it.", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-085", "prompt": "Find activities for HTTP Request in my legacy project and add one to call our API", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-086", "prompt": "Create a new XAML library that wraps our login flow as an InvokeWorkflow target", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-087", "prompt": "Add an Assign with a LINQ query that filters rows where Status = \"Open\"", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-088", "prompt": "Help me read a PDF with the classic Read PDF Text activity", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-089", "prompt": "Set the project's expressionLanguage to C# and update Main.xaml to use C# expressions", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-090", "prompt": "In my legacy XAML, add a While loop with a counter that retries the HTTP Request activity up to 3 times", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-091", "prompt": "In my Windows-Legacy REFramework project, add a Switch activity in Process.xaml with cases for each transaction type", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-092", "prompt": "Build the dispatcher that adds queue items from an Excel sheet", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-093", "prompt": "Generate a Document Understanding pipeline XAML for a legacy project", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-094", "prompt": "Add an in_FilePath argument to Main.xaml in my Windows-Legacy project and wire it through to the Excel Application Scope", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-095", "prompt": "Validate the whole project and tell me what errors come up", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-096", "prompt": "Open project in Studio Desktop, write a workflow that scrapes a table from a web page using classic UI Automation", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-097", "prompt": "Set ContinueOnError=True on a non-critical classic activity in my legacy XAML so the workflow doesn't fail", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-098", "prompt": "Create test data \u2014 an Excel file and a JSON config \u2014 for testing my legacy workflow", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-099", "prompt": "Refactor this monolithic Main.xaml into smaller InvokeWorkflowFile blocks", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-100", "prompt": "Add Get Asset and Get Credential activities to read Orchestrator assets", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-101", "prompt": "Fix the dependencies in project.json so packages resolve for a Windows-Legacy target", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-102", "prompt": "I want to add a Persistence (Wait For) pattern in my legacy workflow \u2014 is that possible? show how", "expected_skill": "uipath-rpa"}
+{"id": "uipath-rpa-103", "prompt": "Build a UiPath Studio Desktop project targeting .NET Framework 4.6.1 with a Main.xaml that prints Hello", "expected_skill": "uipath-rpa"}


### PR DESCRIPTION
The `uipath-rpa` activation set still carried `uipath-rpa-legacy-*` ids left over from when the `uipath-rpa-legacy` skill was merged into `uipath-rpa`. Every row is already correctly labeled `expected_skill: uipath-rpa`, so coder-eval scoring is unaffected — but the evalboard buckets rows by their id prefix, so these 51 rows were attributed to a phantom `uipath-rpa-legacy` skill. That split `uipath-rpa`'s sampled prompts below the coverage threshold and surfaced a false 0% coverage gap, dragging down the headline activation score.

This renumbers the 51 legacy ids into the existing `uipath-rpa-*` sequence (053–103). No prompts or expected-skill labels change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)