### PR TITLE
ci: grant pull-requests:write to cherry-pick init and status jobs

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -18,6 +18,8 @@ jobs:
       (startsWith(github.event.comment.body, '/cherrypick') ||
        startsWith(github.event.comment.body, '/cherry-pick'))
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     outputs:
       branch: ${{ steps.set-branch.outputs.branch }}
       jira_issue_id: ${{ steps.set-branch.outputs.jira_issue_id }}
@@ -248,6 +250,8 @@ jobs:
        startsWith(github.event.comment.body, '/cherry-pick'))
     needs: [run-cherry-pick, cherry-pick-init]
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Message success (clean)
         if: ${{ !contains(join(needs.*.result, ','), 'failure') && needs.run-cherry-pick.outputs.had_conflicts != 'true' }}


### PR DESCRIPTION
## What

Follow-up fix for the cherry-pick workflow (#1772).

The `cherry-pick-init` and `comment-status` jobs only post PR comments but had no `permissions:` block, so they inherited the repo's read-only default token and failed at runtime:

```
GraphQL: Resource not accessible by integration (addComment)
Error: Process completed with exit code 1.
```

Only `run-cherry-pick` had explicit write scopes. This adds `pull-requests: write` to the two commenting jobs.

## Verified against

A live `/cherrypick release/v1.197` run on PR #1710, which surfaced the `addComment` failure in the init job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
