### PR TITLE
feat(uipath-maestro-case): refresh entry-points.json input/output from In/Out vars

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -79,10 +79,11 @@ Read [references/implementation.md](references/implementation.md) + [references/
 1. Solution + project + root case (Step 6)
 2. Triggers — manual / timer / event, including placeholder event triggers per Rule 8 (Step 6.1)
 3. Global variables + arguments (Step 6.2) — including In arguments whose `elementId` references the `TriggerId` (captured in Step 6.1) of the trigger named by the row's `sourceTriggers`, or the primary trigger when blank
-4. Stages (Step 7)
-5. Tasks — shape only (Step 9): non-connector with full `data.inputs[]` schema + empty values; connector with `typeId` + `connectionId` only (no `case spec`); unresolved as placeholders per Rule 8
-6. Informational validate (Step 9.5.1) — do NOT halt on errors/warnings
-7. **HARD STOP** (Step 9.5.2–9.5.5): `Publish for review` / `Skip publish and continue` / `Abort`. On `Publish`: `uip solution resources refresh --solution-folder <SolutionDir> --output json` then `uip solution upload`, print DesignerUrl, AskUserQuestion: `Continue to phase 3` / `Abort`. On `Abort`: dump `build-issues.md`, exit (no cleanup).
+4. Refresh entry-points.json input/output from the declared In/Out args (Step 6.3) — per [`references/entry-points-sync.md`](references/entry-points-sync.md)
+5. Stages (Step 7)
+6. Tasks — shape only (Step 9): non-connector with full `data.inputs[]` schema + empty values; connector with `typeId` + `connectionId` only (no `case spec`); unresolved as placeholders per Rule 8
+7. Informational validate (Step 9.5.1) — do NOT halt on errors/warnings
+8. **HARD STOP** (Step 9.5.2–9.5.5): `Publish for review` / `Skip publish and continue` / `Abort`. On `Publish`: `uip solution resources refresh --solution-folder <SolutionDir> --output json` then `uip solution upload`, print DesignerUrl, AskUserQuestion: `Continue to phase 3` / `Abort`. On `Abort`: dump `build-issues.md`, exit (no cleanup).
 
 ### Phase 3 — Implementation
 
@@ -127,6 +128,7 @@ Completion report + **HARD STOP** AskUserQuestion (Step 13): `Run debug session`
 | Construct `case spec --input-details` JSON | [references/case-spec-input-details.md](references/case-spec-input-details.md) |
 | Placeholder tasks for unresolved resources | [references/placeholder-tasks.md](references/placeholder-tasks.md) |
 | Sync bindings_v2.json + connection resources | [references/bindings-v2-sync.md](references/bindings-v2-sync.md) |
+| Refresh entry-points.json input/output from In/Out args | [references/entry-points-sync.md](references/entry-points-sync.md) |
 
 ### Plugin Index
 

--- a/skills/uipath-maestro-case/references/entry-points-sync.md
+++ b/skills/uipath-maestro-case/references/entry-points-sync.md
@@ -1,0 +1,204 @@
+# entry-points.json Input/Output Refresh
+
+Refresh `entry-points.json` `entryPoints[].input` / `.output` JSON-Schemas from the declared case In/Out arguments. The entry-point `input`/`output` is the case's external-caller contract — the typed arguments another process/case passes in and reads back.
+
+Trigger plugins scaffold ([`plugins/case/impl-json.md`](plugins/case/impl-json.md)) and append ([`plugins/triggers/*/impl-json.md`](plugins/triggers/manual/impl-json.md)) each entry with **empty** `input`/`output` (`{ "type": "object", "properties": {} }`) at Step 6.1 — variables don't exist yet. This step back-fills them once variables are declared. No trigger-plugin change: empty-at-emit is correct.
+
+> **This is a direct port of the Studio Web canvas transformation.** Source: `PO.Frontend/src/utils/PackagingUtil.ts` — `getEntryPoints()`, `getEntryPointJsonSchemaForVariable()`, `getTypeAndFormatForType()`, and the `JOB_ATTACHMENTS_DEFINITION` constant; variable extraction in `src/services/uipath/variables/VariableUtil.ts` (`getVariablesDefinedInRootUiPath`). The FE runs this on every canvas save and (since PR #6062, `always save canvas file on canvas load`) on first load, regenerating `entry-points.json` from the case variables. The skill produces the same file directly.
+
+## When to Run
+
+**Phase 2 Step 6.3** — immediately after Step 6.2 (variable declaration). One run. Both prerequisites complete:
+
+- all `entryPoints[]` entries exist (Step 6.1 triggers),
+- all In/Out formal args exist (Step 6.2 variables Loop B).
+
+In/Out formal args (`variables.inputs[]` / `outputs[]`) are final at 6.2 — Phase 3 never adds or renames them (the uniqueness rule suffixes `var`/`id`, never `name`, and this step keys on `name`). Running at 6.3 keeps the Phase-2 publish-for-review artifact correct.
+
+Re-run on regenerate-from-scratch (Rule 6). Idempotent — full recompute, never append.
+
+**Check 6** (end of Phase 3, [`implementation.md` § Step 12](implementation.md)) re-verifies parity as cheap insurance.
+
+## Source → target
+
+| Entry-point field | Source (`getEntryPoints`) | Scope |
+|---|---|---|
+| `input` | `variables.inputs[]` | only In-args whose `elementId` == THIS entry's trigger id (= `filePath` after `#`) |
+| `output` | `variables.outputs[]` | ALL Out-args → every entry |
+
+NOT projected: `variables.inputOutputs[]` root state and trigger-payload `Variable`s. Only formal In/Out args reach the contract.
+
+**Out-arg field sourcing.** The FE reads `default`/`required`/`body` directly off the in-memory output Variable. On disk those fields are split: `variables.outputs[]` carries only `{id,name,type,var}`; the matching `inputOutputs[]` companion (same `name`, `elementId:"root"`) carries `default`/`required`/`body`. So treat each Out-arg as its `outputs[]` entry **merged with its `inputOutputs[]` companion** (matched by `name`). In-args need no merge — `variables.inputs[]` already carries `default`/`required`/`body`.
+
+## Procedure
+
+1. Read `caseplan.json` (`variables.inputs[]`, `variables.outputs[]`, `variables.inputOutputs[]`) and `entry-points.json`.
+2. For each entry in `entryPoints[]`:
+   - `triggerId` = `filePath` substring after the last `#`.
+   - `entry.input`  = projectSchema(`inputs[]` where `elementId === triggerId`).
+   - `entry.output` = projectSchema(Out-args from all `outputs[]`, each merged with its companion).
+   - Preserve `filePath`, `uniqueId`, `type`, `displayName` verbatim. `displayName` is FE-derived (`getElementLabel`) but the trigger plugin already set it — the refresh does NOT recompute it, only the `input`/`output`. Mint NO `uniqueId` (`uniqueId` == the BPMN start-event `entryPointId` GUID; a pure refresh keeps it).
+   - `isTransactionRoot: true` is emitted by the FE only when `root.data.isTransactionRoot` is set. The case skill does not set it today; if a future entry carries it, preserve it — never strip.
+3. Preserve top-level `$schema`, `$id`. Write the whole file with **4-space indent** (matches the trigger recipe — no whitespace churn).
+
+> **FE entry set ≡ existing `entryPoints[]`.** `getEntryPoints` emits an entry only for a BPMN start event that (a) has an `entryPointId` and (b) is not inside a `bpmn:SubProcess`. In the skill these map 1:1 to the entries the trigger plugin already created (each case trigger is a top-level start event with a minted `uniqueId`/`entryPointId`). So iterating existing `entryPoints[]` is equivalent — the refresh creates none and drops none. (Case triggers are never inside a subprocess, so the SubProcess guard never excludes one.)
+
+Never append `entryPoints[]` entries here — entries are owned by the trigger plugins (Step 6.1).
+
+### projectSchema(vars) → schema object
+
+Mirrors `getEntryPointJsonSchemaForVariable`:
+
+- **Empty set** (`vars.length === 0`) → `{ "type": "object", "properties": {} }`. No `required`, no `definitions`. (This is exactly the scaffold/trigger empty shape — correct when a trigger has no In-args, or a case has no Out-args.)
+- **Non-empty** →
+
+```json
+{ "type": "object", "properties": { /* one per var, source order */ }, "required": [ /* see below */ ], "definitions": { /* only if needed */ } }
+```
+
+Object key order: `type`, `properties`, `required`, then `definitions`.
+
+- **`properties`** — one entry per var, in source-array order, keyed by `var.name` (NOT `id`/`var`). Body per the type rules below.
+- **`required`** — `var.name` for every var with `required === true`, in source order (`variables.filter(v => v.required)`). **No type exclusion** — `jsonSchema`/`file`/etc. all qualify. The FE UI permits marking any start-event **input** required regardless of type (`canMarkRequired = isStartEvent && variableType === "input"`, `InputOutputVariablesAddNewDialog.tsx:148`), and `required` is preserved through every serialization stage for all types (no per-type branch; repo round-trip test `xml-serialization.test.ts:2657`). Confirmed against a re-saved `test_in_out` FE export: `input.required` = `["test_date","test_file","test_json"]` — the `jsonSchema` var `test_json` **is** included. (An earlier export of the same case omitted it only because `entry-points.json` hadn't been regenerated after `test_json` was marked required — the staleness PR #6062 addresses; re-saving produced the correct array.) Include every `.required` var, regardless of type.
+- **`definitions`** — present only when a `file`-typed var, or a `jsonSchema`/`array` body that contained a JobAttachment schema, was projected (the `shouldAddJobAttachmentsDefinition` flag). Value = the constant `JOB_ATTACHMENTS_DEFINITION` block below.
+
+### Per-variable property body
+
+Keyed by `var.name`. Branch on `var.type`:
+
+| `type` | property body | `title` | `default` |
+|---|---|---|---|
+| `string` | `{ "type": "string" }` | yes | yes |
+| `integer` | `{ "type": "integer" }` | yes | yes |
+| `boolean` | `{ "type": "boolean" }` | yes | yes |
+| `float` | `{ "type": "number", "format": "float" }` | yes | yes |
+| `double` | `{ "type": "number", "format": "double" }` | yes | yes |
+| `date` | `{ "type": "string", "format": "date" }` | yes | yes |
+| `datetime` | `{ "type": "string", "format": "date-time" }` | yes | yes |
+| `time` | `{ "type": "string", "format": "time" }` | yes | yes |
+| `file` | `{ "$ref": "#/definitions/job-attachment" }` | no | no |
+| `jsonSchema` | inlined body (see below) | no | no |
+| `array` | `{ "type": "array", "items": <items>, "title": <name> }` (see below) | yes | no |
+
+- **scalar / date / datetime / time / float / double** (the `getTypeAndFormatForType` path) — emit `{ <type>, <format?> }`, then append `"title": <var.name>` (always), then `"default": <var.default>` **only when `var.default` is truthy** (verbatim string — never coerced; `""`/absent → omit). Property body key order: `type`, `format`, `title`, `default`. **Fallback:** any `type` not matched above (i.e. not double/float/date/datetime/time and not file/jsonSchema/array) falls through to bare `{ "type": <rawType> }` — string/integer/boolean today, and any future enum value degrades to `{type}` rather than failing.
+- **`file`** — `{ "$ref": "#/definitions/job-attachment" }` only. Sets the definitions flag. No `title`/`default`.
+- **`jsonSchema`** — `body = var.body ?? var._jsonSchema`. **Fallback:** if `body` is null/absent, or (when a string) fails `JSON.parse`, the property is `{}` (empty object — no schema, no title/default). Otherwise: parse if string, delete its `$schema` key, run `rewriteJobAttachmentRefs`, inline the result. No `title`/`default`.
+- **`array`** — `{ "type":"array", "items": <items>, "title": <var.name> }` (title always; no default). `body = var.body` parsed if string (unparseable → `{}`, so `body?.items` is absent and resolution falls to `subType`). `<items>` =
+  1. `rewriteJobAttachmentRefs(body.items)` if `body?.items` exists,
+  2. else `{ "$ref": "#/definitions/job-attachment" }` if `var.subType` is `file`/`octet-stream` (sets definitions flag),
+  3. else `getTypeAndFormatForType(var.subType)` if `subType` is a primitive,
+  4. else `{}`.
+
+> The current case-variable type enum ([`global-vars/planning.md` § Types](plugins/variables/global-vars/planning.md)) is `string | integer | float | double | boolean | datetime | date | jsonSchema | file` — no `array` or `time`. Those two rows are ported from the FE for fidelity/future-proofing; today array-shaped data arrives as `jsonSchema` with an array body (handled by the jsonSchema branch).
+
+### `rewriteJobAttachmentRefs` (nested JobAttachment rewrite)
+
+Used by the `jsonSchema` and `array` branches to normalize a file embedded inside a schema. Walk the schema node:
+
+- Non-object / null → returned unchanged.
+- A node carrying `"x-uipath-resource-kind": "JobAttachment"` → replaced with `{ "$ref": "#/definitions/job-attachment" }`; sets the definitions flag.
+- A node already equal to `{ "$ref": "#/definitions/job-attachment" }` → kept; sets the flag (counts as a match).
+- Object/array → recurse into children, **except** the `definitions` and `$defs` keys, which are left as-authored (no recursion). If no descendant matched, the original node is returned unchanged (identity preserved).
+
+So a `jsonSchema`/`array` body whose items or properties include a JobAttachment schema gets those occurrences rewritten to `$ref` and triggers the input/output-level `definitions` block — same mechanism as a top-level `file` var.
+
+### `JOB_ATTACHMENTS_DEFINITION` (constant)
+
+Emit verbatim. Note the inner quotes in `MimeType.description` — reproduce exactly (this matches the FE constant; a divergent `description` triggers FE re-save drift):
+
+```json
+{
+    "job-attachment": {
+        "type": "object",
+        "properties": {
+            "ID": { "type": "string", "description": "Orchestrator attachment key" },
+            "FullName": { "type": "string", "description": "File name" },
+            "MimeType": { "type": "string", "description": "The MIME type of the content, such as \"application/json\" or \"image/png" },
+            "Metadata": { "type": "object", "description": "Dictionary<string, string> of metadata", "additionalProperties": { "type": "string" } }
+        },
+        "required": ["ID"],
+        "x-uipath-resource-kind": "JobAttachment"
+    }
+}
+```
+
+Fixed constant — NOT sourced from the file var's `body` (the FE emits it even when the var carries no `body`).
+
+## FE branch coverage (audit)
+
+Every conditional in the FE source (`PackagingUtil.ts`) and where this doc handles it:
+
+| FE function / branch | Handled |
+|---|---|
+| `getEntryPoints`: start event **has** `entryPointId` | → one entry (≡ existing `entryPoints[]`) |
+| `getEntryPoints`: **no** `entryPointId` | → no entry (skill never creates an entry without a minted `uniqueId`) |
+| `getEntryPoints`: start event inside `bpmn:SubProcess` | → skipped (N/A — case triggers are top-level) |
+| `getEntryPoints`: `displayName` truthy / falsy | preserved as-is (not recomputed) |
+| `getEntryPoints`: `isTransactionRoot` set / unset | preserved if present; skill doesn't set it |
+| `getEntryPoints`: input scoped `elementId === startNode.id`; output = all | Source → target |
+| `getEntryPointJsonSchemaForVariable`: empty var set | `{type:object,properties:{}}` — no `required`/`definitions` |
+| …non-empty | `properties` + `required` (+ `definitions` if flagged) |
+| …`required = vars.filter(v=>v.required)` | required rule — no type exclusion |
+| per-var: `jsonSchema` body present | inline (strip `$schema`, rewrite) |
+| per-var: `jsonSchema` body null / unparseable | property `{}` |
+| per-var: `file` | `$ref` + definitions flag |
+| per-var: `array` (4 item fallbacks) | array bullet |
+| per-var: scalar / date / datetime / time / float / double | scalar bullet + type table |
+| per-var: type not matched anywhere | bare `{type:<raw>}` passthrough |
+| `getTypeAndFormatForType`: double/float, date, datetime, time, else | type table |
+| `rewriteJobAttachmentRefs`: non-object, JobAttachment, existing `$ref`, recurse (skip `definitions`/`$defs`), no-match identity | `rewriteJobAttachmentRefs` subsection |
+| `default` emitted iff `variable.default` truthy (verbatim) | scalar bullet |
+| Out-arg `default`/`required`/`body` from companion | Out-arg field sourcing |
+
+## Check 6 — Entry-point schema parity (Step 12 validator)
+
+Non-HALT. For each entry in `entryPoints[]` (`triggerId` = `filePath` after `#`):
+
+1. `input` == projectSchema(`inputs[]` where `elementId == triggerId`); `output` == projectSchema(Out-args). Compare keys, type/format mapping, `$ref` for `file`, inlined body for `jsonSchema`, `title`/`default` presence, the empty-set `{type,properties:{}}` (no `required`) shape, and `definitions` presence.
+2. `required` == names of all vars with `required === true` (no type exclusion).
+3. **Uniqueness guard** — `filePath` `#`-fragments unique across `entryPoints[]`. The trigger append is blind — a re-run duplicates an entry; the refresh propagates schemas to duplicates but cannot dedup (that is trigger-plugin identity).
+4. **Orphan guard** — every `inputs[].elementId` matches some entry's trigger fragment (an orphaned In-arg projects into no entry and silently vanishes from the contract).
+
+On a (1)/(2) mismatch → re-run the Procedure (deterministic recompute), re-check once. On a (3)/(4) finding or still-divergent (1)/(2) → log to `## Open Items for User` in `tasks/build-issues.md`, continue. Never HALT (build-with-best policy, [`implementation.md` § Step 12](implementation.md)).
+
+## Worked example
+
+`variables.inputs[]` (all `elementId: trigger_1`): `test_date` (datetime, default `"2029-10-12"`, `required:true`), `test_arrary` (jsonSchema, body `{"$schema":…,"type":"array","items":{"type":"string"}}`), `test_default` (float, default `"12.0"`), `test_date_time` (datetime, default `""`), `test_file` (file, `required:true`), `test_json` (jsonSchema, body `{"$schema":…,"type":"object","properties":{…},"required":[]}`, `required:true`). `variables.outputs[]`: `test_out` (double); its `inputOutputs[]` companion default `"1.3"`.
+
+Entry `/content/caseplan.json.bpmn#trigger_1`:
+
+```json
+"input": {
+    "type": "object",
+    "properties": {
+        "test_date": { "type": "string", "format": "date-time", "title": "test_date", "default": "2029-10-12" },
+        "test_arrary": { "type": "array", "items": { "type": "string" } },
+        "test_default": { "type": "number", "format": "float", "title": "test_default", "default": "12.0" },
+        "test_date_time": { "type": "string", "format": "date-time", "title": "test_date_time" },
+        "test_file": { "$ref": "#/definitions/job-attachment" },
+        "test_json": { "type": "object", "properties": { "test": { "type": "string" }, "newProperty2": { "type": "boolean" } }, "required": [] }
+    },
+    "required": ["test_date", "test_file", "test_json"],
+    "definitions": { "job-attachment": { "...": "constant block above" } }
+},
+"output": {
+    "type": "object",
+    "properties": {
+        "test_out": { "type": "number", "format": "double", "title": "test_out", "default": "1.3" }
+    },
+    "required": []
+}
+```
+
+Notes: `test_arrary`/`test_json` inline their body minus `$schema` (no `title`/`default`). `test_file` → `$ref`, and triggers the `input`-level `definitions` block. `test_date_time`'s empty default is omitted. `test_json` (jsonSchema, `required:true`) **is** included in `input.required` — confirmed against a re-saved `test_in_out` FE export (`["test_date","test_file","test_json"]`).
+
+## Multi-trigger distribution (confirmed)
+
+A `test_in_out` re-saved with two triggers — `trigger_1` (primary) and `StartEvent_Trigger_OkGfLw` (Trigger 2) — produces **two** entries, confirming the scoping rule from a real FE export:
+
+| entry (`filePath#`) | `input.properties` (scoped by `elementId`) | `output.properties` (all) |
+|---|---|---|
+| `trigger_1` | trigger_1's In-args (`test_date` … `test_intput_t1_bool`) | `test_out`, `test_out_t2` |
+| `StartEvent_Trigger_OkGfLw` | **only `test_t2_in_var`** | `test_out`, `test_out_t2` |
+
+Each entry's `input` carries only the In-args whose `elementId` is that trigger; **every** entry carries **all** Out-args. An In-arg bound to a trigger with no entry — e.g. one still pointing at a `preview-node-id` ghost node (an uncommitted canvas preview that leaked into `caseplan.json`) — matches no entry and is silently dropped from the contract; the `elementId` filter skips it (Check 6's orphan guard catches it).

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -61,10 +61,11 @@ Before Step 6, seed TodoWrite with the section-level items below. Mark each `in_
 1. Scaffold solution + project + root case (Step 6)
 2. Add triggers (Step 6.1)
 3. Declare variables + arguments (Step 6.2)
-4. Add stages (Step 7)
-5. Write task shapes (Step 9)
-6. Regenerate bindings_v2.json (Step 9.4)
-7. Skeleton validate + hard stop (Step 9.5)
+4. Refresh entry-points.json input/output (Step 6.3)
+5. Add stages (Step 7)
+6. Write task shapes (Step 9)
+7. Regenerate bindings_v2.json (Step 9.4)
+8. Skeleton validate + hard stop (Step 9.5)
 
 (No edge step — edges are retired; stage transitions are condition-driven and written in Phase 3 Step 10.)
 
@@ -100,6 +101,10 @@ Each plugin writes one node to `caseplan.json.nodes[]` and appends one entry to 
 ## Step 6.2 — Declare global variables and arguments
 
 For each variable/argument T-entry from `tasks.md §4.2.1`, write entries directly into `caseplan.json` per [`plugins/variables/global-vars/impl-json.md`](plugins/variables/global-vars/impl-json.md). This step populates top-level `variables` (inputs, outputs, inputOutputs) and trigger output mappings. Execute these before adding stages — downstream tasks and conditions reference variables via `=vars.<id>`.
+
+## Step 6.3 — Refresh entry-points.json input/output
+
+After Step 6.2, project the declared In/Out arguments onto every `entry-points.json` entry's `input`/`output` schema per [entry-points-sync.md](entry-points-sync.md). Triggers (Step 6.1) scaffold each entry with empty `input`/`output` because variables don't exist yet; this back-fills them. Prerequisites — all entries (Step 6.1) + all In/Out args (Step 6.2) — are complete here, and In/Out formal args never change in Phase 3, so the file is correct from the Phase-2 publish branch onward. Idempotent — re-run on regenerate. Verified by Step 12 Check 6.
 
 ## Step 7 — Add stages
 
@@ -256,7 +261,7 @@ Runs after bindings (9.8), conditions (10), and SLA (11) — when every task / t
 
 > **Algorithm reference:** the per-check pseudocode + AskUserQuestion prompt templates + skill-response-per-pick details all live in [`plugins/variables/io-binding/impl-json.md § Binding Procedure`](plugins/variables/io-binding/impl-json.md#binding-procedure). This step is the orchestration hook; that doc is the algorithm. When in doubt, follow the impl-json doc.
 
-After all value bindings (Step 9.8), conditions (Step 10), SLA (Step 11), and marker resolution (Step 11.5) are written, invoke the end-of-Phase-3 validator — Checks 1, 2, 3, 4, 5.
+After all value bindings (Step 9.8), conditions (Step 10), SLA (Step 11), and marker resolution (Step 11.5) are written, invoke the end-of-Phase-3 validator — Checks 1, 2, 3, 4, 5, 6.
 
 - **Check 1** — Resolve every `=vars.X` reference against `variables.{inputs, inputOutputs}[].id`. Scan all task input `value` fields, entry/exit condition expressions (stage and task), case-exit and trigger rule expressions, SLA expressions, and `=js:` expressions anywhere they appear. On unresolved → **AskUserQuestion** offering: (a) name the intended variable, (b) remove the reference, (c) continue with best-effort emit (entry logged under Open Items, runtime returns undefined).
 - **Check 2 — Out-arg producer presence** — For every formal Out-arg in `variables.outputs[]`, verify the producer/Default situation per [`io-binding/impl-json.md` § Check 2](plugins/variables/io-binding/impl-json.md):
@@ -266,6 +271,7 @@ After all value bindings (Step 9.8), conditions (Step 10), SLA (Step 11), and ma
 - **Check 3** — Type mismatch between `=vars.X` reference and consumer slot → log WARN inline (non-blocking; string coercion is runtime-tolerant).
 - **Check 4 — No surviving `$xref` markers** — Scan every string value in `caseplan.json` for the literal `$xref(`. Step 11.5 resolves all; any survivor means its name-triple failed (typo'd stage / task / output) — the same class of failure as a Check 1 unresolved `=vars.X`, so it gets the same interactive remediation. On unresolved → **AskUserQuestion** (present the outputs that DO exist on the named task as candidates): (a) name the intended source output — skill rewrites the triple, re-resolves, substitutes `vars.<var>`; (b) edit the SDD expression + re-run the Phase 1 dispatcher (when the output genuinely doesn't exist); (c) continue with best-effort emit (token left unsubstituted, entry logged under Open Items; `vars.$xref(...)` throws at runtime until fixed). Detail: [`io-binding/impl-json.md` § Check 4](plugins/variables/io-binding/impl-json.md).
 - **Check 5 — Resolved-resource I/O completeness** — For each task with a persisted contract in `tasks/registry-resolved.json`, verify every **required** declared input has a bound `value` and every extract output `Field` exists in the resolved output contract. An upstream-output-fed input (`=vars.<var>` / resolved `$xref`) counts as bound with NO §1.5 row. On unbound-required-input or phantom-output-field → **AskUserQuestion**: (a) bind / re-point, (b) `<UNRESOLVED>`+review-item / drop row, (c) continue with best-effort emit (entry logged under Open Items; runtime null until fixed). Tasks with no contract (placeholder / `<UNRESOLVED>`) are skipped. Detail: [`io-binding/impl-json.md` § Check 5](plugins/variables/io-binding/impl-json.md#check-5--resolved-resource-io-completeness).
+- **Check 6 — Entry-point schema parity** — Verify every `entry-points.json` entry's `input`/`output` matches the In/Out args projected at Step 6.3 (keys, type mapping, `required`, `file`/`jsonSchema` shapes), plus unique `filePath` fragments and no orphaned `inputs[].elementId`. **Non-interactive:** on mismatch re-run the Step 6.3 refresh once; if still divergent (or a uniqueness/orphan finding) log to `## Open Items for User` and continue. No AskUserQuestion. Algorithm: [`entry-points-sync.md § Check 6`](entry-points-sync.md#check-6--entry-point-schema-parity-step-12-validator).
 
 **Build-with-best policy:** for any user pick of "continue with best-effort emit" on a Check 1, Check 2, Check 4, or Check 5 AskUserQuestion, append a `## Open Items for User` entry to `tasks/build-issues.md` and proceed to Phase 4. AskUserQuestion is the surface; build-with-best is the escape. The skill conservatively emits what it has; Phase 4 validate stays green (structural validity is intact); runtime concerns are listed for pre-publish review.
 

--- a/skills/uipath-maestro-case/references/phased-execution.md
+++ b/skills/uipath-maestro-case/references/phased-execution.md
@@ -43,6 +43,7 @@ Each hard stop gives user review checkpoint before agent commits to costly downs
 - Stages — all StageIds generated and captured.
 - Edges — none authored; `schema.edges` stays `[]`. Stage transitions are condition-driven (written in Phase 3).
 - Triggers — fully built. Trigger output mappings written (they reference global variables, which already exist).
+- Entry-points input/output — `entry-points.json` `input`/`output` schemas refreshed from the declared In/Out arguments (Step 6.3, per [entry-points-sync.md](entry-points-sync.md)). Makes the Phase-2 publish-for-review contract correct; idempotent.
 
 ### Tasks (shape depends on resolution state + task class)
 
@@ -147,7 +148,7 @@ After re-entry:
    - Case exit conditions
 4. **SLA + escalation** — per [`plugins/sla/impl-json.md`](plugins/sla/impl-json.md). Group `tasks.md §4.8` by target (root or stage); write full `slaRules[]` in one mutation per target.
 5. **In-expression marker resolution** — per [`plugins/variables/io-binding/impl-json.md § In-Expression Marker Resolution`](plugins/variables/io-binding/impl-json.md). After all outputs are minted/deduped and bindings/conditions/SLA are written, resolve every `vars.$xref('Stage','Task','output')` marker in `caseplan.json` to bare `vars.<var>` in one sink-blind whole-file pass (input payloads, conditions, SLA, connector bodies). Unresolved triple → ERROR.
-6. **End-of-Phase-3 validator pass** — per [`implementation.md § Step 12`](implementation.md). Run Checks 1-5 (=vars.X resolution, Q10 II Out-arg producer presence, type mismatch, surviving `$xref` markers, resolved-resource I/O completeness). AskUserQuestion for unresolved references (incl. `$xref` markers), pure orphan Out-args, and unbound required inputs / phantom output fields; option (c)/(d) "continue with best-effort emit" preserves forward progress. Never HALT.
+6. **End-of-Phase-3 validator pass** — per [`implementation.md § Step 12`](implementation.md). Run Checks 1-6 (=vars.X resolution, Out-arg producer presence, type mismatch, surviving `$xref` markers, resolved-resource I/O completeness, entry-point schema parity). AskUserQuestion for unresolved references (incl. `$xref` markers), pure orphan Out-args, and unbound required inputs / phantom output fields; option (c)/(d) "continue with best-effort emit" preserves forward progress. Check 6 is non-interactive (auto re-run, else log). Never HALT.
 
 Phase 3 produces a `caseplan.json` that should pass authoritative validation. No hard stop on Phase 3 exit — agent proceeds directly to Phase 4.
 

--- a/skills/uipath-maestro-case/references/plugins/triggers/manual/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/triggers/manual/impl-json.md
@@ -89,7 +89,7 @@ Read the file, parse, append:
 
 Where `basename(caseplanFile)` is the schema file's base name including extension (typically `caseplan.json`), yielding a `filePath` fragment like `/content/caseplan.json.bpmn#trigger_xY2mNp`.
 
-`input`/`output` stay empty here — no variables exist yet. Step 6.3 back-fills them from the declared In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
+Leave this entry's `input`/`output` schemas (the `entry-points.json` fields above — not the trigger node's I/O) empty here — Step 6.3 back-fills them from the case's In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
 
 Write back with **4-space indent** (`JSON.stringify(obj, null, 4)`).
 

--- a/skills/uipath-maestro-case/references/plugins/triggers/manual/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/triggers/manual/impl-json.md
@@ -89,6 +89,8 @@ Read the file, parse, append:
 
 Where `basename(caseplanFile)` is the schema file's base name including extension (typically `caseplan.json`), yielding a `filePath` fragment like `/content/caseplan.json.bpmn#trigger_xY2mNp`.
 
+`input`/`output` stay empty here — no variables exist yet. Step 6.3 back-fills them from the declared In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
+
 Write back with **4-space indent** (`JSON.stringify(obj, null, 4)`).
 
 ## Write order

--- a/skills/uipath-maestro-case/references/plugins/triggers/timer/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/triggers/timer/impl-json.md
@@ -89,7 +89,7 @@ Locate `entry-points.json` adjacent to `caseplan.json` (same directory). Append 
 - `<caseplan-basename>` — the literal filename of the case file (typically `caseplan.json`), producing a path like `/content/caseplan.json.bpmn#trigger_xxxxxx`.
 - `<UUID v4>` — fresh `crypto.randomUUID()` per write. Non-deterministic; normalizer strips in golden diff.
 - `displayName` matches `node.data.label` (including the `Trigger <N>` default if `displayName` absent).
-- `input`/`output` stay empty here — no variables exist yet. Step 6.3 back-fills them from the declared In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
+- Leave this entry's `input`/`output` schemas (the `entry-points.json` fields above — not the trigger node's I/O) empty here — Step 6.3 back-fills them from the case's In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
 
 **Write order:** `caseplan.json` first, then `entry-points.json`. If the second write fails, the skill surfaces the inconsistency to the user rather than silently half-applying.
 

--- a/skills/uipath-maestro-case/references/plugins/triggers/timer/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/triggers/timer/impl-json.md
@@ -89,6 +89,7 @@ Locate `entry-points.json` adjacent to `caseplan.json` (same directory). Append 
 - `<caseplan-basename>` — the literal filename of the case file (typically `caseplan.json`), producing a path like `/content/caseplan.json.bpmn#trigger_xxxxxx`.
 - `<UUID v4>` — fresh `crypto.randomUUID()` per write. Non-deterministic; normalizer strips in golden diff.
 - `displayName` matches `node.data.label` (including the `Trigger <N>` default if `displayName` absent).
+- `input`/`output` stay empty here — no variables exist yet. Step 6.3 back-fills them from the declared In/Out args ([entry-points-sync.md](../../../entry-points-sync.md)).
 
 **Write order:** `caseplan.json` first, then `entry-points.json`. If the second write fails, the skill surfaces the inconsistency to the user rather than silently half-applying.
 

--- a/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
@@ -15,6 +15,22 @@ import os
 import sys
 
 
+# Canonical JOB_ATTACHMENTS_DEFINITION["job-attachment"] — must be emitted verbatim
+# (PackagingUtil.ts; references/entry-points-sync.md). Note the unbalanced inner quotes in
+# MimeType.description — reproduced exactly, as the FE does.
+EXPECTED_JOB_ATTACHMENT = {
+    "type": "object",
+    "properties": {
+        "ID": {"type": "string", "description": "Orchestrator attachment key"},
+        "FullName": {"type": "string", "description": "File name"},
+        "MimeType": {"type": "string", "description": 'The MIME type of the content, such as "application/json" or "image/png'},
+        "Metadata": {"type": "object", "description": "Dictionary<string, string> of metadata", "additionalProperties": {"type": "string"}},
+    },
+    "required": ["ID"],
+    "x-uipath-resource-kind": "JobAttachment",
+}
+
+
 def fail(msg):
     sys.exit(f"FAIL: {msg}")
 
@@ -84,8 +100,12 @@ def main():
     ja = defs.get("job-attachment")
     if not ja:
         fail("input.definitions.job-attachment is missing for the file-typed In-arg")
-    if ja.get("x-uipath-resource-kind") != "JobAttachment":
-        fail(f"job-attachment definition missing x-uipath-resource-kind, got {ja}")
+    if ja != EXPECTED_JOB_ATTACHMENT:
+        fail(
+            "job-attachment definition is not the verbatim JOB_ATTACHMENTS_DEFINITION constant.\n"
+            f"  expected: {json.dumps(EXPECTED_JOB_ATTACHMENT, sort_keys=True)}\n"
+            f"  got:      {json.dumps(ja, sort_keys=True)}"
+        )
 
     # required must be a present array; no Required column in the SDD -> []
     if not isinstance(inp.get("required"), list):

--- a/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
@@ -91,15 +91,25 @@ def main():
     if not isinstance(inp.get("required"), list):
         fail(f"input.required must be a present array, got {inp.get('required')!r}")
 
-    # Out-arg projected with its companion-sourced default
+    # Out-args projected with companion-sourced defaults — output side exercises the type/format mapping too.
     oprops = out.get("properties") or {}
     dec = oprops.get("decision")
     if not dec or dec.get("type") != "string":
         fail(f"output decision should be {{type:string}}, got {dec}")
     if dec.get("default") != "Pending":
         fail(f"output decision default should be 'Pending' (from the inputOutputs companion), got {dec.get('default')!r}")
+    # double Out -> {number, format:double}
+    fs = oprops.get("finalScore")
+    if not fs or fs.get("type") != "number" or fs.get("format") != "double":
+        fail(f"output finalScore should be {{type:number, format:double}}, got {fs}")
+    if fs.get("default") != "1.5":
+        fail(f"output finalScore default should be '1.5', got {fs.get('default')!r}")
+    # datetime Out -> {string, format:date-time}
+    ca = oprops.get("closedAt")
+    if not ca or ca.get("type") != "string" or ca.get("format") != "date-time":
+        fail(f"output closedAt should be {{type:string, format:date-time}}, got {ca}")
 
-    print(f"PASS: {path} input/output projected from In/Out args (5 props, file $ref + definitions, Out default).")
+    print(f"PASS: {path} input/output projected from In/Out args (input 5 props incl. file $ref + definitions; output string/double/datetime Out-args).")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Assert entry-points.json input/output were back-filled from the case In/Out args (Step 6.3).
+
+Verifies the FE-ported projection (see uipath-maestro-case/references/entry-points-sync.md):
+- input.properties populated (not the empty `{}` bug shape)
+- type/format mapping: string, datetime->date-time, float->number/float
+- file -> {"$ref": "#/definitions/job-attachment"} + an input-level definitions block
+- title == var name; float default emitted verbatim as a string
+- output.properties carries the Out-arg with its companion-sourced default
+- input.required is a present array (no Required column in the SDD -> [])
+"""
+import glob
+import json
+import os
+import sys
+
+
+def fail(msg):
+    sys.exit(f"FAIL: {msg}")
+
+
+def find_entry_points():
+    # Prefer the explicit path; fall back to a recursive search for a populated one.
+    if len(sys.argv) > 1 and os.path.isfile(sys.argv[1]):
+        return sys.argv[1]
+    candidates = sorted(glob.glob("**/entry-points.json", recursive=True))
+    for path in candidates:
+        try:
+            data = json.load(open(path))
+        except (OSError, json.JSONDecodeError):
+            continue
+        eps = data.get("entryPoints") or []
+        if eps and eps[0].get("input", {}).get("properties"):
+            return path
+    if candidates:
+        return candidates[0]
+    fail(f"no entry-points.json found (argv={sys.argv[1:]}, cwd={os.getcwd()})")
+
+
+def main():
+    path = find_entry_points()
+    try:
+        data = json.load(open(path))
+    except (OSError, json.JSONDecodeError) as e:
+        fail(f"could not read {path}: {e}")
+
+    entries = data.get("entryPoints") or []
+    if not entries:
+        fail(f"{path} has no entryPoints (trigger entry never written)")
+    entry = entries[0]
+
+    inp = entry.get("input") or {}
+    out = entry.get("output") or {}
+    props = inp.get("properties") or {}
+
+    # Core fix: input must be populated, not the empty `{type:object,properties:{}}` bug shape.
+    if not props:
+        fail("input.properties is empty — Step 6.3 refresh did not run (this is the pre-fix bug shape)")
+
+    # string In-arg
+    claim = props.get("claimId")
+    if not claim or claim.get("type") != "string":
+        fail(f"claimId should be {{type:string}}, got {claim}")
+    if claim.get("title") != "claimId":
+        fail(f"claimId missing title==name, got {claim}")
+
+    # datetime -> {type:string, format:date-time}
+    sub = props.get("submittedAt")
+    if not sub or sub.get("type") != "string" or sub.get("format") != "date-time":
+        fail(f"submittedAt should be {{type:string, format:date-time}}, got {sub}")
+
+    # float -> {type:number, format:float}; default emitted verbatim as a string
+    risk = props.get("riskScore")
+    if not risk or risk.get("type") != "number" or risk.get("format") != "float":
+        fail(f"riskScore should be {{type:number, format:float}}, got {risk}")
+    if risk.get("default") != "1.5":
+        fail(f"riskScore default should be the verbatim string '1.5', got {risk.get('default')!r}")
+
+    # file -> $ref + input-level definitions/job-attachment
+    ev = props.get("evidenceDoc")
+    if not ev or ev.get("$ref") != "#/definitions/job-attachment":
+        fail(f"evidenceDoc should be {{$ref:#/definitions/job-attachment}}, got {ev}")
+    defs = inp.get("definitions") or {}
+    ja = defs.get("job-attachment")
+    if not ja:
+        fail("input.definitions.job-attachment is missing for the file-typed In-arg")
+    if ja.get("x-uipath-resource-kind") != "JobAttachment":
+        fail(f"job-attachment definition missing x-uipath-resource-kind, got {ja}")
+
+    # required must be a present array; no Required column in the SDD -> []
+    if not isinstance(inp.get("required"), list):
+        fail(f"input.required must be a present array, got {inp.get('required')!r}")
+
+    # Out-arg projected with its companion-sourced default
+    oprops = out.get("properties") or {}
+    dec = oprops.get("decision")
+    if not dec or dec.get("type") != "string":
+        fail(f"output decision should be {{type:string}}, got {dec}")
+    if dec.get("default") != "Pending":
+        fail(f"output decision default should be 'Pending' (from the inputOutputs companion), got {dec.get('default')!r}")
+
+    print(f"PASS: {path} input/output projected from In/Out args (5 props, file $ref + definitions, Out default).")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io_multi_trigger.py
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io_multi_trigger.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Assert the per-trigger In-arg distribution in entry-points.json (Step 6.3 + per-trigger binding).
+
+SDD binds two In-args to different triggers via §1.5 sourceTriggers:
+  claimId  → T02 (manual, primary)   priority → T03 (timer)   decision → Out (default "Resolved")
+
+The FE-ported projection (entry-points-sync.md) scopes input per trigger by elementId and
+projects every Out-arg to every entry. So the two entries must partition the In-args:
+  - one entry (claimId's trigger)  : input.properties == {claimId} only
+  - the other entry (priority's)   : input.properties == {priority} only
+  - BOTH entries                   : output.properties has decision (default "Resolved")
+(Trigger node ids are minted, e.g. `trigger_mNq7kX` — do NOT assume `trigger_1`.)
+
+This FAILS the old "all In → primary trigger" behavior (which would put both In-args on
+trigger_1 and leave the timer's input empty) — so it specifically validates per-trigger binding.
+"""
+import glob
+import json
+import os
+import sys
+
+
+def fail(msg):
+    sys.exit(f"FAIL: {msg}")
+
+
+def find_entry_points():
+    if len(sys.argv) > 1 and os.path.isfile(sys.argv[1]):
+        return sys.argv[1]
+    for path in sorted(glob.glob("**/entry-points.json", recursive=True)):
+        try:
+            data = json.load(open(path))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if len(data.get("entryPoints") or []) >= 2:
+            return path
+    fail(f"no 2-entry entry-points.json found (argv={sys.argv[1:]}, cwd={os.getcwd()})")
+
+
+def in_keys(entry):
+    return set((entry.get("input") or {}).get("properties", {}) or {})
+
+
+def out_props(entry):
+    return (entry.get("output") or {}).get("properties", {}) or {}
+
+
+def main():
+    path = find_entry_points()
+    try:
+        data = json.load(open(path))
+    except (OSError, json.JSONDecodeError) as e:
+        fail(f"could not read {path}: {e}")
+
+    entries = data.get("entryPoints") or []
+    if len(entries) != 2:
+        fail(f"expected 2 entryPoints (manual T02 + timer T03), got {len(entries)} in {path}")
+
+    by_frag = {e.get("filePath", "").split("#")[-1]: e for e in entries}
+
+    # Partition: each In-arg on exactly one entry, the two entries disjoint.
+    keysets = [in_keys(e) for e in entries]
+    union = set().union(*keysets)
+    inter = set.intersection(*keysets)
+    if union != {"claimId", "priority"}:
+        fail(f"input union across entries should be {{claimId, priority}}, got {union}")
+    if inter:
+        fail(f"In-arg(s) on more than one trigger (scoping violation): {inter}")
+    if not all(len(k) == 1 for k in keysets):
+        fail(f"each entry's input should hold exactly ONE In-arg; got keysets {[sorted(k) for k in keysets]}")
+
+    # Identify each entry by the In-arg it scopes — trigger node ids are minted
+    # (e.g. `trigger_mNq7kX`), so do NOT assume the primary is literally `trigger_1`.
+    # The partition above already guarantees one entry == {claimId} and one == {priority}.
+    claim_entry = next(e for e in entries if in_keys(e) == {"claimId"})
+    prio_entry = next(e for e in entries if in_keys(e) == {"priority"})
+
+    # Types / defaults of the scoped In-args.
+    claim = (claim_entry.get("input") or {}).get("properties", {}).get("claimId", {})
+    if claim.get("type") != "string":
+        fail(f"claimId should be {{type:string}}, got {claim}")
+    prio = (prio_entry.get("input") or {}).get("properties", {}).get("priority", {})
+    if prio.get("type") != "string" or prio.get("default") != "Medium":
+        fail(f"priority should be {{type:string, default:'Medium'}}, got {prio}")
+
+    # Output projected to EVERY entry with its companion default.
+    for frag, e in by_frag.items():
+        dec = out_props(e).get("decision")
+        if not dec or dec.get("type") != "string":
+            fail(f"entry '{frag}' output.decision should be {{type:string}}, got {dec}")
+        if dec.get("default") != "Resolved":
+            fail(f"entry '{frag}' output.decision default should be 'Resolved', got {dec.get('default')!r}")
+
+    print(
+        f"PASS: {path} — per-trigger partition confirmed "
+        f"(claimId and priority on separate triggers' entries, no overlap); decision projected to both entries."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io_multi_trigger.py
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/check_entry_points_io_multi_trigger.py
@@ -45,6 +45,28 @@ def out_props(entry):
     return (entry.get("output") or {}).get("properties", {}) or {}
 
 
+def load_sibling_caseplan(ep_path):
+    cp = os.path.join(os.path.dirname(os.path.abspath(ep_path)), "caseplan.json")
+    if not os.path.isfile(cp):
+        hits = glob.glob(os.path.join(os.path.dirname(ep_path) or ".", "**", "caseplan.json"), recursive=True)
+        cp = hits[0] if hits else None
+    if not cp or not os.path.isfile(cp):
+        fail(f"sibling caseplan.json not found next to {ep_path} (needed to verify each entry's trigger type)")
+    try:
+        return json.load(open(cp))
+    except (OSError, json.JSONDecodeError) as e:
+        fail(f"could not read {cp}: {e}")
+
+
+def trigger_service_type(caseplan, node_id):
+    """serviceType of the trigger node — 'Intsvc.TimerTrigger' for a timer, None/other for a manual."""
+    for n in caseplan.get("nodes", []):
+        if n.get("id") == node_id:
+            up = n.get("data", {}).get("uipath")
+            return up.get("serviceType") if isinstance(up, dict) else None
+    fail(f"trigger node {node_id!r} (from an entry-point filePath fragment) not found in caseplan.json")
+
+
 def main():
     path = find_entry_points()
     try:
@@ -75,6 +97,19 @@ def main():
     claim_entry = next(e for e in entries if in_keys(e) == {"claimId"})
     prio_entry = next(e for e in entries if in_keys(e) == {"priority"})
 
+    # Map each entry back to its trigger node in the sibling caseplan.json and assert the binding
+    # DIRECTION — claimId on the MANUAL trigger (T02), priority on the TIMER trigger (T03). The
+    # partition check above passes even if T-resolution swapped the two; this catches that.
+    caseplan = load_sibling_caseplan(path)
+    claim_frag = claim_entry.get("filePath", "").split("#")[-1]
+    prio_frag = prio_entry.get("filePath", "").split("#")[-1]
+    claim_svc = trigger_service_type(caseplan, claim_frag)
+    prio_svc = trigger_service_type(caseplan, prio_frag)
+    if claim_svc == "Intsvc.TimerTrigger":
+        fail(f"claimId is bound to the TIMER trigger ({claim_frag}); expected the manual trigger (T02) — bindings swapped?")
+    if prio_svc != "Intsvc.TimerTrigger":
+        fail(f"priority is bound to a non-timer trigger ({prio_frag}, serviceType={prio_svc!r}); expected the timer trigger (T03, Intsvc.TimerTrigger) — bindings swapped?")
+
     # Types / defaults of the scoped In-args.
     claim = (claim_entry.get("input") or {}).get("properties", {}).get("claimId", {})
     if claim.get("type") != "string":
@@ -92,8 +127,8 @@ def main():
             fail(f"entry '{frag}' output.decision default should be 'Resolved', got {dec.get('default')!r}")
 
     print(
-        f"PASS: {path} — per-trigger partition confirmed "
-        f"(claimId and priority on separate triggers' entries, no overlap); decision projected to both entries."
+        f"PASS: {path} — per-trigger binding verified via caseplan "
+        f"(claimId→manual T02, priority→timer T03, no overlap); decision projected to both entries."
     )
 
 

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
@@ -9,7 +9,7 @@ description: >
   projected into output.properties with companion-sourced defaults, plus
   that input.required is a present empty array. Integration tier — builds +
   validates, no debug run.
-tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:single-node, feature:arguments]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:single-node, feature:trigger]
 
 run_limits:
   expected_turns: 95

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
@@ -10,9 +10,9 @@ description: >
 tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:single-node, feature:arguments]
 
 run_limits:
