### PR TITLE
test(uipath-ixp): require inline --fields in create_field_group smoke (cherry-pick #1806 → v1.197)

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -20,7 +20,8 @@ sandbox:
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
   "Subscriber information" with fields: surname, address, bank account, and
-  phone number.
+  phone number. Pass all four fields inline in the single `groups add --fields`
+  JSON array — do not load the payload from a separate file.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in
@@ -29,6 +30,9 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
+  # Offline smoke (mock CLI, no tenant) can only grade the command text, so the prompt requires the fields
+  # inline: a `$(cat file)` / variable payload hides the field names from this pattern (a real run failed this
+  # way). Verifying the four field names is the point of the test — keep the per-field lookaheads.
   - type: command_executed
     description: "Agent created the group with multiple fields in one `groups add … --fields` call (batch)"
     tool_name: "Bash"


### PR DESCRIPTION
Cherry-pick of #1806 onto `release/v1.197`.

The `create_field_group` smoke asserts all four field names appear in one `groups add --fields` call, but a real run failed because the agent passed the fields via `--fields "$(cat file)"` — hiding the names from the offline command match. Fix: steer the prompt to pass the fields inline (with a YAML comment explaining why), so the per-field lookaheads keep verifying the four names.

Cherry-picked from ab9170cc1 (see #1806 for full context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)