### PR TITLE
feat(sprint-cut): cut current line, bump main forward, alpha-to-GitHub-only

### DIFF
--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -1,33 +1,31 @@
 name: Sprint Release Cut
 
-# Biweekly per-sprint release cut (skills side of the CLI↔skills lockstep,
-# PILOT-5518). Runs Sunday 06:00 UTC — 6 hours BEFORE the CLI's own cut
-# (12:00 UTC) — so the skills npm package is live first. Self-anchored and
-# self-driven: it does NOT read the CLI version (skills lead, never follow).
-# On each release Sunday it:
+# Biweekly per-sprint release cut (PILOT-5518). Runs Sunday 06:00 UTC on the
+# 14-day cadence (anchor below). Each release Sunday it:
 #
-#   1. cuts release/v<minor> from main with package.json = M.N.0
-#      (sync-version.mjs resets plugin/marketplace/Codex to M.N.0 too)
-#   2. publishes @uipath/skills@M.N.0 to npm `latest` — creates the GitHub
-#      Release v<minor>.0 (durable record) and dispatches publish.yml on the
-#      tag (a GITHUB_TOKEN-created release can't trigger publish.yml itself)
-#   3. opens a PR against main with the same version bump
+#   1. cuts release/v<current> from main — the release line is the version main
+#      is currently on (main on 1.197.0 -> release/v1.197, frozen at 1.197.0);
+#   2. bumps main forward to the next minor (1.197.0 -> 1.198.0), pushed
+#      DIRECTLY to main (requires branch protection to let the Actions identity
+#      push main — see docs/RELEASE.md);
+#   3. publishes an ALPHA of the new main line to GitHub Packages only
+#      (dispatches publish.yml target=github-alpha → 1.198.0-alpha.<date>.<run>).
 #
-# No cross-repo secret is required — the target line is the current skills
-# minor + 1, gated to the CLI's 14-day cadence (anchor below). The cli-repo
-# side cuts itself, in lockstep, from the same anchor.
+# It NEVER publishes to npmjs. The stable npmjs release is always MANUAL: create
+# a GitHub Release on the release/v<minor> branch (or dispatch publish.yml
+# target=npmjs --ref release/v<minor>). See docs/RELEASE.md.
 
 on:
   schedule:
-    - cron: '0 6 * * 0' # Sunday 06:00 UTC — 6 h before the CLI cut (12:00 UTC)
+    - cron: '0 6 * * 0' # Sunday 06:00 UTC
   workflow_dispatch:
     inputs:
-      minor_override:
-        description: 'Target line as MAJOR.MINOR (e.g. 1.198) — skips the cadence gate and the auto-increment'
+      release_override:
+        description: 'Release line to cut as MAJOR.MINOR (e.g. 1.197) — defaults to the version main is on; skips the cadence gate'
         required: false
         default: ''
       dry_run:
-        description: 'Print the computed plan without pushing, publishing, or opening a PR'
+        description: 'Print the computed plan without cutting, bumping, or publishing'
         type: boolean
         required: false
         default: false
@@ -35,9 +33,12 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for `gh workflow run publish.yml` (Actions POST .../dispatches) —
+  # without it the dispatch 403s with "Resource not accessible by integration".
+  actions: write
 
 # GitHub cron runs in UTC and cannot express "every two Sundays" — fire every
-# Sunday, then gate on the 14-day cadence anchor (mirrors UiPath/cli).
+# Sunday, then gate on the 14-day cadence anchor.
 env:
   RELEASE_CADENCE_ANCHOR: "2026-06-14"
 
@@ -59,21 +60,22 @@ jobs:
         with:
           node-version: "22.x"
 
-      - name: Cadence gate and resolve target line
+      - name: Cadence gate and resolve lines
         id: target
         env:
-          MINOR_OVERRIDE: ${{ github.event.inputs.minor_override }}
+          RELEASE_OVERRIDE: ${{ github.event.inputs.release_override }}
         run: |
+          # The release line is the version main is currently on.
           CURRENT_LINE=$(jq -r '.version | split(".") | "\(.[0]).\(.[1])"' package.json)
           echo "current_line=$CURRENT_LINE" >> "$GITHUB_OUTPUT"
 
