### PR TITLE
test(uipath-ixp): delete each run's own IXP project via post_run cleanup

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -17,9 +17,11 @@ Post-run cleanup for IXP e2e/integration tasks. Two stages, both best-effort:
        safely beyond the longest task_timeout (~50 min), so a concurrent run's
        freshly-created project is never in range.
 
-Delete is `uip ixp projects delete <name> -y --output json`. Everything is
-idempotent (missing project == already clean) and ALWAYS exits 0: cleanup
-failures never fail the test. Locally without a tenant this is a no-op.
+Delete is `uip ixp projects delete <name> -y --output json`. Best-effort and
+ALWAYS exits 0 (any delete failure is logged as WARN, never fails the test).
+NOTE: `delete` 404s on dataset-less (orphaned) project shells that `list` still
+returns — those are un-deletable via the current CLI and will WARN each run.
+Locally without a tenant this is a no-op.
 
 Env knobs:
   IXP_CLEANUP_SWEEP=1            enable stage 2 sweep (default OFF; set only on e2e)
@@ -56,16 +58,14 @@ def delete_project(name):
     if proc is None:
         return
     out = (proc.stdout or proc.stderr or "").strip()
-    low = out.lower()
-    # ONLY a genuine "gone" response is benign. Do NOT treat 409/conflict/"already"
-    # as benign — those are real delete failures (e.g. a published model blocking
-    # delete, or a concurrent-modification conflict) and must surface as WARN, not
-    # be silently swallowed as "already gone".
-    gone = any(s in low for s in ("not found", "not_found", "does not exist")) or "404" in out
+    # Only rc==0 is success. Do NOT treat any error — including 404 — as benign:
+    # `uip ixp projects delete <name>` 404s on projects that `projects list` still
+    # returns (the CLI's name->id resolution doesn't reach older/deep projects), so
+    # a 404 does NOT mean the project is gone. Masking it hid a real failure. With
+    # the e2e task as the sole sweeper there are no concurrent-delete races, so any
+    # non-zero exit is a genuine failure worth surfacing.
     if proc.returncode == 0:
         print(f"OK: deleted IXP project '{name}'")
-    elif gone:
-        print(f"SKIP: IXP project '{name}' not found (already deleted)")
     else:
         print(f"WARN: could not delete '{name}' (exit {proc.returncode}): {out[:200]}")
 

--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -7,7 +7,9 @@ Post-run cleanup for IXP e2e/integration tasks. Two stages, both best-effort:
      {"project_name": "<ProjectName from `uip ixp projects create` output>"}
 
 2. Sweep STALE leftover test projects — ones a previous crashed run never
