### PR TITLE
fix(uipath-agents): treat conversational scaffold model as must-override, not solid default

### DIFF
--- a/skills/uipath-agents/references/lowcode/model-selection-guide.md
+++ b/skills/uipath-agents/references/lowcode/model-selection-guide.md
@@ -4,7 +4,7 @@ How to pick the LLM for a low-code agent's `settings.model`. The tenant is the s
 
 > `uip agent init` for an autonomous agent scaffolds `settings.model: "gpt-5.4"` with a 128000 output cap. **Always override it** with a discovered current model before validating.
 
-> `uip agent init --conversational` for a conversational agent scaffolds `settings.model: "anthropic.claude-sonnet-4-5-20250929-v1:0"` with a 64000 output cap. It serves as a solid default but can be overwritten with a discovered current model before validating. 
+> `uip agent init --conversational` for a conversational agent scaffolds `settings.model: "anthropic.claude-sonnet-4-5-20250929-v1:0"` with a 64000 output cap. **Always override it** with a discovered current model before validating — do not use the scaffold ID as-is. It is a versioned vendor string specific to one tenant snapshot; it may not exist on other tenants and will fail governance policy if shortened or abbreviated (`anthropic.claude-sonnet-4-5` is not a valid ID).
 
 ## 1. Discover (primary path)
 


### PR DESCRIPTION
## Summary

- The conversational scaffold note in `model-selection-guide.md` said the model ID "serves as a solid default" — permissive language that allowed sub-agents to skip `uip agent model list` discovery
- A sub-agent building an inline agent read the versioned scaffold ID (`anthropic.claude-sonnet-4-5-20250929-v1:0`) and inferred the short form `anthropic.claude-sonnet-4-5` was valid — this ID is rejected by governance policy on tenants that don't list it
- Fix matches the autonomous agent note: **"Always override it"**, and adds an explicit warning that the scaffold ID is a versioned vendor string that must never be shortened or used as-is

## Root cause

`anthropic.claude-sonnet-4-5-20250929-v1:0` (scaffold default) → LLM truncates suffix → `anthropic.claude-sonnet-4-5` (not a valid tenant model ID) → governance policy error at runtime.

## Test plan

- [ ] Read `model-selection-guide.md` — both scaffold notes now say "Always override it" with consistent language
- [ ] Confirm no valid model ID is shortened or removed from the doc

🤖 Generated with [Claude Code](https://claude.com/claude-code)