### PR TITLE
fix(uipath-test): customfield-population teardown + defer tm from uipath-platform (TMHUB-32228)

### DIFF
--- a/skills/uipath-platform/SKILL.md
+++ b/skills/uipath-platform/SKILL.md
@@ -258,7 +258,6 @@ The UiPath CLI (`uip`) is a unified command-line tool for interacting with the U
 | **Resource** | `resource` | Assets, queues, queue items, storage buckets, bucket files | Available |
 | **Integration Service** | `is` | Connectors, connections, activities, resources | Available |
 | **Data Fabric** | `df` | Entities, records, files, choice sets (`@uipath/data-fabric-tool`) | Available |
-| **Test Manager** | `tm` | Test projects, test sets, test cases, executions, reports | Available |
 | **Tools** | `tools` | CLI tool extension management | Available |
 | **MCP** | `mcp` | Model Context Protocol server | Available |
 | **Coded Agents** | `codedagent` | Python agent lifecycle (setup, exec) | Available |

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -123,7 +123,6 @@ LLM execution trace observability and feedback annotation. See [traces/traces.md
 |---|---|---|
 | **Integration Service** | `uip is --help` | See [`uipath-integration-service`](integration-service/integration-service.md) |
 | **Traces** | `uip traces spans get <trace-id>` | LLM execution trace observability (`--job-key` to scope) |
-| **Test Manager** | `uip tm --help` | Test projects, sets, cases, executions |
 | **RPA** | `uip rpa --help` | RPA workflow management |
 | **MCP** | `uip mcp serve` | Start Model Context Protocol server |
 | **Coded Agents** | `uip codedagent --help` | Python agent development |

--- a/tests/tasks/uipath-test/customfield_population_integration.yaml
+++ b/tests/tasks/uipath-test/customfield_population_integration.yaml
@@ -11,11 +11,26 @@ description: >
   (create then update), tags HEALTH:11 with Label values, and reads the
   label rows back. Assertions validate the complete command shape with the
   exact field names and the case-sensitive `--object-type TestCase`.
+  The "Eval Reviewer"/"Eval Risk" field definitions are deleted in `pre_run`
+  (clean slate so the `customfield create` step always runs) and again in
+  `post_run` (leaves no state), keeping the task deterministic on the shared
+  HEALTH project across runs.
 tags: [uipath-test, integration, mode:operate, lifecycle:manage, feature:customfield]
 
 run_limits:
   expected_turns: 22
   max_turns: 55
+
+# Delete the field definitions this task creates BEFORE the run so the agent
+# always starts from a clean slate and must re-create them. Without this, a
+# prior passing run leaves the fields behind, the agent (correctly) skips
+# `customfield create`, and the create criterion fails (0/2). `|| true` keeps
+# the run green when the fields are already absent.
+pre_run:
+  - command: |
+      uip tm customfield delete --project-key HEALTH --name "Eval Reviewer" --object-type TestCase --yes --output json || true
+      uip tm customfield delete --project-key HEALTH --name "Eval Risk" --object-type TestCase --yes --output json || true
+    timeout: 60
 
 initial_prompt: |
   I'm working in the HEALTH project in Test Manager. I'd like to add some
@@ -31,6 +46,14 @@ initial_prompt: |
   "qa-team-lead" (create the value entry for that field on the test case),
   and tag it under Eval Risk with "high" and "regression". When that's
   done, show me the Eval Risk tags on it so I can confirm they stuck.
+
+# Safety net: delete the field definitions again after the run so this task
+# never leaves persistent state on the shared HEALTH project.
+post_run:
+  - command: |
+      uip tm customfield delete --project-key HEALTH --name "Eval Reviewer" --object-type TestCase --yes --output json || true
+      uip tm customfield delete --project-key HEALTH --name "Eval Risk" --object-type TestCase --yes --output json || true
+    timeout: 60
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## Jira
[TMHUB-32228](https://uipath.atlassian.net/browse/TMHUB-32228) (epic [CA-5](https://uipath.atlassian.net/browse/CA-5) — Coding Agents for Test - Public Preview)

Two `uipath-test` eval-reliability fixes uncovered while investigating the 14/14 → 13/14 drop (2026-06-26+). Neither is a CLI bug.

---

### 1. customfield-population: fixture-pollution teardown
`skill-test-customfield-population-integration` seeds two custom-field definitions ("Eval Reviewer" Text, "Eval Risk" Label) on the **shared HEALTH project** with **no teardown**. Once the first passing run created them, every later run found them present, (correctly) skipped `uip tm customfield create`, and matched **0/2** on that criterion (weight 2.0) → score ~0.79, FAILURE. Deterministic once polluted — why it flipped green→red and stuck. Confirmed live: the fields persisted in HEALTH (now cleared).

**Fix:** add `pre_run` (delete both definitions before the run → agent always re-creates them) and `post_run` (delete after → no leftover state). Teardown command verified against the live eval tenant; idempotent via `|| true`.

### 2. uipath-platform: stop claiming Test Manager
`uipath-platform`'s CLI-overview table (SKILL.md) and the uip-commands reference listed `tm` / Test Manager as an "Available" capability. Once `uipath-platform` activated for a Test Manager request, it kept driving `uip tm` instead of deferring to `uipath-test` — contributing to the `requirement-list-export` miss (agent skipped uipath-test's login-status-first rule on 06-29).

**Fix:** remove both Test Manager rows. The description keeps the mandated `Test Manager→uipath-test` sibling redirect (the deferral path; frontmatter untouched, so no activation-gate retrigger).

> Note: the deeper activation win — strengthening `uipath-test`'s description (front-load requirements/export/coverage-report) — is intentionally **not** in this PR.

## Test
- customfield YAML validated; teardown verified live (both definitions deleted, idempotent on re-run).
- uipath-platform: only the description redirect references Test Manager now; body capability rows removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TMHUB-32228]: https://uipath.atlassian.net/browse/TMHUB-32228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CA-5]: https://uipath.atlassian.net/browse/CA-5?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