### PR TITLE
test(uipath-maestro-flow): identify generic list node by semantics, not slug

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
@@ -3,17 +3,24 @@
 
 Validates a generic connector activity: the node type encodes only the
 operation, so the object is supplied dynamically at configure time and must be
-resolved + set on the node. Uses ServiceNow `list-all-records` on `acr_user` as
-the concrete generic activity. Structural pre-checks fail fast and prevent
-gaming, then a live `flow debug` proves the generic node actually executed:
+resolved + set on the node. Uses ServiceNow's generic "List All Records"
+activity on `acr_user` as the concrete generic activity. Structural pre-checks
+fail fast and prevent gaming, then a live `flow debug` proves the generic node
+actually executed:
 
 1. A connector node targets the ServiceNow connector (`uipath-servicenow-servicenow`)
-   using the generic `list-all-records` operation on `objectName: "acr_user"`.
+   using the generic list operation on `objectName: "acr_user"`.
 2. `flow debug` completes (`finalStatus == "Completed"`).
 3. The connector result is surfaced as an array output variable.
 
+The generic list activity is identified by its SEMANTICS — a Generic-type
+`list` operation — not by a hard-coded node-type slug. The registry has emitted
+both `…list-all-records` and `…list-records` for this same generic activity
+across connector versions, so the dynamically-resolved `objectName` (not the
+slug) is the real signal that the generic node was configured correctly.
+
 The `acr_user` table is empty in the codereval ServiceNow tenant, so the
-list-all-records call legitimately returns `[]`. The runtime assertion therefore
+list call legitimately returns `[]`. The runtime assertion therefore
 checks that the connector completed and surfaced an array output (empty
 allowed) — not that rows came back. When records ARE present the IS connector
 returns FLATTENED records (top-level `sys_id`, …), which the check reports.
@@ -35,7 +42,11 @@ from _shared.flow_check import (  # noqa: E402
 )
 
 CONNECTOR_KEY = "uipath-servicenow-servicenow"
-OPERATION = "list-all-records"
+# Known node-type slugs for the generic list activity. The registry has emitted
+# both across connector versions for the SAME generic activity, so treat either
+# as a match — and fall back to the parsed configuration (Generic + `list`) when
+# the slug is something new. Keep these lowercase for substring matching.
+OPERATION_SLUGS = ("list-all-records", "list-records")
 # API object name (not the "Acr User" display name) — `node configure` stores
 # the connector's case-sensitive `Name`, which for this table is `acr_user`.
 OBJECT_NAME = "acr_user"
@@ -50,29 +61,67 @@ def _load_flow_nodes(project_dir: str) -> list[dict]:
     return flow.get("nodes") or []
 
 
-def _detail_object_name(detail: dict) -> str | None:
-    """Resolve the configured object name for a generic connector node.
+def _parse_detail_config(detail: dict) -> dict:
+    """Deserialize a connector node's `configuration` payload.
 
-    `node configure` stores it in a few places depending on CLI version: a
-    top-level `inputs.detail.objectName`, or inside the serialized
-    `configuration` string (`=jsonString:{...}`) at `objectName`,
-    `essentialConfiguration.objectName`, or `…instanceParameters.objectName`."""
-    if detail.get("objectName"):
-        return detail["objectName"]
+    `node configure` serializes it as a `=jsonString:{...}` string (newer CLIs)
+    or stores a plain dict (older shapes). Returns {} when nothing parses."""
     cfg = detail.get("configuration")
+    if isinstance(cfg, dict):
+        return cfg
     if isinstance(cfg, str):
         prefix = "=jsonString:"
         body = cfg[len(prefix):] if cfg.startswith(prefix) else cfg
         try:
             obj = json.loads(body)
         except (json.JSONDecodeError, ValueError):
