### PR TITLE
test(uipath-maestro-flow): steer lowcode_agent to the existing published agent

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/check_lowcode_agent_flow.py
@@ -13,10 +13,14 @@ from _shared.flow_check import (  # noqa: E402
 
 
 def main():
-    # Coded and low-code agents share the `uipath.core.agent.{guid}` node-type
-    # family on this tenant — distinguished only by registry DisplayName, not
-    # by node-type prefix. The prompt drives the coded-vs-lowcode choice;
-    # this check just verifies an agent node was used.
+    # The prompt names the EXISTING, published "CountLetters" low-code agent.
+    # The skill must discover it in the registry and wire it as a published
+    # agent resource node — `uipath.core.agent.{guid}` (published coded and
+    # low-code agents share this node-type family, distinguished only by
+    # registry DisplayName). Scaffolding a NEW inline agent
+    # (`uipath.agent.autonomous`) is the wrong shape here: it ignores the
+    # existing resource the task targets, so it fails this assert even when it
+    # returns the right count.
     assert_flow_has_node_type(["uipath.core.agent"])
     payload = run_debug(timeout=240)
     # 2 r's in 'arrow'.

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -1,8 +1,13 @@
 task_id: skill-flow-lowcode-agent
 description: >
-  Create a UiPath Flow that uses the CountLetters low-code agent to count the
-  number of r's in 'arrow' and return the answer. Exercises agent resource
-  node discovery and wiring.
+  Create a UiPath Flow that wires in the existing CountLetters low-code agent
+  (published to the tenant) to count the number of r's in 'arrow' and return
+  the answer. The agent already exists, so the skill must DISCOVER it via the
+  registry and wire it as a published agent resource node
+  (uipath.core.agent.{key}) — NOT scaffold a new inline agent
+  (uipath.agent.autonomous). Exercises published agent resource node discovery
+  and wiring. A correct answer from an inline agent does not satisfy the test:
+  the node-type check below requires the published-resource node.
 tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
 
 run_limits:
@@ -11,8 +16,9 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project named "CountLettersLowCode" that uses the
-  CountLetters low-code agent to count the number of r's in 'arrow'
-  and return the answer.
+  existing CountLetters low-code agent to count the number of r's in 'arrow'
+  and return the answer. The agent already exists — discover it and wire it
+  in rather than creating a new one.
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.


### PR DESCRIPTION
## What

The `skill-flow-lowcode-agent` task (`tests/tasks/uipath-maestro-flow/single_node/lowcode_agent`) targets **discovering and wiring an existing published low-code agent** into a flow. The tenant already hosts the `CountLetters LowCode Agent` (folder `Shared/uipath-maestro-flow/CountLetters LowCode`), which surfaces as a `uipath.core.agent.{key}` resource node — see `canary/Canary/Canary.flow`.

## Why it was failing

The prompt ("uses the CountLetters low-code agent") was ambiguous, so the agent scaffolded a **new inline** agent (`uipath.agent.autonomous`) rather than discovering the published one. That fails the node-type check:

```
No node matches type hint 'uipath.core.agent'. Node types seen: ['core.control.end', 'core.trigger.manual', 'uipath.agent.autonomous']
```

Building an inline agent isn't *wrong* — it just isn't the resource-discovery path the test is meant to exercise. The maestro-flow skill itself documents this distinction (`plugins/agent/planning.md`: *"If the user names an existing agent, it is a published agent — not inline."*).

## Change

- **Prompt** — a light steer: *"uses the **existing** CountLetters low-code agent ... discover it and wire it in rather than creating a new one."* No folder path / login hand-holding, so registry discovery is still genuinely exercised.
- **Description** — documents the published-resource intent (`uipath.core.agent.{key}`, not inline `uipath.agent.autonomous`) for maintainers.
- **Check comment** — clarifies that an inline agent is the wrong shape here even when it returns the right count. The assertion itself is unchanged.

## Verification

Re-ran the eval against the live tenant (`coder-eval run ... -e experiments/default.yaml`):

- **2/2 criteria passed, weighted score 1.000** (was 0.375).
- Flow wires the published resource node `uipath.core.agent.0b676e4e-...` (resourceKey `Shared/uipath-maestro-flow/CountLetters LowCode.CountLetters LowCode Agent`) — not an inline `uipath.agent.autonomous`.
- `uip maestro flow validate` passes; debug returns the count `2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)