### PR TITLE
fix(test): unbreak schema gate — correct skill_triggered field on two planner tasks

### DIFF
--- a/tests/tasks/uipath-planner/asdd_crosswalk/asdd_crosswalk.yaml
+++ b/tests/tasks/uipath-planner/asdd_crosswalk/asdd_crosswalk.yaml
@@ -52,7 +52,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent engaged the uipath-planner skill for the crosswalk"
     skill_name: "uipath-planner"
-    expected: "yes"
+    expected_skill: "uipath-planner"
     weight: 1.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-planner/attended_reauth/attended_reauth.yaml
+++ b/tests/tasks/uipath-planner/attended_reauth/attended_reauth.yaml
@@ -47,7 +47,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent engaged the uipath-planner skill (rather than free-forming the SDD)"
     skill_name: "uipath-planner"
-    expected: "yes"
+    expected_skill: "uipath-planner"
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## What

Two planner task YAMLs added in #1739 declare their `skill_triggered` criterion with `expected: "yes"`. The pinned `coder_eval` (0.8.0) `SkillTriggeredCriterion` schema **requires** `expected_skill` and **forbids** `expected`, so each file fails `coder-eval plan` with **59 validation errors for TaskDefinition**.

- `tests/tasks/uipath-planner/asdd_crosswalk/asdd_crosswalk.yaml`
- `tests/tasks/uipath-planner/attended_reauth/attended_reauth.yaml`

Because the **Validate task schema (advisory)** job (`smoke-skills.yml`) scans the *entire* `tests/tasks` tree, these two files have shown the job red on **every PR in the repo since Jul 2** — independent of what the PR touches. The job is `continue-on-error: true`, so it never blocked merge, but it's persistent red noise on every PR's check list.

This is a genuine regression from #1739, confirmed against the live CI log (job `Validate task schema (advisory)`):

```
✗ asdd_crosswalk.yaml
  Error: Invalid task definition: 59 validation errors for TaskDefinition
  success_criteria.0.SkillTriggeredCriterion.expected_skill
    Field required
  success_criteria.0.SkillTriggeredCriterion.expected
    Extra inputs are not permitted
  ...
✗ attended_reauth.yaml
  Error: Invalid task definition: 59 validation errors for TaskDefinition
```

The other 57 errors per file are just pydantic trying every other member of the criterion union; the only real defects are the two `SkillTriggeredCriterion` fields above.

## Fix

Replace `expected: "yes"` → `expected_skill: "uipath-planner"` in both files (2-line diff). This matches the canonical `skill_triggered` shape used by every other passing task in the repo (both `skill_name` and `expected_skill`, no `expected`). `skill_name` is accepted by the schema (not flagged) and is kept for consistency with siblings.

## Scope / verification

- Grepped the whole `tests/tasks` tree — **no other task** uses the bad `expected: "yes"` pattern, so these two are the complete set.
- Both files re-parse as valid YAML and their `success_criteria[0]` now matches the `SkillTriggeredCriterion` shape (`expected_skill` present, `expected` absent).
- `sandbox.template_sources` blocks in both files already validate — the CI errors were confined to `success_criteria[0]`.
- `coder-eval plan` itself can't be run locally (private Azure feed), so the schema-shape check was done by parsing + matching the exact fields the CI log demanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)