### PR TITLE
fix(hitl-skill): remove stale v1.6 inputs.type discriminator from docs

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -107,7 +107,7 @@ Read the existing `.flow` file to understand current nodes and edges. Use the Re
 2. **What the human needs to see** — data produced by upstream nodes
 3. **What the human must provide back** — data needed by downstream nodes
 4. **What actions they can take** — the named outcome buttons
-5. **Form type**: QuickForm (`inputs.type = "quick"`, inline schema) or AppTask (`inputs.type = "custom"`, deployed coded app)?
+5. **Form type**: QuickForm (inline schema, node type `uipath.human-in-the-loop.quick-form`) or AppTask (deployed coded app, node type `uipath.human-in-the-loop.coded-action-app`)?
 
 ---
 
@@ -140,11 +140,11 @@ Wait for confirmation. Do not proceed to schema design until the user confirms.
 
 Present the user with three options. Do not choose on their behalf or perform any registry search.
 
-| # | Option | `inputs.type` value | Description |
+| # | Option | Node type | Description |
 |---|---|---|---|
-| 1 | **QuickForm** | `"quick"` | Inline typed form — fields rendered by Action Center from the schema you design here |
-| 2 | **New Coded Action App** | `"custom"` | Scaffold a new React + TypeScript app inside the solution — full UI control |
-| 3 | **Existing Deployed App** | `"custom"` | Reference an app already deployed to Orchestrator |
+| 1 | **QuickForm** | `uipath.human-in-the-loop.quick-form` | Inline typed form — fields rendered by Action Center from the schema you design here |
+| 2 | **New Coded Action App** | `uipath.human-in-the-loop.coded-action-app` | Scaffold a new React + TypeScript app inside the solution — full UI control |
+| 3 | **Existing Deployed App** | `uipath.human-in-the-loop.coded-action-app` | Reference an app already deployed to Orchestrator |
 
 > **If the user's request is purely business-oriented** (no mention of a deployed app, coded action app, or custom UI): skip the question and proceed directly with QuickForm. Do not ask. Say: "I'll use QuickForm — it's inline, no deployment step needed, and works for most approval and review tasks."
 
@@ -238,7 +238,7 @@ uip maestro flow validate <file> --output json
 
 Step 4c must be completed first — app name confirmed, solution directory located, SDK tarball identified, schema designed and confirmed.
 
-Scaffold the project directory and all source files, add the project to the solution, write the solution resource files, then write the HITL node with `inputs.type = "custom"` and `inputs.app` referencing the new app (`appSystemName: null` since the app has not been deployed yet).
+Scaffold the project directory and all source files, add the project to the solution, write the solution resource files, then write the HITL node (type `uipath.human-in-the-loop.coded-action-app`) with `inputs.app` referencing the new app (`appSystemName: null` since the app has not been deployed yet).
 
 Full project template, UUID generation, solution CLI commands, resource file templates, node JSON, and post-creation build steps: **[How to scaffold a new Coded Action App](references/hitl-node-coded-action-app.md)**
 
@@ -252,7 +252,7 @@ uip maestro flow validate <file> --output json
 
 Step 4b must be completed first — app resolved, configuration retrieved. Then:
 
-Resolve the solution context (`.uipx` file), write solution resource files, register the app reference, merge `debug_overwrites.json`, then write the node JSON with `inputs.type = "custom"` and `inputs.app` populated from the Step 3b configuration.
+Resolve the solution context (`.uipx` file), write solution resource files, register the app reference, merge `debug_overwrites.json`, then write the node JSON (type `uipath.human-in-the-loop.coded-action-app`) with `inputs.app` populated from the Step 3b configuration.
 
 App search/selection, retrieve-configuration, resource file writing, complete node JSON with `appInputBindings`: **[How to wire an existing deployed Action App](references/hitl-node-apptask.md)**
 

--- a/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-apptask.md
@@ -1,6 +1,6 @@
 # HITL AppTask Node — Direct JSON Reference
 
-The AppTask variant uses a deployed coded app (Studio Web) as the task form. Same node type as QuickForm (`uipath.human-in-the-loop`), same three output handles. Difference: `inputs.type = "custom"` and `inputs.app` points to the deployed app.
+The AppTask variant uses a deployed coded app (Studio Web) as the task form. Node type: `uipath.human-in-the-loop.coded-action-app`. Same three handles (`input`, `completed`) as QuickForm. Difference from QuickForm: `inputs.app` points to the deployed app (no inline schema).
 
 ---
 
@@ -285,7 +285,6 @@ Merge rules:
   "typeVersion": "1.0",
   "display": { "label": "Invoice Review" },
   "inputs": {
-    "type": "custom",
     "recipient": {
       "channels": ["ActionCenter"],
       "connections": {},

--- a/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-coded-action-app.md
@@ -278,7 +278,6 @@ All values below come directly from the `ParsedActionSchema` assembled in Step 4
   "display": { "label": "<LABEL>" },
   "ui": { "position": { "x": 474, "y": 144 } },
   "inputs": {
-    "type": "custom",
     "channels": [],
     "recipient": {
       "channels": ["ActionCenter"],

--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -106,7 +106,6 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
   "typeVersion": "1.0",
   "display": { "label": "Invoice Review" },
   "inputs": {
-    "type": "quick",
     "title": "Invoice Review",
     "recipient": {
       "channels": ["Email", "ActionCenter"],
@@ -222,7 +221,6 @@ Every `.flow` file must have one definition entry for `uipath.human-in-the-loop.
   ],
   "model": { "type": "bpmn:UserTask", "serviceType": "Actions.HITL" },
   "inputDefaults": {
-    "type": "quick",
     "schema": {
       "fields": [],
       "outcomes": [{ "id": "submit", "name": "Submit", "type": "string", "isPrimary": true, "action": "Continue" }]


### PR DESCRIPTION
Closes: model was generating `uipath.human-in-the-loop` + `inputs.type: "quick"` (v1.6 format) instead of `uipath.human-in-the-loop.quick-form` (v1.7).

The docs taught the wrong thing. SKILL.md Step 3 table had a column `inputs.type value` showing `"quick"` / `"custom"` as the discriminator. The v1.6→v1.7 migration deletes `inputs.type` — the node type itself (`uipath.human-in-the-loop.quick-form`, `uipath.human-in-the-loop.coded-action-app`) is the v1.7 discriminator.

**Changes:**
- `SKILL.md` Step 3 table: replaced `inputs.type value` column with `node type` — now shows the actual node type string the model must write
- `SKILL.md` Step 2: form type description now names node types, not `inputs.type` values
- `SKILL.md` Step 5: removed `inputs.type = "custom"` from app-based node descriptions
- `hitl-node-quickform.md`: removed `"type": "quick"` from node `inputs` and definition `inputDefaults`
- `hitl-node-apptask.md`: removed `"type": "custom"` from node `inputs`, fixed intro sentence (was claiming wrong base type)
- `hitl-node-coded-action-app.md`: removed `"type": "custom"` from node `inputs`

Note: last session we fixed the test assertions that checked for `"type": "quick"` in the flow file — but didn't fix the docs that tell the model to write it. This PR fixes the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)