### PR TITLE
fix(ci): allowlist comment authors passed to claude-pr-review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -53,6 +53,18 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           track_progress: true
+          # Comment-source allowlist (public repo). Only comments authored by
+          # these actors are passed to Claude as context; everyone else's
+          # comments — including external contributors' — are ignored, closing
+          # the "trusted user triggers @claude on a thread containing a planted
+          # injection comment" vector. NOTE: this filters COMMENTS only; the PR
+          # diff, changed-file contents, PR body and title are still ingested,
+          # so this stacks on the tool allowlist below, it does not replace it.
+          # Keep this list in sync with the global CODEOWNERS maintainers.
+          include_comments_by_actor: "gabrielavaduva,AlvinStanescu,marius-bughiu,RaduAna-Maria,uipreliga,dmetzgar,rockymadden,gozhang2,smflorentino,bai-uipath,akshaylive"
+          # Drop all bot comments (dependabot, renovate, etc.). Exclusion wins
+          # over the include list if an actor somehow matches both.
+          exclude_comments_by_actor: "*[bot]"
           # Tool allowlist (prompt-injection containment). This review reads
           # attacker-controlled content (diff, PR comments, file contents), so
           # Claude is restricted to read-only commands plus the single write


### PR DESCRIPTION
## What

Follow-up hardening for `claude-pr-review.yml` (builds on #1771). Adds two `claude-code-action` inputs:

```yaml
include_comments_by_actor: "gabrielavaduva,AlvinStanescu,marius-bughiu,RaduAna-Maria,uipreliga,dmetzgar,rockymadden,gozhang2,smflorentino,bai-uipath,akshaylive"
exclude_comments_by_actor: "*[bot]"
```

- **include** — only these core CODEOWNERS maintainers' comments are passed to Claude as review context.
- **exclude** — drops all bot comments (dependabot, renovate, etc.); exclusion wins if an actor matches both.

## Why

Closes the vector where a **trusted** user triggers `@claude` on a PR/issue thread that contains a comment with a hidden (`<!-- ... -->`) prompt-injection payload planted by an external actor. The `author_association` trigger gate from #1771 controls *who can start* a run; this controls *whose comments are fed in* once it runs.

## Scope / honest limits

⚠️ This filters **comments only**. The PR **diff, changed-file contents, PR body, and title are still ingested** and remain attacker-controllable. So this does **not** by itself eliminate prompt injection — it stacks on the tool allowlist from #1771 (read-only tools + no network exfil channel), which is what actually contains blast radius. Reference: [claude-code-action security docs](https://github.com/anthropics/claude-code-action/blob/main/docs/security.md#%EF%B8%8F-prompt-injection-risks).

## Maintenance note

The maintainer list must be kept in sync with the global CODEOWNERS `*` line by hand (noted in an inline comment). No automated check ties them together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)