### PR TITLE
fix(api-workflow): grade outlook_send against init project layout

### DIFF
--- a/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
+++ b/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
@@ -11,10 +11,10 @@ description: >
 tags: [uipath-api-workflow, e2e, mode:build, lifecycle:generate, connector, feature:registry]
 
 initial_prompt: |
-  Author — but do NOT run — a UiPath API Workflow at Workflow.json that sends
-  an email via the Outlook Integration Service connector. Build the connector
-  activity through the skill's discovery flow against a working Outlook
-  connection, then validate the workflow offline.
+  Author — but do NOT run — a UiPath API Workflow that sends an email via the
+  Outlook Integration Service connector. Create the project named `OutlookSend`
+  (its workflow file will be OutlookSend/Workflow.json), wire the activity to a
+  working Outlook connection, then validate the workflow offline.
 
   Do NOT run the workflow with auth and do NOT send a real email — stop once it
   validates. The activity must come from the registry (not hand-authored) wired
@@ -23,8 +23,8 @@ initial_prompt: |
 
 success_criteria:
   - type: file_exists
-    description: "Workflow.json was created"
-    path: "Workflow.json"
+    description: "Workflow.json was created in the project folder"
+    path: "OutlookSend/Workflow.json"
     weight: 1.0
     pass_threshold: 1.0
 
@@ -46,15 +46,15 @@ success_criteria:
 
   - type: file_contains
     description: "Uses the IntSvc kind (call: UiPath.IntSvc)"
-    path: "Workflow.json"
+    path: "OutlookSend/Workflow.json"
     includes:
       - "UiPath.IntSvc"
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "No unresolved connection placeholder survived (rule 16 — sentinel must be replaced)"
-    command: "! grep -q 'REPLACE_WITH' Workflow.json"
+    description: "Workflow exists AND no unresolved connection placeholder survived (rule 16 — sentinel must be replaced)"
+    command: 'test -f OutlookSend/Workflow.json && ! grep -q ''REPLACE_WITH'' OutlookSend/Workflow.json'
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -62,7 +62,7 @@ success_criteria:
 
   - type: run_command
     description: "Workflow passes offline validation"
-    command: 'uip api-workflow validate ./Workflow.json --output json | grep -q ''"Status": "Valid"'''
+    command: 'uip api-workflow validate ./OutlookSend/Workflow.json --output json | grep -q ''"Status": "Valid"'''
     timeout: 30
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
+++ b/tests/tasks/uipath-api-workflow/connector-intsvc/outlook_send.yaml
@@ -62,7 +62,7 @@ success_criteria:
 
   - type: run_command
     description: "Workflow passes offline validation"
-    command: 'uip api-workflow validate ./OutlookSend/Workflow.json --output json | grep -q ''"Status": "Valid"'''
+    command: 'uip api-workflow validate OutlookSend/Workflow.json --output json | grep -q ''"Status": "Valid"'''
     timeout: 30
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
## What

Fixes the `skill-api-workflow-intsvc-outlook-send` e2e task so it grades against the project layout the skill actually produces.

## Why

The task's success criteria checked a root-level `Workflow.json`. But the skill's **Critical Rule 19a** requires `uip api-workflow init <name>`, which scaffolds `<name>/Workflow.json` and explicitly forbids a root-level hand-authored workflow (`invalid_project_folder`). So the test graded against a layout the skill prohibits.

A recent run confirmed the mismatch: the agent did everything right — pinged a real Outlook connection, stubbed the activity, produced `OutlookSend/Workflow.json` with `"call": "UiPath.IntSvc"` and no `REPLACE_WITH` placeholder — but scored **3/6** because every path-based criterion looked at the root and missed the file.

A separate run also exposed a **false positive**: `! grep -q 'REPLACE_WITH' Workflow.json` returns success when the file is *absent* (grep errors → `!` flips to a pass), so a missing workflow banked the placeholder point.

## Changes

- Point `file_exists`, `file_contains`, and the `validate` criterion at `OutlookSend/Workflow.json`.
- Gate the placeholder check on `test -f OutlookSend/Workflow.json` so it fails when the workflow is missing.
- Prompt now names the `OutlookSend` project (the path anchor the criteria grade against) but no longer prescribes CLI commands — `init` and `validate` are inherited from the skill, per the minimal-prompt rule.

No skill or environment changes. Against the recent correct run, the task now scores **6/6**.

## Validation

- `/lint-task` verdict: **OK** (0 Critical/High/Medium/Low).
- `scripts/check-cli-verbs.py`: clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)