### PR TITLE
fix(uipath-platform): poll job logs in e2e check to beat ingestion lag

### DIFF
--- a/tests/tasks/uipath-platform/orchestrator/check_job_run_logs.py
+++ b/tests/tasks/uipath-platform/orchestrator/check_job_run_logs.py
@@ -6,6 +6,7 @@ Reads only the job key from `job_key.txt`; everything else queried live."""
 import json
 import subprocess
 import sys
+import time
 from pathlib import Path
 
 
@@ -41,14 +42,29 @@ state = _pick(env.get("Data") or {}, "State")
 if state not in ("Successful", "Faulted", "Stopped"):
     sys.exit(f"FAIL: job state={state!r}, expected Successful/Faulted/Stopped")
 
-# 2. Logs non-empty
-logs = uip_json("or", "jobs", "logs", job_key)
-if logs.get("Result") != "Success":
-    sys.exit(f"FAIL: jobs logs Result={logs.get('Result')!r}")
-log_data = logs.get("Data") or []
-if isinstance(log_data, dict):
-    log_data = _pick(log_data, "Value", "Items", "Results") or []
+# 2. Logs non-empty. Job log ingestion lags slightly behind the job reaching
+# a terminal state, so poll rather than reading once — a single early read
+# races the ingestion and reports an empty (false-negative) result.
+log_data: list = []
+last_result = None
+deadline = time.monotonic() + 60
+while True:
+    logs = uip_json("or", "jobs", "logs", job_key)
+    last_result = logs.get("Result")
+    if last_result == "Success":
+        data = logs.get("Data") or []
+        if isinstance(data, dict):
+            data = _pick(data, "Value", "Items", "Results") or []
+        if data:
+            log_data = data
+            break
+    if time.monotonic() >= deadline:
+        break
+    time.sleep(5)
+
+if last_result != "Success":
+    sys.exit(f"FAIL: jobs logs Result={last_result!r}")
 if not log_data:
-    sys.exit("FAIL: jobs logs returned empty")
+    sys.exit("FAIL: jobs logs returned empty after polling 60s")
 
 print(f"OK: job {job_key} state={state} logs={len(log_data)}")

--- a/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/job_run_logs_e2e.yaml
@@ -32,7 +32,7 @@ success_criteria:
   - type: run_command
     description: "Tenant: job is terminal with at least one log entry"
     command: "python3 $TASK_DIR/check_job_run_logs.py"
-    timeout: 30
+    timeout: 90
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0


### PR DESCRIPTION
## What

`tests/tasks/uipath-platform/orchestrator/check_job_run_logs.py` read `uip or jobs logs` **once**, immediately after the job reached a terminal state.

## Why

Job log ingestion lags slightly behind the job's terminal transition. A single early read races that lag and returns empty, so the check fails with `FAIL: jobs logs returned empty` even though the job ran fine and its logs appear moments later. This made `skill-platform-job-run-logs-e2e` flaky (FAILURE 0.0 in the 2026-06-26 nightly).

Confirmed on `alpha`/`codereval`/`DefaultTenant`: every recent terminal job on the seeded stub **does** have logs (`execution started` / workflow log / `execution ended`) — the logs are real, the check was just reading too early.

## Fix

- Poll `jobs logs` for up to 60s (job is already confirmed terminal — we only wait for logs to flush) instead of reading once.
- Bump the check command `timeout` 30 → 90 so the poll fits inside it.

## Testing

On `alpha`/`codereval`/`DefaultTenant`:

| Test | Result |
|------|--------|
| Real terminal job with logs | `OK ... logs=3` in ~2s (no needless waiting) |
| Bogus job key | fails fast at the terminal-state check (~0.8s), never reaches the poll |

🤖 Generated with [Claude Code](https://claude.com/claude-code)