### PR TITLE
docs(uipath-agents): document @{ } expression tokens in agent prompts

### DIFF
--- a/skills/uipath-agents/references/lowcode/agent-definition.md
+++ b/skills/uipath-agents/references/lowcode/agent-definition.md
@@ -271,7 +271,7 @@ For conversational, typically general behavior and steps to respond to users. Sh
 
 ### User Message
 
-For autonomous agents, templates input fields into the prompt using `{{input.fieldName}}`, and agent resources/outputs using `@{ }` expressions — `@{tools.<Name>}`, `@{contexts.<Name>}`, `@{escalations.<Name>}`, `@{output.<path>}` (see § contentTokens Construction). For `job-attachment` fields the token renders metadata only (see § File Attachments).
+For autonomous agents, templates input fields into the prompt using `{{input.fieldName}}`, and agent resources/outputs using `@{ }` expressions (see § contentTokens Construction). For `job-attachment` fields the token renders metadata only (see § File Attachments).
 
 ```json
 {
@@ -300,16 +300,7 @@ Three token types: `simpleText`, `variable`, `expression`.
 3. Text inside `@{ }` → `{ "type": "expression", "rawString": "<expr>" }` (strip delimiters; Studio expression referencing an agent resource or output — see families below)
 4. Every segment including whitespace gets its own entry
 
-`@{ }` expression families (the `rawString` is the inner text verbatim, prefix included):
-
-| Prefix | References | Example rawString |
-|--------|-----------|-------------------|
-| `tools.<Name>` | a tool resource | `tools.SearchWeb` |
-| `contexts.<Name>` | a context (index) resource | `contexts.Test` |
-| `escalations.<Name>` | an escalation resource | `escalations.HumanReview` |
-| `output.<path>` | the agent's output schema (dotted path) | `output.result.data` |
-
-`{{ }}` (`variable`) is for `inputSchema` fields only; `@{ }` (`expression`) is for everything else (tools, contexts, escalations, outputs). None of the `@{ }` targets are `inputSchema` fields — do not declare them under `inputSchema.properties`.
+`@{ }` (`expression`) references an agent resource or output by family + name — `tools.<Name>`, `contexts.<Name>`, `escalations.<Name>`, or `output.<path>` — with the inner text verbatim as `rawString` (e.g. `@{contexts.Knowledge}` → `rawString: "contexts.Knowledge"`). `{{ }}` (`variable`) is for `inputSchema` fields only; `@{ }` targets are runtime-resolved and must never be declared under `inputSchema.properties`.
 
 **Example — adjacent variables:**
 
@@ -325,7 +316,7 @@ Content: `"{{input.field1}} {{input.field2}}"`
 
 **Example — resource reference (`@{ }` expression):**
 
-Reference an agent resource by family + name, e.g. a context (`resources/<Name>/resource.json`, `contextType: "index"`) with `@{contexts.<Name>}`. The resource is resolved at runtime — it is **not** an `inputSchema` field, so do not declare it under `inputSchema.properties`.
+Reference an agent resource by family + name, e.g. a context (`resources/<Name>/resource.json`) with `@{contexts.<Name>}`.
 
 Content: `"Extract information from the @{contexts.Test} context"`
 
@@ -341,7 +332,6 @@ Content: `"Extract information from the @{contexts.Test} context"`
 - Forgetting to update contentTokens after editing content
 - Including `{{`/`}}` or `@{`/`}` in the rawString
 - Missing whitespace tokens between adjacent variables
-- Declaring a `@{ }` target (tool, context, escalation, output) as an `inputSchema` field — those are runtime-resolved resources/outputs, not inputs
 
 ## entry-points.json
 

--- a/skills/uipath-agents/references/lowcode/agent-definition.md
+++ b/skills/uipath-agents/references/lowcode/agent-definition.md
@@ -271,7 +271,7 @@ For conversational, typically general behavior and steps to respond to users. Sh
 
 ### User Message
 
-For autonomous agents, templates input fields into the prompt using `{{input.fieldName}}`. For `job-attachment` fields the token renders metadata only (see § File Attachments).
+For autonomous agents, templates input fields into the prompt using `{{input.fieldName}}`, and agent resources/outputs using `@{ }` expressions — `@{tools.<Name>}`, `@{contexts.<Name>}`, `@{escalations.<Name>}`, `@{output.<path>}` (see § contentTokens Construction). For `job-attachment` fields the token renders metadata only (see § File Attachments).
 
 ```json
 {
@@ -292,10 +292,24 @@ For conversational agents, the user-message should be ignored after initializati
 
 Every message needs both `content` (string) and `contentTokens` (array). Keep them in sync.
 
+Three token types: `simpleText`, `variable`, `expression`.
+
 **Rules:**
-1. Text outside `{{ }}` → `{ "type": "simpleText", "rawString": "<text>" }`
-2. Text inside `{{ }}` → `{ "type": "variable", "rawString": "input.fieldName" }` (strip delimiters)
-3. Every segment including whitespace gets its own entry
+1. Text outside `{{ }}` and `@{ }` → `{ "type": "simpleText", "rawString": "<text>" }`
+2. Text inside `{{ }}` → `{ "type": "variable", "rawString": "input.fieldName" }` (strip delimiters; input-field reference)
+3. Text inside `@{ }` → `{ "type": "expression", "rawString": "<expr>" }` (strip delimiters; Studio expression referencing an agent resource or output — see families below)
+4. Every segment including whitespace gets its own entry
+
+`@{ }` expression families (the `rawString` is the inner text verbatim, prefix included):
+
+| Prefix | References | Example rawString |
+|--------|-----------|-------------------|
+| `tools.<Name>` | a tool resource | `tools.SearchWeb` |
+| `contexts.<Name>` | a context (index) resource | `contexts.Test` |
+| `escalations.<Name>` | an escalation resource | `escalations.HumanReview` |
+| `output.<path>` | the agent's output schema (dotted path) | `output.result.data` |
+
+`{{ }}` (`variable`) is for `inputSchema` fields only; `@{ }` (`expression`) is for everything else (tools, contexts, escalations, outputs). None of the `@{ }` targets are `inputSchema` fields — do not declare them under `inputSchema.properties`.
 
 **Example — adjacent variables:**
 
@@ -309,10 +323,25 @@ Content: `"{{input.field1}} {{input.field2}}"`
 ]
 ```
 
+**Example — resource reference (`@{ }` expression):**
+
+Reference an agent resource by family + name, e.g. a context (`resources/<Name>/resource.json`, `contextType: "index"`) with `@{contexts.<Name>}`. The resource is resolved at runtime — it is **not** an `inputSchema` field, so do not declare it under `inputSchema.properties`.
+
+Content: `"Extract information from the @{contexts.Test} context"`
+
+```json
+"contentTokens": [
+  { "type": "simpleText", "rawString": "Extract information from the " },
+  { "type": "expression", "rawString": "contexts.Test" },
+  { "type": "simpleText", "rawString": " context" }
+]
+```
+
 **Common mistakes:**
 - Forgetting to update contentTokens after editing content
-- Including `{{` or `}}` in the variable rawString
+- Including `{{`/`}}` or `@{`/`}` in the rawString
 - Missing whitespace tokens between adjacent variables
+- Declaring a `@{ }` target (tool, context, escalation, output) as an `inputSchema` field — those are runtime-resolved resources/outputs, not inputs
 
 ## entry-points.json
 

--- a/skills/uipath-agents/references/lowcode/capabilities/context/attachments.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/context/attachments.md
@@ -25,6 +25,7 @@ For other context variants, see [context.md](context.md).
   "description": "",
   "contextType": "attachments",
   "indexName": "<ContextName>",          // same as name for attachments
+  "folderPath": "solution_folder",
   "attachments": {
     "description": "Array of files, documents, images to process."
   },

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/check_context_prompt_reference.py
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/check_context_prompt_reference.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Context prompt-reference check.
 
-Validates that the agent referenced an attachments context in the user
-prompt via the Studio expression syntax `@{contexts.Knowledge}` and kept
-`content` and `contentTokens` aligned:
+Validates that the agent referenced an attachments context in a prompt
+message (system or user) via the Studio expression syntax
+`@{contexts.Knowledge}` and kept `content` and `contentTokens` aligned:
 
   1. The Knowledge resource is a context (`$resourceType: "context"`) with
      `contextType: "attachments"` (lowercase — Anti-pattern 12).
-  2. The user message content contains `@{contexts.Knowledge}`.
-  3. contentTokens contains a matching `{type: "expression",
+  2. At least one message's content contains `@{contexts.Knowledge}`.
+  3. That message's contentTokens contains a matching `{type: "expression",
      rawString: "contexts.Knowledge"}` token (Critical Rule 6 — the `@{ }`
      expression family, not a `variable`).
   4. `Knowledge` is NOT declared as an inputSchema property — a context is a
@@ -57,36 +57,47 @@ def assert_context_resource() -> None:
     print("OK: Knowledge is an attachments context resource")
 
 
-def assert_user_prompt_references_context(agent: dict) -> None:
+def assert_prompt_references_context(agent: dict) -> None:
     messages = agent.get("messages")
     if not isinstance(messages, list):
         sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
-    user_messages = [
-        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    referencing = [
+        m
+        for m in messages
+        if isinstance(m, dict) and EXPR_LITERAL in m.get("content", "")
     ]
-    if not user_messages:
-        sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
-    user = user_messages[0]
-    content = user.get("content", "")
-    tokens = user.get("contentTokens")
-    if not isinstance(tokens, list):
-        sys.exit(f"FAIL: user message contentTokens is not a list: {tokens!r}")
-
-    if EXPR_LITERAL not in content:
+    if not referencing:
+        contents = {
+            m.get("role"): m.get("content")
+            for m in messages
+            if isinstance(m, dict)
+        }
         sys.exit(
-            f"FAIL: user message content does not reference {EXPR_LITERAL}: "
-            f"content={content!r}"
+            f"FAIL: no message content references {EXPR_LITERAL}: "
+            f"messages={contents!r}"
         )
 
     expected = {"type": "expression", "rawString": EXPR_RAW}
-    if expected not in tokens:
-        sys.exit(
-            "FAIL: contentTokens has no expression token with rawString "
-            f"{EXPR_RAW!r} (Critical Rule 6 — context refs are `expression` "
-            f"tokens, not `variable`)\n  expected: {expected}\n"
-            f"  got tokens: {json.dumps(tokens, indent=2)}"
-        )
-    print("OK: user prompt references @{contexts.Knowledge} with a synced expression token")
+    for msg in referencing:
+        tokens = msg.get("contentTokens")
+        if not isinstance(tokens, list):
+            sys.exit(
+                f"FAIL: {msg.get('role')} message contentTokens is not a list: "
+                f"{tokens!r}"
+            )
+        if expected not in tokens:
+            sys.exit(
+                f"FAIL: {msg.get('role')} message contentTokens has no "
+                f"expression token with rawString {EXPR_RAW!r} (Critical "
+                "Rule 6 — context refs are `expression` tokens, not "
+                f"`variable`)\n  expected: {expected}\n"
+                f"  got tokens: {json.dumps(tokens, indent=2)}"
+            )
+    roles = ", ".join(str(m.get("role")) for m in referencing)
+    print(
+        "OK: prompt references @{contexts.Knowledge} with a synced "
+        f"expression token (message roles: {roles})"
+    )
 
 
 def assert_context_not_an_input(agent: dict) -> None:
@@ -122,7 +133,7 @@ def main() -> None:
     agent = load(AGENT)
     entry = load(ENTRY)
     assert_context_resource()
-    assert_user_prompt_references_context(agent)
+    assert_prompt_references_context(agent)
     assert_context_not_an_input(agent)
     assert_schema_sync(agent, entry)
 

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/check_context_prompt_reference.py
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/check_context_prompt_reference.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Context prompt-reference check.
+
+Validates that the agent referenced an attachments context in the user
+prompt via the Studio expression syntax `@{contexts.Knowledge}` and kept
+`content` and `contentTokens` aligned:
+
+  1. The Knowledge resource is a context (`$resourceType: "context"`) with
+     `contextType: "attachments"` (lowercase — Anti-pattern 12).
+  2. The user message content contains `@{contexts.Knowledge}`.
+  3. contentTokens contains a matching `{type: "expression",
+     rawString: "contexts.Knowledge"}` token (Critical Rule 6 — the `@{ }`
+     expression family, not a `variable`).
+  4. `Knowledge` is NOT declared as an inputSchema property — a context is a
+     runtime-resolved resource, not an input field.
+  5. inputSchema/outputSchema stay in sync with entry-points.json
+     (Critical Rule 4).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "DocSol" / "DocAssistant"
+AGENT = ROOT / "agent.json"
+ENTRY = ROOT / "entry-points.json"
+RESOURCE = ROOT / "resources" / "Knowledge" / "resource.json"
+
+CONTEXT_NAME = "Knowledge"
+EXPR_RAW = f"contexts.{CONTEXT_NAME}"          # token rawString, prefix included
+EXPR_LITERAL = "@{" + EXPR_RAW + "}"           # how it appears in content
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def assert_context_resource() -> None:
+    res = load(RESOURCE)
+    if res.get("$resourceType") != "context":
+        sys.exit(
+            f"FAIL: {RESOURCE} $resourceType is {res.get('$resourceType')!r}, "
+            "expected 'context'"
+        )
+    ctype = res.get("contextType")
+    if ctype != "attachments":
+        sys.exit(
+            f"FAIL: Knowledge contextType is {ctype!r}, expected 'attachments' "
+            "(lowercase — Anti-pattern 12)"
+        )
+    print("OK: Knowledge is an attachments context resource")
+
+
+def assert_user_prompt_references_context(agent: dict) -> None:
+    messages = agent.get("messages")
+    if not isinstance(messages, list):
+        sys.exit(f"FAIL: agent.json.messages is not a list: {messages!r}")
+    user_messages = [
+        m for m in messages if isinstance(m, dict) and m.get("role") == "user"
+    ]
+    if not user_messages:
+        sys.exit("FAIL: agent.json.messages has no entry with role == 'user'")
+    user = user_messages[0]
+    content = user.get("content", "")
+    tokens = user.get("contentTokens")
+    if not isinstance(tokens, list):
+        sys.exit(f"FAIL: user message contentTokens is not a list: {tokens!r}")
+
+    if EXPR_LITERAL not in content:
+        sys.exit(
+            f"FAIL: user message content does not reference {EXPR_LITERAL}: "
+            f"content={content!r}"
+        )
+
+    expected = {"type": "expression", "rawString": EXPR_RAW}
+    if expected not in tokens:
+        sys.exit(
+            "FAIL: contentTokens has no expression token with rawString "
+            f"{EXPR_RAW!r} (Critical Rule 6 — context refs are `expression` "
+            f"tokens, not `variable`)\n  expected: {expected}\n"
+            f"  got tokens: {json.dumps(tokens, indent=2)}"
+        )
+    print("OK: user prompt references @{contexts.Knowledge} with a synced expression token")
+
+
+def assert_context_not_an_input(agent: dict) -> None:
+    in_schema = agent.get("inputSchema")
+    props = in_schema.get("properties") if isinstance(in_schema, dict) else None
+    if isinstance(props, dict) and CONTEXT_NAME in props:
+        sys.exit(
+            f"FAIL: inputSchema.properties declares {CONTEXT_NAME!r} — a context "
+            "is a runtime-resolved resource, not an inputSchema field"
+        )
+    print("OK: Knowledge is not declared as an inputSchema field")
+
+
+def assert_schema_sync(agent: dict, entry: dict) -> None:
+    entry_points = entry.get("entryPoints")
+    if not isinstance(entry_points, list) or not entry_points:
+        sys.exit("FAIL: entry-points.json has no entryPoints[0]")
+    ep = entry_points[0]
+    if agent.get("inputSchema") != ep.get("input"):
+        sys.exit(
+            "FAIL: agent.json.inputSchema != entry-points.json entryPoints[0].input "
+            "(Critical Rule 4)"
+        )
+    if agent.get("outputSchema") != ep.get("output"):
+        sys.exit(
+            "FAIL: agent.json.outputSchema != entry-points.json entryPoints[0].output "
+            "(Critical Rule 4)"
+        )
+    print("OK: inputSchema and outputSchema are in sync with entry-points.json")
+
+
+def main() -> None:
+    agent = load(AGENT)
+    entry = load(ENTRY)
+    assert_context_resource()
+    assert_user_prompt_references_context(agent)
+    assert_context_not_an_input(agent)
+    assert_schema_sync(agent, entry)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
@@ -1,0 +1,82 @@
+task_id: skill-agent-context-prompt-reference
+description: >
+  Skill-guided evaluation: scaffold a low-code agent with an attachments
+  context resource and reference that context in the user prompt via the
+  Studio expression syntax `@{contexts.<Name>}`, then validate. Exercises
+  the `@{ }` -> `expression` contentToken path (Critical Rules 5 + 6) and
+  the rule that a context is a runtime-resolved resource, NOT an
+  inputSchema field. No existing task covers `@{ }` expression tokens —
+  every prior contentTokens test only exercises `{{input.X}}` variables.
+  Uses an attachments context (contextType "attachments") so the project is
+  fully self-contained: no solution-level files and no tenant binding.
+tags: [uipath-agents, smoke, mode:build, low-code]
+
+run_limits:
+  expected_turns: 14
+  max_turns: 60
+  turn_timeout: 1200
+
+initial_prompt: |
+  Create a UiPath low-code agent "DocAssistant" inside a solution named
+  "DocSol". The agent processes files the caller uploads at runtime and
+  retrieves relevant information from them (semantic retrieval over the
+  uploaded files — use a context resource named "Knowledge", not a plain
+  input field). Reference that context in the agent's user prompt so the
+  model is told to use it. Make sure the agent validates successfully.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent scaffolded the agent project with uip agent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: file_exists
+    description: "DocAssistant/agent.json was created"
+    path: "DocSol/DocAssistant/agent.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Knowledge context resource.json was created at the agent level"
+    path: "DocSol/DocAssistant/resources/Knowledge/resource.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "User prompt references @{contexts.Knowledge} with a matching expression contentToken, content<->contentTokens stay in sync, context is NOT an inputSchema field, and the resource is an attachments context"
+    command: "python3 $TASK_DIR/check_context_prompt_reference.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
@@ -1,8 +1,9 @@
 task_id: skill-agent-context-prompt-reference
 description: >
   Skill-guided evaluation: scaffold a low-code agent with an attachments
-  context resource and reference that context in the user prompt via the
-  Studio expression syntax `@{contexts.<Name>}`, then validate. Exercises
+  context resource and reference that context in a prompt message (system
+  or user) via the Studio expression syntax `@{contexts.<Name>}`, then
+  validate. Exercises
   the `@{ }` -> `expression` contentToken path (Critical Rules 5 + 6) and
   the rule that a context is a runtime-resolved resource, NOT an
   inputSchema field. No existing task covers `@{ }` expression tokens —
@@ -12,8 +13,8 @@ description: >
 tags: [uipath-agents, smoke, mode:build, low-code]
 
 run_limits:
-  expected_turns: 14
-  max_turns: 60
+  expected_turns: 20
+  max_turns: 30
   turn_timeout: 1200
 
 initial_prompt: |
@@ -21,7 +22,7 @@ initial_prompt: |
   "DocSol". The agent processes files the caller uploads at runtime and
   retrieves relevant information from them (semantic retrieval over the
   uploaded files — use a context resource named "Knowledge", not a plain
-  input field). Reference that context in the agent's user prompt so the
+  input field). Reference that context in the agent's prompt so the
   model is told to use it. Make sure the agent validates successfully.
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
@@ -74,7 +75,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "User prompt references @{contexts.Knowledge} with a matching expression contentToken, content<->contentTokens stay in sync, context is NOT an inputSchema field, and the resource is an attachments context"
+    description: "A prompt message (system or user) references @{contexts.Knowledge} with a matching expression contentToken, content<->contentTokens stay in sync, context is NOT an inputSchema field, and the resource is an attachments context"
     command: "python3 $TASK_DIR/check_context_prompt_reference.py"
     timeout: 30
     expected_exit_code: 0


### PR DESCRIPTION
agent-definition.md only documented `{{ }}` (variable tokens). The `@{ }` expression syntax (tools/contexts/escalations/output references) was undocumented, which let an automated review misclassify a valid @{contexts.X} prompt reference as invalid and flag the empty inputSchema as a defect (a context is a runtime-resolved resource, not an input).

- Document the `expression` token type and its @{ } families (tools.<Name>, contexts.<Name>, escalations.<Name>, output.<path>)
- Clarify {{ }} is inputSchema-only; @{ } targets are never inputs
- Add a context-reference worked example
- Add a smoke task + grader covering the @{contexts.X} -> expression token path and content<->contentTokens sync (no prior task exercised @{ } tokens; uses an attachments context so it stays self-contained)

Tested by asking Claude to create an agent referencing a context resource.