### PR TITLE
fix(uipath-governance): make access-policy evaluate smoke task_id unique

### DIFF
--- a/tests/tasks/uipath-governance/access-policy/access_evaluate_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access_evaluate_smoke.yaml
@@ -1,4 +1,4 @@
-task_id: skill-gov-access-policy-evaluate-smoke
+task_id: skill-gov-access-policy-access-evaluate-smoke
 description: >
   Skill-guided evaluation: agent uses the uipath-governance skill to
   evaluate whether current access policies would allow a Maestro flow


### PR DESCRIPTION
Two access-policy task files shipped with the same `task_id` (`skill-gov-access-policy-evaluate-smoke`), which makes `coder-eval run` abort with a duplicate-id error before executing any skills task. The effect is that the **entire skills suite is excluded from the nightly run** — it produces no top-level `run.json`, so the nightly pipeline fails its upload gate even though activation runs fine.

This gives the skill-guided evaluate task a unique id that matches its filename, restoring one id per file and unblocking the skills suite.