-          if [ -n "$MINOR_OVERRIDE" ]; then
-            if ! echo "$MINOR_OVERRIDE" | grep -Eq '^[0-9]+\.[0-9]+$'; then
-              echo "::error::minor_override '$MINOR_OVERRIDE' is not MAJOR.MINOR."
+          if [ -n "$RELEASE_OVERRIDE" ]; then
+            if ! echo "$RELEASE_OVERRIDE" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+              echo "::error::release_override '$RELEASE_OVERRIDE' is not MAJOR.MINOR."
               exit 1
             fi
-            TARGET_LINE="$MINOR_OVERRIDE"
-            echo "Manual override -> $TARGET_LINE (cadence gate skipped)."
+            RELEASE_LINE="$RELEASE_OVERRIDE"
+            echo "Manual override -> release line $RELEASE_LINE (cadence gate skipped)."
           else
             # Biweekly cadence gate: act only on release Sundays (every 14 days
             # from the anchor). A manual run without an override also honors the
@@ -86,50 +88,17 @@ jobs:
               {
                 echo "## Skipped: off-cadence Sunday"
                 echo ""
-                echo "Release Sundays are every 14 days from \`$RELEASE_CADENCE_ANCHOR\`; today is +$days_since days. Use \`minor_override\` to cut anyway."
+                echo "Release Sundays are every 14 days from \`$RELEASE_CADENCE_ANCHOR\`; today is +$days_since days. Use \`release_override\` to cut anyway."
               } >> "$GITHUB_STEP_SUMMARY"
               exit 0
             fi
-            # Self-increment the minor — never read the CLI (we lead it).
-            MAJOR=$(echo "$CURRENT_LINE" | cut -d. -f1)
-            MINOR=$(echo "$CURRENT_LINE" | cut -d. -f2)
-            TARGET_LINE="$MAJOR.$((MINOR + 1))"
+            RELEASE_LINE="$CURRENT_LINE"
           fi
 
-          echo "target_line=$TARGET_LINE" >> "$GITHUB_OUTPUT"
-
-          # Never regress, never cut the same line twice.
-          if [ "$(printf '%s\n%s\n' "$CURRENT_LINE" "$TARGET_LINE" | sort -V | tail -1)" = "$CURRENT_LINE" ]; then
-            echo "proceed=false" >> "$GITHUB_OUTPUT"
-            {
-              echo "## Skipped: target not ahead of current"
-              echo ""
-              echo "Skills are on \`$CURRENT_LINE\`, target line is \`$TARGET_LINE\` — nothing to cut."
-            } >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "proceed=true" >> "$GITHUB_OUTPUT"
-
-            # Warn-only drift check (NO gate — skills lead, never follow). Skills
-            # cuts 6 h before the CLI on the same anchor, so at this moment the
-            # CLI's latest published minor should be exactly one behind our
-            # target. A gap in either direction means a skipped/extra cut has
-            # drifted the lines apart — surface it (it's otherwise silent, and
-            # `targetCli` would keep claiming a pairing that no longer holds).
-            # Reads public npm only — no token, no cross-repo coupling.
-            CLI_LATEST=$(npm view @uipath/cli version 2>/dev/null || echo "")
-            if [ -n "$CLI_LATEST" ]; then
-              CLI_MINOR=$(echo "$CLI_LATEST" | cut -d. -f1-2)
-              EXPECTED=$(echo "$CLI_MINOR" | awk -F. '{print $1"."$2+1}')
-              if [ "$TARGET_LINE" != "$EXPECTED" ]; then
-                echo "::warning::Skills target $TARGET_LINE is not CLI_latest+1 (CLI latest published is $CLI_LATEST, minor $CLI_MINOR) — the skills/CLI lines may have drifted. Realign with a minor_override dispatch (see docs/RELEASE.md)."
-                {
-                  echo "## ⚠️ Possible skills/CLI line drift"
-                  echo ""
-                  echo "Target is \`$TARGET_LINE\`; the CLI's latest npm release is \`$CLI_LATEST\` (minor \`$CLI_MINOR\`), so the expected target is \`$EXPECTED\`. If unexpected, realign with a \`minor_override\` dispatch — see docs/RELEASE.md. (Proceeding with the cut regardless — this is a warning, not a gate.)"
-                } >> "$GITHUB_STEP_SUMMARY"
-              fi
-            fi
-          fi
+          NEXT_LINE=$(echo "$RELEASE_LINE" | awk -F. '{print $1"."$2+1}')
+          echo "release_line=$RELEASE_LINE" >> "$GITHUB_OUTPUT"
+          echo "next_line=$NEXT_LINE" >> "$GITHUB_OUTPUT"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
 
       - name: Dry run — print plan
         if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run == 'true'
