### PR TITLE
fix(ixp): mock uip in shape-only smoke tasks so they don't hit live alpha

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/mock_template/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template/README.md
@@ -1,0 +1,18 @@
+# uipath-ixp smoke mock
+
+Shape-only smoke tasks under `../../smoke/` must not authenticate or hit a live
+tenant — the smoke harness injects a live alpha bot token, so a bare `uip ixp …`
+would otherwise reach designtime-api on alpha (404-ing on fixture ids). Every
+smoke task therefore mocks `uip` with this template:
+
+```yaml
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+```
+
+`mocks/uip` PATH-shadows the real CLI and fails offline with no network call, so
+grading sees the command shape while no real request is made. Integration/e2e
+tasks (which intentionally exercise the live API) do **not** use this.

--- a/tests/tasks/uipath-ixp/_shared/mock_template/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template/mocks/uip
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Offline `uip` mock for the uipath-ixp SHAPE-ONLY smoke tasks.
+#
+# These smoke tasks are graded purely on command shape (command_executed /
+# command_not_executed) and must NOT authenticate or reach a live tenant.
+# Without this mock the smoke harness (tests/experiments/smoke.yaml +
+# .github/workflows/smoke-skills.yml) injects a live alpha bot token, so a bare
+# `uip ixp ...` would hit designtime-api on alpha — 404-ing on fixture ids like
+# `doc-abc-123` — i.e. real traffic with no test value. `mock_path_dirs: [mocks]`
+# PATH-prepends this script so `uip` resolves here instead of the real CLI.
+#
+# It records each invocation and fails like an unauthenticated CLI WITHOUT any
+# network call, matching each task's "commands will fail with auth errors —
+# expected" prompt framing.
+printf '%s\n' "$*" >> "$(dirname "$0")/.calls.log" 2>/dev/null || true
+echo "uip (mock): not connected to a tenant in this sandbox; offline smoke mock." >&2
+exit 1

--- a/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, change the type of the field
   "Total" in the "Invoice Header" group to Exact Text.

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 6
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, confirm all predictions on
   document doc-abc-123 as ground truth.

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -12,6 +12,12 @@ tags: [uipath-ixp, smoke, lifecycle:execute]
 run_limits:
   expected_turns: 6
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Review the IXP model's predictions for document `doc-abc-123` on
   project `my_invoices-f1afa9ef-ixp` and record your verdict in the

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new Field Type named
   "clause presence" of data type Choice with the display values: True, False,

--- a/tests/tasks/uipath-ixp/smoke/create_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field.yaml
@@ -9,6 +9,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, add a new field named "email"
   to the "Subscriber information" group.

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
   "Subscriber information" with fields: surname, address, bank account, and

--- a/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Create a blank IXP project named "test project".
 

--- a/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Create an IXP project named ap-invoices from the invoices in ./invoices/,
   and let IXP suggest the taxonomy.

--- a/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
@@ -12,6 +12,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, delete document doc-abc-123.
 

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, delete the field group
   "name group".

--- a/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 6
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, delete the fields "field1" and
   "field2" from the "Invoice Header" group.

--- a/tests/tasks/uipath-ixp/smoke/delete_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_project.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Delete the IXP project my_invoices-f1afa9ef-ixp.
 

--- a/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
+++ b/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
@@ -12,6 +12,12 @@ tags: [uipath-ixp, smoke, lifecycle:discover]
 run_limits:
   expected_turns: 4
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   A document automation engineer wants to inspect the per-field F1 scores
   of the IXP project named `my_invoices-f1afa9ef-ixp` before iterating on

--- a/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
+++ b/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, import the taxonomy from
   ./taxonomy.json.

--- a/tests/tasks/uipath-ixp/smoke/list_documents.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_documents.yaml
@@ -9,6 +9,12 @@ tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, list all documents.
 

--- a/tests/tasks/uipath-ixp/smoke/list_projects.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_projects.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, lifecycle:discover]
 run_limits:
   expected_turns: 4
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   A document automation engineer wants to see every IXP project on the
   tenant before deciding which one to iterate on.

--- a/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
+++ b/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
@@ -9,6 +9,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 6
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, document doc-abc-123, the field
   "Discount Code" (field id a7c3e9105f2b4d86) is genuinely absent from the

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, get the metrics for version 14.
 

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -12,6 +12,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project `my_invoices-f1afa9ef-ixp`, the `live` tag is currently
   on model version 15. Make version 16 live instead.

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -13,6 +13,12 @@ run_limits:
   expected_turns: 9
   max_turns: 30
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   You have five tasks against IXP project `my_invoices-f1afa9ef-ixp`.
   Follow the documented workflow for each one — even

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -15,6 +15,12 @@ tags: [uipath-ixp, smoke, lifecycle:execute]
 run_limits:
   expected_turns: 6
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Review the IXP model's `Line Items` predictions for document
   `doc-freight-7` on project `freight_docs-df33115f-ixp` and confirm only

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
@@ -16,6 +16,12 @@ tags: [uipath-ixp, smoke, lifecycle:execute]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   On project `freight_docs-df33115f-ixp`, document `doc-freight-9`, the
   `Line Items` field group was confirmed earlier with four extractions,

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, the documents are 150-page
   filings with many inferred fields, and the current Flash model's F1 is low.

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project named `my_invoices-f1afa9ef-ixp`, make model version
   27 the live model.

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project `my_invoices-f1afa9ef-ixp`, publish model version 15
   and tag it as staging.

