### PR TITLE
chore(ci): lower smoke pass-rate gate from 95% to 90%

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -567,10 +567,19 @@ jobs:
       # known-broken tasks through without blocking every PR, while still
       # catching systemic regressions. Cancellation (120m timeout) is
       # always a fail since a truncated run has no meaningful rate.
-      - name: Enforce pass-rate threshold (>= 95%)
+      #
+      # Threshold is 0.90, not 0.95: the suite is ~11 single-shot LLM tasks, and
+      # 0.95 of 11 needs all 11 to pass (10/11 = 90.9% < 95%) — i.e. 0.95 is
+      # effectively 100% and tolerates ZERO flakes, contradicting the intent
+      # above. A threshold only tolerates one flake once (N-1)/N >= it: for our
+      # N that means <= 0.909, so 0.90. At 0.90 one single-shot flake passes
+      # (10/11 = 90.9%) while 2+ failures still fail (9/11 = 81.8%), which keeps
+      # catching real regressions. Raise back toward 0.95 only once the suite is
+      # ~20+ tasks or per-task --repeats aggregation lands.
+      - name: Enforce pass-rate threshold (>= 90%)
         if: always()
         env:
-          PASS_RATE_THRESHOLD: "0.95"
+          PASS_RATE_THRESHOLD: "0.90"
         run: |
           if [ "${{ steps.smoke.outcome }}" = "cancelled" ]; then
             echo "::error::Smoke step cancelled (timeout) — failing without rate check"


### PR DESCRIPTION
## What changed?

Lowers the smoke pass-rate gate in `.github/workflows/smoke-skills.yml` from **0.95 → 0.90** (and updates the step name + comment with the rationale).

**Why:** the suite is ~11 single-shot LLM tasks. At 0.95, `10/11 = 90.9% < 95%`, so **one flake fails the whole gate** — 0.95 is effectively a 100% requirement and tolerates zero flakes, which directly contradicts the step's own comment ("Lets a small number of flakes … through without blocking every PR"). A threshold only tolerates one flake once `(N-1)/N >= threshold`; for `N=11` that's `<= 0.909`, so 0.90.

At **0.90**: one single-shot flake passes (`10/11 = 90.9%`), but **2+ failures still fail** (`9/11 = 81.8%`) — so real/systemic regressions are still caught.

## How has this been tested?

Validated against live evidence from PR #1665 (two consecutive runs, both green on the actually-changed tasks):

| Run | Pass rate | Failure (different each time) | At 0.90 |
|---|---|---|---|
| 1 | 81.8% (9/11) | `coded-pii-in-traces`, `prompt-instruction-conflicts` | still fails (correct — 2 flakes) |
| re-run | 90.9% (10/11) | `guardrail-unknown-validator` | **would pass** |

A different unrelated task flakes each run; with ~11 tasks each ~94% reliable, a fully-green run is `0.94^11 ≈ 51%` — a coin flip even with no real regression. 0.90 unblocks the single-flake case while keeping the gate meaningful.

Follow-up (separate): raise back toward 0.95 once the suite is ~20+ tasks, or add per-task `--repeats` aggregation so flakes are absorbed per task rather than across the whole suite.

## Are there any breaking changes?

- [x] None — CI gate threshold only; no product/CLI/skill behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)