### PR TITLE
fix(test): simplify my-ip smoke prompt and add skill_triggered criterion

### DIFF
--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -17,12 +17,10 @@ initial_prompt: |
   service on my UiPath organization.
 
   Important:
-  - The `uip` CLI is available but the `admin` subcommand may not be
-    installed and/or the CLI is not connected to a live tenant.
-    Commands WILL fail — that is expected and acceptable.
+  - The `uip` CLI is available but is not connected to a live tenant.
+    Commands WILL fail with auth errors — that is expected and acceptable.
     Run each command exactly once regardless of errors.
-    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
-    do NOT troubleshoot errors.
+    Do NOT retry, do NOT attempt to login, do NOT troubleshoot errors.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:

--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -13,8 +13,8 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  What public IP does my UiPath organization see for my current connection?
-  I need this to update the IP restriction allowlist.
+  Look up my public IP address as seen by the UiPath admin IP restriction
+  service on my UiPath organization.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be

--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -13,10 +13,8 @@ run_limits:
   expected_turns: 4
 
 initial_prompt: |
-  Before I update our UiPath IP restriction allowlist, I need to verify
-  what IP address the UiPath admin service resolves for my connection.
-  Use the `uip` CLI to query this — a generic IP lookup won't
-  necessarily match what the platform sees behind its gateway.
+  What public IP does my UiPath organization see for my current connection?
+  I need this to update the IP restriction allowlist.
 
   Important:
   - The `uip` CLI is available but the `admin` subcommand may not be
@@ -29,10 +27,17 @@ initial_prompt: |
 
 success_criteria:
 
+  - type: skill_triggered
+    description: "Agent activated the uipath-admin skill"
+    skill_name: "uipath-admin"
+    expected: "yes"
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent ran ip-restriction my-ip with --output json"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip[\s\S]*--output\s+json'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -30,7 +30,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-admin skill"
     skill_name: "uipath-admin"
-    expected: "yes"
+    expected_skill: "uipath-admin"
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary
The `apms_get_my_ip_smoke` test has been repeatedly flaky — the agent skips skill activation and guesses `uip admin get-my-ip` (wrong command).

### Root cause
The narrative prompt ("Before I update our UiPath IP restriction allowlist, I need to verify what IP address the UiPath admin service resolves for my connection") doesn't reliably trigger the `uipath-admin` skill. Without the skill, the agent has no knowledge of `ip-restriction my-ip`.

### Fix
1. **Simplified prompt** to match the pattern of passing sibling tests: "What public IP does my UiPath organization see for my current connection?"
2. **Added `skill_triggered` criterion** to catch activation failures explicitly — if the skill doesn't activate, the test fails fast with a clear signal instead of scoring 0 on a command mismatch.
3. **`[\s\S]*` in command regex** for multiline resilience.

## Test plan
- [x] 3 consecutive PASS runs on CI
  - [Run 1](https://github.com/UiPath/skills/actions/runs/28532039217) — 1/1 PASS
  - [Run 2](https://github.com/UiPath/skills/actions/runs/28532201246) — 1/1 PASS
  - [Run 3](https://github.com/UiPath/skills/actions/runs/28532373369) — 1/1 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)