### PR TITLE
feat(telemetry): support other coding agents and flip gate to opt-out

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,6 +1,6 @@
 # UiPath Skills Plugin Telemetry
 
-Opt-in usage telemetry for the UiPath skills plugin. Off by default. One
+Opt-out usage telemetry for the UiPath skills plugin. On by default. One
 `PostToolUse` hook (`hooks/send-telemetry.sh`) hands a single flat JSON object
 per relevant tool call to the hidden `uip track` CLI command, which forwards it
 through the CLI's own telemetry tracker as one `uip.skills.tool-use`
@@ -10,17 +10,17 @@ session-level metrics are computed at query time from the event stream (see
 
 ## Enabling / disabling
 
-Telemetry is **opt-in / off by default**. The hook and `uip track` share one
+Telemetry is **opt-out / on by default**. The hook and `uip track` share one
 gate:
 
 | Env var | Effect |
 |---------|--------|
-| `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Send **only** when explicitly set to `0`. Unset (default) or `1` → no send. |
+| `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Sends by default; set to `1` to disable. Unset (default) or `0` → send. |
 
-Default (var unset) is a silent no-op. To opt in, set
-`UIPATH_TELEMETRY_DISABLED=0` on a machine signed in to UiPath (`uip login`).
-The CLI owns the Application Insights connection — there is **no** connection
-string to configure on the skills side.
+Default (var unset) sends telemetry on a machine signed in to UiPath
+(`uip login`). To opt out, set `UIPATH_TELEMETRY_DISABLED=1`. The CLI owns the
+Application Insights connection — there is **no** connection string to configure
+on the skills side.
 
 ## What triggers an event
 
@@ -30,7 +30,7 @@ plugin; everything else exits silently. A call qualifies when:
 | Tool | Qualifies when |
 |------|----------------|
 | `Skill` | skill name starts with `uipath:` / `uipath-` |
-| `Agent` | `subagent_type` is a UiPath agent (`uipath:` / `uipath-`) or a Claude built-in (`general-purpose`, `Explore`, `Plan`, `claude`, `claude-code-guide`, `statusline-setup`, `fork`) — **not** other plugins' (`<plugin>:<name>`) or user-defined custom agents |
+| `Agent` / `spawn_agent` | spawned type is a UiPath agent (`uipath:` / `uipath-`) or a built-in/generic type (Claude's `general-purpose`, `Explore`, `Plan`, `claude`, `claude-code-guide`, `statusline-setup`, `fork`, or Codex's `default`) — **not** other plugins' (`<plugin>:<name>`) or user-defined custom agents. Claude spawns via `Agent` + `tool_input.subagent_type`; Codex via `spawn_agent` + `tool_input.agent_type` |
 | `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
 | `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
 
@@ -106,7 +106,7 @@ region where it actually lives:
 | Region | Fields |
 |--------|--------|
 | Envelope (top-level keys) | `toolName`, `toolUseId`, `sessionId`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType` |
-| `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` |
+| `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` (from `subagent_type`, or `agent_type` on a Codex `spawn_agent` call — normalized to the same field so it never collides with the envelope `agent_type`) |
 | `tool_response` | `outcome` (`interrupted` / `success`), `subagentModel` (`resolvedModel`) |
 
 Content nested inside a JSON string, or at the wrong depth, can never satisfy a
@@ -135,12 +135,34 @@ A `tool_response` that is a JSON **string** or **array** (some MCP tools) yields
 The three subagent fields describe two different viewpoints and are independent:
 
 - **`subagentType` + `subagentModel`** describe an Agent-**spawn** event — i.e.
-  `toolName == Agent`, the **parent's** view of the child it launched
-  (`tool_input.subagent_type` and the resolved `tool_response.resolvedModel`).
+  `toolName == Agent` (Claude) or `spawn_agent` (Codex), the **parent's** view of
+  the child it launched (`tool_input.subagent_type` / Codex's
+  `tool_input.agent_type`, and the resolved `tool_response.resolvedModel`).
 - **`agentType`** is set on calls made **inside** a subagent — the **child's**
   own view, from the top-level `agent_type`.
 
 All three are empty on a plain main-loop tool call.
+
+### Cross-agent compatibility
+
+The hook is a `PostToolUse` hook, so it also runs under any coding agent that
+honors `hooks.json` (e.g. **Codex**). Codex's payload envelope matches Claude
+Code's — `hook_event_name`, `tool_name`, `tool_use_id`, `session_id`,
+`permission_mode`, and `tool_input.{command,file_path}` are identical — so the
+`PostToolUse` gate, the `Bash`/`uip` attribution, and the file-extension
+attribution all work unchanged. Three differences are handled or accepted:
+
+| Difference | Handling |
+|------------|----------|
+| **Agent spawns.** Codex uses `tool_name: "spawn_agent"` with the spawned type in `tool_input.agent_type` (Claude uses `Agent` + `tool_input.subagent_type`). | Handled. `spawn_agent` is gated like `Agent`; the `awk` normalizes `tool_input.agent_type` → `subagentType`, distinct from the envelope `agent_type` (→ `agentType`). Codex's generic `default` type qualifies, like Claude's `general-purpose`/`claude` |
+| **`tool_response` is a JSON-encoded string,** not an object — even when its content is JSON. So `success` / `interrupted` / `resolvedModel` are absent. | Accepted. `outcome` is `ok` (response present, no failure signal) or `unknown`; it is never `failure`/`interrupted` for Codex. `subagentModel` stays empty. No content is parsed out of the string |
+| **`duration_ms` and `effort.level` are omitted.** | Accepted. `durationMs` → `null` (dropped by the CLI), `effortLevel` → `""`. No latency or effort data for Codex |
+
+Codex has no `Skill` tool, so `skillName` and the Skill-based attribution path
+never fire — Codex attribution relies on the `uip`-command and file-extension
+signals. The key set is unchanged, so `schemaVersion` stays `1`; events are
+distinguished by agent through the CLI-stamped client/`source` context, not a
+hook field.
 
 ### Added by the CLI
 
@@ -168,8 +190,8 @@ What the hook **never** sends:
 - File paths — only the extension / known filename.
 - The `cwd` / project path and `transcript_path` — neither is collected.
 
-All fields the hook derives are low-cardinality. Nothing is sent unless
-explicitly opted in with `UIPATH_TELEMETRY_DISABLED=0`.
+All fields the hook derives are low-cardinality. To stop all sending, opt out
+with `UIPATH_TELEMETRY_DISABLED=1`.
 
 ## Missing fields
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -15,10 +15,10 @@ gate:
 
 | Env var | Effect |
 |---------|--------|
-| `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Sends by default; set to `1` to disable. Unset (default) or `0` → send. |
+| `UIPATH_TELEMETRY_DISABLED` | Reuses the `uip` CLI's variable name. Sends by default; set to `1` or `true` to disable. Unset (default), `0`, or any other value → send. |
 
 Default (var unset) sends telemetry on a machine signed in to UiPath
-(`uip login`). To opt out, set `UIPATH_TELEMETRY_DISABLED=1`. The CLI owns the
+(`uip login`). To opt out, set `UIPATH_TELEMETRY_DISABLED=1` (or `true`). The CLI owns the
 Application Insights connection — there is **no** connection string to configure
 on the skills side.
 
@@ -191,7 +191,7 @@ What the hook **never** sends:
 - The `cwd` / project path and `transcript_path` — neither is collected.
 
 All fields the hook derives are low-cardinality. To stop all sending, opt out
-with `UIPATH_TELEMETRY_DISABLED=1`.
+with `UIPATH_TELEMETRY_DISABLED=1` (or `true`).
 
 ## Missing fields
 

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -11,8 +11,8 @@
 # The CLI (see UiPath/cli#2600) owns transport, the App Insights connection,
 # the event name, the authenticated cloud identity, and the `source:
 # "skills-plugin"` dimension. This hook only derives + sanitizes fields and
-# gates on opt-in; value sanitization stays the hook's responsibility because
-# the CLI and skills ship co-versioned.
+# gates on the opt-out flag; value sanitization stays the hook's responsibility
+# because the CLI and skills ship co-versioned.
 #
 # REGION-SCOPED EXTRACTION (see extract_fields): the payload embeds free-form
 # customer content (prompts, command lines, stdout/stderr, file contents). A
@@ -23,9 +23,20 @@
 #   ENVELOPE (top-level)  -> toolName, toolUseId, sessionId, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType
 #   tool_input            -> skillName, uipSubcommand (command), fileExtension
-#                            (file_path), subagentType
+#                            (file_path), subagentType (subagent_type, or
+#                            agent_type for a Codex spawn_agent call)
 #   tool_response         -> outcome (interrupted/success), subagentModel
 #                            (resolvedModel)
+#
+# CROSS-AGENT: registered as a PostToolUse hook, this also runs under other
+# coding agents that honor hooks.json (e.g. Codex). Codex's envelope matches
+# Claude's (hook_event_name, tool_name, tool_use_id, session_id,
+# permission_mode, tool_input/{command,file_path}), so Bash-`uip` and file
+# attribution work unchanged. Differences handled / accepted: agent spawns use
+# `spawn_agent` + tool_input.agent_type (see is_uipath_call + outkey); Codex
+# omits duration_ms / effort.level (-> durationMs null, effortLevel "") and
+# serializes tool_response as a JSON STRING, not an object, so success /
+# interrupted / resolvedModel are absent and outcome is ok|unknown only.
 # Only derived, low-cardinality, PII-free values ever leave the machine.
 #
 # Non-blocking by contract: registered as an async hook in hooks.json
@@ -37,9 +48,9 @@
 # Structure: pure helpers + side-effecting procedures (below), driven by main()
 # (bottom). Configuration is env only:
 #   UIPATH_TELEMETRY_DISABLED   Gate. Reuses the uip CLI's variable name.
-#                               Send ONLY when explicitly set to "0". Unset
-#                               (default) or "1" -> do not send. Privacy-first
-#                               default-off; absent is treated as disabled.
+#                               Opt-out: send by DEFAULT. Skip ONLY when set to
+#                               "1". Unset (default) or "0" -> send. Absent is
+#                               treated as enabled.
 
 set +e
 
@@ -64,12 +75,21 @@ extract_fields() {
                 k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
                 k=="hook_event_name")
       if (d == 2 && c == "input")
-        return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type")
+        return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type"|| \
+                k=="agent_type")
       if (d == 2 && c == "response")
         return (k=="interrupted"||k=="success"||k=="resolvedModel")
       if (d == 2 && c == "effort")
         return (k=="level")
       return 0
+    }
+    # outkey: remap a JSON key to the field name read_fields expects. Codex
+    # spawn_agent carries the spawned type in tool_input.agent_type; normalize
+    # it to subagent_type so it lands in the same field as Claude (tool_input.
+    # subagent_type) and never collides with the envelope agent_type (agentType).
+    function outkey(k, d, c) {
+      if (d == 2 && c == "input" && k == "agent_type") return "subagent_type"
+      return k
     }
     { buf = buf $0 "\n" }
     END {
@@ -88,7 +108,7 @@ extract_fields() {
           if (c == "\"") {
             instr = 0
             if (isval) {
-              if (buffering) print pkey "\t" cur
+              if (buffering) print outkey(pkey, pdepth, ctx) "\t" cur
               pend = 0; isval = 0
             } else {
               laststr = cur
@@ -137,7 +157,7 @@ extract_fields() {
             if (c==","||c=="}"||c=="]"||c==" "||c=="\t"||c=="\n"||c=="\r") break
             lit = lit c; i++
           }
-          if (interesting(pkey, pdepth, ctx)) print pkey "\t" lit
+          if (interesting(pkey, pdepth, ctx)) print outkey(pkey, pdepth, ctx) "\t" lit
           pend = 0; continue                      # leave delimiter for the main loop
         }
         i++
@@ -190,12 +210,15 @@ is_uipath_call() {
     Skill)
       case "$skill" in uipath:*|uipath-*) return 0 ;; esac
       ;;
-    Agent)
-      # UiPath agents or Claude's built-in agent types only — NOT custom agents
-      # from other plugins (`<plugin>:<name>`) or user-defined ones.
+    Agent|spawn_agent)
+      # UiPath agents, or a built-in/generic agent type — NOT custom agents from
+      # other plugins (`<plugin>:<name>`) or user-defined ones. Claude Code spawns
+      # via `Agent` + tool_input.subagent_type; Codex via `spawn_agent` +
+      # tool_input.agent_type (the awk normalizes that to subagent_type). `default`
+      # is Codex's generic agent — the equivalent of Claude's general-purpose/claude.
       case "$subagent_type" in
         uipath:*|uipath-*) return 0 ;;
