### PR TITLE
docs(uipath-ixp): drop --confirm-data-loss from CLI reference

### DIFF
--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -2,7 +2,7 @@
 
 All commands use `uip ixp` prefix. Always append `--output json` when parsing output programmatically.
 
-> **Destructive commands require `-y, --yes`.** Every irreversible `uip ixp` command (all `delete`s and `fields change-type`) gates on `-y/--yes`; the CLI never prompts. `--confirm-data-loss` is accepted but is a **deprecated no-op** — it does NOT satisfy the confirmation, so always pass `-y/--yes`.
+> **Destructive commands require `-y, --yes`.** Every irreversible `uip ixp` command (all `delete`s and `fields change-type`) gates on `-y/--yes`; the CLI never prompts. Always pass `-y/--yes`.
 
 ## Projects
 


### PR DESCRIPTION
## What

Removes the only reference to the `--confirm-data-loss` flag in the `uipath-ixp` skill.

`--confirm-data-loss` is being removed from `ixp-tool`. The skill's CLI reference (`skills/uipath-ixp/references/cli-reference.md`) described it as an accepted-but-deprecated no-op alongside the required `-y/--yes` flag. That note is now removed so the destructive-command guidance references only `-y/--yes`.

## Scope

- One tracked file changed: `skills/uipath-ixp/references/cli-reference.md`.
- All destructive-command examples in the reference already pass only `-y`/`--yes` — no command lines needed changing.
- A repo-wide grep for `confirm-data-loss` / `confirmDataLoss` / `confirm_data_loss` found no other tracked references (remaining matches are untracked `runs/` test-output artifacts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ajc5iruisuF7ovBB1e14E4