### PR TITLE
fix(uipath-review): restore read-only contract for coded apps; add BPMN + API workflow coverage

### DIFF
--- a/skills/uipath-review/SKILL.md
+++ b/skills/uipath-review/SKILL.md
@@ -20,8 +20,8 @@ Review UiPath solutions and individual artifacts for structural validity, qualit
 
 ## Critical Rules
 
-1. **NEVER modify any files.** This skill is read-only. If fixes are needed, identify them in the report and tell the user which skill to use (uipath-rpa, uipath-agents, uipath-maestro-flow, uipath-coded-apps, uipath-platform, uipath-solution).
-2. **ALWAYS run validation and Workflow Analyzer before manual review.** For RPA projects, run **both** `uip rpa validate` on every entry point AND `uip rpa build "<PROJECT_DIR>"` — `validate` catches structural / analyzer issues, `build` catches compile-time issues `validate` misses (unknown member names, invalid enum values, JIT failures). Run `uip agent validate` on agents, `uip maestro flow validate` on flows. Report every Error, Warning, and Info result from every command. A review without both `validate` AND `build` (for RPA) is incomplete and may ship broken member references.
+1. **NEVER modify any files.** This skill is read-only. If fixes are needed, identify them in the report and tell the user which skill to use (uipath-rpa, uipath-agents, uipath-maestro-flow, uipath-maestro-bpmn, uipath-api-workflow, uipath-coded-apps, uipath-platform, uipath-solution).
+2. **ALWAYS run validation and Workflow Analyzer before manual review.** For RPA projects, run **both** `uip rpa validate` on every entry point AND `uip rpa build "<PROJECT_DIR>"` — `validate` catches structural / analyzer issues, `build` catches compile-time issues `validate` misses (unknown member names, invalid enum values, JIT failures). Run `uip agent validate` on agents, `uip maestro flow validate` on flows, `uip maestro bpmn validate` on BPMN processes, `uip api-workflow validate` on API workflows. Report every Error, Warning, and Info result from every command. A review without both `validate` AND `build` (for RPA) is incomplete and may ship broken member references.
 3. **ALWAYS discover and classify before reviewing.** For solutions: classify every project before reviewing any individual one. For single projects: identify the project type and find the enclosing project directory before reviewing individual files.
 4. **Report severity for every finding.** Use: **Critical** (blocks deployment), **Warning** (should fix), **Info** (improvement opportunity).
 5. **Understand business context first.** Before evaluating optimization, ask or infer what the solution is trying to accomplish. A queue-based architecture is not "better" if the use case processes 5 items/day.
