### PR TITLE
test(uipath-agents): cover guardrail variants + log/filter actions [AL-487]

### DIFF
--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/deterministic.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/deterministic.yaml
@@ -6,7 +6,7 @@ description: >
   the word "secret" in the input. The user may choose middleware or decorator style.
   Verifies that the guardrails list was fetched, a rule checking for "secret" is
   present, and BlockAction is used.
-tags: [uipath-agents, e2e, coded, mode:build, guardrail]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/check_intellectual_property_coded.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/check_intellectual_property_coded.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Check that an intellectual property middleware guardrail was added to graph.py.
+
+Validates (middleware style, LangChain agent):
+- guardrail symbols imported from uipath_langchain.guardrails (NOT
+  uipath.platform.guardrails — the LangChain adapter only registers from the
+  framework module; the platform path silently no-ops)
+- UiPathIntellectualPropertyMiddleware is spread (*) into create_agent(middleware=[...])
+- IntellectualPropertyEntityType entities TEXT and CODE are referenced
+- GuardrailExecutionStage.POST is used (IP is an output-only / POST-stage concern)
+- An LLM or Agent scope is configured, and Tool scope is NOT used
+  (intellectual_property does not support Tool scope)
+- BlockAction is used (block, not log)
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import call_name, spread_middleware_calls  # noqa: E402
+
+GRAPH = Path("graph.py")
+MIDDLEWARE = "UiPathIntellectualPropertyMiddleware"
+
+
+def read() -> str:
+    if not GRAPH.is_file():
+        sys.exit(f"FAIL: {GRAPH} not found in {Path.cwd()}")
+    return GRAPH.read_text()
+
+
+def check(condition: bool, msg: str) -> None:
+    if not condition:
+        sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    src = read()
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph.py no longer parses as Python: {exc}")
+
+    # Import source — the #1 coded-guardrail correctness rule.
+    check(
+        "from uipath_langchain.guardrails import" in src,
+        "guardrail symbols not imported from uipath_langchain.guardrails — the "
+        "uipath.platform.guardrails path silently no-ops for LangChain agents",
+    )
+    print("OK: imports from uipath_langchain.guardrails")
+
+    check(MIDDLEWARE in src, f"{MIDDLEWARE} not found in graph.py")
+    print(f"OK: {MIDDLEWARE} referenced")
+
+    check(
+        any(call_name(c) == MIDDLEWARE for c in spread_middleware_calls(tree)),
+        f"{MIDDLEWARE} not spread with * into the middleware list "
+        f"(accepts inline `[*{MIDDLEWARE}(...)]` or a variable "
+        f"`m = {MIDDLEWARE}(...); middleware=[*m]`)",
+    )
+    print(f"OK: {MIDDLEWARE} spread with * into middleware list")
+
+    check("middleware=" in src, "create_agent() has no middleware= argument")
+    print("OK: middleware= argument present")
+
+    # Entities — Text and Code.
+    check(
+        "IntellectualPropertyEntityType" in src,
+        "IntellectualPropertyEntityType not referenced — entities not configured",
+    )
+    check("TEXT" in src, "IntellectualPropertyEntityType.TEXT not referenced")
+    check("CODE" in src, "IntellectualPropertyEntityType.CODE not referenced")
+    print("OK: IntellectualPropertyEntityType TEXT and CODE referenced")
+
+    # POST stage — IP is output-only.
+    check(
+        "GuardrailExecutionStage.POST" in src,
+        "GuardrailExecutionStage.POST not found — intellectual property runs at POST stage only",
+    )
+    print("OK: GuardrailExecutionStage.POST used")
+
+    # Scope — LLM or Agent, never Tool.
+    check(
+        "GuardrailScope.LLM" in src or "GuardrailScope.AGENT" in src,
+        "no GuardrailScope.LLM or GuardrailScope.AGENT — intellectual property "
+        "must be scoped to LLM or Agent",
+    )
+    check(
+        "GuardrailScope.TOOL" not in src,
+        "GuardrailScope.TOOL present — intellectual property does NOT support Tool scope",
+    )
+    print("OK: LLM/Agent scope configured, Tool scope absent")
+
+    check(
+        "BlockAction" in src,
+        "BlockAction not found — protected material should be blocked",
+    )
+    print("OK: BlockAction used")
+
+    print("OK: intellectual property middleware guardrail correctly added to graph.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/intellectual_property.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/intellectual_property.yaml
@@ -1,0 +1,54 @@
+task_id: skill-agent-guardrail-coded-intellectual-property
+description: >
+  Middleware-style intellectual property guardrail for a coded agent. A simple
+  LangGraph customer support agent is seeded with no guardrails. Use the skill
+  to add an intellectual_property detection guardrail (middleware style) that
+  blocks copyrighted text and licensed code in the LLM output. Verifies the
+  correct middleware class is imported from uipath_langchain.guardrails and
+  spread into create_agent(), uses Text+Code entities, a POST stage (IP is
+  output-only), an LLM/Agent scope (NOT Tool), and a BlockAction. Closes the
+  coded intellectual_property gap (untested in both coded and low-code before).
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+  # Disallow subagent dispatch — Critical Rule 13: a context-less subagent reports
+  # the module where symbols physically live (uipath.platform.guardrails), the
+  # no-op import path for LangChain agents. Force inline authoring where the
+  # skill's import-source rule (uipath_langchain.guardrails) still applies.
+  disallowed_tools: ["Task"]
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/SimpleCodedAgent
+
+initial_prompt: |
+  I have a coded UiPath LangGraph agent in graph.py. It handles customer support
+  questions. I want to add a UiPath intellectual property guardrail using the
+  middleware style — the agent's LLM output should be checked for copyrighted
+  text and licensed source code (Text and Code), and blocked when detected.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation. Complete the entire task
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Intellectual property middleware guardrail correctly added to graph.py"
+    command: "python3 $TASK_DIR/check_intellectual_property_coded.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 11
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/pii_middleware.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/pii_middleware/pii_middleware.yaml
@@ -5,7 +5,7 @@ description: >
   Use the skill to add a PII detection middleware guardrail at Agent and Tool scope
   that logs Email and PhoneNumber entities. Verifies that the guardrails list was
   the correct middleware class is imported and spread into create_agent().
-tags: [uipath-agents, e2e, coded, mode:build, guardrail]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
@@ -8,7 +8,7 @@ description: >
   are added, an LLM-scoped adversarial-input guardrail is present, and a
   PII/harmful-content guardrail is present. graph.py must remain syntactically
   valid.
-tags: [uipath-agents, e2e, coded, mode:build, guardrail]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
@@ -7,7 +7,7 @@ description: >
   lookup_account_info (decorator above @tool, OR middleware with
   tools=[lookup_account_info] and scopes=[GuardrailScope.TOOL]), and that
   graph.py still parses. Forbids configuring both representations simultaneously.
-tags: [uipath-agents, e2e, coded, mode:build, guardrail]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
@@ -4,7 +4,7 @@ description: >
   guardrail to a coded LangGraph agent. Uses a deterministic (custom rule)
   guardrail as the simplest scenario — no ML backend required. Verifies
   key structural elements are present without requiring backend connectivity.
-tags: [uipath-agents, smoke, coded, mode:build, guardrail]
+tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_decorator/user_prompt_attacks_decorator.yaml
@@ -5,7 +5,7 @@ description: >
   create_llm() factory function. Use the skill to add a user prompt attacks detection
   guardrail using the decorator style at LLM scope. Verifies that the @guardrail
   with UserPromptAttacksValidator is placed above the LLM factory.
-tags: [uipath-agents, e2e, coded, mode:build, guardrail]
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/check_user_prompt_attacks_middleware.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/check_user_prompt_attacks_middleware.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Check that a user prompt attacks MIDDLEWARE guardrail was added to graph.py.
+
+Validates (middleware style, LangChain agent):
+- guardrail symbols imported from uipath_langchain.guardrails (NOT
+  uipath.platform.guardrails — the platform path silently no-ops for LangChain)
+- UiPathUserPromptAttacksMiddleware is spread (*) into create_agent(middleware=[...])
+- GuardrailScope.LLM is configured (user prompt attacks is LLM-only)
+- GuardrailExecutionStage.PRE is used (PRE-only — input concern)
+- BlockAction is used (block adversarial inputs)
+- Decorator style is NOT used (no @guardrail decorator) — this test specifically
+  covers the middleware path, distinct from the decorator-style sibling test
+"""
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import call_name, spread_middleware_calls  # noqa: E402
+
+GRAPH = Path("graph.py")
+MIDDLEWARE = "UiPathUserPromptAttacksMiddleware"
+
+
+def read() -> str:
+    if not GRAPH.is_file():
+        sys.exit(f"FAIL: {GRAPH} not found in {Path.cwd()}")
+    return GRAPH.read_text()
+
+
+def check(condition: bool, msg: str) -> None:
+    if not condition:
+        sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    src = read()
+    try:
+        tree = ast.parse(src)
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph.py no longer parses as Python: {exc}")
+
+    # Import source — the #1 coded-guardrail correctness rule.
+    check(
+        "from uipath_langchain.guardrails import" in src,
+        "guardrail symbols not imported from uipath_langchain.guardrails — the "
+        "uipath.platform.guardrails path silently no-ops for LangChain agents",
+    )
+    print("OK: imports from uipath_langchain.guardrails")
+
+    check(MIDDLEWARE in src, f"{MIDDLEWARE} not found in graph.py")
+    print(f"OK: {MIDDLEWARE} referenced")
+
+    check(
+        any(call_name(c) == MIDDLEWARE for c in spread_middleware_calls(tree)),
+        f"{MIDDLEWARE} not spread with * into the middleware list "
+        f"(accepts inline `[*{MIDDLEWARE}(...)]` or a variable "
+        f"`m = {MIDDLEWARE}(...); middleware=[*m]`)",
+    )
+    print(f"OK: {MIDDLEWARE} spread with * into middleware list")
+
+    check("middleware=" in src, "create_agent() has no middleware= argument")
+    print("OK: middleware= argument present")
+
+    # LLM-only scope.
+    check(
+        "GuardrailScope.LLM" in src,
+        "GuardrailScope.LLM not found — user prompt attacks is LLM-scoped only",
+    )
+    print("OK: GuardrailScope.LLM configured")
+
+    # PRE-only stage.
+    check(
+        "GuardrailExecutionStage.PRE" in src,
+        "GuardrailExecutionStage.PRE not found — user prompt attacks runs at PRE stage only",
+    )
+    print("OK: GuardrailExecutionStage.PRE used")
+
+    check(
+        "BlockAction" in src,
+        "BlockAction not found — adversarial inputs should be blocked",
+    )
+    print("OK: BlockAction used")
+
+    # Must NOT be decorator style — this is the middleware variant.
+    check(
+        not bool(re.search(r"@guardrail\s*\(", src)),
+        "@guardrail(...) decorator found — this task requires the middleware style, "
+        "not the decorator style (see the decorator-style sibling test)",
+    )
+    print("OK: no @guardrail decorator (middleware style confirmed)")
+
+    print("OK: user prompt attacks middleware guardrail correctly added to graph.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/user_prompt_attacks_middleware.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/user_prompt_attacks_middleware.yaml
@@ -1,0 +1,54 @@
+task_id: skill-agent-guardrail-coded-user-prompt-attacks-middleware
+description: >
+  Middleware-style user prompt attacks guardrail for a coded agent. A simple
+  LangGraph customer support agent is seeded with no guardrails. Use the skill
+  to add a user_prompt_attacks detection guardrail using the MIDDLEWARE style
+  at LLM scope — adversarial inputs should be blocked before they reach the
+  LLM. Verifies UiPathUserPromptAttacksMiddleware is imported from
+  uipath_langchain.guardrails and spread into create_agent(), uses LLM scope,
+  PRE stage, and a BlockAction — and that it is NOT done in decorator style.
+  Complements the existing decorator-style test by covering the middleware path.
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:generate, guardrail]
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+  # Disallow subagent dispatch — Critical Rule 13: a context-less subagent reports
+  # the module where symbols physically live (uipath.platform.guardrails), the
+  # no-op import path for LangChain agents. Force inline authoring where the
+  # skill's import-source rule (uipath_langchain.guardrails) still applies.
+  disallowed_tools: ["Task"]
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/SimpleCodedAgent
+
+initial_prompt: |
+  I have a coded UiPath LangGraph agent in graph.py. It handles customer support
+  questions. I want to add a UiPath user prompt attacks guardrail using the
+  middleware style at LLM scope — adversarial / jailbreak inputs should be
+  blocked before they reach the LLM.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation. Complete the entire task
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "User prompt attacks middleware guardrail correctly added to graph.py"
+    command: "python3 $TASK_DIR/check_user_prompt_attacks_middleware.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 11
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/check_custom_boolean_filter.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/check_custom_boolean_filter.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Custom boolean-rule guardrail with filter action check — Send message to channel.
+
+Validates that a custom guardrail was added on the Slack send tool:
+  - At least 1 guardrail with $guardrailType == "custom" targeting
+    "Send message to channel"
+  - selector.scopes contains "Tool" and matchNames contains the tool
+  - rules[0].$ruleType == "boolean", operator == "equals", value is a bool
+  - rules[0].fieldSelector has a $selectorType ("all" or "specific")
+  - action.$actionType == "filter" with a non-empty fields array; each field
+    has path / source / title
+  - guardrail id is a UUID
+
+Note: filter is only valid on custom (deterministic) guardrails — never on
+built-in validators (anti-pattern 7). This test exercises that legal pairing.
+"""
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "WebResearchBriefingSolution" / "WebResearchBriefingAgent"
+AGENT = ROOT / "agent.json"
+
+TARGET_TOOL = "Send message to channel"
+VALID_SELECTOR_TYPES = {"all", "specific"}
+VALID_SOURCES = {"input", "output"}
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    # --- find custom guardrail targeting the Slack tool ---
+    custom = [g for g in guardrails if g.get("$guardrailType") == "custom"]
+    if not custom:
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
+        sys.exit(f'FAIL: no guardrail with $guardrailType == "custom". Got: {types}')
+
+    targeted = [
+        g for g in custom
+        if TARGET_TOOL in ((g.get("selector") or {}).get("matchNames") or [])
+    ]
+    if not targeted:
+        all_match = [(g.get("selector") or {}).get("matchNames") or [] for g in custom]
+        sys.exit(
+            f'FAIL: no custom guardrail targets "{TARGET_TOOL}". '
+            f"matchNames across custom guardrails: {all_match}"
+        )
+    g = targeted[0]
+    print(f'OK: custom guardrail targets "{TARGET_TOOL}"')
+
+    # --- UUID id ---
+    gid = g.get("id")
+    try:
+        if not isinstance(gid, str):
+            raise ValueError
+        uuid.UUID(gid)
+    except (ValueError, AttributeError):
+        sys.exit(f"FAIL: guardrail.id is not a valid UUID: {gid!r}")
+    print(f"OK: guardrail id is a UUID: {gid}")
+
+    # --- selector.scopes contains Tool ---
+    scopes = (g.get("selector") or {}).get("scopes") or []
+    if "Tool" not in scopes:
+        sys.exit(f'FAIL: selector.scopes must contain "Tool", got {scopes!r}')
+    print(f"OK: selector.scopes includes 'Tool': {scopes}")
+
+    # --- rules: a boolean rule ---
+    rules = g.get("rules")
+    if not isinstance(rules, list) or len(rules) == 0:
+        sys.exit(f"FAIL: guardrail.rules must be a non-empty array, got {rules!r}")
+    bool_rules = [r for r in rules if isinstance(r, dict) and r.get("$ruleType") == "boolean"]
+    if not bool_rules:
+        rule_types = [r.get("$ruleType") for r in rules if isinstance(r, dict)]
+        sys.exit(
+            f'FAIL: no rule with $ruleType == "boolean". Got rule types: {rule_types}'
+        )
+    rule = bool_rules[0]
+    print('OK: found rule with $ruleType == "boolean"')
+
+    # fieldSelector
+    fs = rule.get("fieldSelector")
+    if not isinstance(fs, dict) or fs.get("$selectorType") not in VALID_SELECTOR_TYPES:
+        sys.exit(
+            f"FAIL: boolean rule fieldSelector.$selectorType must be one of "
+            f"{sorted(VALID_SELECTOR_TYPES)}, got {fs!r}"
+        )
+    print(f'OK: fieldSelector.$selectorType == "{fs.get("$selectorType")}"')
+
+    # operator must be "equals" (only operator supported for boolean rules)
+    if rule.get("operator") != "equals":
+        sys.exit(
+            f'FAIL: boolean rule operator must be "equals", got {rule.get("operator")!r}'
+        )
+    print('OK: boolean rule operator == "equals"')
+
+    # value must be a real bool
+    val = rule.get("value")
+    if not isinstance(val, bool):
+        sys.exit(f"FAIL: boolean rule value must be true/false, got {val!r}")
+    print(f"OK: boolean rule value is a bool: {val}")
+
+    # --- action.$actionType == "filter" with a non-empty fields array ---
+    action = g.get("action")
+    if not isinstance(action, dict):
+        sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
+    if action.get("$actionType") != "filter":
+        sys.exit(
+            f'FAIL: action.$actionType must be "filter", got {action.get("$actionType")!r}'
+        )
+    fields = action.get("fields")
+    if not isinstance(fields, list) or len(fields) == 0:
+        sys.exit(f"FAIL: filter action.fields must be a non-empty array, got {fields!r}")
+    for i, fld in enumerate(fields):
+        if not isinstance(fld, dict):
+            sys.exit(f"FAIL: filter fields[{i}] must be an object, got {fld!r}")
+        if not fld.get("path"):
+            sys.exit(f"FAIL: filter fields[{i}] missing path. field={fld!r}")
+        if fld.get("source") not in VALID_SOURCES:
+            sys.exit(
+                f"FAIL: filter fields[{i}].source must be one of {sorted(VALID_SOURCES)}, "
+                f"got {fld.get('source')!r}"
+            )
+        if not fld.get("title"):
+            sys.exit(f"FAIL: filter fields[{i}] missing title. field={fld!r}")
+    print(f"OK: action.$actionType == 'filter' with {len(fields)} field(s) to redact")
+
+    print("OK: custom boolean-rule guardrail with filter action is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/custom_boolean_filter.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/custom_boolean_filter.yaml
@@ -1,0 +1,77 @@
+task_id: skill-agent-guardrail-custom-boolean-filter
+description: >
+  Custom guardrail with a boolean rule and a filter (redact) action (low-code).
+  A pre-built Web Research Briefing Agent is seeded with no guardrails. Its
+  "Send message to channel" (Slack) tool returns a boolean `ok` and a string
+  `ts` (message timestamp). Add a custom (deterministic) guardrail that, when a
+  send succeeds (`ok` == true), redacts the `ts` field from the tool output
+  instead of blocking. Verifies a Tool-scoped custom guardrail with $ruleType
+  "boolean" (operator "equals", boolean value) and a filter action with a
+  non-empty fields array. Covers the boolean-rule and filter-action gaps —
+  filter is only legal on custom rules, never on built-in validators.
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
+max_iterations: 1
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/WebResearchBriefingSolution
+
+initial_prompt: |
+  I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent.
+  It posts briefings to Slack with the "Send message to channel" tool. That tool
+  returns a boolean `ok` flag and a `ts` message-timestamp string in its output.
+  When a post succeeds (`ok` is true), I want the `ts` timestamp redacted from the
+  tool output so it does not leak downstream — don't block the run, just filter
+  that field out. Add a guardrail on the "Send message to channel" tool that does
+  this, and validate when you are done.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched the guardrails list (mandatory discovery step)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+guardrails\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the agent"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: run_command
+    description: "Custom boolean-rule guardrail with filter action on Send message to channel"
+    command: "python3 $TASK_DIR/check_custom_boolean_filter.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 16
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/check_custom_number_log.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/check_custom_number_log.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Custom number-rule guardrail with log action check — Count Sources tool.
+
+Validates that a custom guardrail was added on the Count Sources tool:
+  - At least 1 guardrail with $guardrailType == "custom" targeting "Count Sources"
+  - selector.scopes contains "Tool" and matchNames contains "Count Sources"
+  - rules[0].$ruleType == "number"
+  - rules[0].operator is a valid numeric operator
+  - rules[0].value is numeric
+  - rules[0].fieldSelector has a $selectorType ("all" or "specific")
+  - action.$actionType == "log" with a valid severityLevel (Info/Warning/Error)
+  - guardrail id is a UUID
+"""
+
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "WebResearchBriefingSolution" / "WebResearchBriefingAgent"
+AGENT = ROOT / "agent.json"
+
+TARGET_TOOL = "Count Sources"
+NUMBER_OPERATORS = {
+    "equals", "doesNotEqual", "greaterThan", "greaterThanOrEqual",
+    "lessThan", "lessThanOrEqual",
+}
+VALID_SEVERITIES = {"Info", "Warning", "Error"}
+VALID_SELECTOR_TYPES = {"all", "specific"}
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    # --- find custom guardrail targeting Count Sources ---
+    custom = [g for g in guardrails if g.get("$guardrailType") == "custom"]
+    if not custom:
+        types = [(g.get("$guardrailType"), g.get("validatorType")) for g in guardrails]
+        sys.exit(f'FAIL: no guardrail with $guardrailType == "custom". Got: {types}')
+
+    targeted = [
+        g for g in custom
+        if TARGET_TOOL in ((g.get("selector") or {}).get("matchNames") or [])
+    ]
+    if not targeted:
+        all_match = [(g.get("selector") or {}).get("matchNames") or [] for g in custom]
+        sys.exit(
+            f'FAIL: no custom guardrail targets "{TARGET_TOOL}". '
+            f"matchNames across custom guardrails: {all_match}"
+        )
+    g = targeted[0]
+    print(f'OK: custom guardrail targets "{TARGET_TOOL}"')
+
+    # --- UUID id ---
+    gid = g.get("id")
+    try:
+        if not isinstance(gid, str):
+            raise ValueError
+        uuid.UUID(gid)
+    except (ValueError, AttributeError):
+        sys.exit(f"FAIL: guardrail.id is not a valid UUID: {gid!r}")
+    print(f"OK: guardrail id is a UUID: {gid}")
+
+    # --- selector.scopes contains Tool ---
+    scopes = (g.get("selector") or {}).get("scopes") or []
+    if "Tool" not in scopes:
+        sys.exit(f'FAIL: selector.scopes must contain "Tool", got {scopes!r}')
+    print(f"OK: selector.scopes includes 'Tool': {scopes}")
+
+    # --- rules: a number rule ---
+    rules = g.get("rules")
+    if not isinstance(rules, list) or len(rules) == 0:
+        sys.exit(f"FAIL: guardrail.rules must be a non-empty array, got {rules!r}")
+    number_rules = [r for r in rules if isinstance(r, dict) and r.get("$ruleType") == "number"]
+    if not number_rules:
+        rule_types = [r.get("$ruleType") for r in rules if isinstance(r, dict)]
+        sys.exit(
+            f'FAIL: no rule with $ruleType == "number". Got rule types: {rule_types}'
+        )
+    rule = number_rules[0]
+    print('OK: found rule with $ruleType == "number"')
+
+    # fieldSelector
+    fs = rule.get("fieldSelector")
+    if not isinstance(fs, dict) or fs.get("$selectorType") not in VALID_SELECTOR_TYPES:
+        sys.exit(
+            f"FAIL: number rule fieldSelector.$selectorType must be one of "
+            f"{sorted(VALID_SELECTOR_TYPES)}, got {fs!r}"
+        )
+    print(f'OK: fieldSelector.$selectorType == "{fs.get("$selectorType")}"')
+
+    # operator
+    op = rule.get("operator")
+    if op not in NUMBER_OPERATORS:
+        sys.exit(
+            f"FAIL: number rule operator must be one of {sorted(NUMBER_OPERATORS)}, "
+            f"got {op!r}"
+        )
+    print(f'OK: number rule operator == "{op}"')
+
+    # numeric value (bool is a subclass of int — reject it explicitly)
+    val = rule.get("value")
+    if isinstance(val, bool) or not isinstance(val, (int, float)):
+        sys.exit(f"FAIL: number rule value must be numeric, got {val!r}")
+    print(f"OK: number rule value is numeric: {val}")
+
+    # --- action.$actionType == "log" with valid severityLevel ---
+    action = g.get("action")
+    if not isinstance(action, dict):
+        sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
+    if action.get("$actionType") != "log":
+        sys.exit(
+            f'FAIL: action.$actionType must be "log", got {action.get("$actionType")!r}'
+        )
+    sev = action.get("severityLevel")
+    if sev not in VALID_SEVERITIES:
+        sys.exit(
+            f"FAIL: log action severityLevel must be one of {sorted(VALID_SEVERITIES)}, "
+            f"got {sev!r}"
+        )
+    print(f'OK: action.$actionType == "log" with severityLevel == "{sev}"')
+
+    print("OK: custom number-rule guardrail with log action is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/custom_number_log.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/custom_number_log.yaml
@@ -1,0 +1,74 @@
+task_id: skill-agent-guardrail-custom-number-log
+description: >
+  Custom guardrail with a number rule and a log action (low-code). A pre-built
+  Web Research Briefing Agent is seeded with no guardrails. It has a "Count
+  Sources" tool that returns an integer `sum`. Add a custom (deterministic)
+  guardrail that logs a Warning when that count exceeds a numeric threshold —
+  without blocking. Verifies the agent authors a Tool-scoped custom guardrail
+  with $ruleType "number" (numeric operator + numeric value) and a log action
+  with a valid severityLevel. Covers the number-rule and log-action gaps.
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
+max_iterations: 1
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/WebResearchBriefingSolution
+
+initial_prompt: |
+  I have a web research agent at WebResearchBriefingSolution/WebResearchBriefingAgent.
+  It uses a "Count Sources" tool that returns a numeric total in its `sum` output
+  field. I don't want to block anything — I just want a Warning written to the
+  logs whenever that source count comes back unusually high, above 100. Add a
+  guardrail on the "Count Sources" tool that does exactly that, and validate when
+  you are done.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent fetched the guardrails list (mandatory discovery step)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+guardrails\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the agent"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: run_command
+    description: "Custom number-rule guardrail with log action on Count Sources"
+    command: "python3 $TASK_DIR/check_custom_number_log.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 16
+  max_turns: 40
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -5,7 +5,7 @@ description: >
   blocks the word "CONFIDENTIAL" in agent and LLM output. Verifies the
   guardrail uses correct discriminator fields ($guardrailType, $ruleType,
   $selectorType, $actionType), PascalCase scope values, and a unique UUID.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "SafeAgent" that answers user questions. Add a
   guardrail that blocks any agent or LLM output containing the word

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -8,7 +8,7 @@ description: >
 # BLOCKED: `uip agent guardrails list` not available in @uipath/cli@latest
 # (currently 0.9.0 on public npm). Re-enable smoke tag once CLI >= 1.0.0
 # is published.
-tags: [uipath-agents, smoke-blocked, mode:build, low-code, guardrail]
+tags: [uipath-agents, smoke-blocked, mode:build, lifecycle:generate, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "DiscoverAgent". Discover what guardrail
   validators are available using the CLI and add any built-in validator

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -8,7 +8,7 @@ description: >
   `uip solution resources list` to look up the escalation app, and
   correctly authors the escalate action with $actionType, app.name,
   app.version, app.folderName, and a recipient.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 
 agent:
   # Disallow built-in todo tools — they aren't gated by allowed_tools, and the

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app_validation/escalation_app_validation.yaml
@@ -6,7 +6,7 @@ description: >
   (missing 8 required inputs, 3 required outputs, wrong outcome names).
   The agent must validate the action schema and reject the app with the
   error message instead of writing the guardrail.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "ReviewAgent" that handles compliance review
   requests. Add a guardrail that watches for personal data (email addresses)

--- a/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/check_intellectual_property.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/check_intellectual_property.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Intellectual property guardrail check (low-code builtInValidator).
+
+Validates that the agent authored a builtInValidator guardrail for
+intellectual_property in agent.json:
+
+  - guardrails array exists and is non-empty
+  - At least one guardrail has $guardrailType == "builtInValidator"
+    and validatorType == "intellectual_property"
+  - validatorParameters contains an enum-list parameter id "ipEntities"
+    whose value includes the PascalCase entities "Text" and "Code"
+  - selector.scopes is a subset of {"Llm", "Agent"} and does NOT include
+    "Tool" (intellectual_property does not support Tool scope — anti-pattern 4)
+  - action.$actionType == "block"
+  - id is UUID-shaped
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "IPSol" / "IPAgent"
+AGENT = ROOT / "agent.json"
+
+REQUIRED_ENTITIES = {"Text", "Code"}
+ALLOWED_SCOPES = {"Llm", "Agent"}
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    # --- guardrails array exists ---
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    # --- find intellectual_property validator ---
+    ip = [
+        g for g in guardrails
+        if g.get("$guardrailType") == "builtInValidator"
+        and g.get("validatorType") == "intellectual_property"
+    ]
+    if not ip:
+        types = [
+            (g.get("$guardrailType"), g.get("validatorType"))
+            for g in guardrails
+        ]
+        sys.exit(
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "intellectual_property". Got: {types}'
+        )
+    g = ip[0]
+    print('OK: found builtInValidator guardrail with validatorType == "intellectual_property"')
+
+    # --- id is UUID-shaped ---
+    gid = g.get("id")
+    if not isinstance(gid, str) or "-" not in gid:
+        sys.exit(f"FAIL: guardrail id missing or malformed: {gid!r}")
+    print(f"OK: guardrail id is UUID-shaped: {gid}")
+
+    # --- validatorParameters: ipEntities enum-list with Text + Code ---
+    params = g.get("validatorParameters")
+    if not isinstance(params, list):
+        sys.exit(f"FAIL: validatorParameters must be an array, got {params!r}")
+    ip_param = next(
+        (p for p in params if isinstance(p, dict) and p.get("id") == "ipEntities"),
+        None,
+    )
+    if ip_param is None:
+        ids = [p.get("id") for p in params if isinstance(p, dict)]
+        sys.exit(
+            f'FAIL: validatorParameters missing parameter with id == "ipEntities". '
+            f"Got ids: {ids}"
+        )
+    if ip_param.get("$parameterType") != "enum-list":
+        sys.exit(
+            f'FAIL: ipEntities parameter.$parameterType must be "enum-list", '
+            f"got {ip_param.get('$parameterType')!r}"
+        )
+    value = ip_param.get("value")
+    if not isinstance(value, list):
+        sys.exit(f"FAIL: ipEntities value must be an array, got {value!r}")
+    missing = REQUIRED_ENTITIES - set(value)
+    if missing:
+        sys.exit(
+            f"FAIL: ipEntities must include PascalCase {sorted(REQUIRED_ENTITIES)}, "
+            f"missing {sorted(missing)}. Got: {value}"
+        )
+    print(f"OK: ipEntities enum-list includes {sorted(REQUIRED_ENTITIES)}: {value}")
+
+    # --- selector.scopes subset of {Llm, Agent}, excludes Tool ---
+    selector = g.get("selector")
+    if not isinstance(selector, dict):
+        sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
+    scopes = selector.get("scopes")
+    if not isinstance(scopes, list) or len(scopes) == 0:
+        sys.exit(f"FAIL: guardrail.selector.scopes must be a non-empty array, got {scopes!r}")
+    if "Tool" in scopes:
+        sys.exit(
+            f'FAIL: intellectual_property does not support "Tool" scope '
+            f"(anti-pattern 4). Got scopes: {scopes}"
+        )
+    invalid = [s for s in scopes if s not in ALLOWED_SCOPES]
+    if invalid:
+        sys.exit(
+            f"FAIL: scopes {invalid} not valid for intellectual_property. "
+            f"Allowed: {sorted(ALLOWED_SCOPES)}. Got: {scopes}"
+        )
+    print(f"OK: selector.scopes ⊆ {sorted(ALLOWED_SCOPES)} (no Tool): {scopes}")
+
+    # --- action.$actionType == "block" ---
+    action = g.get("action")
+    if not isinstance(action, dict):
+        sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
+    if action.get("$actionType") != "block":
+        sys.exit(
+            f'FAIL: guardrail.action.$actionType must be "block", '
+            f"got {action.get('$actionType')!r}"
+        )
+    print('OK: action.$actionType == "block"')
+
+    print("OK: intellectual property guardrail is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/intellectual_property.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/intellectual_property.yaml
@@ -1,0 +1,91 @@
+task_id: skill-agent-guardrail-intellectual-property
+description: >
+  Intellectual property guardrail (low-code, builtInValidator). End-to-end
+  test: scaffold a standalone low-code agent and add a builtInValidator
+  guardrail for intellectual_property that blocks copyrighted text and
+  licensed code in the LLM output. Verifies the agent uses the enum-list
+  ipEntities parameter with PascalCase values (Text, Code), restricts scopes
+  to Llm/Agent (NOT Tool — anti-pattern 4), and a block action.
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
+initial_prompt: |
+  Create a UiPath low-code agent "IPAgent" that drafts content for users. Add a
+  guardrail that detects copyrighted text and licensed source code in the
+  agent's LLM output and blocks it with the message "Protected material
+  detected." The solution should be named "IPSol".
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the solution with uip solution init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scaffolded the agent project with uip agent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
+  # `uip solution project add` both populate Projects[] in the .uipx).
+  - type: json_check
+    description: "Project is registered in the parent solution .uipx"
+    path: "IPSol/IPSol.uipx"
+    assertions:
+      - expression: "length(Projects)"
+        operator: "gte"
+        expected: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: file_exists
+    description: "IPAgent/agent.json was created"
+    path: "IPSol/IPAgent/agent.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+
+  - type: run_command
+    description: "IP guardrail shape (ipEntities enum-list, Llm/Agent scope not Tool, block action)"
+    command: "python3 $TASK_DIR/check_intellectual_property.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 15
+  max_turns: 30
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -6,7 +6,7 @@ description: >
   correct $guardrailType, validatorType, $parameterType discriminators,
   PascalCase entity names, enum-list and map-enum parameter types, and
   PascalCase scope values.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "PiiSafeAgent" that answers user questions about
   their accounts. Add a guardrail that blocks email addresses and phone numbers

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -5,7 +5,7 @@ description: >
   guardrail for prompt_injection. Verifies the agent correctly restricts
   scopes to ["Llm"] only (not Agent or Tool), uses $parameterType "number"
   for the threshold parameter, and does not add it to PostExecution stage.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 initial_prompt: |
   Create a UiPath low-code agent "InjSafeAgent" that answers user questions. Add
   a guardrail that catches prompt-injection attempts (use a 0.5 threshold) and

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_all/recommend_all.yaml
@@ -6,7 +6,7 @@ description: >
   that catalog and guardrails list are fetched, at least 2 guardrails are added, and the
   added guardrails include Llm-scoped protection (prompt injection or user prompt attacks)
   and post-execution content protection (harmful content or intellectual property).
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 max_iterations: 1
 
 sandbox:

--- a/tests/tasks/uipath-agents/lowcode/guardrails/recommend_scoped/recommend_scoped.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/recommend_scoped/recommend_scoped.yaml
@@ -5,7 +5,7 @@ description: >
   channel" (Slack) tool that blocks posts containing forbidden terms before they are sent.
   Verifies that the catalog is fetched, a custom guardrail is written with Tool scope and
   matchNames targeting "Send message to channel", and the guardrail has valid rules.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
 max_iterations: 1
 
 sandbox:

--- a/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/check_user_prompt_attacks.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/check_user_prompt_attacks.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""User prompt attacks guardrail check (low-code builtInValidator).
+
+Validates that the agent authored a builtInValidator guardrail for
+user_prompt_attacks in agent.json with correct scope constraints:
+
+  - guardrails array exists and is non-empty
+  - At least one guardrail has $guardrailType == "builtInValidator"
+    and validatorType == "user_prompt_attacks"
+  - selector.scopes is exactly ["Llm"] — NOT Agent or Tool
+    (user_prompt_attacks is Llm-only, PreExecution-only — anti-pattern 3)
+  - validatorParameters is empty (this validator takes no parameters)
+  - action.$actionType == "block"
+  - id is UUID-shaped
+
+This test specifically validates the most dangerous anti-pattern:
+adding user_prompt_attacks to Agent or Tool scope (which is invalid).
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "UPASol" / "UPAAgent"
+AGENT = ROOT / "agent.json"
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    # --- guardrails array exists ---
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    # --- find user_prompt_attacks validator ---
+    upa = [
+        g for g in guardrails
+        if g.get("$guardrailType") == "builtInValidator"
+        and g.get("validatorType") == "user_prompt_attacks"
+    ]
+    if not upa:
+        types = [
+            (g.get("$guardrailType"), g.get("validatorType"))
+            for g in guardrails
+        ]
+        sys.exit(
+            f'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "user_prompt_attacks". Got: {types}'
+        )
+    g = upa[0]
+    print('OK: found builtInValidator guardrail with validatorType == "user_prompt_attacks"')
+
+    # --- id is UUID-shaped ---
+    gid = g.get("id")
+    if not isinstance(gid, str) or "-" not in gid:
+        sys.exit(f"FAIL: guardrail id missing or malformed: {gid!r}")
+    print(f"OK: guardrail id is UUID-shaped: {gid}")
+
+    # --- selector.scopes must be exactly ["Llm"] ---
+    selector = g.get("selector")
+    if not isinstance(selector, dict):
+        sys.exit(f"FAIL: guardrail.selector must be an object, got {selector!r}")
+    scopes = selector.get("scopes")
+    if not isinstance(scopes, list):
+        sys.exit(f"FAIL: guardrail.selector.scopes must be an array, got {scopes!r}")
+
+    forbidden = {"Agent", "Tool"}
+    bad = [s for s in scopes if s in forbidden]
+    if bad:
+        sys.exit(
+            f"FAIL: user_prompt_attacks guardrail must NOT include {bad} in scopes. "
+            f'Only "Llm" is supported. Got scopes: {scopes}'
+        )
+    if scopes != ["Llm"]:
+        sys.exit(
+            f'FAIL: user_prompt_attacks scopes should be exactly ["Llm"]. '
+            f"Got: {scopes}"
+        )
+    print('OK: selector.scopes == ["Llm"] (correct Llm-only constraint)')
+
+    # --- action.$actionType == "block" ---
+    action = g.get("action")
+    if not isinstance(action, dict):
+        sys.exit(f"FAIL: guardrail.action must be an object, got {action!r}")
+    if action.get("$actionType") != "block":
+        sys.exit(
+            f'FAIL: guardrail.action.$actionType must be "block", '
+            f"got {action.get('$actionType')!r}"
+        )
+    print('OK: action.$actionType == "block"')
+
+    # --- validatorParameters: must be empty (no parameters for this validator) ---
+    params = g.get("validatorParameters", [])
+    if not isinstance(params, list):
+        sys.exit(f"FAIL: validatorParameters must be an array, got {params!r}")
+    if len(params) != 0:
+        sys.exit(
+            "FAIL: user_prompt_attacks takes no parameters — validatorParameters "
+            f"must be empty, got {params!r}"
+        )
+    print("OK: validatorParameters is empty (correct — validator takes no params)")
+
+    print("OK: user prompt attacks guardrail is valid with Llm-only scope")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/user_prompt_attacks.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/user_prompt_attacks.yaml
@@ -1,0 +1,93 @@
+task_id: skill-agent-guardrail-user-prompt-attacks
+description: >
+  User prompt attacks guardrail (low-code, builtInValidator) with Llm-only
+  scope. End-to-end test: scaffold a standalone low-code agent and add a
+  builtInValidator guardrail for user_prompt_attacks that blocks adversarial
+  inputs before they reach the LLM. Verifies the agent restricts scopes to
+  ["Llm"] only (not Agent or Tool — anti-pattern 3), uses an empty
+  validatorParameters array (this validator takes no parameters), and a block
+  action. Complements the coded decorator-style test by covering the low-code
+  builtInValidator path.
+tags: [uipath-agents, e2e, mode:build, lifecycle:generate, low-code, guardrail]
+initial_prompt: |
+  Create a UiPath low-code agent "UPAAgent" that answers user questions. Add a
+  guardrail that detects jailbreak / prompt-attack attempts in the user prompt
+  and blocks them before they reach the LLM, with the message "Adversarial
+  input detected." The solution should be named "UPASol".
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent created the solution with uip solution init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scaffolded the agent project with uip agent init"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+init'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # Outcome-based check (auto-registration via `uip <kind> init` OR explicit
+  # `uip solution project add` both populate Projects[] in the .uipx).
+  - type: json_check
+    description: "Project is registered in the parent solution .uipx"
+    path: "UPASol/UPASol.uipx"
+    assertions:
+      - expression: "length(Projects)"
+        operator: "gte"
+        expected: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+.*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: file_exists
+    description: "UPAAgent/agent.json was created"
+    path: "UPASol/UPAAgent/agent.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+
+  - type: run_command
+    description: "User prompt attacks guardrail shape (Llm-only scope, no params, block action)"
+    command: "python3 $TASK_DIR/check_user_prompt_attacks.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 15
+  max_turns: 30
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/validate/validate.yaml
@@ -3,7 +3,7 @@ description: >
   Guardrail validation: a pre-built Web Research Briefing Agent is pre-seeded with a deliberately misconfigured harmful_content guardrail (harmfulContentEntityThresholds
   has an extra key "Sexual" not in harmfulContentEntities). The agent must detect and fix it. Verifies that the catalog is fetched, the misconfiguration is detected
   and corrected, and the agent validates successfully after the fix.
-tags: [uipath-agents, e2e, mode:build, low-code, guardrail]
+tags: [uipath-agents, e2e, mode:build, lifecycle:edit, low-code, guardrail]
 max_iterations: 1
 
 sandbox:


### PR DESCRIPTION
## What changed?

Adds 6 coder-eval tasks under `tests/tasks/uipath-agents/` closing the Medium guardrails coverage gap (untested guardrail variants and actions). [AL-487]

**Low-code (`agent.json`)**
- `lowcode/guardrails/user_prompt_attacks` — builtInValidator, Llm-only scope, block action
- `lowcode/guardrails/intellectual_property` — builtInValidator, `ipEntities` Text/Code, block action
- `lowcode/guardrails/custom_number_log` — custom **number** rule + **log** action (Tool scope)
- `lowcode/guardrails/custom_boolean_filter` — custom **boolean** rule + **filter** action (Tool scope)

**Coded (Python / LangGraph)**
- `coded/guardrails/intellectual_property` — `UiPathIntellectualPropertyMiddleware`, POST stage, Llm/Agent scope
- `coded/guardrails/user_prompt_attacks_middleware` — middleware style (complements the existing decorator-style test)

Each task is a leaf dir with `<name>.yaml` + a weight-5.0 `check_*.py` that asserts the guardrail shape (discriminators, scopes, rule types, actions) from the real `agent.json` / `graph.py` — no self-report files. The custom-rule tasks reuse the existing `WebResearchBriefingSolution` fixture; the coded tasks reuse `SimpleCodedAgent`. No new fixtures, no skill/runtime changes.

## How has this been tested?

- **Check scripts proven** — for each of the 6, a correct config exits 0 and a mutated/broken config exits non-zero (not rubber stamps).
- **`/lint-task` clean** — all 6: `0 Critical, 0 High, 0 Medium, 0 Low` (only non-gating Info on the `--output json` advisory pattern). CLI-verb reachability clean.
- **Built-in shapes validated live** — `user_prompt_attacks` and `intellectual_property` authored into a fresh agent and run through `uip agent refresh` + `uip agent validate` (uip 1.197.0) → `Result: Success`, `Status: Valid`.
- ⚠️ **Full `coder-eval` task runs are pending** — the harness is not installed in the authoring environment; the e2e runs (live tenant) will execute on CI/nightly. A passing-run claim should be appended once they complete.

> **Pre-existing, not introduced here:** the shared `WebResearchBriefingSolution` fixture (used by the two custom-rule tasks and the existing `recommend_scoped` test) fails `uip agent refresh` under uip 1.197.0 — its resource folders aren't named after the resource `name` (`CountSources` vs `"Count Sources"`). The check scripts read `agent.json` directly, so they're resilient, but a fixture-maintenance follow-up is recommended (also unblocks `recommend_scoped`).

## Are there any breaking changes?

- [x] **None** — adds test tasks only; no skill, runtime, or API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrmwnEUWPNoxbzxaPMEM6s


[AL-487]: https://uipath.atlassian.net/browse/AL-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