### PR TITLE
fix(maestro-case): centralize the create-on-missing 'already exists' adopt contract (two live-run gaps)

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/agent/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/agent/planning.md
@@ -120,7 +120,7 @@ Delivery: a **coded** sibling delivered via **`uip solution upload`** then **ins
 
 Mirrors [connector-integration.md § Creating a Connection](../../../connector-integration.md#creating-a-connection) step 4. If a build sub-agent returns `built:false` (or dies), show its `error` verbatim, then AskUserQuestion: `Retry create` / `Skip (defer)`. On `Skip` or repeated failure, fall to the Unresolved Fallback above (placeholder + completion-report note) and finish planning — never halt. A verify-time I/O mismatch is a **warning**, not a failure: rewire matched fields, report missing/extra, continue.
 
-> **"Already exists" is NOT a failure** (idempotency residual). If a build reports the project directory already exists / `agent init` fails *"directory exists / not empty"* or `project add` returns *"Project name already exists"*, the sibling was built by an interrupted prior run but wasn't surfaced by the pre-gate local check (it was never registered in the `.uipx`, so `--local` didn't see it). Do **not** route to Retry/Skip — instead register it (`uip solution project add`, if not already registered), then rediscover + bind (Step 3/4). It's already built.
+> **"Already exists" is NOT a failure** — an interrupted prior run already built the sibling; adopt it per [registry-discovery.md § Create-on-Missing → 3b](../../../registry-discovery.md#create-on-missing-build-and-rediscovery). Agent tokens for that procedure: init verb `uip agent init`; kind markers `Category: "agent"` (registered) / `agent.json` on disk (unregistered).
 
 ## tasks.md Entry Format
 

--- a/skills/uipath-maestro-case/references/registry-discovery.md
+++ b/skills/uipath-maestro-case/references/registry-discovery.md
@@ -102,6 +102,16 @@ uip solution project add "<built path>" "<solution .uipx>" --output json   # one
 
 Both positionals MUST be absolute paths — the relative form fails with `Failed to add project to solution` regardless of CWD (see [implementation.md](implementation.md) § Step 6.0b). Then run `uip solution resources refresh` (Rule 14) so the solution-level resource files + `debug_overwrites.json` are generated before any upload/debug.
 
+### 3b — "Already exists" = adopt (kind-agnostic residual)
+
+An interrupted prior run can leave a built sibling **on disk but unregistered**. Nothing that reads `.uipx` `Projects[]` sees it — the pre-gate `--local` check misses, the gate fires, and the build/register step collides: the type's `init` fails *"directory exists / not empty"*, or `uip solution project add` returns *"Project name already exists"*. **Neither is a failure.** Adopt:
+
+1. **Kind-check the collision.** Name present in `uip maestro case registry list --local --output json` → its `Category` identifies a registered owner; a different kind = cross-kind name collision, NOT a prior build → rename the new resource (§1 name-uniqueness) and rebuild. Name absent (`list --local` also reads only `Projects[]`) → read the colliding directory's `project.uiproj` `ProjectType`. Matching kind → adopt:
+2. **Register.** `uip solution project add` (absolute paths). It can refuse *"Project name already exists"* even when the name is absent from `.uipx` `Projects[]` — its collision check keys on **stale resource declaration files** from a prior registration, not the manifest. Delete `resources/solution_folder/package/<Name>.json` and the kind's `resources/solution_folder/process/<category>/<Name>.json`, re-run `project add`, then `uip solution resources refresh` regenerates them.
+3. **Continue at §4** (rediscover, verify, bind). Never rebuild, never Retry/Skip, never placeholder — the sibling is already built.
+
+Per-type verbs and kind markers: each plugin's § Failure blockquote.
+
 ### 4 — Rediscover + verify + bind (offline `--local`)
 
 Rediscover **by name** with `search` (not `get`): `registry get <id> --local` matches only on `entityKey`/project Id, never the display name, so `get "<Name>"` returns 0. `search` matches the keyword against the name. Read keys in **PascalCase** (`--output json` PascalCases recursively):


### PR DESCRIPTION
## Summary

Two gaps in the create-on-missing "already exists" adopt path, surfaced by the api-workflow L4 suite (T2b: on-disk-unregistered residual) and **root-caused live on CLI 1.198**. Both affect the already-merged agent leg too. Docs-only, 2 files.

1. **Kind-check blind spot.** The adopt path must confirm the colliding project's kind before adopting, but `registry list --local` enumerates only `.uipx`-registered projects — an unregistered on-disk residual (the exact case the residual handles) is invisible to it. Fixed: two-step kind-check — registered name → `list --local` `Category`; unregistered dir → on-disk `project.uiproj` `ProjectType`.
2. **`project add` stale-decl refusal.** `uip solution project add` refuses `Project name already exists` even when the name is absent from `.uipx` `Projects[]` — its collision check keys on **stale resource declaration files** left by a prior registration, not the manifest. Verified live: deleting `resources/solution_folder/package/<Name>.json` + the kind's `process/<category>/<Name>.json` makes the same command succeed ("Added successfully"); `resources refresh` regenerates them. (Arguably a CLI bug — the collision check could key on the manifest; docs carry the remediation either way.)

## Structure

The corrected contract now lives **once, kind-agnostically**, as `registry-discovery.md` § Create-on-Missing **3b** ("Already exists" = adopt). `agent/planning.md`'s residual blockquote shrinks to a pointer + agent-specific tokens (error verbs, kind markers). This removes the duplication that let each new creatable-kind leg re-author (and re-break) the same recovery logic.

## Downstream

Merge-first by design: the open create-on-missing legs — #1802 (api-workflow), #1803 (rpa), #1723 (agentic) — inherit on their next rebase and should slim their per-type residual blockquotes to the same pointer shape. Future legs link §3b instead of re-authoring.

Runtime evidence: `case_coding_agent_tests/create-on-missing-api-workflow-test/T2b-ondisk-unregistered/run-log.md` + `results.md` (adopt completed end-to-end via the corrected procedure: project add "Added successfully" → refresh → rediscover `Source:local` → validate Valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)