### PR TITLE
test: drop Claude-biased --output-json and review-catalog grader criteria

### DIFF
--- a/.claude/rules/test-writing.md
+++ b/.claude/rules/test-writing.md
@@ -53,7 +53,7 @@ Use side effects (`command_executed`, `file_exists`, `file_contains`, `json_chec
 
 Weight: `1.0` supporting · `1.5` core command/artifact · `2.0` artifact content · `3.0` primary validation · `5.0–6.0` e2e execution. `pass_threshold: 1.0` unless the criterion has multiple sub-assertions.
 
-When criteria parse CLI output, steer the prompt toward `--output json` and add a low-weight check matching `(uip|\$UIP)\s+.*--output\s+json`.
+When criteria parse CLI output, steer the prompt toward `--output json`, but grade the **outcome** (the parsed value, via `run_command` / `file_check`), NOT the literal flag. Never add a gating `command_executed` check on `(uip|\$UIP)\s+.*--output\s+json`: the flag is outcome-invisible (often the CLI default), so gating on it docks agents that reach the same result without typing it. To record convention adherence, use an advisory check (`pass_threshold: 0`).
 
 ## Prompts
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -339,12 +339,12 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip commands"
+    description: "Agent used --output json (advisory — convention only, non-gating)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+.*--output\s+json'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0   # advisory: the flag is outcome-invisible — never gate on it
 
   - type: command_executed
     description: "Agent linked flow project to solution"
@@ -478,7 +478,7 @@ Score is binary: 1.0 when matches ≤ `max_count` (default `0`), else 0.0. Empty
 
 | Weight | When to use | Example from existing tests |
 |--------|-------------|---------------------------|
-| `1.0` | Supporting checks | `--output json` flag used, presence of an auxiliary file |
+| `1.0` | Supporting checks | presence of an auxiliary file, an advisory (`pass_threshold: 0`) convention check such as `--output json` used |
 | `1.5` | Core behavior | `uip solution new` executed, `.flow` file created |
 | `2.0` | Important artifact content | `.flow` file contains the expected node type or handle wiring |
 | `3.0` | Primary artifact validity | `uip maestro flow validate` passes on the generated flow file |

--- a/tests/tasks/uipath-admin/apms_add_ip_range_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_add_ip_range_smoke.yaml
@@ -41,11 +41,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_bypass_rule_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_bypass_rule_lifecycle_e2e.yaml
@@ -62,11 +62,3 @@ success_criteria:
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_enforcement_enable_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_enforcement_enable_e2e.yaml
@@ -70,11 +70,3 @@ success_criteria:
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_get_enforcement_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_enforcement_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran ip-restriction enforcement get with --output json"
+    description: "Agent ran ip-restriction enforcement get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+enforcement\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_get_my_ip_smoke.yaml
@@ -33,9 +33,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran ip-restriction my-ip with --output json"
+    description: "Agent ran ip-restriction my-ip"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+my-ip'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_ip_range_edit_e2e.yaml
+++ b/tests/tasks/uipath-admin/apms_ip_range_edit_e2e.yaml
@@ -52,11 +52,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_list_bypass_rules_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_list_bypass_rules_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran ip-restriction bypass-rules list with --output json"
+    description: "Agent ran ip-restriction bypass-rules list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+bypass-rules\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_list_ip_ranges_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_list_ip_ranges_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran ip-restriction ip-ranges list with --output json"
+    description: "Agent ran ip-restriction ip-ranges list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+ip-restriction\s+ip-ranges\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/apms_troubleshoot_ip_lockout_smoke.yaml
+++ b/tests/tasks/uipath-admin/apms_troubleshoot_ip_lockout_smoke.yaml
@@ -55,11 +55,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_events_basic_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_events_basic_smoke.yaml
@@ -45,9 +45,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the events call (advisory — json is the CLI default)"
+    description: "Agent ran `uip admin audit tenant events` (advisory, non-gating)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events'
     min_count: 1
     weight: 1.0
     # Non-gating: `--output json` is the CLI default, so omitting it is harmless. Keep the

--- a/tests/tasks/uipath-admin/audit_events_pagination_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_events_pagination_smoke.yaml
@@ -44,9 +44,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the events call (advisory — json is the CLI default)"
+    description: "Agent ran `uip admin audit tenant events` (advisory, non-gating)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events'
     min_count: 1
     weight: 1.0
     # Non-gating: `--output json` is the CLI default, so omitting it is harmless. Reports

--- a/tests/tasks/uipath-admin/audit_export_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_export_e2e.yaml
@@ -37,7 +37,7 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip admin audit tenant sources` (discovery before query)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/audit_org_events_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_org_events_smoke.yaml
@@ -40,9 +40,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the events call (advisory — json is the CLI default)"
+    description: "Agent ran `uip admin audit org events` (advisory, non-gating)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+org\s+events\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+org\s+events'
     min_count: 1
     weight: 1.0
     # Non-gating: `--output json` is the CLI default, so omitting it is harmless. Reports

--- a/tests/tasks/uipath-admin/audit_status_filter_smoke.yaml
+++ b/tests/tasks/uipath-admin/audit_status_filter_smoke.yaml
@@ -44,9 +44,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json (advisory — json is the CLI default)"
+    description: "Agent ran `uip admin audit tenant events` (advisory, non-gating)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events'
     min_count: 1
     weight: 1.0
     # Non-gating: `--output json` is the CLI default, so omitting it is harmless. Reports

--- a/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
@@ -41,16 +41,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consistently used --output json (advisory — json is the CLI default)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    # Non-gating: `--output json` is the CLI default, so omitting it is harmless. Reports
-    # Rule-3 adherence but pass_threshold 0 keeps a benign miss from failing the task.
-    pass_threshold: 0
-
 run_limits:
   expected_turns: 8
   max_turns: 40

--- a/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
+++ b/tests/tasks/uipath-admin/audit_who_did_x_e2e.yaml
@@ -28,7 +28,7 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip admin audit tenant sources` (discovery before query)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+audit\s+tenant\s+sources'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_check_access_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_check_access_smoke.yaml
@@ -36,9 +36,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent passed --output json"
+    description: "Agent ran `uip admin authorization check-access`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+check-access\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+check-access'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_diagnose_permission_denied_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_diagnose_permission_denied_smoke.yaml
@@ -41,11 +41,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json consistently"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_diagnose_role_not_working_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_diagnose_role_not_working_e2e.yaml
@@ -49,11 +49,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json consistently"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_diagnose_role_not_working_e2e.yaml
+++ b/tests/tasks/uipath-admin/authz_diagnose_role_not_working_e2e.yaml
@@ -37,7 +37,7 @@ success_criteria:
   - type: command_executed
     description: "Agent inspected the role definition via roles get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_get_role_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_get_role_smoke.yaml
@@ -36,9 +36,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent passed --output json"
+    description: "Agent ran `uip admin authorization roles get`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+get'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_list_permissions_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_permissions_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran authorization permissions list with --output json"
+    description: "Agent ran authorization permissions list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+permissions\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_list_role_assignments_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_role_assignments_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran authorization roles assignments list with --output json"
+    description: "Agent ran authorization roles assignments list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+assignments\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_list_roles_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran authorization roles list with --output json"
+    description: "Agent ran authorization roles list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+authorization\s+roles\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/authz_role_assignment_grant_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_role_assignment_grant_smoke.yaml
@@ -44,11 +44,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json consistently"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
+++ b/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
@@ -42,7 +42,7 @@ success_criteria:
   - type: command_executed
     description: "Agent verified federated credential by listing credentials on the app"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+external-apps\s+federated-credentials\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+external-apps\s+federated-credentials\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
+++ b/tests/tasks/uipath-admin/federated_credentials_e2e.yaml
@@ -47,14 +47,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_federated_app.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -62,14 +62,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consistently used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 4
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_group.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -57,7 +57,7 @@ success_criteria:
   - type: command_executed
     description: "Agent verified membership via members list (at least twice: after add and after revoke)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+groups\s+members\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+groups\s+members\s+list'
     min_count: 2
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
@@ -47,7 +47,7 @@ success_criteria:
   - type: command_executed
     description: "Agent verified invite by listing users after invite"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+users\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+users\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/human_user_onboarding_e2e.yaml
@@ -52,14 +52,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consistently used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_invited_user.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/identity_create_external_app_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_create_external_app_smoke.yaml
@@ -22,11 +22,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_create_robot_account_smoke.yaml
@@ -34,14 +34,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_smoke_test_bot.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_oauth_failing_smoke.yaml
@@ -29,7 +29,7 @@ success_criteria:
   - type: command_executed
     description: "Agent inspected external apps via get or list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+external-apps\s+(get|list)\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+external-apps\s+(get|list)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_diagnose_pat_rejected_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_pat_rejected_smoke.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_diagnose_pat_rejected_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_pat_rejected_smoke.yaml
@@ -29,7 +29,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed PATs to check status"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+pat\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+pat\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_diagnose_smtp_failing_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_diagnose_smtp_failing_smoke.yaml
@@ -26,7 +26,7 @@ success_criteria:
   - type: command_executed
     description: "Agent checked current SMTP config"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+smtp\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+smtp\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_external_app_secret_rotate_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_external_app_secret_rotate_smoke.yaml
@@ -27,7 +27,7 @@ success_criteria:
   - type: command_executed
     description: "Agent generated a new secret for the specified client id"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+external-apps\s+generate-secret\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+external-apps\s+generate-secret\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_group_membership_update_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_group_membership_update_smoke.yaml
@@ -39,7 +39,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed groups to find the target group"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+groups\s+list\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+groups\s+list'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_list_groups_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_groups_smoke.yaml
@@ -14,9 +14,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran groups list with --output json"
+    description: "Agent ran groups list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+groups\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+groups\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_list_pats_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_pats_smoke.yaml
@@ -15,9 +15,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran pat list with --output json"
+    description: "Agent ran pat list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+pat\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+pat\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_list_robot_accounts_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_robot_accounts_smoke.yaml
@@ -14,9 +14,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran robot-accounts list with --output json"
+    description: "Agent ran robot-accounts list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+robot-accounts\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+robot-accounts\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_list_users_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_list_users_smoke.yaml
@@ -14,9 +14,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran users list with --output json"
+    description: "Agent ran users list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+users\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+users\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_pat_revoke_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_pat_revoke_smoke.yaml
@@ -28,7 +28,7 @@ success_criteria:
   - type: command_executed
     description: "Agent revoked the PAT"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+pat\s+revoke\b.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+pat\s+revoke'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_scopes_list_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_scopes_list_smoke.yaml
@@ -16,9 +16,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran scopes list with --output json"
+    description: "Agent ran scopes list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+scopes\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+scopes\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_smtp_get_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_smtp_get_smoke.yaml
@@ -15,9 +15,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran smtp get with --output json"
+    description: "Agent ran smtp get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+smtp\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+smtp\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_troubleshoot_access_denied_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_troubleshoot_access_denied_smoke.yaml
@@ -54,11 +54,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_troubleshoot_login_failure_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_troubleshoot_login_failure_smoke.yaml
@@ -56,11 +56,3 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+admin\s+audit\s+tenant\s+events\b'
     weight: 2.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_user_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/identity_user_lifecycle_e2e.yaml
@@ -62,11 +62,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_get_organization_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_get_organization_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran organizations get with --output json"
+    description: "Agent ran organizations get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+organizations\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+organizations\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_org_services_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_org_services_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran organizations services list with --output json"
+    description: "Agent ran organizations services list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+organizations\s+services\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+organizations\s+services\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_regions_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_regions_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran organizations regions list with --output json"
+    description: "Agent ran organizations regions list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+organizations\s+regions\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+organizations\s+regions\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_tenant_services_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_tenant_services_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran tenants services list with --output json"
+    description: "Agent ran tenants services list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+tenants\s+services\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_list_tenants_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_list_tenants_smoke.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 success_criteria:
 
   - type: command_executed
-    description: "Agent ran tenants list with --output json"
+    description: "Agent ran tenants list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+tenants\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+tenants\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_service_provisioning_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_service_provisioning_smoke.yaml
@@ -45,11 +45,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_create_poll_e2e.yaml
@@ -56,11 +56,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_create_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_create_smoke.yaml
@@ -43,11 +43,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_disable_smoke.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_disable_smoke.yaml
@@ -44,11 +44,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
+++ b/tests/tasks/uipath-admin/oms_tenant_service_remove_e2e.yaml
@@ -61,11 +61,3 @@ success_criteria:
     min_count: 2
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
@@ -36,14 +36,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_pat.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-admin/pat_lifecycle_e2e.yaml
@@ -31,7 +31,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed PATs to verify creation"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+pat\s+list\s+.*--output\s+json'
+    command_pattern: 'uip\s+admin\s+pat\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
+++ b/tests/tasks/uipath-admin/pat_regenerate_smoke.yaml
@@ -46,11 +46,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
@@ -61,14 +61,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consistently used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_robot_account.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
+++ b/tests/tasks/uipath-admin/robot_account_onboarding_e2e.yaml
@@ -53,14 +53,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent verified robot account by listing after create"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+robot-accounts\s+list\s+.*--output\s+json'
-    min_count: 2
-    weight: 2.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_robot_account.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-admin/smtp_configure_e2e.yaml
+++ b/tests/tasks/uipath-admin/smtp_configure_e2e.yaml
@@ -34,14 +34,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "SMTP settings were applied (host is non-empty)"
     command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''TASK_DIR''],''check_smtp_settings.py''))"'

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -73,14 +73,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Coded agent project exists (main.py)"
     path: "GreeterSol/InputProcessor/main.py"

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_published/coded_in_flow_published.yaml
@@ -79,14 +79,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Coded agent project has the LangGraph marker"
     path: "tone-classifier/langgraph.json"

--- a/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/batch_transform/e2e_enable_tool.yaml
@@ -71,14 +71,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "BatchAgent/agent.json was created"
     path: "BatchSol/BatchAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/builtin_tool/builtin_tool.yaml
@@ -68,14 +68,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "DocAnalystAgent/agent.json was created"
     path: "DocsSol/DocAnalystAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_index/context_index.yaml
@@ -94,14 +94,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ProductSupportAgent/agent.json was created"
     path: "KnowledgeSol/ProductSupportAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/conversational/guardrail_custom_tool/guardrail_custom_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/guardrail_custom_tool/guardrail_custom_tool.yaml
@@ -61,14 +61,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "DocGuardBot/agent.json was created"
     path: "DocGuardSol/DocGuardBot/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
@@ -62,14 +62,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "ChatAgent/agent.json was created"
     path: "ChatSol/ChatAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/debug/debug.yaml
+++ b/tests/tasks/uipath-agents/lowcode/debug/debug.yaml
@@ -41,9 +41,9 @@ success_criteria:
   # in any order. Only MathAgent exists in the sandbox, so the agent path is
   # implied.
   - type: command_executed
-    description: "Agent ran a successful `uip agent debug` with both --inputs and --output json"
+    description: "Agent ran a successful `uip agent debug` with both --inputs"
     tool_name: "Bash"
-    command_pattern: 'uip\s+agent\s+debug\b(?=.*--inputs)(?=.*--output\s+json)'
+    command_pattern: 'uip\s+agent\s+debug\b(?=.*--inputs)'
     min_count: 1
     require_success: true
     weight: 6.0

--- a/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/deeprag/e2e_enable_tool.yaml
@@ -71,14 +71,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "DeepAgent/agent.json was created"
     path: "DeepSol/DeepAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/dispute_analyst_agent/dispute_analyst_agent.yaml
@@ -97,14 +97,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "DisputeAnalystAgent/agent.json was created"
     path: "DisputeSol/DisputeAnalystAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
+++ b/tests/tasks/uipath-agents/lowcode/edit_roundtrip/edit_roundtrip.yaml
@@ -42,14 +42,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "GreeterAgent/agent.json was created"
     path: "GreetSol/GreeterAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_agent_tool/external_agent_tool.yaml
@@ -98,14 +98,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "OutreachAgent/agent.json was created"
     path: "OutreachSol/OutreachAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_apiworkflow_tool/external_apiworkflow_tool.yaml
@@ -97,14 +97,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "WeatherAgent/agent.json was created"
     path: "WeatherSol/WeatherAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_escalation/external_escalation.yaml
@@ -91,14 +91,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "FraudTriageAgent/agent.json was created"
     path: "FraudSol/FraudTriageAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_maestro_tool/external_maestro_tool.yaml
@@ -97,14 +97,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ProcurementAgent/agent.json was created"
     path: "ProcurementSol/ProcurementAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/external_rpa_tool/external_rpa_tool.yaml
@@ -97,14 +97,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "FibonacciAgent/agent.json was created"
     path: "FibonacciSol/FibonacciAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/custom_boolean_filter.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_boolean_filter/custom_boolean_filter.yaml
@@ -47,14 +47,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: run_command
     description: "Custom boolean-rule guardrail with filter action on Send message to channel"
     command: "python3 $TASK_DIR/check_custom_boolean_filter.py"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/custom_number_log.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_number_log/custom_number_log.yaml
@@ -44,14 +44,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: run_command
     description: "Custom number-rule guardrail with log action on Count Sources"
     command: "python3 $TASK_DIR/check_custom_number_log.py"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/custom_word/custom_word.yaml
@@ -61,14 +61,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "SafeAgent/agent.json was created"
     path: "GuardSol/SafeAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/discovery/discovery.yaml
@@ -60,14 +60,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "DiscoverAgent/agent.json was created"
     path: "DiscoverSol/DiscoverAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/escalation_app/escalation_app.yaml
@@ -98,14 +98,6 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ComplianceAgent/agent.json was created"
     path: "EscalateSol/ComplianceAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/intellectual_property.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/intellectual_property/intellectual_property.yaml
@@ -62,14 +62,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "IPAgent/agent.json was created"
     path: "IPSol/IPAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/pii_detection/pii_detection.yaml
@@ -62,14 +62,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "PiiSafeAgent/agent.json was created"
     path: "PiiGuardSol/PiiSafeAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/prompt_injection/prompt_injection.yaml
@@ -61,14 +61,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "InjSafeAgent/agent.json was created"
     path: "InjGuardSol/InjSafeAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/user_prompt_attacks.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/user_prompt_attacks/user_prompt_attacks.yaml
@@ -64,14 +64,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "UPAAgent/agent.json was created"
     path: "UPASol/UPAAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/init_validate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/init_validate.yaml
@@ -63,14 +63,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "GreeterAgent/agent.json was created"
     path: "GreetSol/GreeterAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_builtin_tool/inline_builtin_tool.yaml
@@ -93,14 +93,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "DocsFlowSol/DocsFlow/DocsFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_context_index/inline_context_index.yaml
@@ -117,14 +117,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "KnowledgeFlowSol/KnowledgeFlow/KnowledgeFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_agent_tool/inline_external_agent_tool.yaml
@@ -110,14 +110,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "OutreachFlowSol/OutreachFlow/OutreachFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_apiworkflow_tool/inline_external_apiworkflow_tool.yaml
@@ -110,14 +110,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "WeatherFlowSol/WeatherFlow/WeatherFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_escalation/inline_external_escalation.yaml
@@ -118,14 +118,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "FraudFlowSol/FraudFlow/FraudFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_maestro_tool/inline_external_maestro_tool.yaml
@@ -111,14 +111,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "ProcurementFlowSol/ProcurementFlow/ProcurementFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_external_rpa_tool/inline_external_rpa_tool.yaml
@@ -109,14 +109,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "FibonacciFlowSol/FibonacciFlow/FibonacciFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_in_flow/inline_in_flow.yaml
@@ -68,14 +68,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "GreetingSol/GreetingFlow/GreetingFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -89,14 +89,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "ResearchFlowSol/ResearchFlow/ResearchFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -70,14 +70,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "DevToolsFlowSol/DevToolsFlow/DevToolsFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_memory_space/inline_memory_space.yaml
@@ -85,14 +85,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: command_not_executed
     description: "Agent must not hand-author memory feature JSON with shell redirection"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool/inline_solution_agent_tool.yaml
@@ -141,14 +141,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "OrchestratorFlowSol/OrchestratorFlow/OrchestratorFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_apiworkflow_tool/inline_solution_apiworkflow_tool.yaml
@@ -110,14 +110,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "ShippingFlowSol/ShippingFlow/ShippingFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_escalation/inline_solution_escalation.yaml
@@ -114,14 +114,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "ReviewFlowSol/ReviewFlow/ReviewFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_maestro_tool/inline_solution_maestro_tool.yaml
@@ -121,14 +121,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "OnboardingFlowSol/OnboardingFlow/OnboardingFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_solution_rpa_tool/inline_solution_rpa_tool.yaml
@@ -110,14 +110,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "Flow file was created"
     path: "PayrollFlowSol/PayrollFlow/PayrollFlow.flow"

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -86,14 +86,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ResearchAgent/agent.json was created"
     path: "ResearchSol/ResearchAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/local_escalation/local_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/local_escalation/local_escalation.yaml
@@ -64,14 +64,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ApprovalEscalation escalation resource.json was created"
     path: "AgentWithLocalEscalation/Agent/resources/ApprovalEscalation/resource.json"

--- a/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/mcp_server_tool/mcp_server_tool.yaml
@@ -67,14 +67,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "DevAssistantAgent/agent.json was created"
     path: "DevToolsSol/DevAssistantAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/memory_help/memory_help.yaml
+++ b/tests/tasks/uipath-agents/lowcode/memory_help/memory_help.yaml
@@ -26,7 +26,7 @@ success_criteria:
   - type: command_executed
     description: "Agent discovered existing memory spaces (read-only) before attaching"
     tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+resources\s+list\b.*--kind\s+MemorySpace\b.*--output\s+json'
+    command_pattern: 'uip\s+solution\s+resources\s+list\b.*--kind\s+MemorySpace'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
+++ b/tests/tasks/uipath-agents/lowcode/memory_space/memory_space.yaml
@@ -97,14 +97,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: command_not_executed
     description: "Agent must not hand-author memory feature JSON with shell redirection"
     tool_name: "Bash"

--- a/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
+++ b/tests/tasks/uipath-agents/lowcode/resolution_drafter_agent/resolution_drafter_agent.yaml
@@ -91,14 +91,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ResolutionDrafterAgent/agent.json was created"
     path: "ResolutionSol/ResolutionDrafterAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
+++ b/tests/tasks/uipath-agents/lowcode/schema_update/schema_update.yaml
@@ -38,14 +38,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: run_command
     description: "Schema sync, prompt-matching schemas, and user message inlines {{input.userQuery}}"
     command: "python3 $TASK_DIR/check_schema_update.py"

--- a/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_agent_tool/solution_agent_tool.yaml
@@ -111,14 +111,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ParentAgent/agent.json was created"
     path: "OrchestratorSol/ParentAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_apiworkflow_tool/solution_apiworkflow_tool.yaml
@@ -101,14 +101,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ShippingAgent/agent.json was created"
     path: "ShippingSol/ShippingAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_escalation/solution_escalation.yaml
@@ -100,14 +100,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "ModerationAgent/agent.json was created"
     path: "ReviewSol/ModerationAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_maestro_tool/solution_maestro_tool.yaml
@@ -106,14 +106,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "OnboardingAgent/agent.json was created"
     path: "OnboardingSol/OnboardingAgent/agent.json"

--- a/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_rpa_tool/solution_rpa_tool.yaml
@@ -96,14 +96,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Advisory: agent used --output json on uip commands (informational, non-gating)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 0.0
-
   - type: file_exists
     description: "PayrollAgent/agent.json was created"
     path: "PayrollSol/PayrollAgent/agent.json"

--- a/tests/tasks/uipath-api-workflow/package/package_solution.yaml
+++ b/tests/tasks/uipath-api-workflow/package/package_solution.yaml
@@ -30,14 +30,6 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Packager invoked with --output json (rule 18)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+pack.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
 # Packaging is a multi-step lifecycle task (scaffold solution -> Type: Api -> pack);
 # it inherits the experiment's generous turn budget rather than a tight smoke cap.
 # Tiered integration (not smoke) so it runs on the nightly runner, not the PR gate.

--- a/tests/tasks/uipath-api-workflow/validate/validate_smoke.yaml
+++ b/tests/tasks/uipath-api-workflow/validate/validate_smoke.yaml
@@ -40,7 +40,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran the offline validator with JSON output (rule 20 + rule 18)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+api-workflow\s+validate\s+.*--output\s+json'
+    command_pattern: 'uip\s+api-workflow\s+validate'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-functions/coded_in_flow_register/coded_in_flow_register.yaml
+++ b/tests/tasks/uipath-functions/coded_in_flow_register/coded_in_flow_register.yaml
@@ -70,14 +70,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used structured output when listing solution resources"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+solution\s+resources\s+list\b.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Coded agent main.py exists"
     path: "ClaimsSol/ClassifierAgent/main.py"

--- a/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access-policy_lifecycle_e2e.yaml
@@ -88,14 +88,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on at least 3 access-policy commands (skill convention)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+[\s\S]*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'CLEANUP_POLICY_KIND="access-policy" CLEANUP_POLICY_NAME="lifecycle-test-access-policy" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''cleanup_policy.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-governance/access-policy/access_diagnose_blocked_invocation_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access_diagnose_blocked_invocation_smoke.yaml
@@ -38,17 +38,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov access-policy evaluate` with --resource-type and --output json"
+    description: "Agent invoked `uip gov access-policy evaluate` with --resource-type"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate\s+[\s\S]*--resource-type\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate\s+[\s\S]*--resource-type'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip gov access-policy list` with --output json to inspect candidate policies"
+    description: "Agent invoked `uip gov access-policy list` to inspect candidate policies"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/access_evaluate_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/access_evaluate_smoke.yaml
@@ -37,9 +37,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov access-policy evaluate` with --resource-type and --output json"
+    description: "Agent invoked `uip gov access-policy evaluate` with --resource-type"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate\s+[\s\S]*--resource-type\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate\s+[\s\S]*--resource-type'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/evaluate_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/evaluate_smoke.yaml
@@ -35,9 +35,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked access-policy evaluate with --output json"
+    description: "Agent invoked access-policy evaluate"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate\b[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+evaluate'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/get_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/get_policy_smoke.yaml
@@ -32,9 +32,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov access-policy get <UUID>` with --output json against the requested UUID"
+    description: "Agent invoked `uip gov access-policy get <UUID>` against the requested UUID"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+get\s+.*00000000-0000-0000-0000-000000000001[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+get\s+.*00000000-0000-0000-0000-000000000001'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
@@ -38,25 +38,25 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip admin users list --search` for the email-based user lookup with --output json"
+    description: "Agent invoked `uip admin users list --search` for the email-based user lookup"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+users\s+list\s+[\s\S]*--search\s+["'']?[^"'' ]*alice[^"'' ]*["'']?\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+admin\s+users\s+list\s+[\s\S]*--search\s+["'']?[^"'' ]*alice[^"'' ]*["'']?'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip admin robot-accounts list --search` for the robot lookup with --output json"
+    description: "Agent invoked `uip admin robot-accounts list --search` for the robot lookup"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+robot-accounts\s+list\s+[\s\S]*--search\s+["'']?[^"'' ]*build-bot[^"'' ]*["'']?\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+admin\s+robot-accounts\s+list\s+[\s\S]*--search\s+["'']?[^"'' ]*build-bot[^"'' ]*["'']?'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip admin groups list --output json` for the group lookup (groups list has no --search; agent filters client-side)"
+    description: "Agent invoked `uip admin groups list` for the group lookup (groups list has no --search; agent filters client-side)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+groups\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+admin\s+groups\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/list_policies_smoke.yaml
@@ -33,9 +33,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov access-policy list` with --output json"
+    description: "Agent invoked `uip gov access-policy list`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+access-policy\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+access-policy\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops-policy_lifecycle_e2e.yaml
@@ -78,14 +78,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on at least 3 aops-policy commands (skill convention)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
 post_run:
   - command: 'CLEANUP_POLICY_KIND="aops-policy" CLEANUP_POLICY_NAME="aitl-crud-lifecycle-clie2e" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''cleanup_policy.py''))"'
     timeout: 30

--- a/tests/tasks/uipath-governance/aops-policy/aops_deploy_tenant_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deploy_tenant_smoke.yaml
@@ -38,19 +38,11 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `deployment tenant configure` with --input and --output json"
+    description: "Agent invoked `deployment tenant configure` with --input"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+tenant\s+configure\b(?=[\s\S]*--input\s)(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+tenant\s+configure\b(?=[\s\S]*--input\s)'
     min_count: 1
     weight: 2.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on at least one uip gov aops-policy command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_policy_query_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_policy_query_smoke.yaml
@@ -37,9 +37,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployed-policy get` with license-type, product, tenant and --output json"
+    description: "Agent invoked `uip gov aops-policy deployed-policy get` with license-type, product, tenant"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+.*NoLicense.*AITrustLayer.*00000000-0000-0000-0000-000000000099[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+.*NoLicense.*AITrustLayer.*00000000-0000-0000-0000-000000000099'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_policy_not_applied_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_policy_not_applied_smoke.yaml
@@ -39,17 +39,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `deployed-policy get` or `deployed-policy list` with --output json to check effective policy"
+    description: "Agent invoked `deployed-policy get` or `deployed-policy list` to check effective policy"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+(get|list)\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+(get|list)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `deployment group get` or `deployment group list` with --output json to check group-level deployment"
+    description: "Agent invoked `deployment group get` or `deployment group list` to check group-level deployment"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+group\s+(get|list)\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+group\s+(get|list)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/deployed_policy_s2s_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployed_policy_s2s_smoke.yaml
@@ -53,14 +53,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployed_policy_smoke.yaml
@@ -36,15 +36,15 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip gov aops-policy deployed-policy get` with three positional args in order (license-type product-name tenant)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+.*Attended.*StudioX[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+get\s+.*Attended.*StudioX'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployed-policy list` with --output json"
+    description: "Agent invoked `uip gov aops-policy deployed-policy list`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployed-policy\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/deployment_discovery_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_discovery_smoke.yaml
@@ -35,25 +35,25 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployment user list` with --output json"
+    description: "Agent invoked `uip gov aops-policy deployment user list`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployment user get <USER_ID>` with --output json"
+    description: "Agent invoked `uip gov aops-policy deployment user get <USER_ID>`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+get\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+user\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy deployment tenant list` with --output json"
+    description: "Agent invoked `uip gov aops-policy deployment tenant list`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+tenant\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+deployment\s+tenant\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/deployment_group_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/deployment_group_smoke.yaml
@@ -51,14 +51,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/aops-policy/discover_catalog_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/discover_catalog_smoke.yaml
@@ -34,17 +34,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy product list` (or pre-rename `list-products`) with --output json"
+    description: "Agent invoked `uip gov aops-policy product list` (or pre-rename `list-products`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+(product\s+list|list-products)\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+(product\s+list|list-products)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent invoked `uip gov aops-policy license-type list` (or pre-rename `list-license-types`) with --output json"
+    description: "Agent invoked `uip gov aops-policy license-type list` (or pre-rename `list-license-types`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+(license-type\s+list|list-license-types)\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+(license-type\s+list|list-license-types)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/list_policies_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/list_policies_smoke.yaml
@@ -40,9 +40,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the list command"
+    description: "Agent ran the list command"
     tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+list\s+[\s\S]*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/product_get_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/product_get_smoke.yaml
@@ -45,14 +45,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/aops-policy/template_get_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/template_get_smoke.yaml
@@ -38,14 +38,6 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Command output captured to ./output.txt"
     path: "output.txt"

--- a/tests/tasks/uipath-governance/compliance-pack/already_configured_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/already_configured_smoke.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent ran state coverage to check current posture"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/apply_commands_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/apply_commands_smoke.yaml
@@ -27,14 +27,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent ran state coverage for posture analysis before apply"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state enable for full pack configuration"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/check_routing_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/check_routing_smoke.yaml
@@ -29,14 +29,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state coverage for posture analysis"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/disable_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/disable_smoke.yaml
@@ -25,14 +25,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent checked current pack state before disabling"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+get\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+get\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state disable to remove standard settings"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+disable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+disable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/gap_scan_commands_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/gap_scan_commands_smoke.yaml
@@ -26,14 +26,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state coverage for posture analysis"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/interactive_values_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/interactive_values_smoke.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for Robot UIAutomation settings data"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/nonregression_branch_a_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/nonregression_branch_a_smoke.yaml
@@ -43,7 +43,7 @@ success_criteria:
 
   - type: command_executed
     description: "Agent called aops-policy create (Branch A behaviour)"
-    command_pattern: 'uip\s+gov\s+aops-policy\s+create\s+.*--output\s+json'
+    command_pattern: 'uip\s+gov\s+aops-policy\s+create'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/org_scope_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/org_scope_smoke.yaml
@@ -24,21 +24,21 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent listed tenants in the org to discover all targets"
-    command_pattern: 'uip\s+login\s+tenant\s+list.*--output\s+json'
+    command_pattern: 'uip\s+login\s+tenant\s+list'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent ran state coverage at tenant scope (per-tenant iteration)"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+tenant\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+tenant\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state enable at tenant scope (not organization scope)"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+tenant\s+\S+\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+tenant\s+\S+\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/partial_apply_aitl_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/partial_apply_aitl_smoke.yaml
@@ -30,7 +30,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/partial_apply_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/partial_apply_smoke.yaml
@@ -28,7 +28,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+.*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/query_clause_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/query_clause_smoke.yaml
@@ -23,7 +23,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get to retrieve clause recommendations"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+).*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/state_list_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/state_list_smoke.yaml
@@ -26,7 +26,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called state list to discover configured compliance standards"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+list\s+(?:tenant|organization)\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+list\s+(?:tenant|organization)\s+\S+'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -78,7 +78,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -59,7 +59,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow after all changes"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -60,7 +60,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated after wiring"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
@@ -38,7 +38,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -34,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
+++ b/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
@@ -68,9 +68,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Pulled metrics for each version (--output json)"
+    description: "Pulled metrics for each version"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+get-metrics\b.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+ixp\s+projects\s+get-metrics'
     min_count: 2
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
@@ -35,11 +35,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -43,11 +43,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+labellings\s+confirm\b.*--fields'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -93,11 +93,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -38,11 +38,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -40,11 +40,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
@@ -44,11 +44,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+projects\s+(create\b.*--skip-taxonomy|import-taxonomy)\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
@@ -35,11 +35,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -35,11 +35,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
@@ -43,11 +43,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/delete_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_project.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
+++ b/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
@@ -38,11 +38,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
+++ b/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/list_documents.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_documents.yaml
@@ -32,11 +32,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/list_projects.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_projects.yaml
@@ -35,11 +35,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
+++ b/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -45,11 +45,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+projects\s+untag\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -44,11 +44,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+labellings\s+confirm\s+["'']?my_invoices-f1afa9ef-ixp["'']?\s*(--|$)'
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -102,11 +102,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+labellings\s+confirm\s+["'']?freight_docs-df33115f-ixp["'']?\s+["'']?doc-freight-7["'']?.*--corrections'
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
@@ -78,11 +78,3 @@ success_criteria:
     command_pattern: '^(?!.*--group).*uip\s+ixp\s+labellings\s+unconfirm\s+["'']?freight_docs-df33115f-ixp["'']?\s+["'']?doc-freight-9["'']?\s+.*--fields'
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -37,11 +37,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
@@ -35,11 +35,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field.yaml
@@ -40,11 +40,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+fields\s+delete\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -41,11 +41,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+groups\s+delete\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/rename_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_project.yaml
@@ -40,11 +40,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+projects\s+delete\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
+++ b/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
@@ -80,11 +80,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+fields\s+add\s+["'']?my_invoices-f1afa9ef-ixp["'']?\s+.*--group\s+["'']?Invoice Header["'']?'
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
@@ -49,14 +49,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   # Anti-pattern: re-running `confirm` with a different --fields list
   # does NOT remove a prior annotation — the SDK preserves carry-forward
   # annotations. The agent must not reach for confirm to undo a confirm.

--- a/tests/tasks/uipath-ixp/smoke/unpublish.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unpublish.yaml
@@ -45,11 +45,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+projects\s+delete\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/untag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/untag.yaml
@@ -44,11 +44,3 @@ success_criteria:
     command_pattern: 'uip\s+ixp\s+(projects\s+unpublish|projects\s+delete)\b'
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -45,11 +45,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -53,11 +53,3 @@ success_criteria:
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on a uip ixp command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/registry_discovery.yaml
@@ -57,14 +57,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json for parsed registry calls"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?bpmn\s+registry\s+[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Registry evidence covers documented agent, queue, and connector wrapper types"
     command: "python3 $TASK_DIR/check_registry_discovery.py"

--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -48,7 +48,7 @@ success_criteria:
   - type: command_executed
     description: "Agent checked the BPMN job status"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+job\s+status\s+job-triage-001\s+--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+job\s+status\s+job-triage-001'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -56,7 +56,7 @@ success_criteria:
   - type: command_executed
     description: "Agent read instance incidents with folder context"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+incidents\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public\s+--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+incidents\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent inspected runtime variables with folder context"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+variables\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public\s+--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+variables\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent fetched the deployed BPMN asset"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+asset\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public\s+--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+instance\s+asset\s+inst-triage-001\s+(-f|--folder-key)\s+folder-public'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
@@ -57,14 +57,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on registry commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Raw registry evidence covers the RPA-job and receive-message types"
     command: "python3 $TASK_DIR/check_registry_discovery.py"

--- a/tests/tasks/uipath-maestro-case/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-case/init_validate.yaml
@@ -52,14 +52,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "sdd.md fixture was written"
     path: "sdd.md"

--- a/tests/tasks/uipath-maestro-case/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_discovery.yaml
@@ -41,9 +41,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent pulled the case registry with --output json"
+    description: "Agent pulled the case registry"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull[^\n]*--output\s+json'
+    command_pattern: 'uip\s+maestro\s+case\s+registry\s+pull[^\n]*'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -55,9 +55,9 @@ success_criteria:
 
   # ── Agent invoked debug ────────────────────────────────────────────────
   - type: command_executed
-    description: "Agent ran flow debug with --output json"
+    description: "Agent ran flow debug"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--output\s+json'
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -69,7 +69,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
@@ -133,14 +133,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on eval commands"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Inline agent + llm-judge evaluator + eval set with a data point all exist on disk"
     command: 'python3 "$TASK_DIR/check_inline_agent_eval.py"'

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -100,14 +100,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on every eval command"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+.*--output\s+json'
-    min_count: 4
-    weight: 1.5
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Evaluator + eval-set JSON files exist on disk with correct shape"
     command: "python3 $TASK_DIR/check_local_crud.py"

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -127,14 +127,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on every eval command"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+.*--output\s+json'
-    min_count: 5
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Eval-set JSON shows the Llm simulation persisted and the removed one is gone"
     command: "python3 $TASK_DIR/check_simulation_crud.py"

--- a/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
@@ -93,14 +93,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: json_check
     description: "New Flow project is registered in the new parent solution .uipx"
     path: "WeatherAlert/WeatherAlert.uipx"

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -46,9 +46,9 @@ success_criteria:
 
   # ── Agent invoked debug with an --attachment binding ───────────────────
   - type: command_executed
-    description: "Agent ran flow debug with an --attachment binding and --output json"
+    description: "Agent ran flow debug with an --attachment binding"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--attachment\s+\S+=\S+.*--output\s+json|(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--output\s+json.*--attachment\s+\S+=\S+'
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug.*--attachment\s+\S+=\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -53,14 +53,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   # Outcome-based check (auto-registration via `flow init` OR explicit
   # `uip solution project add` both populate Projects[] in the .uipx).
   - type: json_check

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -50,14 +50,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Flow file was created inside the solution"
     path: "EmailTriage/EmailTriage/EmailTriage.flow"

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -41,14 +41,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on registry commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent retrieved details on the HTTP node type via registry get"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+get\s+.*core\.action\.http'

--- a/tests/tasks/uipath-mcp-servers/e2e-command-server/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/e2e-command-server/task.yaml
@@ -61,14 +61,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Used --output json so CLI output is machine-parseable (repo convention)"
-    tool_name: "Bash"
-    command_pattern: '--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Live tenant: the command server is retrievable"
     command: 'uip agenthub mcp get "$(jq -r .slug report.json)" --folder-path Shared --output json | jq -e ".Data"'

--- a/tests/tasks/uipath-mcp-servers/e2e-platform-server/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/e2e-platform-server/task.yaml
@@ -75,14 +75,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Used --output json so CLI output is machine-parseable (repo convention)"
-    tool_name: "Bash"
-    command_pattern: '--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Live tenant: the platform server exposes the two selected tools"
     command: 'uip agenthub mcp-tools list --mcp "$(jq -r .slug report.json)" --folder-path Shared --output json | jq -e ".Data.Items | length >= 2"'

--- a/tests/tasks/uipath-mcp-servers/e2e-remote-server/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/e2e-remote-server/task.yaml
@@ -51,14 +51,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Used --output json so CLI output is machine-parseable (repo convention)"
-    tool_name: "Bash"
-    command_pattern: '--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Live tenant: the remote server is retrievable"
     command: 'uip agenthub mcp get "$(jq -r .slug report.json)" --folder-path Shared --output json | jq -e ".Data"'

--- a/tests/tasks/uipath-mcp-servers/e2e-swagger-server/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/e2e-swagger-server/task.yaml
@@ -60,14 +60,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Used --output json so CLI output is machine-parseable (repo convention)"
-    tool_name: "Bash"
-    command_pattern: '--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Live tenant: the swagger server is retrievable"
     command: 'uip agenthub mcp get "$(jq -r .slug report.json)" --folder-path Shared --output json | jq -e ".Data"'

--- a/tests/tasks/uipath-mcp-servers/e2e-uipath-allkinds/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/e2e-uipath-allkinds/task.yaml
@@ -119,14 +119,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Used --output json so CLI output is machine-parseable (repo convention)"
-    tool_name: "Bash"
-    command_pattern: '--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Discovered the curated Jira activity metadata via `is resources describe` (is-activity authoring path)"
     tool_name: "Bash"
     command_pattern: '(?s)is\s+resources\s+describe.*curated_create_issue'

--- a/tests/tasks/uipath-planner/asdd_crosswalk/asdd_crosswalk.yaml
+++ b/tests/tasks/uipath-planner/asdd_crosswalk/asdd_crosswalk.yaml
@@ -52,7 +52,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent engaged the uipath-planner skill for the crosswalk"
     skill_name: "uipath-planner"
-    expected: "yes"
+    expected_skill: "uipath-planner"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-planner/attended_reauth/attended_reauth.yaml
+++ b/tests/tasks/uipath-planner/attended_reauth/attended_reauth.yaml
@@ -47,7 +47,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent engaged the uipath-planner skill (rather than free-forming the SDD)"
     skill_name: "uipath-planner"
-    expected: "yes"
+    expected_skill: "uipath-planner"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-platform/auth_profile_smoke.yaml
+++ b/tests/tasks/uipath-platform/auth_profile_smoke.yaml
@@ -40,7 +40,7 @@ success_criteria:
   - type: command_executed
     description: "Agent used JSON output on profile auth commands"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+login\s+(status|which)\b.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+login\s+(status|which)'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/context-grounding/list_smoke.yaml
+++ b/tests/tasks/uipath-platform/context-grounding/list_smoke.yaml
@@ -32,9 +32,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Advisory: agent used --output json (informational, non-gating)"
+    description: "Agent ran `uip context-grounding list` (advisory, non-gating)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+context-grounding\s+list\b.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+context-grounding\s+list'
     min_count: 1
     weight: 1.0
     pass_threshold: 0.0

--- a/tests/tasks/uipath-platform/data-fabric/smoke_bulk_import.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_bulk_import.yaml
@@ -43,14 +43,6 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "products.csv was created"
     path: "products.csv"

--- a/tests/tasks/uipath-platform/data-fabric/smoke_choice_multiple_filter.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_choice_multiple_filter.yaml
@@ -104,14 +104,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
@@ -180,14 +180,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/data-fabric/smoke_csv_complex_drop.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_csv_complex_drop.yaml
@@ -84,14 +84,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/data-fabric/smoke_entities.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_entities.yaml
@@ -119,14 +119,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/data-fabric/smoke_files.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_files.yaml
@@ -60,14 +60,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on uip df commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/data-fabric/smoke_records.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_records.yaml
@@ -156,14 +156,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json at least once (informational; agent may operate on human-readable output when not parsing)"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+df\s+.*--output\s+json'
-    min_count: 1
-    weight: 0.5
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent must NOT delete any entity — the list stays intact even if columns or rows are dropped"
     tool_name: "Bash"
     command_pattern: 'uip\s+df\s+entities\s+delete'

--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -40,11 +40,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on activity commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+activities\s+list.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -50,11 +50,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on connection commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+connections\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
@@ -56,11 +56,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on connection commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+connections\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -32,11 +32,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on connector commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+connectors\s+list.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
@@ -68,11 +68,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json consistently across the CRUD walk"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+.*--output\s+json'
-    min_count: 4
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -55,11 +55,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -70,11 +70,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json consistently"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
@@ -57,11 +57,3 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
@@ -104,11 +104,3 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
@@ -78,13 +78,6 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
     require_success: true
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
 
   - type: run_command
     description: "Data-grounded: retrieved name == created (seeded) name — real round-trip through the connector"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
@@ -85,13 +85,6 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
 
   - type: run_command
     description: "Data-grounded: retrieved name == created (seeded) name — real round-trip through the connector"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -77,13 +77,6 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
 
   - type: run_command
     description: "Data-grounded: retrieved name == created (seeded) name — real round-trip through the connector"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
@@ -93,13 +93,6 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-  - type: command_executed
-    description: "Used --output json on resource commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
 
   - type: run_command
     description: "Data-grounded: retrieved name == created (seeded) name — real round-trip through the connector"

--- a/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
@@ -54,11 +54,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on diagnose commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+(triggers|webhooks)\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_daily.yaml
@@ -18,9 +18,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform licenses consumables get --mode daily` with date range and --output json"
+    description: "Agent ran `uip platform licenses consumables get --mode daily` with date range"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+daily.*--start-date\s+2026-04-01.*--end-date\s+2026-04-30.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+daily.*--start-date\s+2026-04-01.*--end-date\s+2026-04-30'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_folders.yaml
@@ -17,9 +17,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform licenses consumables get --mode folders --tenant` with --output json"
+    description: "Agent ran `uip platform licenses consumables get --mode folders --tenant`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+folders.*--tenant\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get.*--mode\s+folders.*--tenant\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
+++ b/tests/tasks/uipath-platform/licensing/consumables_summary.yaml
@@ -16,9 +16,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform licenses consumables get` for a summary report (summary is the default --mode) with --output json"
+    description: "Agent ran `uip platform licenses consumables get` for a summary report (summary is the default --mode)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders)).*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders))'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_details.yaml
@@ -16,9 +16,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform groups rules details <group>` with --output json"
+    description: "Agent ran `uip platform groups rules details <group>`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+groups\s+rules\s+details\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+details\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_list.yaml
@@ -18,9 +18,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform groups rules get` with --output json"
+    description: "Agent ran `uip platform groups rules get`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/groups_rules_set.yaml
@@ -50,9 +50,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip platform groups rules set` with --input and --output json"
+    description: "Agent ran `uip platform groups rules set` with --input"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+groups\s+rules\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+set\s+\S+.*--input\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
+++ b/tests/tasks/uipath-platform/licensing/licensing_read_e2e.yaml
@@ -35,7 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran users licenses available"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran groups rules get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+groups\s+rules\s+get'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -51,7 +51,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran consumables get for a summary (summary is the default --mode)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders)).*--output\s+json'
+    command_pattern: 'uip\s+platform\s+licenses\s+consumables\s+get(?!.*--mode\s+(?:daily|folders))'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_get.yaml
@@ -21,9 +21,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform tenants licenses get` with --output json"
+    description: "Agent ran `uip platform tenants licenses get`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+get\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+get\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/tenant_allocation_set.yaml
@@ -35,9 +35,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip platform tenants licenses set` with --input and --output json"
+    description: "Agent ran `uip platform tenants licenses set` with --input"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+tenants\s+licenses\s+set\s+\S+.*--input\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_available.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform users licenses available` with --output json"
+    description: "Agent ran `uip platform users licenses available`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+available'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_get.yaml
@@ -27,9 +27,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent ran `uip platform users licenses get` with --output json"
+    description: "Agent ran `uip platform users licenses get`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+users\s+licenses\s+get\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+get\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
+++ b/tests/tasks/uipath-platform/licensing/users_licenses_set.yaml
@@ -51,9 +51,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip platform users licenses set` with --input and --output json"
+    description: "Agent ran `uip platform users licenses set` with --input"
     tool_name: "Bash"
-    command_pattern: 'uip\s+platform\s+users\s+licenses\s+set\s+\S+.*--input\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+platform\s+users\s+licenses\s+set\s+\S+.*--input\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
@@ -77,9 +77,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the create call"
+    description: "Agent ran the create call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+create(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+create'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/delete_force_smoke.yaml
@@ -29,9 +29,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the delete call"
+    description: "Agent ran the delete call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+delete\s+\S+(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+delete\s+\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/get_force_refresh_smoke.yaml
@@ -34,9 +34,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the get call"
+    description: "Agent ran the get call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+get\s+\S+(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+get\s+\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_product_configs_smoke.yaml
@@ -44,11 +44,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on every llm-configuration call"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+list-product-configs.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/list_smoke.yaml
@@ -41,11 +41,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on the list commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+list.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/reprobe_validation_smoke.yaml
@@ -35,9 +35,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the update call"
+    description: "Agent ran the update call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/update_full_put_smoke.yaml
@@ -48,9 +48,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on the update call"
+    description: "Agent ran the update call"
     tool_name: "Bash"
-    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+(?=[\s\S]*--output\s+json)'
+    command_pattern: 'uip\s+llm-configuration\s+byo-connections\s+update\s+\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/assets_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/assets_get_smoke.yaml
@@ -34,11 +34,3 @@ success_criteria:
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/assets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/assets_list_smoke.yaml
@@ -30,11 +30,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/buckets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/buckets_list_smoke.yaml
@@ -33,11 +33,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
@@ -22,11 +22,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on the folders list call"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list.*--output\s+json'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
@@ -38,11 +38,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/libraries_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/libraries_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
@@ -36,11 +36,3 @@ success_criteria:
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/queue_items_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/queue_items_list_smoke.yaml
@@ -30,11 +30,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/queues_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/queues_list_smoke.yaml
@@ -30,11 +30,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -34,14 +34,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "spans.json (raw CLI output) was written to the sandbox root"
     path: "spans.json"

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -45,14 +45,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 3
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "feedback_create.json written to sandbox"
     path: "feedback_create.json"

--- a/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
@@ -26,14 +26,6 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on all uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
     description: "Agent included --folder-key on write operations"
     tool_name: "Bash"
     command_pattern: 'uip\s+traces\s+feedback\s+create.*--folder-key'

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -22,11 +22,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
+++ b/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
@@ -63,14 +63,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import[\s\S]*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: command_not_executed
     description: "Agent did NOT omit --type (would default to DirectoryUser → silent corruption)"
     tool_name: "Bash"

--- a/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
@@ -60,22 +60,6 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*CodedAgent'
     weight: 3.0
 
-  - type: command_executed
-    description: "Agent consulted the coded judgment catalog (agents-coded-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-coded-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites CODED_ERROR_HANDLING"
     command: "python3 $TASK_DIR/check_coded_review_error_handling.py"

--- a/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
@@ -61,22 +61,6 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*CodedAgent'
     weight: 3.0
 
-  - type: command_executed
-    description: "Agent consulted the coded judgment catalog (agents-coded-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-coded-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites CODED_OUTPUT_ENUM_MISSING_ON_CLASSIFIER for the classification field"
     command: "python3 $TASK_DIR/check_coded_review_output_enum_missing.py"

--- a/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
@@ -60,22 +60,6 @@ success_criteria:
     command_pattern: '"file_path":\s*"[^"]*CodedAgent'
     weight: 3.0
 
-  - type: command_executed
-    description: "Agent consulted the coded judgment catalog (agents-coded-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-coded-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites CODED_PII_IN_TRACES for the email_body param"
     command: "python3 $TASK_DIR/check_coded_review_pii_in_traces.py"

--- a/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
@@ -69,22 +69,6 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consulted the coded judgment catalog (agents-coded-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-coded-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "A non-trivial review report was produced"
     command: "python3 $TASK_DIR/check_coded_review_runs_review_cli.py"

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -69,22 +69,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consulted the low-code judgment catalog (agents-lowcode-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-lowcode-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites LC_GUARDRAIL_RECOMMENDED for the missing PII guardrail"
     command: "python3 $TASK_DIR/check_lowcode_review_guardrail_pii_missing.py"

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -68,22 +68,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consulted the low-code judgment catalog (agents-lowcode-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-lowcode-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites LC_PROMPT_INSTRUCTION_CONFLICTS"
     command: "python3 $TASK_DIR/check_lowcode_review_prompt_instruction_conflicts.py"

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -68,22 +68,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consulted the low-code judgment catalog (agents-lowcode-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-lowcode-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent judgment catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the judgment catalog: cites LC_TOOL_OVERLAP for find_customer"
     command: "python3 $TASK_DIR/check_lowcode_review_tool_overlap.py"

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -69,22 +69,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent consulted the low-code rule catalog (agents-lowcode-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-lowcode-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent consulted the common agent rule catalog (agents-common-rules.md)"
-    tool_name: "Read"
-    command_pattern: 'agents-common-rules\.md'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Review report applies the catalog: cites VAGUE_TOOL_DESCRIPTION for vague_tool; no invented rule_ids"
     command: "python3 $TASK_DIR/check_lowcode_review_vague_tool_description.py"

--- a/tests/tasks/uipath-review/review_multi_project_solution.yaml
+++ b/tests/tasks/uipath-review/review_multi_project_solution.yaml
@@ -139,11 +139,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-review/review_rpa_project.yaml
+++ b/tests/tasks/uipath-review/review_rpa_project.yaml
@@ -83,11 +83,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
+++ b/tests/tasks/uipath-rpa/legacy/create_and_validate.yaml
@@ -49,13 +49,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json (not --format json) on uip rpa-legacy commands"
-    command_pattern: 'uip\s+rpa-legacy\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "project.json was created"
     path: "HelloLegacy/project.json"

--- a/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
+++ b/tests/tasks/uipath-rpa/legacy/edit_existing_xaml.yaml
@@ -134,13 +134,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip rpa-legacy commands"
-    command_pattern: 'uip\s+rpa-legacy\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.5
-    pass_threshold: 1.0
-
   - type: run_command
     description: "Main.xaml has a TryCatch that actually nests the WriteLine inside its Try block"
     command: "python -c \"import re,sys; s=open('HelloLegacy/Main.xaml',encoding='utf-8').read(); sys.exit(0 if re.search(r'<TryCatch\\b[^>]*>[\\s\\S]*?<TryCatch\\.Try>[\\s\\S]*?<WriteLine\\b[\\s\\S]*?</TryCatch\\.Try>[\\s\\S]*?<TryCatch\\.Catches>[\\s\\S]*?</TryCatch>', s) else 1)\""

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -162,7 +162,7 @@ success_criteria:
   # the Retry Scope / Excel / Log Message activities before authoring.
   - type: command_executed
     description: "Agent ran `uip rpa-legacy find-activities` for discovery before authoring"
-    command_pattern: 'uip\s+rpa-legacy\s+find-activities\b.*--output\s+json'
+    command_pattern: 'uip\s+rpa-legacy\s+find-activities'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
+++ b/tests/tasks/uipath-rpa/legacy/refactor_with_retry_scope_e2e.yaml
@@ -167,14 +167,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # --output json was used somewhere on rpa-legacy
-  - type: command_executed
-    description: "Agent used --output json on uip rpa-legacy commands"
-    command_pattern: 'uip\s+rpa-legacy\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   # Edit shape: Retry Scope correctly wraps the Excel read.
   # Accept any prefix (ui:, uca:, excel:, uea:, ueab:, none) on <RetryScope>
   # and any of the canonical Excel read activity classes — Interop

--- a/tests/tasks/uipath-solution/deploy_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/deploy_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-solution/new_smoke.yaml
+++ b/tests/tasks/uipath-solution/new_smoke.yaml
@@ -29,11 +29,3 @@ success_criteria:
     path: "MySolution/MySolution.uipx"
     weight: 2.0
     pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0

--- a/tests/tasks/uipath-solution/pack_integration.yaml
+++ b/tests/tasks/uipath-solution/pack_integration.yaml
@@ -36,14 +36,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "Deployable package was produced on disk"
     path: "ShipDemo.zip"

--- a/tests/tasks/uipath-solution/packages_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/packages_list_smoke.yaml
@@ -21,11 +21,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-solution/project_add_integration.yaml
+++ b/tests/tasks/uipath-solution/project_add_integration.yaml
@@ -46,14 +46,6 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: llm_judge
     description: "Final reply confirms the solution now has exactly one registered project"
     include_agent_output: true

--- a/tests/tasks/uipath-solution/resource_list_smoke.yaml
+++ b/tests/tasks/uipath-solution/resource_list_smoke.yaml
@@ -35,11 +35,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-solution/resources_refresh_integration.yaml
+++ b/tests/tasks/uipath-solution/resources_refresh_integration.yaml
@@ -47,14 +47,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on uip commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+.*--output\s+json'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
   - type: llm_judge
     description: "Final reply confirms resources are synced and the solution is ready to pack"
     include_agent_output: true

--- a/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
+++ b/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed tasks across folders"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+list\s+--output\s+json'
+    command_pattern: 'uip\s+tasks\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
+++ b/tests/tasks/uipath-tasks/e2e_fetch_tasks.yaml
@@ -98,11 +98,3 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on every tasks command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+.*--output\s+json'
-    min_count: 2
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-tasks/smoke_assignment.yaml
+++ b/tests/tasks/uipath-tasks/smoke_assignment.yaml
@@ -69,11 +69,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on every tasks command"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+.*--output\s+json'
-    min_count: 4
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-tasks/smoke_discovery.yaml
+++ b/tests/tasks/uipath-tasks/smoke_discovery.yaml
@@ -80,11 +80,3 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used --output json on tasks commands"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+.*--output\s+json'
-    min_count: 4
-    weight: 1.0
-    pass_threshold: 1.0
-

--- a/tests/tasks/uipath-tasks/smoke_discovery.yaml
+++ b/tests/tasks/uipath-tasks/smoke_discovery.yaml
@@ -35,7 +35,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed tasks across all folders"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+list\s+--output\s+json'
+    command_pattern: 'uip\s+tasks\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/auth_and_hierarchy_discovery.yaml
+++ b/tests/tasks/uipath-test/auth_and_hierarchy_discovery.yaml
@@ -21,33 +21,33 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json` — auth-first, Critical Rule #1 + #2)"
+    description: "Agent checked login status (`uip login status` — auth-first, Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed Test Manager projects (`project list --output json`)"
+    description: "Agent listed Test Manager projects (`project list`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+project\s+list.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+project\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test sets scoped to a project (`testsets list --project-key` + `--output json`)"
+    description: "Agent listed test sets scoped to a project (`testsets list --project-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets?\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+testsets?\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+testsets?\s+list\s+.*--project-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test cases in a test set (`testsets list-testcases --test-set-key` + `--output json`)"
+    description: "Agent listed test cases in a test set (`testsets list-testcases --test-set-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets?\s+list-testcases\s+.*--test-set-key.*--output\s+json|uip\s+tm\s+testsets?\s+list-testcases\s+.*--output\s+json.*--test-set-key'
+    command_pattern: 'uip\s+tm\s+testsets?\s+list-testcases\s+.*--test-set-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/customfield_definition_crud_smoke.yaml
+++ b/tests/tasks/uipath-test/customfield_definition_crud_smoke.yaml
@@ -23,9 +23,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -33,15 +33,15 @@ success_criteria:
   - type: command_executed
     description: "Complete create command: `uip tm customfield create --project-key HEALTH --name \"Eval Reviewer\" --data-type Text --object-type Requirement --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Reviewer)(?=.*--data-type\s+Text)(?=.*--object-type\s+Requirement)(?=.*--output\s+json)uip\s+tm\s+customfield\s+create\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Reviewer)(?=.*--data-type\s+Text)(?=.*--object-type\s+Requirement)uip\s+tm\s+customfield\s+create'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete list command: `uip tm customfield list --project-key HEALTH --output json`"
+    description: "Complete list command: `uip tm customfield list --project-key HEALTH`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output\s+json)uip\s+tm\s+customfield\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)uip\s+tm\s+customfield\s+list\s'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -49,7 +49,7 @@ success_criteria:
   - type: command_executed
     description: "Complete rename command: `uip tm customfield update --project-key HEALTH --rename-to \"Eval Reviewer Team\" --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--rename-to\s+["\x27]?Eval Reviewer Team)(?=.*--output\s+json)uip\s+tm\s+customfield\s+update\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--rename-to\s+["\x27]?Eval Reviewer Team)uip\s+tm\s+customfield\s+update'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -57,7 +57,7 @@ success_criteria:
   - type: command_executed
     description: "Complete delete command: `uip tm customfield delete --project-key HEALTH (--field-ids <uuid> | --name \"Eval Reviewer Team\" --object-type Requirement) --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*(--field-ids\s+\S+|--object-type\s+Requirement))(?=.*--output\s+json)uip\s+tm\s+customfield\s+delete\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*(--field-ids\s+\S+|--object-type\s+Requirement))uip\s+tm\s+customfield\s+delete'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/customfield_population_integration.yaml
+++ b/tests/tasks/uipath-test/customfield_population_integration.yaml
@@ -57,33 +57,33 @@ post_run:
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Resolved HEALTH:11's id (`uip tm testcases list --project-key HEALTH --output json`)"
+    description: "Resolved HEALTH:11's id (`uip tm testcases list --project-key HEALTH`)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output\s+json)uip\s+tm\s+testcases?\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)uip\s+tm\s+testcases?\s+list\s'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete create commands defining fields scoped TestCase: `uip tm customfield create --project-key HEALTH --name <name> --data-type <Text|Label> --object-type TestCase --output json` (x2)"
+    description: "Complete create commands defining fields scoped TestCase: `uip tm customfield create --project-key HEALTH --name <name> --data-type <Text|Label> --object-type TestCase` (x2)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--data-type\s+(Text|Label))(?=.*--output\s+json)uip\s+tm\s+customfield\s+create\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--data-type\s+(Text|Label))uip\s+tm\s+customfield\s+create'
     min_count: 2
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete value row command on the Text field: `uip tm customfield value (create|update) --project-key HEALTH --object-type TestCase ... --output json`"
+    description: "Complete value row command on the Text field: `uip tm customfield value (create|update) --project-key HEALTH --object-type TestCase ...`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--output\s+json)uip\s+tm\s+customfield\s+value\s+(create|update)\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)uip\s+tm\s+customfield\s+value\s+(create|update)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -91,15 +91,15 @@ success_criteria:
   - type: command_executed
     description: "Complete label tag command — either form: `uip tm customfield label add --project-key HEALTH --object-type TestCase --custom-field-name \"Eval Risk\" --object-ids <uuid> --values high regression --output json`, or `label create ... --values '{\"Eval Risk\":[\"high\",\"regression\"]}'`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*Eval Risk)(?=.*--values)(?=.*--output\s+json)uip\s+tm\s+customfield\s+label\s+(add|create)\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*Eval Risk)(?=.*--values)uip\s+tm\s+customfield\s+label\s+(add|create)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete read-back command: `uip tm customfield label list --project-key HEALTH --object-type TestCase --output json`"
+    description: "Complete read-back command: `uip tm customfield label list --project-key HEALTH --object-type TestCase`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--output\s+json)uip\s+tm\s+customfield\s+label\s+list\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)uip\s+tm\s+customfield\s+label\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/flaky_tests_analysis.yaml
+++ b/tests/tasks/uipath-test/flaky_tests_analysis.yaml
@@ -22,33 +22,33 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with --output json"
+    description: "Agent checked login status"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed executions for a test set with --test-set-id + --output json"
+    description: "Agent listed executions for a test set with --test-set-id"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--test-set-id.*--output\s+json|uip\s+tm\s+executions?\s+list\s+.*--output\s+json.*--test-set-id'
+    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--test-set-id'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent retrieved testcase logs for at least one execution (--execution-id + --output json)"
+    description: "Agent retrieved testcase logs for at least one execution (--execution-id)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+(executions?\s+testcaselogs\s+list|execution\s+list-testcaselogs)\s+.*--execution-id.*--output\s+json|uip\s+tm\s+(executions?\s+testcaselogs\s+list|execution\s+list-testcaselogs)\s+.*--output\s+json.*--execution-id'
+    command_pattern: 'uip\s+tm\s+(executions?\s+testcaselogs\s+list|execution\s+list-testcaselogs)\s+.*--execution-id'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent fetched assertions for a failing testcase log (--test-case-log-id + --output json)"
+    description: "Agent fetched assertions for a failing testcase log (--test-case-log-id)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcaselog\s+list-assertions\s+.*--test-case-log-id.*--output\s+json|uip\s+tm\s+testcaselog\s+list-assertions\s+.*--output\s+json.*--test-case-log-id'
+    command_pattern: 'uip\s+tm\s+testcaselog\s+list-assertions\s+.*--test-case-log-id'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
+++ b/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
@@ -39,41 +39,41 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with `--output json` (Critical Rule #1 + #2)"
+    description: "Agent checked login status (Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent looked up Shipment Routing project with `project list --filter` + `--output json`"
+    description: "Agent looked up Shipment Routing project with `project list --filter`"
     tool_name: "Bash"
-    command_pattern: '(?i)uip\s+tm\s+project\s+list\s+.*--filter\s+\S*ship.*--output\s+json|uip\s+tm\s+project\s+list\s+.*--output\s+json.*--filter\s+\S*ship'
+    command_pattern: '(?i)uip\s+tm\s+project\s+list\s+.*--filter\s+\S*ship|uip\s+tm\s+project\s+list\s+.*--filter\s+\S*ship'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test sets scoped to project (`testsets list --project-key` + `--output json`)"
+    description: "Agent listed test sets scoped to project (`testsets list --project-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+testsets\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+testsets\s+list\s+.*--project-key'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent enumerated test cases in test set (`testsets list-testcases --project-key --test-set-key` + `--output json` — all three flags required; SKILL.md documents `--project-key` as required)"
+    description: "Agent enumerated test cases in test set (`testsets list-testcases --project-key --test-set-key` — all three flags required; SKILL.md documents `--project-key` as required)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key)(?=.*--test-set-key)(?=.*--output\s+json)uip\s+tm\s+testsets\s+list-testcases\b'
+    command_pattern: '(?=.*--project-key)(?=.*--test-set-key)uip\s+tm\s+testsets\s+list-testcases'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent retrieved execution history (`executions list --project-key` + `--output json`)"
+    description: "Agent retrieved execution history (`executions list --project-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+executions\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--project-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
+++ b/tests/tasks/uipath-test/integration_release_readiness_qa_lead.yaml
@@ -35,57 +35,57 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with `--output json` (Critical Rule #1 + #2)"
+    description: "Agent checked login status (Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent looked up the Banking project with `project list --filter` + `--output json`"
+    description: "Agent looked up the Banking project with `project list --filter`"
     tool_name: "Bash"
-    command_pattern: '(?i)uip\s+tm\s+project\s+list\s+.*--filter\s+\S*bank.*--output\s+json|uip\s+tm\s+project\s+list\s+.*--output\s+json.*--filter\s+\S*bank'
+    command_pattern: '(?i)uip\s+tm\s+project\s+list\s+.*--filter\s+\S*bank|uip\s+tm\s+project\s+list\s+.*--filter\s+\S*bank'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed test sets scoped to the project (`testsets list --project-key` + `--output json`)"
+    description: "Agent listed test sets scoped to the project (`testsets list --project-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+testsets\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+testsets\s+list\s+.*--project-key'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent enumerated test cases in a test set (`testsets list-testcases --test-set-key` + `--output json`)"
+    description: "Agent enumerated test cases in a test set (`testsets list-testcases --test-set-key`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets\s+list-testcases\s+.*--test-set-key.*--output\s+json|uip\s+tm\s+testsets\s+list-testcases\s+.*--output\s+json.*--test-set-key'
+    command_pattern: 'uip\s+tm\s+testsets\s+list-testcases\s+.*--test-set-key'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent enumerated the full project's test cases (`testcases list --project-key` + `--output json`) — needed to compute the coverage gap"
+    description: "Agent enumerated the full project's test cases (`testcases list --project-key`) — needed to compute the coverage gap"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+testcases\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+testcases\s+list\s+.*--project-key'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed executions for the regression suite (`executions list --project-key --test-set-id` + `--output json` — all three flags must appear; SKILL.md documents `--project-key` as required)"
+    description: "Agent listed executions for the regression suite (`executions list --project-key --test-set-id` — all three flags must appear; SKILL.md documents `--project-key` as required)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key)(?=.*--test-set-id)(?=.*--output\s+json)uip\s+tm\s+executions\s+list\b'
+    command_pattern: '(?=.*--project-key)(?=.*--test-set-id)uip\s+tm\s+executions\s+list'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent drilled into test case logs of an execution (`executions testcaselogs list --execution-id --project-key` + `--output json`)"
+    description: "Agent drilled into test case logs of an execution (`executions testcaselogs list --execution-id --project-key`)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--execution-id)(?=.*--project-key)(?=.*--output\s+json)uip\s+tm\s+executions\s+testcaselogs\s+list\b'
+    command_pattern: '(?=.*--execution-id)(?=.*--project-key)uip\s+tm\s+executions\s+testcaselogs\s+list'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -23,9 +23,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with --output json"
+    description: "Agent checked login status"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -33,7 +33,7 @@ success_criteria:
   - type: command_executed
     description: "Agent discovered folder key with `folders list -n <folder-name> --all`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list\s+-n\s+\S+.*--output\s+json'
+    command_pattern: 'uip\s+or\s+folders\s+list\s+-n\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -41,15 +41,15 @@ success_criteria:
   - type: command_executed
     description: "Agent probed available test entry points via list-automations before linking (Critical Rule #8)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+list-automations\s+.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+testcases?\s+list-automations'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent linked automation using link-automation with --project-key + --output json"
+    description: "Agent linked automation using link-automation with --project-key"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+link-automation\s+.*--project-key.*--output\s+json|uip\s+tm\s+testcases?\s+link-automation\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+testcases?\s+link-automation\s+.*--project-key'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -57,7 +57,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran testcase with --test-case-id (UUID) and --execution-type automated (not --test-case-key)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+run\s+.*--test-case-id.*--execution-type\s+automated.*--output\s+json|uip\s+tm\s+testcases?\s+run\s+.*--execution-type\s+automated.*--test-case-id.*--output\s+json|uip\s+tm\s+testcase\s+execute\s+.*--test-case-id.*--execution-type\s+automated.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+testcases?\s+run\s+.*--test-case-id.*--execution-type\s+automated|uip\s+tm\s+testcases?\s+run\s+.*--execution-type\s+automated.*--test-case-id|uip\s+tm\s+testcase\s+execute\s+.*--test-case-id.*--execution-type\s+automated'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/objectlabel_lifecycle_integration.yaml
+++ b/tests/tasks/uipath-test/objectlabel_lifecycle_integration.yaml
@@ -33,41 +33,41 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Resolved the three test-case ids (`uip tm testcases list --project-key HEALTH --output json`)"
+    description: "Resolved the three test-case ids (`uip tm testcases list --project-key HEALTH`)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output\s+json)uip\s+tm\s+testcases?\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)uip\s+tm\s+testcases?\s+list\s'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete attach command naming both labels: `uip tm objectlabel add --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-regression eval-smoke --output json`"
+    description: "Complete attach command naming both labels: `uip tm objectlabel add --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-regression eval-smoke`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-)(?=.*--output\s+json)uip\s+tm\s+objectlabel\s+add\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-)uip\s+tm\s+objectlabel\s+add'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete narrowed-list command: `uip tm objectlabel list --project-key HEALTH --object-type TestCase --filter eval-regression --output json`"
+    description: "Complete narrowed-list command: `uip tm objectlabel list --project-key HEALTH --object-type TestCase --filter eval-regression`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--filter\s+["\x27]?eval-regression)(?=.*--output\s+json)uip\s+tm\s+objectlabel\s+list\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--filter\s+["\x27]?eval-regression)uip\s+tm\s+objectlabel\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete detach command removing only eval-smoke: `uip tm objectlabel remove --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-smoke --output json`"
+    description: "Complete detach command removing only eval-smoke: `uip tm objectlabel remove --project-key HEALTH --object-type TestCase --object-ids <ids> --labels eval-smoke`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-smoke)(?=.*--output\s+json)uip\s+tm\s+objectlabel\s+remove\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-smoke)uip\s+tm\s+objectlabel\s+remove'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
+++ b/tests/tasks/uipath-test/organize_testcases_into_testsets.yaml
@@ -21,9 +21,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with --output json (Critical Rules #1 + #2)"
+    description: "Agent checked login status (Critical Rules #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -31,23 +31,23 @@ success_criteria:
   - type: command_executed
     description: "Agent listed testcases with --project-key and --filter flag (Critical Rules #2 + #8)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+list\s+.*--filter.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+testcases?\s+list\s+.*--filter'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent created a test set with --project-key and --output json"
+    description: "Agent created a test set with --project-key"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets?\s+create\s+.*--project-key.*--output\s+json|uip\s+tm\s+testsets?\s+create\s+.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+testsets?\s+create\s+.*--project-key|uip\s+tm\s+testsets?\s+create'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added testcases to the new test set with --test-set-key + --test-case-keys + --output json"
+    description: "Agent added testcases to the new test set with --test-set-key + --test-case-keys"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+add\s+.*--test-set-key.*--test-case-keys.*--output\s+json|uip\s+tm\s+testsets?\s+add-testcases\s+.*--test-set-key.*--output\s+json'
+    command_pattern: 'uip\s+tm\s+testcases?\s+add\s+.*--test-set-key.*--test-case-keys|uip\s+tm\s+testsets?\s+add-testcases\s+.*--test-set-key'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/report_generation.yaml
+++ b/tests/tasks/uipath-test/report_generation.yaml
@@ -28,17 +28,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with `--output json` (Critical Rule #1 + #2)"
+    description: "Agent checked login status (Critical Rule #1 + #2)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed executions for a test set (`executions list --test-set-id` + `--output json`)"
+    description: "Agent listed executions for a test set (`executions list --test-set-id`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--test-set-id.*--output\s+json|uip\s+tm\s+executions\s+list\s+.*--output\s+json.*--test-set-id'
+    command_pattern: 'uip\s+tm\s+executions\s+list\s+.*--test-set-id'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/requirement_crud_smoke.yaml
+++ b/tests/tasks/uipath-test/requirement_crud_smoke.yaml
@@ -25,9 +25,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -35,15 +35,15 @@ success_criteria:
   - type: command_executed
     description: "Complete create command: `uip tm requirements create --project-key HEALTH --name \"Eval CRUD - PHI access audit\" --description ... --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval CRUD - PHI access audit)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+create\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval CRUD - PHI access audit)uip\s+tm\s+requirements?\s+create'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete get command: `uip tm requirements get --project-key HEALTH --requirement-key <key> --output json`"
+    description: "Complete get command: `uip tm requirements get --project-key HEALTH --requirement-key <key>`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-(key|id)\s+\S+)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+get\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-(key|id)\s+\S+)uip\s+tm\s+requirements?\s+get'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -51,15 +51,15 @@ success_criteria:
   - type: command_executed
     description: "Complete update command: `uip tm requirements update --project-key HEALTH --requirement-id <uuid> --name \"Eval CRUD - PHI access audit (v2)\" --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)(?=.*--name\s+["\x27]?Eval CRUD - PHI access audit \(v2\))(?=.*--output\s+json)uip\s+tm\s+requirements?\s+update\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)(?=.*--name\s+["\x27]?Eval CRUD - PHI access audit \(v2\))uip\s+tm\s+requirements?\s+update'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete delete command: `uip tm requirements delete --project-key HEALTH --requirement-ids <uuid> --output json`"
+    description: "Complete delete command: `uip tm requirements delete --project-key HEALTH --requirement-ids <uuid>`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-ids\s+\S+)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+delete\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-ids\s+\S+)uip\s+tm\s+requirements?\s+delete'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
+++ b/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
@@ -25,9 +25,9 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -35,31 +35,31 @@ success_criteria:
   - type: command_executed
     description: "Complete create command: `uip tm requirements create --project-key HEALTH --name \"Eval Export Marker - HIPAA retention\" --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Export Marker - HIPAA retention)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+create\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Export Marker - HIPAA retention)uip\s+tm\s+requirements?\s+create'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete tag command: `uip tm objectlabel add --project-key HEALTH --object-type Requirement --object-ids <uuid> --labels eval-export --output json`"
+    description: "Complete tag command: `uip tm objectlabel add --project-key HEALTH --object-type Requirement --object-ids <uuid> --labels eval-export`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+Requirement)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-export)(?=.*--output\s+json)uip\s+tm\s+objectlabel\s+add\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+Requirement)(?=.*--object-ids\s+\S+)(?=.*--labels\s+["\x27]?eval-export)uip\s+tm\s+objectlabel\s+add'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete list command: `uip tm requirements list --project-key HEALTH --labels eval-export --output json`"
+    description: "Complete list command: `uip tm requirements list --project-key HEALTH --labels eval-export`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--labels\s+["\x27]?eval-export)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--labels\s+["\x27]?eval-export)uip\s+tm\s+requirements?\s+list\s'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete export command: `uip tm requirements export --project-key HEALTH --output-file ./health-requirements.xlsx --output json`"
+    description: "Complete export command: `uip tm requirements export --project-key HEALTH --output-file ./health-requirements.xlsx`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output-file\s+\S*health-requirements\.xlsx)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+export\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output-file\s+\S*health-requirements\.xlsx)uip\s+tm\s+requirements?\s+export'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/requirement_traceability_integration.yaml
+++ b/tests/tasks/uipath-test/requirement_traceability_integration.yaml
@@ -35,17 +35,17 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status (`uip login status --output json`)"
+    description: "Agent checked login status (`uip login status`)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Resolved the named test cases (`uip tm testcases list --project-key HEALTH --output json`)"
+    description: "Resolved the named test cases (`uip tm testcases list --project-key HEALTH`)"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--output\s+json)uip\s+tm\s+testcases?\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)uip\s+tm\s+testcases?\s+list\s'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -53,31 +53,31 @@ success_criteria:
   - type: command_executed
     description: "Complete create command: `uip tm requirements create --project-key HEALTH --name \"Eval Trace - PHI masking coverage\" --output json`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Trace - PHI masking coverage)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+create\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--name\s+["\x27]?Eval Trace - PHI masking coverage)uip\s+tm\s+requirements?\s+create'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete attach command: `uip tm requirements testcases --project-key HEALTH --requirement-id <uuid> --add-testcase-ids <uuid> <uuid> --output json`"
