### PR TITLE
feat(telemetry): emit skill/session lifecycle events from the hook

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -7,6 +7,7 @@ on:
       - 'tests/tasks/uipath-maestro-case/**'
       - 'tests/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
+      - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
       - '.github/workflows/test-helpers.yml'
   workflow_dispatch:
 
@@ -80,3 +81,23 @@ jobs:
       # (see #1203).
       - name: Run catalog guard tests
         run: pytest tests/scripts/test_catalog_build_guards.py -v
+
+  telemetry-hook-tests:
+    runs-on: ubuntu-latest
+    name: telemetry hook contract guard
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      # Runs hooks/send-telemetry.sh with a stubbed uip and asserts the
+      # eventName mapping (session-start/-end/completion/tool-use), lifecycle
+      # fields, and drop paths; and hooks/set-session-env.sh against a temp
+      # CLAUDE_ENV_FILE (export line, host-wins, idempotence, sanitization).
+      - name: Run telemetry hook tests
+        run: pytest tests/scripts/test_send_telemetry_hook.py tests/scripts/test_set_session_env_hook.py -v

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -63,8 +63,12 @@ plugin; everything else exits silently. A call qualifies when:
 
 ## How it works
 
-1. The `PostToolUse` hook fires on every tool call and exits silently unless
-   the call is attributable to this plugin (table above).
+1. The hook fires on every registered event. On `PostToolUse` it exits
+   silently unless the tool call is attributable to this plugin (table above);
+   the lifecycle events (`SessionStart` / `SessionEnd` / `Stop` /
+   `StopFailure`) are session-scoped and skip that per-call gate — steps 2–4
+   below describe the richer tool-use path, lifecycle events carry only the
+   envelope fields (see [Events](#events)).
 2. For a qualifying call it derives a small set of low-cardinality fields and
    sanitizes each value (charset + 120-char cap). Field extraction is
    **region-scoped**: a single string-aware `awk` pass walks the payload once,

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -28,10 +28,26 @@ they are the denominator for activation-rate and session-mix metrics.
 | `SessionEnd` | `session-end` | `uip.skills.session-end` | per session |
 
 `Stop` and `StopFailure` both map to `completion`, distinguished by `outcome`,
-so an API-error turn is not lost from completion/abandonment metrics. This hook
-is the **Claude Code** emitter; other agents (Codex, Gemini, Cursor CLI) expose
-the same lifecycle moments under their own hook names and are separate
-follow-ups. **Cursor cloud agents are out of scope** — they run in an ephemeral
+so an API-error turn is not lost from completion/abandonment metrics.
+
+### Per-agent availability
+
+The hook runs under any agent that honors `hooks.json`. **Codex fires
+`SessionStart` and `Stop` under the same names with a matching envelope**
+(`session_id`, `source`, `model` — [Codex hooks
+docs](https://developers.openai.com/codex/hooks)), so the mapping above works
+for both agents unchanged:
+
+| Event | Claude Code | Codex | Field differences on Codex |
+|-------|-------------|-------|----------------------------|
+| `session-start` | ✓ `SessionStart` | ✓ `SessionStart` | none relevant — `source` and `model` present on both |
+| `completion` | ✓ `Stop` (`outcome=ok`) / `StopFailure` (`outcome=failure`) | ✓ `Stop` only — `outcome` is always `ok` (Codex has no `StopFailure`; API-error turns are not distinguished) | extras `turn_id` / `stop_hook_active` / `last_assistant_message` are **not read**; no `duration_ms` → `durationMs: null` |
+| `session-end` | ✓ `SessionEnd` (`reason`) | ✗ — no `SessionEnd` hook; `completion` is the terminal signal | `reason` never present |
+| `tool-use` | ✓ `PostToolUse` | ✓ `PostToolUse` | `tool_response` is a JSON string → `outcome` is `ok`/`unknown` only; no `duration_ms`/`effort.level` (see [Cross-agent compatibility](#cross-agent-compatibility)) |
+
+**Gemini CLI and the Cursor CLI** expose the same lifecycle moments under
+different hook names/registration formats and are separate follow-ups.
+**Cursor cloud agents are out of scope** — they run in an ephemeral
 remote VM with no local `uip` CLI, no authenticated identity, and no
 session-start/-end trigger point.
 
@@ -278,6 +294,12 @@ when the variable is already set), the value is sanitized to `[A-Za-z0-9._-]`
 before being written into the sourced env file, and the step is not gated on
 `UIPATH_TELEMETRY_DISABLED` — writing a variable transmits nothing; the CLI's
 own gate governs whether any event carrying it is sent.
+
+This mechanism is **Claude Code-only**: Codex offers no env-file equivalent for
+hooks, and its `CODEX_THREAD_ID` matches the payload `session_id` only for the
+root thread (subagent threads carry their own thread id) — so native-command
+correlation is currently not available under Codex. Codex **skills events**
+still carry `session_id` and correlate with each other normally.
 
 ## Reliability & performance
 

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -1,12 +1,39 @@
 # UiPath Skills Plugin Telemetry
 
 Opt-out usage telemetry for the UiPath skills plugin. On by default. One
-`PostToolUse` hook (`hooks/send-telemetry.sh`) hands a single flat JSON object
-per relevant tool call to the hidden `uip track` CLI command, which forwards it
-through the CLI's own telemetry tracker as one `uip.skills.tool-use`
-Application Insights event. No local state file, no session daemon —
-session-level metrics are computed at query time from the event stream (see
-[Correlation](#correlation)).
+emitting hook (`hooks/send-telemetry.sh`), registered on several Claude Code
+hook events, hands a single flat JSON object to the hidden `uip track` CLI
+command, which forwards it through the CLI's own telemetry tracker as one
+`uip.skills.<event>` Application Insights event. A second, synchronous
+SessionStart step (`hooks/set-session-env.sh`) exports the agent session id as
+`UIPATH_SESSION_ID` so native `uip` command telemetry carries the same
+`session_id` (see [Correlation](#correlation)). No local state file, no
+session daemon — session-level metrics are computed at query time from the
+event stream.
+
+## Events
+
+The hook carries an `eventName` token; `uip track` owns the `uip.skills.*`
+namespace and maps the token to the emitted event. `tool-use` is **per tool
+call** and gated on plugin attribution (table below); the lifecycle events are
+**session-scoped** and fire for every session where this plugin is installed —
+they are the denominator for activation-rate and session-mix metrics.
+
+| Claude Code hook | `eventName` | Emitted event | Scope |
+|------------------|-------------|---------------|-------|
+| `PostToolUse` | `tool-use` | `uip.skills.tool-use` | per tool call (gated) |
+| `SessionStart` | `session-start` | `uip.skills.session-start` | per session |
+| `Stop` | `completion` | `uip.skills.completion` | per turn (`outcome=ok`) |
+| `StopFailure` | `completion` | `uip.skills.completion` | per turn (`outcome=failure`, API error) |
+| `SessionEnd` | `session-end` | `uip.skills.session-end` | per session |
+
+`Stop` and `StopFailure` both map to `completion`, distinguished by `outcome`,
+so an API-error turn is not lost from completion/abandonment metrics. This hook
+is the **Claude Code** emitter; other agents (Codex, Gemini, Cursor CLI) expose
+the same lifecycle moments under their own hook names and are separate
+follow-ups. **Cursor cloud agents are out of scope** — they run in an ephemeral
+remote VM with no local `uip` CLI, no authenticated identity, and no
+session-start/-end trigger point.
 
 ## Enabling / disabling
 
@@ -38,9 +65,8 @@ plugin; everything else exits silently. A call qualifies when:
 
 1. The `PostToolUse` hook fires on every tool call and exits silently unless
    the call is attributable to this plugin (table above).
-2. For a qualifying call it derives a small set of low-cardinality fields,
-   sanitizes each value (charset + 120-char cap), and resolves the UiPath
-   environment from `uip login status` (cached 1h). Field extraction is
+2. For a qualifying call it derives a small set of low-cardinality fields and
+   sanitizes each value (charset + 120-char cap). Field extraction is
    **region-scoped**: a single string-aware `awk` pass walks the payload once,
    tracking brace/string depth, and pulls each field only from the region it
    lives in — envelope (top-level keys), `tool_input`, `tool_response`, or
@@ -49,12 +75,15 @@ plugin; everything else exits silently. A call qualifies when:
    [Region scoping](#region-scoping)).
 3. It pipes one flat `key:value` JSON object to `uip track` on stdin, in a
    detached subshell, then exits 0.
-4. `uip track` ([UiPath/cli#2600](https://github.com/UiPath/cli/pull/2600))
-   reads that object, hard-codes the event name `uip.skills.tool-use`, stamps a
-   `source: "skills-plugin"` dimension, attaches the authenticated UiPath cloud
-   identity and the CLI app version, and forwards it through the CLI's
-   telemetry tracker. Every key becomes an event property; non-scalar values
-   (objects / arrays / `null`) are dropped.
+4. `uip track` ([UiPath/cli#2600](https://github.com/UiPath/cli/pull/2600),
+   extended for lifecycle events in
+   [UiPath/cli#2815](https://github.com/UiPath/cli/pull/2815)) reads that
+   object, maps the `eventName` token to the CLI-owned `uip.skills.<event>`
+   name (an unrecognized token drops the event; an absent one means
+   `tool-use`), stamps a `source: "skills-plugin"` dimension, attaches the
+   authenticated UiPath cloud identity and the CLI app version, and forwards it
+   through the CLI's telemetry tracker. Every key becomes an event property;
+   non-scalar values (objects / arrays / `null`) are dropped.
 
 The hook builds **no** App Insights envelope and makes **no** direct HTTP POST.
 Transport, the connection, the event name, the `source` dimension, and identity
@@ -62,26 +91,27 @@ all belong to the CLI.
 
 ## What is collected
 
-Each event is the App Insights event `uip.skills.tool-use`. Every key the hook
-sends becomes an event property.
+Each event is an App Insights event named `uip.skills.<event>` (see
+[Events](#events)). Every key the hook sends becomes an event property.
 
 ### Properties sent by the hook
 
 | Field | Example | Notes |
 |-------|---------|-------|
-| `schemaVersion` | `1` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas |
-| `toolName` | `Skill`, `Bash` | Claude Code tool. From the top-level `tool_name` |
+| `schemaVersion` | `2` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas. `2` added `eventName` / `session_source` / `reason`, renamed `sessionId` → `session_id`, and dropped `environment` / `baseUrl` (CLI-stamped since [UiPath/cli#2806](https://github.com/UiPath/cli/pull/2806) — see [Added by the CLI](#added-by-the-cli)) |
+| `eventName` | `session-start` | Which lifecycle event this is (see [Events](#events)). Consumed by `uip track` to pick the `uip.skills.<event>` name; **not** emitted as an event property |
+| `toolName` | `Skill`, `Bash` | Claude Code tool. From the top-level `tool_name`. `tool-use` only |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
-| `sessionId` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key |
+| `session_id` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key. Canonical snake_case, matching the CLI command stream ([UiPath/cli#2800](https://github.com/UiPath/cli/pull/2800)); `uip track` still accepts the v1 `sessionId` spelling and maps it |
 | `subagentModel` | `opus` | From `tool_response.resolvedModel`, normalized to a family — `opus` / `sonnet` / `haiku` / `fable` (`other` if unrecognized). The context-window marker is dropped (`claude-opus-4-8[1m]` → `opus`). Set on an Agent-**spawn** event; empty otherwise |
 | `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type. Set on an Agent-**spawn** event; empty otherwise |
 | `agentType` | `Explore` | From the top-level `agent_type` — type of the subagent the call runs **inside**. Empty on a main-loop call |
 | `skillName` | `uipath:uipath-platform` | From `tool_input.skill`. `Skill` calls only |
 | `uipSubcommand` | `solution publish` | First 1–2 verbs derived from `tool_input.command` — never the full command line, never `stdout` |
 | `fileExtension` | `.flow` | Derived from `tool_input.file_path`. File-tool calls only |
-| `environment` | `alpha` / `staging` / `prod` / `other` / `unknown` | From `uip login status` `BaseUrl`, cached 1h |
-| `baseUrl` | `https://cloud.uipath.com` | Cloud base URL only |
-| `outcome` | `ok` / `failure` / `interrupted` / `unknown` | From the `tool_response` region **only**, never output content — see [Outcome semantics](#outcome-semantics) |
+| `outcome` | `ok` / `failure` / `interrupted` / `unknown` | On `tool-use`, from the `tool_response` region **only**; on `completion`, `ok` (`Stop`) or `failure` (`StopFailure`) — see [Outcome semantics](#outcome-semantics) |
+| `session_source` | `startup` / `resume` / `clear` / `compact` | `session-start` only. From the top-level `source` (renamed to avoid the CLI-owned `source` dimension) |
+| `reason` | `logout` / `clear` / `resume` / … | `session-end` only. Why the session ended, from the top-level `reason` (values are agent-specific) |
 | `permissionMode` | `bypassPermissions` | From the top-level `permission_mode` |
 | `effortLevel` | `high` | From the top-level `effort.level`, when present (`low` / `medium` / `high` / `xhigh` / `max`) |
 | `skillsVersion` | `1.196.0` | `skillsVersion` from `version-manifest.json` |
@@ -105,7 +135,7 @@ region where it actually lives:
 
 | Region | Fields |
 |--------|--------|
-| Envelope (top-level keys) | `toolName`, `toolUseId`, `sessionId`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType` |
+| Envelope (top-level keys) | `toolName`, `toolUseId`, `session_id`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType`, `source` (→`session_source`, session-start), `reason` (session-end) |
 | `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` (from `subagent_type`, or `agent_type` on a Codex `spawn_agent` call — normalized to the same field so it never collides with the envelope `agent_type`) |
 | `tool_response` | `outcome` (`interrupted` / `success`), `subagentModel` (`resolvedModel`) |
 
@@ -117,8 +147,8 @@ is matched against `tool_input.command`, file extensions against
 
 ### Outcome semantics
 
-`outcome` is computed from the `tool_response` region **only** — output content
-never flips it:
+On `tool-use`, `outcome` is computed from the `tool_response` region **only** —
+output content never flips it:
 
 | Value | Condition |
 |-------|-----------|
@@ -129,6 +159,11 @@ never flips it:
 
 A `tool_response` that is a JSON **string** or **array** (some MCP tools) yields
 `ok` — it is present but exposes no `success` / `interrupted` field.
+
+On `completion`, `outcome` comes from the hook event itself, not a tool
+response: `ok` for `Stop` (normal turn end) and `failure` for `StopFailure` (the
+turn ended on an API error). `session-start` and `session-end` carry no
+`outcome` (an empty string); `session-end`'s `reason` conveys why it ended.
 
 ### Subagent fields — distinct meanings
 
@@ -160,19 +195,21 @@ attribution all work unchanged. Three differences are handled or accepted:
 
 Codex has no `Skill` tool, so `skillName` and the Skill-based attribution path
 never fire — Codex attribution relies on the `uip`-command and file-extension
-signals. The key set is unchanged, so `schemaVersion` stays `1`; events are
-distinguished by agent through the CLI-stamped client/`source` context, not a
-hook field.
+signals. The cross-agent handling itself changes no keys; the current key set
+is **schema v2** (see the [field table](#properties-sent-by-the-hook)). Events
+are distinguished by agent through the CLI-stamped client/`source` context, not
+a hook field.
 
 ### Added by the CLI
 
-The CLI stamps these on every `uip.skills.tool-use` event — the hook never
-sends them, and a `source` value sent by the hook would be overridden:
+The CLI stamps these on every `uip.skills.*` event — the hook never sends them,
+and a `source` value sent by the hook would be overridden:
 
 | Field | Notes |
 |-------|-------|
 | `source` | Always `skills-plugin` |
 | `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity |
+| `environment` / `base_url` / `region` | Normalized from the CLI's **own** auth context at startup ([UiPath/cli#2806](https://github.com/UiPath/cli/pull/2806)) — always fresh, `base_url` reduced to its origin. Replaces the hook's former `environment` / `baseUrl` (schema v1), which came from a 1h-cached `uip login status` and could go stale |
 | `application_Version` | The `uip` CLI's own version (replaces the hook's former `cliVersion`) |
 | OS / client context | Recorded by the tracker by default (replaces the hook's former `operatingSystem`) |
 
@@ -207,14 +244,32 @@ is absent from the payload, so query schemas stay stable:
 ## Correlation
 
 Session-level metrics need no local state file — they are query-time
-aggregations over events sharing `sessionId`:
+aggregations over events sharing `session_id`:
 
 | Metric | Query shape |
 |--------|-------------|
-| Tool calls per session | `count() by sessionId` |
-| Session duration | `max(timestamp) - min(timestamp) by sessionId` |
-| Time-to-first-skill | first `Skill` event − first event, per session |
+| Tool calls per session | `count() by session_id` |
+| Session duration | `session-end` − `session-start` per `session_id` (fallback `max(timestamp) − min(timestamp)` where no `session-end`, e.g. Codex) |
+| Activation rate | sessions with ≥1 `tool-use` ÷ all `session-start`, by `session_id` |
+| Session outcome mix | `session-end` count by `reason`; sessions containing a `completion` with `outcome=failure` |
+| Time-to-first-skill | first `Skill` event − `session-start`, per session |
 | Retries | repeated `uipSubcommand` flipping `failure → ok`, ordered by `timestamp` then `toolUseId` |
+| Hook coverage % | sessions with ≥1 `uip.skills.*` lifecycle event ÷ agent sessions seen on the command stream (`execution_context == "agent"`), per period — report alongside any hook-based rate |
+
+### Cross-stream correlation (`UIPATH_SESSION_ID`)
+
+The synchronous SessionStart step (`hooks/set-session-env.sh`) writes
+`export UIPATH_SESSION_ID='<session_id>'` to Claude Code's `CLAUDE_ENV_FILE`,
+so every `uip` command the agent runs inherits it and the CLI stamps the same
+`session_id` on **native command telemetry**
+([UiPath/cli#2800](https://github.com/UiPath/cli/pull/2800)). Skills events and
+command events then join on `session_id` — e.g. "commands per turn" or
+"sessions whose skill invocation produced no successful build/operate command".
+Safety: a host-provided `UIPATH_SESSION_ID` always wins (the step is a no-op
+when the variable is already set), the value is sanitized to `[A-Za-z0-9._-]`
+before being written into the sourced env file, and the step is not gated on
+`UIPATH_TELEMETRY_DISABLED` — writing a variable transmits nothing; the CLI's
+own gate governs whether any event carrying it is sent.
 
 ## Reliability & performance
 
@@ -225,9 +280,9 @@ aggregations over events sharing `sessionId`:
   exits 0, emits nothing when telemetry is off or on any error).
 - **Best-effort delivery:** an event is dropped on failure (no local retry
   queue). Telemetry is for aggregate trends, not exact accounting.
-- **Environment cost:** `uip login status` (~0.5s) runs at most once per hour;
-  the result is cached in a per-user, `chmod 700` directory and parsed as data,
-  never sourced.
+- **Session id export:** `set-session-env.sh` is the one synchronous step
+  (it must run before the session's first Bash call); it costs a few
+  milliseconds — pure text processing, no network and no `uip` invocation.
 - **Cross-platform:** pure POSIX `bash` + `grep`/`sed`/`awk`, no `jq`
   dependency (macOS, Linux, Windows Git Bash). Requires the `uip` CLI on `PATH`
   — the plugin's `SessionStart` hook ensures it is installed.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -102,7 +102,7 @@ Each event is an App Insights event named `uip.skills.<event>` (see
 
 | Field | Example | Notes |
 |-------|---------|-------|
-| `schemaVersion` | `2` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas. `2` added `eventName` / `session_source` / `reason`, renamed `sessionId` → `session_id`, and dropped `environment` / `baseUrl` (CLI-stamped since [UiPath/cli#2806](https://github.com/UiPath/cli/pull/2806) — see [Added by the CLI](#added-by-the-cli)) |
+| `schemaVersion` | `2` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas. `2` added `eventName` / `session_source` / `reason` / `agent_model`, renamed `sessionId` → `session_id`, and dropped `environment` / `baseUrl` (CLI-stamped since [UiPath/cli#2806](https://github.com/UiPath/cli/pull/2806) — see [Added by the CLI](#added-by-the-cli)) |
 | `eventName` | `session-start` | Which lifecycle event this is (see [Events](#events)). Consumed by `uip track` to pick the `uip.skills.<event>` name; **not** emitted as an event property |
 | `toolName` | `Skill`, `Bash` | Claude Code tool. From the top-level `tool_name`. `tool-use` only |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
@@ -110,6 +110,7 @@ Each event is an App Insights event named `uip.skills.<event>` (see
 | `subagentModel` | `opus` | From `tool_response.resolvedModel`, normalized to a family — `opus` / `sonnet` / `haiku` / `fable` (`other` if unrecognized). The context-window marker is dropped (`claude-opus-4-8[1m]` → `opus`). Set on an Agent-**spawn** event; empty otherwise |
 | `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type. Set on an Agent-**spawn** event; empty otherwise |
 | `agentType` | `Explore` | From the top-level `agent_type` — type of the subagent the call runs **inside**. Empty on a main-loop call |
+| `agent_model` | `claude-sonnet-5` | The session's **main** model, from the top-level `model` where the agent provides it — Claude Code sends it on `SessionStart` payloads, Codex on every hook event. Full sanitized slug (no family collapse — model-comparison views need version granularity); distinct from `subagentModel` (a spawned child's model family). Empty when the payload carries none; Claude sessions get full coverage at query time by joining on `session_id` from the `session-start` event |
 | `skillName` | `uipath:uipath-platform` | From `tool_input.skill`. `Skill` calls only |
 | `uipSubcommand` | `solution publish` | First 1–2 verbs derived from `tool_input.command` — never the full command line, never `stdout` |
 | `fileExtension` | `.flow` | Derived from `tool_input.file_path`. File-tool calls only |
@@ -139,7 +140,7 @@ region where it actually lives:
 
 | Region | Fields |
 |--------|--------|
-| Envelope (top-level keys) | `toolName`, `toolUseId`, `session_id`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType`, `source` (→`session_source`, session-start), `reason` (session-end) |
+| Envelope (top-level keys) | `toolName`, `toolUseId`, `session_id`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType`, `source` (→`session_source`, session-start), `reason` (session-end), `model` (→`agent_model`) |
 | `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` (from `subagent_type`, or `agent_type` on a Codex `spawn_agent` call — normalized to the same field so it never collides with the envelope `agent_type`) |
 | `tool_response` | `outcome` (`interrupted` / `success`), `subagentModel` (`resolvedModel`) |
 
@@ -180,7 +181,10 @@ The three subagent fields describe two different viewpoints and are independent:
 - **`agentType`** is set on calls made **inside** a subagent — the **child's**
   own view, from the top-level `agent_type`.
 
-All three are empty on a plain main-loop tool call.
+All three are empty on a plain main-loop tool call. **`agent_model`** is none
+of these: it is the **session's main model** (from the envelope `model`),
+independent of any subagent — the dimension for model-comparison views
+(UiPath/cli#2785).
 
 ### Cross-agent compatibility
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -15,6 +15,16 @@
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/suggest-permissions.sh\"",
             "timeout": 5,
             "once": true
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/set-session-env.sh\"",
+            "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
+            "async": true
           }
         ]
       }
@@ -22,6 +32,39 @@
     "PostToolUse": [
       {
         "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/send-telemetry.sh\"",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "StopFailure": [
+      {
         "hooks": [
           {
             "type": "command",

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -409,6 +409,13 @@ main() {
     outcome="$(lifecycle_outcome)"
   fi
 
+  # Enforce the per-event field scoping the contract documents: session_source
+  # only on session-start, reason only on session-end. The awk pass extracts
+  # `source`/`reason` from ANY event's envelope, so a future payload that adds
+  # either key to another event must not bleed into these dimensions.
+  [ "$event_name" = "session-start" ] || session_source=""
+  [ "$event_name" = "session-end" ]   || reason=""
+
   skills_ver="$(read_skills_version)"
 
   # durationMs is a JSON number. Emit JSON null (not 0) when absent, so a missing

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -1,18 +1,25 @@
 #!/bin/bash
-# PostToolUse telemetry hook for the UiPath skills plugin.
+# Telemetry hook for the UiPath skills plugin (Claude Code).
 #
-# Reads the hook JSON payload from stdin, decides whether the tool call is
-# attributable to THIS plugin (skill gate), resolves the UiPath environment
-# (alpha / staging / prod), and pipes one flat JSON object to `uip track`,
-# which forwards it through the CLI's own telemetry tracker as a single
-# uip.skills.tool-use Application Insights event. Calls from other plugins or
-# bare Claude Code are dropped.
+# Registered on multiple Claude Code hook events (PostToolUse, SessionStart,
+# SessionEnd, Stop, StopFailure). Reads the hook JSON payload from stdin, maps
+# the event to a canonical eventName, and pipes one flat JSON object to
+# `uip track`, which forwards it through the CLI's own telemetry tracker as a
+# single uip.skills.<event> Application Insights event.
+#
+# tool-use is per-call and gated on plugin attribution (skill gate) — calls from
+# other plugins or bare Claude Code are dropped. Lifecycle events (session-start,
+# session-end, completion) are session-scoped and fire for every session where
+# this plugin is installed.
 #
 # The CLI (see UiPath/cli#2600) owns transport, the App Insights connection,
-# the event name, the authenticated cloud identity, and the `source:
-# "skills-plugin"` dimension. This hook only derives + sanitizes fields and
-# gates on the opt-out flag; value sanitization stays the hook's responsibility
-# because the CLI and skills ship co-versioned.
+# the event name, the authenticated cloud identity, the `source:
+# "skills-plugin"` dimension, and — since UiPath/cli#2806 — the
+# environment/base_url/region base dimensions stamped fresh on every event
+# from its own auth context (so this hook sends no environment info). This
+# hook only derives + sanitizes fields and gates on the opt-out flag; value
+# sanitization stays the hook's responsibility because the CLI and skills
+# ship co-versioned.
 #
 # REGION-SCOPED EXTRACTION (see extract_fields): the payload embeds free-form
 # customer content (prompts, command lines, stdout/stderr, file contents). A
@@ -20,8 +27,9 @@
 # contains JSON-shaped text (`"success":false`, `uip solution publish`,
 # `.flow"`, `"resolvedModel":"..."`). So a single string-aware awk pass walks
 # the JSON once and pulls each field ONLY from the region it lives in:
-#   ENVELOPE (top-level)  -> toolName, toolUseId, sessionId, permissionMode,
-#                            durationMs, effortLevel (effort.level), agentType
+#   ENVELOPE (top-level)  -> toolName, toolUseId, session_id, permissionMode,
+#                            durationMs, effortLevel (effort.level), agentType,
+#                            source (-> session_source), reason (session-end)
 #   tool_input            -> skillName, uipSubcommand (command), fileExtension
 #                            (file_path), subagentType (subagent_type, or
 #                            agent_type for a Codex spawn_agent call)
@@ -55,8 +63,12 @@
 set +e
 
 # schemaVersion of the emitted event. Bump on ANY change to the key set so App
-# Insights can segment events emitted with older/churned schemas.
-SCHEMA_VERSION=1
+# Insights can segment events emitted with older/churned schemas. v2: adds the
+# eventName / session_source / reason keys for lifecycle events, renames
+# sessionId -> session_id (canonical casing, matches the CLI command stream,
+# UiPath/cli#2800), and drops environment/baseUrl (the CLI stamps fresh
+# environment/base_url/region base dimensions itself, UiPath/cli#2806).
+SCHEMA_VERSION=2
 
 # --- extraction ------------------------------------------------------------
 
@@ -73,7 +85,7 @@ extract_fields() {
       if (d == 1)
         return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
                 k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
-                k=="hook_event_name")
+                k=="hook_event_name"||k=="source"||k=="reason")
       if (d == 2 && c == "input")
         return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type"|| \
                 k=="agent_type")
@@ -173,7 +185,7 @@ read_fields() {
   event=""; tool=""; tool_use_id=""; session_id=""; permission_mode=""
   duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
   subagent_type=""; interrupted=""; success=""; resolved_model=""
-  effort_level=""; response_seen=""
+  effort_level=""; response_seen=""; session_source=""; reason=""
   local k v
   while IFS="$(printf '\t')" read -r k v; do
     case "$k" in
@@ -184,6 +196,8 @@ read_fields() {
       permission_mode)    permission_mode="$v" ;;
       duration_ms)        duration_ms="$v" ;;
       agent_type)         agent_type="$v" ;;
+      source)             session_source="$v" ;;
+      reason)             reason="$v" ;;
       skill)              skill="$v" ;;
       command)            command="$v" ;;
       file_path)          file_path="$v" ;;
@@ -233,54 +247,6 @@ is_uipath_call() {
   return 1
 }
 
-# --- environment resolution ------------------------------------------------
-
-# cache_val <file> <key>: emit a cached value stripped to a safe charset. Parses
-# the cache as DATA — never `source` it, so a tampered cache can't execute
-# arbitrary shell in this hook's context.
-cache_val() {
-  grep -E "^$2=" "$1" 2>/dev/null | head -1 | cut -d= -f2- | tr -cd 'A-Za-z0-9:._/-'
-}
-
-# resolve_environment: set env_name + base_url from `uip login status` (~0.5s),
-# cached per-user for 1h so only one tool call per hour pays the cost. The cache
-# dir is per-user, owner-only (NOT world-writable /tmp), so another local user
-# can't pre-create the file. chmod is a no-op on Windows but harmless.
-resolve_environment() {
-  local cache_dir cache ttl now _ts status_json
-  cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/uipath-telemetry"
-  mkdir -p "$cache_dir" 2>/dev/null && chmod 700 "$cache_dir" 2>/dev/null
-  cache="$cache_dir/env.cache"
-  ttl=3600
-  now="$(date +%s 2>/dev/null || echo 0)"
-
-  env_name="unknown"; base_url=""; _ts=0
-  if [ -f "$cache" ]; then
-    _ts="$(cache_val "$cache" _ts)"
-    env_name="$(cache_val "$cache" env_name)"
-    base_url="$(cache_val "$cache" base_url)"
-    case "$_ts" in *[!0-9]*|"") _ts=0 ;; esac   # non-numeric -> treat as stale
-  fi
-
-  [ "$(( now - _ts ))" -ge "$ttl" ] || return 0
-
-  status_json="$(uip login status --output json 2>/dev/null)"
-  base_url="$(printf '%s' "$status_json" \
-    | grep -oE '"BaseUrl"[[:space:]]*:[[:space:]]*"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')"
-  case "$base_url" in
-    *alpha.uipath.com*)   env_name="alpha" ;;
-    *staging.uipath.com*) env_name="staging" ;;
-    *cloud.uipath.com*)   env_name="prod" ;;
-    "")                   env_name="unknown" ;;
-    *)                    env_name="other" ;;
-  esac
-  {
-    echo "_ts=$now"
-    echo "env_name=$env_name"
-    echo "base_url=$base_url"
-  } > "$cache" 2>/dev/null
-}
-
 # --- field derivation ------------------------------------------------------
 
 # derive_fields: set skill_name, uip_subcommand, file_ext from the parsed
@@ -321,6 +287,31 @@ compute_outcome() {
   fi
 }
 
+# map_event_name: translate the Claude Code hook event into the canonical
+# eventName token the CLI's `uip track` maps to a uip.skills.<event> event. An
+# unrecognized event prints empty so main() drops it. Stop and StopFailure both
+# map to `completion`, distinguished by outcome (see lifecycle_outcome).
+map_event_name() {
+  case "$event" in
+    PostToolUse)      printf 'tool-use' ;;
+    SessionStart)     printf 'session-start' ;;
+    SessionEnd)       printf 'session-end' ;;
+    Stop|StopFailure) printf 'completion' ;;
+    *)                printf '' ;;
+  esac
+}
+
+# lifecycle_outcome: outcome for the non-tool events. A normal turn end (Stop)
+# is `ok`; an API-error turn end (StopFailure) is `failure`. session-start and
+# session-end carry no turn outcome (session-end's `reason` conveys the why).
+lifecycle_outcome() {
+  case "$event" in
+    Stop)        printf 'ok' ;;
+    StopFailure) printf 'failure' ;;
+    *)           printf '' ;;
+  esac
+}
+
 # model_family <resolvedModel>: print the low-cardinality family and drop the
 # context-window marker (e.g. claude-opus-4-8[1m] -> opus). Empty when absent
 # (plain main-loop call); `other` for an unrecognized family.
@@ -357,21 +348,22 @@ san() { printf '%s' "$1" | tr -c 'A-Za-z0-9:._/ -' '_' | cut -c1-120; }
 build_event_json() {
   local spec json sep fkey ftyp fval
   spec="schemaVersion|n|$SCHEMA_VERSION
+eventName|s|$event_name
 toolName|s|$tool
 skillName|s|$skill_name
 uipSubcommand|s|$uip_subcommand
 fileExtension|s|$file_ext
-environment|s|$env_name
-baseUrl|s|$base_url
 outcome|s|$outcome
 permissionMode|s|$permission_mode
 effortLevel|s|$effort_level
 skillsVersion|s|$skills_ver
 toolUseId|s|$tool_use_id
-sessionId|s|$session_id
+session_id|s|$session_id
 subagentModel|s|$subagent_model
 subagentType|s|$subagent_type
 agentType|s|$agent_type
+session_source|s|$session_source
+reason|s|$reason
 durationMs|n|$dur_json"
   json="{"; sep=""
   while IFS='|' read -r fkey ftyp fval; do
@@ -397,27 +389,39 @@ main() {
   payload="$(cat)"
   read_fields "$(printf '%s' "$payload" | extract_fields)"
 
-  [ "$event" = "PostToolUse" ] || exit 0
-  is_uipath_call || exit 0
+  # Map the hook event to a canonical eventName; drop unrecognized events.
+  event_name="$(map_event_name)"
+  [ -n "$event_name" ] || exit 0
 
-  resolve_environment
-  derive_fields
+  # Derived only on tool-use; keep defined so the fixed key set always assembles.
+  skill_name=""; uip_subcommand=""; file_ext=""; subagent_model=""
 
-  outcome="$(compute_outcome)"
+  if [ "$event_name" = "tool-use" ]; then
+    # tool-use is per-call: gate on plugin attribution, then derive tool fields.
+    is_uipath_call || exit 0
+    derive_fields
+    outcome="$(compute_outcome)"
+    subagent_model="$(model_family "$resolved_model")"
+  else
+    # Lifecycle events are session-scoped — they fire for every session where
+    # this plugin is installed (the activation-rate denominator), so they skip
+    # the per-call attribution gate and tool-field derivation.
+    outcome="$(lifecycle_outcome)"
+  fi
+
+  skills_ver="$(read_skills_version)"
+
   # durationMs is a JSON number. Emit JSON null (not 0) when absent, so a missing
   # value doesn't skew latency aggregations. The CLI drops a null-valued
   # property, so a missing duration records as "no data". Stays unquoted.
   case "$duration_ms" in ''|*[!0-9]*) dur_json="null" ;; *) dur_json="$duration_ms" ;; esac
-  subagent_model="$(model_family "$resolved_model")"
-  skills_ver="$(read_skills_version)"
 
   # Sanitize every string field before assembly.
+  event_name="$(san "$event_name")"
   tool="$(san "$tool")"
   skill_name="$(san "$skill_name")"
   uip_subcommand="$(san "$uip_subcommand")"
   file_ext="$(san "$file_ext")"
-  env_name="$(san "$env_name")"
-  base_url="$(san "$base_url")"
   outcome="$(san "$outcome")"
   permission_mode="$(san "$permission_mode")"
   effort_level="$(san "$effort_level")"
@@ -427,12 +431,14 @@ main() {
   subagent_model="$(san "$subagent_model")"
   subagent_type="$(san "$subagent_type")"
   agent_type="$(san "$agent_type")"
+  session_source="$(san "$session_source")"
+  reason="$(san "$reason")"
 
-  # Hand off to the CLI telemetry tracker. The CLI hard-codes the event name
-  # (uip.skills.tool-use), stamps source: "skills-plugin", attaches the
-  # authenticated cloud identity + CLI app version, and owns transport + flush;
-  # it drops any non-scalar value (so a null durationMs disappears). Send no
-  # `event` key, no envelope, and no `source` (the CLI overrides it).
+  # Hand off to the CLI telemetry tracker. The CLI maps our eventName token to
+  # the uip.skills.<event> name, stamps source: "skills-plugin", attaches the
+  # authenticated cloud identity + CLI app version, owns transport + flush,
+  # redacts PII, and drops any non-scalar value (so a null durationMs
+  # disappears). Send no envelope and no `source` (the CLI overrides it).
   #
   # Detached subshell ( cmd & ) survives this hook's exit so the agent never
   # waits. `uip track` is never-fail (exits 0, emits nothing when telemetry is

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -29,7 +29,9 @@
 # the JSON once and pulls each field ONLY from the region it lives in:
 #   ENVELOPE (top-level)  -> toolName, toolUseId, session_id, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType,
-#                            source (-> session_source), reason (session-end)
+#                            source (-> session_source), reason (session-end),
+#                            model (-> agent_model; Claude sends it on
+#                            SessionStart, Codex on every event)
 #   tool_input            -> skillName, uipSubcommand (command), fileExtension
 #                            (file_path), subagentType (subagent_type, or
 #                            agent_type for a Codex spawn_agent call)
@@ -64,7 +66,7 @@ set +e
 
 # schemaVersion of the emitted event. Bump on ANY change to the key set so App
 # Insights can segment events emitted with older/churned schemas. v2: adds the
-# eventName / session_source / reason keys for lifecycle events, renames
+# eventName / session_source / reason / agent_model keys, renames
 # sessionId -> session_id (canonical casing, matches the CLI command stream,
 # UiPath/cli#2800), and drops environment/baseUrl (the CLI stamps fresh
 # environment/base_url/region base dimensions itself, UiPath/cli#2806).
@@ -85,7 +87,7 @@ extract_fields() {
       if (d == 1)
         return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
                 k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
-                k=="hook_event_name"||k=="source"||k=="reason")
+                k=="hook_event_name"||k=="source"||k=="reason"||k=="model")
       if (d == 2 && c == "input")
         return (k=="skill"||k=="command"||k=="file_path"||k=="subagent_type"|| \
                 k=="agent_type")
@@ -186,6 +188,7 @@ read_fields() {
   duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
   subagent_type=""; interrupted=""; success=""; resolved_model=""
   effort_level=""; response_seen=""; session_source=""; reason=""
+  agent_model=""
   local k v
   while IFS="$(printf '\t')" read -r k v; do
     case "$k" in
@@ -198,6 +201,7 @@ read_fields() {
       agent_type)         agent_type="$v" ;;
       source)             session_source="$v" ;;
       reason)             reason="$v" ;;
+      model)              agent_model="$v" ;;
       skill)              skill="$v" ;;
       command)            command="$v" ;;
       file_path)          file_path="$v" ;;
@@ -362,6 +366,7 @@ session_id|s|$session_id
 subagentModel|s|$subagent_model
 subagentType|s|$subagent_type
 agentType|s|$agent_type
+agent_model|s|$agent_model
 session_source|s|$session_source
 reason|s|$reason
 durationMs|n|$dur_json"
@@ -438,6 +443,7 @@ main() {
   subagent_model="$(san "$subagent_model")"
   subagent_type="$(san "$subagent_type")"
   agent_type="$(san "$agent_type")"
+  agent_model="$(san "$agent_model")"
   session_source="$(san "$session_source")"
   reason="$(san "$reason")"
 

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -291,10 +291,15 @@ compute_outcome() {
   fi
 }
 
-# map_event_name: translate the Claude Code hook event into the canonical
-# eventName token the CLI's `uip track` maps to a uip.skills.<event> event. An
+# map_event_name: translate the agent hook event into the canonical eventName
+# token the CLI's `uip track` maps to a uip.skills.<event> event. An
 # unrecognized event prints empty so main() drops it. Stop and StopFailure both
 # map to `completion`, distinguished by outcome (see lifecycle_outcome).
+# CROSS-AGENT: Codex fires SessionStart and Stop under these SAME names with a
+# matching envelope (session_id/source/model; docs: developers.openai.com/
+# codex/hooks), so both map here unchanged. Codex has NO SessionEnd (completion
+# is its terminal signal) and no StopFailure (its API-error turns are not
+# distinguished). Gemini/Cursor use different hook names — separate follow-ups.
 map_event_name() {
   case "$event" in
     PostToolUse)      printf 'tool-use' ;;

--- a/hooks/set-session-env.sh
+++ b/hooks/set-session-env.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# SessionStart step: export the agent's session id to the uip CLI.
+#
+# Reads the SessionStart payload on stdin, takes its top-level `session_id`,
+# and appends `export UIPATH_SESSION_ID='<id>'` to $CLAUDE_ENV_FILE so every
+# subsequent Bash tool subprocess — and therefore every `uip` command the
+# agent runs — inherits it. The CLI stamps that value as the `session_id`
+# dimension on native command telemetry (UiPath/cli#2800), which joins the
+# command stream with the skills events emitted by send-telemetry.sh: both
+# streams then carry the same session id.
+#
+# Registered SYNCHRONOUSLY in hooks.json (no "async": true): the write must
+# complete before the session's first Bash call, or early `uip` commands would
+# miss the id. Costs a few ms (grep/sed/tr only, no network, no uip call).
+#
+# Deliberately NOT gated on UIPATH_TELEMETRY_DISABLED: writing a variable
+# transmits nothing — whether any event carrying it is ever sent stays
+# governed by the CLI's own telemetry gate.
+#
+# Safety:
+#   - host wins: no-op when UIPATH_SESSION_ID is already set in the env;
+#   - idempotent: no-op when the env file already exports it;
+#   - injection-safe: $CLAUDE_ENV_FILE is sourced by the agent, so the value
+#     is stripped to [A-Za-z0-9._-] and length-capped before being written
+#     inside single quotes (agent session ids are UUIDs, so a legitimate
+#     value is never altered);
+#   - never-fail: always exits 0, never blocks the session.
+
+set +e
+
+main() {
+  [ -n "$CLAUDE_ENV_FILE" ] || exit 0
+  [ -z "$UIPATH_SESSION_ID" ] || exit 0
+  if [ -f "$CLAUDE_ENV_FILE" ] \
+    && grep -q '^export UIPATH_SESSION_ID=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    exit 0
+  fi
+
+  # Top-level `session_id` from the SessionStart payload. The payload for this
+  # event is small and carries no tool output, and the value is hard-sanitized
+  # anyway, so a plain grep is sufficient here (no region-scoped pass needed).
+  sid="$(grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/' | tr -cd 'A-Za-z0-9._-' | cut -c1-64)"
+  [ -n "$sid" ] || exit 0
+
+  printf "export UIPATH_SESSION_ID='%s'\n" "$sid" >> "$CLAUDE_ENV_FILE" 2>/dev/null
+
+  exit 0
+}
+
+main

--- a/hooks/set-session-env.sh
+++ b/hooks/set-session-env.sh
@@ -43,6 +43,15 @@ main() {
     | head -1 | sed 's/.*"\([^"]*\)"$/\1/' | tr -cd 'A-Za-z0-9._-' | cut -c1-64)"
   [ -n "$sid" ] || exit 0
 
+  # If the file exists but doesn't end with a newline (another hook's partial
+  # write), appending directly would concatenate onto its last line and could
+  # break the sourced env file for the whole session — repair it first.
+  # `tail -c 1` in a $() strips a trailing newline, so "" means the file is
+  # newline-terminated.
+  if [ -s "$CLAUDE_ENV_FILE" ] && [ -n "$(tail -c 1 "$CLAUDE_ENV_FILE" 2>/dev/null)" ]; then
+    printf '\n' >> "$CLAUDE_ENV_FILE" 2>/dev/null
+  fi
+
   printf "export UIPATH_SESSION_ID='%s'\n" "$sid" >> "$CLAUDE_ENV_FILE" 2>/dev/null
 
   exit 0

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -11,6 +11,9 @@ forwards to ``uip track``. Covers:
   ``schemaVersion``;
 * the v2 key set — canonical ``session_id`` (not the v1 ``sessionId``) and no
   ``environment`` / ``baseUrl`` (the CLI stamps its own base dimensions);
+* Codex-shaped payloads — Codex fires ``SessionStart``/``Stop`` under the same
+  names with a matching envelope, so mapping and fields work unchanged and
+  Codex-only extras are never forwarded;
 * the drop paths — a non-UiPath tool call, an unrecognized event, and opt-out.
 
 The hook forwards in a detached subshell (``( … | uip track & )``), so the
@@ -82,6 +85,47 @@ def test_stop_maps_to_completion_ok():
     event = run_hook({"hook_event_name": "Stop", "session_id": "sess-1"})
     assert event["eventName"] == "completion"
     assert event["outcome"] == "ok"
+
+
+def test_codex_session_start_maps_with_source_and_model():
+    """Codex fires SessionStart under the same name with a matching envelope
+    (session_id / source / model / permission_mode — Codex hooks docs), so the
+    mapping, session_source, and agent_model work unchanged."""
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "019f1347-4dab-7b31-9277-29c6af7572fe",
+            "source": "startup",
+            "model": "gpt-5.1-codex",
+            "permission_mode": "on-request",
+        }
+    )
+    assert event["eventName"] == "session-start"
+    assert event["session_source"] == "startup"
+    assert event["agent_model"] == "gpt-5.1-codex"
+
+
+def test_codex_stop_maps_to_completion_and_ignores_codex_extras():
+    """Codex Stop carries turn_id / stop_hook_active / last_assistant_message
+    and no duration_ms. It maps to completion(ok); the Codex-only extras are
+    never extracted or forwarded (last_assistant_message is free text)."""
+    event = run_hook(
+        {
+            "hook_event_name": "Stop",
+            "session_id": "019f1347-4dab-7b31-9277-29c6af7572fe",
+            "model": "gpt-5.1-codex",
+            "turn_id": "turn-3",
+            "stop_hook_active": False,
+            "last_assistant_message": "free text that must never leak",
+        }
+    )
+    assert event["eventName"] == "completion"
+    assert event["outcome"] == "ok"
+    assert event["agent_model"] == "gpt-5.1-codex"
+    assert event["durationMs"] is None
+    assert "turn_id" not in event
+    assert "stop_hook_active" not in event
+    assert "last_assistant_message" not in event
 
 
 def test_session_fields_do_not_bleed_across_events():

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -81,6 +81,23 @@ def test_stop_maps_to_completion_ok():
     assert event["outcome"] == "ok"
 
 
+def test_session_fields_do_not_bleed_across_events():
+    """`source`/`reason` are extracted from any envelope, but the contract
+    scopes session_source to session-start and reason to session-end — a stray
+    key on another event (future payload additions) must come out empty."""
+    event = run_hook(
+        {
+            "hook_event_name": "Stop",
+            "session_id": "sess-1",
+            "source": "startup",
+            "reason": "spurious",
+        }
+    )
+    assert event["eventName"] == "completion"
+    assert event["session_source"] == ""
+    assert event["reason"] == ""
+
+
 def test_stop_failure_maps_to_completion_failure():
     event = run_hook({"hook_event_name": "StopFailure", "session_id": "sess-1"})
     assert event["eventName"] == "completion"

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -60,6 +60,9 @@ def test_session_start_maps_and_carries_source():
     assert event["eventName"] == "session-start"
     assert event["session_source"] == "startup"
     assert event["session_id"] == "sess-1"
+    # The session's main model (envelope `model`) rides as agent_model —
+    # full slug, not family-collapsed (UiPath/cli#2785).
+    assert event["agent_model"] == "claude-sonnet-5"
     assert event["schemaVersion"] == 2
 
 

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -1,0 +1,213 @@
+"""Contract guard for the skills telemetry hook (``hooks/send-telemetry.sh``).
+
+Runs the hook as a subprocess with a stubbed ``uip`` on ``PATH``, pipes a Claude
+Code hook payload on stdin, and asserts the single flat JSON object the hook
+forwards to ``uip track``. Covers:
+
+* the ``eventName`` mapping — ``PostToolUse``→``tool-use``,
+  ``SessionStart``→``session-start``, ``SessionEnd``→``session-end``,
+  ``Stop``/``StopFailure``→``completion``;
+* the lifecycle fields ``session_source`` / ``reason`` / ``outcome`` and
+  ``schemaVersion``;
+* the v2 key set — canonical ``session_id`` (not the v1 ``sessionId``) and no
+  ``environment`` / ``baseUrl`` (the CLI stamps its own base dimensions);
+* the drop paths — a non-UiPath tool call, an unrecognized event, and opt-out.
+
+The hook forwards in a detached subshell (``( … | uip track & )``), so the
+stubbed ``uip`` writes the payload to a capture file and we poll for it.
+
+POSIX-only: the stub is a ``bash`` script invoked via a real ``uip`` name on
+``PATH``. Skipped on native Windows (Git Bash path translation makes the stub
+unreliable) — CI runs it on ubuntu.
+
+Run from repo root:
+    pytest tests/scripts/test_send_telemetry_hook.py
+"""
+
+import json
+import os
+import shutil
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "hooks" / "send-telemetry.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="requires bash on a POSIX filesystem (CI runs this on ubuntu)",
+)
+
+
+# ── event-mapping tests ────────────────────────────────────────────────────
+
+
+def test_session_start_maps_and_carries_source():
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-1",
+            "source": "startup",
+            "model": "claude-sonnet-5",
+        }
+    )
+    assert event["eventName"] == "session-start"
+    assert event["session_source"] == "startup"
+    assert event["session_id"] == "sess-1"
+    assert event["schemaVersion"] == 2
+
+
+def test_session_end_carries_reason():
+    event = run_hook(
+        {
+            "hook_event_name": "SessionEnd",
+            "session_id": "sess-1",
+            "reason": "logout",
+        }
+    )
+    assert event["eventName"] == "session-end"
+    assert event["reason"] == "logout"
+
+
+def test_stop_maps_to_completion_ok():
+    event = run_hook({"hook_event_name": "Stop", "session_id": "sess-1"})
+    assert event["eventName"] == "completion"
+    assert event["outcome"] == "ok"
+
+
+def test_stop_failure_maps_to_completion_failure():
+    event = run_hook({"hook_event_name": "StopFailure", "session_id": "sess-1"})
+    assert event["eventName"] == "completion"
+    assert event["outcome"] == "failure"
+
+
+def test_post_tool_use_uipath_skill_maps_to_tool_use():
+    event = run_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Skill",
+            "tool_input": {"skill": "uipath:uipath-platform"},
+            "tool_response": {"success": True},
+            "duration_ms": 1234,
+        }
+    )
+    assert event["eventName"] == "tool-use"
+    assert event["skillName"] == "uipath:uipath-platform"
+    assert event["outcome"] == "ok"
+
+
+def test_v2_key_set_has_no_env_fields_or_legacy_session_id():
+    """Schema v2 drops environment/baseUrl (the CLI stamps fresh
+    environment/base_url/region base dimensions itself, UiPath/cli#2806) and
+    sends only the canonical session_id spelling (UiPath/cli#2800)."""
+    event = run_hook(
+        {
+            "hook_event_name": "SessionStart",
+            "session_id": "sess-1",
+            "source": "startup",
+        }
+    )
+    assert "environment" not in event
+    assert "baseUrl" not in event
+    assert "sessionId" not in event
+    assert "sessionSource" not in event
+
+
+# ── drop-path tests ────────────────────────────────────────────────────────
+
+
+def test_non_uipath_tool_call_is_dropped():
+    assert (
+        run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Bash",
+                "tool_input": {"command": "ls -la"},
+            },
+            expect_drop=True,
+        )
+        is None
+    )
+
+
+def test_unrecognized_event_is_dropped():
+    assert (
+        run_hook(
+            {"hook_event_name": "PreToolUse", "tool_name": "Bash"},
+            expect_drop=True,
+        )
+        is None
+    )
+
+
+def test_opt_out_drops_everything():
+    assert (
+        run_hook(
+            {"hook_event_name": "SessionStart", "session_id": "sess-1"},
+            telemetry_disabled="1",
+            expect_drop=True,
+        )
+        is None
+    )
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def run_hook(payload, *, telemetry_disabled="0", expect_drop=False):
+    """Invoke the hook with a stubbed ``uip``; return the forwarded JSON object
+    (parsed) or ``None`` when the hook drops the event.
+
+    The hook pipes to ``uip track`` in a detached subshell, so we poll a capture
+    file. A dropped event never writes it, so ``expect_drop`` polls a short grace
+    window instead of the full timeout.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        capture = tmp_path / "capture.json"
+        _write_fake_uip(tmp_path / "uip")
+
+        env = {
+            **os.environ,
+            "PATH": f"{tmp_path}{os.pathsep}{os.environ.get('PATH', '')}",
+            "UIPATH_TELEMETRY_DISABLED": telemetry_disabled,
+            "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
+            "CAPTURE_FILE": str(capture),
+        }
+        # A UIPATH_SESSION_ID inherited from the CI env would override the
+        # payload session id — keep the hook's own behavior under test.
+        env.pop("UIPATH_SESSION_ID", None)
+
+        subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            env=env,
+            timeout=30,
+            check=True,
+        )
+
+        deadline = time.time() + (1.5 if expect_drop else 5.0)
+        while time.time() < deadline:
+            if capture.exists():
+                return json.loads(capture.read_text())
+            time.sleep(0.05)
+        return None
+
+
+def _write_fake_uip(path):
+    """Stub ``uip``: capture the piped payload on ``uip track`` (atomic write so
+    the poller never sees a partial file)."""
+    path.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" = "track" ]; then\n'
+        '  cat > "$CAPTURE_FILE.tmp" && mv "$CAPTURE_FILE.tmp" "$CAPTURE_FILE"\n'
+        "fi\n"
+    )
+    path.chmod(path.stat().st_mode | stat.S_IRWXU | stat.S_IEXEC)

--- a/tests/scripts/test_set_session_env_hook.py
+++ b/tests/scripts/test_set_session_env_hook.py
@@ -70,6 +70,17 @@ def test_appends_after_unrelated_lines():
     )
 
 
+def test_repairs_missing_trailing_newline_before_appending():
+    """A pre-existing file WITHOUT a final newline must not have the export
+    concatenated onto its last line (that could break the sourced env file)."""
+    preexisting = "export OTHER_VAR='x'"  # no trailing newline
+    content = run_hook(PAYLOAD, env_file_content=preexisting)
+    assert content == (
+        "export OTHER_VAR='x'\n"
+        "export UIPATH_SESSION_ID='3f2504e0-4f89-41d3-9a0c-0305e82c3301'\n"
+    )
+
+
 def test_sanitizes_hostile_session_id():
     """The env file is sourced by the agent, so a quote-breaking id must not
     survive: everything outside [A-Za-z0-9._-] is stripped."""

--- a/tests/scripts/test_set_session_env_hook.py
+++ b/tests/scripts/test_set_session_env_hook.py
@@ -1,0 +1,126 @@
+"""Contract guard for the session-env SessionStart step
+(``hooks/set-session-env.sh``).
+
+Runs the hook as a subprocess with a SessionStart payload on stdin and asserts
+what lands in ``CLAUDE_ENV_FILE``. Covers:
+
+* the happy path — ``export UIPATH_SESSION_ID='<id>'`` appended;
+* host wins — no-op when ``UIPATH_SESSION_ID`` is already set in the env;
+* idempotence — no duplicate line when the file already exports it;
+* sanitization — hostile ``session_id`` values are stripped to a safe charset
+  before being written into the sourced env file;
+* the skip paths — no ``CLAUDE_ENV_FILE``, or a payload without ``session_id``.
+
+POSIX-only, like the send-telemetry guard — CI runs it on ubuntu.
+
+Run from repo root:
+    pytest tests/scripts/test_set_session_env_hook.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HOOK = REPO_ROOT / "hooks" / "set-session-env.sh"
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32" or shutil.which("bash") is None,
+    reason="requires bash on a POSIX filesystem (CI runs this on ubuntu)",
+)
+
+PAYLOAD = {
+    "hook_event_name": "SessionStart",
+    "session_id": "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+    "source": "startup",
+}
+
+
+def test_writes_export_line():
+    content = run_hook(PAYLOAD)
+    assert (
+        content
+        == "export UIPATH_SESSION_ID='3f2504e0-4f89-41d3-9a0c-0305e82c3301'\n"
+    )
+
+
+def test_host_provided_session_id_wins():
+    content = run_hook(PAYLOAD, extra_env={"UIPATH_SESSION_ID": "host-id"})
+    assert content == ""
+
+
+def test_no_duplicate_when_already_exported():
+    preexisting = "export UIPATH_SESSION_ID='earlier-id'\n"
+    content = run_hook(PAYLOAD, env_file_content=preexisting)
+    assert content == preexisting
+
+
+def test_appends_after_unrelated_lines():
+    preexisting = "export OTHER_VAR='x'\n"
+    content = run_hook(PAYLOAD, env_file_content=preexisting)
+    assert content == (
+        preexisting
+        + "export UIPATH_SESSION_ID='3f2504e0-4f89-41d3-9a0c-0305e82c3301'\n"
+    )
+
+
+def test_sanitizes_hostile_session_id():
+    """The env file is sourced by the agent, so a quote-breaking id must not
+    survive: everything outside [A-Za-z0-9._-] is stripped."""
+    content = run_hook({**PAYLOAD, "session_id": "x'; rm -rf $HOME; echo 'y"})
+    assert content == "export UIPATH_SESSION_ID='xrm-rfHOMEechoy'\n"
+
+
+def test_skips_without_env_file():
+    with tempfile.TemporaryDirectory() as tmp:
+        env = {**os.environ}
+        env.pop("CLAUDE_ENV_FILE", None)
+        env.pop("UIPATH_SESSION_ID", None)
+        subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps(PAYLOAD),
+            text=True,
+            env=env,
+            cwd=tmp,
+            timeout=15,
+            check=True,
+        )
+
+
+def test_skips_payload_without_session_id():
+    content = run_hook({"hook_event_name": "SessionStart", "source": "startup"})
+    assert content == ""
+
+
+# ── helpers ────────────────────────────────────────────────────────────────
+
+
+def run_hook(payload, *, extra_env=None, env_file_content=None):
+    """Invoke the hook with a temp CLAUDE_ENV_FILE; return the file's content
+    afterwards ("" when the hook wrote nothing and the file did not pre-exist)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        env_file = Path(tmp) / "claude-env"
+        if env_file_content is not None:
+            env_file.write_text(env_file_content)
+
+        env = {**os.environ, "CLAUDE_ENV_FILE": str(env_file)}
+        env.pop("UIPATH_SESSION_ID", None)
+        if extra_env:
+            env.update(extra_env)
+
+        subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps(payload),
+            text=True,
+            env=env,
+            timeout=15,
+            check=True,
+        )
+
+        return env_file.read_text() if env_file.exists() else ""

--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
   "skillsVersion": "1.198.0",
   "targetCli": "^1.198.0"
 }


### PR DESCRIPTION
## Shipping plan — merge BEFORE the Sunday 2026-07-12 release cut

- [ ] **`targetCli` pairing — schedule + post-cut verification, not a merge blocker.** The v2 hook must *ship* paired with the first CLI release carrying UiPath/cli#2815 — a pre-lifecycle CLI treats `eventName` as an unknown field and would emit lifecycle payloads as **phantom `tool-use` events** (identifiable/filterable: `schemaVersion == 2` with empty `toolName`). The pairing is enforced by the release train, not by this file: `uip skills install` pins the skills package to the CLI's own minor, and the skills `sprint-release-cut` stamps `targetCli` to the paired line at cut time. So: **merge this PR and cli#2815 to their mains before the Sunday 2026-07-12 cut** (skills cut 06:00 UTC, CLI cut 12:00 UTC; missing it slips the emitter to the Jul 26 train while CLI 1.199 ships ingestion unpaired) — then **verify after the cut** that the skills `1.199` release line carries `targetCli: ^1.199.0` (the automation's drift check is warn-only). Residual exposure between merge and CLI-1.199 reaching users: only channels tracking the repo directly (marketplace/main dogfooders — overwhelmingly `IsInternalUser`), bounded by the CLI's self-update.
- [x] ~~**Reconcile with #1745** after it lands~~ — done: rebased on the merged #1745; lifecycle events inherit the flipped opt-out gate (verified: unset sends, `1` drops, `0` sends); its "`schemaVersion` stays `1`" wording updated to v2.

## What

Extends the telemetry hook (`hooks/send-telemetry.sh`) from a single `PostToolUse`
tool-use event to skill/session **lifecycle** events, and adds a synchronous
SessionStart step (`hooks/set-session-env.sh`) that exports `UIPATH_SESSION_ID`
so native `uip` command telemetry carries the same session id. This is the
**emitter half** of UiPath/cli#2786; it requires the CLI ingestion change in
**UiPath/cli#2815** (the CLI resolves the `eventName` token this hook now sends
to a `uip.skills.<event>` event). Co-versioned via `schemaVersion` (bumped 1 → 2).

## Mapping

`send-telemetry.sh` is now registered on four more Claude Code hook events and maps
each to a canonical `eventName`:

| Claude Code hook | `eventName` | Notes |
|---|---|---|
| `PostToolUse` *(existing)* | `tool-use` | unchanged — per-call, plugin-attribution gated |
| `SessionStart` | `session-start` | `source` → `session_source` |
| `Stop` | `completion` | `outcome=ok` |
| `StopFailure` | `completion` | `outcome=failure` (API-error turn) |
| `SessionEnd` | `session-end` | `reason` |

## Schema v2

- Adds `eventName` / `session_source` / `reason`.
- Adds **`agent_model`** (UiPath/cli#2785 enrichment, riding the same bump): the
  session's **main** model from the envelope `model` — Claude Code sends it on
  `SessionStart`, Codex on every hook event. Full sanitized slug (model-comparison
  views need version granularity); distinct from `subagentModel` (spawned child's
  family). Claude sessions get full coverage at query time via the `session_id`
  join from `session-start`. The CLI-side acceptance (`ALLOWED_FIELDS` + contract-doc row) is
  UiPath/cli#2869.
- **Renames `sessionId` → `session_id`** — the canonical casing, matching the CLI
  command stream after UiPath/cli#2800 (`uip track` still accepts and maps the
  legacy spelling, so no flag-day).
- **Drops `environment` / `baseUrl` and the whole `resolve_environment` path**
  (the `uip login status` call + 1h cache + cache file): since UiPath/cli#2806
  the CLI stamps fresh `environment`/`base_url`/`region` base dimensions on every
  event from its own auth context, so a stale hook-cached copy must not shadow
  them. Removes ~45 lines and the hook's only subprocess call.

## Design

- **Lifecycle events are session-scoped**: they skip the per-call plugin-attribution
  gate and tool-field derivation, and fire for every session where this plugin is
  installed (the activation-rate denominator).
- **`StopFailure` → `completion(outcome=failure)`** so API-error turns aren't lost
  from completion/abandonment metrics. `Stop`/`StopFailure` are mutually exclusive
  per turn (Claude Code docs), so `completion` cannot double-count.
- **`set-session-env.sh` (new, synchronous)**: reads the SessionStart payload's
  `session_id` and appends `export UIPATH_SESSION_ID='<id>'` to `CLAUDE_ENV_FILE`,
  so every subsequent `uip` command inherits it and the CLI stamps the same
  `session_id` on native command telemetry (UiPath/cli#2800) — skills events and
  command events join at query time. Host-provided value wins; idempotent;
  value sanitized to `[A-Za-z0-9._-]` before being written into the sourced env
  file; not gated on `UIPATH_TELEMETRY_DISABLED` (writing a variable transmits
  nothing — the CLI's gate governs whether any event carrying it is sent).
- **Gate inherited from #1745** (merged): lifecycle events pass through the same
  opt-out gate as tool-use — this PR neither moves nor duplicates the gate line,
  and its tests set `UIPATH_TELEMETRY_DISABLED` explicitly so they hold under
  either polarity.

## Scope

This is primarily the **Claude Code** emitter. Under **Codex** — whose hooks.json
support and payload envelope match Claude's (#1745) — `SessionStart`/`Stop` flow
through this same hook already, so Codex gets `session-start`/`completion` for
free (it has no session-end hook; `completion` is its terminal signal).
**Gemini CLI and the Cursor CLI** expose the same lifecycle moments under
different hook names/registration formats and are **separate follow-ups**.
**Cursor cloud agents are out of scope** (ephemeral remote VM — no local `uip`, no
auth identity, no session-start/-end trigger point).

## Testing

- pytest contract guards (POSIX/CI): `test_send_telemetry_hook.py` — eventName
  mapping, lifecycle fields, the v2 key set (canonical `session_id`/`session_source`,
  no `environment`/`baseUrl`/legacy camel keys), drop paths;
  `test_set_session_env_hook.py` — export line, host-wins, idempotence, hostile
  session-id sanitization, skip paths. Both wired into `test-helpers.yml`.
- Manual end-to-end (stubbed `uip`): all five Claude hook payloads produce the
  correct v2 JSON; a `UIPATH_SKILL=uipath-platform uip or assets list` tool call
  still attributes cleanly (`uipSubcommand: "or assets"`).
- Post-#1745 rebase re-verified the flipped gate end-to-end on the lifecycle
  paths: unset sends, `1` drops, `0` sends; v2 envelope unchanged.
- Earlier verified against the **real** `uip track` (CLI's `telemetry-capture.ts`):
  maps to `uip.skills.session-start`/`uip.skills.completion`, `eventName` consumed
  and not emitted, session id → stable `uuid#hash`.
- `bash -n` clean on both hooks; `hooks.json` / `version-manifest.json` valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes UiPath/cli#2786
