### PR TITLE
fix(troubleshoot): remove relative-path confounder from python-pipe scenario

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/process/Main.xaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/process/Main.xaml
@@ -22,7 +22,7 @@
       <Variable x:TypeArguments="x:Double" Name="invoiceTotal" />
     </Sequence.Variables>
     <ui:LogMessage DisplayName="Log: starting invoice parse" sap2010:WorkflowViewState.IdRef="LogMessage_1" Level="Info" Message="[&quot;[PythonInvoiceParser] Invoking parse_invoice.extract_total via Python Scope&quot;]" />
-    <upa:PythonScope DisplayName="Python Scope" sap2010:WorkflowViewState.IdRef="PythonScope_1" Path="C:\Program Files\Python311" Library="" Target="x64" Version="Python_311" WorkingFolder="" Timeout="30000">
+    <upa:PythonScope DisplayName="Python Scope" sap2010:WorkflowViewState.IdRef="PythonScope_1" Path="C:\Program Files\Python311" Library="" Target="x64" Version="Python_311" WorkingFolder="C:\Robot\Data" Timeout="30000">
       <upa:PythonScope.Body>
         <ActivityAction>
           <Sequence DisplayName="Python Scope Body" sap2010:WorkflowViewState.IdRef="Sequence_2">
@@ -30,7 +30,7 @@
             <upa:InvokeMethod DisplayName="Invoke Python Method: extract_total" sap2010:WorkflowViewState.IdRef="InvokeMethod_1" Instance="[scriptHandle]" Name="extract_total" Result="[totalObj]">
               <upa:InvokeMethod.InputParameters>
                 <scg:List x:TypeArguments="x:Object" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" Capacity="1">
-                  <x:String>invoices\inv-2026-05.csv</x:String>
+                  <x:String>C:\Robot\Data\invoices\inv-2026-05.csv</x:String>
                 </scg:List>
               </upa:InvokeMethod.InputParameters>
             </upa:InvokeMethod>


### PR DESCRIPTION
The `python-pipe-broken-missing-module` scenario was ambiguous: its `Main.xaml` passed a relative csv path (`invoices\inv-2026-05.csv`) with a blank `WorkingFolder` to `pd.read_csv`. That produces the same swallowed "Pipe is broken" signature as the intended missing-pandas cause, so a `FileNotFoundError`-from-relative-path diagnosis was equally supported by the evidence — making the scenario flaky and its RESOLUTION unreachable by reasoning.

Removes the confounder: absolute csv path + `WorkingFolder="C:\Robot\Data"`, leaving the third-party `import pandas` as the only plausible hidden cause. Consistent with RESOLUTION.md, which already states this is "not a WorkingFolder / relative-path issue."

Scenario-only change (one `Main.xaml`, 2 lines); no playbook, fixture-log, or RESOLUTION edits. Validated locally via coder-eval: 5/5 runs now reach the correct missing-pandas diagnosis (skill_triggered 1.0; llm_judge graded by hand as the local judge transport is unconfigured).