### PR TITLE
fix(test): broaden oauth failing smoke to accept list or get

### DIFF
--- a/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent inspected the external app via get"
+    description: "Agent inspected external apps via get or list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+external-apps\s+get\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+external-apps\s+(get|list)\b.*--output\s+json'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

Agent sometimes uses `external-apps list` instead of `external-apps get <id>` to inspect app configuration — both are valid diagnostic approaches for an OAuth scope mismatch. Broadened criterion regex from `get\b` to `(get|list)\b`.

## Evidence

Failed in nightly eval 2026-06-25 (score 0.33). Agent ran `external-apps list --output json` which is a valid way to inspect app configuration but didn't match the `get`-only criterion. Passes 3/3 on-demand runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)