### PR TITLE
docs(uipath-maestro-case): auto-name escalation rules to avoid SW duplicate-name errors

### DIFF
--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -386,6 +386,7 @@ All SLA data on a target (root or stage) lives in a single `slaRules[]` array. T
     "escalationRule": [
       {
         "id": "esc_aB3kL9",
+        "displayName": "Escalation 1",
         "triggerInfo": { "type": "sla-breached" },
         "action": {
           "type": "notification",
@@ -420,6 +421,8 @@ All SLA data on a target (root or stage) lives in a single `slaRules[]` array. T
 Time units: `"min"` (minutes), `"h"` (hours), `"d"` (days), `"w"` (weeks), `"m"` (months).
 Escalation `triggerInfo.type`: `"at-risk"` or `"sla-breached"`. `atRiskPercentage` is required when `type === "at-risk"` and omitted otherwise.
 Escalation `action.recipients[].scope`: `"User"` or `"UserGroup"`. `target` is the user / group UUID; `value` is the display string (email or group name).
+
+Every escalation rule carries a **unique, non-blank `displayName`** — author-supplied from `sdd.md`, else a default `"Escalation <n>"` (1-based counter across the whole case). Studio Web auto-labels un-named escalations identically and rejects duplicate names; `uip maestro case validate` treats `displayName` as optional and does NOT flag this. (SLA *rules* themselves have no name field at v23 — only their escalations do.)
 
 ### SlaRuleEntry
 

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -85,13 +85,14 @@ Emission rules:
 3. **Bare default rule is legal.** If a target has escalations but no default SLA T-entry, emit `{expression:"=js:true", escalationRule:[…]}` with no `count` / `unit`.
 4. **Always emit `escalationRule` on every rule.** Use `"escalationRule": []` when a rule has no attached escalations. Never omit the key.
 5. **Omit `slaRules` key entirely** on targets with no SLA T-entries.
+6. **Every escalation carries a unique, non-blank `displayName`.** Use the T-entry's name when `sdd.md` supplies one; otherwise default to `"Escalation <n>"`, where `<n>` is a **1-based counter incremented across every escalation in the case** (root + every stage), in write order — so names are globally unique. Studio Web auto-labels un-named escalations identically and rejects the result as duplicate names; `uip maestro case validate` treats `displayName` as optional and will NOT flag this. (SLA *rules* themselves have no name field at schema v23 — only their escalations do.)
 
 ## Recipe — one escalation entry
 
 ```json
 {
   "id": "esc_xxxxxx",
-  "displayName": "<from T-entry, optional>",
+  "displayName": "<from T-entry; default \"Escalation <n>\" when none — see emission rule 6>",
   "action": {
     "type": "notification",
     "recipients": [
@@ -105,7 +106,7 @@ Emission rules:
 }
 ```
 
-- `displayName` omitted entirely when T-entry doesn't supply one (don't emit `undefined`).
+- `displayName` is **always emitted, never blank.** Use the T-entry's name when supplied; otherwise default to `"Escalation <n>"` (1-based counter across every escalation in the case, in write order — globally unique). Studio Web rejects blank/duplicate escalation names; the CLI's `validate` does not catch it.
 - `atRiskPercentage` included only when `triggerInfo.type === "at-risk"`.
 - `recipients` is an array — **one entry per sdd-declared recipient**.
 

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -32,6 +32,8 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 
 > **Per-conditional-rule escalations are supported.** Attach an escalation rule to any entry in `slaRules[]`, not only the default `"=js:true"` rule.
 
+> **Escalation names are auto-assigned and unique.** Every escalation gets a non-blank `displayName` — author-supplied from `sdd.md`, else a default `"Escalation <n>"`. Studio Web requires unique escalation names (blank/duplicate names are rejected in SW even though `validate` passes). See [`impl-json.md`](impl-json.md).
+
 ## Required Fields from sdd.md
 
 ### Default SLA

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -282,6 +282,38 @@ def get_default_sla(target: dict) -> dict | None:
     return last if (last or {}).get("expression") == "=js:true" else None
 
 
+def assert_unique_sla_escalation_names(plan: dict) -> None:
+    """Every escalation rule must have a non-blank, case-unique ``displayName``.
+
+    Studio Web auto-labels un-named escalation rules identically and rejects the
+    result as duplicate names. ``uip maestro case validate`` treats ``displayName`` as
+    optional and does NOT catch this, so a caseplan can pass the CLI yet fail in SW.
+    (Escalation ``displayName`` is a v23 field; SLA *rules* themselves have no name
+    field until schema v26, so only their escalations are checked here.)
+    """
+    targets = [(plan.get("metadata") or {})]
+    targets += [(n.get("data") or {}) for n in (plan.get("nodes") or [])]
+    esc_names: list = []
+    for d in targets:
+        for r in (d.get("slaRules") or []):
+            for e in ((r or {}).get("escalationRule") or []):
+                esc_names.append((e or {}).get("displayName"))
+
+    blank = sum(1 for x in esc_names if not x)
+    if blank:
+        sys.exit(
+            f"FAIL: {blank} escalation rule(s) have a blank/missing displayName — Studio Web "
+            f"auto-labels un-named escalations identically and rejects them as duplicate names. "
+            f"Emit a unique default (e.g. 'Escalation 1', 'Escalation 2', ...)."
+        )
+    seen: set = set()
+    dups: set = set()
+    for x in esc_names:
+        (dups.add(x) if x in seen else seen.add(x))
+    if dups:
+        sys.exit(f"FAIL: duplicate escalation displayName(s) {sorted(dups)} — Studio Web requires unique names.")
+
+
 def _stringify(v: Any) -> str:
     return json.dumps(v, default=str)
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/check_exception_stage.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/check_exception_stage.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    assert_unique_sla_escalation_names,
     find_node_by_label,
     first_rule_of_condition,
     get_default_sla,
@@ -18,6 +19,7 @@ from _shared.case_check import (  # noqa: E402
 
 def main():
     plan = read_caseplan()
+    assert_unique_sla_escalation_names(plan)
 
     process = find_node_by_label(plan, "Process")
     if process.get("type") != "case-management:Stage":

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/check_sla_with_escalation.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/check_sla_with_escalation.py
@@ -6,6 +6,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
+    assert_unique_sla_escalation_names,
     find_node_by_label,
     get_default_sla,
     get_sla_rules,
@@ -15,6 +16,7 @@ from _shared.case_check import (  # noqa: E402
 
 def main():
     plan = read_caseplan()
+    assert_unique_sla_escalation_names(plan)
     rules = get_sla_rules(plan)
 
     if len(rules) < 3:


### PR DESCRIPTION
## What

The case skill omitted the escalation `displayName` whenever the SDD didn't supply one, so Studio Web auto-labeled every un-named escalation identically and rejected the case with **"duplicate names"** — even though `uip maestro case validate` passed (it treats `displayName` as optional and never checks it).

## Fix

- **`sla/impl-json.md` + `sla/planning.md`**: every escalation now carries a unique, non-blank `displayName` — author-supplied from `sdd.md`, else a default **`"Escalation <n>"`** (1-based counter across the whole case, in write order → globally unique). `displayName` is a real v23 field (`CaseManagementJsonEscalationRuleSchemaV7`), so SW honors it.
- **`case-schema.md` §6**: document the escalation-name uniqueness rule and show names in the example.
- **tests**: add `assert_unique_sla_escalation_names` to `_shared/case_check.py` and call it from the SLA-bearing checks so blank/duplicate escalation names fail the eval.

SLA *rules* themselves have no name field until schema v26, so only their escalations are named (the v26 SLA-rule `displayName` is intentionally out of scope here).

## Why a separate PR

Split out of #1717 (the ExceptionStage→Stage v22 consolidation) — escalation naming is an orthogonal Studio Web compatibility fix, not part of the schema consolidation.

## Verified

- The guard catches the real failing build that triggered this (10 unnamed escalations) and passes a v23 caseplan with named escalations.
- `uip maestro case validate` (v1.197.0) reports **Valid** on a named caseplan.
- `py_compile` clean on all modified checkers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
