### PR TITLE
test(uipath-admin): add 8 tasks closing coverage gaps (61% → ~78%)

### DIFF
--- a/tests/tasks/uipath-admin/apms_bypass_rule_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_bypass_rule_lifecycle_e2e.yaml
@@ -1,0 +1,72 @@
+task_id: skill-admin-apms-bypass-rule-lifecycle-e2e
+description: >
+  End-to-end test: full bypass-rule CRUD lifecycle — create a bypass
+  rule from a file body, get it by ID, update its regex pattern, then
+  delete it. Only `bypass-rules list` is currently covered; this test
+  exercises the entire mutation surface.
+
+  Command-construction only — no live tenant. What matters is correct
+  command sequencing and flag usage for bypass-rule CRUD.
+tags: [uipath-admin, e2e, mode:build, lifecycle:setup, apms, bypass-rules]
+
+run_limits:
+  expected_turns: 12
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  Create an IP restriction bypass rule that exempts the URL pattern
+  "^https://webhook\.example\.com/.*$" with the name "Webhook Bypass
+  Test". After creating, retrieve the rule by its ID to verify it,
+  then update the pattern to "^https://webhook\.example\.com/api/.*$",
+  and finally delete the rule to clean up.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created a bypass rule with --file"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+create\b.*--file'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved the bypass rule via get with positional ID"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated the bypass rule"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+update\b'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deleted the bypass rule"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+delete\b'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_enforcement_enable_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_enforcement_enable_e2e.yaml
@@ -1,0 +1,80 @@
+task_id: skill-admin-apms-enforcement-enable-e2e
+description: >
+  End-to-end test: agent follows the full enforcement-enable safety workflow
+  from Rule 31 — my-ip pre-flight, ip-ranges verification, impact prompt,
+  --confirm flag, then enforcement disable to restore. Validates the agent
+  runs the mandatory pre-flight chain before the lockout-sensitive toggle
+  and cleans up by disabling enforcement afterward.
+
+  Command-construction only — no live tenant. What matters is correct
+  command ordering and flag usage, not command success.
+tags: [uipath-admin, e2e, mode:operate, lifecycle:setup, apms, enforcement]
+
+run_limits:
+  expected_turns: 12
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  Enable IP restriction enforcement on the organization. Follow the
+  skill's full safety procedure — do not skip the pre-flight checks.
+  After verifying enforcement is active, disable it again to restore
+  the original state. This is a test run.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran my-ip pre-flight before enable (Rule 31)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed IP ranges to verify coverage (Rule 31)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+list\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent checked enforcement status before toggling"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+get\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent enabled enforcement with --confirm flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+enable\b.*--confirm'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent disabled enforcement to restore state"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+disable\b'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_ip_range_edit_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_ip_range_edit_e2e.yaml
@@ -1,0 +1,62 @@
+task_id: skill-admin-apms-ip-range-edit-e2e
+description: >
+  End-to-end test: IP range mutation lifecycle — create a CIDR range,
+  update its description, then delete it with --confirm (Rule 31 requires
+  --confirm on ip-ranges delete while enforcement is on). Tests the
+  ip-ranges create/update/delete mutation path that is currently untested.
+
+  Command-construction only — no live tenant. What matters is correct
+  command sequencing and flag usage for ip-range CRUD.
+tags: [uipath-admin, e2e, mode:build, lifecycle:edit, apms, ip-ranges]
+
+run_limits:
+  expected_turns: 10
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  Add a new IP range entry for our staging environment: CIDR "203.0.113.0/24"
+  with description "Staging office". After creating, update the description
+  to "Staging office - primary". Then delete the range entry to clean up.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the IP range"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+create\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated the IP range"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+update\b'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deleted the IP range with --confirm"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+delete\b.*--confirm'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_scope_ambiguity_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_scope_ambiguity_smoke.yaml
@@ -1,0 +1,65 @@
+task_id: skill-admin-audit-scope-ambiguity-smoke
+description: >
+  Smoke test: agent receives an ambiguous audit request ("show me the
+  audit log") with no prior scope context. Per Rule 23, the agent must
+  stop and ask the user to disambiguate org vs tenant scope — never
+  silently default to one. Validates the stop-and-ask safety behavior
+  via command_not_executed on unscoped audit queries.
+
+  Known limitation: an idle agent that does nothing also passes. This is
+  acceptable — silently defaulting to a scope is the failure mode being
+  tested, and doing nothing is a less-bad false-positive.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is that the
+  agent does NOT silently run an audit command before clarifying scope.
+tags: [uipath-admin, smoke, mode:diagnose, lifecycle:discover, audit, scope-ambiguity]
+
+run_limits:
+  expected_turns: 5
+
+initial_prompt: |
+  Show me the audit log for the last 24 hours.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+    HOWEVER: if you are unsure about the audit scope (org vs tenant),
+    you SHOULD ask to clarify — that is the correct behavior per the
+    skill's rules.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent loaded the uipath-admin skill"
+    skill_name: "uipath-admin"
+    expected: "yes"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT run audit tenant events without clarifying scope first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b'
+    weight: 3.0
+
+  - type: command_not_executed
+    description: "Agent must NOT run audit org events without clarifying scope first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+events\b'
+    weight: 3.0
+
+  - type: command_not_executed
+    description: "Agent must NOT run audit tenant sources without clarifying scope first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b'
+    weight: 2.0
+
+  - type: command_not_executed
+    description: "Agent must NOT run audit org sources without clarifying scope first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+sources\b'
+    weight: 2.0

--- a/tests/tasks/uipath-admin/audit_scope_ambiguity_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_scope_ambiguity_smoke.yaml
@@ -36,7 +36,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent loaded the uipath-admin skill"
     skill_name: "uipath-admin"
-    expected: "yes"
+    expected_skill: "uipath-admin"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-admin/identity_user_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/identity_user_lifecycle_e2e.yaml
@@ -1,0 +1,72 @@
+task_id: skill-admin-identity-user-lifecycle-e2e
+description: >
+  End-to-end test: full user lifecycle — invite a user, search to
+  confirm the invite, update user details, then delete. Tests the
+  identity CRUD tail (update/delete) that is currently untested, plus
+  Rule 5 (resolve before high-risk ops) and Rule 10 (confirm before
+  delete).
+
+  Command-construction only — no live tenant. What matters is correct
+  command sequencing and flag usage across the full lifecycle.
+tags: [uipath-admin, e2e, mode:build, lifecycle:edit, identity, user-lifecycle]
+
+run_limits:
+  expected_turns: 12
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  Onboard a test user with email "lifecycle-test@example.com", name "Test",
+  surname "LifecycleUser". After inviting, search for the user to confirm
+  they exist. Then update the user's surname to "UpdatedUser". Finally,
+  delete the user to clean up.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent invited the user with email, name, and surname"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+users\s+invite\b.*--email\s+\S*lifecycle-test'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent searched/listed users to find the new user"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+users\s+list\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated the user (positional id + changed field)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+users\s+update\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent deleted the user (positional id)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+users\s+delete\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
@@ -1,0 +1,62 @@
+task_id: skill-admin-oms-tenant-create-poll-e2e
+description: >
+  End-to-end test: agent creates a tenant and then polls the async
+  operation via `organizations operation get <OP_ID>` per Rule 18.
+  Validates the agent auto-polls after a tenant mutation instead of
+  leaving the user with an unresolved operation.
+
+  Command-construction only — no live tenant. What matters is correct
+  command sequencing: regions list -> tenants create -> operation get poll.
+tags: [uipath-admin, e2e, mode:operate, lifecycle:setup, oms, tenant-lifecycle, async-poll]
+
+run_limits:
+  expected_turns: 10
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  Create a new tenant named "Staging-Env-Poll-Test" in an appropriate region.
+  After creation, poll the returned operation to check whether the tenant
+  was created successfully. Report the final status.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed regions before creating (Rule 21)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+organizations\s+regions\s+list\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the tenant with name and region"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+create\b.*(?:--file|--region)'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent polled async operation via organizations operation get (Rule 18)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+organizations\s+operation\s+get\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
@@ -19,6 +19,10 @@ initial_prompt: |
   After creation, poll the returned operation to check whether the tenant
   was created successfully. Report the final status.
 
+  If the create command fails and returns no operation ID, use a
+  placeholder ID (e.g. "00000000-0000-0000-0000-000000000000") and
+  still run the poll command so we can verify the command shape.
+
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
     installed and/or the CLI is not connected to a live tenant.

--- a/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
@@ -1,0 +1,71 @@
+task_id: skill-admin-oms-tenant-service-remove-e2e
+description: >
+  End-to-end test: agent adds a service to a tenant, then removes it,
+  then re-lists to verify post-state (Rule 22 — remove may no-op on
+  platform-pinned services). Validates the services add/remove workflow
+  and the mandatory post-mutation re-list.
+
+  Command-construction only — no live tenant. What matters is correct
+  command sequencing: list-available -> add -> remove -> re-list verify.
+tags: [uipath-admin, e2e, mode:operate, lifecycle:setup, oms, service-provisioning]
+
+run_limits:
+  expected_turns: 10
+  max_turns: 40
+  turn_timeout: 600
+
+initial_prompt: |
+  On the "Development" tenant, add the "actioncenter" service, verify
+  it appears in the tenant's service list, then remove it and re-list
+  to confirm removal. Check the available service catalog first so you
+  use the correct service type name.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed available services first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list-available\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added the service to the tenant"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+add\b'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent removed the service from the tenant"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+remove\b'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent re-listed tenant services after remove to verify post-state (Rule 22)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list\b'
+    min_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
@@ -57,7 +57,7 @@ success_criteria:
   - type: command_executed
     description: "Agent re-listed tenant services after remove to verify post-state (Rule 22)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list\b'
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list(?![-])\b'
     min_count: 2
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
+++ b/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
@@ -17,6 +17,10 @@ initial_prompt: |
   to find it, then regenerate the first token in the list with a new
   expiration 90 days from now.
 
+  If listing fails, use a placeholder token ID (e.g.
+  "00000000-0000-0000-0000-000000000000") and still run the regenerate
+  command so we can verify the command shape.
+
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
     installed and/or the CLI is not connected to a live tenant.

--- a/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
+++ b/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
@@ -1,0 +1,52 @@
+task_id: skill-admin-pat-regenerate-smoke
+description: >
+  Smoke test: agent regenerates a personal access token by listing
+  tokens, selecting one, and calling pat regenerate with an expiration.
+  Tests the one PAT verb with zero coverage.
+
+  Platform note: runs without an authenticated tenant — commands will
+  fail with auth errors. That is acceptable; what matters is correct
+  command invocation with correct flags.
+tags: [uipath-admin, smoke, mode:operate, lifecycle:setup, pat]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  I have a personal access token that's expiring soon. List my tokens
+  to find it, then regenerate the first token in the list with a new
+  expiration 90 days from now.
+
+  Important:
+  - The `uip` CLI is available but the `admin` subcommand may not be
+    installed and/or the CLI is not connected to a live tenant.
+    Commands WILL fail — that is expected and acceptable.
+    Run each command exactly once regardless of errors.
+    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
+    do NOT troubleshoot errors.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed PATs first to find the token"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+pat\s+list\b'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent called pat regenerate with expiration"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+pat\s+regenerate\b.*--expiration'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- Adds 8 new test tasks for `uipath-admin` targeting the highest-priority coverage gaps from the `/test-coverage` report
- Estimated component coverage improvement: **61% → ~78%** (14 previously untested verbs now covered)
- Operate mode floor rises from 56% → ~68%; build from 60% → ~71%

### New tests

| Test | Tier | Mode | Gap Closed |
|------|------|------|-----------|
| `apms_enforcement_enable_e2e` | e2e | operate | `enforcement enable/disable` — highest-risk untested verb (Rule 31) |
| `oms_tenant_create_poll_e2e` | e2e | operate | `organizations operation get` — async poll spine (Rule 18) |
| `oms_tenant_service_remove_e2e` | e2e | operate | `tenants services remove` + post-state re-list (Rule 22) |
| `audit_scope_ambiguity_smoke` | smoke | diagnose | Scope disambiguation stop-and-ask (Rule 23, negative test) |
| `identity_user_lifecycle_e2e` | e2e | build | `users invite/update/delete` — identity CRUD tail |
| `apms_bypass_rule_lifecycle_e2e` | e2e | build | `bypass-rules create/get/update/delete` — only `list` was covered |
| `apms_ip_range_edit_e2e` | e2e | build | `ip-ranges update/delete --confirm` — mutation tail |
| `pat_regenerate_smoke` | smoke | operate | `pat regenerate` — last uncovered PAT verb |

All tasks are command-construction only (no live tenant required). Linted with `/lint-task` — 4 OK, 2 Low, 2 Medium (prompt over-spec fixed, audit scope negative-test limitation documented).

## Test plan

- [ ] `/lint-task tests/tasks/uipath-admin/apms_enforcement_enable_e2e.yaml` — passes
- [ ] `/lint-task` on all 8 new files — no Critical or High issues
- [ ] YAML is valid (parseable, no syntax errors)
- [ ] CLI verb check passes (all verbs exist in catalog)
- [ ] No `env_packages` with `@uipath/cli`
- [ ] No `agent:` block with run-limit fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)