### PR TITLE
test(uipath-agents): anchor llm-judge eval-results.json to project root

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -25,7 +25,8 @@ initial_prompt: |
   Write a couple evaluations backed by LLMs if possible: 
   one that checks the answer the agent gives back and one that checks
   the path it took to get there.
-  Save the eval results to `eval-results.json`.
+  Save the eval results to `eval-results.json` in the agent project
+  root, next to `pyproject.toml`.
   
 
   Don't publish, upload, or deploy. Just work through it to the end in


### PR DESCRIPTION
## Summary
- the llm-judge eval task prompt now tells the agent to save `eval-results.json` in the project root, next to `pyproject.toml`

## Why

the checker looks for `eval-results.json` at the project root, but the prompt did not say where to put it, so agents would run the eval from a subdir and write a cwd-relative path that landed one level up. the task then failed on a missing results file even though the eval ran fine.