### PR TITLE
fix(test): steer apms_get_my_ip_smoke away from curl fallback

### DIFF
--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -13,9 +13,10 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  I need to check what public IP the UiPath platform sees for my
-  machine before I add it to our IP restriction allowlist. What's my
-  current outbound IP?
+  Before I update our UiPath IP restriction allowlist, I need to verify
+  what IP address the UiPath admin service resolves for my connection.
+  Use the `uip` CLI to query this — a generic IP lookup won't
+  necessarily match what the platform sees behind its gateway.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be


### PR DESCRIPTION
## Summary
The `apms_get_my_ip_smoke` task consistently fails because the agent runs `curl ipify.org` instead of `uip admin ip-restriction my-ip`. Three prior fix attempts rephrased the question but the agent always takes the path of least resistance for "What's my outbound IP?"

New prompt explicitly tells the agent to use the `uip` CLI and explains why a generic IP lookup won't work (the platform may see a different IP behind its gateway).

## Coder-eval results — 3 consecutive passes ✅

| Run | Link | Duration | Score |
|-----|------|----------|-------|
| #1 | [28047061413](https://github.com/UiPath/skills/actions/runs/28047061413) | 116s | 1.000 |
| #2 | [28047315681](https://github.com/UiPath/skills/actions/runs/28047315681) | 22s | 1.000 |
| #3 | [28047449654](https://github.com/UiPath/skills/actions/runs/28047449654) | 19s | 1.000 |

## Test plan
- [x] Coder-eval: task passes 3x consecutively (score=1.000 each)

🤖 Generated with [Claude Code](https://claude.com/claude-code)