### PR TITLE
fix(uipath-agents): flag isConversational in setup path; humanize hitl + in-flow coded prompts

### DIFF
--- a/skills/uipath-agents/references/coded/lifecycle/setup.md
+++ b/skills/uipath-agents/references/coded/lifecycle/setup.md
@@ -94,7 +94,7 @@ Edit the scaffolded `main.py`'s `Input` / `Output` models and `async def main` t
 ```
 
 **Key fields:**
-- **`runtimeOptions.isConversational`** - Set `true` for conversational/chat agents
+- **`runtimeOptions.isConversational`** - scaffold defaults to `false` (single-shot). Building a chat/conversational agent? Flip to `true` BEFORE `uip codedagent init` so `entry-points.json` gets the chat shape. See [conversational-agents](../capabilities/conversational-agents.md).
 - **`packOptions`** - Control which files are included when packaging for deployment
 - **`functions`** - Entrypoint mappings (format: `"file_path:function_name"`)
 

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -17,16 +17,22 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  I'm building a UiPath Flow that hands work off to a UiPath coded agent that uses LangGraph. Set it
-  up as a solution called `GreeterSol`: a flow `GreeterFlow` that runs a
-  LangGraph coded agent `InputProcessor` — the agent takes some user
-  input and returns a short summary of it. Make sure the finished flow
-  validates.
+  I want a uipath coded agent (LangGraph) called `InputProcessor` that
+  takes some user input and returns a short summary. Wrap it in a solution
+  `GreeterSol` with a flow `GreeterFlow` that runs the agent, and make
+  sure the flow validates.
 
-  All local — nothing to publish or deploy. Work straight through in a
-  single pass.
+  All local, nothing to publish or deploy. Complete the task end-to-end.
+  Only stop if there is a critical blocker you cannot resolve.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not uipath-planner/maestro-flow alone)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent created the solution with uip solution init"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -21,18 +21,23 @@ pre_run:
     timeout: 300
 
 initial_prompt: |
-  I want to test that this UiPath coded agent works as it should.
-  Write a couple evaluations backed by LLMs if possible: 
-  one that checks the answer the agent gives back and one that checks
-  the path it took to get there.
-  Save the eval results to `eval-results.json` in the agent project
-  root, next to `pyproject.toml`.
-  
+  I want to make sure this uipath coded agent actually works. Can you
+  write a couple of LLM-backed evals - one that checks the answer it gives
+  back, and one that checks the path it took to get there? Save the
+  results to eval-results.json in the agent project root, next to
+  pyproject.toml.
 
-  Don't publish, upload, or deploy. Just work through it to the end in
-  one go — only stop if you hit a real blocker.
+  Don't publish, upload, or deploy. Just work through it to the end in one
+  go - only stop if you hit a real blocker.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent ran the eval suite with --no-report"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/eval_llm_judges.yaml
@@ -21,11 +21,10 @@ pre_run:
     timeout: 300
 
 initial_prompt: |
-  I want to make sure this uipath coded agent actually works. Can you
-  write a couple of LLM-backed evals - one that checks the answer it gives
-  back, and one that checks the path it took to get there? Save the
-  results to eval-results.json in the agent project root, next to
-  pyproject.toml.
+  I've got a uipath coded agent in this project and I want to evaluate it.
+  Can you set up a couple of LLM-backed evals - one that judges the answer
+  it gives back, and one that judges the path it took to get there - and
+  run them? Save the results to eval-results.json next to pyproject.toml.
 
   Don't publish, upload, or deploy. Just work through it to the end in one
   go - only stop if you hit a real blocker.

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/hitl_create_task.yaml
@@ -12,23 +12,27 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a Python UiPath coded agent (LangGraph) named `expense-approver`
-  that handles expense-reimbursement requests. Requests of $1000 or less
-  are auto-approved; anything above that has to be escalated to a manager
-  for sign-off before it can be approved.
+  Can you build me a uipath coded agent in LangGraph for expense
+  reimbursements? Call it expense-approver. Anything $1000 or under can
+  just get auto-approved, but bigger than that needs a manager to sign off
+  before it goes through. When something's over the limit, escalate it to
+  a reviewer through the ExpenseReview app (it's in the Finance folder) and
+  pass along the whole request - the agent should wait while that's pending,
+  then pick back up once the reviewer decides and report whether it got
+  approved and what they said.
 
-  When a request goes over the limit, escalate it to a reviewer through
-  an Action Center app called `ExpenseReview` in the `Finance` folder,
-  passing along the full request. The agent should pause while the
-  escalation is outstanding and pick back up once the reviewer's
-  decision comes in, then report whether it was approved and what the
-  reviewer decided.
-
-  I just need it built with the ExpenseReview app hooked up so it can
-  actually escalate — no need to run it, sign in, or deploy. Take it
-  through in one pass.
+  Just build it with the ExpenseReview app wired up so it can actually
+  escalate - no need to run, sign in, or deploy. Take it all the way
+  through and only stop if you hit something you genuinely can't get past.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not uipath-human-in-the-loop alone)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent scaffolded the project with uip codedagent new"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -12,16 +12,18 @@ tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framew
 max_iterations: 1
 
 initial_prompt: |
-  Build me a uipath coded agent (LangGraph) called `refund-gate` in a
-  `refund-gate/` folder. Refunds over $500 should pause for a reviewer on
-  the Compliance team via their `RefundReview` Action Center app (folder
-  `Compliance`) - they need the customer, amount, and reason - then
-  continue with the reviewer's decision and note. $500 or under goes
-  through automatically. Wire the RefundReview app up so the request can
-  be filed.
+  Can you build me a uipath coded agent in LangGraph for handling refunds?
+  Call it refund-gate, put it in a refund-gate folder. The idea: anything
+  over $500 needs a human to sign off first. Someone on the Compliance team
+  reviews it in their RefundReview app (that's in the Compliance folder) -
+  show them the customer, the amount, and why the refund's being asked for.
+  Once they decide, carry on with their call and whatever note they left.
+  Anything $500 or under just goes through. And please make sure the
+  RefundReview app is actually hooked up, otherwise it can't send them the
+  request.
 
-  Just build it, no run or deploy. Complete the task end-to-end. Only stop
-  if there is a critical blocker you cannot resolve.
+  No need to run or deploy it, just build it. Run it all the way through
+  and only stop if you hit something you genuinely can't get past.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -12,24 +12,25 @@ tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framew
 max_iterations: 1
 
 initial_prompt: |
-  Build a UiPath coded agent (LangGraph) named `refund-gate`. When it's
-  asked to issue a
-  refund over $500, it must pause and file a structured request for a
-  reviewer on the Compliance team in their `RefundReview` Action Center
-  app (folder `Compliance`) — the reviewer needs the customer, the
-  amount, and the stated reason. Once the reviewer replies, the agent
-  continues and produces a final outcome: whether to issue the refund
-  and the reviewer's note. Refunds of $500 or less go through without
-  review.
+  Build me a uipath coded agent (LangGraph) called `refund-gate` in a
+  `refund-gate/` folder. Refunds over $500 should pause for a reviewer on
+  the Compliance team via their `RefundReview` Action Center app (folder
+  `Compliance`) - they need the customer, amount, and reason - then
+  continue with the reviewer's decision and note. $500 or under goes
+  through automatically. Wire the RefundReview app up so the request can
+  be filed.
 
-  Make sure the RefundReview app is hooked up for the agent — without it
-  the request can't be filed. Put the project in a `refund-gate/`
-  directory at the working-directory root.
-
-  I just need it built — no need to run it, sign in, or deploy. Work
-  through it in one pass.
+  Just build it, no run or deploy. Complete the task end-to-end. Only stop
+  if there is a critical blocker you cannot resolve.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent scaffolded the project"
     tool_name: "Bash"


### PR DESCRIPTION
## Summary
- `setup.md`: make the `runtimeOptions.isConversational` note imperative and link the conversational-agents reference, so chat agents flip it to `true` before `uip codedagent init` instead of shipping the `false` default
- humanize and shorten the `hitl_create_task_with_app` and `coded_in_flow_e2e` prompts, leading with "uipath coded agent" so routing lands on uipath-agents (in-flow previously routed to planner/maestro-flow and never built the agent)
- add a `skill_triggered` gate to both tasks so mis-routing is a measured failure

## Why

these 3 coded evals failed on a full main run: conversational built everything but left `isConversational` false, while hitl and in-flow routed to the wrong skill (human-in-the-loop / maestro-flow) and never scaffolded the coded agent. shorter, agent-first prompts plus the activation gate steer the agent back to the coded-agent build.