### PR TITLE
ci(coder-eval): add codex (gpt-5.4) agent option to run-coder-eval

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -36,6 +36,13 @@ on:
         description: 'coder_eval version to test (blank = pinned).'
         type: string
         default: ''
+      # Decouples the GHCR agent image from the wheel version, so an ad-hoc /
+      # unreleased image (e.g. a codex-baked `sha-<commit>` build) can be tested
+      # while the host CLI installs a matching dev wheel via coder_eval_version.
+      coder_eval_image_tag:
+        description: 'Agent image tag (blank = coder_eval_version).'
+        type: string
+        default: ''
       cli_version:
         description: '@uipath/cli version.'
         type: string
@@ -62,6 +69,7 @@ jobs:
       linux_count:    ${{ steps.split.outputs.linux_count }}
       windows_count:  ${{ steps.split.outputs.windows_count }}
       coder_eval_version: ${{ steps.ceref.outputs.version }}
+      coder_eval_image_tag: ${{ steps.ceref.outputs.image_tag }}
     steps:
       - uses: actions/checkout@v4
 
@@ -73,12 +81,17 @@ jobs:
         id: ceref
         env:
           CE_VERSION_INPUT: ${{ inputs.coder_eval_version }}
+          CE_IMAGE_TAG_INPUT: ${{ inputs.coder_eval_image_tag }}
         run: |
           if [ -n "$CE_VERSION_INPUT" ]; then
-            echo "version=$CE_VERSION_INPUT" >> "$GITHUB_OUTPUT"
+            version="$CE_VERSION_INPUT"
           else
-            echo "version=$(tr -d '[:space:]' < tests/.coder-eval-version)" >> "$GITHUB_OUTPUT"
+            version="$(tr -d '[:space:]' < tests/.coder-eval-version)"
           fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          # Agent image tag defaults to the wheel version; a non-blank input
+          # decouples them (ad-hoc / unreleased image vs. dev-wheel host CLI).
+          echo "image_tag=${CE_IMAGE_TAG_INPUT:-$version}" >> "$GITHUB_OUTPUT"
 
       - name: Resolve globs, split by tag, enforce large-run gate
         id: split
@@ -164,19 +177,21 @@ jobs:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@pkgs.dev.azure.com/uipath/ML%20Platform/_packaging/coder_eval/pypi/simple/ https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
         run: uv pip install --system "coder-eval==${{ needs.partition.outputs.coder_eval_version }}"
 
-      # Pull the pinned agent image from GHCR (never built from source); the
-      # skills image extends it below. GH_PAT needs read:packages.
-      - name: Pull pinned coder-eval-agent image
+      # Pull the agent image from GHCR (never built from source); the skills
+      # image extends it below. Tag defaults to the wheel version but can be
+      # overridden (coder_eval_image_tag) for ad-hoc / unreleased images.
+      # GH_PAT needs read:packages.
+      - name: Pull coder-eval-agent image
         run: |
           echo "${{ secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
-          docker pull ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_version }}
+          docker pull ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_image_tag }}
 
       # Build the skills extension image (`@uipath/cli` + `@uipath/admin-tool`
       # on top of coder-eval-agent). Matches smoke-skills.yml + daily.sh.
       - name: Build skills Docker image
         run: |
           docker build \
-            --build-arg CODER_EVAL_IMAGE=ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_version }} \
+            --build-arg CODER_EVAL_IMAGE=ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_image_tag }} \
             --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
             --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
             -t skills-image:latest \

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -156,21 +156,13 @@ jobs:
 
       # Host coder-eval CLI = pinned wheel (coder_eval feed + ml-packages for
       # deps). No source checkout.
+      # codex is NOT installed on the host here: under the docker driver the
+      # agent runs inside skills-image, so the codex SDK belongs in that image
+      # (separate TODO), not on the host CLI.
       - name: Install coder-eval
         env:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@pkgs.dev.azure.com/uipath/ML%20Platform/_packaging/coder_eval/pypi/simple/ https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