-  expected_turns: 70
-  task_timeout: 1200
-  max_turns: 90
+  expected_turns: 95
+  task_timeout: 1500
+  max_turns: 130
   turn_timeout: 1200
 
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
@@ -1,0 +1,121 @@
+task_id: skill-case-entry-points-io
+description: >
+  Build a Case Management definition whose manual trigger declares In/Out
+  arguments of several types, and assert the generated entry-points.json
+  has its input/output JSON-Schemas back-filled from those arguments
+  (Step 6.3 refresh). Covers the type->format mapping (string, datetime,
+  float), the file->$ref + job-attachment definitions block, the
+  companion-sourced Out-arg default, and that input.required is a present
+  empty array. Integration tier — builds + validates, no debug run.
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:single-node, feature:arguments]
+
+run_limits:
+  expected_turns: 70
+  task_timeout: 1200
+  max_turns: 90
+  turn_timeout: 1200
+
+initial_prompt: |
+  Build a UiPath Case Management solution named "EntryPointsIOCase" containing
+  a project also named "EntryPointsIOCase" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
+
+  ```
+  # SDD — EntryPointsIOCase
+
+  Minimal single-stage case verifying that entry-points.json input/output is
+  back-filled from the case's In/Out arguments.
+
+  ## Section 1: Case Definition
+
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | EntryPointsIOCase |
+  | Case Description | Minimal case whose manual trigger declares typed In/Out arguments. |
+  | Case Identifier | Prefix: EPIO, Type: constant |
+
+  ### 1.3 Triggers
+  | Trigger Type | Source | Configuration | Initial Variable Mapping |
+  |---|---|---|---|
+  | manual | User-initiated start of the case | - | - |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+  |---|---|---|---|---|---|---|
+  | claimId | In | string | | | | Claimant id supplied by the caller. |
+  | submittedAt | In | datetime | | | | Submission timestamp supplied by the caller. |
+  | riskScore | In | float | | | 1.5 | Pre-seeded risk score. |
+  | evidenceDoc | In | file | | | | Uploaded evidence attachment. |
+  | decision | Out | string | | | Pending | Final decision returned to the caller. |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Intake (`intake`)
+  **Type:** Stage
+  **Description:** Wait briefly, then complete.
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Tasks
+  | # | Task ID | Task Name | Type | Required | Run Only Once | Persona | SLA |
+  |---|---------|-----------|------|----------|---------------|---------|-----|
+  | 1 | `intake.hold` | Hold | wait-for-timer | Yes | No | system | — |
+
+  ##### Task 1.1: Hold (`intake.hold`)
+  **Type:** wait-for-timer
+  **Description:** Wait a fixed short duration before the stage completes.
+
+  | Field | Value |
+  |---|---|
+  | Duration | 1 m |
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build
+  end-to-end in a single pass and finish with `uip maestro case validate`
+  passing on the resulting caseplan.json.
+
+  Before starting, load the uipath-maestro-case skill and follow its workflow.
+
+success_criteria:
+  - type: file_exists
+    description: "entry-points.json was generated for the case project"
+    path: "EntryPointsIOCase/EntryPointsIOCase/entry-points.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate EntryPointsIOCase/EntryPointsIOCase/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "entry-points.json input/output is projected from the In/Out args (Step 6.3)"
+    command: "python3 $TASK_DIR/check_entry_points_io.py EntryPointsIOCase/EntryPointsIOCase/entry-points.json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io.yaml
@@ -3,10 +3,12 @@ description: >
   Build a Case Management definition whose manual trigger declares In/Out
   arguments of several types, and assert the generated entry-points.json
   has its input/output JSON-Schemas back-filled from those arguments
-  (Step 6.3 refresh). Covers the type->format mapping (string, datetime,
-  float), the file->$ref + job-attachment definitions block, the
-  companion-sourced Out-arg default, and that input.required is a present
-  empty array. Integration tier — builds + validates, no debug run.
+  (Step 6.3 refresh). Covers the input type->format mapping (string,
+  datetime, float), the file->$ref + job-attachment definitions block, and
+  — on the OUTPUT side — Out-args of several types (string, double, datetime)
+  projected into output.properties with companion-sourced defaults, plus
+  that input.required is a present empty array. Integration tier — builds +
+  validates, no debug run.
 tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:single-node, feature:arguments]
 
 run_limits:
@@ -52,7 +54,9 @@ initial_prompt: |
   | submittedAt | In | datetime | | | | Submission timestamp supplied by the caller. |
   | riskScore | In | float | | | 1.5 | Pre-seeded risk score. |
   | evidenceDoc | In | file | | | | Uploaded evidence attachment. |
-  | decision | Out | string | | | Pending | Final decision returned to the caller. |
+  | decision | Out | string | | | Pending | Final decision returned to the caller (string Out, default). |
+  | finalScore | Out | double | | | 1.5 | Numeric score returned to the caller (double Out, default — exercises output format mapping). |
+  | closedAt | Out | datetime | | | 2026-03-01T00:00:00Z | Closure timestamp returned (datetime Out, default — exercises output format mapping). |
 
   ## Section 2: Stages & Tasks
 

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io_multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io_multi_trigger.yaml
@@ -1,0 +1,122 @@
+task_id: skill-case-entry-points-io-multi-trigger
+description: >
+  Build a Case Management definition with TWO triggers and In-args bound to
+  DIFFERENT triggers via the §1.5 sourceTriggers column (claimId→T02 manual,
+  priority→T03 timer), then assert the multi-trigger distribution in the
+  generated entry-points.json: each trigger's entry carries ONLY its own
+  In-arg (input scoped by elementId), while every entry carries all Out-args.
+  Exercises the per-trigger In-arg binding (feat/case-in-arg-trigger) feeding
+  the Step 6.3 entry-points refresh. Integration tier — builds + validates,
+  no debug run.
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, feature:arguments, feature:multi-trigger, feature:timer]
+
+run_limits:
+  expected_turns: 95
+  task_timeout: 1500
+  max_turns: 130
+  turn_timeout: 1200
+
+initial_prompt: |
+  Build a UiPath Case Management solution named "MultiTriggerIOCase" containing
+  a project also named "MultiTriggerIOCase" from the sdd.md below. Write the
+  sdd.md to disk first, then build from it.
+
+  ```
+  # SDD — MultiTriggerIOCase
+
+  Two-trigger single-stage case. Two In-args are bound to DIFFERENT triggers
+  via the §1.5 `sourceTriggers` column; entry-points.json must scope each
+  trigger's `input` to only its own In-arg and project the Out-arg to every entry.
+
+  ## Section 1: Case Definition
+
+  ### 1.1 Case Metadata
+  | Property | Value |
+  |---|---|
+  | Case Name | MultiTriggerIOCase |
+  | Case Description | Two triggers (manual T02 + timer T03); In-args bound per-trigger via sourceTriggers. |
+  | Case Identifier | Prefix: MTIO, Type: constant |
+
+  ### 1.3 Triggers
+  | T# | Trigger Type | Source | Configuration |
+  |---|---|---|---|
+  | T02 | manual | User-initiated start of the case | N/A |
+  | T03 | timer | Schedule | timeCycle "R/PT1H" — infinite repeating interval, every 1 hour. |
+
+  ### 1.4 Case Completion Conditions
+  | WHEN | IF | THEN | Marks Case Complete |
+  |---|---|---|---|
+  | required-stages-completed | - | Case marked complete | Yes |
+
+  ### 1.5 Case Variables
+  | Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+  |---|---|---|---|---|---|---|
+  | claimId | In | string | T02 | | | Caller-supplied claim id; bound to the primary manual trigger (T02) via sourceTriggers. |
+  | priority | In | string | T03 | | Medium | Caller-supplied priority; bound to the timer trigger (T03) via sourceTriggers (Default initializes it at fire — timer has no caller). |
+  | decision | Out | string | | | Resolved | Final decision returned to the caller. |
+
+  ## Section 2: Stages & Tasks
+
+  ### Stage 1: Process (`process`)
+  **Type:** Stage
+  **Description:** Wait briefly, then complete (reached via case-entered after either trigger fires).
+  **Required for Case Completion:** Yes
+
+  #### Stage Entry Conditions
+  | WHEN | IF | Interrupting |
+  |---|---|---|
+  | case-entered | - | No |
+
+  #### Stage Completion Conditions
+  | WHEN | IF | Exit Type | Marks Stage Complete |
+  |---|---|---|---|
+  | required-tasks-completed | - | exit-only | Yes |
+
+  #### Tasks
+  | # | Task ID | Task Name | Type | Required | Run Only Once | Persona | SLA |
+  |---|---------|-----------|------|----------|---------------|---------|-----|
+  | 1 | `process.hold` | Hold | wait-for-timer | Yes | No | system | — |
+
+  ##### Task 1.1: Hold (`process.hold`)
+  **Type:** wait-for-timer
+  **Description:** Wait a fixed short duration before the stage completes.
+
+  | Field | Value |
+  |---|---|
+  | Duration | 1 m |
+  ```
+
+  Treat the generated tasks.md plan as pre-approved — do NOT block on the
+  HARD STOP / AskUserQuestion approval step. Do NOT run `uip maestro case
+  debug`. Do NOT ask for approval, confirmation, or feedback. Build
+  end-to-end in a single pass and finish with `uip maestro case validate`
+  passing on the resulting caseplan.json.
+
+  Before starting, load the uipath-maestro-case skill and follow its workflow.
+
+success_criteria:
+  - type: file_exists
+    description: "entry-points.json was generated for the case project"
+    path: "MultiTriggerIOCase/MultiTriggerIOCase/entry-points.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "uip maestro case validate passes on the generated caseplan.json"
+    command: "uip maestro case validate MultiTriggerIOCase/MultiTriggerIOCase/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "entry-points.json scopes each trigger's input to its own In-arg (claimId and priority land on separate triggers' entries, no overlap) and projects the Out-arg to every entry (Step 6.3)"
+    command: "python3 $TASK_DIR/check_entry_points_io_multi_trigger.py MultiTriggerIOCase/MultiTriggerIOCase/entry-points.json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io_multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/entry_points_io/entry_points_io_multi_trigger.yaml
@@ -8,7 +8,7 @@ description: >
   Exercises the per-trigger In-arg binding (feat/case-in-arg-trigger) feeding
   the Step 6.3 entry-points refresh. Integration tier — builds + validates,
   no debug run.
-tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, feature:arguments, feature:multi-trigger, feature:timer]
+tags: [uipath-maestro-case, integration, mode:build, lifecycle:generate, shape:multi-node, feature:trigger]
 
 run_limits:
   expected_turns: 95


### PR DESCRIPTION
## Problem

The case skill's trigger plugins scaffold/append each `entry-points.json` entry with **empty** `input`/`output` (`{"type":"object","properties":{}}`) at Step 6.1 — correct, because variables don't exist yet. But **nothing ever back-filled them**, so a case's external-caller contract never reflected its declared In/Out arguments. Studio Web regenerates `entry-points.json` from the case variables on every canvas save/load (PR #6062), so a published/debugged case looked right in SW but the skill's own artifact didn't.

## Fix

New **Step 6.3** (Phase 2, immediately after variable declaration): project the declared In/Out args onto every entry's `input`/`output`. Idempotent full recompute. Placed at 6.3 because In/Out formal args are final at 6.2 and never change in Phase 3 — so even the Phase-2 publish-for-review artifact is correct. Verified at end of Phase 3 by a non-HALT **Check 6** (parity + uniqueness/orphan guards).

## Ported, not guessed

`references/entry-points-sync.md` is a **direct port of the Studio Web canvas transformation** — `PO.Frontend/src/utils/PackagingUtil.ts` (`getEntryPoints` / `getEntryPointJsonSchemaForVariable` / `getTypeAndFormatForType` / `rewriteJobAttachmentRefs` / `JOB_ATTACHMENTS_DEFINITION`), variable extraction in `services/uipath/variables/VariableUtil.ts`. A full branch-completeness pass over every conditional is captured in the doc's "FE branch coverage" audit table.

Key rules:
- `input` ← `variables.inputs[]` scoped by trigger `elementId`; `output` ← all `variables.outputs[]` (each Out-arg merged with its `inputOutputs[]` companion — the on-disk home of its `default`/`required`/`body`).
- key/`title` = `var.name`; `float/double → number`+format, `date/datetime/time → string`+format, else bare `{type}`; `file → $ref` + `JOB_ATTACHMENTS_DEFINITION`; `jsonSchema →` inlined body minus `$schema` with `rewriteJobAttachmentRefs` (null/unparseable body → `{}`); `array →` `{type:array,items,title}`. `default` emitted when truthy.
- Empty var set → `{type:object,properties:{}}` (no `required`); non-empty → `required = vars.filter(v=>v.required)`, **no type exclusion** (any input type, incl. jsonSchema/file, may be required per `canMarkRequired`); `definitions` added only when a JobAttachment is projected.

Ground-truthed against a Studio-Web export covering every type. The `required` rule was independently verified end-to-end (serializer preserves `required` for all types; repo round-trip test `xml-serialization.test.ts:2657`) — an earlier sample whose export omitted a required `jsonSchema` var was confirmed **stale**, not a real exclusion.

## Files

- **new** `references/entry-points-sync.md` — canonical recipe + Check 6 + audit table
- `references/implementation.md` — Step 6.3 + Phase-2 todo seed + Step 12 Check 6
- `references/phased-execution.md` — Phase 2 list + Checks 1→6
- `SKILL.md` — Reference Navigation row + Phase 2 body step
- `references/plugins/triggers/{manual,timer}/impl-json.md` — forward-pointer notes (empty-at-emit is intentional; 6.3 back-fills)

Trigger plugins otherwise unchanged. Rule 13 already lists `entry-points.json` (no rule change).

## Not included / follow-ups

- No end-to-end build run or coder-eval task yet (docs-only change).
- A separate, real FE export-freshness inconsistency was observed in the test bundle (BPMN marks a var required, `entry-points.json` doesn't) — that's a canvas-team item (the gap PR #6062 targets), not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)