### PR TITLE
docs(uipath-rpa): document tm Test Manager CLI commands [PILOT-6016]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -261,6 +261,7 @@ uip rpa activities find --query log --output json > /dev/null 2>&1 &
 | **Use mock testing** | XAML | [testing-guide.md § Mock Testing (WIP)](references/testing-guide.md) — requires CLI command not yet available |
 | **Use XAML test activities** | XAML | [testing-guide.md § XAML Test Activities](references/testing-guide.md) |
 | **Use execution templates** | XAML | [testing-guide.md § Execution Templates](references/testing-guide.md) |
+| **Set up Test Manager for the project** (server URL + default project) | Both | [cli-reference.md § Test Manager](references/cli-reference.md) — `uip rpa tm connect` / `set-default-project` |
 | **Create/edit XAML workflow** | XAML | [xaml/workflow-guide.md](references/xaml/workflow-guide.md) → [xaml/xaml-basics-and-rules.md](references/xaml/xaml-basics-and-rules.md) |
 | **Use a common activity** (`Sequence` / `If` / `Switch<T>` / `TryCatch` / `While` / `DoWhile` / `ForEach<T>` / `Assign` / `LogMessage` / `WriteLine` / `Delay` / `Throw` / `Rethrow`) | XAML | [common-activity-card.md](references/common-activity-card.md) |
 | **Create/edit Flowchart** | XAML | [xaml/flowchart-guide.md](references/xaml/flowchart-guide.md) → [xaml/canvas-layout-guide.md](references/xaml/canvas-layout-guide.md) |

--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -209,9 +209,35 @@ The verbs you'll reach for: list/describe **connectors** and their **activities*
 
 ---
 
-## Test Manager (`uip tm`)
+## Test Manager
 
-Test Manager integration lives in the dedicated `uip tm` tool — `uip tm --help`. Do not document or invoke Test Manager verbs from `uip rpa`.
+Two distinct surfaces — pick by intent:
+
+- **`uip tm` (dedicated tool)** — *runtime* Test Manager operations: browsing manual test cases, runs, results. `uip tm --help`. Do **not** invoke these runtime verbs from `uip rpa`.
+- **`uip rpa tm` (project configuration)** — *authoring/setup*: wire an RPA project to Test Manager by editing its `.tmh/config.json`. Pure file I/O — no Studio or Helm process is needed, so it works with everything closed.
+
+### `uip rpa tm` verbs
+
+| Verb | Purpose |
+|---|---|
+| `uip rpa tm connect --url <url>` | Set the Test Manager **server URL** (`testManagerBasePath`). Switching to a **different** server (different host/org/tenant) also **clears the default project**, since it belonged to the old server. |
+| `uip rpa tm set-default-project --id <guid> [--name <name>] [--key <key>]` | Link the **default Test Manager project** (`defaultProject`). **Requires a connected server** — run `connect` first or it is rejected. |
+| `uip rpa tm clear-default-project` | Unlink the default project; the server URL is kept. |
+| `uip rpa tm status` | Show the current configuration — server URL and linked default project. |
+
+Typical setup flow (all verbs take the standard `--project-dir` and `--output json`):
+
+```
+uip rpa tm connect --url "https://cloud.uipath.com/<org>/<tenant>/testmanager_" --project-dir "<PROJECT_DIR>" --output json
+uip rpa tm set-default-project --id <project-guid> --name "<project-name>" --key "<KEY>" --project-dir "<PROJECT_DIR>" --output json
+uip rpa tm status --project-dir "<PROJECT_DIR>" --output json
+```
+
+`set-default-project` does **not** call the server to validate the id (there is no server round-trip) — pass a real Test Manager project id (and optional name/key). Listing projects from the server is not available here; obtain the id from Test Manager itself. Confirm exact flags via `uip rpa tm --help`.
+
+#### Acting on `reloadHint` in the output
+
+A `connect` / `set-default-project` / `clear-default-project` response may include a **`reloadHint`** field. It appears only when the project is currently **open in a Studio older than 26.0.197**, which reads `.tmh/config.json` *only on project open*. When you see it, tell the user to **close and reopen the project in Studio** for the change to take effect — the CLI cannot do this for them. No `reloadHint` means nothing to do: either the project isn't open in Studio, or it's open in Studio 26.0.197+, which applies the change live.
 
 ---
 

