### PR TITLE
fix(maestro): prevent agents concluding "doesn't exist" from truncated discovery output

### DIFF
--- a/skills/uipath-maestro-bpmn/references/cli-conventions.md
+++ b/skills/uipath-maestro-bpmn/references/cli-conventions.md
@@ -25,6 +25,8 @@ particular, there is **no** `uip maestro bpmn validate` command — see
 [Validation](structural-bpmn.md#validation). Validation is done with the bundled
 offline validator, not a CLI.
 
+> **Don't conclude "it doesn't exist" from truncated discovery output.** A row past a cutoff reads exactly like a missing row. Two cutoffs bite here: `registry list` defaults to **30** — pass `--limit -1` for the full set — and piping `registry search`/`is connections list` through `head`/`tail`/`grep -m`/a pager drops everything past the cap. To check existence, narrow the query (keyword to `registry search`, `--all-folders` to connection lists) rather than capping rows; cap only data already known complete.
+
 ## Output parsing
 
 Whenever a CLI result is parsed programmatically, pass `--output json`. If a

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -74,6 +74,13 @@ uip maestro flow registry search slack --output json \
 
 `registry search` returns `Data` as a **flat array of PascalCase objects** — `NodeType`, `Category`, `DisplayName`, `Description`, `Version`, `Tags`, `AvailableOnTenant`. Not `Data.Nodes`, not lowercase `type`/`category`; those shapes do not exist. Knowing the shape lets you write the right expression on call #1 — which is the actual protection. Do **not** rely on `--output-filter` to *catch* a wrong-shape guess: a syntactically valid expression that simply doesn't match (e.g. `--output-filter "Nodes"` or `"Nodes[*].NodeType"` against the flat array) returns `Data: []` with **exit 0** — the same silent trap as `python3`/`jq` (see the silent-`[]` note below). Only an *invalid* expression fails loudly with exit 3: a syntax error, or a type error such as `keys(@)` on an array.
 
+> **Never `head`/`tail`/`grep -m`/pager a discovery query** (`registry search`, `is connectors list`, any `list`/`search`). A row past the cutoff reads exactly like a row that doesn't exist — the same false-absence trap as the silent `[]`, self-inflicted. To check existence, push the predicate into `--output-filter` so the result is *all* matches and already small; cap rows only on data already known complete or already filtered.
+>
+> ```bash
+> uip … registry search slack --output json --output-filter "[?contains(NodeType,'get-channel-info')].NodeType"   # right: every match
+> uip … registry search slack --output json --output-filter "[*].{…}" | head -100                                # wrong: hides matches past line 100
+> ```
+
 ### When to fall back to `python3` / `jq`
 
 `--output-filter` is the preferred extraction mechanism, but it is not a general-purpose transformation tool. Fall back to `python3 -c` or `jq` when JMESPath cannot express the operation:


### PR DESCRIPTION
## What

Adds a condensed rule to the maestro **flow** and **bpmn** CLI-conventions docs: don't conclude something "doesn't exist" from truncated discovery output. A row past a cutoff is indistinguishable from a missing row.

- `uipath-maestro-flow/references/shared/cli-conventions.md` (§3, after the silent-`[]` note) — never `head`/`tail`/`grep -m`/pager a discovery query; push the predicate into `--output-filter` instead. Includes a right/wrong one-liner using the real `get-channel-info` case.
- `uipath-maestro-bpmn/references/cli-conventions.md` (Discovery section) — same principle, tailored to its two cutoffs: `registry list` defaults to **30** (use `--limit -1`) and `head`/pager on `registry search`/`is connections list`.

## Why

A flow eval (`skill-flow-slack-weather-pipeline`) failed this way. The agent correctly found the Slack connector and followed the connector→HTTP decision ladder, but its own search command piped through `| head -100`:

```
uip maestro flow registry search slack --output json --output-filter "[*].{…}" | head -100
```

The curated `get-channel-info` activity sits at **line 240 of 336**, so it was truncated away. The agent concluded "no dedicated get-channel-info activity exists," fell back to manual HTTP against a raw `slack.com/api/conversations.info` URL, and produced a flow that **validates but skips the real connector node** — failing the check (`No node uses connector target 'uipath-salesforce-slack'`).

Root cause was not an http.v2 bias, an unavailable connector, or a missing connection (all verified present). It was a self-inflicted false-absence from truncated output — the same failure family as the silent `[]` the docs already warn about.

## Scope

Limited to the two skills that have a `cli-conventions.md` and run discovery/search commands. No repo-wide conventions file exists today; happy to extend to the platform skill's connector discovery in a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)