### PR TITLE
fix(sprint-cut): grant actions:write so the publish.yml dispatch isn't 403'd

### DIFF
--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -35,6 +35,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for `gh workflow run publish.yml` (the Actions
+  # POST .../dispatches endpoint) — without it the dispatch 403s with
+  # "Resource not accessible by integration".
+  actions: write
 
 # GitHub cron runs in UTC and cannot express "every two Sundays" — fire every
 # Sunday, then gate on the 14-day cadence anchor (mirrors UiPath/cli).


### PR DESCRIPTION
## Problem

Sunday's scheduled sprint cut created the `v1.198.0` GitHub Release but then failed:

```
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
(…/actions/workflows/289749925/dispatches)
Error: Process completed with exit code 1.
```

`gh workflow run publish.yml` calls the Actions `POST …/dispatches` endpoint, which requires the `actions: write` permission. `sprint-release-cut.yml` only granted `contents` + `pull-requests`, so the dispatch was denied — leaving the cut **published to GitHub (tag + release + `release/v1.198` branch) but never to npm**, and no bump PR opened.

## Fix

Add `actions: write` to the workflow's `permissions:` block. `workflow_dispatch` *is* triggerable by `GITHUB_TOKEN` once it has that scope.

## Recovering the interrupted v1.198.0 cut

After this merges, re-dispatch the cut for the same line — it resumes idempotently:

```
gh workflow run sprint-release-cut.yml -f minor_override=1.198
```

It finds `release/v1.198` already at `1.198.0` → skips re-cutting, dispatches `publish.yml` (now permitted) → `@uipath/skills@1.198.0` to npm, and opens the bump PR to `main`.

(Or, to publish immediately without waiting: `gh workflow run publish.yml --ref v1.198.0 -f target=npmjs` from your own credentials.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)