### PR TITLE
test(uipath-ixp): require inline --fields in create_field_group smoke

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -20,7 +20,8 @@ sandbox:
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
   "Subscriber information" with fields: surname, address, bank account, and
-  phone number.
+  phone number. Pass all four fields inline in the single `groups add --fields`
+  JSON array — do not load the payload from a separate file.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -29,6 +30,9 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
+  # Offline smoke (mock CLI, no tenant) can only grade the command text, so the prompt requires the fields
+  # inline: a `$(cat file)` / variable payload hides the field names from this pattern (a real run failed this
+  # way). Verifying the four field names is the point of the test — keep the per-field lookaheads.
   - type: command_executed
     description: "Agent created the group with multiple fields in one `groups add … --fields` call (batch)"
     tool_name: "Bash"


### PR DESCRIPTION
## Why this failed

The `create_field_group` smoke asserts the agent batches all four fields in one `groups add --fields` call, via per-field lookaheads:

```
uip\s+ixp\s+groups\s+add\b (?=.*my_invoices-f1afa9ef-ixp)(?=.*Subscriber information)
(?=.*--fields)(?=.*surname)(?=.*address)(?=.*bank account)(?=.*phone number)
```

A real run (`2026-07-02_04-20-18`) **did the right thing** — one batched `groups add --fields` call with all four fields — but wrote the JSON to a file and passed it by substitution:

```bash
uip ixp groups add my_invoices-f1afa9ef-ixp --name "Subscriber information" \
  --fields "$(cat /tmp/ixp/…/subscriber_fields.json)" --output json
```

So the field names lived in the **file**, not on the command line → the four `(?=.*<name>)` lookaheads matched nothing → **0/1 → FAIL**. A false negative from command-text matching that can't see through `$(cat file)`.

## Fix

This is an **offline** smoke (mock CLI, no tenant), so there's no wire-effect to grade — the command text is all we have. Rather than drop the per-field lookaheads (which would gut the test — it'd pass on `--fields '[]'`), **steer the prompt to pass the fields inline**:

> *Pass all four fields inline in the single `groups add --fields` JSON array — do not load the payload from a separate file.*

A YAML comment (not sent to the agent) documents *why* the constraint exists, so the coupling is clear to maintainers:

```yaml
# Offline smoke (mock CLI, no tenant) can only grade the command text, so the prompt requires the fields
# inline: a `$(cat file)` / variable payload hides the field names from this pattern (a real run failed this
# way). Verifying the four field names is the point of the test — keep the per-field lookaheads.
```

A heredoc/inline variable is still fine (the text stays in the command string); only a separate-file payload hid the names. This preserves the test's core assertion (the four named fields) while making the command observable offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)