+    description: "Complete attach command: `uip tm requirements testcases --project-key HEALTH --requirement-id <uuid> --add-testcase-ids <uuid> <uuid>`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)(?=.*--add-testcase-ids\s+\S+)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+testcases\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)(?=.*--add-testcase-ids\s+\S+)uip\s+tm\s+requirements?\s+testcases'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete forward-lookup command: `uip tm requirements list-testcase-ids --project-key HEALTH --requirement-id <uuid> --output json`"
+    description: "Complete forward-lookup command: `uip tm requirements list-testcase-ids --project-key HEALTH --requirement-id <uuid>`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+list-testcase-ids\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--requirement-id\s+\S+)uip\s+tm\s+requirements?\s+list-testcase-ids'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete execution-back command: `uip tm requirements list-by-test-execution --project-key HEALTH --execution-id <uuid> --output json`"
+    description: "Complete execution-back command: `uip tm requirements list-by-test-execution --project-key HEALTH --execution-id <uuid>`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--execution-id\s+\S+)(?=.*--output\s+json)uip\s+tm\s+requirements?\s+list-by-test-execution\b'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--execution-id\s+\S+)uip\s+tm\s+requirements?\s+list-by-test-execution'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/test_report_junit_export.yaml
+++ b/tests/tasks/uipath-test/test_report_junit_export.yaml
@@ -19,25 +19,25 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent checked login status with --output json"
+    description: "Agent checked login status"
     tool_name: "Bash"