--- a/skills/uipath-rpa/references/testing-guide.md
+++ b/skills/uipath-rpa/references/testing-guide.md
@@ -6,11 +6,30 @@ Reference for XAML test automation features in UiPath RPA projects — XAML test
 
 ## Table of Contents
 
+- [Test Manager Setup (CLI)](#test-manager-setup-cli)
 - [XAML Test Case Structure (Given-When-Then)](#xaml-test-case-structure-given-when-then)
 - [Data-Driven Testing](#data-driven-testing)
 - [XAML Test Activities](#xaml-test-activities)
 - [Execution Templates](#execution-templates)
 - [Mock Testing (XAML Only) — WIP](#mock-testing-xaml-only--wip)
+
+---
+
+## Test Manager Setup (CLI)
+
+Linking a project to Test Manager (server connection + default project) can be done headlessly with `uip rpa tm`, without opening Studio — useful before authoring test cases that reference Test Manager test cases. Full verb/flag reference: [cli-reference.md § Test Manager](cli-reference.md). The essentials:
+
+```
+uip rpa tm connect --url "https://<host>/<org>/<tenant>/testmanager_" --project-dir "<PROJECT_DIR>" --output json
+uip rpa tm set-default-project --id <project-guid> --name "<name>" --key "<KEY>" --project-dir "<PROJECT_DIR>" --output json
+uip rpa tm status --project-dir "<PROJECT_DIR>" --output json
+```
+
+Behavior to know when authoring:
+- **`set-default-project` requires a connected server** — run `connect` first, or it is rejected (nothing is written).
+- **Switching to a different server** (`connect` to a different host/org/tenant) **clears the default project** — it belonged to the old server. Re-link one with `set-default-project` afterwards.
+- **`reloadHint` in the output**: if the project is open in a **Studio older than 26.0.197**, the change isn't picked up until the project is reloaded. When you see `reloadHint`, tell the user to **close and reopen the project in Studio**. Studio 26.0.197+ applies the change live (no `reloadHint`).
+- The CLI does **not** validate the project id against the server; obtain a real id from Test Manager (the runtime `uip tm project list` tool can list them).
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the new `uip rpa tm` Test Manager configuration commands in the `uipath-rpa` skill. Fulfills [PILOT-6016](https://uipath.atlassian.net/browse/PILOT-6016) (the `[SKILL]` follow-up to [PILOT-5063](https://uipath.atlassian.net/browse/PILOT-5063)).

Implementation PRs (UiPath/Studio): rpa-tool CLI **#28578**, Studio live-reload + version-in-status-file **#28590**.

## Changes

- **`references/cli-reference.md` § Test Manager**
  - Clarifies the two surfaces: `uip tm` (runtime) vs `uip rpa tm` (project configuration).
  - Verb table for `connect` / `set-default-project` / `clear-default-project` / `status`, including the behaviors: `connect` to a **different** server clears the default project; `set-default-project` **requires a connected server** (rejected otherwise).
  - New **"Acting on `reloadHint`"** subsection: when the response includes `reloadHint`, the project is open in a Studio older than 26.0.197 and the agent must tell the user to **close and reopen the project**; no hint means nothing to do (not open, or Studio 26.0.197+ applies it live).

- **`references/testing-guide.md`** — new **"Test Manager Setup (CLI)"** section (+ TOC entry) so test authors find the connect → set-default-project → status flow and the same behavior notes, including the close-and-reopen action on `reloadHint`.

- **`SKILL.md`** — Task Navigation row: "Set up Test Manager for the project" → cli-reference § Test Manager.

## Notes

- `set-default-project` does not validate the id against the server; the doc points to `uip tm project list` for real ids.
- Studio 26.0.197+ live-reloads `.tmh/config.json`; older Studio needs the project closed and reopened — documented as the action to take on `reloadHint`.

[PILOT-6016]: https://uipath.atlassian.net/browse/PILOT-6016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PILOT-5063]: https://uipath.atlassian.net/browse/PILOT-5063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