### PR TITLE
test(uipath-ixp): fix labelling_correctness confirm criteria (cherry-pick #1794 → v1.197)

### DIFF
--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -32,10 +32,11 @@ initial_prompt: |
   predictions.
 
   Then, on that invoice's line items:
-  - Confirm only the first line item — the other rows look wrong, leave them.
-  - The OCR mangled the "Amount" on the first two line items — confirm both of them
-    in one call, correcting the first's Amount to `1,234.56` and the second's to
-    `2,500.00`. Save that command's response to `confirm_result.json`.
+  - Line 1 (the first line item) is extracted correctly — confirm just that one
+    line on its own, leaving every other row untouched.
+  - Separately, the OCR mangled the "Amount" on line 2 and line 3 — correct both
+    of those Amounts in a single batched call (line 2 to `500.00`, line 3 to
+    `105.42`). Save that command's response to `confirm_result.json`.
   - Actually, scrap that — roll back everything you just confirmed on this document,
     and save that command's response to `unconfirm_result.json`.
   - These line items have no tax column, so "Tax" doesn't apply here — mark it

--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Batched confirm with --updates carrying a corrections entry across occurrences"
     tool_name: "Bash"
-    command_pattern: '(?s)(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b.*--group.*--updates.*corrections'
+    command_pattern: '(?s)(?=.*(uip|\$UIP)\s+ixp\s+labellings\s+confirm\b)(?=.*--group)(?=.*--updates)(?=.*corrections)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
Cherry-pick of #1794 (both commits) onto `release/v1.197`.

Two paired fixes to `labelling_correctness`:
1. **De-overlap the confirm steps** — line 1 alone via `--occurrence 0`, lines 2 & 3 corrected in one `--updates` call — so each criterion (single-occurrence and batched) is genuinely exercised instead of the agent folding both into one call.
2. **Make criterion #2 robust to shell-var `--updates`** — unordered lookahead regex, so `corrections` is matched whether inline or passed via `--updates "$UPDATES"` (the old ordered pattern missed it → 3/20 false negatives in a repeat run).

Cherry-picked from f46c2a9f4 + 7c7de77d1 (see #1794 for full context and the 20× validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)