### PR TITLE
test(uipath-agents): prime env in pre_run for pre-seeded coded eval tasks

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/setup.md
+++ b/skills/uipath-agents/references/coded/lifecycle/setup.md
@@ -44,6 +44,8 @@ uip codedagent init
 
 `uipath-dev` is added to the dev dependency group during scaffold so `uip codedagent dev` works later without a second install pass. Skipping it causes `uip codedagent dev` to fail with *"The 'uipath-dev' package is required to use the dev command"*.
 
+**What `uip codedagent setup` does:** locates a Python that has `uipath` installed and caches its path, so later commands (`init`/`run`/`eval`/`pack`) can invoke the Python SDK. It searches PATH (`python3.x`, `python3`, `python`) and uses your `.venv` only when activated. So when using uv, always `uv sync` then activate the venv before the `setup` command.
+
 ## Coded Function Agents
 
 `uipath.json` carries the entrypoint mapping:

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -17,6 +17,8 @@ run_limits:
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/eval_llm_judges/_fixtures/intent-classifier ."
     timeout: 10
+  - command: "bash -c 'cd intent-classifier && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 300
 
 initial_prompt: |
   I want to test that this UiPath coded agent works as it should.

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -16,6 +16,8 @@ max_iterations: 1
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever ."
     timeout: 10
+  - command: "bash -c 'cd asset-retriever && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 180
 
 initial_prompt: |
   I have an existing coded agent project at `asset-retriever/`

--- a/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/eval_trajectory_empty_history.yaml
@@ -16,6 +16,8 @@ max_iterations: 1
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/eval_trajectory_empty_history/_fixtures/ticket-router ."
     timeout: 10
+  - command: "bash -c 'cd ticket-router && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 180
 
 initial_prompt: |
   I have a LangGraph coded agent project at `ticket-router/`. It

--- a/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
+++ b/tests/tasks/uipath-agents/coded/existing_project_resume/existing_project_resume.yaml
@@ -13,6 +13,8 @@ max_iterations: 1
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/existing_project_resume/_fixtures/mood-meter ."
     timeout: 10
+  - command: "bash -c 'cd mood-meter && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 180
 
 initial_prompt: |
   I've got a half-built UiPath coded agent under `mood-meter/` that

--- a/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
+++ b/tests/tasks/uipath-agents/coded/local_workspace_iterate/local_workspace_iterate.yaml
@@ -14,6 +14,8 @@ max_iterations: 1
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/local_workspace_iterate/_fixtures/GateSol ."
     timeout: 10
+  - command: "bash -c 'cd GateSol/gate-agent && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 180
 
 initial_prompt: |
   I've got a UiPath coded agent in `GateSol/gate-agent/` that I set up

--- a/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/coded/push_pull_roundtrip/push_pull_roundtrip.yaml
@@ -21,6 +21,8 @@ sandbox:
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/push_pull_roundtrip/_fixtures/roundtrip-agent ."
     timeout: 10
+  - command: "bash -c 'cd roundtrip-agent && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
+    timeout: 180
 
 initial_prompt: |
   I've been working on my `roundtrip-agent` project and need to sync


### PR DESCRIPTION
## Summary
- add an env-prime `pre_run` step (`uv sync && source .venv/bin/activate && uip codedagent setup --force`) to the 6 pre-seeded coded tasks that execute the project CLI: `eval_llm_judges`, `eval_mocking_mockito`, `eval_trajectory_empty_history`, `local_workspace_iterate`, `existing_project_resume`, `push_pull_roundtrip`
- document in `setup.md` what `uip codedagent setup` does and that the venv must be synced + activated before it

## Why

pre-seeded fixture tasks (unlike `uip codedagent new`) ship a project with no installed deps and an unconfigured CLI, so the agent burned its whole turn budget bootstrapping the env (`Python not configured`) instead of doing the task, timing out at MAX. priming the env in `pre_run` mirrors what `new` does and lets the agent start ready. matches the existing `deploy_folder_and_rebump` pattern.