### PR TITLE
fix: open flow file on editor after generating it [MST-8633]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/greenfield.md
@@ -332,11 +332,13 @@ When you finish building the flow, report to the user:
 4. **Format status** — confirm `flow format` was run
 5. **Mock placeholders** — list any `core.logic.mock` nodes that need to be replaced, and which skill to use
 6. **Missing connections** — any connector nodes that need connections the user must create
-7. **What's next** — ask the user, presenting the dropdown below (see the dropdown question rule in [SKILL.md](../../../SKILL.md))
+7. **What's next** — ask the user, following the two questions below (see the dropdown question rule in [SKILL.md](../../../SKILL.md))
 
-### What's next dropdown
+### What's next
 
-Authoring terminates here. Each option below hands off to Operate — read [operate/CAPABILITY.md](../../operate/CAPABILITY.md) for the command sequence.
+First ask a **yes/no** question — **Open the flow in editor?** Skip this question **only when the generated `<ProjectName>.flow` file itself is already open** (e.g. you opened it earlier this session, or the user already has that exact file open) — then do not ask, do not re-open. Having other/unrelated files open does NOT count — still ask when only other files are open. On **Yes**, run `code -r "<ProjectName>.flow"` (`.flow` opens in the visual Flow editor by default — no viewType/flags; if `code` isn't on `PATH`, try `code-insiders` then `cursor`; if none resolve, report the file path; skip in headless/CI). On **No**, continue. Independent of the next action — opening the flow does not replace publish/debug/deploy.
+
+Then present the **next-action** dropdown. Authoring terminates here. Each option below hands off to Operate — read [operate/CAPABILITY.md](../../operate/CAPABILITY.md) for the command sequence.
 
 | Option | What it does |
 | --- | --- |


### PR DESCRIPTION
## What & why

When Claude generates a `.flow` via the `uipath-maestro-flow` skill, the resulting file is written to disk but never opened — the user has to locate and open it by hand ([MST-8633](https://uipath.atlassian.net/browse/MST-8633)).

This adds an **"Open the flow?"** step to the **Completion Output** section of the greenfield authoring guide. It's a **separate yes/no question asked before** the existing what's-next dropdown — so the user can open the generated `.flow` *and* still pick a next action (publish / debug / deploy). Opening is not mutually exclusive with those.

## Demo


https://github.com/user-attachments/assets/87cb95a1-5e64-44a4-b6b2-b1101a14879b



## Change

`skills/uipath-maestro-flow/references/author/references/greenfield.md` — one new step:

- **Step 7 — Open the flow? (yes/no)**: on **Yes**, opens the generated file with `code -r "<ProjectName>.flow"`.
  - `.flow` is handled by the visual Flow editor automatically (default editor for `*.flow`), so no viewType/flags are needed.
  - Editor-fork fallbacks (`code-insiders`, `cursor`); if none resolve, skip and just report the path — never fail the build over the open.
  - Skipped in non-interactive / headless (CI) runs.
- **Step 8 — What's next**: the existing publish / debug / deploy / something-else dropdown, unchanged.

Scoped to the **greenfield** (newly generated) path — the ticket's scenario. Brownfield edits act on an already-open flow, so that path is left unchanged.


## Notes

- Instruction-only change (no code); behavior is guidance the agent follows at build completion.
- If UiPath has a preferred house pattern for "open in editor" (e.g. a dedicated `uip` command or printing a clickable path), happy to align to it.

[MST-8633]: https://uipath.atlassian.net/browse/MST-8633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
