### PR TITLE
fix(maestro-case): restore Agent to allowed-tools

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uipath-maestro-case
 description: "Always invoke for `caseplan.json` files. UiPath Case Management authoring (caseplan.json) from sdd.md, or via lightweight interview if sdd.md absent. Produces tasks.md plan, writes caseplan.json via per-plugin JSON recipes. Edits an existing caseplan.json via targeted operations (skips planning). For .xaml→uipath-rpa, .flow→uipath-maestro-flow, .bpmn→uipath-maestro-bpmn. For PDD→SDD or complex/multi-product→uipath-planner."
-allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion, TodoWrite, Agent
 ---
 
 # UiPath Case Management Authoring Assistant


### PR DESCRIPTION
## Summary

PR #1622 added `Agent` (the sub-agent launcher) to the case skill's `allowed-tools` — the Rule 17 create-on-missing path spawns sub-agents that invoke `uipath-agents` to build missing agents inline. PR #1521's frontmatter rewrite was based on the pre-#1622 file and silently reverted that addition (no textual conflict, so git never flagged it), leaving the shipped create-on-missing flow with no tool to run on.

One-line restore: re-append `Agent` to `allowed-tools` in `skills/uipath-maestro-case/SKILL.md`. #1521's intentional `description` change (brownfield edits) is untouched — `description` is unchanged, so no activation-gate impact.

## Verification

- `f5df70a34` (#1622): `allowed-tools: … TodoWrite, Agent`
- `11f32620e` (#1521): rewrote the line without `Agent` (branch predates #1622 merge)
- This PR: current main line + `, Agent`

🤖 Generated with [Claude Code](https://claude.com/claude-code)