-          CE_VERSION: ${{ needs.partition.outputs.coder_eval_version }}
-          AGENT: ${{ inputs.agent }}
-        run: |
-          pkgs="coder-eval==${CE_VERSION}"
-          # codex agent needs the openai-codex SDK. Under the docker driver the
-          # agent runs INSIDE skills-image, so codex must also be installed in
-          # that image (separate TODO) — this host install only covers the
-          # tempdir path. 0.1.0b3 is the version verified against coder-eval 0.6.2.
-          if [ "$AGENT" = "codex" ]; then
-            pkgs="$pkgs openai-codex==0.1.0b3"
-          fi
-          uv pip install --system $pkgs
+        run: uv pip install --system "coder-eval==${{ needs.partition.outputs.coder_eval_version }}"
 
       # Pull the pinned agent image from GHCR (never built from source); the
       # skills image extends it below. GH_PAT needs read:packages.
@@ -340,14 +332,16 @@ jobs:
           CE_VERSION: ${{ needs.partition.outputs.coder_eval_version }}
           AGENT: ${{ inputs.agent }}
         run: |
-          pkgs="coder-eval==${CE_VERSION}"
+          uv pip install --system "coder-eval==${CE_VERSION}"
           # Windows runs the tempdir driver (agent on host), so the codex SDK
-          # installed here is what the codex agent actually uses. 0.1.0b3 is the
-          # version verified against coder-eval 0.6.2.
+          # installed here is what the codex agent actually uses. openai-codex
+          # 0.1.0b3 (verified against coder-eval 0.6.2) pulls a pre-release
+          # cli-bin that spans both internal feeds, so allow pre-releases and
+          # best-match across indexes.
           if [ "$AGENT" = "codex" ]; then
-            pkgs="$pkgs openai-codex==0.1.0b3"
+            uv pip install --system --prerelease=allow --index-strategy unsafe-best-match \
+              "openai-codex==0.1.0b3"
           fi
-          uv pip install --system $pkgs
 
       - name: Configure NuGet feed for Helm packages
         shell: bash

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -40,6 +40,13 @@ on:
         description: '@uipath/cli version.'
         type: string
         default: alpha
+      agent:
+        description: 'Agent (codex = gpt-5.4).'
+        type: choice
+        options:
+          - claude
+          - codex
+        default: claude
 
 concurrency:
   group: run-coder-eval-${{ github.ref }}
@@ -152,7 +159,18 @@ jobs:
       - name: Install coder-eval
         env:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@pkgs.dev.azure.com/uipath/ML%20Platform/_packaging/coder_eval/pypi/simple/ https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
-        run: uv pip install --system "coder-eval==${{ needs.partition.outputs.coder_eval_version }}"
+          CE_VERSION: ${{ needs.partition.outputs.coder_eval_version }}
+          AGENT: ${{ inputs.agent }}
+        run: |
+          pkgs="coder-eval==${CE_VERSION}"
+          # codex agent needs the openai-codex SDK. Under the docker driver the
+          # agent runs INSIDE skills-image, so codex must also be installed in
+          # that image (separate TODO) — this host install only covers the
+          # tempdir path. 0.1.0b3 is the version verified against coder-eval 0.6.2.
+          if [ "$AGENT" = "codex" ]; then
+            pkgs="$pkgs openai-codex==0.1.0b3"
+          fi
+          uv pip install --system $pkgs
 
       # Pull the pinned agent image from GHCR (never built from source); the
       # skills image extends it below. GH_PAT needs read:packages.
@@ -207,15 +225,26 @@ jobs:
           TASK_GLOBS:               ${{ needs.partition.outputs.linux_globs }}
           TASK_COUNT:               ${{ needs.partition.outputs.linux_count }}
           TASK_PARALLELISM:         ${{ inputs.parallelism }}