-    command_pattern: 'uip\s+login\s+status.*--output\s+json'
+    command_pattern: 'uip\s+login\s+status'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed executions with --project-key + --output json to resolve execution ID"
+    description: "Agent listed executions with --project-key to resolve execution ID"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--project-key.*--output\s+json|uip\s+tm\s+executions?\s+list\s+.*--output\s+json.*--project-key'
+    command_pattern: 'uip\s+tm\s+executions?\s+list\s+.*--project-key'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent downloaded JUnit results with --execution-id + --output json"
+    description: "Agent downloaded JUnit results with --execution-id"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+result\s+download\s+.*--execution-id.*--output\s+json|uip\s+tm\s+result\s+download\s+.*--output\s+json.*--execution-id'
+    command_pattern: 'uip\s+tm\s+result\s+download\s+.*--execution-id'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## What

Rebalances the skills eval suite to grade on what the work produced rather than which exact command shape produced it. Two families of `command_executed` criteria scored correct work as a failure for non-Claude agents (Sonnet vs Codex vs Antigravity, late-June snapshot). This PR removes the form-only ones, rewrites the specific-command ones to drop the biasing flag while keeping the real assertion, removes a redundant review-catalog Read check, and updates the task-authoring guidance that generated these checks so they don't regrow. 309 task files across 18 skills, plus 2 authoring-guidance docs.

