### PR TITLE
test(uipath-agents): humanize coded-agent deploy/resume prompts

### DIFF
--- a/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
+++ b/tests/tasks/uipath-agents/coded/diagnose_deploy_failure/diagnose_deploy_failure.yaml
@@ -15,14 +15,9 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  I have a Simple Function UiPath coded agent at `daily-digest/`.
-  Shipping it to the personal workspace with
-  `uip codedagent deploy --my-workspace` fails with:
-
-      Project authors cannot be empty
-
-  Fix what's blocking the deploy and ship it to the personal
-  workspace.
+  I have a UiPath coded agent at `daily-digest/` and I'm trying to
+  deploy it to my personal workspace, but it keeps getting rejected.
+  Can you figure out what's wrong and get it shipped?
 
   The test harness has UiPath auth pre-configured. Do NOT rewrite
   the agent — it works as-is. Complete it in a single pass.

--- a/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
+++ b/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
@@ -15,27 +15,19 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  There's a half-finished LangGraph coded agent project on disk
-  under `mood-meter/`. Pick it up from this state and add one
-  small feature.
+  I've got a half-built UiPath coded agent under `mood-meter/` that
+  I started a while ago. Can you pick it up where I left off and
+  add one thing: besides the `mood` it already returns, I want a
+  `confidence` score between 0.0 and 1.0 saying how sure it is.
+  Nothing fancy for the scoring is fine.
 
-  The project is mid-scaffold: it has `pyproject.toml`, `main.py`,
-  and `langgraph.json`, but there is NO `.venv/` and NO
-  `entry-points.json` yet — that is the starting state, not a
-  mistake. Do not run `uip codedagent new` over it; that would
-  clobber the existing project.
+  Once it's working, run it locally on `{"text": "I really love how
+  great this is"}` and drop the output in `mood-meter/run_result.json`
+  so I can sanity-check it.
 
-  The feature to add: alongside the existing `mood`, the output
-  must also include a `confidence` field — a float between `0.0`
-  and `1.0` indicating how sure the agent is about the mood label.
-  A simple heuristic (e.g. number of matching keywords / something
-  bounded) is fine. After the change, run the agent locally with
-  `{"text": "I really love how great this is"}` and write the
-  result to `mood-meter/run_result.json`.
-
-  Do NOT publish, upload, or deploy. Do NOT call `uip login`. Do
-  NOT pause between planning and implementation. Complete
-  end-to-end in a single pass.
+  Just keep my existing project as-is — don't start it over from
+  scratch. No need to publish or deploy. Please take it all the way
+  through in one go.
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## What

Rewrites the `initial_prompt` of two coded-agent e2e tasks to read like a real human ask instead of a spec sheet. The over-specified prompts were doing the skill's job for it — spelling out the exact error to fix and enumerating internal scaffold state — which weakens what the test actually measures.

### `diagnose_deploy_failure`
- Dropped the spelled-out `Project authors cannot be empty` error and the exact failing command. The agent must now diagnose the rejection itself from the deploy failure.
- Kept the harness footer (`The test harness has UiPath auth pre-configured. Do NOT rewrite the agent...`).

### `existing_project_resume`
- Trimmed the bloated file-by-file scaffold inventory (`pyproject.toml`/`langgraph.json`/`.venv`/`entry-points.json`) and the prescriptive heuristic guidance.
- Says **"UiPath coded agent"** explicitly so the right skill activates (dropped the `LangGraph` lead-in that was steering rather than letting the skill detect framework).
- Retained the criteria-relevant bits: `confidence` field (0.0–1.0), local run, and `run_result.json`.

## Verification

Ran both tasks locally via `coder-eval run ... -e experiments/default.yaml`:

| Task | Status | Score | Criteria |
|------|--------|-------|----------|
| `skill-agent-coded-diagnose-deploy-failure` | ✅ SUCCESS | 1.000 | 4/4 |
| `skill-agent-coded-existing-project-resume` | ✅ SUCCESS | 1.000 | 4/4 |

**2/2 succeeded.** With the guidance removed, the skill still drove the agent to the correct outcome in both cases (diagnose-and-fix `pyproject.toml` authors + deploy; resume-without-clobber + add feature).

## Eval run workflow
[Eval run](https://github.com/UiPath/skills/actions/runs/28184828342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)