### PR TITLE
fix(ci): harden claude-pr-review against prompt injection

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -21,18 +21,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    # Only run on non-fork PRs (secrets required), or on @claude mentions
+    # Only run on non-fork PRs (secrets required), or on @claude mentions from
+    # trusted authors (OWNER/MEMBER/COLLABORATOR). Untrusted actors must not be
+    # able to trigger a privileged run via a comment — see Layer 2 in the
+    # prompt-injection hardening notes.
     if: |
       (github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude') && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.review.author_association))
 
+    # Least privilege. contents stays read (no push). pull-requests/issues:write
+    # are required by track_progress to post and update the review comment.
+    # actions:read dropped — this prompt never reads workflow-run data.
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      actions: read
 
     steps:
       - name: Checkout code
@@ -41,12 +46,25 @@ jobs:
           fetch-depth: 0
 
       - name: Claude Code Action
-        uses: anthropics/claude-code-action@v1
+        # Pinned to a full commit SHA (not @v1) so a moved tag cannot run
+        # untrusted action code with our token/secrets. SHA = v1.0.160.
+        uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280 # v1.0.160
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
-          claude_args: "--model claude-opus-4-6"
+          # Tool allowlist (prompt-injection containment). This review reads
+          # attacker-controlled content (diff, PR comments, file contents), so
+          # Claude is restricted to read-only commands plus the single write
+          # tool track_progress needs to post its review comment. Arbitrary
+          # Bash, network tools (WebFetch/WebSearch/curl/wget), git push, and
+          # `gh api`/`gh secret` are NOT in the list and therefore blocked —
+          # an injected instruction cannot reach env secrets (GITHUB_TOKEN /
+          # ANTHROPIC_API_KEY are env vars, not files) or mutate the repo.
+          # Residual: readable repo content could be echoed into the PR comment.
+          claude_args: >-
+            --model claude-opus-4-6
+            --allowedTools "Read,Grep,Glob,Bash(git diff:*),Bash(gh pr view:*),Bash(ls:*),Bash(cat:*),mcp__github_comment__update_claude_comment"
           prompt: |
             You are reviewing a PR for a Claude Code plugin repository that contains
             markdown skill definitions, YAML frontmatter, shell hooks, and coder_eval


### PR DESCRIPTION
## Problem

`claude-pr-review.yml` runs `anthropics/claude-code-action` over **attacker-controlled text** — PR/issue comments (including invisible `<!-- ... -->` HTML comments), the diff, and changed-file contents — with a write-scoped `GITHUB_TOKEN` and tool access. That is a prompt-injection → privilege-escalation path: injected instructions could steer Claude to exfiltrate secrets or mutate the repo in the name of a privileged user. Two concrete gaps:

1. The `issue_comment` branch of `if:` had **no author or fork check** — any external actor could trigger a privileged run by commenting `@claude`.
2. Untrusted content reached an LLM that had broad tool access and a write token.

## Fix (defense in depth, strongest first)

1. **Tool allowlist (containment).** `claude_args` now restricts Claude to read-only commands (`Read`, `Grep`, `Glob`, scoped `git diff` / `gh pr view` / `ls` / `cat`) plus the single write tool `track_progress` needs (`mcp__github_comment__update_claude_comment`). Arbitrary Bash, `WebFetch`/`WebSearch`/`curl`/`wget`, `git push`, `gh api`, `gh secret` are not listed → blocked. Env secrets (`GITHUB_TOKEN`, `ANTHROPIC_API_KEY`) are env vars, not files, so they're unreachable via the allowed read commands. Also dropped `actions: read` (unused).
2. **Trigger gating.** All three comment/review branches now require `author_association` ∈ {OWNER, MEMBER, COLLABORATOR}, closing the unauthenticated `issue_comment` trigger hole.
3. **SHA pin.** `anthropics/claude-code-action@v1` → `@4633baf...` (v1.0.160) so a moved tag can't run untrusted action code with our token.

## Notes / verification

- The `issue_comment` branch intentionally does **not** add `github.event.pull_request.head.repo.full_name` — that field doesn't exist on `issue_comment` payloads (it would resolve to null and silently disable the branch). `author_association` gating is the correct mitigation there.
- The `mcp__github_comment__update_claude_comment` tool name was confirmed against the pinned action source (`src/modes/tag/index.ts`).
- **Merge gate:** confirm the "Claude Code Review" run on this PR posts its review comment — that validates the allowlist + permission set end-to-end at runtime.
- Reviewed via multi-model code review (Gemini 3, GPT-5.3-codex, Opus 4.6); residual risk (untrusted *content* reaching the LLM) is contained by layer 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)