### PR TITLE
test(uipath-agents): fix unreachable memory_help discovery criterion

### DIFF
--- a/tests/tasks/uipath-agents/lowcode/memory_help/memory_help.yaml
+++ b/tests/tasks/uipath-agents/lowcode/memory_help/memory_help.yaml
@@ -1,8 +1,8 @@
 task_id: skill-agents-memory-smoke-help
 description: >
   Smoke test: agent should trigger the uipath-agents skill for a low-code
-  agent memory request and verify the `uip agent memory` CLI surface without
-  mutating project files.
+  agent memory request and run the skill's read-only memory-space discovery
+  before walking through the wiring, without mutating project files.
 tags: [uipath-agents, smoke, mode:build, lifecycle:discover, low-code]
 
 run_limits:
@@ -11,8 +11,9 @@ run_limits:
 initial_prompt: |
   I've got a low-code Agent Builder project and want to wire up one of our
   existing Memory Spaces so the agent can pull few-shot examples at runtime.
-  What's the command for that? Don't touch any of my files yet — just walk me
-  through the steps first.
+  I don't remember the exact name of the space — can you check which Memory
+  Spaces already exist, then walk me through the steps to attach one? Don't
+  modify any of my files yet.
 
 success_criteria:
   - type: skill_triggered
@@ -23,9 +24,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent inspected the memory CLI help"
+    description: "Agent discovered existing memory spaces (read-only) before attaching"
     tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+memory\s+--help\b.*--output\s+json'
+    command_pattern: 'uip\s+solution\s+resources\s+list\b.*--kind\s+MemorySpace\b.*--output\s+json'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
## What

Fixes the smoke task `tests/tasks/uipath-agents/lowcode/memory_help/memory_help.yaml` (board slug `skill-agents-memory-smoke-help`), which failed deterministically.

## Why

Run [`2026-06-29_04-19-02`](https://coder-evalboard.uipath-dev.com/runs/2026-06-29_04-19-02/skill-agents-memory-smoke-help) scored **0.67 → FAILURE**:

- ✅ `skill_triggered` (uipath-agents) — PASS
- ❌ `command_executed` — `Matched 0/1 required commands (pattern=/uip\s+agent\s+memory\s+--help\b.*--output\s+json/)`

The second criterion graded `uip agent memory --help --output json`. That command is taught **nowhere** in the `uipath-agents` skill, and `--help` does not emit JSON, so the `--help` + `--output json` pairing is unnatural. For this prompt ("wire up an *existing* Memory Space, what's the command, don't touch my files"), a skill-following agent does what `references/lowcode/capabilities/memory/memory.md` mandates as **step 1** — discover the existing space with `uip solution resources list --kind MemorySpace --output json`. It has no reason to run a `--help` probe, so the criterion was unreachable.

## Change

- Re-point criterion 2 to the skill's real read-only discovery command (`uip solution resources list --kind MemorySpace --output json`) — non-mutating, so it still honors "don't touch my files".
- Nudge the prompt to ask which Memory Spaces exist before walking through, so the agent reliably runs discovery without leaking procedure.
- Update `description` accordingly. `task_id` unchanged so board history is preserved.

## Validation

- `/lint-task` → **OK** (0 issues).
- `python3 scripts/check-cli-verbs.py` → clean (`solution resources list` exists in catalog 1.197.0).
- **Local passing run** (`coder-eval run … -e experiments/default.yaml`): **2/2 criteria passed, weighted score 1.000, status SUCCESS**. The agent ran `uip solution resources list --source remote --kind MemorySpace --output json`, matching the new criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)