### PR TITLE
docs(uipath-agents): correct coded IS push + connection model [PRODEV-760]

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/integration-service.md
+++ b/skills/uipath-agents/references/coded/capabilities/integration-service.md
@@ -34,7 +34,7 @@ Then, as needed:
 Coded-specific layers:
 
 1. **Reuse before discover** — grep cwd for existing `ActivityMetadata` constants before re-running describe.
-2. **Present concrete options, then echo every pick.** At each stop point call `AskUserQuestion` with the actual candidates as selectable options (one per candidate: short label + one-line description, per the option-label format in the `uipath-platform` skill's `connectors.md`). Recommend the safest default; let the user choose. Never ask open-ended — derive options from the discovery output. After the pick, echo the chosen option back before the next call. Ambiguous answer or "other" → follow up to narrow; do not infer.
+2. **Present concrete options, then echo every pick.** At each stop point ask the user, presenting the actual candidates as concrete options (one per candidate: short label + one-line description, per the option-label format in the `uipath-platform` skill's `connectors.md`). Recommend the safest default; let the user choose. Never ask open-ended — derive options from the discovery output. After the pick, echo the chosen option back before the next step. Ambiguous answer or "other" → follow up to narrow; do not infer.
    - **Stop points:** connector (multi-hit on `connectors list --filter`), curated-vs-raw object, ambiguous operation verb (`Update` vs `Replace`), parent-field `-f` values, custom-field-by-name with >1 candidate.
    - Silent inference produces wrong-connector / wrong-form / wrong-customfield writes.
 
@@ -139,10 +139,10 @@ from uipath.platform.connections import ActivityMetadata, ActivityParameterLocat
 
 def post_to_slack(channel: str, message: str) -> dict:
     sdk = UiPath()
-    # Binding key, NOT a UUID. Locally this 400s unless resourceOverwrites
-    # is set — see § Local runtime binding. Do NOT add a try/except or a
-    # state health-check around it; gate any deployed-only probe on env.
-    connection = sdk.connections.retrieve("slack-triage")
+    # The connection id (the `Id` from `uip is connections list`) — the same
+    # value as bindings.json `ConnectionId.defaultValue`. Let it raise; don't
+    # wrap in try/except.
+    connection = sdk.connections.retrieve("<connection_id>")
     return sdk.connections.invoke_activity(
         activity_metadata=SLACK_SEND_MESSAGE,
         connection_id=connection.id,
@@ -151,7 +151,7 @@ def post_to_slack(channel: str, message: str) -> dict:
 ```
 
 - **`activity_input` is the single bucket** for query, path, header, multipart, and body values. SDK routes by `parameter_location_info`. No `query=`/`path=`/`header=` kwarg exists.
-- **`invoke_activity` calls `retrieve()` internally** (`_connections_service.py:675`), so `connection_id` can be a UUID or a binding-key string — the `@resource_override` decorator on `retrieve` resolves it. The pattern above (explicit retrieve, then pass `connection.id`) is preferred because it gives the agent a typed `Connection` for `metadata()` / `retrieve_token()`; one-shots can use `invoke_activity(connection_id="slack-triage", ...)` directly.
+- **`invoke_activity` calls `retrieve()` internally** (`_connections_service.py:675`). The pattern above (explicit retrieve, then pass `connection.id`) is preferred because it gives the agent a typed `Connection` for `metadata()` / `retrieve_token()`; one-shots can pass the connection id straight to `invoke_activity(connection_id="<connection_id>", ...)`.
 - **Return value** is `response.json()` — keys mirror `responseFields[].name`. Flat connectors return top-level; some wrap in `Data` / `result`. Auto-traced via `@traced`; see [tracing.md](tracing.md).
 - **Silent drops** — `None` values and any key not in `parameter_location_info` are skipped (`_connections_service.py:753-770`). Mistyped keys never surface as errors; echo-check writes per Error Handling § "Silent rename / typo".
 
@@ -198,7 +198,7 @@ Wrap `invoke_activity_async` in the framework's tool primitive — runtime body 
 
 ## Connection Resolution — `bindings.json`
 
-Invocation URL is `/elements_/v3/element/instances/<UUID>/…`, so the SDK ultimately needs a UUID. To let admins rebind per environment, write code against a binding key string; `@resource_override("connection", resource_identifier="key")` (`_connections_service.py:51`) on `retrieve` maps it to the deployed UUID. `uip codedagent init` writes `resources: []` — author the connection entry after picking the connection.
+Write the connection's id (the `Id` from `uip is connections list`, a GUID) as the `retrieve()` argument in code AND as `ConnectionId.defaultValue` in `bindings.json` — the two must match. That way it resolves locally (no override) and `bindings.json` lets users rebind the resource per environment when deployed. `uip codedagent init` writes `resources: []` — author the connection entry after picking the connection.
 
 Minimal connection entry (`uip codedagent init` writes `resources: []`; add this). The entry-type field is **`resource`** (NOT `type`) — the CLI bindings schema is `{ resource, key, value, metadata }`:
 
@@ -220,42 +220,28 @@ Full JSON schema lives in [`../lifecycle/bindings-reference.md`](../lifecycle/bi
 
 - Entry type field is `resource` (`"resource": "connection"`), never `type` — matches every other binding entry.
 - `key` is just `<CONNECTION_KEY>` (no `<NAME>.<FOLDER>` dot suffix used by other resources). Same string passed positionally to `retrieve()`.
-- `value.ConnectionId.defaultValue` is the binding key string, NOT a UUID. Capital-C `ConnectionId` (other resources use `name`); no `folderPath`.
+- `value.ConnectionId.defaultValue` is the connection id — the same value passed to `retrieve()` in code (and the binding `key`). Capital-C `ConnectionId` (other resources use `name`); no `folderPath`.
 - `metadata.UseConnectionService: "True"` is mandatory; `Connector: ""` (empty); `BindingsVersion: "2.2"` is the per-resource rev and is independent of the top-level envelope `version: "2.0"`.
 - `uip codedagent deploy` repackages as `content/bindings_v2.json` — never hand-author that path.
 
-### Required artifact — `__uipath/uipath.json` (local-run binding)
+### Connection value: code and bindings must match
 
-Every coded IS agent MUST write `__uipath/uipath.json`. It is the file `uipath run` reads for connection overwrites: `cli_run.py` → `read_resource_overwrites_from_file(ctx.runtime_dir)`, `runtime_dir` defaults to `__uipath` (`runtime/context.py`), config name `uipath.json` (`UIPATH_CONFIG_FILE`). Without it, local `retrieve("<KEY>")` 400s with `CNS1026 The value '<KEY>' is not valid` — `bindings.json` is deploy-time only (packed into `content/bindings_v2.json`) and ignored by local run. This is distinct from `./uipath.json` (pack/deploy config). Write both:
+Write the **same connection id** in code and in `bindings.json`:
 
-```jsonc
-{
-  "functions": { "main": "main.py:main" },
-  "runtime": {
-    "internalArguments": {
-      "resourceOverwrites": {
-        "connection.slack-triage": {
-          "connectionId": "<Id from `uip is connections list`>",
-          "folderKey":    "<FolderKey from `uip is connections list`>"
-        }
-      }
-    }
-  }
-}
-```
+- In code, pass it to `retrieve()` — `sdk.connections.retrieve("<connection_id>")`.
+- In `bindings.json`, use it as the connection's `ConnectionId.defaultValue` (and the binding `key`).
 
-`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`, **NOT** `uipath/_utils/_bindings.py`) requires exactly two fields — `connectionId` (alias accepts `ConnectionId`) and `folderKey` — and has `extra="ignore"`, so `elementInstanceId` and any other extras are silently dropped (see anti-pattern #1). Key format is `connection.<BINDING_KEY>` matching the `bindings.json` `key`. After override, `Connection.element_instance_id` (for `sdk.connections.metadata()` calls) comes from the live IS API response — never write it locally.
+Because they match, the agent resolves the connection both **locally** (run uses the code value directly, no override) and **when deployed** (`bindings.json` lets Studio Web / Orchestrator override the resource per environment). Get the connection id from the `Id` field of `uip is connections list --output json` (a GUID).
 
-**Required outputs — every coded IS agent ships all four:**
+`Connection.element_instance_id` (needed for `sdk.connections.metadata()` calls) comes from the live IS API response after `retrieve()` — never hardcode it.
+
+**Required outputs — every coded IS agent ships these three:**
 
 | File | Read by | Must contain |
 |---|---|---|
-| `main.py` | runtime | lazy `UiPath()` (not module-scope), inline `ActivityMetadata` literal, `retrieve(<KEY>)` + `invoke_activity` |
-| `bindings.json` | `uip codedagent deploy` | connection resource, `key`, `ConnectionId.defaultValue`=binding key, `UseConnectionService: "True"` |
+| `main.py` | runtime | lazy `UiPath()` (not module-scope), inline `ActivityMetadata` literal, `retrieve("<connection_id>")` + `invoke_activity` |
+| `bindings.json` | `uip codedagent deploy` | connection resource, `key` + `ConnectionId.defaultValue` = the same connection id, `UseConnectionService: "True"` |
 | `uipath.json` | `uip` pack/deploy | `functions`, `packOptions` |
-| `__uipath/uipath.json` | `uipath run` (local) | `runtime.internalArguments.resourceOverwrites["connection.<KEY>"]` = `connectionId` + `folderKey` |
-
-Omitting `__uipath/uipath.json` means the agent cannot run locally — incomplete, not optional. Personal-workspace connections also need `UIPATH_FOLDER_KEY=<KEY>` (`FolderKey` from `uip is connections list`) in the environment at local run.
 
 ## Error Handling
 
@@ -274,7 +260,7 @@ Network / 5xx are retried with exponential backoff by `BaseService.request`; onl
 
 These six are the ones the SDK / IS / vendor will NOT tell you about. Positive guidance for everything else lives in the relevant section above; do not pad this list.
 
-1. **Adding `elementInstanceId` to `resourceOverwrites`.** `ConnectionResourceOverwrite` (`_bindings.py:100`) defines only `connectionId` + `folderKey` with `extra="ignore"` — extras are silently dropped. The `element_instance_id` you need for `sdk.connections.metadata()` comes from the live `Connection.element_instance_id` after `retrieve()`, never from local config.
+1. **Hardcoding `element_instance_id`.** The `element_instance_id` needed for `sdk.connections.metadata()` comes from the live `Connection.element_instance_id` after `retrieve()` — never hardcode it.
 2. **Hand-authoring `object_path` / `method_name` / `body_fields`.** Curated activities rename fields silently between connector versions. Always source from `uip is resources describe` and re-run after upgrades. Sidecar-JSON literals also drift — keep `ActivityMetadata` literals inline in a `.py` file; `pack` bundles them and mypy / pyright catch shape errors at edit time.
 3. **Typos and unknown keys in `activity_input`.** Anything not in `parameter_location_info` is silently dropped (`_connections_service.py:753-770`); the request goes out missing the field, vendor returns 2xx, the data is just gone. Echo-check writes by reading back the created object (see Error Handling § "Silent rename / typo").
 4. **`invoke_activity` for trigger payloads.** IS-triggered jobs receive `EventArguments` as input — unwrap with `sdk.connections.retrieve_event_payload(event_args)` (`_connections_service.py:421`). Calling `invoke_activity` to "receive" anything is a category error.

--- a/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
+++ b/skills/uipath-agents/references/coded/lifecycle/bindings-reference.md
@@ -66,7 +66,7 @@ Use Grep to find calls matching these patterns across all project Python files. 
 
 First check the project's pinned `uipath` version (see **SubType Metadata → Version-detection rule**). If `uipath < 2.10.58`, **skip SubType entirely** — emit no `SubType` for any binding, including `retrieve_credential*`.
 
-If `uipath >= 2.10.58`, then for `retrieve_credential` / `retrieve_credential_async` calls always emit `"SubType": "credentialAsset"` — the method name is definitive. For all other calls, follow the full lookup procedure in the **SubType Metadata** section below: fetch metadata → filter by kind → disambiguate from code → fall back to `AskUserQuestion` → omit `SubType` if the user skips. Omitting `SubType` is always safe — `uipath push` still creates a virtual placeholder for supported kinds, just with the base `kind` only.
+If `uipath >= 2.10.58`, then for `retrieve_credential` / `retrieve_credential_async` calls always emit `"SubType": "credentialAsset"` — the method name is definitive. For all other calls, follow the full lookup procedure in the **SubType Metadata** section below: fetch metadata → filter by kind → disambiguate from code → ask the user → omit `SubType` if the user skips or can't be asked. Omitting `SubType` is always safe — `uip codedagent push` still creates a virtual placeholder for supported kinds, just with the base `kind` only.
 
 ### Step 3: Compare with Existing Bindings
 
@@ -90,7 +90,7 @@ Each resource can optionally be linked to an entrypoint from `entry-points.json`
 
 **Workflow:**
 1. **Single entrypoint** — If `entry-points.json` contains exactly one entrypoint, automatically bind all resources to it. Add `EntryPointUniqueId` (preferred) or `EntryPointPath` (fallback). No need to ask the user.
-2. **Multiple entrypoints** — Call `AskUserQuestion` once with all detected resources and the entrypoint choices. Exact phrasing:
+2. **Multiple entrypoints** — Ask the user once, presenting all detected resources and the entrypoint choices. Suggested phrasing:
 
    > Which entrypoint should each of these resources be bound to? Choose one per resource, or `None` to leave it unbound.
    > Resources: `<list: name + type>`
@@ -115,7 +115,7 @@ For the exact JSON structure of each resource type, see § bindings.json Referen
 - Each resource entry has `resource`, `key`, `value`, and `metadata` fields
 - The `key` is `<name>.<folder_path>` for most types, just `<connection_key>` for connections. When `folder_path` is empty, omit the dot separator — the key is just `<name>`
 - `ActivityName` in metadata always uses the `_async` variant name
-- Connection entries use a `ConnectionId` field in their binding `value` (other resource types use `name`) and have no `folderPath`. The `ConnectionId`'s `defaultValue` is the connection key — the same string passed as the positional argument to `sdk.connections.retrieve()` / `retrieve_async()`.
+- Connection entries use a `ConnectionId` field in their binding `value` (other resource types use `name`) and have no `folderPath`. The `ConnectionId`'s `defaultValue` is the connection's **id**.
 - The `app` resource type uses the app name as `DisplayLabel`; all others use `"FullName"`
 - `SubType` is an optional metadata field — see the **SubType Metadata** section for the full lookup procedure and the `retrieve_credential*` shortcut.
 - Entrypoint fields (`EntryPointUniqueId`, `EntryPointPath`) are optional in any resource's `value` block, but when present must include a `displayName` set to the entrypoint's `filePath` from `entry-points.json`
@@ -150,8 +150,8 @@ After writing the updated `bindings.json`:
 | Duplicate key in resources array | Same resource scanned from multiple code paths | Deduplicate — keep one entry per unique key |
 | Missing project root | No `pyproject.toml` or `uipath.json` found | Verify the working directory is a UiPath agent project |
 | Stale entries after refactor | Old resource calls removed but bindings.json not updated | Run the full sync workflow to detect and remove orphaned entries |
-| Push creates wrong asset type as virtual resource | Missing `SubType` in metadata for a `retrieve_credential*` call | Add `"SubType": "credentialAsset"` to the asset's metadata and re-run `uipath push` |
-| Push warns "was not found" for connection/mcpServer/index | These kinds do not support virtual-resource fallback | Create the resource in Orchestrator / Integration Service before running `uipath push` |
+| Push creates wrong asset type as virtual resource | Missing `SubType` in metadata for a `retrieve_credential*` call | Add `"SubType": "credentialAsset"` to the asset's metadata and re-run `uip codedagent push` |
+| Push warns "was not found" for connection/mcpServer/index | These kinds do not support virtual-resource fallback | Create the resource in Orchestrator / Integration Service before running `uip codedagent push` |
 
 ## Additional Instructions
 
@@ -254,7 +254,7 @@ When the SDK call is `retrieve_credential` or `retrieve_credential_async`, add `
 }
 ```
 
-This SubType is required for `uipath push` to create a credential-asset placeholder (rather than a plain string asset) when the asset doesn't yet exist in Orchestrator.
+This SubType is required for `uip codedagent push` to create a credential-asset placeholder (rather than a plain string asset) when the asset doesn't yet exist in Orchestrator.
 
 ---
 
@@ -590,7 +590,7 @@ connection = sdk.connections.retrieve("connection_key")
 **Key construction:** Just `<connection_key>` (no folder path, no dot).
 
 **Parameter extraction:**
-- `connection_key` — first positional argument to `retrieve_async()` / `retrieve()`
+- The connection id is the first positional argument to `retrieve_async()` / `retrieve()`, and the same value is used as the binding `key` and `ConnectionId.defaultValue` — all three match.
 
 **Differences from other resource types:**
 - No `folderPath` in `value`
@@ -646,15 +646,15 @@ server = sdk.mcp.retrieve(slug="mcp_server_slug", folder_path="folder_path")
 
 ## SubType Metadata
 
-The `SubType` field in a resource's `metadata` block specifies a sub-classification of the resource `kind`. It is **optional** but should be emitted when determinable, so `uipath push` can create the correct virtual-resource placeholder when the resource isn't found in the catalog (see `Virtual Resource Fallback on uipath push` below).
+The `SubType` field in a resource's `metadata` block specifies a sub-classification of the resource `kind`. It is **optional** but should be emitted when determinable, so `uip codedagent push` can create the correct virtual-resource placeholder when the resource isn't found in the catalog (see `Virtual Resource Fallback on uip codedagent push` below).
 
-> **Minimum `uipath` version: 2.10.58 ([PyPI](https://pypi.org/project/uipath/)).** Below that version, **omit `SubType` entirely** — older `uipath push` releases ignore the field, so emitting it gives no benefit and just adds noise to `bindings.json`.
+> **Minimum `uipath` version: 2.10.58 ([PyPI](https://pypi.org/project/uipath/)).** Below that version, **omit `SubType` entirely** — older `uip codedagent push` releases ignore the field, so emitting it gives no benefit and just adds noise to `bindings.json`.
 >
 > **Version-detection rule (run before the lookup procedure):**
 >
 > 1. Read the project's `pyproject.toml` (or `requirements.txt` / `uv.lock`) and extract the resolved `uipath` version.
 > 2. If the version is **`>= 2.10.58`**, follow the full lookup procedure.
-> 3. If the version is **`< 2.10.58`** (or unspecified / unresolvable), **ask the user** before falling back. Do **not** run the upgrade command yourself. Call `AskUserQuestion` with the warning prefix and two options:
+> 3. If the version is **`< 2.10.58`** (or unspecified / unresolvable), **ask the user** before falling back. Do **not** run the upgrade command yourself. Ask with the warning prefix and two options:
 >
 >    - **Question:** `⚠️ uipath is pinned to <version>. SubType support requires uipath >= 2.10.58 — without it every binding will be written with no SubType. Do you want to upgrade?`
 >    - **Option A — Yes, upgrade `uipath`** — print the upgrade command for the user to run themselves and stop the workflow. Tell them to re-run the bindings task after the upgrade lands. Suggested commands (do **not** execute them):
@@ -663,7 +663,7 @@ The `SubType` field in a resource's `metadata` block specifies a sub-classificat
 >      # Poetry: poetry add 'uipath@^2.10.58'
 >      # pip:    pip install --upgrade 'uipath>=2.10.58'
 >      ```
->    - **Option B — No, continue with current version** — skip the entire SubType lookup, do **not** call `AskUserQuestion` for sub-types, and write every binding with no `SubType` in `metadata` (including `retrieve_credential*`). Tell the user once: *"`uipath` is pinned to `<version>`; SubType emission is disabled."*
+>    - **Option B — No, continue with current version** — skip the entire SubType lookup, do **not** ask about sub-types, and write every binding with no `SubType` in `metadata` (including `retrieve_credential*`). Tell the user once: *"`uipath` is pinned to `<version>`; SubType emission is disabled."*
 
 ### Authoritative source for valid SubType values
 
@@ -722,10 +722,7 @@ For each binding, follow these steps:
 4. **Choose a SubType:**
    - **No candidates** (all entries lack `type`) → omit `SubType`.
    - **One candidate** → emit it as `SubType`.
-   - **Multiple candidates** → try code-based disambiguation first (see rules below). If no rule matches, ask the user. Use the path that fits the candidate count:
-     - **≤ 3 candidates** → call `AskUserQuestion` with each candidate as an `option` (`label` = the `type` string). `AskUserQuestion`'s `options` array is capped at 4 entries, and one slot is reserved for the trailing `skip`. The harness presents a picker UI and returns the chosen `label` directly — no numbered list needed in the prompt body.
-     - **≥ 4 candidates** → emit a plain-text **numbered list** (one per line, `N. <type>`) ending with a final numbered `skip` line. The user replies with just the number; map it back to the `type` string. Do not use `AskUserQuestion` here — the list won't fit.
-     Either way, include the resource name and folder in the prompt for context. If the user picks `skip` (or its number), omit `SubType`.
+   - **Multiple candidates** → try code-based disambiguation first (see rules below). If no rule matches, ask the user — present each candidate `type` as a concrete option plus a `skip` option. Include the resource name and folder for context. If the user picks `skip` or cannot be asked (non-interactive), omit `SubType`.
 
    **Numbered-list rules** (plain-text path only):
    - One candidate per line, prefixed with `N. ` (1-indexed).
@@ -749,7 +746,7 @@ curl -s -H "Authorization: Bearer <TOKEN>" \
 
 ### Known code-based disambiguation rules
 
-Apply these rules in order. Only fall through to the `AskUserQuestion` prompt if none of them produces a confident match.
+Apply these rules in order. Only fall through to asking the user if none of them produces a confident match.
 
 | Kind | Rule | SubType | Confidence |
 |------|------|---------|------------|
@@ -768,7 +765,7 @@ Apply these rules in order. Only fall through to the `AskUserQuestion` prompt if
    - Used in arithmetic, compared numerically → `integerAsset`.
    - Used in `if x:` as a truth check where Orchestrator stores it as boolean → `booleanAsset`.
 4. Check the variable name and surrounding context against sensitive patterns (`password`, `pwd`, `api_key`, `secret`, `token`, `credential`). If a match is found, prompt the user to choose between `credentialAsset` and `secretAsset` (they differ in how Orchestrator exposes the value).
-5. If the heuristic is inconclusive or produces only medium confidence, fall through to the `AskUserQuestion` prompt with the heuristic's best guess pre-highlighted.
+5. If the heuristic is inconclusive or produces only medium confidence, fall through to asking the user with the heuristic's best guess pre-highlighted.
 
 ### Asking the user (example prompts)
 
@@ -842,9 +839,23 @@ Always include a final `skip` option — it means "I don't know, emit no SubType
 
 ---
 
-## Virtual Resource Fallback on uipath push
+## What `uip codedagent push` does with bindings
 
-Starting with `uipath` 2.10.52, `uipath push` creates a virtual resource placeholder when a binding's resource isn't found in the Resource Catalog — the project can be deployed before its dependencies exist. The fallback only works for a subset of kinds.
+`uip codedagent push` uploads the source files, then (unless `--ignore-resources`) resolves every `bindings.json` entry against the Resource Catalog. It searches by the binding's identity: most kinds by **`name` + `folderPath`** (both must match an existing resource in that folder — a wrong/missing `folderPath` causes a miss), `connection` by its **`ConnectionId`** (the connection id) — a value that doesn't match a real connection is a common miss.
+
+Each binding: **found** → imported as a reference; **not found, virtual-capable kind** → placeholder created, project still deploys; **not found, non-virtual kind** (`connection`, `mcpServer`, `index`) → warned and **skipped entirely**.
+
+> ⚠️ **A "was not found" warning is NEVER "expected".** For a non-virtual kind the binding is dropped from the deployed project. The agent may still run (it can resolve to in-code defaults), but the resource is **not overridable from Studio Web** — so the solution cannot be cleanly promoted/deployed to another tenant. Treat every "not found" as a defect to resolve before reporting push successful.
+
+### When push reports a resource was not found
+
+1. **Diagnose the miss** — the binding's identity matched no catalog resource. Check: wrong `folderPath` (resource exists in another folder), wrong `name`/`ConnectionId` (typo or stale value), or resource genuinely doesn't exist.
+2. **Resolve, then re-push** — fix the binding's `name`/`folderPath`/`ConnectionId`, or have the user create the missing resource, then re-run `uip codedagent push` and confirm the warning is gone.
+3. **If unresolvable, state it plainly** — e.g. *"Code uploaded, but connection `<key>` was not imported (no IS connection with that key/folder; connections cannot be auto-created), so it cannot be overridden in Studio Web."* Do not report push as done.
+
+## Virtual Resource Fallback on uip codedagent push
+
+Starting with `uipath` 2.10.52, `uip codedagent push` creates a virtual resource placeholder when a binding's resource isn't found in the Resource Catalog — the project can be deployed before its dependencies exist. The fallback only works for a subset of kinds.
 
 The push command fetches the supported-kinds list from `/studio_/backend/api/resourcebuilder/metadata` at push time. The static fallback (used when that endpoint is unreachable) is `app, asset, bucket, process, queue, taskCatalog, trigger`.
 
@@ -857,7 +868,7 @@ The push command fetches the supported-kinds list from `/studio_/backend/api/res
 ### Implications for binding generation
 
 1. **Emit `SubType` only when `uipath >= 2.10.58`.** Below that version, omit `SubType` from every binding — see **SubType Metadata → Version-detection rule**. When the version gate is met, always emit `"SubType": "credentialAsset"` for `retrieve_credential*` asset calls; without it the virtual-resource fallback creates a plain string asset placeholder, causing runtime failures when the agent expects a credential.
-2. **Warn the user about non-fallback kinds.** For `connection`, `mcpServer`, and `index` bindings, the referenced resource must exist in Orchestrator before `uipath push`. If it doesn't, the binding is skipped with a warning and the agent will fail at runtime. Flag this to the user when generating such bindings.
+2. **Warn the user about non-fallback kinds.** For `connection`, `mcpServer`, and `index` bindings, the referenced resource must exist in Orchestrator before `uip codedagent push`. If it doesn't, the binding is skipped with a warning and the agent will fail at runtime. Flag this to the user when generating such bindings.
 3. **Optional `SubType` for bucket.** The bucket's backing storage is not inferable from code. Consider asking the user which storage type their buckets use, so virtual-resource fallback creates the correct kind.
 
 ---

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -78,7 +78,7 @@ When the user asks to create and deploy an agent end-to-end, follow these steps 
 
 **IMPORTANT: Do NOT stop between steps to ask "would you like me to continue?" or list next steps. Execute the entire flow automatically.** Pause only when (a) you hit an **architectural fork** — a step with multiple valid implementations (framework choice, HITL pattern, evaluator type, deploy target, conversational vs not, etc.) — or (b) you need data only the user has (credentials, project ID). At a fork, apply **infer-or-ask**: if the prompt or context names the choice, infer it and continue; otherwise output ONLY the choice question as your entire response, then STOP and wait. For missing data, output ONLY the data request. After getting the answer, resume immediately. Forks for each step are documented in that step's referenced file — read the reference when you reach the step; do not guess.
 
-Steps 8 and 9 are mandatory stops **for greenfield**: always ask, even if the user only said "build". Use `AskUserQuestion` (or platform equivalent); fall back to plain text only when no UI tool exists. They are **automatically resolved** for `local-workspace` (auto-sync) and for `existing-coded` with `has_project_id == true` (push) — see steps 8 and 9 for the branch logic.
+Steps 8 and 9 are mandatory stops **for greenfield**: always ask the user, even if the user only said "build". They are **automatically resolved** for `local-workspace` (auto-sync) and for `existing-coded` with `has_project_id == true` (push) — see steps 8 and 9 for the branch logic.
 
 1. **Framework** — **Skip if `framework != none`** (already chosen — verify the right `<framework>.json` is present and continue). Else select per the [Framework Selection](#framework-selection) section below.
 2. **Setup** — Idempotent by `project_state` and `has_venv`:
@@ -165,7 +165,7 @@ Then STOP and wait. On reply, run the matching one-shot login from [../authentic
    **Finally**, run `uip codedagent eval <ENTRYPOINT> evaluations/eval-sets/smoke-test.json --no-report` (use the entrypoint name from `entry-points.json`).
 8. **Delivery target.** Single branch point. **Evaluate branches in order — Local Workspace projects also have `UIPATH_PROJECT_ID` set in `.env`, so the `local-workspace` check MUST come before the `has_project_id` check, or Local Workspace will incorrectly fall into the push branch:**
 
-   - **(1) `project_state == local-workspace`** → Studio Web auto-syncs saves to the remote SW project, so options A and B (manual push / solution upload) are skipped — they would be redundant or break sync identity. The user may still want a local dev console. Stop and ask via `AskUserQuestion` (header `"Delivery"`, `multiSelect: false`):
+   - **(1) `project_state == local-workspace`** → Studio Web auto-syncs saves to the remote SW project, so options A and B (manual push / solution upload) are skipped — they would be redundant or break sync identity. The user may still want a local dev console. Stop and ask the user (single choice, "Delivery"):
 
      **Question:** *Studio Web is auto-syncing this workspace. Do you want a local dev console too?*
 
@@ -180,7 +180,7 @@ Then STOP and wait. On reply, run the matching one-shot login from [../authentic
 
      Do **not** run `uip codedagent push` for this branch (that's recovery only — see [lifecycle/local-workspace.md](lifecycle/local-workspace.md) § Studio-Web-Auto-Sync). Do **not** present options A or B.
    - **(2) `has_project_id == true` (cloud workspace, project ID already set)** → Run `uip codedagent push` to upload local edits, then continue to step 9. No fork question — the delivery choice was made in a prior session.
-   - **(3) Else (greenfield / cloud workspace not yet wired)** → Stop and ask via `AskUserQuestion` (header `"Delivery"`, `multiSelect: false`).
+   - **(3) Else (greenfield / cloud workspace not yet wired)** → Stop and ask the user (single choice, "Delivery").
 
      **Question:** *How do you want to use the agent next?*
 
@@ -206,7 +206,7 @@ Then STOP and wait. On reply, run the matching one-shot login from [../authentic
      - **C** → run `uip codedagent dev` in the background; surface the URL (default `http://localhost:8080`). Prereq: `uipath-dev` (added during scaffold). **STOP — do NOT proceed to step 9.** Local dev is a terminal choice.
      - **Skip** → continue to step 9.
 
-9. **Deploy.** Reachable from any `project_state` after option **Skip** at step 8 (greenfield or local-workspace), after the auto-push in branch (2), or after options **A** / **B** in greenfield. After option **C** at step 8, the run ends — do not ask. Stop and ask via `AskUserQuestion` (header `"Deploy target"`, `multiSelect: false`).
+9. **Deploy.** Reachable from any `project_state` after option **Skip** at step 8 (greenfield or local-workspace), after the auto-push in branch (2), or after options **A** / **B** in greenfield. After option **C** at step 8, the run ends — do not ask. Stop and ask the user (single choice, "Deploy target").
 
    **Question:** *Do you want to deploy the agent? If yes, which target?*
 

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/check_is_jira_create_issue.py
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/check_is_jira_create_issue.py
@@ -5,9 +5,8 @@
   python3 check_coded_is_jira_create_issue.py tenant
 
 `shape` runs offline: validates that the project on disk has the
-ActivityMetadata literal, lazy SDK construction, bindings.json
-connection entry, and a two-field `connection.jira-coded-eval`
-resourceOverwrites block (connectionId + folderKey).
+ActivityMetadata literal, lazy SDK construction, and a bindings.json
+connection entry.
 
 `tenant` runs against the live Jira tenant via `uip is resources run` —
 calls `get_issue` against the new issue key (read from
@@ -95,33 +94,6 @@ def check_shape() -> None:
             "`invoke_activity(...)` — capability runtime pattern missing."
         )
     print("OK: main.py uses lazy UiPath() + retrieve + invoke_activity")
-
-    # 4. resourceOverwrites with the two required fields (NO elementInstanceId)
-    uipath_json = _load_json(ROOT / "__uipath" / "uipath.json")
-    overwrites = (
-        uipath_json.get("runtime", {})
-        .get("internalArguments", {})
-        .get("resourceOverwrites", {})
-    )
-    key = "connection.jira-coded-eval"
-    if key not in overwrites:
-        sys.exit(f"FAIL: __uipath/uipath.json missing resourceOverwrites key `{key}`")
-    entry_keys = set(overwrites[key].keys())
-    has_conn = "connectionId" in entry_keys or "ConnectionId" in entry_keys
-    has_folder = "folderKey" in entry_keys
-    if not (has_conn and has_folder):
-        sys.exit(
-            f"FAIL: resourceOverwrites for `{key}` must carry `connectionId` "
-            "(alias `ConnectionId`) and `folderKey` per "
-            "`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)."
-        )
-    if "elementInstanceId" in entry_keys:
-        sys.exit(
-            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`, "
-            "which `ConnectionResourceOverwrite` ignores (`extra=\"ignore\"`). "
-            "Remove it — see capability anti-pattern #1."
-        )
-    print("OK: resourceOverwrites has connectionId + folderKey (and no spurious elementInstanceId)")
     print("PASS: shape checks complete")
 
 

--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
@@ -6,8 +6,8 @@ description: >
   `-f` fields → ActivityMetadata literal → invoke_activity) against a
   live Jira connection, then run the coded agent locally and create a
   real Jira issue. The check script verifies tenant state (issue exists
-  with expected summary) and project shape (bindings + literal +
-  two-field resourceOverwrites: connectionId + folderKey, no elementInstanceId).
+  with expected summary) and project shape (bindings connection entry +
+  ActivityMetadata literal).
 
   Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
   `Shared/uipath-agents` named `jira-coded-eval`. The Jira project
