### PR TITLE
test(uipath-agents): humanize bindings + guardrail prompts, add skill_triggered gates

### DIFF
--- a/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -19,22 +19,20 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  I have a UiPath coded agent project in the current directory. Its
-  `entry-points.json` declares two entrypoints (`main` and `report`),
-  each file makes one SDK resource call, and `bindings.json` is
-  currently empty.
+  I have a uipath coded agent in the current directory. Can you sync its
+  `bindings.json` so it reflects the resources the code uses?
 
-  Sync `bindings.json` so it reflects every resource call across the
-  project. Two entrypoints exist; the bindings reference allows either
-  binding each resource to a chosen entrypoint or leaving the
-  entrypoint field off the resource entirely. Whatever you choose,
-  every entrypoint id you write must match one of the two real
-  entrypoints in `entry-points.json`.
-
-  Do NOT publish, upload, or deploy. Do NOT pause between planning
-  and implementation. Complete end-to-end in a single pass.
+  Do NOT publish, upload, or deploy. Complete the task end-to-end. Only stop
+  if there is a critical blocker you cannot resolve.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "bindings.json exists"
     path: "bindings.json"

--- a/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
@@ -20,17 +20,21 @@ sandbox:
       path: ../_fixtures/MisplacedPromptAttacksAgent
 
 initial_prompt: |
-  I have a coded UiPath LangGraph customer-support agent in graph.py. I added a
-  guardrail to block prompt-injection / adversarial user inputs, but I'm not
-  confident I attached it in the right place. Can you check whether it's
-  configured correctly and fix it if it isn't? Make sure graph.py still parses
-  when you're done.
+  I have a uipath coded agent in graph.py. I added a guardrail recently but
+  I'm not sure I put it in the right place. Can you make sure it's configured
+  correctly and fix it if it isn't?
 
-  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or
-  feedback. Do NOT pause between planning and implementation. Complete the
-  entire task end-to-end in a single pass.
+  Do NOT publish, upload, or deploy. Complete the task end-to-end. Only stop
+  if there is a critical blocker you cannot resolve.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent fetched the guardrail catalog"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/coded/push_resource_not_found/push_resource_not_found.yaml
+++ b/tests/tasks/uipath-agents/coded/push_resource_not_found/push_resource_not_found.yaml
@@ -41,10 +41,10 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran uip codedagent push (did not stop at the first warning)"
+    description: "Agent ran uip codedagent push"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+push(?!\s+--help)'
-    min_count: 2
+    min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary
- shorten `bindings_multi_entrypoint` and `guardrails/validate` prompts to short, user-voiced asks that name a "uipath coded agent" without spelling out the bindings/guardrail mechanics
- add a `skill_triggered` (uipath-agents) criterion to both tasks so non-activation is a measured failure, not an invisible one
- relax `push_resource_not_found` push criterion to `min_count: 1` (an agent that diagnoses before pushing only needs one push)

## Why

these tasks failed because the agent never invoked the uipath-agents skill: the prompts pre-explained the mechanics, so the agent felt it could edit directly and produced wrong-schema bindings / misplaced guardrails. shorter prompts that read like a real user request push the agent to reach for the skill, and the skill_triggered gate surfaces it when it doesn't.