-            return None
-        ess = obj.get("essentialConfiguration") if isinstance(obj, dict) else None
-        ess = ess if isinstance(ess, dict) else {}
-        params = ess.get("instanceParameters") if isinstance(ess, dict) else None
-        params = params if isinstance(params, dict) else {}
-        return obj.get("objectName") or ess.get("objectName") or params.get("objectName")
-    return None
+            return {}
+        return obj if isinstance(obj, dict) else {}
+    return {}
+
+
+def _config_layers(detail: dict) -> tuple[dict, dict, dict]:
+    """Return the (top, essentialConfiguration, instanceParameters) dicts of the
+    parsed `configuration`, each defaulted to {} so callers can read freely."""
+    obj = _parse_detail_config(detail)
+    ess = obj.get("essentialConfiguration")
+    ess = ess if isinstance(ess, dict) else {}
+    params = ess.get("instanceParameters")
+    params = params if isinstance(params, dict) else {}
+    return obj, ess, params
+
+
+def _detail_object_name(detail: dict) -> str | None:
+    """Resolve the configured object name for a generic connector node.
+
+    `node configure` stores it in a few places depending on CLI version: a
+    top-level `inputs.detail.objectName`, or inside the serialized
+    `configuration` payload at `objectName`, `essentialConfiguration.objectName`,
+    or `…instanceParameters.objectName`."""
+    if detail.get("objectName"):
+        return detail["objectName"]
+    obj, ess, params = _config_layers(detail)
+    return obj.get("objectName") or ess.get("objectName") or params.get("objectName")
+
+
+def _is_generic_list(node: dict, detail: dict) -> bool:
+    """Identify the generic (dynamic) list activity by its semantics.
+
+    A generic list node either carries one of the known list slugs in its node
+    type, or — slug-agnostically — its parsed configuration marks the activity
+    `Generic` with a `list` operation. Keying on semantics (not the slug) keeps
+    the check stable as the registry's node-type slug drifts across versions."""
+    node_type = str(node.get("type", "")).lower()
+    if any(slug in node_type for slug in OPERATION_SLUGS):
+        return True
+    obj, ess, params = _config_layers(detail)
+    activity_type = str(
+        params.get("activityType") or ess.get("activityType") or obj.get("activityType") or ""
+    ).lower()
+    operation = str(
+        params.get("operation") or ess.get("operation") or obj.get("operation") or ""
+    ).lower()
+    return activity_type == "generic" and operation == "list"
 
 
 def _assert_structure() -> None:
@@ -80,20 +129,22 @@ def _assert_structure() -> None:
     assert_flow_uses_connector_target(CONNECTOR_KEY)
 
     nodes = _load_flow_nodes(find_project_dir())
-    list_nodes = [
-        n
-        for n in nodes
-        if CONNECTOR_KEY in str(n.get("type", "")).lower()
-        and OPERATION in str(n.get("type", "")).lower()
-    ]
+    list_nodes = []
+    for n in nodes:
+        if CONNECTOR_KEY not in str(n.get("type", "")).lower():
+            continue
+        detail = (n.get("inputs") or {}).get("detail") or {}
+        if isinstance(detail, dict) and _is_generic_list(n, detail):
+            list_nodes.append(n)
     if not list_nodes:
         types = sorted({str(n.get("type", "")) for n in nodes})
         sys.exit(
-            f"FAIL: No ServiceNow {OPERATION!r} connector node found. "
+            f"FAIL: No generic ServiceNow list activity found on the "
+            f"{CONNECTOR_KEY} connector (expected a Generic 'list' operation). "
             f"Node types seen: {types}"
         )
 
-    # The configured object must be Acr User. Generic list-all-records carries
+    # The configured object must be Acr User. The generic list activity carries
     # objectName on inputs.detail (top-level) or inside the serialized
     # `configuration` payload — accept either.
     found = []
@@ -106,8 +157,8 @@ def _assert_structure() -> None:
         if name == OBJECT_NAME:
             return
     sys.exit(
-        f"FAIL: ServiceNow {OPERATION} node found but objectName != {OBJECT_NAME!r} "
-        f"(resolved object names: {found}). The list-all-records activity is generic — "
+        f"FAIL: Generic ServiceNow list node found but objectName != {OBJECT_NAME!r} "
+        f"(resolved object names: {found}). The list activity is generic — "
         f"it must set the object name to {OBJECT_NAME!r}."
     )
 
@@ -117,7 +168,7 @@ def _assert_array_output(payload: dict) -> None:
 
     `run_debug` already enforced `finalStatus == "Completed"`, so the connector
     call succeeded by the time we get here. The `acr_user` table is empty in the
-    codereval ServiceNow tenant, so the list-all-records call legitimately
+    codereval ServiceNow tenant, so the generic list call legitimately
     returns `[]` — assert an array-typed output exists rather than requiring it
     to be non-empty. When records ARE present they carry a `sys_id`, so report
     that to keep the check meaningful if the table is ever populated.

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
@@ -14,10 +14,13 @@ actually executed:
 3. The connector result is surfaced as an array output variable.
 
 The generic list activity is identified by its SEMANTICS — a Generic-type
-`list` operation — not by a hard-coded node-type slug. The registry has emitted
-both `…list-all-records` and `…list-records` for this same generic activity
-across connector versions, so the dynamically-resolved `objectName` (not the
-slug) is the real signal that the generic node was configured correctly.
+`list` operation — not by a hard-coded node-type slug. The registry's slug for
+it is `…list-records` ("List Records" — object-agnostic; the object-specific
+lists are named after their object, e.g. `…list-incidents`); the activity's
+*display* name is "List All Records", which is why an earlier slug guess of
+`…list-all-records` (a node the registry does not emit) slipped in. The
+dynamically-resolved `objectName` (not the slug) is the real signal that the
+generic node was configured correctly.
 
 The `acr_user` table is empty in the codereval ServiceNow tenant, so the
 list call legitimately returns `[]`. The runtime assertion therefore
@@ -42,11 +45,12 @@ from _shared.flow_check import (  # noqa: E402
 )
 
 CONNECTOR_KEY = "uipath-servicenow-servicenow"