## `--output json` checks

The flag is a formatting preference — the skills teach it only when CLI output is parsed programmatically, and it is never itself a capability. As a **gating** check it penalizes an agent that reaches the same independently-verified outcome without typing the flag. Every one of these sits next to an outcome/artifact check that already confirms the work. Two dispositions:

- **Removed entirely — 195.** These asserted the flag habit, not any specific command:
  - 178 pure wildcard-verb checks (`(uip|$UIP)\s+.*--output json`) that matched *any* command carrying the flag.
  - 11 flag-habit repetition checks — `min_count > 1` on `<category> .*--output json` with descriptions like "used --output json on every eval command" / "on at least 3 aops-policy commands". Stripping the flag would leave a meaningless "ran N commands in this category" repetition check, so these are dropped.
  - 6 redundant duplicates — a sibling check in the same task already asserts the identical command without the flag.
- **Rewritten — flag stripped, command kept — 188.** Specific-command checks keep the command and args the task actually cares about; only the trailing formatting flag is removed. Examples: `uip admin tenants list ... --output json` → `uip admin tenants list`; `uip tm executions list --test-set-id ... --output json` → `... --test-set-id`. Two-ordering alternations collapse to the meaningful branch, and lookahead compounds retain every non-flag constraint (e.g. `--project-key`, `--object-type`, `--data-type`).

