### PR TITLE
fix(maestro-case): prefix variable formal-slot IDs with `v` for valid case BPMN

### DIFF
--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -36,6 +36,8 @@ When using the literal/expression mode, the `--value` string can start with one 
 
 > The prefix tells you WHAT the value refers to. The **sink** tells you HOW to wrap it — see [§ Canonical form per sink](#canonical-form-per-sink) below.
 
+> **Variable / binding ids are always letter-leading.** Formal-arg slots use a `v` prefix, bindings use `b`, and companion ids inherit the (letter-leading) variable name — so `<id>` in `=vars.<id>` / `=bindings.<id>` is always a valid C# identifier. Dot notation is always safe; bracket notation (`vars["…"]`) is never needed. A digit-leading id would fail the case BPMN with `illegal ID` — see [global-vars § Formal-arg slot ID format](plugins/variables/global-vars/impl-json.md#formal-arg-slot-id-format).
+
 ## Canonical form per sink
 
 Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime evaluators based on the sink it lands in. **The wrap form must match the sink** — wrong wrap is a silent runtime fault (the literal string arrives at the consumer instead of the resolved value).

--- a/skills/uipath-maestro-case/references/case-editing-operations.md
+++ b/skills/uipath-maestro-case/references/case-editing-operations.md
@@ -90,6 +90,9 @@ All IDs follow the CLI's `prefixedId(prefix, count)` scheme: a fixed prefix + `c
 | Sticky note | `StickyNote_` | 6 | `StickyNote_aBcDeF` | |
 | SLA escalation | `esc_` | 6 | `esc_gH2jKl` | |
 | Binding | `b` | 8 | `b3KmNp7Q9` | |
+| Variable formal arg slot (`variables.inputs[]` / `variables.outputs[]` `id`) | `v` | 8 | `vK3mNp9Qx` | In/Out-arg formal slot. Surfaces in case BPMN as `<uipath:input id>` + dot-referenced via `=vars.<id>` — MUST be letter-leading. See [global-vars](plugins/variables/global-vars/impl-json.md#formal-arg-slot-id-format). |
+
+> **Leading-letter requirement.** Any id that surfaces as a BPMN element / input id, or is referenced via `=vars.<id>` / `=bindings.<id>` dot notation, MUST start with a letter or underscore (C# identifier + XML NCName rules). Every prefix above is letter-leading, which satisfies this — never mint a **prefix-less** random id for a variable / argument slot; a digit-leading id fails BPMN with `illegal ID`.
 
 ### Algorithm — inline, no subprocess
 

--- a/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/global-vars/impl-json.md
@@ -88,6 +88,12 @@ Build the uniqueness pool from EVERY `var` / `id` currently in `caseplan.json`. 
 
 **Skip guard.** Rules with no `uipath.outputs[]` (connector configuration unresolved — see [`connector-trigger-common.md § Placeholder fallback`](../../../connector-trigger-common.md#placeholder-fallback)) contribute zero outputs to the pool and must be skipped during enumeration. Same skip pattern as placeholder tasks (`data:{}`).
 
+## Formal-arg slot ID format
+
+In/Out-arg formal slots (`variables.inputs[].id`, `variables.outputs[].id`) MUST start with a letter — mint as **`v` + 8 chars** from `[A-Za-z0-9]` (e.g. `vK3mNp9Qx`), same convention as task-input slots ([io-binding](../io-binding/impl-json.md)) and the FE. NOT a bare prefix-less random id.
+
+Rationale: the formal In-arg slot id surfaces in the case BPMN as `<uipath:input id="...">` and is dot-referenced via `=vars.<id>` (the bridge, § In argument). A prefix-less random id can lead with a digit → BPMN parser rejects it (`illegal ID <5AinMKBDm>`); C# identifier + XML NCName rules require a leading letter/underscore. Companion ids (`inputOutputs[].id`) keep the human-readable name (`applicantName`) and are already letter-leading — only the random formal-slot id needs the `v` prefix.
+
 ## Inputs the plugin reads at Phase 3 Step 6.2
 
 1. **`tasks.md`** variable T-entries — for category, type, default, sourceTrigger(s), sourceField(s)
@@ -149,8 +155,8 @@ For each variable T-entry in `tasks.md` that has **no `sourceTrigger` / `sourceT
 | SDD row | `root.inputs[]` | `root.outputs[]` | `root.inputOutputs[]` |
 |---|---|---|---|
 | `Category=Variable` (pure state, no trigger) | — | — | `{id: <sdd-name>, name: <sdd-name>, type: <type>, elementId: "root", default: <value if Default set>, custom: true}` |
-| `Category=In` (any trigger type — manual / timer / event) | `{id: <random9>, name: <sdd-name>, type: <type>, default: <value>, elementId: <triggerId>}` | — | `{id: <sdd-name>, name: <sdd-name>, type: <type>, elementId: <triggerId>}` (no `custom` — argument companion). Additionally write the **bridge** on `triggerNode.outputs[]` (see § In argument below). |
-| `Category=Out` (companion ALWAYS emitted — see § Out argument) | — | `{id: <random9>, name: <sdd-name>, type: <type>, var: <sdd-name>}` (formal-arg pointer) | `{id: <sdd-name>, name: <sdd-name>, type: <type>, default: <value or "">, elementId: "root"}` (no `custom`) |
+| `Category=In` (any trigger type — manual / timer / event) | `{id: v<random8>, name: <sdd-name>, type: <type>, default: <value>, elementId: <triggerId>}` | — | `{id: <sdd-name>, name: <sdd-name>, type: <type>, elementId: <triggerId>}` (no `custom` — argument companion). Additionally write the **bridge** on `triggerNode.outputs[]` (see § In argument below). |
+| `Category=Out` (companion ALWAYS emitted — see § Out argument) | — | `{id: v<random8>, name: <sdd-name>, type: <type>, var: <sdd-name>}` (formal-arg pointer) | `{id: <sdd-name>, name: <sdd-name>, type: <type>, default: <value or "">, elementId: "root"}` (no `custom`) |
 | `Category=InOut` | (not supported in v1 — see SDD template) | (not supported in v1) | (not supported in v1) |
 
 > Loop A and Loop B can write the SAME `root.inputOutputs[]` entry when an SDD row appears in both contexts (e.g., a `Category=Variable` row with `sourceTrigger`). Apply dedup by `id`: if an entry with the same `id` already exists from Loop A, do not re-write in Loop B; Phase 2 validator has already confirmed there's no Type/Default conflict.
@@ -218,7 +224,7 @@ Three entries — formal slot + companion + bridge:
 
 ```json
 // 1. root.inputs[]  — formal-arg slot (caller writes here at fire, OR initialized via default for event triggers)
-{ "id": "<random9>", "name": "applicantName", "type": "string",
+{ "id": "v<random8>", "name": "applicantName", "type": "string",
   "default": "", "elementId": "<triggerId>" }
 
 // 2. root.inputOutputs[]  — companion (readable as =vars.applicantName)
@@ -226,11 +232,11 @@ Three entries — formal slot + companion + bridge:
   "elementId": "<triggerId>" }
 
 // 3. triggerNode.data.uipath.outputs[]  — bridge from formal slot to companion
-{ "name": "applicantName", "type": "string", "source": "=vars.<random9>", "var": "applicantName" }
+{ "name": "applicantName", "type": "string", "source": "=vars.v<random8>", "var": "applicantName" }
 // No `id`, no `elementId` on bridge — FE convention. `type` matches the SDD row's Type column.
 ```
 
-**Why three entries instead of one?** The runtime resolver (`VariablesService.findVariableByVariableId`) is a single string-equality find on `Variable.id`. The caller (or trigger fire for event triggers) writes the formal-arg's value into `vars.<random9>` at trigger fire (because `inputs[].id` is `<random9>`); downstream code wants to read it as `=vars.applicantName` (because that's the readable name). There is no automatic forwarding between the two slots — the bridge entry on `triggerNode.outputs[]` executes the copy at fire time: `source: "=vars.<random9>"` reads the formal slot, `var: "applicantName"` writes to the companion's slot. Without the bridge, `=vars.applicantName` resolves to undefined. The companion's `inputOutputs[]` entry alone declares the *name* in the namespace, but holds no *value* because nobody writes to it.
+**Why three entries instead of one?** The runtime resolver (`VariablesService.findVariableByVariableId`) is a single string-equality find on `Variable.id`. The caller (or trigger fire for event triggers) writes the formal-arg's value into `vars.v<random8>` at trigger fire (because `inputs[].id` is `v<random8>`); downstream code wants to read it as `=vars.applicantName` (because that's the readable name). There is no automatic forwarding between the two slots — the bridge entry on `triggerNode.outputs[]` executes the copy at fire time: `source: "=vars.v<random8>"` reads the formal slot, `var: "applicantName"` writes to the companion's slot. Without the bridge, `=vars.applicantName` resolves to undefined. The companion's `inputOutputs[]` entry alone declares the *name* in the namespace, but holds no *value* because nobody writes to it.
 
 > **Placeholder trigger interaction:** if the trigger is a placeholder (any type), write entries 1 + 2 only; skip the bridge (entry 3) — the placeholder has no `data.uipath.outputs` array. The placeholder trigger never fires, so the bridge would never execute anyway. **Consequence:** at runtime `vars.<name>` (the companion slot) is undefined — the `default` on the `inputs[]` formal slot does NOT propagate to the companion without the bridge. This is expected: a placeholder case is structurally incomplete and not meant to run until the trigger is resolved. Re-generate from scratch (Rule 6) after the trigger resolves to get the working bridge.
 
@@ -257,7 +263,7 @@ Same shape regardless of Default presence (two entries):
 
 ```json
 // 1. variables.outputs[]  — formal Out-arg pointer
-{ "id": "<random9>", "name": "finalDecision", "type": "string",
+{ "id": "v<random8>", "name": "finalDecision", "type": "string",
   "var": "finalDecision" }
 // var is a POINTER — at case end, engine reads vars.finalDecision via this pointer
 
@@ -277,17 +283,17 @@ Combines In + Out. One shared companion serves both:
 
 ```json
 // 1. root.inputs[]  — formal In slot
-{ "id": "<random9-in>", "name": "claimId", "type": "string",
+{ "id": "v<random8-in>", "name": "claimId", "type": "string",
   "default": "", "elementId": "<triggerId>" }
 
 // 2. root.inputOutputs[]  — shared companion
 { "id": "claimId", "name": "claimId", "type": "string", "elementId": "<triggerId>" }
 
 // 3. root.outputs[]  — formal Out slot pointing at same companion
-{ "id": "<random9-out>", "name": "claimId", "type": "string", "var": "claimId" }
+{ "id": "v<random8-out>", "name": "claimId", "type": "string", "var": "claimId" }
 
 // 4. triggerNode.outputs[]  — bridge from In formal slot to shared companion
-{ "name": "claimId", "type": "string", "source": "=vars.<random9-in>", "var": "claimId" }
+{ "name": "claimId", "type": "string", "source": "=vars.v<random8-in>", "var": "claimId" }
 ```
 
 Caller writes value; bridge copies to companion at trigger fire; task body updates `vars.claimId`; case end returns updated value to caller.

--- a/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/variables/io-binding/impl-json.md
@@ -15,7 +15,7 @@ Wire task inputs by editing `caseplan.json` directly. Runs after all tasks are c
   "value": "=vars.customerId" }
 ```
 
-Inputs are populated with empty `value` from the `tasks describe` schema when the task's `data.inputs[]` are written during the task plugin's impl-json write. Input IDs are random (`v` + 8 chars).
+Inputs are populated with empty `value` from the `tasks describe` schema when the task's `data.inputs[]` are written during the task plugin's impl-json write. Input IDs are random (`v` + 8 chars) — letter-leading, same convention as variable formal slots ([global-vars § Formal-arg slot ID format](../global-vars/impl-json.md#formal-arg-slot-id-format)).
 
 ## Task Output Shape
 
@@ -183,7 +183,7 @@ for entry in root.outputs[]:
 **On AskUserQuestion ("pure orphan" branch):**
 
 ```
-Out-argument "<name>" (id <random>, var <var>) has no value source:
+Out-argument "<name>" (id v<random8>, var <var>) has no value source:
   SDD row Default: <"" (empty)>
   Companion root.inputOutputs[].id="<var>": exists, default=""
   Producing task in tasks.md (extraction or assignment): none found


### PR DESCRIPTION
## What

Mint case variable formal-arg slot ids (`variables.inputs[].id` / `variables.outputs[].id`) as `v` + 8 chars (letter-leading) instead of a prefix-less `<random9>`.

## Why

The formal In-arg slot id surfaces in the generated case BPMN as `<uipath:input id="...">` and is dot-referenced via `=vars.<id>`. A prefix-less random id can lead with a digit, which the BPMN parser rejects (`illegal ID <5AinMKBDm>`) — C# identifier + XML NCName rules require a leading letter/underscore. The `v` prefix matches the existing binding (`b` + 8) and task-input (`v` + 8) conventions; total id length is unchanged (9).

## Changes (docs only, `uipath-maestro-case`)

- `plugins/variables/global-vars/impl-json.md` — new **Formal-arg slot ID format** section (canonical rationale); all In/Out/InOut examples + the resolver explanation use `v<random8>`.
- `case-editing-operations.md` — ID-scheme table row for the variable formal slot + a general leading-letter requirement covering any BPMN/`=vars`/`=bindings`-referenced id.
- `bindings-and-expressions.md` — letter-leading invariant callout (dot notation always safe).
- `plugins/variables/io-binding/impl-json.md` — cross-link to the canonical section + example.

Companion ids (which inherit the camelCase variable name per the SDD template) are already letter-leading; only the random formal slot needed the prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)