@@ -44,7 +44,7 @@ Run this from the directory the user specified (or the current working directory
 
 ```bash
 # Discover solution files, project markers, and documentation
-find . -maxdepth 3 \( -name "*.uipx" -o -name "project.json" -o -name "agent.json" -o -name "*.flow" -o -name "app.config.json" -o -name ".uipath" -o -name "langgraph.json" -o -name "llama_index.json" -o -name "openai_agents.json" -o -name "uipath.json" -o -name "main.py" \) 2>/dev/null
+find . -maxdepth 3 \( -name "*.uipx" -o -name "project.json" -o -name "project.uiproj" -o -name "agent.json" -o -name "*.flow" -o -name "*.bpmn" -o -name "app.config.json" -o -name ".uipath" -o -name "langgraph.json" -o -name "llama_index.json" -o -name "openai_agents.json" -o -name "uipath.json" -o -name "main.py" \) 2>/dev/null
 
 # Search for PDD or design documents
 find . -maxdepth 3 \( -name "*PDD*" -o -name "*pdd*" -o -name "*Process_Design*" -o -name "*process_design*" -o -name "*Process-Design*" -o -name "*ProcessDesign*" -o -name "*SDD*" -o -name "*Solution_Design*" -o -name "*design_document*" -o -name "*DesignDocument*" -o -name "*requirements*" -o -name "*specification*" \) 2>/dev/null
@@ -94,7 +94,7 @@ Classify the scope internally using these rules:
 
 **Scope: Solution or Multi-project** — `.uipx` exists at root, OR 2+ **executable** project markers exist in different subdirectories.
 
-- Executable project = `project.json` with `outputType` of `Process`/`Tests`/unspecified, OR `agent.json`, OR `.flow`
+- Executable project = `project.json` with `outputType` of `Process`/`Tests`/unspecified, OR `agent.json`, OR `.flow`, OR `project.uiproj` with `ProjectType` `Flow`/`ProcessOrchestration`/`Api`
 - Library projects (`outputType: "Library"`) co-located with consumers do NOT trigger this scope — that is the normal library+consumer pattern
 - **Windows-Legacy executables do NOT trigger this scope for `.uipx` purposes**: `.uipx` solutions are not supported for Legacy projects. If any detected executable is Legacy, do not flag missing `.uipx` — recommend migration to Modern compatibility if solution bundling is desired. Review each Legacy project independently.
 
@@ -139,6 +139,8 @@ Record the language per project alongside the type (see solution table below).
 | `main.py` + `langgraph.json` / `llama_index.json` / `openai_agents.json` / `google_adk.json` / `pydantic_ai.json` / `agent_framework.json` / `uipath.json` | Agent (Coded) | Checklist: [agent-review-checklist.md](references/agents/agent-review-checklist.md). Rule catalog (Step 2.5): [agents-common-rules.md](references/agents/agents-common-rules.md) + [agents-coded-rules.md](references/agents/agents-coded-rules.md) |
 | `agent.json` + `main.py` + `pyproject.toml` (agent-builder coded layout) | Agent (Low-Code + Coded) | Checklist: [agent-review-checklist.md](references/agents/agent-review-checklist.md). Rule catalog (Step 2.5): all three — [agents-common-rules.md](references/agents/agents-common-rules.md) + [agents-lowcode-rules.md](references/agents/agents-lowcode-rules.md) + [agents-coded-rules.md](references/agents/agents-coded-rules.md) |
 | `*.flow` + `project.uiproj` with `"ProjectType": "Flow"` | Flow | [flow-review-checklist.md](references/flows/flow-review-checklist.md) |
+| `*.bpmn` + `project.uiproj` with `"ProjectType": "ProcessOrchestration"` | Maestro BPMN | [bpmn-review-checklist.md](references/bpmn/bpmn-review-checklist.md) |
+| `Workflow.json` (`document.dsl` + `do[]`) + `project.uiproj` with `"ProjectType": "Api"` | API Workflow | [api-workflow-review-checklist.md](references/api-workflows/api-workflow-review-checklist.md) |
 | `.uipath/` directory or `app.config.json` | Coded App | [coded-app-review-checklist.md](references/coded-apps/coded-app-review-checklist.md) |
 
 For **Solution / Multi-project scope**, record all projects in a table:
@@ -203,10 +205,14 @@ If `uip rpa analyze` is not available, `uip rpa validate` includes Workflow Anal
 
 | Project Type | Validation Command | Report All Severities |
 |---|---|---|
-| Agent (Low-Code) | `uip agent validate ./path --output json` | Yes — errors, warnings, info |
-| Flow | `uip maestro flow validate <ProjectName>.flow --output json` | Yes — schema errors, reference errors, warnings |
-| Coded App | `uip codedapp pack dist --dry-run` | Yes — build errors, pack warnings |
-| Solution | `uip solution pack <SolutionDir> <OutputDir> --output json` | Yes — per-project pack results |
+| Agent (Low-Code) | `uip agent validate "<PROJECT_DIR>" --output json` | Yes — errors, warnings, info |
+| Flow | `uip maestro flow validate "<PROJECT_NAME>.flow" --output json` | Yes — schema errors, reference errors, warnings |
+| Maestro BPMN | `uip maestro bpmn validate "<FILE>.bpmn" --output json` | Yes — model errors, warnings |
+| API Workflow | `uip api-workflow validate "<WORKFLOW_JSON>" --output json` | Yes — schema + semantic errors, warnings |
+| Coded App | `uip codedapp pack dist --dry-run --output json` | Yes — build errors, pack warnings |
+| Solution | `uip solution pack "<SOLUTION_DIR>" "<OUTPUT_DIR>" --output json` | Yes — per-project pack results |
+
+> `uip api-workflow validate` is offline (no auth, no network, no side effects). Do NOT run `uip api-workflow run` — it executes vendor calls with real side effects. If the CLI reports an unknown command for `maestro bpmn validate` or `api-workflow validate` (older CLI), record it under "Rules Skipped" and fall back to the manual structural checks in the type's checklist.
 
 #### 2d. Record All Results
 
@@ -298,9 +304,10 @@ Every project has two units of work: what the **contract** declares one invocati
 | RPA + queue | Queue item schema (`Data/*.json`, `JSON Schema/`, or the SpecificContent fields used by `Add Queue Item` / `Get Transaction Item`) |
 | RPA without queue | `Main.xaml` input arguments |
 | Flow | `.flow` file → `variables.globals` → entries with `direction: "in"` or `"inout"` |
+| Maestro BPMN | Process start-event payload / process input variables |
 | Agent (low-code) | `agent.json` → `inputSchema` |
 | Agent (coded) | `Input` class in `main.py` (Pydantic `BaseModel`) |
-| API workflow | Request schema defined in the workflow |
+| API workflow | Request input schema in `Workflow.json` |
 | Coded app | Entry point input schema in `operate.json` / `entry-points.json` |
 
 **Step 3a.2 — Discover the actual unit of work** (core execution body):
@@ -579,6 +586,8 @@ Route each fix to the appropriate skill:
 | Fix RPA Windows-Legacy project | `uipath-rpa` (Legacy mode) |
 | Fix agent (coded or low-code) | `uipath-agents` |
 | Fix flow (.flow) | `uipath-maestro-flow` |
+| Fix Maestro BPMN (.bpmn) | `uipath-maestro-bpmn` |
+| Fix API workflow (Workflow.json) | `uipath-api-workflow` |
 | Fix coded app | `uipath-coded-apps` |
 | Fix Orchestrator resources (assets, queues, folders) | `uipath-platform` |
 | Fix `.uipx` solution / pack / publish / deploy lifecycle | `uipath-solution` |
@@ -629,6 +638,8 @@ This maps the letter to the verdict word only. The agent grade is `min(G_det, G_
 | Find common agent issues | [agent-common-issues.md](references/agents/agent-common-issues.md) |
 | Review a flow project | [flow-review-checklist.md](references/flows/flow-review-checklist.md) |
 | Find common flow issues | [flow-common-issues.md](references/flows/flow-common-issues.md) |
+| Review a Maestro BPMN project (.bpmn) | [bpmn-review-checklist.md](references/bpmn/bpmn-review-checklist.md) |
+| Review an API workflow project (Workflow.json) | [api-workflow-review-checklist.md](references/api-workflows/api-workflow-review-checklist.md) |
 | Review a coded app | [coded-app-review-checklist.md](references/coded-apps/coded-app-review-checklist.md) |
 | Review Orchestrator resources | [platform-resources-checklist.md](references/platform/platform-resources-checklist.md) |
 | Deep-dive an RPA project | [rpa-advanced-checklist.md](references/rpa/rpa-advanced-checklist.md) |

--- a/skills/uipath-review/references/api-workflows/api-workflow-review-checklist.md
+++ b/skills/uipath-review/references/api-workflows/api-workflow-review-checklist.md
@@ -1,0 +1,72 @@
+# API Workflow Review Checklist
+
+Quality checklist for UiPath API Workflow projects — serverless JSON workflows (`Workflow.json`, Serverless Workflow DSL: top-level `document` with `dsl` version + `do[]` activity array).
+
+> **Unit of Work:** Before the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. Declared unit: the request input schema. Actual unit: external calls per request. One request fanning out to N vendor writes over a sub-collection of the input is one-to-many — assess per Step 3a.
+
+> **Read-only:** fixes route to `uipath-api-workflow`.
+
+## 1. Structural Validation
+
+### Project Markers
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| `project.uiproj` exists with `"ProjectType": "Api"` | Critical | Read project.uiproj |
+| Legacy `project.json`-only layout (no `.uiproj`) | Warning | Packs and runs but Studio Web rejects it (`invalid_project_folder`) — flag, route to `uipath-api-workflow` for conversion |
+| `Workflow.json` is valid JSON with `document.dsl` and `do[]` | Critical | Read Workflow.json |
+| `entry-points.json` present | Warning | `ls entry-points.json` |
+| `bindings_v2.json` present (if connector activities used) | Warning | `ls bindings_v2.json` |
+
+### CLI Validation
+
+```bash
+uip api-workflow validate "<WORKFLOW_JSON>" --output json
+```
+
+Offline static validation — no auth, no network, no side effects (safe for review). Catches: malformed JSON, unknown `activityType` values, per-activity required keys, missing `metadata.activityType`/`displayName`, duplicate or empty-named variables, empty task lists.
+
+- `Result: "Success"`, `Data.Status: "Valid"` — report any `Data.Warnings`.
+- `Result: "Failure"` — report each semantic error with its JSON path. Focus on semantic-tail errors (`Unknown activityType 'X'`, missing required keys) — AJV `oneOf` fanout duplicates are noise, not separate findings.
+
+> **Do NOT run `uip api-workflow run`.** It executes the workflow — Integration Service vendor calls cause real side effects (emails sent, tickets created, files uploaded). Runtime verification is an operator task — route to `uipath-api-workflow`.
+
+> If the CLI reports an unknown command for `api-workflow validate` (older CLI), record it under "Rules Skipped" and run the manual checks below.
+
+## 2. Design Quality
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| Input validation before business logic (required-field / type checks first) | Warning | Inspect first activities in `do[]` |
+| Structured error responses (Response activity with 4xx for bad input, not deep null failures) | Warning | Check Response activities |
+| TryCatch wraps vendor / HTTP calls | Warning | Check for TryCatch around connector and HTTP activities |
+| No inline secrets (tokens, API keys in headers or configuration) | Critical | Grep Workflow.json for `token`, `apiKey`, `secret`, `password`, `Bearer ` |
+| Connector activities reference connections by ID — no hardcoded credentials | Critical | Check connector `metadata.configuration` |
+| Long-running logic not synchronous (hard timeout ~10 minutes; 5 min CPU for serverless) | Warning | Bulk processing / chained calls → flag; recommend async pattern |
+| Variables have non-empty names and types; no duplicates | Warning | Covered by `validate` — carry its findings verbatim |
+
+## Common Issues
+
+### No Input Schema Enforcement
+
+**Symptom:** API workflow has input schema defined, but the first steps do not validate required inputs. Callers can send malformed payloads and the workflow tries to process them.
+
+**Impact:** NullReferenceException deep in the logic instead of a clear 400 Bad Request. Consumers get unhelpful errors.
+
+**Detection:** Inspect API workflow's initial activities. Check for explicit validation (required-field checks, type validation) before business logic begins.
+
+**Fix:** Add input validation as the first step. Return structured 400 responses with field-specific error messages.
+
+**Severity:** Warning
+
+### Synchronous Long-Running API Workflow
+
+**Symptom:** API workflow performing long-running logic (DB migrations, bulk processing, chained API calls) synchronously. Hard timeout: 10 minutes (5 min CPU for serverless).
+
+**Impact:** Request times out with no result, no recovery path. Caller sees timeout error. Work may be partially complete with no rollback.
+
+**Detection:** Long-running logic visible in `do[]` (bulk loops over external calls, chained vendor requests).
+
+**Fix:** Convert to async pattern — accept request, return job ID, process in background (via queue), let caller poll. Or use `Wait for Event and Resume` for suspend/resume.
+
+**Severity:** Warning

--- a/skills/uipath-review/references/bpmn/bpmn-review-checklist.md
+++ b/skills/uipath-review/references/bpmn/bpmn-review-checklist.md
@@ -1,0 +1,92 @@
+# Maestro BPMN Review Checklist
+
+Quality checklist for UiPath Maestro BPMN (Process Orchestration) projects — `.bpmn` process models orchestrating RPA processes, agents, API workflows, and human tasks.
+
+> **Unit of Work:** Before the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. For BPMN the declared unit is the process start-event payload / process input variables. The actual unit is the external effects per process instance — count service tasks, agent calls, and human tasks executed per instance. One instance fanning out to N external writes over a sub-collection of the input is one-to-many — assess per Step 3a.
+
+> **Read-only:** never run, publish, or migrate the process during review. Fixes route to `uipath-maestro-bpmn`.
+
+## 1. Structural Validation
+
+### Project Markers and Required Files
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| `project.uiproj` exists with `"ProjectType": "ProcessOrchestration"` | Critical | Read project.uiproj |
+| At least one `.bpmn` file exists and is well-formed XML | Critical | `ls *.bpmn` + parse check |
+| `entry-points.json` present; entry `filePath` points to an existing `.bpmn` element | Critical | Read entry-points.json |
+| Entry-point `uniqueId` values unique across entries | Critical | Parse entry-points.json for duplicate `uniqueId` — duplicates block publishing |
+| `bindings_v2.json` present (if external resources used) | Warning | `ls bindings_v2.json` |
+| `operate.json` and `package-descriptor.json` present | Info | `ls operate.json package-descriptor.json` |
+
+### CLI Validation
+
+```bash
+uip maestro bpmn validate "<FILE>.bpmn" --output json
+```
+
+> Requires a current CLI. If the CLI reports an unknown command, record `uip maestro bpmn validate` under "Rules Skipped" and run the manual structural checks below.
+
+## 2. BPMN Element Support (Execution-Ready)
+
+| Element Category | Supported for Execution | Modeling Only |
+|---|---|---|
+| **Start Events** | None, Message, Timer | Error, Signal, Conditional, Compensation, Escalation |
+| **Intermediate Catch** | Message, Timer | Signal, Conditional, Link |
+| **Boundary (Interrupting)** | Message, Timer, Error | Signal, Conditional, Escalation, Compensation |
+| **Boundary (Non-Interrupting)** | Message, Timer | Signal, Conditional, Escalation |
+| **End Events** | None, Message, Error, Terminate | Signal, Escalation, Compensation |
+| **Tasks** | User, Service, Send, Receive, Business Rule, Script, Manual | — |
+| **Gateways** | Exclusive, Parallel, Inclusive, Event-Based | Complex |
+| **Markers** | Multi-instance (parallel/sequential) | Loop, Compensation |
+| **Subprocesses** | Sub-process, Call Activity, Event Sub-process | Transaction |
+
+### Structural Checks
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| All BPMN elements used are execution-ready (not modeling-only) | Critical | Compare against support table above |
+| One clear start event and explicit end events | Critical | Check process structure |
+| Parallel gateways have matching parallel join gateways | Critical | Verify parallel synchronization |
+| Inclusive gateways have matching inclusive merge | Critical | Verify inclusive synchronization |
+| No mixed gateway split/merge pairs (Parallel split → Exclusive merge, etc.) | Critical | Deadlock risk — trace every diverging gateway to its merge; types MUST match |
+| Default path defined on exclusive gateways (prevents runtime faults) | Warning | Check gateway configuration |
+| Task sizes are uniform in diagrams | Info | Visual review |
+| Flow direction is left-to-right or top-to-bottom | Info | Check element positions |
+| Separate process flow from business rules (use DMN Business Rule Tasks) | Info | Check for complex conditionals |
+
+## 3. Timer Configuration
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| Timer events use valid ISO 8601 durations (e.g., `PT1H`, `P1D`, `R/PT5M`) | Critical | Check timer values |
+| Timer boundary events configured for long-running tasks (SLA enforcement) | Info | Check boundary events |
+| Non-interrupting timers used when parallel execution is needed | Info | Check timer interrupt mode |
+| Cycle timers use correct repeat format (`R/P[duration]`) | Warning | Check cycle syntax |
+
+## 4. Multi-Instance Configuration
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| Parallel multi-instance batch size appropriate (runs in batches of 50) | Info | Check batch config |
+| Sequential multi-instance used when item ordering matters | Warning | Verify ordering requirement |
+| Multi-instance loops configured to **continue on individual item failure** (one item's error does not halt the entire batch) | Warning | Check multi-instance configuration for continueOnException/continue-on-failure flag. Batches of 50 where item #15 fails should still process items 16..50 |
+| Nested loops use subprocess pattern (outer sequential, inner parallel) | Info | Check nesting pattern |
+
+## 5. Error Handling
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| Error boundary events attached to tasks with failure risk | Warning | Check boundary events |
+| Error end events used for unrecoverable failures | Info | Check error paths |
+| Event subprocesses configured for centralized error handling | Info | Check event subprocesses |
+| Error mappings configured at element level (first match wins) | Warning | Check error mapping order |
+
+## 6. Actor Fitness
+
+| Check | Severity | How to Verify |
+|---|---|---|
+| Each task assigned to the correct executor type (robot, agent, human, API) | Warning | Review task executor assignments |
+| Agent tasks have guardrails and fallback to human escalation | Warning | Review agent task configuration |
+| Deterministic rule-based logic not assigned to agents (unnecessary cost) | Info | Compare task nature to executor type |
+| Human steps use User Tasks with deadlines and escalation rules | Warning | Check user task configuration |

--- a/skills/uipath-review/references/coded-apps/coded-app-review-checklist.md
+++ b/skills/uipath-review/references/coded-apps/coded-app-review-checklist.md
@@ -2,7 +2,7 @@
 
 Quality checklist for UiPath Coded Web Applications — apps built with web frameworks (React, Angular, Vue, etc.) and deployed through the UiPath platform.
 
-> **Unit of Work:** Before running the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. For coded apps the declared unit is the entry point input schema (`operate.json` / `entry-points.json`). The actual unit is what each endpoint/page action produces. If a single user action triggers N unbounded downstream calls over a sub-collection of input, that is a Granularity Mismatch (see [rpa-common-issues.md](../rpa/rpa-common-issues.md) for the generic pattern).
+> **Unit of Work:** Before running the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. For coded apps the declared unit is the entry point input schema (`operate.json` / `entry-points.json`). The actual unit is what each endpoint/page action produces. If a single user action triggers N unbounded downstream calls over a sub-collection of input, the shape is one-to-many — assess per Step 3a (see [rpa-common-issues.md](../rpa/rpa-common-issues.md) for the generic pattern).
 
 ## 1. Project Structure
 
@@ -32,12 +32,13 @@ Quality checklist for UiPath Coded Web Applications — apps built with web fram
 
 ## 2. Build Verification
 
+> Review is read-only — do NOT run `npm run build` (mutates the workspace). Verify the existing build output; a missing or stale `dist/` is itself a finding.
+
 | Check | Severity | How to Verify |
 |---|---|---|
-| `npm run build` completes successfully | Critical | Run build command |
-| `dist/` (or configured output) contains expected files | Critical | `ls dist/` |
+| Build output exists (`dist/` or configured output) with expected files | Critical | `ls dist/` — if missing, report as finding; do not build |
 | Build output includes an `index.html` entry point | Critical | `ls dist/index.html` |
-| No build warnings about missing dependencies | Warning | Check build output |
+| No build warnings about missing dependencies | Warning | Check CI/build logs if available; otherwise record under "Rules Skipped" |
 | Bundle size is reasonable (no massive unoptimized bundles) | Info | Check dist/ file sizes |
 
 ## 3. Pack Readiness
@@ -115,20 +116,20 @@ Quality checklist for UiPath Coded Web Applications — apps built with web fram
 | Environment-specific configuration externalized | Warning | No hardcoded env-specific URLs |
 | Deployment target correctly configured | Warning | Check deploy config |
 
-## 9. Deployment Lifecycle Verification
+## 9. Deployment Lifecycle Readiness
 
-The complete deployment lifecycle:
+The lifecycle this project must be ready for. **Do NOT execute any of it during review** — publish and deploy are operator tasks (route to `uipath-coded-apps`). The only sanctioned command is the dry-run pack (§3).
 
-```
-1. Build: npm run build → dist/
-2. Pack:  uip codedapp pack dist → .uipath/*.nupkg
+```text
+1. Build:   npm run build → dist/
+2. Pack:    uip codedapp pack dist → .uipath/*.nupkg
 3. Publish: uip codedapp publish → registers with Apps service
-4. Deploy: uip codedapp deploy → deploys to UiPath platform
+4. Deploy:  uip codedapp deploy → deploys to UiPath platform
 ```
 
-| Check | Severity | How to Verify |
+| Check | Severity | How to Verify (read-only) |
 |---|---|---|
-| Full lifecycle completes without errors | Critical | Run each step |
-| Published version matches expected version | Warning | Check version after publish |
-| App accessible after deployment | Critical | Verify app URL |
-| Upgrade path works (not just fresh deploy) | Info | Test upgrade scenario |
+| Pack readiness (build output + dry-run pack) | Critical | §2 and §3 results — do not re-run |
+| Version consistent across `package.json`, `.uipath/` metadata, `app.config.json` | Warning | Compare version fields |
+| Prior publish evidence consistent (`app.config.json` present after first publish, IDs match `.uipath/` metadata) | Info | Read app.config.json + `.uipath/` metadata |
+| Upgrade path documented (version bump strategy, release notes — not just fresh deploy) | Info | Check versioning fields + changelog |

--- a/skills/uipath-review/references/flows/flow-common-issues.md
+++ b/skills/uipath-review/references/flows/flow-common-issues.md
@@ -253,28 +253,4 @@ grep "console.log" *.flow
 
 **Severity:** Warning
 
-## API Workflow Antipatterns (Studio Web)
-
-### No Input Schema Enforcement
-
-**Symptom:** API workflow has input schema defined, but the first steps do not validate required inputs. Callers can send malformed payloads and the workflow tries to process them.
-
-**Impact:** NullReferenceException deep in the logic instead of a clear 400 Bad Request. Consumers get unhelpful errors.
-
-**Detection:** Inspect API workflow's initial activities. Check for explicit validation (required-field checks, type validation) before business logic begins.
-
-**Fix:** Add input validation as the first step. Return structured 400 responses with field-specific error messages.
-
-**Severity:** Warning
-
-### Synchronous Long-Running API Workflow
-
-**Symptom:** API workflow performing long-running logic (DB migrations, bulk processing, chained API calls) synchronously. Hard timeout: 10 minutes (5 min CPU for serverless).
-
-**Impact:** Request times out with no result, no recovery path. Caller sees timeout error. Work may be partially complete with no rollback.
-
-**Detection:** API workflow test execution exceeds 5 minutes.
-
-**Fix:** Convert to async pattern — accept request, return job ID, process in background (via queue), let caller poll. Or use `Wait for Event and Resume` for suspend/resume.
-
-**Severity:** Warning
+API workflow antipatterns moved to [api-workflow-review-checklist.md](../api-workflows/api-workflow-review-checklist.md) — API workflows are a separate project type.

--- a/skills/uipath-review/references/flows/flow-review-checklist.md
+++ b/skills/uipath-review/references/flows/flow-review-checklist.md
@@ -2,7 +2,7 @@
 
 Comprehensive quality checklist for UiPath Flow projects (`.flow` files) — orchestration of RPA processes, agents, apps, and human tasks.
 
-> **Unit of Work:** Before running the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. For flows, the declared unit is in the `.flow` file under `variables.globals` with `direction: "in"` or `"inout"`. The actual unit is what the flow body produces — count downstream resource-node invocations and side effects per flow execution. If one flow invocation fans out to N downstream calls over a sub-collection of the input, that is a Granularity Mismatch (see [rpa-common-issues.md](../rpa/rpa-common-issues.md)).
+> **Unit of Work:** Before running the technical checks below, complete Step 3a (Unit of Work Discovery) from SKILL.md. For flows, the declared unit is in the `.flow` file under `variables.globals` with `direction: "in"` or `"inout"`. The actual unit is what the flow body produces — count downstream resource-node invocations and side effects per flow execution. If one flow invocation fans out to N downstream calls over a sub-collection of the input, the shape is one-to-many — assess per Step 3a (see [rpa-common-issues.md](../rpa/rpa-common-issues.md)).
 
 ## 1. Structural Validation
 
@@ -21,7 +21,7 @@ Comprehensive quality checklist for UiPath Flow projects (`.flow` files) — orc
 Run the CLI validator first:
 
 ```bash
-uip maestro flow validate <ProjectName>.flow --output json
+uip maestro flow validate "<PROJECT_NAME>.flow" --output json
 ```
 
 | Check | Severity | How to Verify |
@@ -191,75 +191,18 @@ If the flow uses queues for work distribution:
 | No orphan definitions (types not used by any node) | Info | Cross-reference definitions and nodes |
 | Definition versions match node `typeVersion` | Warning | Compare versions |
 
-## 8. BPMN / Maestro Compliance (If Using Maestro)
+## 8. Maestro BPMN Projects
 
-For flows that target UiPath Maestro execution:
+Maestro BPMN (`.bpmn` + `project.uiproj` with `"ProjectType": "ProcessOrchestration"`) is a separate project type — review it with [bpmn-review-checklist.md](../bpmn/bpmn-review-checklist.md), not this checklist.
 
-### BPMN Element Support (Execution-Ready)
-
-| Element Category | Supported for Execution | Modeling Only |
-|---|---|---|
-| **Start Events** | None, Message, Timer | Error, Signal, Conditional, Compensation, Escalation |
-| **Intermediate Catch** | Message, Timer | Signal, Conditional, Link |
-| **Boundary (Interrupting)** | Message, Timer, Error | Signal, Conditional, Escalation, Compensation |
-| **Boundary (Non-Interrupting)** | Message, Timer | Signal, Conditional, Escalation |
-| **End Events** | None, Message, Error, Terminate | Signal, Escalation, Compensation |
-| **Tasks** | User, Service, Send, Receive, Business Rule, Script, Manual | — |
-| **Gateways** | Exclusive, Parallel, Inclusive, Event-Based | Complex |
-| **Markers** | Multi-instance (parallel/sequential) | Loop, Compensation |
-| **Subprocesses** | Sub-process, Call Activity, Event Sub-process | Transaction |
-
-### Structural Checks
+### Flow vs Maestro BPMN Fitness
 
 | Check | Severity | How to Verify |
 |---|---|---|
-| All BPMN elements used are execution-ready (not modeling-only) | Critical | Compare against support table above |
-| One clear start event and explicit end events | Critical | Check node structure |
-| Parallel gateways have matching parallel join gateways | Critical | Verify parallel synchronization |
-| Inclusive gateways have matching inclusive merge | Critical | Verify inclusive synchronization |
-| Default path defined on exclusive gateways (prevents runtime faults) | Warning | Check gateway configuration |
-| Task sizes are uniform in diagrams | Info | Visual review |
-| Flow direction is left-to-right or top-to-bottom | Info | Check node positions |
-| Separate process flow from business rules (use DMN Business Rule Tasks) | Info | Check for complex conditionals |
-
-### Timer Configuration
-
-| Check | Severity | How to Verify |
-|---|---|---|
-| Timer events use valid ISO 8601 durations (e.g., `PT1H`, `P1D`, `R/PT5M`) | Critical | Check timer values |
-| Timer boundary events configured for long-running tasks (SLA enforcement) | Info | Check boundary events |
-| Non-interrupting timers used when parallel execution is needed | Info | Check timer interrupt mode |
-| Cycle timers use correct repeat format (`R/P[duration]`) | Warning | Check cycle syntax |
-
-### Multi-Instance Configuration
-
-| Check | Severity | How to Verify |
-|---|---|---|
-| Parallel multi-instance batch size appropriate (runs in batches of 50) | Info | Check batch config |
-| Sequential multi-instance used when item ordering matters | Warning | Verify ordering requirement |
-| Multi-instance loops configured to **continue on individual item failure** (one item's error does not halt the entire batch) | Warning | Check multi-instance configuration for continueOnException/continue-on-failure flag. Batches of 50 where item #15 fails should still process items 16..50 |
-| Entry-points UUIDs are unique (no duplicates across entries in `entry-points.json`) | Critical | Parse `entry-points.json`, check for duplicate `uniqueId` values. Duplicates block publishing |
-| Nested loops use subprocess pattern (outer sequential, inner parallel) | Info | Check nesting pattern |
-
-### Error Handling in BPMN
-
-| Check | Severity | How to Verify |
-|---|---|---|
-| Error boundary events attached to tasks with failure risk | Warning | Check boundary events |
-| Error end events used for unrecoverable failures | Info | Check error paths |
-| Event subprocesses configured for centralized error handling | Info | Check event subprocesses |
-| Error mappings configured at element level (first match wins) | Warning | Check error mapping order |
-
-### Maestro vs Flow Decision
-
-If the project uses the simple Flow format (not full Maestro BPMN):
-
-| Check | Severity | How to Verify |
-|---|---|---|
-| Flow complexity appropriate (simple flows don't need Maestro) | Info | Assess process complexity |
-| Long-running processes use Maestro (not simple flows) | Warning | Check process duration |
-| Human-in-the-loop steps use Maestro User Tasks | Warning | Check for HITL requirements |
-| Process mining integration needed → use Maestro (auto-creates Process Optimization apps) | Info | Check monitoring needs |
+| Flow complexity appropriate (simple flows don't need Maestro BPMN) | Info | Assess process complexity |
+| Long-running, multi-actor processes use Maestro BPMN (not simple flows) | Warning | Check process duration and actor mix |
+| Human-in-the-loop steps needing case tracking/SLA use Maestro User Tasks | Warning | Check for HITL requirements |
+| Process mining integration needed → Maestro BPMN (auto-creates Process Optimization apps) | Info | Check monitoring needs |
 
 ## 9. Performance and Optimization
 
@@ -280,7 +223,9 @@ If the project uses the simple Flow format (not full Maestro BPMN):
 | No mock placeholder nodes remain | Critical | Grep for `core.logic.mock` |
 | Entry points correctly defined | Warning | Check entry-points.json |
 | Environment-specific values externalized | Warning | Check for hardcoded URLs/paths |
-| Debug flow succeeds end-to-end | Warning | `uip maestro flow debug <project-dir>` |
+| Entry-point `uniqueId` values unique (duplicates block publishing) | Critical | Parse `entry-points.json` for duplicate `uniqueId` values |
+
+> Do NOT execute the flow (`uip maestro flow debug` / `run`) during review — review is read-only. Runtime verification routes to `uipath-maestro-flow`.
 
 ## 11. Action Center / Human-in-the-Loop
 


### PR DESCRIPTION
## Problem

A full audit of `uipath-review` (SKILL.md + all 25 references, cross-checked against the CLI catalog snapshot and sibling domain skills) found two contract-level defects:

1. **Read-only violations.** Critical Rule 1 says the skill NEVER modifies anything, but `coded-app-review-checklist.md` §9 instructed the reviewer to run the full deployment lifecycle — `npm run build`, `uip codedapp publish`, `uip codedapp deploy` — and verify the app URL post-deploy ("Full lifecycle completes without errors | Critical | Run each step"). §2 also instructed running the build. `flow-review-checklist.md` §10 told the reviewer to run `uip maestro flow debug` (executes the flow, invoking real resource nodes).
2. **BPMN and API workflows promised but unreviewable.** The frontmatter description and README claim `.bpmn` coverage, but the Step 1 detection table had no `.bpmn` row, Step 2c no validation command, and no checklist existed — a `.bpmn` project fell through classification entirely. The only BPMN content sat inside the *flow* checklist (§8), conflating Maestro Flow with Maestro BPMN. API workflows likewise: listed as a unit-of-work type in Step 3a, but their only coverage was two antipatterns misfiled at the bottom of `flow-common-issues.md`.

## Changes

**Read-only restoration**
- Rewrote coded-app §9 as "Deployment Lifecycle Readiness": evidence-based checks (version consistency across `package.json`/`.uipath/`/`app.config.json`, prior-publish evidence, documented upgrade path); publish/deploy explicitly routed to `uipath-coded-apps`. Dry-run pack remains the only sanctioned command.
- Coded-app §2: verify existing build output; a missing `dist/` is a finding, not a build trigger.
- Flow §10: dropped the `flow debug` row; added an explicit do-not-execute note routing runtime verification to `uipath-maestro-flow`. Added the entry-point `uniqueId` duplicate check (previously buried in §8).

**BPMN + API workflow coverage**
- New `references/bpmn/bpmn-review-checklist.md` — project markers (`project.uiproj` `ProjectType: ProcessOrchestration` + `.bpmn`, per the `uip maestro init` scaffold), `uip maestro bpmn validate --output json` (verb confirmed in `assets/uip-catalog-snapshot.json` @ CLI 1.197.0-alpha), plus the element-support, gateway-pairing, timer, multi-instance, error-handling content extracted from flow §8, and an actor-fitness section.
- New `references/api-workflows/api-workflow-review-checklist.md` — markers (`ProjectType: Api` + `Workflow.json` with `document.dsl`/`do[]`), `uip api-workflow validate --output json` (offline: no auth/network/side effects — review-safe) with its output contract, an explicit **never run `uip api-workflow run`** rule (vendor side effects), design-quality checks, and the two antipatterns relocated from flow-common-issues.
- SKILL.md: two detection rows, two Step 2c validation rows + older-CLI fallback note ("Rules Skipped"), Critical Rules 1–2 updated, executable-project definition extended to `project.uiproj` types, Step 0a probe extended (`*.bpmn`, `project.uiproj`), Step 3a table row for BPMN, routing table + Task Navigation entries for both new checklists.
- Flow §8 reduced to a redirect + a "Flow vs Maestro BPMN fitness" table.

**Consistency fixes in touched files**: banned "Granularity Mismatch" vocabulary replaced with Step 3a shape terms (coded-app:5, flow:5); placeholder style normalized to `<UPPER_SNAKE_CASE>` in the Step 2c table and flow validate example; `--output json` added to the coded-app dry-run row (Critical Rule 6).

Note: `uip maestro bpmn validate` shipped in CLI `1.197.0-alpha.20260623` (catalog refreshed 2026-06-24) — two days after the `uipath-maestro-bpmn` skill wrote "no such command", so both new commands carry a graceful unknown-command fallback.

## Testing
- Relative-link check across the skill: no broken links introduced (1 pre-existing broken link in `agents/agent-review-checklist.md:204` is tracked separately).
- No retired CLI verbs introduced; both new verbs verified against `assets/uip-catalog-snapshot.json`.
- Frontmatter untouched (no activation-gate impact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)