### PR TITLE
fix(uipath-platform): fix the three platform e2e failures (seed folder, job logs, role surface)

### DIFF
--- a/skills/uipath-platform/references/orchestrator/setup-environment.md
+++ b/skills/uipath-platform/references/orchestrator/setup-environment.md
@@ -100,6 +100,8 @@ The `--all` flag enables filtering options (`--type`, `--name`, `--path`, `--top
 
 Roles group permissions and are scoped to either the tenant or a folder. Create the role first (it starts with zero permissions), then add permissions to it.
 
+> **⚠️ `uip or roles` is the Orchestrator RBAC catalog — a different store from Identity/organization authorization roles (`uip admin authorization roles`, see [uipath-admin](/uipath:uipath-admin)). The two are disjoint: a role created with `admin authorization roles` does NOT appear in `uip or roles list`, and vice versa.** Both have Tenant-scoped roles, so "a tenant-level role" alone doesn't tell you which one. For any Orchestrator role/permission lifecycle — create, add/remove permissions, assign to users/folders — use `uip or roles`. Reach for `admin authorization roles` only for org-level Identity roles that span services.
+
 ```bash
 # Create a folder-scoped role
 uip or roles create --name "FinanceOperator" --type Folder --output json

--- a/skills/uipath-solution/SKILL.md
+++ b/skills/uipath-solution/SKILL.md
@@ -53,7 +53,7 @@ All other `solution` subcommands (`pack`, `publish`, `deploy activate/status/uni
 6. **Run `uip solution resources refresh` before `pack` or `upload`.** Bundled artefact files and `userProfile/<userId>/debug_overwrites.json` must reflect current cloud state. Skipping refresh ships stale bindings.
 7. **Coded apps are NOT registered in `.uipx`.** `uip solution project add` does not apply to coded-app directories; they deploy independently via `uip codedapp publish / deploy`. A coded app folder can sit alongside a solution but is not part of its manifest.
 8. **Verify the artifact after every CLI mutation.** Read `project.json`, `.uipx`, or `uip solution deploy status` output — exit codes lie. Verification is additional; it does not replace requested read-only list commands. If the user asks to show or list registered projects, solution resources, packages, deployments, or statuses, run the matching `uip solution ... list/status --output json` command and then inspect files only as a secondary sanity check.
-9. **For multi-environment promotion, the deploy config (`-c <CONFIG_KEY>`) is the environment selector.** Same `.uipx` deploys to dev/staging/prod via different config keys, not different packages.
+9. **For multi-environment promotion, switch tenants with `uip login tenant set <tenant>` and pass a per-environment deploy config via `--config-file <path>`.** The same packed `.uipx` deploys to dev/staging/prod — the environment differs by the target tenant and the config file (generated with `deploy config get`, edited with `config set` / `config link`), not by a different package. There is no `-c <CONFIG_KEY>` flag.
 
 ## Workflow
 
@@ -61,7 +61,7 @@ The typical lifecycle for a UiPath Solution:
 
 ```
 1. init / project add  → Create solution, register projects (.uipx + resources/solution_folder/)
-2. resource refresh    → Sync bundled artefacts and debug overwrites with cloud state
+2. resources refresh   → Sync bundled artefacts and debug overwrites with cloud state
 3. (optional) restore  → Resolve NuGet deps in place (incl. authenticated Orchestrator feeds); login first
 4. pack                → Produce deployable .zip package
 5. login               → uip login (if not already authenticated)
@@ -87,7 +87,7 @@ This skill is the terminal step of an SDD-driven build: after `uipath-planner` p
 | File | Purpose |
 |------|---------|
 | [Solution Overview](references/solution-overview.md) | What a Solution is, `.uipx` manifest, file structure, lifecycle diagram, command tree |
-| [Develop a Solution](references/develop-solution.md) | `uip solution init / project add / import / remove / resource refresh / resource add / resource remove / resource edit`; field-tested gotchas |
+| [Develop a Solution](references/develop-solution.md) | `uip solution init / project add / import / remove / resources refresh / resources add / resources remove / resources edit`; field-tested gotchas |
 | [Pack and Deploy](references/pack-and-deploy.md) | `restore / pack / publish / deploy run`, deploy configs, CI/CD pipeline patterns |
 | [Activate and Manage](references/activate-and-manage.md) | `deploy activate / status / uninstall`, environment management |
 | [Scenarios Index](references/scenarios.md) | Failure modes and edge cases — manual edits, shared resources, virtual resources, name collisions |
@@ -98,6 +98,6 @@ This skill is the terminal step of an SDD-driven build: after `uipath-planner` p
 2. **Editing `resources/solution_folder/` directly.** It is auto-generated and auto-cleaned. Manual edits desync from `.uipx`. Use `uip solution project add/remove` instead.
 3. **Skipping `uip solution resources refresh` before `pack` or `upload`.** Ships stale bindings and debug-overwrite state.
 4. **Adding a coded-app directory via `uip solution project add`.** Coded apps have no `project.uiproj` / `project.json` and are not packed by `uip solution pack`. Deploy them independently via `uip codedapp publish / deploy`.
-5. **Creating a new `.uipx` per environment instead of using deploy configs.** One solution package promotes to dev/staging/prod via different `-c <CONFIG_KEY>` values. Different `.uipx` files per environment defeats version tracking.
+5. **Creating a new `.uipx` per environment instead of using deploy configs.** One packed solution promotes to dev/staging/prod via a per-environment `--config-file` (and `uip login tenant set` to target the tenant). Different `.uipx` files per environment defeats version tracking.
 6. **Using `uip solution upload` (Studio Web) as a deployment path.** Upload is for browser-based debugging only — it does not produce a published package and cannot be promoted via `deploy run`. Use `pack` → `publish` → `deploy run` for real deploys. `upload` also lands the solution in Studio Web's **Cloud workspace** tab — not the Local tab; SW's Local tab is a separate registration not addressable by `uip solution`.
 7. **Trusting exit codes alone after a mutation.** Always read the artefact (`project.json`, `.uipx`, deploy status) — a non-zero exit may indicate partial state and a zero exit can mask warnings.

--- a/skills/uipath-solution/references/solution-overview.md
+++ b/skills/uipath-solution/references/solution-overview.md
@@ -51,7 +51,7 @@ MySolution/
 ```mermaid
 graph LR
     A[init] --> B[project add]
-    B --> C[resource refresh]
+    B --> C[resources refresh]
     C --> D[pack]
     D --> E[publish]
     E --> F["deploy run<br/>(auto-activate by default)"]
@@ -63,7 +63,7 @@ Two distinct distribution paths from the same solution source:
 - **`pack` → `publish` → `deploy run`** — promotes a versioned package to Orchestrator.
 - **`upload`** — pushes the solution to Studio Web for browser-based debugging only. Does not produce a published package and cannot be deployed via `deploy run`.
 
-Always run `resource refresh` before either path so the bundled artefact files and `userProfile/<userId>/debug_overwrites.json` reflect the current cloud state.
+Always run `resources refresh` before either path so the bundled artefact files and `userProfile/<userId>/debug_overwrites.json` reflect the current cloud state.
 
 ---
 

--- a/tests/tasks/uipath-platform/orchestrator/check_job_run_logs.py
+++ b/tests/tasks/uipath-platform/orchestrator/check_job_run_logs.py
@@ -6,6 +6,7 @@ Reads only the job key from `job_key.txt`; everything else queried live."""
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -41,14 +42,29 @@ state = _pick(env.get("Data") or {}, "State")
 if state not in ("Successful", "Faulted", "Stopped"):
     sys.exit(f"FAIL: job state={state!r}, expected Successful/Faulted/Stopped")
 
-# 2. Logs non-empty
-logs = uip_json("or", "jobs", "logs", job_key)
-if logs.get("Result") != "Success":
-    sys.exit(f"FAIL: jobs logs Result={logs.get('Result')!r}")
-log_data = logs.get("Data") or []
-if isinstance(log_data, dict):
-    log_data = _pick(log_data, "Value", "Items", "Results") or []
+# 2. Logs non-empty. Job log ingestion lags slightly behind the job reaching
+# a terminal state, so poll rather than reading once — a single early read
+# races the ingestion and reports an empty (false-negative) result.
+log_data: list = []
+last_result = None
+deadline = time.monotonic() + 60
+while True:
+    logs = uip_json("or", "jobs", "logs", job_key)
+    last_result = logs.get("Result")
+    if last_result == "Success":
+        data = logs.get("Data") or []
+        if isinstance(data, dict):
+            data = _pick(data, "Value", "Items", "Results") or []
+        if data:
+            log_data = data
+            break
+    if time.monotonic() >= deadline:
+        break
+    time.sleep(5)
+
+if last_result != "Success":
+    sys.exit(f"FAIL: jobs logs Result={last_result!r}")
 if not log_data:
-    sys.exit("FAIL: jobs logs returned empty")
+    sys.exit("FAIL: jobs logs returned empty after polling 60s")
 
 print(f"OK: job {job_key} state={state} logs={len(log_data)}")

--- a/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
@@ -32,7 +32,7 @@ success_criteria:
   - type: run_command
     description: "Tenant: job is terminal with at least one log entry"
     command: "python3 $TASK_DIR/check_job_run_logs.py"
-    timeout: 30
+    timeout: 90
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/role_lifecycle_e2e.yaml
@@ -21,8 +21,8 @@ run_limits:
   expected_turns: 24
 
 initial_prompt: |
-  I need a new tenant-level role set up. Name it `e2e-role-` followed by
-  the unique prefix from `seed.json`.
+  I need a new tenant-level Orchestrator role set up. Name it `e2e-role-`
+  followed by the unique prefix from `seed.json`.
 
   The role should end up with exactly one permission attached. Pick the
   first permission from the list of grantable permissions on the tenant

--- a/tests/tasks/uipath-platform/seed.py
+++ b/tests/tasks/uipath-platform/seed.py
@@ -63,12 +63,24 @@ if not key:
     )
 if key:
     seed["process_key"] = key
-    # `or processes get` doesn't populate FolderPath — use list and match by Key.
-    items = (uip_json("or", "processes", "list", "--all-folders").get("Data") or [])
-    if isinstance(items, dict):
-        items = items.get("Value") or items.get("Items") or items.get("Results") or []
-    match = next((p for p in items if (p.get("Key") or "").lower() == key.lower()), None)
-    fp = (match or {}).get("FolderPath") or (match or {}).get("FolderName") or ""
+    # `or processes get` doesn't populate FolderPath, so derive the folder from
+    # `processes list` matched by Key. The list paginates (default page size),
+    # sorted Id desc — under a busy parallel run, processes created by other
+    # tasks can push the seeded stub off page 1, so page through every folder
+    # until we find it instead of trusting the first page.
+    fp, offset = "", 0
+    while True:
+        page = (uip_json("or", "processes", "list", "--all-folders",
+                         "--limit", "200", "--offset", str(offset)).get("Data") or [])
+        if isinstance(page, dict):
+            page = page.get("Value") or page.get("Items") or page.get("Results") or []
+        match = next((p for p in page if (p.get("Key") or "").lower() == key.lower()), None)
+        if match:
+            fp = match.get("FolderPath") or match.get("FolderName") or ""
+            break
+        if len(page) < 200:  # last page reached, key not found anywhere
+            break
+        offset += 200
     if not fp:
         print(f"seed.py: could not resolve folder for E2E_PROCESS_KEY={key} via 'or processes list' — check the key is correct and the process exists.", file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
Fixes the `uipath-platform` e2e failures seen in the nightly runs (3 independent root causes), plus two verified doc-accuracy fixes in the `uipath-solution` skill.

## 1. Seed folder resolution races pagination (`seed.py`)
`seed.py` resolved the seeded process's folder by listing `or processes list --all-folders` and reading only the **first page** (default 50, `Id desc`). The stub sits ~30-40 deep, so under a busy parallel run, processes other tasks create push it past page 1 — the match fails, `seed.py` exits 1, and **every e2e task that depends on the seed errors before the agent runs**. This took out all 7 orchestrator e2e tasks in the 2026-06-30 nightly.

Fix: page through all folders (`--limit 200`, walking `--offset`) until the key is found. Keeps deriving the folder from the key per the test contract; does not hardcode the e2e parent folder.

## 2. Job-log check reads too early (`check_job_run_logs.py`)
The check read `or jobs logs` once, right after the job went terminal. Log ingestion lags that transition, so a single read races it and reports empty — a false-negative `FAIL: jobs logs returned empty` (FAILURE 0.0 on 2026-06-26) even though the logs show up moments later.

Fix: poll `jobs logs` up to 60s (job already confirmed terminal — only waiting for logs to flush); bump the check timeout 30 to 90.

## 3. Orchestrator vs Identity role confusion (`setup-environment.md`, `role_lifecycle_e2e.yaml`)
`uip or roles` (Orchestrator RBAC) and `uip admin authorization roles` (Identity/org) are **disjoint** stores. The disambiguation existed only one way (a rule in `uipath-admin`); `uipath-platform`'s roles section never mentioned the admin surface. With both skills loaded the agent created the role via `admin authorization roles`, but `skill-platform-role-lifecycle-e2e` verifies via `or roles list` — so the check reported "role not in roles list" though the role existed in the other store.

Fix: add a callout in the platform roles section (the two are disjoint; Orchestrator role/permission lifecycle goes through `or roles`) and nudge the e2e prompt to say "Orchestrator role".

## 4. uipath-solution doc accuracy (`SKILL.md`, `solution-overview.md`)
Two stale references, verified against the CLI source:
- `uip solution resource ...` to `uip solution resources ...` (command is plural — leftovers from the #1309 migration).
- Drop the non-existent `-c <CONFIG_KEY>` deploy flag; multi-env promotion uses `uip login tenant set` + `deploy run --config-file <path>`.

## Testing
All platform fixes verified live on `alpha`/`codereval`/`DefaultTenant`:
- seed: resolves both stub keys; bogus key exits 1 with a clear message; a page-size-10 traversal finds the stub on page 4 (offset 30), confirming root cause + fix.
- job-logs: real terminal job passes in ~2s; bogus key fails fast at the terminal-state check.
- roles: confirmed the two role surfaces are disjoint, and `or roles` fully supports the create + add/remove-permission flow.
- solution: command name and `--config-file` flag confirmed against `packages/solution-tool` source.