No `--output json` remains in any `command_executed` check, including the handful that were previously non-gating advisory (`pass_threshold: 0`) — those are normalized the same way for consistency. Skill documentation is unchanged: it still teaches `--output json` where output is parsed. Only the grading stops keying on the literal flag.

## uipath-review "consulted the catalog" checks — 16 removed

**The removed check** observes a `Read` tool call, not the review:

```yaml
- type: command_executed
  tool_name: Read
  command_pattern: 'agents-coded-rules\.md'   # did the agent Read this file?
  pass_threshold: 1.0                          # gating
```

**The outcome check sitting next to it (kept)** already verifies the review is correct:

```yaml
- type: run_command
  description: "Review report cites CODED_PII_IN_TRACES for the email_body param"
  command: "python3 check_coded_review_pii_in_traces.py"
  pass_threshold: 1.0
```

So the Read check grades *how the agent obtained the rules*, not *whether the finding is right* — and that splits along agent lines:

- **Claude** — its review workflow opens the catalog with `Read` → grader sees it → pass.
- **Antigravity** — rules arrive via native skill injection, no `Read` call → fail.
- **Codex** — reaches the file through its own access the matcher doesn't record → fail.

Late-June runs, review tasks where the finding was correct (outcome check passed) but the Read check failed:

| Agent | correct review, failed only the Read check |
|---|---|
| Codex | 7 |
| Antigravity | 2 |