@@ -105,7 +105,7 @@ success_criteria:
     pass_threshold: 0.3
 
   - type: run_command
-    description: "Project shape: ActivityMetadata literal, lazy SDK init, bindings connection entry, 2-field resourceOverwrites (connectionId + folderKey, no elementInstanceId)"
+    description: "Project shape: ActivityMetadata literal, lazy SDK init, bindings connection entry"
     command: "python3 $TASK_DIR/check_is_jira_create_issue.py shape"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/check_is_outlook_send_mail.py
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/check_is_outlook_send_mail.py
@@ -91,32 +91,6 @@ def check_shape() -> None:
     if violations:
         sys.exit("FAIL: module-level UiPath* construction: " + " | ".join(violations))
     print("OK: main.py uses lazy UiPath() construction")
-
-    uipath_json = _load_json(ROOT / "__uipath" / "uipath.json")
-    overwrites = (
-        uipath_json.get("runtime", {})
-        .get("internalArguments", {})
-        .get("resourceOverwrites", {})
-    )
-    key = "connection.outlook-coded-eval"
-    if key not in overwrites:
-        sys.exit(f"FAIL: resourceOverwrites missing key `{key}`")
-    entry_keys = set(overwrites[key].keys())
-    has_conn = "connectionId" in entry_keys or "ConnectionId" in entry_keys
-    has_folder = "folderKey" in entry_keys
-    if not (has_conn and has_folder):
-        sys.exit(
-            f"FAIL: resourceOverwrites for `{key}` must carry `connectionId` "
-            "(alias `ConnectionId`) and `folderKey` per "
-            "`ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)."
-        )
-    if "elementInstanceId" in entry_keys:
-        sys.exit(
-            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`, "
-            "which `ConnectionResourceOverwrite` ignores (`extra=\"ignore\"`). "
-            "Remove it — see capability anti-pattern #1."
-        )
-    print("OK: resourceOverwrites has connectionId + folderKey (and no spurious elementInstanceId)")
     print("PASS: shape checks complete")
 
 

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
@@ -6,7 +6,7 @@ description: >
   `multipart_params` for Outlook's `send-mail-v2`, build the correct
   `ActivityMetadata(content_type="multipart/form-data",
   json_body_section="body", multipart_params=[...])` literal, wire