-   deleted. Scoped two ways so it can never touch a live/real project:
+   deleted. OPT-IN via IXP_CLEANUP_SWEEP=1 (only the e2e task sets it, so the
+   suite doesn't run N concurrent janitors conflicting on the same deletes).
+   Scoped two ways so it can never touch a live/real project:
      - name/title must start with a known test prefix (IXP_CLEANUP_PREFIXES,
        default "codereval-,e2e-test-,ixp-it-" — the last two are legacy
        prefixes, kept so pre-rename leftovers still get swept), and
@@ -20,7 +22,7 @@ idempotent (missing project == already clean) and ALWAYS exits 0: cleanup
 failures never fail the test. Locally without a tenant this is a no-op.
 
 Env knobs:
-  IXP_CLEANUP_SWEEP=0            disable stage 2 (default on)
+  IXP_CLEANUP_SWEEP=1            enable stage 2 sweep (default OFF; set only on e2e)
   IXP_CLEANUP_PREFIXES=a-,b-     comma-separated test-title prefixes to sweep
   IXP_CLEANUP_MAX_AGE_HOURS=6    only sweep projects older than this
 """
@@ -55,17 +57,15 @@ def delete_project(name):
         return
     out = (proc.stdout or proc.stderr or "").strip()
     low = out.lower()
-    benign = (
-        any(s in low for s in ("not found", "not_found", "does not exist",
-                               "already", "conflict"))
-        or "404" in out
-        or "409" in out
-    )
+    # ONLY a genuine "gone" response is benign. Do NOT treat 409/conflict/"already"
+    # as benign — those are real delete failures (e.g. a published model blocking
+    # delete, or a concurrent-modification conflict) and must surface as WARN, not
+    # be silently swallowed as "already gone".
+    gone = any(s in low for s in ("not found", "not_found", "does not exist")) or "404" in out
     if proc.returncode == 0:
         print(f"OK: deleted IXP project '{name}'")
-    elif benign:
-        # Already gone, or a concurrent run's sweep deleted it first / mid-flight.
-        print(f"SKIP: IXP project '{name}' already gone / being deleted concurrently")
+    elif gone:
+        print(f"SKIP: IXP project '{name}' not found (already deleted)")
     else:
         print(f"WARN: could not delete '{name}' (exit {proc.returncode}): {out[:200]}")
 
@@ -114,7 +114,11 @@ def cleanup_own_project():
 
 
 def sweep_stale(own_name):
-    if os.environ.get("IXP_CLEANUP_SWEEP", "1") == "0":
+    # Opt-IN: the backlog sweep runs ONLY when IXP_CLEANUP_SWEEP=1. Just ONE task
+    # (the e2e) enables it, so the whole suite doesn't run N concurrent janitors
+    # racing to delete the same projects (which caused 409 conflicts). Every other
+    # task only deletes its own project (stage 1).
+    if os.environ.get("IXP_CLEANUP_SWEEP", "0") != "1":
         return
     prefixes = tuple(
         p.strip()

--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""
+Post-run cleanup for IXP e2e/integration tasks. Two stages, both best-effort:
+
+1. Delete THIS run's project, named in report.json (CWD), written by the agent
+   right after creation:
+     {"project_name": "<ProjectName from `uip ixp projects create` output>"}
+
+2. Sweep STALE leftover test projects — ones a previous crashed run never
+   deleted. Scoped two ways so it can never touch a live/real project:
+     - name/title must start with a known test prefix (IXP_CLEANUP_PREFIXES,
+       default "codereval-,e2e-test-,ixp-it-" — the last two are legacy
+       prefixes, kept so pre-rename leftovers still get swept), and
+     - CreatedAt must be older than IXP_CLEANUP_MAX_AGE_HOURS (default 6h) —
+       safely beyond the longest task_timeout (~50 min), so a concurrent run's
+       freshly-created project is never in range.
+
+Delete is `uip ixp projects delete <name> -y --output json`. Everything is
+idempotent (missing project == already clean) and ALWAYS exits 0: cleanup
+failures never fail the test. Locally without a tenant this is a no-op.
+
+Env knobs:
+  IXP_CLEANUP_SWEEP=0            disable stage 2 (default on)
+  IXP_CLEANUP_PREFIXES=a-,b-     comma-separated test-title prefixes to sweep
+  IXP_CLEANUP_MAX_AGE_HOURS=6    only sweep projects older than this
+"""
+
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# codereval- = current root for all coder_eval test projects (codereval-e2e-*,
+# codereval-it-*). e2e-test- and ixp-it- are legacy prefixes kept so pre-rename
+# leftovers still get swept.
+DEFAULT_PREFIXES = "codereval-,e2e-test-,ixp-it-"
+DEFAULT_MAX_AGE_HOURS = 6.0
+LIST_PAGE_SIZE = 100        # projects fetched per `projects list` page
+LIST_MAX_SCAN = 5000        # stop paging after this many (safety bound)
+
+
+def run(cmd, timeout=60):
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except Exception as e:
+        print(f"WARN: command failed to invoke ({' '.join(cmd)}): {e}")
+        return None
+
+
+def delete_project(name):
+    """Delete one project by name. Idempotent; best-effort."""
+    proc = run(["uip", "ixp", "projects", "delete", name, "-y", "--output", "json"])
+    if proc is None:
+        return
+    out = (proc.stdout or proc.stderr or "").strip()
+    low = out.lower()
+    benign = (
+        any(s in low for s in ("not found", "not_found", "does not exist",
+                               "already", "conflict"))
+        or "404" in out
+        or "409" in out
+    )
+    if proc.returncode == 0:
+        print(f"OK: deleted IXP project '{name}'")
+    elif benign:
+        # Already gone, or a concurrent run's sweep deleted it first / mid-flight.
+        print(f"SKIP: IXP project '{name}' already gone / being deleted concurrently")
+    else:
+        print(f"WARN: could not delete '{name}' (exit {proc.returncode}): {out[:200]}")
+
+
+def load_report():
+    path = os.path.join(os.getcwd(), "report.json")
+    if not os.path.exists(path):
+        print(f"SKIP: no report.json at {path}")
+        return None
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception as e:
+        print(f"SKIP: could not parse report.json: {e}")
+        return None
+
+
+def parse_created_at(value):
+    """Parse an IXP CreatedAt timestamp to an aware datetime, or None."""
+    if not value or not isinstance(value, str):
+        return None
+    s = value.strip().replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def cleanup_own_project():
+    report = load_report()
+    if not report:
+        return None
+    name = (
+        report.get("project_name")
+        or report.get("name")
+        or report.get("ProjectName")
+    )
+    if not name:
+        print("SKIP: no 'project_name' key in report.json")
+        return None
+    delete_project(name)
+    return name
+
+
+def sweep_stale(own_name):
+    if os.environ.get("IXP_CLEANUP_SWEEP", "1") == "0":
+        return
+    prefixes = tuple(
+        p.strip()
+        for p in os.environ.get("IXP_CLEANUP_PREFIXES", DEFAULT_PREFIXES).split(",")
+        if p.strip()
+    )
+    if not prefixes:
+        return
+    try:
+        max_age_hours = float(
+            os.environ.get("IXP_CLEANUP_MAX_AGE_HOURS", DEFAULT_MAX_AGE_HOURS)
+        )
+    except ValueError:
+        max_age_hours = DEFAULT_MAX_AGE_HOURS
+
+    # Page through the list rather than one giant limit, so we always reach the
+    # OLDEST projects (the stale ones we want) regardless of list ordering.
+    projects = []
+    offset = 0
+    while offset < LIST_MAX_SCAN:
+        proc = run([
+            "uip", "ixp", "projects", "list",
+            "-l", str(LIST_PAGE_SIZE), "--offset", str(offset), "--output", "json",
+        ])
+        if proc is None or proc.returncode != 0:
+            if offset == 0:
+                print("SKIP sweep: could not list projects (no tenant / auth?)")
+                return
+            print(f"WARN sweep: list failed at offset {offset}; "
+                  f"proceeding with {len(projects)} project(s) fetched")
+            break
+        try:
+            data = json.loads(proc.stdout).get("Data") or {}
+        except Exception as e:
+            print(f"SKIP sweep: could not parse project list: {e}")
+            return
+        page = data.get("Projects") or []
+        projects.extend(page)
+        offset += LIST_PAGE_SIZE
+        total = data.get("Total")
+        if len(page) < LIST_PAGE_SIZE:
+            break
+        if isinstance(total, int) and offset >= total:
+            break
+
+    now = datetime.now(timezone.utc)
+    cutoff_seconds = max_age_hours * 3600
+    swept = 0
+    for p in projects:
+        name = p.get("Name")
+        if not name:
+            continue
+        if name == own_name:  # already handled in stage 1
+            continue
+        # Match on Name only: test projects are created with the prefixed string
+        # as their Name, and only the Title is ever renamed — so Name reliably
+        # carries the prefix, and matching Title risks sweeping a real project
+        # that merely has a prefixed display title.
+        if not name.startswith(prefixes):
+            continue
+        created = parse_created_at(p.get("CreatedAt"))
+        if created is None:
+            print(f"SKIP sweep: '{name}' has unparseable CreatedAt; leaving it")
+            continue
+        age_s = (now - created).total_seconds()
+        if age_s < cutoff_seconds:
+            continue  # too recent — could be a live concurrent run
+        print(f"SWEEP: stale test project '{name}' (age {age_s / 3600:.1f}h)")
+        delete_project(name)
+        swept += 1
+    print(
+        f"SWEEP done: {swept} stale test project(s) removed "
+        f"(prefixes={list(prefixes)}, older_than={max_age_hours}h)"
+    )
+
+
+def main():
+    own = cleanup_own_project()
+    sweep_stale(own)
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -1,47 +1,22 @@
 #!/usr/bin/env python3
 """
-Post-run cleanup for IXP e2e/integration tasks. Two stages, both best-effort:
+Post-run cleanup for IXP e2e/integration tasks: delete THIS run's project.
 
-1. Delete THIS run's project, named in report.json (CWD), written by the agent
-   right after creation:
-     {"project_name": "<ProjectName from `uip ixp projects create` output>"}
+Reads report.json (CWD), written by the agent right after creation:
+  {"project_name": "<ProjectName from `uip ixp projects create` output>"}
 
-2. Sweep STALE leftover test projects — ones a previous crashed run never
-   deleted. OPT-IN via IXP_CLEANUP_SWEEP=1 (only the e2e task sets it, so the
-   suite doesn't run N concurrent janitors conflicting on the same deletes).
-   Scoped two ways so it can never touch a live/real project:
-     - name/title must start with a known test prefix (IXP_CLEANUP_PREFIXES,
-       default "codereval-,e2e-test-,ixp-it-" — the last two are legacy
-       prefixes, kept so pre-rename leftovers still get swept), and
-     - CreatedAt must be older than IXP_CLEANUP_MAX_AGE_HOURS (default 6h) —
-       safely beyond the longest task_timeout (~50 min), so a concurrent run's
-       freshly-created project is never in range.
+and deletes that one project via `uip ixp projects delete <name> -y --output json`.
+It only ever removes the project the current run created — it does NOT sweep or
+touch any other (older / leftover) project.
 
-Delete is `uip ixp projects delete <name> -y --output json`. Best-effort and
-ALWAYS exits 0 (any delete failure is logged as WARN, never fails the test).
-NOTE: `delete` 404s on dataset-less (orphaned) project shells that `list` still
-returns — those are un-deletable via the current CLI and will WARN each run.
-Locally without a tenant this is a no-op.
-
-Env knobs:
-  IXP_CLEANUP_SWEEP=1            enable stage 2 sweep (default OFF; set only on e2e)
-  IXP_CLEANUP_PREFIXES=a-,b-     comma-separated test-title prefixes to sweep
-  IXP_CLEANUP_MAX_AGE_HOURS=6    only sweep projects older than this
+Best-effort and ALWAYS exits 0 (a delete failure is logged as WARN, never fails
+the test). Locally without a tenant this is a no-op.
 """
 
 import json
 import os
 import subprocess
 import sys
-from datetime import datetime, timezone
-
-# codereval- = current root for all coder_eval test projects (codereval-e2e-*,
-# codereval-it-*). e2e-test- and ixp-it- are legacy prefixes kept so pre-rename
-# leftovers still get swept.
-DEFAULT_PREFIXES = "codereval-,e2e-test-,ixp-it-"
-DEFAULT_MAX_AGE_HOURS = 6.0
-LIST_PAGE_SIZE = 100        # projects fetched per `projects list` page
-LIST_MAX_SCAN = 5000        # stop paging after this many (safety bound)
 
 
 def run(cmd, timeout=60):
@@ -53,17 +28,15 @@ def run(cmd, timeout=60):
 
 
 def delete_project(name):
-    """Delete one project by name. Idempotent; best-effort."""
+    """Delete one project by name. Best-effort."""
     proc = run(["uip", "ixp", "projects", "delete", name, "-y", "--output", "json"])
     if proc is None:
         return
     out = (proc.stdout or proc.stderr or "").strip()
     # Only rc==0 is success. Do NOT treat any error — including 404 — as benign:
-    # `uip ixp projects delete <name>` 404s on projects that `projects list` still
-    # returns (the CLI's name->id resolution doesn't reach older/deep projects), so
-    # a 404 does NOT mean the project is gone. Masking it hid a real failure. With
-    # the e2e task as the sole sweeper there are no concurrent-delete races, so any
-    # non-zero exit is a genuine failure worth surfacing.
+    # `uip ixp projects delete <name>` 404s on a dataset-less project shell (the
+    # delete resolves the dataset first), so a 404 does NOT mean the project is
+    # gone. Surface every non-zero exit as WARN rather than masking it.
     if proc.returncode == 0:
         print(f"OK: deleted IXP project '{name}'")
     else:
@@ -83,24 +56,10 @@ def load_report():
         return None
 
 
-def parse_created_at(value):
-    """Parse an IXP CreatedAt timestamp to an aware datetime, or None."""
-    if not value or not isinstance(value, str):
-        return None
-    s = value.strip().replace("Z", "+00:00")
-    try:
-        dt = datetime.fromisoformat(s)
-    except ValueError:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt
-
-
 def cleanup_own_project():
     report = load_report()
     if not report:
-        return None
+        return
     name = (
         report.get("project_name")
         or report.get("name")
@@ -108,96 +67,12 @@ def cleanup_own_project():
     )
     if not name:
         print("SKIP: no 'project_name' key in report.json")
-        return None
+        return
     delete_project(name)
-    return name
-
-
-def sweep_stale(own_name):
-    # Opt-IN: the backlog sweep runs ONLY when IXP_CLEANUP_SWEEP=1. Just ONE task
-    # (the e2e) enables it, so the whole suite doesn't run N concurrent janitors
-    # racing to delete the same projects (which caused 409 conflicts). Every other
-    # task only deletes its own project (stage 1).
-    if os.environ.get("IXP_CLEANUP_SWEEP", "0") != "1":
-        return
-    prefixes = tuple(
-        p.strip()
-        for p in os.environ.get("IXP_CLEANUP_PREFIXES", DEFAULT_PREFIXES).split(",")
-        if p.strip()
-    )
-    if not prefixes:
-        return
-    try:
-        max_age_hours = float(
-            os.environ.get("IXP_CLEANUP_MAX_AGE_HOURS", DEFAULT_MAX_AGE_HOURS)
-        )
-    except ValueError:
-        max_age_hours = DEFAULT_MAX_AGE_HOURS
-
-    # Page through the list rather than one giant limit, so we always reach the
-    # OLDEST projects (the stale ones we want) regardless of list ordering.
-    projects = []
-    offset = 0
-    while offset < LIST_MAX_SCAN:
-        proc = run([
-            "uip", "ixp", "projects", "list",
-            "-l", str(LIST_PAGE_SIZE), "--offset", str(offset), "--output", "json",
-        ])
-        if proc is None or proc.returncode != 0:
-            if offset == 0:
-                print("SKIP sweep: could not list projects (no tenant / auth?)")
-                return
-            print(f"WARN sweep: list failed at offset {offset}; "
-                  f"proceeding with {len(projects)} project(s) fetched")
-            break
-        try:
-            data = json.loads(proc.stdout).get("Data") or {}
-        except Exception as e:
-            print(f"SKIP sweep: could not parse project list: {e}")
-            return
-        page = data.get("Projects") or []
-        projects.extend(page)
-        offset += LIST_PAGE_SIZE
-        total = data.get("Total")
-        if len(page) < LIST_PAGE_SIZE:
-            break
-        if isinstance(total, int) and offset >= total:
-            break
-
-    now = datetime.now(timezone.utc)
-    cutoff_seconds = max_age_hours * 3600
-    swept = 0
-    for p in projects:
-        name = p.get("Name")
-        if not name:
-            continue
-        if name == own_name:  # already handled in stage 1
-            continue
-        # Match on Name only: test projects are created with the prefixed string
-        # as their Name, and only the Title is ever renamed — so Name reliably
-        # carries the prefix, and matching Title risks sweeping a real project
-        # that merely has a prefixed display title.
-        if not name.startswith(prefixes):
-            continue
-        created = parse_created_at(p.get("CreatedAt"))
-        if created is None:
-            print(f"SKIP sweep: '{name}' has unparseable CreatedAt; leaving it")
-            continue
-        age_s = (now - created).total_seconds()
-        if age_s < cutoff_seconds:
-            continue  # too recent — could be a live concurrent run
-        print(f"SWEEP: stale test project '{name}' (age {age_s / 3600:.1f}h)")
-        delete_project(name)
-        swept += 1
-    print(
-        f"SWEEP done: {swept} stale test project(s) removed "
-        f"(prefixes={list(prefixes)}, older_than={max_age_hours}h)"
-    )
 
 
 def main():
-    own = cleanup_own_project()
-    sweep_stale(own)
+    cleanup_own_project()
     sys.exit(0)
 
 

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -161,5 +161,9 @@ success_criteria:
 # (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
 # always exits 0 so it never fails the test.
 post_run:
-  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
-    timeout: 60
+  # IXP_CLEANUP_SWEEP=1: the e2e task is the SOLE backlog sweeper (integration
+  # tasks only delete their own project), so the suite never runs concurrent
+  # janitors conflicting on the same deletes. Longer timeout gives the sole
+  # sweeper room to drain the backlog.
+  - command: "IXP_CLEANUP_SWEEP=1 python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 300

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -3,8 +3,8 @@ description: >
   Full IXP lifecycle against the live tenant: agent creates a project
   from bundled invoice fixtures, configures the model, reviews and
   confirms predictions, captures baseline metrics, improves one
-  low-F1 field's prompt, captures improved metrics, publishes, and
-  deletes the project as cleanup.
+  low-F1 field's prompt, captures improved metrics, and publishes.
+  Cleanup (project deletion) is handled automatically post-run.
   Exercises every reference file in the skill end-to-end.
 tags: [uipath-ixp, e2e, mode:build, lifecycle:setup]
 
@@ -35,8 +35,9 @@ initial_prompt: |
   - Create the project WITHOUT a taxonomy, then import the bundled
     `./fixtures/taxonomy.json` (a taxonomy already exists for this
     scenario).
-  - Use a unique title `e2e-test-<random-suffix>` so concurrent
+  - Use a unique title `codereval-e2e-<random-suffix>` so concurrent
     runs do not collide.
+  - Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
   Goal: configure the model, review and confirm predictions, then
   improve the single lowest-F1 field — ONE iteration only (update
@@ -52,10 +53,6 @@ initial_prompt: |
     improvement and retrain. If retrain has not completed after a few
     minutes of polling, capture the current metrics and proceed rather
     than waiting indefinitely.
-
-  Cleanup (final step): once the artifacts above are saved and the model
-  is published, delete the project to clean up. The task is NOT complete
-  until the project is deleted.
 
   - The `uip` CLI is already authenticated.
   - Do NOT ask for approval, confirmation, or feedback; do NOT pause
@@ -121,6 +118,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
     description: "Target field artifact written"
     path: "target_field.json"
     weight: 1.0
@@ -154,10 +157,9 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent deleted the project as cleanup (with -y/--yes)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\s+.*(--yes\b|-y\b)'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -157,13 +157,9 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-# Safety net: delete the project even if the agent's in-band cleanup never ran
-# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
-# always exits 0 so it never fails the test.
+# Safety net: delete THIS run's project even if the agent's in-band cleanup never
+# ran (crash / MAX_TURNS before the final delete). Reads report.json; only removes
+# the project this run created; always exits 0 so it never fails the test.
 post_run:
-  # IXP_CLEANUP_SWEEP=1: the e2e task is the SOLE backlog sweeper (integration
-  # tasks only delete their own project), so the suite never runs concurrent
-  # janitors conflicting on the same deletes. Longer timeout gives the sole
-  # sweeper room to drain the backlog.
-  - command: "IXP_CLEANUP_SWEEP=1 python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
-    timeout: 300
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -25,9 +25,10 @@ sandbox:
 initial_prompt: |
   Set up a trained invoice project. Use the tenant I'm already signed into
   (check I'm logged in; don't re-authenticate): create a blank project (give it a unique title
-  `ixp-it-labelling-<random-suffix>` so concurrent runs don't collide) and upload
+  `codereval-integ-labelling-<random-suffix>` so concurrent runs don't collide) and upload
   `./fixtures/csi_tower_invoice.png`. Work only on the project you create; other
   runs share this tenant, so never list, read, or modify any other project.
+  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
   Then set up the taxonomy yourself — add a
   "Line Items" field group with three fields: "Description" (text), "Amount"
   (monetary), and "Tax" (monetary).
@@ -47,8 +48,6 @@ initial_prompt: |
     and save that command's response to `unconfirm_result.json`.
   - These line items have no tax column, so "Tax" doesn't apply here — mark it
     missing, and save that response to `mark_missing_result.json`.
-
-  Clean up by deleting the project when you're done — even if a step above failed.
 
 success_criteria:
   - type: command_executed
@@ -99,11 +98,9 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Deleted the project as cleanup"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
-    min_count: 1
+  - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -168,3 +165,10 @@ success_criteria:
         expected: 0
     weight: 2.0
     pass_threshold: 1.0
+
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -25,16 +25,16 @@ initial_prompt: |
   Use the tenant I'm already signed into (check I'm logged in; don't
   re-authenticate). Set up an invoice project from the files in `./fixtures/` —
   import the taxonomy and upload the three invoices — and give it a unique title
-  `ixp-it-resolve-<random-suffix>` so concurrent runs don't collide.
+  `codereval-integ-resolve-<random-suffix>` so concurrent runs don't collide.
 
   Then:
   - Delete the file `york_solutions_invoice.png`, then save the remaining document
     list to `documents_after.json`.
   - Rename that project to the same title with `-renamed` appended (i.e.
-    `ixp-it-resolve-<random-suffix>-renamed`), then save the project's details to
+    `codereval-integ-resolve-<random-suffix>-renamed`), then save the project's details to
     `project_after.json`.
 
-  Clean up by deleting the project at the end.
+  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
 success_criteria:
   - type: command_executed
@@ -76,11 +76,9 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Deleted the project as cleanup"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
-    min_count: 1
+  - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -96,6 +94,13 @@ success_criteria:
   - type: file_contains
     description: "The project was renamed: title now carries the `-renamed` suffix"
     path: "project_after.json"
-    includes: ["ixp-it-resolve", "-renamed"]
+    includes: ["codereval-integ-resolve", "-renamed"]
     weight: 2.0
     pass_threshold: 1.0
+
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -25,7 +25,7 @@ initial_prompt: |
   I need to manage releases on an invoice project. Use the tenant I'm already
   signed into (check I'm logged in; don't re-authenticate): start a project from
   the files in `./fixtures/` (give it a unique title
-  `ixp-it-publish-<random-suffix>` so concurrent runs don't collide) — import the taxonomy, upload one of the invoices —
+  `codereval-integ-publish-<random-suffix>` so concurrent runs don't collide) — import the taxonomy, upload one of the invoices —
   and let it train. I want two trained versions to tag, so once the first has
   trained, tweak the "Total Amount" field's instruction to retrain a second.
   Work only on the project you create; other runs share this tenant, so never
@@ -44,7 +44,7 @@ initial_prompt: |
   - Take the tags off the first version → save to `models_after_untag.json`.
   - Unpublish the second version → save to `models_after_unpublish.json`.
 
-  Delete the project when you're done — even if a step above failed.
+  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
 success_criteria:
   - type: command_executed
@@ -87,11 +87,9 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Deleted the project as cleanup"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
-    min_count: 1
+  - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -104,3 +102,10 @@ success_criteria:
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
+
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
@@ -28,7 +28,7 @@ initial_prompt: |
   Use the tenant I'm already signed into (check I'm logged in; don't re-authenticate).
   Create the project from the invoices in `./fixtures/` and let IXP auto-suggest the
   taxonomy — I only care about the taxonomy structure here, so don't label or train.
-  Use a unique project title `ixp-it-taxonomy-<random-suffix>` so concurrent runs
+  Use a unique project title `codereval-integ-taxonomy-<random-suffix>` so concurrent runs
   don't collide. Save the suggested taxonomy to `taxonomy_initial.json`.
 
   Then make these exact edits, checking after each that it took:
@@ -45,7 +45,7 @@ initial_prompt: |
     "Adjustments" group.
   - Save the taxonomy again to `taxonomy_final.json`.
 
-  When you're done, delete the project.
+  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
 success_criteria:
   - type: command_not_executed
@@ -111,11 +111,9 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Deleted the project as cleanup"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
-    min_count: 1
+  - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -179,3 +177,10 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
+
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60

--- a/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
+++ b/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
@@ -27,7 +27,7 @@ initial_prompt: |
   I want to improve an invoice extraction model and end up with two trained
   versions to compare. Use the tenant I'm already signed into (check I'm logged
   in; don't re-authenticate): start a project from the files in `./fixtures/` —
-  give it a unique title `ixp-it-versions-<random-suffix>` so concurrent runs don't
+  give it a unique title `codereval-integ-versions-<random-suffix>` so concurrent runs don't
   collide — import the taxonomy, upload one of the invoices — and let it train.
   Work only on the project you create; other runs share this tenant, so never
   list, read, or modify any other project.
@@ -48,7 +48,7 @@ initial_prompt: |
   instruction so it only captures the grand total payable. Once it has retrained,
   pull the new version's metrics the same way into `metrics_v2.json`.
 
-  Delete the project when you're done — even if a step above failed.
+  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
 success_criteria:
   - type: command_executed
@@ -75,11 +75,9 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Deleted the project as cleanup"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+delete\b(?=.*(--yes|-y))'
-    min_count: 1
+  - type: file_exists
+    description: "report.json written for post-run cleanup"
+    path: "report.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -122,3 +120,10 @@ success_criteria:
         expected: 1
     weight: 2.0
     pass_threshold: 1.0
+
+# Safety net: delete the project even if the agent's in-band cleanup never ran
+# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
+# always exits 0 so it never fails the test.
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
+    timeout: 60


### PR DESCRIPTION
## Problem

IXP e2e/integration tasks create real projects on the live tenant and relied on the **agent** deleting them in-band as its final step. Any run that crashed or hit MAX_TURNS before that step **leaked** the project.

## Change

Make each task's cleanup **harness-owned** (`post_run`), so it runs regardless of task pass/fail — and delete **only the project that run created** (it does not sweep or touch any other/older project).

- **`_shared/cleanup_project.py`** — reads `report.json` and deletes that one project via `uip ixp projects delete <name> -y --output json`. Best-effort, always exits 0; a non-zero delete (incl. a 404 on a dataset-less shell) is surfaced as `WARN` — never masked, never fails the test.
- **6 tasks wired** (e2e + 5 integration): a `report.json` instruction (written right after create) + a low-weight `file_exists` criterion + the `post_run` hook. The fragile **in-band delete** instruction/criterion is **removed** — `projects delete` is already covered by the `delete_project` smoke test.
- **Naming:** project titles renamed to the `codereval-e2e-` / `codereval-integ-` family (dropping the redundant `ixp-` — every project here is already an IXP project).

## Scope (deliberately narrow)

- Cleans up **only the current run's own project** — no sweeping/GC of older or leftover projects.
- The existing orphan backlog, and the create/delete non-atomicity that mints dataset-less shells (the CLI 404s on those), are **out of scope** — those belong to the platform/backend team.

## Validation

Ran `labelling_correctness` against staging: `post_run` fired `cleanup_project.py`, deleted the run's own project (`OK: deleted …`), and it was confirmed gone from the tenant. It fired **even though the task graded FAILURE**, proving the cleanup is pass/fail-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)