Removing the Read check deletes a Claude-shaped observation, not any measure of review quality — the outcome check remains the gate.

## Measured impact on the non-Claude runs

Re-grading the late-June Antigravity and Codex runs against the post-change criteria, using each run's actual command traces (removed checks stop gating; rewritten checks are re-run with coder_eval's own match rules against the recorded commands). The change is monotonic — it only loosens gating, so no task can regress from pass to fail.

| Agent | Tasks graded | Pass — before | Pass — after | Recovered (fail→pass) |
|---|---|---|---|---|
| Antigravity | 762 | 525 (68.9%) | 539 (70.7%) | **+14** — 12 `--output json`, 2 review-catalog |
| Codex | 554 | 397 (71.7%) | 404 (72.9%) | **+7** — 7 review-catalog |

Every recovered task passed all of its outcome/artifact checks and was failing only on the removed/rewritten form checks. This is a deliberately narrow, safe slice of the total grader bias — it fixes only the `--output json` and review-catalog patterns. It does **not** touch the two larger levers found in the same analysis: the `skill_triggered` activation-detection gap (≈26 Antigravity tasks) and the prescribed-`uip`-verb / repetition form checks — both of which need harness-level changes and are out of scope here. That is why the deltas are a couple of points rather than the full gap. The rewritten `--output json` checks flipped no tasks in these two runs (where an agent skipped the flag it also skipped the command), so their value is structural: they stop docking future correct-without-flag runs rather than recovering past ones.

