### PR TITLE
chore(codeowners): add troubleshoot approvers for the activation dataset

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -124,6 +124,7 @@
 # Troubleshooting
 /skills/uipath-troubleshoot/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
 /tests/tasks/uipath-troubleshoot/ @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
+/tests/tasks/activation/uipath-troubleshoot.jsonl @MarinRzv @dmorosanu @vladimir-cozma @costin-uipath @Stefan-Virgil
 /skills/uipath-troubleshoot/references/products/agents/ @UiPath/llmops-team @andreibalas-uipath
 
 # Governance skill


### PR DESCRIPTION
Changes to tests/tasks/activation/uipath-troubleshoot.jsonl were only covered by the global default owners — the troubleshoot team was not required to review its own skill's activation prompts. Add the troubleshoot approvers as code owners for that file.