### PR TITLE
fix(uipath-maestro-bpmn): script-task arg typing + deploy entry-point schema + validate reconciliation

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -79,15 +79,19 @@ before writing. Read a reference only when you reach the structure it covers.
    authoring runs out of time. Add only the structural pieces your process needs
    (extra gateways, events, boundary events, containers, multi-instance markers),
    then generate one `BPMNShape`/`BPMNEdge` per node and flow.
-4. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
-   bundled validator — it reconstructs the canvas model and runs every
-   PO.Frontend rule:
+4. **Validate.** Run the bundled validator — it reconstructs the canvas model and
+   runs every PO.Frontend structural rule:
 
    ```bash
    cd skills/uipath-maestro-bpmn/validator && npm install --silent
    node validate-bpmn.mjs <file.bpmn>   # prints VALID (exit 0) or the errors (exit 1)
    ```
 
+   It is the authoritative structural check. `uip maestro bpmn validate <file>`
+   is **complementary, not a substitute**: it checks deploy-readiness
+   (supported extension tags; `entry-points.json` `filePath`/start-event linkage
+   and `uniqueId == <uipath:entryPointId value>`) but does **not** run the
+   structural rules or assert `uniqueId` is a GUID. Before deploying, run both.
    A well-formed-XML parse is the secondary fallback if Node is unavailable. See
    [references/structural-bpmn.md#validation](references/structural-bpmn.md#validation).
    Validate once; fix only ERROR-severity findings (warnings do not block import).

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -139,8 +139,12 @@ and honestly surfaced to the user as gaps when asked.
 
 1. **Registry owns every `uipath:*` payload.** Author from
    `registry get` templates; never hand-write `uipath:` XML from prose.
-2. **Never fabricate an identifier.** Connection IDs, process/queue/connector
-   keys, app IDs, folder ids/paths come from discovery or the user.
+2. **Never fabricate or copy an identifier.** Connection IDs, process/queue/connector
+   keys, app IDs, folder ids/paths come from discovery or the user. Every concrete
+   value in a skill example — GUIDs, connection/release keys, URLs, folder names,
+   variable ids — is an **illustrative placeholder**: replace each with a value you
+   discovered or generated (e.g. a fresh GUID for an entry-point `uniqueId`), never
+   the literal from the doc.
 3. **Structural BPMN is authored, not invented.** Follow the spec/canvas
    contract in [references/structural-bpmn.md](references/structural-bpmn.md);
    flag honestly what the registry does not expose.

--- a/skills/uipath-maestro-bpmn/references/cli-conventions.md
+++ b/skills/uipath-maestro-bpmn/references/cli-conventions.md
@@ -19,11 +19,12 @@ All commands below are discovery/read-only. None mutate cloud state.
 | `uip maestro bpmn registry get <extensionType> [--connection-id <id>] [--object-name <name>]` | Get the full spec for one extension type: `xmlTemplate`, `contextFields`, `bindingInfo`, input/output patterns. `--connection-id`/`--object-name` add live Integration Service field metadata for `Intsvc.*` connector types. |
 | `uip is connections list --all-folders` | List live Integration Service connections (id + state) across all folders. Always pass `--all-folders`; a folder-scoped list silently misses connections. |
 
-These are the **only** commands the skill verifies against the CLI source
-(`packages/maestro-tool/src/commands/registry.ts`). Do not invent flags. In
-particular, there is **no** `uip maestro bpmn validate` command — see
-[Validation](structural-bpmn.md#validation). Validation is done with the bundled
-offline validator, not a CLI.
+These are the **only** registry/discovery commands the skill verifies against
+the CLI source (`packages/maestro-tool/src/commands/registry.ts`). Do not invent
+flags. Structural validation uses the bundled offline validator (see
+[Validation](structural-bpmn.md#validation)); `uip maestro bpmn validate <file>`
+is a separate, complementary deploy-readiness check (extension-tag support and
+`entry-points.json` linkage), not a replacement for the bundled validator.
 
 ## Output parsing
 

--- a/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/references/failure-modes.md
@@ -20,6 +20,26 @@ Entry point inputs reference a start event through `elementId`, but the start ev
 `uipath:entryPointId` or the ID is duplicated.
 Fix root start event extensions and variable scoping.
 
+## Solution deploy fails at install (FailedInstall / "Error while installing package")
+
+The project packs, uploads to Studio Web, and runs in the SW designer, but
+Orchestrator solution-deploy fails install with a generic "Error while
+installing package" and no field-level cause. The cause is almost always the
+entry-point identity:
+
+- `entry-points.json` `uniqueId` **must be a GUID** — a non-GUID value (e.g. the
+  start-event element id `Event_start`) installs-fails even when it otherwise
+  matches `entryPointId`.
+- `uniqueId` **must equal** `<uipath:entryPointId value>` — a GUID that differs
+  installs but the trigger won't resolve.
+
+Both must hold (see the two-identity-pairs table in
+[shared/local-metadata-regeneration-guide.md](../../shared/local-metadata-regeneration-guide.md#entry-point-rules)).
+A current `uip maestro bpmn init` scaffolds this correctly; an older scaffold or
+a hand-regenerated file may not. `uip maestro bpmn validate` flags the
+`uniqueId != entryPointId` mismatch but not a non-GUID `uniqueId`, so verify the
+GUID by eye.
+
 ## Binding reference missing
 
 A node context value refers to `=bindings.<id>` but no matching root binding or generated binding resource exists.

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -90,6 +90,10 @@ do not invent `contentFiles` as a substitute for `content`.
 }
 ```
 
+The `uniqueId` here is an **illustrative GUID** — use the start event's actual
+`<uipath:entryPointId value>` (a real GUID), never this literal. See Entry Point
+Rules below.
+
 `bindings_v2.json`:
 
 ```json

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -69,21 +69,22 @@ do not invent `contentFiles` as a substitute for `content`.
 
 ```json
 {
-  "main": "SyntheticProject.bpmn",
+  "main": "/content/SyntheticProject.bpmn#Start_Manual",
   "contentType": "ProcessOrchestration"
 }
 ```
 
-`entry-points.json`:
+`entry-points.json` (deploy schema — see Entry Point Rules below):
 
 ```json
 {
   "entryPoints": [
     {
-      "id": "Entry_ManualStart",
+      "uniqueId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
       "filePath": "/content/SyntheticProject.bpmn#Start_Manual",
-      "inputSchema": { "type": "object", "properties": {} },
-      "outputSchema": { "type": "object", "properties": {} }
+      "type": "ProcessOrchestration",
+      "input": { "type": "object", "properties": {} },
+      "output": { "type": "object", "properties": {} }
     }
   ]
 }
@@ -117,14 +118,31 @@ imported an external process, queue, connector, or agent.
 
 ## Entry Point Rules
 
+Entry-point identity is **two linked pairs** — get both right or Orchestrator
+solution-deploy fails (the symptom is a generic "Error while installing package"
+with no field-level cause):
+
+| Pair | Value | Why |
+| --- | --- | --- |
+| `<bpmn:startEvent id>` == `entry-points.json` `filePath` `#`fragment | the element id (e.g. `Start_Manual`) | element linkage |
+| `<uipath:entryPointId value>` == `entry-points.json` `uniqueId` | one **GUID** | install **requires a GUID**; trigger resolution requires the two be equal |
+
 For each root start event with `uipath:entryPointId`, generated `entry-points.json` must include:
 
-- `id` equal to the `uipath:entryPointId` value.
-- `filePath` equal to `/content/<bpmn-file>#<start-event-id>`.
-- `inputSchema` from root input variables whose `elementId` matches the start event.
-- `outputSchema` from root output variables.
+- `uniqueId` equal to the `uipath:entryPointId` value, which **must be a GUID**
+  (not the element id). A non-GUID `uniqueId` installs-fails; a GUID that
+  differs from `entryPointId` installs but won't resolve the trigger.
+- `filePath` equal to `/content/<bpmn-file>#<start-event-id>` (the `#`fragment
+  is the element id, not the GUID).
+- `type` equal to `ProcessOrchestration` (PascalCase).
+- `input` from root input variables whose `elementId` matches the start event.
+- `output` from root output variables.
 
-JSON schema variables use their CDATA body as the property schema. Strip `$schema` from generated package schemas. Other primitive variables map by type, such as `string`, `integer`, `number`, `boolean`, `array`, `object`, or `json`.
+`uip maestro bpmn init` (post the deploy-metadata fix) scaffolds this shape; if
+you regenerate by hand, mirror it exactly. JSON schema variables use their CDATA
+body as the property schema. Strip `$schema` from generated package schemas.
+Other primitive variables map by type, such as `string`, `integer`, `number`,
+`boolean`, `array`, `object`, or `json`.
 
 ## Binding Rules
 

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -93,7 +93,7 @@ registry `xmlTemplate` of whatever node you need.
         <uipath:scriptVersion value="v3" />
         <uipath:mapping version="v1">
           <uipath:type value="BPMN.ScriptTask" version="v1" />
-          <uipath:input name="args"><![CDATA[{"amount":"=vars.Var_Amount"}]]></uipath:input>
+          <uipath:input name="args" type="json" target="bodyField"><![CDATA[{"amount":"=vars.Var_Amount"}]]></uipath:input>
           <uipath:output name="tier" type="string" var="Var_Tier" source="=result.response" />
         </uipath:mapping>
       </bpmn:extensionElements>
@@ -150,9 +150,14 @@ template, but the runtime contract is fixed:
   / 30 s.
 - Set `uipath:scriptVersion value="v3"` for new scripts; preserve an imported
   `value="v2"`. For v2+ the script returns JSON under `response`.
+- The `args` input **must** be `<uipath:input name="args" type="json"
+  target="bodyField">`. The parser drops any `uipath:input` missing `type` or
+  `target`, so a bare `name="args"` input is silently discarded and the script
+  task fails at runtime with "Arguments is required".
 - Mapped `args` fields are read as **top-level identifiers** in the script body
-  (`amount`, not `args.amount`); the input mapping itself stays `name="args"`
-  and maps each field by variable id (`=vars.Var_Amount`).
+  (`amount`, not `args.amount`) — the runtime spreads the `args` object's keys
+  into the script scope. The input stays named `args` and maps each field by
+  variable id (`=vars.Var_Amount`).
 - Map the return back through `source="=result.response"` (scalar) or
   `source="=result.response.<field>"` (object field); `var` points at a declared
   variable id (do not put the target id in `name`).
@@ -163,7 +168,7 @@ template, but the runtime contract is fixed:
     <uipath:scriptVersion value="v3" />
     <uipath:mapping version="v1">
       <uipath:type value="BPMN.ScriptTask" version="v1" />
-      <uipath:input name="args"><![CDATA[{"amount":"=vars.Var_Amount","daysOverdue":"=vars.Var_DaysOverdue"}]]></uipath:input>
+      <uipath:input name="args" type="json" target="bodyField"><![CDATA[{"amount":"=vars.Var_Amount","daysOverdue":"=vars.Var_DaysOverdue"}]]></uipath:input>
       <uipath:output name="riskScore" type="number" var="Var_RiskScore" source="=result.response" />
     </uipath:mapping>
   </bpmn:extensionElements>

--- a/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/check_script_jint_guidance.py
@@ -133,6 +133,13 @@ def main() -> None:
     args_input = first_uipath_input(task, "args")
     if args_input is None:
         fail('script mapping must include uipath:input name="args"')
+    # The parser drops any uipath:input missing type/target, which silently
+    # discards the args and faults the script at runtime ("Arguments is
+    # required"). Enforce the attributes the doc marks as mandatory.
+    if args_input.attrib.get("type") != "json":
+        fail('uipath:input name="args" must have type="json"')
+    if args_input.attrib.get("target") != "bodyField":
+        fail('uipath:input name="args" must have target="bodyField"')
     args_body = text_content(args_input)
     for variable_name in ("amount", "daysOverdue"):
         expected = f"=vars.{variables[variable_name]}"


### PR DESCRIPTION
Skill-side fixes surfaced by driving a create-on-missing process deploy end-to-end (the CLI root cause C1 is fixed separately in cli#2670). All verified against the engine/CLI source.

## S1 — script-task `args` must be typed bodyField (`structural-bpmn.md`)
The engine parser (`UiPath.PO.BpmnParser` → `ExtractActivityInputs`) drops any `uipath:input` missing `type` OR `target`, so a bare `<uipath:input name="args">` is silently discarded and the script fails at runtime with **"Arguments is required"**. Both examples now use `type="json" target="bodyField"`.

## S2 — deliberately NOT changed (kept top-level read)
The engine (`ScriptActivities`) spreads the `args` object's keys into the script scope as top-level globals, so the body reads `amount`, **not** `args.amount`. A source report claimed the opposite; the engine source refutes it. Added a one-line rule making the parser-drop explicit.

## S4 — deploy entry-point schema (`local-metadata-regeneration-guide.md`, `failure-modes.md`)
The regeneration guide modeled the legacy entry-points schema (`id`/`inputSchema`). Rewrote to the deploy schema matching cli#2670 + Studio Web: `uniqueId` = GUID == `<uipath:entryPointId value>`, `input`/`output`, `type: ProcessOrchestration`, `operate.json main` content path; documented the two-identity-pairs rule. Added a "solution deploy FailedInstall" diagnosis entry.

## S5 — validate reconciliation (`SKILL.md`, `cli-conventions.md`)
The CLI now has `uip maestro bpmn validate` (deploy-readiness: extension-tag support + entry-point linkage, **not** the structural rules). Reconciled the docs to recommend it alongside the bundled validator instead of claiming it doesn't exist.

Bundled validator stays VALID (the complete example uses the typed input).

🤖 Generated with [Claude Code](https://claude.com/claude-code)