## Prevent regrowth — task-authoring guidance

These checks propagated because the authoring rule required them. `.claude/rules/test-writing.md` told authors (and `/generate-task`) to add a gating check matching `(uip|\$UIP)\s+.*--output\s+json` to every CLI-parsing task, and `tests/README.md` shipped it as the canonical `1.0`-weight example. Left unchanged, the next generated task regrows exactly what this PR removed. The guidance now grades the **outcome**, keeps `--output json` as prompt steering, and demotes any convention check to advisory (`pass_threshold: 0`):

```yaml
  - type: command_executed
    description: "Agent used --output json (advisory — convention only, non-gating)"
    command_pattern: '(uip|\$UIP)\s+.*--output\s+json'
    pass_threshold: 0   # advisory: the flag is outcome-invisible — never gate on it
```

## Also — schema fix for two unrelated tasks

`uipath-planner/asdd_crosswalk` and `uipath-planner/attended_reauth` used `expected: "yes"` on their `skill_triggered` criterion, which the current criteria model rejects (`expected_skill` is required; extra keys are forbidden) — both failed to load. Corrected to `expected_skill: "uipath-planner"`, matching the convention used across the rest of the suite. Included here so the whole suite loads clean.

## Validation

All touched task files load through coder_eval's task loader, every `command_pattern` compiles, no `--output json` check remains in any `command_executed`, and each task retains its outcome/artifact checks. Full-suite load is clean (869/869). A superset check over the three runs' real command traces confirms the rewrites only loosen matching: all 549 recorded commands that matched an old pattern (every one carrying `--output json`) still match the rewritten pattern — 0 regressions, so stripping the flag never docks a `--output json` run.