-# Known node-type slugs for the generic list activity. The registry has emitted
-# both across connector versions for the SAME generic activity, so treat either
-# as a match — and fall back to the parsed configuration (Generic + `list`) when
-# the slug is something new. Keep these lowercase for substring matching.
-OPERATION_SLUGS = ("list-all-records", "list-records")
+# Node-type slugs for the generic list activity. The live registry uses
+# `…list-records`; `…list-all-records` is kept only as a defensive alias (it
+# matches the activity's "List All Records" display name) in case the slug ever
+# changes. When neither slug matches, fall back to the parsed configuration
+# (Generic + `list`). Keep these lowercase for substring matching.
+OPERATION_SLUGS = ("list-records", "list-all-records")
 # API object name (not the "Acr User" display name) — `node configure` stores
 # the connector's case-sensitive `Name`, which for this table is `acr_user`.
 OBJECT_NAME = "acr_user"

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -3,16 +3,16 @@ description: >
   Connector feature: validate a generic (dynamic) connector node end-to-end. A
   generic activity encodes only the operation in its node type; the object is
   supplied dynamically at configure time, so the agent must resolve the object
-  name and set it on the node. Uses ServiceNow `list-all-records`
-  (`uipath.connector.uipath-servicenow-servicenow.list-all-records`, API
-  `objectName: "acr_user"`) as the concrete generic activity, bound to the
-  tenant's ServiceNow connection, then runs `flow debug`. Exercises connector
-  discovery (including connections in non-default folders), generic-activity
-  object-name resolution, connection binding, and live execution. The `acr_user`
-  table is empty in the codereval tenant, so the call legitimately returns `[]`;
-  the checker asserts the node is a generic `list-all-records` node on
-  `objectName: "acr_user"`, `finalStatus: "Completed"`, and an array-typed
-  output (empty allowed) rather than requiring rows.
+  name and set it on the node. Uses ServiceNow's generic "List All Records"
+  activity (API `objectName: "acr_user"`) as the concrete generic activity,
+  bound to the tenant's ServiceNow connection, then runs `flow debug`. Exercises
+  connector discovery (including connections in non-default folders),
+  generic-activity object-name resolution, connection binding, and live
+  execution. The `acr_user` table is empty in the codereval tenant, so the call
+  legitimately returns `[]`; the checker asserts the node is a generic list
+  activity (Generic-type `list` operation, whatever the registry's current
+  node-type slug) on `objectName: "acr_user"`, `finalStatus: "Completed"`, and
+  an array-typed output (empty allowed) rather than requiring rows.
   Connection note: ServiceNow developer instances hibernate after inactivity.
   If a run fails with a connection error, log into the ServiceNow account to
   wake the instance, then re-run.


### PR DESCRIPTION
## Problem

The `generic_dynamic_node` checker hard-coded the node-type slug `list-all-records`:

```python
OPERATION = "list-all-records"
... OPERATION in str(n.get("type", "")).lower()
```

But the ServiceNow connector registry now emits `uipath.connector.uipath-servicenow-servicenow.list-records` for the **same** generic "List All Records" activity. (Confirmed from a real run: the agent's registry search returned `…list-records` as the generic list operation, and the produced node carries `activityType: "Generic"`, `operation: "list"`, `objectName: "acr_user"`, and a `helpUrlTemplate` pointing at `…List-All-Records`.)

Result: a **correct** agent run failed the structural pre-check on the slug string alone —

```
FAIL: No ServiceNow 'list-all-records' connector node found.
Node types seen: [..., 'uipath.connector.uipath-servicenow-servicenow.list-records']
```

— short-circuiting `_assert_structure` **before `flow debug` ever ran**, so the entire 6.0-weight criterion was lost to a false negative even though `flow validate` (1.0) and the debug invocation (1.0) both passed.

## Fix

Identify the generic list activity by its **semantics** rather than a brittle slug:

1. Accept either known slug (`list-all-records` **or** `list-records`), and
2. Fall back to the parsed `configuration` marking the activity `Generic` with a `list` operation.

The dynamically-resolved `objectName == "acr_user"` remains the real signal that the generic node was configured correctly, so anti-gaming strength is preserved — a typed/object-specific activity or a non-list generic op still fails.

Also refactors `configuration` parsing into `_parse_detail_config` / `_config_layers` helpers, and updates the task YAML description to stop pinning a specific slug.

## Verification

Ran the new selection logic against the actual flow from the failing run — now selects the `list-records` node and resolves `objectName=acr_user` ✅. Unit-checked the detector:

| node | `_is_generic_list` |
|---|---|
| `…list-all-records` (old slug) | ✅ True |
| `…list-records` (new slug) | ✅ True |
| unknown slug + `Generic`/`list` config | ✅ True |
| typed `get-record` | ❌ False |
| `Generic` + `create` op | ❌ False |

`py_compile` clean.

> Note: I inferred the live registry slug from the captured run transcript + node metadata rather than a fresh `uip maestro flow registry search`. Making the check slug-agnostic is robust either way, but worth a sanity check at review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)