+          AGENT:                    ${{ inputs.agent }}
+          CODEX_API_KEY:            ${{ secrets.CODEX_API_KEY }}
+          CODEX_BASE_URL:           ${{ secrets.CODEX_BASE_URL }}
         working-directory: tests
         id: eval
         run: |
           # Guard the empty case (e.g. a future non-dispatch trigger): the
           # `parallelism` input default (4) only applies on workflow_dispatch.
           j="${TASK_PARALLELISM:-4}"
-          echo "Running: coder-eval run $TASK_GLOBS -e experiments/nightly.yaml -j $j ($TASK_COUNT task files)"
+          # Agent selection. claude (default) takes the experiment YAML's
+          # claude-code/sonnet config; codex overrides to gpt-5.4 and authenticates
+          # via CODEX_API_KEY/CODEX_BASE_URL. Driver is unchanged (docker here).
+          agent_flags=""
+          if [ "$AGENT" = "codex" ]; then
+            agent_flags="--type codex --model gpt-5.4"
+          fi
+          echo "Running: coder-eval run $TASK_GLOBS -e experiments/nightly.yaml $agent_flags -j $j ($TASK_COUNT task files)"
           coder-eval run $TASK_GLOBS \
             -e experiments/nightly.yaml \
+            $agent_flags \
             -j "$j" -v \
             --run-dir /tmp/runs
 
@@ -308,7 +337,17 @@ jobs:
         shell: bash
         env:
           UV_EXTRA_INDEX_URL: "https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@pkgs.dev.azure.com/uipath/ML%20Platform/_packaging/coder_eval/pypi/simple/ https://${{ secrets.UV_INDEX_UIPATH_USERNAME }}:${{ secrets.UV_INDEX_UIPATH_PASSWORD }}@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/"
-        run: uv pip install --system "coder-eval==${{ needs.partition.outputs.coder_eval_version }}"
+          CE_VERSION: ${{ needs.partition.outputs.coder_eval_version }}
+          AGENT: ${{ inputs.agent }}
+        run: |
+          pkgs="coder-eval==${CE_VERSION}"
+          # Windows runs the tempdir driver (agent on host), so the codex SDK
+          # installed here is what the codex agent actually uses. 0.1.0b3 is the
+          # version verified against coder-eval 0.6.2.
+          if [ "$AGENT" = "codex" ]; then
+            pkgs="$pkgs openai-codex==0.1.0b3"
+          fi
+          uv pip install --system $pkgs
 
       - name: Configure NuGet feed for Helm packages
         shell: bash
@@ -431,6 +470,9 @@ jobs:
           BEDROCK_MODEL:            ${{ secrets.BEDROCK_MODEL }}
           ANTHROPIC_API_KEY:        ${{ secrets.ANTHROPIC_API_KEY }}
           TASK_GLOBS:               ${{ needs.partition.outputs.windows_globs }}
+          AGENT:                    ${{ inputs.agent }}
+          CODEX_API_KEY:            ${{ secrets.CODEX_API_KEY }}
+          CODEX_BASE_URL:           ${{ secrets.CODEX_BASE_URL }}
           # Redirect the temp root off the default %TEMP%. On the GH-hosted
           # Windows runner %TEMP% resolves to its 8.3 short form
           # (C:\Users\RUNNER~1\AppData\Local\Temp). coder-eval creates each
@@ -449,6 +491,13 @@ jobs:
           shopt -s globstar nullglob
           # Create the tilde-free temp root pinned via TMP/TEMP above.
           mkdir -p /c/cetmp
+          # Agent selection. claude (default) takes the experiment YAML config;
+          # codex overrides to gpt-5.4 (auth via CODEX_API_KEY/CODEX_BASE_URL).
+          # Driver is unchanged (tempdir here).
+          agent_flags=""
+          if [ "$AGENT" = "codex" ]; then
+            agent_flags="--type codex --model gpt-5.4"
+          fi
           overall_exit=0
           for task in $TASK_GLOBS; do
             echo "--- Killing leftover Helm/Studio processes ---"
