### PR TITLE
Update test prompt

### DIFF
--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -34,7 +34,8 @@ initial_prompt: |
   Important:
   - The `uip` CLI is already available in the environment and is
     authenticated against the sandbox tenant in this CI step.
-  - Do not run `uip rpa-legacy debug` — just attempt validation, and omit optional runtime logging-exclusion settings.
+  - Do not run `uip rpa-legacy debug` — just attempt validation.
+  - Omit optional runtime logging-exclusion settings.
   - Use `--output json` on the uip CLI commands you run.
 
 success_criteria:

--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -34,7 +34,7 @@ initial_prompt: |
   Important:
   - The `uip` CLI is already available in the environment and is
     authenticated against the sandbox tenant in this CI step.
-  - Do not run `uip rpa-legacy debug` — just attempt validation.
+  - Do not run `uip rpa-legacy debug` — just attempt validation, and omit optional runtime logging-exclusion settings.
   - Use `--output json` on the uip CLI commands you run.
 
 success_criteria:


### PR DESCRIPTION
The rule regarding password from the generated `project.json` (`"excludedLoggedData": ["Private:*", "*password*"],`) might sometimes trigger Anthropic's content filtering policy, even though the generated line is harmless.