@@ -137,110 +106,70 @@ jobs:
           {
             echo "## Dry run — planned sprint cut"
             echo ""
-            echo "- current line: \`${{ steps.target.outputs.current_line }}\`"
-            echo "- target line: \`${{ steps.target.outputs.target_line }}\`"
-            echo "- would create: \`release/v${{ steps.target.outputs.target_line }}\` from \`main\` @ \`$(git rev-parse --short HEAD)\`"
-            echo "- would publish: \`@uipath/skills@${{ steps.target.outputs.target_line }}.0\` to npm \`latest\` (GitHub Release \`v${{ steps.target.outputs.target_line }}.0\` + dispatch publish.yml)"
-            echo "- would open PR: \`auto/sprint-cut-${{ steps.target.outputs.target_line }}\` -> \`main\`"
+            echo "- main is on: \`${{ steps.target.outputs.current_line }}\`"
+            echo "- would cut: \`release/v${{ steps.target.outputs.release_line }}\` from \`main\` @ \`$(git rev-parse --short HEAD)\`"
+            echo "- would bump main to: \`${{ steps.target.outputs.next_line }}.0\` (direct push)"
+            echo "- would publish: alpha of \`${{ steps.target.outputs.next_line }}.0\` to GitHub Packages (publish.yml target=github-alpha) — NEVER npmjs"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Cut release branch
+      - name: Cut release branch from main
         id: cutbranch
         if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
         run: |
-          LINE="${{ steps.target.outputs.target_line }}"
-          BRANCH="release/v$LINE"
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          RELEASE_LINE="${{ steps.target.outputs.release_line }}"
+          BRANCH="release/v$RELEASE_LINE"
 
           if git ls-remote --exit-code --heads origin "$BRANCH" > /dev/null; then
-            # Branch already exists. If a prior run pushed it before failing on a
-            # later step, it already carries this line's cut (package.json ==
-            # $LINE.0) — resume idempotently rather than aborting (the later
-            # release/PR guards are only reachable if we don't fail here). If the
-            # version differs, it's a genuine conflict (double-cut / stale
-            # branch) — stop for a human.
-            git fetch origin "$BRANCH"
-            git checkout --detach FETCH_HEAD
-            EXISTING_VERSION=$(node -p "require('./package.json').version")
-            if [ "$EXISTING_VERSION" != "$LINE.0" ]; then
-              echo "::error::$BRANCH already exists at version $EXISTING_VERSION (expected $LINE.0) — resolve manually."
-              exit 1
-            fi
-            echo "$BRANCH already cut at $LINE.0 — resuming (re-publishing if needed)."
+            echo "$BRANCH already exists — leaving it as-is (no re-cut)."
           else
-            git checkout -b "$BRANCH"
-            npm version "$LINE.0" --no-git-tag-version --allow-same-version
-            node scripts/sync-version.mjs
-            git add package.json version-manifest.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
-            git commit -m "chore(release): cut $LINE line"
-            git push origin "HEAD:$BRANCH"
+            # The release line is just main's current snapshot — branch the
+            # pointer, no extra commit.
+            git push origin "HEAD:refs/heads/$BRANCH"
+            echo "Cut $BRANCH from main @ $(git rev-parse --short HEAD)."
           fi
-
-          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Publish stable to npm (ahead of the CLI)
-        id: publish
+      - name: Bump main to the next dev line
+        id: bump
         if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          LINE="${{ steps.target.outputs.target_line }}"
-          TAG="v$LINE.0"
+          CURRENT_LINE="${{ steps.target.outputs.current_line }}"
+          NEXT_LINE="${{ steps.target.outputs.next_line }}"
+          NEXT_VERSION="$NEXT_LINE.0"
 
-          # Create the GitHub Release as the durable record of the cut.
-          if gh release view "$TAG" > /dev/null 2>&1; then
-            echo "Release $TAG already exists — reusing it."
-          else
-            gh release create "$TAG" \
-              --target "${{ steps.cutbranch.outputs.sha }}" \
-              --title "$TAG" \
-              --notes "Automated sprint release cut for the \`$LINE\` line. Publishes \`@uipath/skills@$LINE.0\` to npm \`latest\` ahead of the CLI release. See docs/RELEASE.md."
-          fi
-
-          # A release created with the default GITHUB_TOKEN does NOT start other
-          # workflow runs (GitHub's recursion guard), so `release: published`
-          # will NOT trigger publish.yml. Dispatch it explicitly instead —
-          # workflow_dispatch IS triggerable by GITHUB_TOKEN. publish.yml's
-          # npmjs path checks out the given ref ($TAG = the exact cut state,
-          # package.json = $LINE.0) and publishes via OIDC trusted publishing.
-          # Guard on npm so a resumed/repeated run doesn't re-dispatch an
-          # already-published version (which would only fail noisily).
-          if npm view "@uipath/skills@$LINE.0" version > /dev/null 2>&1; then
-            echo "@uipath/skills@$LINE.0 already on npm — skipping publish dispatch."
-          else
-            gh workflow run publish.yml --ref "$TAG" -f target=npmjs
-            echo "Dispatched publish.yml (target=npmjs) at $TAG."
-          fi
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Open version-bump PR against main
-        id: mainpr
-        if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LINE="${{ steps.target.outputs.target_line }}"
-          PR_BRANCH="auto/sprint-cut-$LINE"
-
-          EXISTING=$(gh pr list --state open --head "$PR_BRANCH" --json url --jq '.[0].url // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "url=$EXISTING" >> "$GITHUB_OUTPUT"
-            echo "Bump PR already open: $EXISTING"
+          # Never regress main: only bump when the next line is actually ahead
+          # of what main is on (it normally is — next = release line + 1). If
+          # main already advanced (e.g. a prior run bumped it), skip.
+          HIGHEST=$(printf '%s\n%s\n' "$CURRENT_LINE" "$NEXT_LINE" | sort -V | tail -1)
+          if [ "$CURRENT_LINE" = "$NEXT_LINE" ] || [ "$HIGHEST" = "$CURRENT_LINE" ]; then
+            echo "main is on $CURRENT_LINE, not behind next line $NEXT_LINE — skipping the bump."
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          # The release branch HEAD already carries exactly the version bump
-          # commit on top of main — reuse it as the PR branch.
-          git push origin "release/v$LINE:refs/heads/$PR_BRANCH"
-          URL=$(gh pr create \
-            --head "$PR_BRANCH" \
-            --base main \
-            --title "chore(release): bump main to $LINE.0 (sprint cut)" \
-            --body "Automated sprint release cut: \`release/v$LINE\` was created and \`@uipath/skills@$LINE.0\` was published to npm \`latest\`. This PR applies the same version bump to \`main\` so \`version:check\` keeps the line consistent. See docs/RELEASE.md.")
-          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          npm version "$NEXT_VERSION" --no-git-tag-version --allow-same-version
+          node scripts/sync-version.mjs
+          git add package.json version-manifest.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
+          git commit -m "chore(release): open $NEXT_LINE dev line (cut release/v${{ steps.target.outputs.release_line }})"
+          # Direct push to main — requires branch protection to allow the
+          # Actions identity to push main (otherwise this 403s).
+          git push origin HEAD:main
+          echo "bumped=true" >> "$GITHUB_OUTPUT"
+
+      - name: Publish alpha to GitHub Packages
+        if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Alpha of the new main line to GitHub Packages ONLY. publish.yml's
+          # github-alpha path checks out the ref, stamps
+          # <base>-alpha.<date>.<run> from package.json (main is now NEXT.0),
+          # and publishes to npm.pkg.github.com with dist-tag `alpha`. npmjs is
+          # never touched here — the stable npmjs release is always manual.
+          gh workflow run publish.yml --ref main -f target=github-alpha
+          echo "Dispatched publish.yml (target=github-alpha) on main."
 
       - name: Summary
         if: steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
@@ -248,8 +177,8 @@ jobs:
           {
             echo "## Sprint cut complete"
             echo ""
-            echo "- \`${{ steps.target.outputs.current_line }}\` → \`${{ steps.target.outputs.target_line }}\`"
-            echo "- \`release/v${{ steps.target.outputs.target_line }}\` @ \`${{ steps.cutbranch.outputs.short_sha }}\`"
-            echo "- published: \`@uipath/skills@${{ steps.target.outputs.target_line }}.0\` to npm \`latest\` (release \`${{ steps.publish.outputs.tag }}\`)"
-            echo "- main bump PR: ${{ steps.mainpr.outputs.url }}"
+            echo "- cut \`release/v${{ steps.target.outputs.release_line }}\` from \`main\` @ \`${{ steps.cutbranch.outputs.short_sha }}\`"
+            echo "- main bumped to \`${{ steps.target.outputs.next_line }}.0\` (direct push: \`${{ steps.bump.outputs.bumped }}\`)"
+            echo "- alpha of \`${{ steps.target.outputs.next_line }}.0\` dispatched to GitHub Packages (publish.yml target=github-alpha)"
+            echo "- npmjs stable release remains **manual** (GitHub Release on \`release/v${{ steps.target.outputs.release_line }}\`, or dispatch publish.yml target=npmjs)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -6,8 +6,8 @@ name: Sprint Release Cut
 #   1. cuts release/v<current> from main — the release line is the version main
 #      is currently on (main on 1.197.0 -> release/v1.197, frozen at 1.197.0);
 #   2. bumps main forward to the next minor (1.197.0 -> 1.198.0), pushed
-#      DIRECTLY to main (requires branch protection to let the Actions identity
-#      push main — see docs/RELEASE.md);
+#      DIRECTLY to main via the GH_PAT write token (a bypass actor on main's
+#      ruleset) — same approach as UiPath/cli's create-release-branch.yml;
 #   3. publishes an ALPHA of the new main line to GitHub Packages only
 #      (dispatches publish.yml target=github-alpha → 1.198.0-alpha.<date>.<run>).
 #
@@ -55,6 +55,11 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          # Privileged write token (a bypass actor on main's ruleset) so the
+          # release-branch and direct main push go through — the default
+          # GITHUB_TOKEN can't push a protected branch. Mirrors UiPath/cli's
+          # create-release-branch.yml (GH_WRITE_TOKEN).
+          token: ${{ secrets.GH_PAT }}
 
       - uses: actions/setup-node@v4
         with:
@@ -147,14 +152,26 @@ jobs:
             exit 0
           fi
 
+          # Guard against a race: main must not have moved since this run was
+          # queued (we cut release/v<current> from this exact HEAD). If it has,
+          # bail rather than push a stale bump. (Mirrors UiPath/cli.)
+          BASE_SHA=$(git rev-parse HEAD)
+          git fetch origin main
+          ORIGIN_MAIN=$(git rev-parse origin/main)
+          if [ "$ORIGIN_MAIN" != "$BASE_SHA" ]; then
+            echo "::error::main moved after this run was queued (origin/main=$ORIGIN_MAIN, based on $BASE_SHA). Re-run."
+            exit 1
+          fi
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           npm version "$NEXT_VERSION" --no-git-tag-version --allow-same-version
           node scripts/sync-version.mjs
           git add package.json version-manifest.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
           git commit -m "chore(release): open $NEXT_LINE dev line (cut release/v${{ steps.target.outputs.release_line }})"
-          # Direct push to main — requires branch protection to allow the
-          # Actions identity to push main (otherwise this 403s).
+          # Direct push to main via the GH_PAT checkout token (a bypass actor on
+          # main's ruleset) — same approach as UiPath/cli. The default
+          # GITHUB_TOKEN cannot push a protected branch.
           git push origin HEAD:main
           echo "bumped=true" >> "$GITHUB_OUTPUT"
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -64,19 +64,21 @@ Both tracks are **manually triggered** — there is no auto-publish on push to `
 
 ### Automated sprint cut (`sprint-release-cut.yml`)
 
-Steps 1–2 are automated per sprint by `sprint-release-cut.yml`. It runs **Sunday 06:00 UTC**, gated to the **14-day cadence** anchored at `2026-06-14` — the same cadence as `UiPath/cli`, but **6 hours earlier** so the skills package lands before the CLI release. It is **self-driven**: the target line is the current skills minor **+ 1**; it never reads the CLI version (skills lead, never follow), so no cross-repo secret is required. On a release Sunday it:
+`sprint-release-cut.yml` runs **Sunday 06:00 UTC**, gated to the **14-day cadence** anchored at `2026-06-14`. The **release line is the version `main` is currently on** (no `+1` — `main` on `1.197.0` cuts `release/v1.197`). On a release Sunday it:
 
-1. cuts `release/v<minor>` from `main` at `M.N.0` (`sync-version.mjs` resets plugin/marketplace/Codex to `M.N.0` too);
-2. publishes `@uipath/skills@M.N.0` to npm `latest` — creates the GitHub Release `v<minor>.0` as the durable record, then **dispatches `publish.yml` on the tag** (`gh workflow run publish.yml --ref v<minor>.0 -f target=npmjs`). A release created with the default `GITHUB_TOKEN` does not trigger other workflows, so `release: published` would never start `publish.yml`; the explicit `workflow_dispatch` (which `GITHUB_TOKEN` *can* trigger) is what publishes. Guarded on `npm view` so a re-run doesn't re-dispatch an already-published version;
-3. opens the matching version-bump PR against `main`.
+1. **cuts `release/v<current>` from `main`** — a frozen snapshot of `main` at its current `M.N.0` (e.g. `release/v1.197` at `1.197.0`). No extra commit; the branch is just `main`'s pointer;
+2. **bumps `main` forward to the next minor** (`1.197.0 → 1.198.0`) via `npm version` + `sync-version.mjs`, **pushed directly to `main`**;
+3. **publishes an alpha of the new `main` line to GitHub Packages only** — dispatches `publish.yml target=github-alpha`, which stamps `<base>-alpha.<YYYYMMDD>.<run>` from `main`'s now-`1.198.0` `package.json` and publishes to `npm.pkg.github.com` under the `alpha` dist-tag.
 
-Off-cadence or ad-hoc cut: dispatch manually with `minor_override` (e.g. `1.198`) to skip the gate and the auto-increment, or `dry_run` to print the plan without pushing.
+**It never publishes to npmjs.** The stable npmjs release is always **manual** (see *Cutting a stable release* above): create a GitHub Release on the `release/v<minor>` branch, or dispatch `publish.yml target=npmjs --ref release/v<minor>`.
 
-> **Drift realignment.** The skills and CLI lines stay paired only because both cut on the same 14-day anchor; nothing reads the other side. If either repo skips a cut or cuts off-cadence, the minors drift permanently. The cut emits a **non-blocking warning** when its target isn't exactly one minor ahead of the CLI's latest npm release (`npm view @uipath/cli`) — the signal that the lines have drifted. **`minor_override` is the realignment lever:** dispatch the cut with `minor_override=<correct M.N>` to skip the gate and the auto-increment and cut exactly that line back into alignment.
+Off-cadence or ad-hoc cut: dispatch manually with `release_override` (e.g. `1.197`) to set the release line and skip the cadence gate, or `dry_run` to print the plan without pushing.
 
-> **Operational dependency — merge the bump PR before the next cut.** The target line is `current + 1` read from `main`'s `package.json`. If the bump PR from step 3 is not merged before the next release Sunday, `main` is still on the old line, so the cut re-targets the line it already created: it finds `release/v<minor>` already at `M.N.0` and **resumes idempotently** (skips the publish since npm already has the version, leaves the existing PR open) — no new line is cut. Safe, but a forgotten bump PR silently **stalls the cadence**. Merge sprint-cut bump PRs promptly. (If the branch exists at a *different* version, the cut stops loudly with `already exists at version <X> (expected <Y>)` for manual resolution.)
+> **Required repo setup (both are hard prerequisites):**
+> - Branch protection must allow the Actions identity (`github-actions[bot]` via `GITHUB_TOKEN`) to **push `main` directly** and to push `release/v*` — otherwise the bump push and the cut 403. (Configure a branch-protection/ruleset bypass for the Actions app, or switch the bump to a PAT/GitHub App token.)
+> - `actions: write` permission on this workflow (already set) so it can dispatch `publish.yml`.
 
-> **Repo setup:** branch protection must allow the Actions identity to push `release/v*` branches.
+> **Recovery if a run fails *after* the main bump.** Because the bump pushes straight to `main`, once `main` has advanced a re-run of the whole cut would target the *new* line. So if a run bumps `main` but the alpha dispatch fails, **don't re-run the cut** — re-dispatch just the publisher: `gh workflow run publish.yml --ref main -f target=github-alpha`. (The 14-day cadence gate prevents an accidental scheduled re-run in the meantime.)
 
 ## Required setup
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -75,7 +75,7 @@ Both tracks are **manually triggered** — there is no auto-publish on push to `
 Off-cadence or ad-hoc cut: dispatch manually with `release_override` (e.g. `1.197`) to set the release line and skip the cadence gate, or `dry_run` to print the plan without pushing.
 
 > **Required repo setup (both are hard prerequisites):**
-> - Branch protection must allow the Actions identity (`github-actions[bot]` via `GITHUB_TOKEN`) to **push `main` directly** and to push `release/v*` — otherwise the bump push and the cut 403. (Configure a branch-protection/ruleset bypass for the Actions app, or switch the bump to a PAT/GitHub App token.)
+> - A `GH_PAT` secret — a write token whose identity is a **bypass actor on `main`'s ruleset** — used as the checkout token so the workflow can push `release/v*` and **push `main` directly** (the default `GITHUB_TOKEN` can't push a protected branch). This mirrors `UiPath/cli`'s `create-release-branch.yml` (`GH_WRITE_TOKEN`); no PR / auto-merge is used.
 > - `actions: write` permission on this workflow (already set) so it can dispatch `publish.yml`.
 
 > **Recovery if a run fails *after* the main bump.** Because the bump pushes straight to `main`, once `main` has advanced a re-run of the whole cut would target the *new* line. So if a run bumps `main` but the alpha dispatch fails, **don't re-run the cut** — re-dispatch just the publisher: `gh workflow run publish.yml --ref main -f target=github-alpha`. (The 14-day cadence gate prevents an accidental scheduled re-run in the meantime.)


### PR DESCRIPTION
Reworks the Sunday sprint cut (`sprint-release-cut.yml`) to the new release model. **Supersedes #1729** (folds in the `actions: write` fix) and changes the behavior merged in #1452.

## New flow each release Sunday (14-day cadence)
1. **Cut `release/v<current>`** — the release line is the version `main` is *currently* on (no `+1`). `main` on `1.197.0` → `release/v1.197`, a frozen snapshot at `1.197.0` (just a branch pointer, no extra commit).
2. **Bump `main` forward** to the next minor (`1.197.0 → 1.198.0`) via `npm version` + `sync-version.mjs`, **pushed directly to `main`**.
3. **Publish an alpha of the new `main` line to GitHub Packages only** — dispatch `publish.yml target=github-alpha` → `1.198.0-alpha.<date>.<run>` on `npm.pkg.github.com`.

**Never publishes to npmjs.** The stable npmjs release stays 100% manual (GitHub Release on `release/v<minor>`, or `publish.yml target=npmjs --ref release/v<minor>`).

## Removed (no longer apply in this model)
- npmjs auto-publish + GitHub Release creation + the `npm view` dup-guard
- the CLI drift-check / `minor_override` realignment (the "target = CLI+1" premise is gone now that we cut the current line)

## ⚠️ Hard prerequisites before the first run
- **Branch protection must allow the Actions identity to push `main` directly** (and `release/v*`). Without a ruleset/branch-protection bypass for `github-actions[bot]` (or a PAT/App token), the bump push will 403 the same way the dispatch did. This is the main thing to confirm.
- `actions: write` (included here) for the `publish.yml` dispatch.

## Note on partial-failure recovery
Because the bump pushes straight to `main`, once `main` advances a full re-run targets the *next* line. If a run bumps `main` but the alpha dispatch fails, **re-dispatch only the publisher** (`gh workflow run publish.yml --ref main -f target=github-alpha`) rather than re-running the cut. Documented in `docs/RELEASE.md`.

Recommend a `dry_run:false` validation on a throwaway line once branch protection is configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)