-  bindings + 2-field resourceOverwrites, and send a real email from
+  bindings, and send a real email from
   the test connection. The tenant check polls the destination inbox
   via the same Outlook connection to confirm delivery.
 
@@ -84,7 +84,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Project shape: multipart ActivityMetadata literal, bindings, 2-field resourceOverwrites (connectionId + folderKey, no elementInstanceId)"
+    description: "Project shape: multipart ActivityMetadata literal, bindings connection entry"
     command: "python3 $TASK_DIR/check_is_outlook_send_mail.py shape"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/is_smoke/check_is_smoke.py
+++ b/tests/tasks/uipath-agents/coded/is_smoke/check_is_smoke.py
@@ -20,12 +20,6 @@ Verifies the invariants the capability doc teaches, AST-linked to the actual
   4. `main.py` does NOT instantiate `UiPath` at module level (anti-pattern #6),
      alias-aware, and constructs it somewhere.
   5. No lowcode-only `resources/<Tool>/resource.json` sidecar.
-  6. `__uipath/uipath.json` resourceOverwrites carries non-empty `connectionId`
-     and `folderKey` (alias `ConnectionId`) for `connection.<key>`;
-     `ConnectionResourceOverwrite` (`uipath/platform/common/_bindings.py:100`)
-     defines only those two with `extra="ignore"`, so an `elementInstanceId`
-     entry is rejected here as a skill-hygiene anti-pattern (#1) — the SDK would
-     silently drop it.
 
 Exits 0 on PASS, with `FAIL: ...` on the first violation.
 """
@@ -354,51 +348,6 @@ def check_invocation_and_metadata(
     )
 
 
-def check_resource_overwrites() -> None:
-    path = ROOT / "__uipath" / "uipath.json"
-    if not path.is_file():
-        sys.exit(
-            "FAIL: missing __uipath/uipath.json — the local-runtime binding "
-            "recipe requires resourceOverwrites to live here "
-            "(cli_run.py reads runtime_dir/uipath.json at local run)."
-        )
-    doc = _load_json(path)
-    overwrites = (
-        doc.get("runtime", {})
-        .get("internalArguments", {})
-        .get("resourceOverwrites", {})
-    )
-    key = f"connection.{BINDING_KEY}"
-    if key not in overwrites:
-        sys.exit(
-            f"FAIL: resourceOverwrites is missing key `{key}` (must match "
-            "the bindings.json connection resource key exactly)."
-        )
-    entry = overwrites[key]
-    if not isinstance(entry, dict):
-        sys.exit(f"FAIL: resourceOverwrites[`{key}`] is not an object.")
-
-    conn_id = entry.get("connectionId", entry.get("ConnectionId"))
-    folder_key = entry.get("folderKey")
-    # Non-empty strings: `ResourceOverwriteParser.parse` would reject null/empty
-    # and the override is silently skipped (`_common.py:217-225`).
-    for field, val in (("connectionId (or ConnectionId)", conn_id), ("folderKey", folder_key)):
-        if not (isinstance(val, str) and val.strip()):
-            sys.exit(
-                f"FAIL: resourceOverwrites for `{key}` field {field} must be a "
-                f"non-empty string (got {val!r}); the SDK skips invalid overrides "
-                "and the binding key 400s at local run."
-            )
-    if "elementInstanceId" in entry:
-        sys.exit(
-            f"FAIL: resourceOverwrites for `{key}` contains `elementInstanceId`. "
-            "`ConnectionResourceOverwrite` has `extra=\"ignore\"` and silently "
-            "drops it (capability anti-pattern #1). Remove it; `element_instance_id` "
-            "is exposed on the live `Connection.element_instance_id` after retrieve()."
-        )
-    print("OK: resourceOverwrites carries non-empty connectionId + folderKey, no elementInstanceId")
-
-
 def main() -> None:
     if not ROOT.is_dir():
         sys.exit(f"FAIL: project directory {ROOT} does not exist")
@@ -410,7 +359,6 @@ def main() -> None:
     check_no_lowcode_sidecar()
     check_lazy_sdk_init(tree, aliases)
     check_invocation_and_metadata(tree, assigns, aliases)
-    check_resource_overwrites()
     print("PASS: coded IS smoke shape checks complete")
 
 

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -62,7 +62,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Project shape: bindings.json + ActivityMetadata mapped from describe fixture + lazy SDK init + no lowcode sidecar + 2-field resourceOverwrites"
+    description: "Project shape: bindings.json connection envelope + ActivityMetadata mapped from describe fixture + lazy SDK init + no lowcode sidecar"
     command: "python3 $TASK_DIR/check_is_smoke.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/bindings.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/bindings.json
@@ -1,0 +1,11 @@
+{
+  "version": "2.0",
+  "resources": [
+    {
+      "resource": "connection",
+      "key": "slack-triage",
+      "value": { "ConnectionId": { "defaultValue": "11111111-1111-1111-1111-111111111111" } },
+      "metadata": { "UseConnectionService": "True", "Connector": "uipath-salesforce-slack", "BindingsVersion": "2.2" }
+    }
+  ]
+}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/entry-points.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/entry-points.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/entry-points",
+  "$id": "entry-points.json",
+  "entryPoints": [
+    {
+      "filePath": "main.py",
+      "uniqueId": "11111111-1111-1111-1111-111111111111",
+      "type": "agent",
+      "input": { "type": "object", "properties": { "message": { "type": "string" } } },
+      "output": { "type": "object", "properties": { "posted": { "type": "boolean" } } }
+    }
+  ]
+}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/main.py
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/main.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+from uipath import UiPath
+
+
+class Input(BaseModel):
+    message: str
+
+
+class Output(BaseModel):
+    posted: bool
+
+
+async def main(payload: Input) -> Output:
+    sdk = UiPath()
+    connection = await sdk.connections.retrieve_async("slack-triage")
+    # Activity invocation omitted — this fixture exercises the connection
+    # binding resolution at push time, not the runtime call.
+    return Output(posted=connection is not None)

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "slack-triage"
+version = "0.0.1"
+description = "Slack triage coded IS agent fixture"
+authors = [{ name = "Test" }]
+requires-python = ">=3.11"
+dependencies = ["uipath"]
+
+[dependency-groups]
+dev = ["uipath-dev"]

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/uipath.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage/uipath.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/uipath",
+  "runtimeOptions": {"isConversational": false},
+  "functions": {"main": "./main.py:main"}
+}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/check_push_resource_not_found.py
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/check_push_resource_not_found.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Check: agent resolved a push-time "connection not found" instead of
+dismissing it.
+
+The seed's `bindings.json` carries a stale connection id in
+`ConnectionId.defaultValue`, but the real Integration Service connection (per
+`uip is connections list`) has id `22222222-2222-2222-2222-222222222222`. Push
+resolves the connection by that id (`GET /Connections/<id>`); a wrong id is
+warned-and-skipped (non-virtual kind, exits 0). The skill must drive the agent
+to diagnose the mismatch and correct the binding so the connection imports — not
+accept the warning.
+
+Check: `slack-triage/bindings.json` has a `connection` resource whose
+`ConnectionId.defaultValue` is now the real connection id. That value is what
+push resolves against, so correcting it is what makes the connection import. The
+code keeps referencing the binding `key` alias (`retrieve("slack-triage")`), so
+the `retrieve()` argument is not constrained here.
+
+The re-push after the fix is graded separately in the task YAML via a
+`command_executed` count on `uip codedagent push`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.project_root import find_project_root  # noqa: E402
+
+REAL_ID = "22222222-2222-2222-2222-222222222222"
+ROOT = find_project_root("slack-triage")
+
+
+def check_bindings() -> None:
+    path = ROOT / "bindings.json"
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    data = json.loads(path.read_text(encoding="utf-8"))
+    conns = [r for r in data.get("resources", []) if r.get("resource") == "connection"]
+    if not conns:
+        sys.exit("FAIL: bindings.json has no connection resource")
+    conn_id = conns[0].get("value", {}).get("ConnectionId", {}).get("defaultValue")
+    if conn_id != REAL_ID:
+        sys.exit(
+            f"FAIL: connection ConnectionId is '{conn_id}', expected '{REAL_ID}' — "
+            "the binding was not corrected to the real connection id."
+        )
+
+
+def main() -> None:
+    check_bindings()
+    print("PASS: connection binding ConnectionId corrected to the real connection id")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/codedagent-setup.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/codedagent-setup.json
@@ -1,0 +1,1 @@
+{"Result":"Success","Message":"Setup complete."}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/is-connections-list.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/is-connections-list.json
@@ -1,0 +1,17 @@
+{
+  "Result": "Success",
+  "Code": "ConnectionList",
+  "Data": [
+    {
+      "Id": "22222222-2222-2222-2222-222222222222",
+      "Name": "uipath_is_test",
+      "ConnectorKey": "uipath-salesforce-slack",
+      "ConnectorName": "Slack",
+      "State": "Enabled",
+      "IsDefault": "Yes",
+      "ElementInstanceId": 100001,
+      "Folder": "Shared",
+      "FolderKey": "33333333-3333-3333-3333-333333333333"
+    }
+  ]
+}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/login-status.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/login-status.json
@@ -1,0 +1,1 @@
+{"Result":"Success","Status":"Authenticated"}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/responses/manifest.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "rules": [
+    {
+      "match": "is connections list",
+      "file": "is-connections-list.json",
+      "description": "Mock uip is connections list — real connection key is slack-triage-prod"
+    },
+    {
+      "match": "login status",
+      "file": "login-status.json",
+      "description": "Mock uip login status — agent is authenticated"
+    },
+    {
+      "match": "codedagent setup",
+      "file": "codedagent-setup.json",
+      "description": "Mock uip codedagent setup"
+    }
+  ],
+  "unmocked_default": {
+    "response": "{\"Result\": \"Success\"}\n",
+    "exit_code": 0
+  }
+}

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/uip
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/mocks/uip
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""uip mock for push_resource_not_found eval.
+
+Stateful `codedagent push`: reads the project's bindings.json and resolves the
+`connection` binding by its ConnectionId (the connection's id) against the known
+catalog. If the id does not match the real connection, push prints the real CLI
+"was not found and will not be added to the solution" warning and exits 0
+(mirroring real push, which warns-and-skips non-virtual kinds but does not fail).
+Once the binding's ConnectionId is corrected to the real id, push reports success.
+
+`is connections list` returns the real connection (with its id) so the mismatch
+is discoverable by the agent.
+"""
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RESPONSES_DIR = SCRIPT_DIR / "responses"
+MANIFEST_PATH = RESPONSES_DIR / "manifest.json"
+CALL_LOG_PATH = SCRIPT_DIR / ".calls.jsonl"
+
+REAL_CONNECTION_ID = "22222222-2222-2222-2222-222222222222"
+CONNECTOR = "uipath-salesforce-slack"
+
+
+def _log(args: str, rule_match, exit_code: int, note: str = "") -> None:
+    record = {"ts": time.time(), "args": args, "matched_rule": rule_match, "exit_code": exit_code}
+    if note:
+        record["note"] = note
+    try:
+        with CALL_LOG_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+    except OSError:
+        pass
+
+
+def _find_project_dir() -> Path | None:
+    cwd = Path(os.getcwd())
+    for candidate in [cwd, cwd / "slack-triage", cwd.parent / "slack-triage"]:
+        if (candidate / "bindings.json").is_file():
+            return candidate
+    return None
+
+
+def _connection_id_from_bindings() -> str | None:
+    proj = _find_project_dir()
+    if proj is None:
+        return None
+    try:
+        data = json.loads((proj / "bindings.json").read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    for res in data.get("resources", []):
+        if res.get("resource") == "connection":
+            return (
+                res.get("value", {})
+                .get("ConnectionId", {})
+                .get("defaultValue")
+            )
+    return None
+
+
+def _push(args: str) -> int:
+    conn_id = _connection_id_from_bindings()
+    if conn_id == REAL_CONNECTION_ID:
+        sys.stdout.write(
+            json.dumps(
+                {
+                    "Result": "Success",
+                    "Message": "Project successfully pushed to Studio Web.",
+                    "ProjectId": "89852b5d-8559-4c57-b752-0e2b500902fc",
+                }
+            )
+            + "\n"
+        )
+        _log(args, "codedagent push", 0, note="push-ok")
+        return 0
+    # Real push behavior: warn-and-skip the non-virtual connection, exit 0.
+    sys.stdout.write("Uploading source files... done.\n")
+    sys.stdout.write(
+        f"Connection with key '{conn_id}' of type '{CONNECTOR}' was not found "
+        "and will not be added to the solution.\n"
+    )
+    sys.stdout.write(
+        "Resource import summary: 1 total resources - 0 created, 0 updated, "
+        "0 unchanged, 0 virtual-created, 0 virtual-existing, 1 not found\n"
+    )
+    _log(args, "codedagent push", 0, note="push-not-found")
+    return 0
+
+
+def _respond_file(rule: dict, args: str) -> int:
+    path = RESPONSES_DIR / rule["file"]
+    text = path.read_text(encoding="utf-8") if path.is_file() else "{}\n"
+    sys.stdout.write(text)
+    code = int(rule.get("exit_code", 0))
+    _log(args, rule.get("match"), code)
+    return code
+
+
+def main(argv: list[str]) -> int:
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
+    args = " ".join(argv[1:])
+
+    # Stateful push takes priority over the static manifest.
+    if "codedagent push" in args:
+        return _push(args)
+
+    if not MANIFEST_PATH.is_file():
+        sys.stderr.write(json.dumps({"error": "manifest.json missing"}) + "\n")
+        return 2
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    for rule in manifest.get("rules", []):
+        match = rule.get("match", "")
+        if match and match in args:
+            return _respond_file(rule, args)
+
+    default = manifest.get("unmocked_default")
+    if isinstance(default, dict):
+        sys.stdout.write(default.get("response", ""))
+        code = int(default.get("exit_code", 0))
+        _log(args, None, code, note="unmocked_default")
+        return code
+
+    sys.stderr.write(json.dumps({"error": "unmocked command", "args": args}) + "\n")
+    _log(args, None, 1, note="unmocked")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/push_resource_not_found.yaml
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/push_resource_not_found.yaml
@@ -1,0 +1,65 @@
+task_id: skill-agent-coded-push-resource-not-found
+description: >
+  Diagnose-mode coverage for PRODEV-760. On `uip codedagent push`, a
+  non-virtual binding (here a `connection`) that is not found is
+  warned-and-skipped (push still exits 0). The seed's bindings.json
+  carries a stale `ConnectionId` (push resolves a connection by id via
+  `GET /Connections/<id>`), so push warns the connection was not found.
+  The code's `retrieve("slack-triage")` (the binding-key alias) is
+  correct and must stay. The skill must drive the agent to NOT dismiss
+  the warning, diagnose the stale id via `uip is connections list`,
+  correct `ConnectionId` in bindings.json, and re-push so the connection
+  actually imports. CLI is mocked — tests behavior, not cloud
+  connectivity.
+tags: [uipath-agents, integration, coded, mode:diagnose, feature:file-sync]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 45
+  turn_timeout: 600
+  task_timeout: 1800
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: mocks
+      mount_point: mocks
+  mock_path_dirs:
+    - mocks
+
+pre_run:
+  - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/push_resource_not_found/_fixtures/slack-triage ."
+    timeout: 10
+  - command: "printf 'UIPATH_PROJECT_ID=89852b5d-8559-4c57-b752-0e2b500902fc\\n' > slack-triage/.env"
+    timeout: 10
+
+initial_prompt: |
+  Push my `slack-triage` coded agent up to Studio Web for me.
+
+  Complete the task to the end. Only stop if there is a critical
+  blocker you cannot resolve.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip codedagent push (did not stop at the first warning)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedagent\s+push(?!\s+--help)'
+    min_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent diagnosed the mismatch by listing IS connections"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+is\s+connections\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Connection binding ConnectionId corrected to the real connection"
+    command: "python3 $TASK_DIR/check_push_resource_not_found.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- document what `uip codedagent push` does with bindings, and flag a non-virtual "resource not found" warning as a defect to diagnose and fix (not dismiss)
- stop instructing agents to author `__uipath/uipath.json`: local run uses the values in code, `bindings.json` is the deploy-time override surface
- correct the connection model: the same connection id (the `Id` from `uip is connections list`) goes in both the `retrieve()` arg and `bindings.json` `ConnectionId.defaultValue`, so it resolves locally and when overridden
- add `push_resource_not_found` eval covering an agent that diagnoses and fixes a stale connection binding then re-pushes

## Why
during coded-agent dogfooding an agent saw a push "connection not found" warning and dismissed it as expected, so the connection was never imported and the agent could not be promoted between tenants. the skill also wrongly told agents to write the internal `__uipath` file. this documents push's resource resolution and the correct connection-binding model.