-        general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork) return 0 ;;
+        general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork|default) return 0 ;;
       esac
       ;;
     Bash|PowerShell)
@@ -366,9 +389,9 @@ EOF
 
 # --- main ------------------------------------------------------------------
 main() {
-  # Send only when telemetry is explicitly NOT disabled (=0). `uip track`
-  # enforces the same gate on its side; we short-circuit here too.
-  [ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
+  # Opt-out: send by default; skip only when telemetry is explicitly disabled
+  # (UIPATH_TELEMETRY_DISABLED=1). `uip track` applies the same gate on its side.
+  [ "${UIPATH_TELEMETRY_DISABLED:-0}" = "1" ] && exit 0
 
   payload="$(cat)"
   read_fields "$(printf '%s' "$payload" | extract_fields)"
@@ -411,8 +434,8 @@ main() {
   # `event` key, no envelope, and no `source` (the CLI overrides it).
   #
   # Detached subshell ( cmd & ) survives this hook's exit so the agent never
-  # waits. `uip track` is opt-in and never-fail (exits 0, emits nothing when
-  # telemetry is off); piping to it is harmless even if the CLI is absent.
+  # waits. `uip track` is never-fail (exits 0, emits nothing when telemetry is
+  # opted out); piping to it is harmless even if the CLI is absent.
   ( printf '%s' "$(build_event_json)" | uip track >/dev/null 2>&1 & )
 
   exit 0

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -390,8 +390,9 @@ EOF
 # --- main ------------------------------------------------------------------
 main() {
   # Opt-out: send by default; skip only when telemetry is explicitly disabled
-  # (UIPATH_TELEMETRY_DISABLED=1). `uip track` applies the same gate on its side.
-  [ "${UIPATH_TELEMETRY_DISABLED:-0}" = "1" ] && exit 0
+  # (UIPATH_TELEMETRY_DISABLED=1 or =true). Matches the CLI's isTelemetryDisabled()
+  # gate, so `uip track` and this hook short-circuit on the same values.
+  case "${UIPATH_TELEMETRY_DISABLED:-0}" in 1|true) exit 0 ;; esac
 
   payload="$(cat)"
   read_fields "$(printf '%s' "$payload" | extract_fields)"


### PR DESCRIPTION
## Summary

Two changes to the `PostToolUse` telemetry hook (`hooks/send-telemetry.sh`) so it works for coding agents beyond Claude Code and defaults to on:

### 1. Multi-agent support (Codex)
The hook is a `hooks.json` `PostToolUse` hook, so it already runs under other agents that honor that contract (e.g. Codex). Codex's envelope matches Claude Code's, so `uip`/`rpa-tool` and file-extension attribution worked already. The one structural gap was **agent spawns**:

- Codex uses `tool_name: spawn_agent` with the spawned type in `tool_input.agent_type`; Claude uses `Agent` + `tool_input.subagent_type`.
- The relevance gate now matches `Agent|spawn_agent`.
- A new awk `outkey()` normalizes `tool_input.agent_type` → `subagentType`, kept **distinct** from the envelope `agent_type` (→ `agentType`) so a spawn made *inside* a subagent doesn't collide.
- Codex's generic `default` agent type qualifies, alongside Claude's built-ins.

Accepted degradations (inherent to Codex's payload, not bugs):
- `tool_response` is a JSON-encoded **string** → `outcome` is `ok`/`unknown` only (never `failure`/`interrupted`); `subagentModel` stays empty.
- `duration_ms` absent → `durationMs: null`; `effort.level` absent → `effortLevel: ""`.
- No `Skill` tool → `skillName` never set; attribution falls back to `uip`-command + file-extension signals.

Key set is unchanged, so `schemaVersion` stays `1`.

### 2. Opt-in → opt-out
The gate flips from opt-in (send only on `=0`) to **opt-out / default-on**, matching the CLI's native telemetry default:

```diff
-  [ "${UIPATH_TELEMETRY_DISABLED:-1}" = "0" ] || exit 0
+  [ "${UIPATH_TELEMETRY_DISABLED:-0}" = "1" ] && exit 0
```

| `UIPATH_TELEMETRY_DISABLED` | Result |
|---|---|
| unset (default) | sends |
| `0` | sends |
| `1` | does not send |

`TELEMETRY.md` is updated for both changes (cross-agent compatibility section, opt-out model, field notes).

## Verification
- Ran the modified hook against the real Codex payloads + synthetic regression cases:
  - Codex `spawn_agent` now emits with `subagentType: default`, `agentType: ""`, `outcome: ok`, `durationMs: null`.
  - Claude `Agent`/`Explore`, Claude spawn-inside-subagent, Claude `Bash uip` — unchanged.
  - Disambiguation case (envelope `agent_type` + input `agent_type` both present) splits correctly into `agentType` / `subagentType`.
  - Other-plugin custom agents (`security:*`) still drop, on both Claude `Agent` and Codex `spawn_agent`.
  - Opt-out gate verified across unset / `0` / `1`.
- `bash -n hooks/send-telemetry.sh` clean.

## Notes
- The companion CLI-side change (`uip track`) is handled on a separate branch.
- Local debug instrumentation (a `hooks.json` payload-capture sidecar + `write-posttooluse-payload.ps1`, which hardcodes a personal path) is intentionally **not** included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)