### PR TITLE
test(uipath-agents): steer coded eval prompts to load the skill

### DIFF
--- a/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
+++ b/tests/tasks/uipath-agents/coded/antipattern_wrong_sdk_import/antipattern_wrong_sdk_import.yaml
@@ -7,7 +7,7 @@ description: >
 tags: [uipath-agents, smoke, coded, lifecycle:edit, feature:antipattern]
 
 run_limits:
-  expected_turns: 8
+  expected_turns: 14
   turn_timeout: 1200
 
 pre_run:
@@ -15,19 +15,22 @@ pre_run:
     timeout: 10
 
 initial_prompt: |
-  I have an existing UiPath coded agent project at `bad-import/`
-  (pyproject.toml + main.py) that I'm trying to run.
-
-  Review it for UiPath coded-agent anti-patterns and fix them in
-  place. main.py uses `from uipath import UiPath` — that import
-  path does not exist and raises `ImportError` at module-import
-  time. Fix the import. The agent should still call
-  `sdk.assets.retrieve_async` with the same arguments.
+  I've got a UiPath coded agent at `bad-import/` that won't run - it
+  blows up on import before it does anything. Can you review it for
+  UiPath coded-agent anti-patterns and fix them in place? It still
+  needs to call `sdk.assets.retrieve_async` with the same arguments.
 
   Do NOT publish, upload, or deploy. Do NOT pause between planning
   and implementation. Complete end-to-end in a single pass.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: file_exists
     description: "main.py exists under bad-import/"
     path: "bad-import/main.py"

--- a/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
+++ b/tests/tasks/uipath-agents/coded/coded_in_flow_e2e/coded_in_flow_e2e.yaml
@@ -17,10 +17,10 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  I want a uipath coded agent (LangGraph) called `InputProcessor` that
-  takes some user input and returns a short summary. Wrap it in a solution
-  `GreeterSol` with a flow `GreeterFlow` that runs the agent, and make
-  sure the flow validates.
+  Build me a UiPath coded agent (LangGraph) called `InputProcessor` that
+  takes some user input and returns a short summary. Once the coded agent
+  itself is built and scaffolded, wrap it in a solution `GreeterSol` with a
+  flow `GreeterFlow` that runs the agent, and make sure the flow validates.
 
   All local, nothing to publish or deploy. Complete the task end-to-end.
   Only stop if there is a critical blocker you cannot resolve.

--- a/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_wait_task/hitl_wait_task.yaml
@@ -11,17 +11,17 @@ tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framew
 max_iterations: 1
 
 initial_prompt: |
-  Build a UiPath coded agent (LangGraph) named `purchase-gate` that
-  closes the loop on a purchase request that's already been opened for
-  human review somewhere else. The open Action Center task is handed to
-  the agent as input — it should wait until the reviewer finishes that
-  existing task, then read their decision and produce a short, structured
-  outcome: whether it was approved and whatever note the reviewer left.
+  Scaffold a fresh UiPath coded agent (LangGraph) named `purchase-gate` in
+  a `purchase-gate/` directory at the working-directory root. It closes the
+  loop on a purchase request that's already been opened for human review
+  somewhere else. The open Action Center task is handed to the agent as
+  input: it should wait until the reviewer finishes that existing task, then
+  read their decision and produce a short, structured outcome, whether it
+  was approved and whatever note the reviewer left.
 
-  It also gets a one-line summary of the purchase for context. Put the
-  project in a `purchase-gate/` directory at the working-directory root.
+  It also gets a one-line summary of the purchase for context.
 
-  I just need it built — no need to run it, sign in, or deploy. Take it
+  I just need it built, no need to run it, sign in, or deploy. Take it
   through in one pass.
 
 success_criteria:


### PR DESCRIPTION
## Summary
- reword three coded eval prompts so the agent loads the uipath-agents skill instead of editing directly or routing to a sibling skill
- antipattern-wrong-sdk-import: remove the spoon-fed import fix from the prompt and add a skill_triggered gate, so the agent consults the skill for the correct `from uipath.platform import UiPath`
- in-flow-e2e: lead with building the coded agent so uipath-agents owns the coded-agent half rather than the planner routing around it
- hitl-wait-task: lead with scaffolding a fresh coded agent so `uip codedagent new`/`init` actually run

## Why

on sonnet these prompts let the agent skip uipath-agents (guessing a wrong SDK import, building only the flow half, or hand-rolling files without scaffolding), so the tasks failed on skill-triggered and command criteria even when the ask was clear. steering the prompts toward the skill fixes the routing without changing the checks.