### PR TITLE
ci: format cherry-pick PR titles (🍒, version-only branch, trailing Jira)

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -187,9 +187,11 @@ jobs:
 
           title_prefix=""
           [ "$HAD_CONFLICTS" = "true" ] && title_prefix="[CONFLICTS]"
-          jira_prefix=""
-          [ -n "$JIRA_ID" ] && jira_prefix="[${JIRA_ID}]"
-          pr_title="${title_prefix}${jira_prefix}[${TARGET_BRANCH}] ${source_pr_title}"
+          jira_suffix=""
+          [ -n "$JIRA_ID" ] && jira_suffix=" (${JIRA_ID})"
+          # Strip the branch prefix (e.g. release/v1.197 → v1.197), like Studio.
+          version="${TARGET_BRANCH##*/}"
+          pr_title="🍒 ${title_prefix}[${version}] ${source_pr_title}${jira_suffix}"
 
           body_file="$(mktemp)"
           {


### PR DESCRIPTION
## What

Formats the titles of PRs opened by the cherry-pick workflow. These tweaks were built during #1773 but didn't reach `main` — that PR merged with only the permissions fix.

**Before:** `[PILOT-1234][release/v1.197] <source title>`
**After:** `🍒 [v1.197] <source title> (PILOT-1234)`

Changes to the `pr_title` line:
- Prefix with 🍒 (matches the Studio repo convention)
- Show only the version segment of the branch — `${TARGET_BRANCH##*/}` turns `release/v1.197` into `v1.197`
- Move the Jira ID to the end in parens (omitted entirely when no Jira ID is given)

## Resulting titles

| Case | Title |
|------|-------|
| Clean, with Jira | `🍒 [v1.197] <source title> (PILOT-1234)` |
| Clean, no Jira | `🍒 [v1.197] <source title>` |
| Conflicts | `🍒 [CONFLICTS][v1.197] <source title> (PILOT-1234)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-1234]: https://uipath.atlassian.net/browse/PILOT-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