### PR TITLE
fix(uipath-agents): unflake coded guardrail middleware tests (IP + user-prompt-attacks)

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
@@ -242,7 +242,7 @@ From the SDK docs and the catalog, look up the validator class referenced in the
 2. Confirm the in-code scope is permitted:
    - Middleware — every `GuardrailScope` in the `scopes=[...]` argument is in `allowed_scopes`.
    - Decorator — the function the `@guardrail` decorates matches the implied scope: `@tool` for Tool scope, LLM factory for LLM scope, agent factory for Agent scope.
-3. Confirm the stage is permitted: `GuardrailExecutionStage.PRE` only where catalog allows pre-execution; `POST` only where catalog allows post-execution.
+3. Confirm the stage is permitted. **Middleware takes no `stage=` argument** — the validator fixes its stage (e.g. `intellectual_property` POST, `user_prompt_attacks` PRE), so do not flag a missing stage. The stage check applies only to the **decorator** `stage=`: `GuardrailExecutionStage.PRE` only where catalog allows pre-execution; `POST` only where catalog allows post-execution.
 4. For Tool-scoped middleware: `tools=[...]` must contain the actual `@tool` Python objects discovered in Step 1 — not strings, not undefined names.
 5. For decorator-style LLM/Agent scope: the decorated function must actually return a `UiPathChat(...)` / `create_agent(...)` — decorating an unrelated function silently no-ops.
 

--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -174,6 +174,8 @@ Middleware classes take **no `stage` argument**. Each validator's stage is fixed
 
 ### Intellectual property (output-only) middleware
 
+> **`scopes=` is REQUIRED** on `UiPathIntellectualPropertyMiddleware` (and on PII / harmful-content middleware). It has no default — omitting it raises `TypeError: missing 1 required positional argument: 'scopes'`. Always pass `scopes=[GuardrailScope.LLM]` or `[GuardrailScope.AGENT]` (Tool not supported).
+
 ```python
 from uipath_langchain.guardrails import (
     BlockAction,
@@ -184,7 +186,7 @@ from uipath.core.guardrails import GuardrailScope
 
 *UiPathIntellectualPropertyMiddleware(
     name="Intellectual property",
-    scopes=[GuardrailScope.LLM],   # LLM or AGENT; Tool not supported
+    scopes=[GuardrailScope.LLM],   # REQUIRED — LLM or AGENT; Tool not supported
     action=BlockAction(),
     entities=[
         IntellectualPropertyEntityType.TEXT,

--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -154,6 +154,47 @@ When the fetched docs show a middleware supports TOOL scope, it requires passing
 ),
 ```
 
