### PR TITLE
fix(ixp-smoke): remove CLI command from field-group prompt

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -20,8 +20,8 @@ sandbox:
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, create a new field group named
   "Subscriber information" with fields: surname, address, bank account, and
-  phone number. Pass all four fields inline in the single `groups add --fields`
-  JSON array — do not load the payload from a separate file.
+  phone number. Pass all four fields inline in one batched call — do not load
+  the payload from a separate file.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in


### PR DESCRIPTION
## Summary

- Prompt was telling the agent to use `groups add --fields` verbatim — leaking the command shape into the task description, which is the criteria''s job.
- Replaced with prose ("one batched call") that describes intent only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)