### PR TITLE
test(uipath-maestro-flow): scope inline-agent graders to named outputs

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -334,6 +334,73 @@ def assert_outputs_contain(
         )
 
 
+def get_last_debug_raw() -> str | None:
+    """Return the raw stdout of the most recent ``run_debug`` call (the full
+    ``uip maestro flow debug`` JSON envelope), or ``None`` if none ran yet.
+    Useful for persisting the execution trace for post-run inspection."""
+    return _LAST_DEBUG_RAW
+
+
+def assert_output_nonempty(payload: dict, name: str) -> Any:
+    """Assert a named output global (e.g. an End-node-mapped ``out`` variable)
+    is present and non-empty, and return its value.
+
+    Looks the variable up by name in the runtime payload's ``variables.globals``
+    dict and ``variables.globalVariables`` array (both casings). "Non-empty"
+    means: present, not ``None``, and — once stringified — not whitespace-only
+    (so ``""``, ``"   "``, ``{}``, ``[]`` all fail)."""
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    globals_dict = _get_ci(variables, "globals", "Globals") or {}
+    value = _get_ci(globals_dict, name)
+    if value is None:
+        for v in _get_ci(variables, "globalVariables", "GlobalVariables") or []:
+            if str(_get_ci(v, "id", "Id", "name", "Name") or "").lower() == name.lower():
+                value = _get_ci(v, "value", "Value")
+                break
+    text = "".join(str(v) for v in _leaves(value) if v is not None).strip()
+    if not text:
+        present = list(globals_dict.keys())
+        _fail_with_capture(
+            f"Output {name!r} is missing or empty; present globals={present}\n"
+            f"value={value!r}"
+        )
+    return value
+
+
+def assert_named_output_contains(
+    payload: dict,
+    name: str,
+    needles: str | Sequence[str],
+    *,
+    require_all: bool = True,
+) -> str:
+    """Assert a NAMED output global is present, non-empty, and contains the
+    needle(s). Returns the stringified value.
+
+    Unlike :func:`assert_outputs_contain` — which flattens the WHOLE payload and
+    so matches trigger-input echoes (e.g. an ``invoiceNumber`` input global makes
+    the invoice string "present" even when the agent never drafted it) — this
+    scopes the match to one declared output global, the value a downstream
+    consumer actually receives. Use it to grade that an agent's drafted text
+    landed in the mapped flow output, not merely that a string appears somewhere
+    in the debug dump.
+    """
+    value = assert_output_nonempty(payload, name)  # fails if missing/empty
+    haystack = _stringify(_leaves(value))
+    if isinstance(needles, str):
+        needles = [needles]
+    present = [n for n in needles if n.lower() in haystack]
+    missing = [n for n in needles if n.lower() not in haystack]
+    ok = len(missing) == 0 if require_all else len(present) > 0
+    if not ok:
+        mode = "all of" if require_all else "any of"
+        _fail_with_capture(
+            f"Output {name!r} missing {mode} {list(needles)}; present={present}; "
+            f"missing={missing}\n{name}={haystack[:1000]}"
+        )
+    return haystack
+
+
 def assert_output_int_in_range(payload: dict, lo: int, hi: int) -> int:
     """Assert at least one integer in [lo, hi] appears in the outputs, and
     return the first match. Extracts integers from output values only, not

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/check_billing_dispute_analyst.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/check_billing_dispute_analyst.py
@@ -8,12 +8,10 @@ handle. Three layers:
      `uipath.agent.resource.context.index.*` node — the agent's context handle
      must be wired to a real index (anti-hardcode).
   2. Behavior: `flow debug` completes.
-  3. Output: the agent returns a real SOP-grounded determination — one that
-     engaged the dispute facts, not a generic refusal. We assert the output
-     references at least one grounded fact / verdict token (contracted rate,
-     billed rate, or a recognized verdict) rather than pinning the exact
-     determination text: the agent under test authors its own determination
-     vocabulary, so a literal-string match would be brittle and unfair.
+  3. Output: the agent returns a non-empty `determination`. We do NOT assert
+     grounding: the dispute facts (290/300/contracted) are in the prompt, so a
+     keyword match proves restatement, not that the SOP index was consulted.
+     Grading the named output keeps the pass honest.
 """
 import os
 import sys
@@ -25,7 +23,8 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
 sys.path.insert(0, _d)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