+### LLM- / Agent-scoped middleware
+
+Pass `scopes=[GuardrailScope.LLM]` or `[GuardrailScope.AGENT]`. No `tools=`.
+
+```python
+*SomeMiddlewareClass(
+    name="...",
+    scopes=[GuardrailScope.LLM],   # or GuardrailScope.AGENT
+    action=...,
+),
+```
+
+`scopes` is required on most middleware. Exceptions: LLM-only validators (`UiPathUserPromptAttacksMiddleware`, `UiPathPromptInjectionMiddleware`) make `scopes` optional — it defaults to LLM. Passing `scopes=[GuardrailScope.LLM]` and omitting it are equivalent; AGENT/TOOL are rejected.
+
+### Stage is fixed by the validator — no `stage=` on middleware
+
+Middleware classes take **no `stage` argument**. Each validator's stage is fixed: input validators (`user_prompt_attacks`, `prompt_injection`, input PII) run PRE; `intellectual_property` runs POST (output-only). Adding `stage=GuardrailExecutionStage....` to a middleware call raises `TypeError`. Only the **decorator** (`@guardrail`) accepts `stage=`.
+
+### Intellectual property (output-only) middleware
+
+```python
+from uipath_langchain.guardrails import (
+    BlockAction,
+    UiPathIntellectualPropertyMiddleware,
+    IntellectualPropertyEntityType,
+)
+from uipath.core.guardrails import GuardrailScope
+
+*UiPathIntellectualPropertyMiddleware(
+    name="Intellectual property",
+    scopes=[GuardrailScope.LLM],   # LLM or AGENT; Tool not supported
+    action=BlockAction(),
+    entities=[
+        IntellectualPropertyEntityType.TEXT,
+        IntellectualPropertyEntityType.CODE,
+    ],
+),
+```
+
+Runs at POST (checks the LLM's output) — fixed by the validator, not a parameter.
+
 ---
 
 ## Decorator Style — Code Patterns
@@ -229,11 +270,10 @@ like `BlockAction`). Get the exact parameters / supported scopes / stages from t
 **The same `EscalateAction` works in both styles** — pass it as the `action`:
 
 ```python
-# Middleware
+# Middleware (no stage= — fixed by the validator)
 *UiPathPIIDetectionMiddleware(
     name="PII escalation",
     scopes=[GuardrailScope.AGENT],
-    stage=GuardrailExecutionStage.PRE,
     action=EscalateAction(
         app_name="Guardrail.Escalation.Action.App",
         app_folder_path="Shared",

--- a/tests/tasks/uipath-agents/_shared/guardrail_middleware.py
+++ b/tests/tasks/uipath-agents/_shared/guardrail_middleware.py
@@ -26,6 +26,19 @@ def call_name(call: ast.Call) -> str | None:
     return None
 
 
+def call_kwarg(call: ast.Call, name: str) -> ast.expr | None:
+    """Return the value node for keyword ``name`` in a Call, or None if absent.
+
+    Used to inspect optional middleware arguments (e.g. ``scopes=``) so a check can
+    accept a guardrail that relies on the SDK default instead of demanding the
+    argument be spelled out explicitly.
+    """
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
 def _var_to_call(tree: ast.AST) -> dict:
     """Map each variable name to the Call it was last assigned (resolves ``*name`` spreads)."""
     mapping: dict = {}

--- a/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/check_intellectual_property_coded.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/intellectual_property/check_intellectual_property_coded.py
@@ -7,10 +7,14 @@ Validates (middleware style, LangChain agent):
   framework module; the platform path silently no-ops)
 - UiPathIntellectualPropertyMiddleware is spread (*) into create_agent(middleware=[...])
 - IntellectualPropertyEntityType entities TEXT and CODE are referenced
-- GuardrailExecutionStage.POST is used (IP is an output-only / POST-stage concern)
 - An LLM or Agent scope is configured, and Tool scope is NOT used
   (intellectual_property does not support Tool scope)
 - BlockAction is used (block, not log)
+
+NOT validated: execution stage. The *Middleware classes take no ``stage``
+argument (only the @guardrail decorator does); IP runs at POST internally,
+fixed by the validator. Requiring a literal ``GuardrailExecutionStage.POST``
+token would force dead code, so stage is left to the SDK.
 """
 
 import ast
@@ -76,13 +80,6 @@ def main() -> None:
     check("TEXT" in src, "IntellectualPropertyEntityType.TEXT not referenced")
     check("CODE" in src, "IntellectualPropertyEntityType.CODE not referenced")
     print("OK: IntellectualPropertyEntityType TEXT and CODE referenced")
-
-    # POST stage — IP is output-only.
-    check(
-        "GuardrailExecutionStage.POST" in src,
-        "GuardrailExecutionStage.POST not found — intellectual property runs at POST stage only",
-    )
-    print("OK: GuardrailExecutionStage.POST used")
 
     # Scope — LLM or Agent, never Tool.
     check(

--- a/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/check_user_prompt_attacks_middleware.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/user_prompt_attacks_middleware/check_user_prompt_attacks_middleware.py
@@ -5,11 +5,17 @@ Validates (middleware style, LangChain agent):
 - guardrail symbols imported from uipath_langchain.guardrails (NOT
   uipath.platform.guardrails — the platform path silently no-ops for LangChain)
 - UiPathUserPromptAttacksMiddleware is spread (*) into create_agent(middleware=[...])
-- GuardrailScope.LLM is configured (user prompt attacks is LLM-only)
-- GuardrailExecutionStage.PRE is used (PRE-only — input concern)
+- Scope is LLM (user prompt attacks is LLM-only): either GuardrailScope.LLM is
+  passed explicitly, or scopes= is omitted (the SDK defaults this middleware to
+  LLM). An explicit AGENT/TOOL scope fails.
 - BlockAction is used (block adversarial inputs)
 - Decorator style is NOT used (no @guardrail decorator) — this test specifically
   covers the middleware path, distinct from the decorator-style sibling test
+
+NOT validated: execution stage. The *Middleware classes take no ``stage``
+argument (only the @guardrail decorator does); user prompt attacks runs at PRE
+internally, fixed by the validator. Requiring a literal
+``GuardrailExecutionStage.PRE`` token would force dead code.
 """
 
 import ast
@@ -22,7 +28,11 @@ sys.path.insert(
     0,
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
 )
-from _shared.guardrail_middleware import call_name, spread_middleware_calls  # noqa: E402
+from _shared.guardrail_middleware import (  # noqa: E402
+    call_kwarg,
+    call_name,
+    spread_middleware_calls,
+)
 
 GRAPH = Path("graph.py")
 MIDDLEWARE = "UiPathUserPromptAttacksMiddleware"
@@ -57,8 +67,9 @@ def main() -> None:
     check(MIDDLEWARE in src, f"{MIDDLEWARE} not found in graph.py")
     print(f"OK: {MIDDLEWARE} referenced")
 
+    middleware_calls = [c for c in spread_middleware_calls(tree) if call_name(c) == MIDDLEWARE]
     check(
-        any(call_name(c) == MIDDLEWARE for c in spread_middleware_calls(tree)),
+        bool(middleware_calls),
         f"{MIDDLEWARE} not spread with * into the middleware list "
         f"(accepts inline `[*{MIDDLEWARE}(...)]` or a variable "
         f"`m = {MIDDLEWARE}(...); middleware=[*m]`)",
@@ -68,19 +79,25 @@ def main() -> None:
     check("middleware=" in src, "create_agent() has no middleware= argument")
     print("OK: middleware= argument present")
 
-    # LLM-only scope.
-    check(
-        "GuardrailScope.LLM" in src,
-        "GuardrailScope.LLM not found — user prompt attacks is LLM-scoped only",
-    )
-    print("OK: GuardrailScope.LLM configured")
+    # LLM-only scope. scopes= is optional and defaults to LLM, so accept either an
+    # explicit GuardrailScope.LLM or an omitted scopes=; reject an explicit AGENT/TOOL.
+    def scope_ok(call: ast.Call) -> bool:
+        scopes = call_kwarg(call, "scopes")
+        if scopes is None:
+            return True  # defaults to LLM (user prompt attacks is LLM-only)
+        rendered = ast.unparse(scopes)
+        return (
+            "GuardrailScope.LLM" in rendered
+            and "GuardrailScope.AGENT" not in rendered
+            and "GuardrailScope.TOOL" not in rendered
+        )
 
-    # PRE-only stage.
     check(
-        "GuardrailExecutionStage.PRE" in src,
-        "GuardrailExecutionStage.PRE not found — user prompt attacks runs at PRE stage only",
+        all(scope_ok(c) for c in middleware_calls),
+        "user prompt attacks is LLM-scoped only — pass scopes=[GuardrailScope.LLM] "
+        "or omit scopes= (it defaults to LLM); do not use AGENT or TOOL scope",
     )
-    print("OK: GuardrailExecutionStage.PRE used")
+    print("OK: LLM scope (explicit or default)")
 
     check(
         "BlockAction" in src,


### PR DESCRIPTION
## What changed?

Two coded-agent guardrail middleware tests added in #1684 —
`skill-agent-guardrail-coded-intellectual-property` and
`skill-agent-guardrail-coded-user-prompt-attacks-middleware` — failed on their
first independent CI run despite a correctly-authored `graph.py`. Root cause:
the check scripts did a literal substring match for scope/stage tokens the SDK
does not accept.

Verified against `uipath-langchain` source (introspected the installed package):

- The `*Middleware` classes take **no `stage=` argument**. Stage is fixed by the
  validator via the LangChain hook it registers — `intellectual_property` →
  `after_model`/`after_agent` (POST); `user_prompt_attacks` → `before_model`
  (PRE). Passing `stage=` raises `TypeError`. Only the `@guardrail` **decorator**
  has a configurable `stage=` (default `PRE_AND_POST`).
- `UiPathUserPromptAttacksMiddleware.scopes` is **optional, defaults to
  `[GuardrailScope.LLM]`**; `UiPathIntellectualPropertyMiddleware.scopes` is
  required. So idiomatic code omits scope for UPA, which the old check rejected.

**Checks — relax to match the real API:**
- IP: removed the impossible `GuardrailExecutionStage.POST` requirement; kept
  scope (LLM/Agent required, Tool rejected), entities, and `BlockAction`.
- UPA: removed the impossible `GuardrailExecutionStage.PRE` requirement; accept
  explicit `GuardrailScope.LLM` **or** an omitted `scopes=` (SDK default) via
  AST; still reject an explicit AGENT/TOOL scope.
- Added a `call_kwarg()` AST helper to `_shared/guardrail_middleware.py`.

**Skill — close the gap so agents reliably produce correct code:**
- `guardrails.md`: added LLM/Agent-scope and `intellectual_property` middleware
  examples; documented that middleware takes no `stage=` (validator-fixed);
  removed an erroneous `stage=` on the PII-middleware `EscalateAction` example
  that would `TypeError`.
- `guardrails-recommend.md`: clarified the validate-flow stage check applies to
  the decorator only, not middleware.

## How has this been tested?

- Reproduced both failures locally against the exact `graph.py` artifacts the
  failing eval agents produced (red), then confirmed green after the fix.
- Negative/regression matrix: wrong scopes (UPA AGENT, IP TOOL, IP no-scope)
  still fail; default and explicit LLM scope pass.
- End-to-end: ran 10 fresh isolated agents (5 per task, no prior context, Sonnet
  to match the CI model class) given only the real task prompt. **10/10 pass**
  under the fixed checks; the same outputs scored **0/10** under the old checks,
  isolating the fix as the cause. The IP task no longer thrashes (was 51 turns
  reverse-engineering the API; now 8–17 tool calls).

## Are there any breaking changes?

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUsmxAYv1CLq9E8CcaHoet
