### PR TITLE
fix: flaky trigger skill (#MST-11661)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector-trigger/impl.md
@@ -42,7 +42,7 @@ Save the response. It carries three pieces per event object that drive later ste
 |------|--------|---------|
 | `byoaConnection` | Step 1c | If `true`, only BYOA connections are valid for this event |
 | `isWebhookUrlVisible` | Step 6b | If `true`, retrieve and present the webhook URL |
-| **`parameters[]`** | Steps 3 & 4 | **Canonical** list of event-parameter input fields. Use exclusively; ignore `eventParameters.fields` from `flow registry get` (Step 2). |
+| **`parameters[]`** | Steps 3 & 4 | Object-, query-, and path-scoped input parameters (e.g. shared mailbox, repo, owner). **NOT the complete event-parameter set** — merge with `EventParameters` from `triggers describe` (Step 1b-2). The full input set is the **union** of both; a field is required if either source marks it `required`. |
 
 It may also include `design.textBlocks` with connector-specific user-facing instructions (e.g., "Add this URL to your Slack app's Event Subscriptions"). Surface that text verbatim when applicable — do not invent service-specific guidance.
 
@@ -63,7 +63,7 @@ Each entry is one input field the user supplies when configuring the trigger (e.
 | `design.position` | `"primary"` indicates a top-level input field; other positions are layout hints — safe to ignore for configure |
 | `type` | Bucket selector in Step 6's `--detail`: `"query"` → `queryParameters`, `"path"` → `pathParameters`, else → `eventParameters` |
 
-> **Source of truth:** `parameters[]` is populated for every connector. `flow registry get`'s `eventParameters.fields` derives from `triggers describe`'s `events.<operation>.required`/`.optional`, which several connectors do not emit. Full field semantics: [/uipath:uipath-platform — triggers.md — `parameters[]`](../../../../../../uipath-platform/references/integration-service/triggers.md#parameters--canonical-event-parameter-input-fields).
+> **Source of truth — the UNION of two calls, never one alone.** The complete event-input set = `triggers objects → parameters[]` (object/query/path scope) **∪** `triggers describe → EventParameters` (event-config scope). Configure every field that **either** marks `required: true`. `triggers describe → FilterFields` feeds the `filter` tree; `OutputFields` / `outputResponseDefinition` feed downstream `$vars`. `flow registry get`'s `eventParameters.fields` mirrors `describe` and is the offline fallback. A required field can appear in `describe → EventParameters` while absent from `parameters[]`, so **both calls are mandatory and you must merge them**. Full field semantics: [/uipath:uipath-platform — triggers.md — `parameters[]`](../../../../../../uipath-platform/references/integration-service/triggers.md#parameters--event-parameter-input-fields).
 
 **1b-2. Resolve the object name and fetch field metadata** — **mandatory** for every trigger node.
 
@@ -77,7 +77,7 @@ uip is triggers describe "<connector-key>" "<OPERATION>" "<objectName>" \
   --connection-id "<id>" --output json
 ```
 
-> **Source of truth for node configuration:** event-parameter inputs come from `triggers objects` → `parameters[]` (Step 1b); field metadata comes from `triggers describe` (this step). Follow these two responses exclusively — do not invent parameters or fields.
+> **Source of truth for node configuration — merge both responses.** Event-parameter inputs = the **union** of `triggers objects → parameters[]` (Step 1b) and `triggers describe → EventParameters` (this step). `triggers describe` also returns `FilterFields` (→ `filter` tree) and `OutputFields` (→ downstream `$vars`). Never treat `triggers describe` as "only field metadata" — its `EventParameters` are first-class event parameters and frequently carry required fields that `parameters[]` omits. Do NOT skip this call, and do NOT invent parameters or fields.
 
 ### Step 1c — Select the final connection
 
@@ -154,7 +154,7 @@ These live in the **definition**, not on the node instance. The instance carries
 
 ### Step 3 — Resolve reference fields in event parameters
 
-Iterate `parameters[]` (Step 1b). For each entry with a `reference` key, run an ID lookup — same mechanism as IS activity nodes.
+Iterate the **union** of `parameters[]` (Step 1b) and `EventParameters` (Step 1b-2). For each entry with a `reference` key, run an ID lookup — same mechanism as IS activity nodes. A referenced field can live in `describe → EventParameters` while absent from `parameters[]` — resolving only `parameters[]` misses it.
 
 > **Resolve every reference field freshly, against the current `--connection-id`, immediately before `node configure` (Step 6)** — even if you think you already know the ID from a previous flow. Reference IDs are connection-scoped and reused values fault silently at runtime. See [Reference IDs Are Connection-Scoped (CRITICAL)](../../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical) for the full mechanism and failure mode, and the top-level Anti-Patterns in [SKILL.md](../../../../../SKILL.md).
 
@@ -172,9 +172,9 @@ The `<id>` in `--connection-id "<id>"` MUST be the connection bound to **this** 
 
 ### Step 4 — Validate required event parameters
 
-Check every entry in `parameters[]` (Step 1b) where `required: true`. All required event parameters must have values before building the flow.
+Check every entry in the **union** of `parameters[]` (Step 1b) and `EventParameters` (Step 1b-2). Treat a field as required if **either** source marks `required: true`. All required event parameters must have values before building the flow.
 
-1. Collect all required entries from `parameters[]`
+1. Collect all required entries from `parameters[]` **and** `describe → EventParameters` (dedupe by `name`); required = required in either
 2. For each, check if the user's prompt provides a value
 3. If any required field is missing, **ask the user** — list the missing fields with their `displayName` (and `description` if useful). Free-form input is appropriate when the value space is open-ended; when a finite set of sensible values exists, present them as options per the dropdown question rule in [SKILL.md](../../../../../SKILL.md).
 4. Only proceed after all required event parameters are resolved
@@ -489,7 +489,7 @@ uip maestro flow debug . --output json
 | `Trigger nodes require --connection-id` | Ran `registry get` without `--connection-id` | Re-run with `--connection-id <id>` — required for all trigger nodes |
 | No trigger nodes in registry | Not authenticated or registry not pulled | Run `uip login` then `uip maestro flow registry pull --force` |
 | Connection not found in bindings | `node configure` not run or connection expired | Re-run `node configure` with valid `connectionId` and `folderKey` |
-| Event parameter missing at runtime | Required event parameter not configured | Re-run `uip is triggers objects` (Step 1b). For each `parameters[]` entry with `required: true`, include under `eventParameters` in `--detail`. |
+| Event parameter missing at runtime | Required event parameter not configured (commonly one returned by `triggers describe` but absent from `triggers objects → parameters[]`) | Re-run **both** `uip is triggers objects` (Step 1b) **and** `uip is triggers describe` (Step 1b-2). Configure every field marked `required` in **either** `parameters[]` or `EventParameters` (resolving references) under the correct `--detail` bucket. |
 | `filterExpression is derived from the filter tree and cannot be provided directly` | Passed `filterExpression` string instead of a `filter` tree | Build a structured `filter` tree — see [Filter Trees](#filter-trees) |
 | `Filter references field '<name>' which is not present in trigger metadata` | Leaf `id` does not match any `filterFields.fields[].name` | Re-run `registry get` and use a valid field name |
 | Trigger not firing | Event parameters point to wrong resource (e.g., wrong folder ID) | Re-resolve reference fields with `uip is resources run list` |

--- a/skills/uipath-platform/references/integration-service/triggers.md
+++ b/skills/uipath-platform/references/integration-service/triggers.md
@@ -10,7 +10,7 @@ Triggers are event-based activities that fire when something happens in an exter
 - [Trigger Discovery Flow](#trigger-discovery-flow)
 - [List Trigger Activities](#list-trigger-activities)
 - [Trigger Objects](#trigger-objects)
-  - [`parameters[]` — canonical event-parameter input fields](#parameters--canonical-event-parameter-input-fields)
+  - [`parameters[]` — event-parameter input fields](#parameters--event-parameter-input-fields)
 - [Object Name Resolution](#object-name-resolution)
 - [Trigger Metadata (Describe)](#trigger-metadata-describe)
 - [CRUD vs Non-CRUD Triggers](#crud-vs-non-crud-triggers)
@@ -31,7 +31,7 @@ Triggers are event-based activities that fire when something happens in an exter
 
 **Decision point at step 2**: CREATED, UPDATED, and DELETED operations require an intermediate "objects" step. For other trigger operations, skip to step 3 using the activity's **ObjectName**.
 
-> **Source of truth:** Event-parameter inputs come from `triggers objects` → `parameters[]`. Field metadata comes from `triggers describe`. Configure trigger nodes exclusively from these two responses — do not invent parameters or fields, and do not substitute metadata from other commands.
+> **Source of truth — UNION of both calls.** Event-parameter inputs = `triggers objects → parameters[]` **∪** `triggers describe → EventParameters`. A required field can appear in `describe → EventParameters` while absent from `parameters[]`, so configure every field either source marks `required` — never read inputs from one call alone. `triggers describe` also supplies `FilterFields` (filter tree) and `OutputFields` (downstream `$vars`). Run **both** calls; do not invent parameters or fields, and do not substitute metadata from other commands.
 
 ---
 
@@ -124,11 +124,11 @@ Array of objects — each has a **name** to use in the describe command. Also in
 | `byoaConnection` | `true` if this event requires a BYOA connection |
 | `isWebhookUrlVisible` | `true` if the webhook URL should be shown to the user |
 | `eventMode` | `"webhooks"` or `"polling"` — how the trigger receives events |
-| **`parameters[]`** | **Canonical** event-parameter input fields for this trigger — see below |
+| **`parameters[]`** | Object/query/path-scoped input fields for this trigger — see below. **Merge with `triggers describe → EventParameters`** for the complete set. |
 
-#### `parameters[]` — canonical event-parameter input fields
+#### `parameters[]` — event-parameter input fields
 
-One entry per configure-time input field (repo, mailbox folder, channel). Canonical across all connectors. `triggers describe` exposes the same set under `events.<operation>.required`/`.optional`, but that block is empty for several connectors — always read `parameters[]` here.
+One entry per configure-time input field (repo, channel, shared mailbox). **Not complete on its own** — `triggers objects → parameters[]` carries object/query/path-scoped inputs, while event-config inputs come from `triggers describe → EventParameters`. The full input set is the **union**; a field is required if either source marks it `required`. Never read inputs from `parameters[]` alone.
 
 | Field | Description |
 |---|---|
@@ -143,17 +143,18 @@ One entry per configure-time input field (repo, mailbox folder, channel). Canoni
 
 ### Trigger Metadata (from `triggers describe`)
 
-Object with field definitions. Structure varies by connector but typically includes field names, types, display names, and descriptions.
-
-Additional fields:
+Object with field definitions. Structure varies by connector but typically returns three arrays plus mode flags:
 
 | Field | Description |
 |---|---|
+| `EventParameters` | Event-config input fields. **First-class event parameters** — merge with `triggers objects → parameters[]`; configure every entry marked `required`. Resolve `reference` fields via `uip is resources run list` before configure. |
+| `FilterFields` | Fields usable in the optional `filter` tree |
+| `OutputFields` | Event payload schema — field names for downstream `$vars.{triggerId}.output.*` |
 | `eventMode` | `"webhooks"` or `"polling"` |
 | `byoaConnection` | `true` if this trigger requires a BYOA connection |
 | `isWebhookUrlVisible` | `true` if the webhook URL should be shown |
 
-> **`events.<operation>.required` from `triggers describe` is connector-dependent and often empty.** Downstream commands that derive `eventParameters.fields` from it inherit the gap. Read input fields from [`parameters[]`](#parameters--canonical-event-parameter-input-fields) instead. `triggers describe` remains the source for **output** field metadata.
+> **`triggers describe → EventParameters` is NOT "output-only" metadata.** It carries required *input* parameters that `triggers objects → parameters[]` frequently omits. Always merge both responses and configure the union — see the Source-of-truth note above. `flow registry get`'s `eventParameters.fields` mirrors `describe` and is the offline fallback.
 
 ---
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -64,6 +64,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
+    description: "Agent described the trigger object for EMAIL_RECEIVED (connector-trigger Step 1b-2, mandatory) — required event params (e.g. parentFolderId) live in describe's EventParameters, not in triggers objects' parameters[]"
+    tool_name: "Bash"
+    # `[\s\S]` matches across newlines — agents often split `uip` commands with
+    # backslash line-continuation, which `.*` would miss. Quotes around the
+    # connector key / operation are optional, so match bare tokens.
+    command_pattern: 'uip\s+is\s+triggers\s+describe[\s\S]+?uipath-microsoft-outlook365[\s\S]+?EMAIL_RECEIVED'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
     description: "Agent resolved MailFolder against the current --connection-id (PR #348 regression)"
     tool_name: "Bash"
     # `[\s\S]` matches across newlines — agents often split `uip` commands with


### PR DESCRIPTION
## Summary

Fixes the flaky connector-trigger skill (MST-11661). The trigger plugin told the agent to source event parameters **exclusively** from `uip is triggers objects → parameters[]` and to treat `uip is triggers describe` as "field metadata only." For several connectors `parameters[]` **omits required event parameters** that only appear in `triggers describe → EventParameters` — most notably Outlook `EMAIL_RECEIVED`'s required `parentFolderId` (the Inbox folder). An agent following the doc would run both commands but still configure the trigger with empty `eventParameters`, leaving the required folder unset. It passed `flow validate` and `solution upload` because the requirement is only enforced at runtime, so the failure was silent — hence the flakiness.

## Root cause

The doc encoded a false binary: **"`triggers objects` = parameters, `triggers describe` = fields."** In reality the two calls return *complementary* input sets, and `triggers describe → EventParameters` are first-class event parameters (frequently required). The required-param check (Step 4) and reference-resolution (Step 3) both iterated `parameters[]` only, so describe's `EventParameters` never entered configuration.

This is why the earlier fix (#1448 — making `triggers describe` mandatory) didn't resolve it: the agent ran describe but the doc still told it the event parameters come from `parameters[]` alone.

## The fix — UNION of both calls

The complete event-input set is the **union** of `triggers objects → parameters[]` (object/query/path scope) **∪** `triggers describe → EventParameters` (event-config scope). A field is required if **either** source marks it `required`. Both calls are mandatory and must be merged.

### `connector-trigger/impl.md`
- **Step 1b table + source-of-truth note** — dropped "`parameters[]` is canonical / use exclusively"; replaced with the union rule.
- **Step 1b-2 note** — `triggers describe → EventParameters` is now stated as first-class event parameters, not "field metadata only"; "do NOT skip this call."
- **Step 3 (reference resolution)** — iterate the union.
- **Step 4 (required-param check)** — collect required from both, dedupe by `name`, required if either.
- **Debug table** — "event parameter missing at runtime" recovery now points at both commands.

### `triggers.md`
- Source-of-truth note, `parameters[]` section, and the Trigger Metadata table rewritten to the union rule (and corrected to describe's real shape: `EventParameters` / `FilterFields` / `OutputFields`). Anchor de-"canonical"-ized (no dangling links).

### `outlook_trigger_inbox.yaml` (regression guard)
- Added a `command_executed` criterion asserting the agent runs `uip is triggers describe … uipath-microsoft-outlook365 … EMAIL_RECEIVED` (weight 1.5). The existing `check_folder_id_fresh` already asserts `parentFolderId` lands in the node and is a live MailFolder ID on the bound connection — together they catch both "skipped describe" and "configured wrong/empty."

## Test results

Ran the regression task **3× in parallel** against the live test tenant — **3/3 SUCCESS, 6/6 criteria each, weighted score 1.000**:

```
coder-eval run tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml -e experiments/default.yaml
```

| Criterion | Run 1 | Run 2 | Run 3 |
|---|:--:|:--:|:--:|
| `flow validate` passes | ✅ | ✅ | ✅ |
| has Outlook email-received trigger node | ✅ | ✅ | ✅ |
| ran `triggers objects` (Step 1b) | ✅ | ✅ | ✅ |
| **ran `triggers describe` (Step 1b-2) — new** | ✅ | ✅ | ✅ |
| resolved MailFolder on bound `--connection-id` | ✅ | ✅ | ✅ |
| `parentFolderId` is a live MailFolder ID | ✅ | ✅ | ✅ |
| duration | 490s | 377s | 424s |

With the corrected docs the agent reliably runs `triggers describe`, resolves the Inbox `parentFolderId`, and writes it into the trigger — the exact gap that caused the flakiness.

Relates to #1448 (made `triggers describe` mandatory; this PR fixes the source-of-truth model that #1448 left intact).
