### PR TITLE
test(uipath-ixp): de-overlap the two confirm steps in labelling_correctness

### DIFF
--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -79,7 +79,7 @@ success_criteria:
   - type: command_executed
     description: "Batched confirm with --updates carrying a corrections entry across occurrences"
     tool_name: "Bash"
-    command_pattern: '(?s)(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b.*--group.*--updates.*corrections'
+    command_pattern: '(?s)(?=.*(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b)(?=.*--group)(?=.*--updates)(?=.*corrections)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -39,10 +39,11 @@ initial_prompt: |
   than waiting longer.
 
   Then, on that invoice's line items:
-  - Confirm only the first line item — the other rows look wrong, leave them.
-  - The OCR mangled the "Amount" on the first two line items — confirm both of them
-    in one call, correcting the first's Amount to `1,234.56` and the second's to
-    `2,500.00`. Save that command's response to `confirm_result.json`.
+  - Line 1 (the first line item) is extracted correctly — confirm just that one
+    line on its own, leaving every other row untouched.
+  - Separately, the OCR mangled the "Amount" on line 2 and line 3 — correct both
+    of those Amounts in a single batched call (line 2 to `500.00`, line 3 to
+    `105.42`). Save that command's response to `confirm_result.json`.
   - Actually, scrap that — roll back everything you just confirmed on this document,
     and save that command's response to `unconfirm_result.json`.
   - These line items have no tax column, so "Tax" doesn't apply here — mark it


### PR DESCRIPTION
## Problem

`labelling_correctness` intends to exercise **both** confirm forms:
- **single-occurrence** — `confirm --group … --occurrence 0`
- **batched** — `confirm --group … --updates '[…corrections…]'`

But the two prompt bullets both targeted **occurrence 0**: *"confirm only the first line item"*, then *"confirm both of the first two … correcting the first's Amount …"*. A competent agent folds those into a **single `--updates` call** covering occ 0 and occ 1 — which satisfies the batched criterion but never runs the `--occurrence 0` form, so that criterion fails.

Observed in a live run: 9/10 criteria passed; the only failure was *"Confirmed the first occurrence via `--group` + `--occurrence 0`"*.

## Why fix the test, not the skill

The skill is **correct** — its `cli-reference` explicitly documents `--updates` as a *superset*: `--occurrence <N>` ≡ `--updates` with one entry. So the agent followed the skill faithfully; it didn't misbehave. "Fix the skill, not the test" applies when a test exposes a skill gap — here the test itself was over-specified/ambiguous (two steps that both touch occ 0), so the test is the artifact to correct. Loosening the criterion to accept `--updates` would instead *erase* the single-occurrence coverage the task exists to provide.

## Fix

**1. Prompt** — split the work onto **non-overlapping occurrences** so each form is genuinely required:
- **Line 1 (occ 0)** — extracted correctly → confirm it **alone** via `--occurrence 0`.
- **Lines 2 & 3 (occ 1, 2)** — OCR-mangled Amounts → correct **both in one `--updates` call**.

Correction values (`500.00`, `105.42`) match the actual `csi_tower_invoice` fixture (8 line items, no Tax column). The `unconfirm` / `mark-missing` steps and their `json_check`s are unchanged (they assert only `Result`/`Code`/counts, not specific values or occurrences).

**2. Criterion #2 regex** — the prompt change is paired with a matcher change, because a repeat run surfaced a **second, pre-existing bug** in the batched-confirm criterion. It was order-sensitive:

```
# before (ordered): requires `corrections` to appear AFTER `--updates`
(?s)(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b.*--group.*--updates.*corrections

# after (unordered lookaheads):
(?s)(?=.*(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b)(?=.*--group)(?=.*--updates)(?=.*corrections)
```

When the agent passes the JSON via a shell variable, the `corrections` literal lands in the assignment *before* `confirm`, so the ordered pattern misses it — a false negative (3/20 in the repeat run, all correct behavior):

```bash
UPDATES='[{"occurrence":1,"corrections":{…}}]'      # "corrections" is here, BEFORE "confirm"
uip ixp labellings confirm … --group "Line Items" --updates "$UPDATES"
```

### What the new pattern means

| Fragment | Meaning |
|---|---|
| `(?s)` | DOTALL — `.` also matches newlines (the command spans multiple lines: the `UPDATES=…` assignment, the `confirm`, `\`-continuations). |
| `(?= … )` | Lookahead — a zero-width "findable ahead?" check that consumes nothing, so all four are tested from the same position → all must be present but in **any order**. |
| `(?=.*(uip\|\$UIP)\s+ixp\s+labellings\s+confirm\b)` | a `uip` (or literal `$UIP` shell var) `ixp labellings confirm` appears somewhere; `\b` keeps it `confirm`, not `unconfirm`. |
| `(?=.*--group)` / `(?=.*--updates)` / `(?=.*corrections)` | each token appears somewhere. |

There is no consuming part — the whole regex is four stacked assertions, so it means: *"this one Bash command is a `labellings confirm` that also contains `--group`, `--updates`, and `corrections`, anywhere and in any order."* It intentionally does **not** check flag order, quoting, inline-vs-variable JSON, or the actual values/occurrences (that would need outcome-based verification via a read-back API, which does not exist yet). `command_executed` matches per executed command, so all four tokens must be in the **same** Bash invocation — which they are.

## Validation

A 20× repeat run of the task: 17/20 fully passed; the only failures were 3 hits of the old ordered regex (all correct agent behavior). Criterion #1 (`--occurrence 0`) passed 20/20 with the de-overlapped prompt. The lookahead fix converts those 3 false negatives to passes → effectively 20/20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)