### PR TITLE
test(ixp): bump run_limits for two integration tests failing CI

### DIFF
--- a/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
@@ -11,8 +11,8 @@ tags: [uipath-ixp, integration, mode:build, lifecycle:setup]
 
 run_limits:
   max_turns: 60
-  task_timeout: 1800
-  turn_timeout: 600
+  task_timeout: 2400
+  turn_timeout: 1200
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
+++ b/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
@@ -10,7 +10,7 @@ description: >
 tags: [uipath-ixp, integration, mode:operate]
 
 run_limits:
-  max_turns: 72
+  max_turns: 120
   task_timeout: 2400
   turn_timeout: 1200
 


### PR DESCRIPTION
## Why

Both tests pass on a live tenant locally but tripped `run_limits` on the slower CI runner ([run 2026-06-25_04-14-23](https://coder-evalboard.uipath-dev.com/runs/2026-06-25_04-14-23?tags=uipath-ixp)) — the board flagged them `turn-timeout-too-short` / `max-turns-too-low`.

## Fix

Config-only `run_limits` bumps; success criteria unchanged.

| Test | Diagnosis | Change |
|------|-----------|--------|
| `taxonomy_lifecycle` | `turn-timeout-too-short` (hit 10m00s) | `turn_timeout` 600→1200, `task_timeout` 1800→2400 |
| `versions_and_metrics` | `max-turns-too-low` (exhausted at 81) | `max_turns` 72→120 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