@@ -457,7 +506,7 @@ jobs:
             for attempt in 1 2 3; do
               echo "--- $task attempt $attempt ---"
               if coder-eval run "$task" \
-                  -e experiments/smoke-windows.yaml -j 1 -v; then
+                  -e experiments/smoke-windows.yaml $agent_flags -j 1 -v; then
                 break
               fi
               # Only retry on Bedrock content-filter ERRORs. Real task

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -26,6 +26,10 @@ defaults:
         - TRACES_SMOKE_PROCESS_KEY
         - E2E_PROCESS_KEY
         - E2E_LONG_PROCESS_KEY
+        # codex agent auth — passed into the container so the codex SDK can
+        # authenticate. Unset / no-op for the default claude-code agent.
+        - CODEX_API_KEY
+        - CODEX_BASE_URL
       extra_mounts:
         - ~/.uipath:/.uipath:rw
 

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -26,8 +26,6 @@ defaults:
         - TRACES_SMOKE_PROCESS_KEY
         - E2E_PROCESS_KEY
         - E2E_LONG_PROCESS_KEY
-        # codex agent auth — passed into the container so the codex SDK can
-        # authenticate. Unset / no-op for the default claude-code agent.
         - CODEX_API_KEY
         - CODEX_BASE_URL
       extra_mounts:

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -26,6 +26,8 @@ defaults:
         - UIPATH_CLI_TENANT_NAME
         - UIPATH_CLI_TENANT_ID
         - TRACES_SMOKE_PROCESS_KEY
+        - CODEX_API_KEY
+        - CODEX_BASE_URL
       extra_mounts:
         - ~/.uipath:/.uipath:rw
 


### PR DESCRIPTION
## What

Adds an `agent` choice input (`claude` default, `codex`) to the Run Coder Eval workflow so the skills task tree can be evaluated against codex (gpt-5.4) as well as Claude, from the same GH-hosted workflow. Also adds a `coder_eval_image_tag` input that decouples the GHCR agent image from the wheel version, so an ad-hoc / unreleased image can be tested while the host CLI installs a matching dev wheel.

## Why

Gives us apples-to-apples codex numbers on the skills suite without standing up a separate runner. Claude runs are unchanged — codex is purely additive and off by default.

## Testing

Ran this workflow on the PR branch with `agent=codex` (gpt-5.4) against 20 real skills tasks (admin, coded agents, api-workflow, ixp, governance, HITL, platform, planner, test — incl. 5 e2e), using a codex-baked ad-hoc `coder-eval-agent` image via the new `coder_eval_image_tag` input plus a matching dev wheel for the host CLI → **26/27 SUCCESS**, identical to a local docker+codex run of the same tasks. The single failure (`role-lifecycle-e2e`) is a pre-existing nondeterministic prompt-ambiguity flake — codex sometimes creates the role via the platform authorization API while the checker queries Orchestrator roles — not a codex/docker issue (it passed on re-run).

## Notes

Sandbox driver is unchanged per job (Linux = docker, Windows = tempdir). The codex auth env (`CODEX_API_KEY` / `CODEX_BASE_URL`) is forwarded into the container by both docker experiments (`nightly.yaml` + `smoke.yaml`) so codex can authenticate if either ever runs it; no-op for the default claude-code agent.

For codex under the Linux docker path, the eval image must contain codex — addressed in UiPath/coder_eval#459, which bakes codex into the published `coder-eval-agent` image. Until that ships in a tagged release, point `coder_eval_image_tag` at an ad-hoc build (e.g. a `sha-<commit>` image) with `coder_eval_version` set to a matching dev wheel; once #459 releases, set `coder_eval_version` to that specific release (≥ 0.7.3) and leave the image tag blank. The Windows tempdir path runs codex as-is today.
