### PR TITLE
fix(test): fix authz list-roles skill activation and add skill_triggered

### DIFF
--- a/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
@@ -13,23 +13,29 @@ run_limits:
   expected_turns: 6
 
 initial_prompt: |
-  List all authorization roles in my UiPath organization.
+  List all UiPath admin authorization roles — both built-in and custom —
+  in my UiPath organization.
 
   Important:
-  - The `uip` CLI is available but the `admin` subcommand may not be
-    installed and/or the CLI is not connected to a live tenant.
-    Commands WILL fail — that is expected and acceptable.
+  - The `uip` CLI is available but is not connected to a live tenant.
+    Commands WILL fail with auth errors — that is expected and acceptable.
     Run each command exactly once regardless of errors.
-    Do NOT retry, do NOT attempt to login, do NOT try to install tools,
-    do NOT troubleshoot errors.
+    Do NOT retry, do NOT attempt to login, do NOT troubleshoot errors.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
 
+  - type: skill_triggered
+    description: "Agent activated the uipath-admin skill"
+    skill_name: "uipath-admin"
+    expected_skill: "uipath-admin"
+    weight: 1.0
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent ran authorization roles list with --output json"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list[\s\S]*--output\s+json'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary
The `authz_list_roles_smoke` test failed because "List all authorization roles" triggered `uipath-platform` (Orchestrator roles via `uip or roles list`) instead of `uipath-admin` (`uip admin authorization roles list`).

### Fix
1. **Front-load "UiPath admin authorization roles"** in prompt to match skill description tokens
2. **Added `skill_triggered` criterion** to catch activation failures explicitly
3. **Removed stale "admin subcommand may not be installed" caveat** — admin is always available
4. **`[\s\S]*` in command regex** for multiline resilience

## Test plan
- [x] 6 consecutive PASS runs on CI
  - [Run 1](https://github.com/UiPath/skills/actions/runs/28609297369)
  - [Run 2](https://github.com/UiPath/skills/actions/runs/28609621344)
  - [Run 3](https://github.com/UiPath/skills/actions/runs/28609877861)
  - [Run 4](https://github.com/UiPath/skills/actions/runs/28621183087)
  - [Run 5](https://github.com/UiPath/skills/actions/runs/28621453682)
  - [Run 6](https://github.com/UiPath/skills/actions/runs/28621666085)

🤖 Generated with [Claude Code](https://claude.com/claude-code)