--- a/tests/tasks/uipath-ixp/smoke/rename_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field.yaml
@@ -9,6 +9,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, rename the field "Amount" in
   the "Invoice Header" group to "Total Amount".

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, rename the field group
   "Usage" to "Consumption".

--- a/tests/tasks/uipath-ixp/smoke/rename_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_project.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   Rename the IXP project my_invoices-f1afa9ef-ixp to "amazing IXP project".
 

--- a/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
@@ -10,6 +10,12 @@ tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, show the values the model
   predicted for document doc-abc-123.

--- a/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
+++ b/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
@@ -15,6 +15,9 @@ agent:
 sandbox:
   driver: tempdir
   python: {}
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
 
 initial_prompt: |
   On project `my_invoices-f1afa9ef-ixp`, set up the taxonomy for

--- a/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
@@ -13,6 +13,9 @@ tags: [uipath-ixp, smoke, lifecycle:execute]
 sandbox:
   driver: tempdir
   python: {}
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
 
 initial_prompt: |
   Yesterday I confirmed the `Invoice Number` field (field id `f-001`)

--- a/tests/tasks/uipath-ixp/smoke/unpublish.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unpublish.yaml
@@ -12,6 +12,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project `my_invoices-f1afa9ef-ixp`, unpublish model version 26.
 

--- a/tests/tasks/uipath-ixp/smoke/untag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/untag.yaml
@@ -11,6 +11,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project `my_invoices-f1afa9ef-ixp`, remove the tag from model
   version 27.

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -9,6 +9,12 @@ tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 run_limits:
   expected_turns: 5
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, update the instructions for the
   field group "Invoice Header" to: "Header section of the invoice — vendor,

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -14,6 +14,12 @@ tags: [uipath-ixp, smoke, lifecycle:edit]
 run_limits:
   expected_turns: 8
 
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
 initial_prompt: |
   The InvoiceNumber field on IXP project `my_invoices-f1afa9ef-ixp` is
   scoring poorly. Validation shows the model is confusing the Purchase


### PR DESCRIPTION
## Problem
The `uipath-ixp` **smoke** tasks are authored as offline, command-shape-only checks — each says *"Harness is unauthenticated; CLI calls fail with auth errors. Grades command shape, not wire effect"* and grades on a RUN-only regex. They share hardcoded fixture ids (`my_invoices-f1afa9ef-ixp`, `doc-abc-123`).

But the smoke harness contradicts that assumption: `tests/experiments/smoke.yaml` forwards `UIPATH_CLI_AUTH_TOKEN` + org/tenant env into the sandbox and `.github/workflows/smoke-skills.yml` mints a **live alpha bot token**. So every `uip ixp …` actually reaches **designtime-api on alpha**, 404-ing on the non-existent `doc-abc-123` but still "passing" (shape-only). Result: recurring real traffic to the live service with zero test value (surfaced in App Insights).

## Fix
Apply the repo's documented convention (`uipath-troubleshoot/CLAUDE.md`: *"task.yaml MUST set `sandbox.mock_path_dirs: ["mocks"]` — without it, bare `uip` resolves to the real CLI and the test will try to authenticate"*): **mock `uip`** so it PATH-shadows the real CLI and fails offline with no network call.

- New shared `tests/tasks/uipath-ixp/_shared/mock_template/mocks/uip` — records the invocation, prints an offline/auth-error message, exits non-zero. No network.
- Every smoke task gains:
  ```yaml
  sandbox:
    driver: tempdir
    mock_path_dirs: [mocks]
    template_sources:
      - {type: template_dir, path: ../_shared/mock_template}
  ```
- `_shared/mock_template/README.md` documents the pattern for future ixp smoke tasks.

This makes the tasks' own "harness is unauthenticated; commands fail" framing **true again** — grading (command shape) is unchanged. Integration/e2e tasks, which intentionally exercise the live API, are **not** touched.

## Verification
- All **35** smoke tasks load via coder-eval's `TaskDefinition` (schema valid; `driver=tempdir`, `mock_path_dirs=[mocks]`, `mock_template/mocks/uip` resolves).
- Functional: with the mock PATH-prepended, `uip ixp labellings get-predictions my_invoices-f1afa9ef-ixp doc-abc-123 …` → offline message, exit 1, **no network**, call logged.
- Mock committed as LF, mode `100755`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mwj1Gyvj9GoEYWULV6eT98