-    assert_outputs_contain,
+    assert_output_nonempty,
+    get_last_debug_raw,
     run_debug,
 )
 
@@ -41,19 +40,22 @@ def main():
     print("OK: flow wires an inline autonomous agent to a context.index node")
 
     payload = run_debug(inputs=INPUTS, timeout=540)
-    # Beat a bare non-empty check (a soft refusal like "please provide the invoice
-    # number to proceed" is itself a non-empty string and would pass): require the
-    # output to engage the grounded dispute facts. OR over the contracted/billed
-    # rates and a few verdict/domain tokens rather than pinning the exact
-    # determination — the agent under test authors its own determination
-    # vocabulary, so a literal match would be unfair. A generic refusal that never
-    # reasoned over the dispute contains none of these.
-    assert_outputs_contain(
-        payload,
-        ["290", "300", "credit", "valid", "contracted", "discrepancy", "overcharge"],
-        require_all=False,
-    )
-    print("OK: grounded inline agent returned a real SOP-grounded determination")
+    # Persist the full debug trace next to the check so the execution (element
+    # runs, agent outputs, traceId) can be inspected after the run — e.g. to
+    # confirm whether the context index was actually retrieved.
+    raw = get_last_debug_raw()
+    if raw:
+        trace_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "last_debug_trace.json")
+        with open(trace_path, "w") as fh:
+            fh.write(raw)
+        print(f"trace: wrote debug payload to {trace_path}")
+    # Assert the flow produced a non-empty `determination` output. We do NOT
+    # assert grounding here: the dispute facts (290/300/contracted) are present
+    # in the prompt, so any keyword match is satisfiable by restatement and
+    # would not prove the SOP index was actually consulted. Grading the named
+    # output keeps this honest — the agent ran and emitted its determination.
+    assert_output_nonempty(payload, "determination")
+    print("OK: flow completed and the agent returned a non-empty determination")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/BillingResolutionWriter.reference.flow
@@ -38,7 +38,23 @@
         "systemPrompt": "Write a billing dispute resolution email.",
         "userPrompt": "Write the resolution email from the provided dispute facts.",
         "source": "75b07752-c283-4ede-b4e5-f4961d0dca77",
