### PR TITLE
fix(codedagent): Use unix timestamp as pkg version

### DIFF
--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
@@ -21,7 +21,7 @@ initial_prompt: |
   model (e.g. `gpt-4o-mini-2024-07-18`) with `temperature=0` for
   deterministic runs. Scaffold the agent in a `tone-classifier/`
   folder at the working-directory root, then publish it into the
-  personal workspace so it's available as a regular UiPath resource.
+  personal workspace so it's available as a regular UiPath resource (use `1.0.current_unix_timestamp_here` as the version).
 
   Then, in a separate Maestro Flow project called `triage-flow`,
   use that published `tone-classifier` agent as one of the steps.


### PR DESCRIPTION
## Description

- Coder eval tries to publish a coded agent package with version 0.0.0, 0.0.1, etc etc, until it stops receiving `409`. This consumes turns uselessly and may contribute to max turns being hit (e.g see [here](https://coder-evalboard.uipath-dev.com/runs/2026-06-30_04-18-15/skill-agent-coded-in-flow-published))

Tests passed: https://github.com/UiPath/skills/actions/runs/28428923385/job/84238611416?pr=1756