### PR TITLE
fix(ixp-skill): drop document image viewing from configure-model step

### DIFF
--- a/skills/uipath-ixp/references/project-setup-guide.md
+++ b/skills/uipath-ixp/references/project-setup-guide.md
@@ -48,32 +48,23 @@ mkdir -p /tmp/ixp/<project-name>/{docs,text,taxonomies,prompts}
 
 ## Step 2 — Configure the Model
 
-Before labelling, configure the extraction model based on what the documents look like. Download 2-3 sample document images and view them:
-
-```bash
-uip ixp documents list <project-name> --output json
-uip ixp documents download <project-name> <document-id> -o /tmp/ixp/<project-name>/docs/sample --output json
-```
-
-View with the **Read tool** — one full Read per document, **no `pages` parameter** (returns text + image natively). Then decide:
-
-| Document characteristics | Pre-processing | Model |
-|--------------------------|---------------|-------|
-| Simple documents, no tables | `none` | `gemini_2_5_flash` |
-| Documents with simple tables or multiple tables | `table_mini` | `gemini_2_5_flash` |
-| Complex nested tables, merged cells, multi-page tables | `table` | `gemini_2_5_flash` |
-| Very long documents (100+ pages) | `none` or `table_mini` | `gemini_2_5_pro` |
-
-Apply the configuration:
+Apply the configuration directly — do NOT download or Read document images to decide:
 
 ```bash
 uip ixp projects configure-model <project-name> \
   --model gemini_2_5_flash \
-  --preprocessing <none|table_mini|table> \
+  --preprocessing table_mini \
   --output json
 ```
 
-**Default recommendation:** `--model gemini_2_5_flash --preprocessing table_mini` — works well for most invoice/document types.
+**Default:** `gemini_2_5_flash` + `table_mini` — correct for invoices and most structured documents. Override only when the user explicitly requests a different model or the document type clearly differs:
+
+| Document characteristics | Pre-processing | Model |
+|--------------------------|---------------|-------|
+| Simple documents, no tables | `none` | `gemini_2_5_flash` |
+| Documents with simple or multiple tables | `table_mini` | `gemini_2_5_flash` |
+| Complex nested/merged/multi-page tables | `table` | `gemini_2_5_flash` |
+| Very long documents (100+ pages) | `none` or `table_mini` | `gemini_2_5_pro` |
 
 ## Step 3 — Name the Project
 


### PR DESCRIPTION
## Problem

The e2e full-lifecycle test was flaky (~2–3 of every 8 runs failed). Root cause: **Step 2 of the project-setup guide told the agent to download 2–3 sample document images and Read them before `configure-model`.** Each image is 50K–170K chars of base64, driving the context to **700–760K tokens** before the lifecycle even got going. The model then emitted a text-only turn, the SDK reported `end_turn`, and the run ended mid-lifecycle — typically right at or after `configure-model`/`get-predictions`, well before `confirm`, `update-prompts`, and `publish`.

This fix was originally made on `fix/ixp-e2e-drop-f1-direction-gate` (commit `110f1ff07`) but was never shipped — PR #1814 merged without it, so `main` still carried the image-dumping Step 2.

## Fix

Step 2 now applies the model configuration directly and explicitly instructs the agent **not** to download or Read document images to decide. `gemini_2_5_flash` + `table_mini` is the default (correct for invoices and most structured docs); a compact table covers the override cases. Image reading remains where it's genuinely needed — per-document labelling and the improve-prompts phase — both of which the passing runs already tolerate.

## Evidence

| Guide state | e2e result |
|-------------|-----------|
| Before (image dump in Step 2) | 6/8 passing — 2 runs died at ~700–760K-token context |
| After (this change) | **8/8 passing, every run 13/13, score 1.000** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)