-        "agentInputVariables": [],
+        "agentInputVariables": [
+          {
+            "id": "customerName",
+            "binding": "=$vars.start.output.customerName",
+            "type": "string"
+          },
+          {
+            "id": "invoiceNumber",
+            "binding": "=$vars.start.output.invoiceNumber",
+            "type": "string"
+          },
+          {
+            "id": "creditAmount",
+            "binding": "=$vars.start.output.creditAmount",
+            "type": "number"
+          }
+        ],
         "agentOutputVariables": [
           {
             "id": "subject",

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/check_billing_resolution_writer.py
@@ -5,7 +5,14 @@ Tests a Maestro Flow whose single work node is an inline low-code agent
 (`uipath.agent.autonomous`). Two layers:
   1. Structural: the flow contains an inline autonomous agent node (anti-hardcode
      — a Script node cannot stand in for the agent).
-  2. Behavior: `flow debug` completes and the drafted email cites the invoice.
+  2. Behavior: `flow debug` completes and the drafted email — landed in the
+     mapped `emailBody` output — cites the invoice and the approved credit.
+
+The behavior grade scopes to the `emailBody` output global, NOT the whole debug
+payload. Matching the whole payload is a false pass: the trigger echoes the
+`invoiceNumber` input back into the outputs, so the invoice string is "present"
+even when the agent refuses to draft OR the End node never maps the agent's
+result into `emailBody`. Scoping to `emailBody` catches both.
 """
 import os
 import sys
@@ -17,7 +24,8 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
 sys.path.insert(0, _d)
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
-    assert_outputs_contain,
+    assert_named_output_contains,
+    assert_output_nonempty,
     run_debug,
 )
 
@@ -30,8 +38,12 @@ def main():
     print("OK: flow contains an inline uipath.agent.autonomous node")
 
     payload = run_debug(inputs=INPUTS, timeout=540)
-    assert_outputs_contain(payload, INVOICE)
-    print(f"OK: inline agent drafted a resolution email citing {INVOICE}")
+    # Subject must be mapped + non-empty.
+    assert_output_nonempty(payload, "emailSubject")
+    # Body must be mapped, cite the invoice, and state the approved credit.
+    assert_named_output_contains(payload, "emailBody", INVOICE)
+    assert_named_output_contains(payload, "emailBody", ["1610", "1,610"], require_all=False)
+    print(f"OK: emailBody drafted, cites invoice {INVOICE} and the approved credit")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/reference_agents/75b07752-c283-4ede-b4e5-f4961d0dca77/agent.json
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/reference_agents/75b07752-c283-4ede-b4e5-f4961d0dca77/agent.json
@@ -10,7 +10,20 @@
   },
   "inputSchema": {
     "type": "object",
-    "properties": {}
+    "properties": {
+      "customerName": {
+        "type": "string",
+        "description": "Customer/account name"
+      },
+      "invoiceNumber": {
+        "type": "string",
+        "description": "Disputed invoice number"
+      },
+      "creditAmount": {
+        "type": "number",
+        "description": "Approved credit amount"
+      }
+    }
   },
   "outputSchema": {
     "type": "object",
@@ -45,7 +58,7 @@
     },
     {
       "role": "user",
-      "content": "Customer: {{ $vars.start.output.customerName }}\nInvoice number: {{ $vars.start.output.invoiceNumber }}\nApproved credit amount (USD): {{ $vars.start.output.creditAmount }}\n\nWrite the resolution email now.",
+      "content": "Customer: {{input.customerName}}\nInvoice number: {{input.invoiceNumber}}\nApproved credit amount (USD): {{input.creditAmount}}\n\nWrite the resolution email now.",
       "contentTokens": [
         {
           "type": "simpleText",
@@ -53,7 +66,7 @@
         },
         {
           "type": "variable",
-          "rawString": " $vars.start.output.customerName "
+          "rawString": "input.customerName"
         },
         {
           "type": "simpleText",
@@ -61,7 +74,7 @@
         },
         {
           "type": "variable",
-          "rawString": " $vars.start.output.invoiceNumber "
+          "rawString": "input.invoiceNumber"
         },
         {
           "type": "simpleText",
@@ -69,7 +82,7 @@
         },
         {
           "type": "variable",
-          "rawString": " $vars.start.output.creditAmount "
+          "rawString": "input.creditAmount"
         },
         {
           "type": "simpleText",


### PR DESCRIPTION
## Problem

The `billing_resolution_writer` and `billing_dispute_analyst` graders matched their needle against the **whole** `flow debug` payload (`assert_outputs_contain` / `collect_outputs`). The manual trigger echoes its inputs back into the outputs, so the match is satisfiable by the **input echo** — the grader passes even when:

- the inline agent **refuses** to draft (literal `input.X` passthrough), or
- the End node **never maps** the agent result into the output global (output null).

Both were observed this round: a run drafted a correct email but left `emailBody` null (End-mapping miss) and still scored 1.000. For `dispute_analyst`, the old token list (`290`, `300`, `contracted`, …) is present verbatim in the input `disputeDescription`, so the match proved nothing.

## Fix

Grade the **mapped output globals by name**, not the whole payload.

- `flow_check.py`: add `assert_output_nonempty(payload, name)` and `assert_named_output_contains(payload, name, needles, *, require_all=)` — scope to one declared output global (present, non-empty, needle match). Add `get_last_debug_raw()` to persist the trace.
- `check_billing_resolution_writer.py`: assert `emailSubject` non-empty and `emailBody` cites the invoice + approved credit.
- `check_billing_dispute_analyst.py`: assert the `determination` output (non-empty, named) and persist the debug trace for post-run grounding inspection. Drops the input-echo-satisfiable token match; deliberately does not assert grounding (unprovable at flow-debug level — dispute facts are in the prompt).
- Refresh the `billing_resolution_writer` reference fixtures to the working `binding:`-based input wiring.

## Validation

Verified the new helpers against real `flow debug` payloads:
- A run whose `emailBody` was null (End-mapping miss) now **FAILS** (old grader passed it).
- A correctly-wired run **PASSES** (`emailBody` cites `MCS-2026-04872` + `$1,610`).

Re-ran the affected tasks end-to-end with the tightened graders — `billing_resolution_writer`, `billing_invoice_lookup`, `billing_dispute_analyst` all pass at 1.000 with the scoped checks.

## Scope

Test-grading correctness only. Independent of the skill-docs fix for inline-agent input/output wiring (separate PR).