### PR TITLE
cherry-pick: align api-workflow skill with CLI project surface (#1744)

### DIFF
--- a/skills/uipath-api-workflow/SKILL.md
+++ b/skills/uipath-api-workflow/SKILL.md
@@ -74,7 +74,18 @@ Do NOT use for: `.flow` Maestro flows (→ `uipath-maestro-flow`), `.xaml` / cod
     - **(Solutions-mode + IntSvc only)** sync the connection into the catalogue: `uip api-workflow bindings sync --workflow <Workflow.json>` then `uip solution resource refresh --solution-folder <path>`. Skip for Http kind, non-connector activities, and standalone (no `Solution/`) projects.
 17. **Pass input as a JSON string.** `--input-arguments '{"key":"value"}'`. Invalid JSON exits 1.
 18. **Always `--output json`** when parsing CLI output programmatically. Success → `{ "Result": "Success", "Code": "WorkflowRun", "Data": {...} }`. Failure → `{ "Result": "Failure", "Message": "...", "Instructions": "..." }` with exit 1.
-19. **Build & publish goes through the solution packager.** API workflows pack via `uip solution pack <solutionDir> <outputDir>` and publish via `uip solution publish <package.zip>`. There is no `uip api-workflow build` or `uip api-workflow publish` command. Project type must be `"Api"` in the solution `.uipx`.
+19. **Scaffold with `uip api-workflow init`; publish goes through the solution packager.** Create every API workflow project with `uip api-workflow init <name>` (rule 19a) — never hand-assemble the project files. Project-level CLI commands also exist: `uip api-workflow build <projectDir>` (compile) and `uip api-workflow pack <projectDir> <outputDir>` (single-project `.nupkg`, useful to test one project in isolation). Solution-level build/publish go through `uip solution pack <solutionDir> <outputDir>` + `uip solution publish <package.zip>`. There is NO `uip api-workflow publish` command. Project type must be `"Api"` in the solution `.uipx`.
+
+19a. **Create projects with `uip api-workflow init <name>` — it produces the correct Studio Web editable shape and wires the solution.** Run it from inside the solution directory (the folder containing the `.uipx`):
+    ```bash
+    uip api-workflow init <name> --output json   # add --skip-solution-registration for a standalone (no .uipx) project
+    ```
+    It scaffolds `project.uiproj` + `Workflow.json` + `entry-points.json` + `bindings_v2.json` and, when run inside a solution, **auto-registers the project in the surrounding `.uipx`** (correct `ProjectRelativePath` + a fresh `Id`). Success → `Code: "ApiWorkflowInit"`. Then edit `Workflow.json` only.
+
+    **Why it matters:** a legacy `project.json` + `workflows/WF_*.json` layout (no `.uiproj`) passes every runtime gate — `validate`, `run`, `pack`, `publish`, deploy — but Studio Web rejects it as `invalid_project_folder` and never shows it. `init` is the one step that can't produce the wrong shape. Full layout + field rules: [references/workflow-file-format.md](references/workflow-file-format.md#project-structure-studio-web-editable-contract).
+
+    To **convert a legacy `project.json` project**, `init` a fresh sibling and move the existing workflow content into its `Workflow.json` (cleanest), or convert in place — see [references/troubleshooting.md](references/troubleshooting.md). Never wire it with `uip solution project add/remove` (errors on an already-registered name; `remove`+`add` destroys the project `Id`).
+
 20. **`uip api-workflow validate <Workflow.json>` is the autonomous closure step for every authoring or edit cycle.** Run it as the LAST command before asking the user anything about runtime. It's offline (no auth, no network, no side effects): JSON Schema + semantic checks on the static file. Output codes:
     - `Result: "Success"`, `Code: "ApiwfValidate"`, `Data.Status: "Valid"` (exit 0) — possibly with `Data.Warnings`. Proceed to rule 21 (ask the user whether to run).
     - `Result: "Failure"` (exit 1) — do NOT bother the user. Read `Instructions`, locate the offending activity by its JSON path (e.g. `/do/0/Sequence_1/do/2/Mystery_1/metadata/activityType`), edit `Workflow.json` to fix it, then re-validate. Loop until pass.
@@ -173,7 +184,7 @@ Fix run failures in category order — **Structure > Expression > Activity Confi
 
 ### Phase 4: Package and Publish
 
-Once the workflow runs locally, deploy via the solution packager.
+Once the workflow runs locally, deploy via the solution packager. If the project must open in Studio Web, confirm it uses the `init`-produced shape first (rule 19a) — runtime/pack success does not prove it.
 
 **Pack:**
 ```bash
@@ -197,20 +208,26 @@ Requires `uip login`.
 ## Quick Start (CREATE from scratch)
 
 ```bash
-# 1. Copy the empty template
-cp ./.claude/plugins/uipath/skills/uipath-api-workflow/assets/templates/api-workflow-template.json \
-   ./MyApiProject/main.json
+# 0. Create the solution (skip if one already exists). Creates ./MySolution/ with the .uipx.
+uip solution init MySolution --output json
 
-# 2. Edit main.json to add user activities after WorkflowStart inside the root sequence
+# 1. Scaffold the project — correct Studio Web shape + auto-registers in the .uipx (rule 19a).
+#    init's <name> arg takes no slashes, so cd into the solution dir first; it registers the
+#    project in the nearest parent .uipx. Creates MyApiProject/ with project.uiproj,
+#    Workflow.json, entry-points.json, bindings_v2.json.
+cd ./MySolution
+uip api-workflow init MyApiProject --output json
+
+# 2. Edit MyApiProject/Workflow.json to add user activities after WorkflowStart inside the root sequence
 
 # 3. Validate (offline, autonomous — fix + re-validate until Status: Valid)
-uip api-workflow validate ./MyApiProject/main.json --output json
+uip api-workflow validate ./MyApiProject/Workflow.json --output json
 
 # 4. Ask the user, then run (only on user "yes")
-uip api-workflow run ./MyApiProject/main.json --no-auth --output json
+uip api-workflow run ./MyApiProject/Workflow.json --no-auth --output json
 
-# 5. Package
-uip solution pack ./MySolution ./build --name MyApiSolution --version 1.0.0 --output json
+# 5. Package (cwd is the solution dir)
+uip solution pack . ./build --name MyApiSolution --version 1.0.0 --output json
 
 # 6. Publish
 uip login
@@ -227,7 +244,7 @@ uip solution publish ./build/MyApiSolution.zip --tenant MyTenant --output json
 | [references/control-flow-patterns.md](references/control-flow-patterns.md) | Combining activities into hierarchical structures — nested If, ForEach inside DoWhile, TryCatch around/inside loops, conditional Break, multi-way branching, key uniqueness rules |
 | [references/connector-activity-discovery.md](references/connector-activity-discovery.md) | Authoring HTTP Request / Gmail / Outlook / GitHub / Slack / etc. activities via `uip api-workflow registry resolve` + `stub` — three-step flow, sample stub output, field-shape rules, multipart subsection, worked examples |
 | [references/expressions-and-context.md](references/expressions-and-context.md) | Writing JS expressions, propagating outputs via `export.as`, accessing `$context` / `$input` / `$workflow`, JS_Invoke argument passing, strict-mode gotchas, key patterns |
-| [references/cli-reference.md](references/cli-reference.md) | All `uip` commands — `api-workflow run`, `solution pack`, `solution publish`, `solution new`, `login` |
+| [references/cli-reference.md](references/cli-reference.md) | All `uip` commands — `api-workflow init`, `run`, `build`, `pack`, `validate`, `solution init`, `solution pack`, `solution publish`, `login` |
 | [references/troubleshooting.md](references/troubleshooting.md) | Failed runs, structure/expression/loop/nesting/response/validation pitfalls, packaging errors, publish errors, debugging strategy |
 
 ## Templates
@@ -251,6 +268,9 @@ The mistakes an agent makes most often (each maps to a Critical Rule above — s
 - **Do NOT** ship a `<REPLACE_WITH_*>` placeholder in a workflow — StudioWeb renders it as a broken connection and it 401s. No pinged UUID → ask the user. See rule 16.
 - **Do NOT** read workflow inputs as `$input.<name>` from a non-first activity — use `$workflow.input.<name>`. See rule 13.
 - **Do NOT** invoke `uip api-workflow run` autonomously, and never with auth without an explicit "yes" — vendor calls have irreversible side effects (emails sent, tickets created). See rules 20–21.
+- **Do NOT** hand-assemble a project (`project.json` + `main.json`/`workflows/WF_*.json`). Scaffold with `uip api-workflow init <name>` — it writes the correct `project.uiproj` shape and registers it in the `.uipx`. The legacy `project.json`-only shape runs and packs but Studio Web rejects it (`invalid_project_folder`) and never shows it. See rules 19–19a.
+- **Do NOT** wire a project into the solution with `uip solution project add/remove` — it errors on an already-registered name, and `remove`+`add` destroys the project `Id`. `init` registers it; for an already-built project, edit the `.uipx` `ProjectRelativePath` in place. See rule 19a.
+- **Do NOT** trust "it packed / published / ran" as proof a project opens in Studio Web — every runtime gate passes on the wrong shape. Scaffolding with `init` is what guarantees it (rule 19a).
 
 ## Infinite Loop Prevention
 

--- a/skills/uipath-api-workflow/references/cli-reference.md
+++ b/skills/uipath-api-workflow/references/cli-reference.md
@@ -2,6 +2,88 @@
 
 All `uip` commands relevant to authoring, running, packaging, and publishing API workflows. The api-workflow-tool ships with `@uipath/cli` (no separate install).
 
+## `uip api-workflow init`
+
+Scaffold a new API workflow project in the **correct Studio Web editable shape**. This is the canonical way to create a project — do NOT hand-assemble the files.
+
+```bash
+uip api-workflow init <name> \
+  [--force] \
+  [--skip-solution-registration] \
+  [--output json]
+```
+
+| Argument / Flag | Required | Description |
+|-----------------|----------|-------------|
+| `<name>` | yes | Project name (and folder created under the cwd). Letters, numbers, spaces, `_`, `-` only. |
+| `--force` | no | Write files even if the target directory is non-empty (does not clear existing contents). |
+| `--skip-solution-registration` | no | Do NOT auto-register the project in the surrounding solution `.uipx`. Use for standalone (CLI-only) projects. |
+
+Run it from inside the solution directory (the folder containing the `.uipx`) so it auto-registers the project. It writes four files into `<name>/`:
+
+| File | Content |
+|------|---------|
+| `project.uiproj` | `{ "ProjectType": "Api", "Name": "<name>", "Description": null, "MainFile": "Workflow.json" }` |
+| `Workflow.json` | The `WorkflowStart` skeleton (same as the empty template) |
+| `entry-points.json` | `$schema`/`$id`, one entry: `filePath: "content/Workflow.json"`, fresh `uniqueId`, `type: "Api"`, `input`/`output` null |
+| `bindings_v2.json` | `{ "version": "2.0", "resources": [] }` |
+
+When run inside a solution, it also appends the project to the `.uipx` `Projects` array (`ProjectRelativePath: "<name>/project.uiproj"`, a fresh `Id`, `Type: "Api"`). It does NOT write `.local/ProjectSettings.json` — Studio Web creates that on first open; do not author it by hand.
+
+### Success output
+
+```json
+{
+  "Result": "Success",
+  "Code": "ApiWorkflowInit",
+  "Data": {
+    "Status": "Created successfully",
+    "Path": "<projectDir>",
+    "SolutionRegistration": { /* registration result; NextSteps when applicable */ }
+  }
+}
+```
+
+Failure (`Result: "Failure"`, exit 1) on an invalid name or a non-empty directory without `--force` (`Message: "Failed to create API Workflow project"`, details in `Instructions`).
+
+## `uip api-workflow build`
+
+Build (compile) a single API workflow project — a fast project-scoped check that does not touch unrelated projects in a solution.
+
+```bash
+uip api-workflow build <project-path> [--output json]
+```
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<project-path>` | yes | Path to the API workflow project directory or `.uip` file. |
+
+Output: `{ "Result": "Success", "Code": "ApiWorkflowBuild", "Data": { "Success": true } }`. Exit 1 on failure.
+
+## `uip api-workflow pack`
+
+Pack a single API workflow project into a `.nupkg`. Use to verify one project in isolation; full solution packaging still goes through `uip solution pack`.
+
+```bash
+uip api-workflow pack <project-path> <destinationPath> \
+  [--package-id <id>] \
+  [--package-version <version>] \
+  [--signing-certificate-path <path>] \
+  [--signing-certificate-password <password>] \
+  [--signing-timestamp-server <url>] \
+  [--output json]
+```
+
+| Argument / Flag | Required | Description |
+|-----------------|----------|-------------|
+| `<project-path>` | yes | API workflow project directory or `.uip` file. |
+| `<destinationPath>` | yes | Directory where the `.nupkg` is written. |
+| `--package-id <id>` | no | NuGet package ID. |
+| `--package-version <version>` | no | NuGet package version. |
+| `--signing-*` | no | Optional package signing (certificate path/password, timestamp server). |
+
+Output: `{ "Result": "Success", "Code": "ApiWorkflowPack", "Data": { "Success": true, "Packages": ["<path>.nupkg"] } }`. Exit 1 on failure.
+
 ## `uip api-workflow run`
 
 Execute an API workflow JSON file locally using the Serverless Workflow executor.
@@ -314,23 +396,23 @@ Sample output (Outlook `getNewestEmail`, `--operation List`):
 
 For every entry with `required: true`, confirm the stub's emitted activity has a value at `with.<location>Parameters.<name>`. Re-stub with `--inputs '{"<name>":"<value>"}'` or hand-edit. See [connector-activity-discovery.md — Required-field cross-check](connector-activity-discovery.md#required-field-cross-check--the-stub-drops-required-true-request-fields) and [troubleshooting.md](troubleshooting.md#required-request-field-dropped-by-registry-stub).
 
-## `uip solution new`
+## `uip solution init`
 
-Create an empty solution file. Required before adding API workflow projects.
+Initialize a new empty solution. Required before adding API workflow projects. (Formerly `uip solution new` — that verb was retired; `new` now errors `unknown command 'new'`.)
 
 ```bash
-uip solution new <solutionName> [--output json]
+uip solution init <solutionName> [--output json]
 ```
 
 | Argument | Description |
 |----------|-------------|
-| `<solutionName>` | Solution name or path. Appends `.uipx` if no extension. Creates a folder with the same base name. |
+| `<solutionName>` | Solution name or path. Creates a directory with this name containing a `.uipx` manifest (empty `Projects` array) plus `AGENTS.md`/`CLAUDE.md` briefing files. |
 
-Output: `{ "Result": "Success", "Code": "SolutionNew", "Data": { "Path": "<file>" } }`.
+Output: `{ "Result": "Success", "Code": "SolutionInit", "Data": { "Status": "Created successfully", ... } }`.
 
 ## `uip solution project add` *(scope: solution-tool)*
 
-Add an API workflow project (folder containing `project.json` with `Type: "Api"`) to a solution. See `uip solution project add --help` for current flags.
+For **new** API workflow projects, prefer `uip api-workflow init <name>` run inside the solution directory — it scaffolds the correct `project.uiproj` shape AND auto-registers the project in the `.uipx`. `uip solution project add` errors (`Project name already exists`) on an already-registered project, and `remove`+`add` destroys the project `Id`. Reserve direct `.uipx` edits for converting a legacy `project.json` project in place (change only `ProjectRelativePath` → `<folder>/project.uiproj`, preserve `Id`/`Type`). A registerable project folder must contain `project.uiproj` (`ProjectType: "Api"`) + `Workflow.json` + `entry-points.json` — see [workflow-file-format.md](workflow-file-format.md#project-structure-studio-web-editable-contract) and SKILL.md rule 19a. See `uip solution project add --help` for current flags.
 
 ## `uip solution pack`
 
@@ -356,7 +438,7 @@ uip solution pack <solutionPath> <outputPath> \
 
 For each `Type: "Api"` project:
 
-1. Validates project structure (must contain `project.json`)
+1. Reads the project file — `project.uiproj` (`ProjectType: "Api"`) for the Studio Web editable shape — and the entry point from `entry-points.json`
 2. Copies workflow JSON files to a clean output directory
 3. Generates `operate.json` — runtime configuration consumed by the executor
 4. Generates `package-descriptor.json` — manifest for the Cloud platform
@@ -401,22 +483,26 @@ Activate / configure / inspect a published solution. Subcommands: `deploy run`, 
 ## End-to-End Example
 
 ```bash
-# 1. Author the workflow
-cp ./.claude/plugins/uipath/skills/uipath-api-workflow/assets/templates/api-workflow-template.json \
-   ./MyApiProject/main.json
-# ... edit main.json to add tasks ...
+# 0. (once) create the solution if you don't have one
+uip solution init MySolution --output json
+
+# 1. Scaffold the project in the correct Studio Web shape + register it in the .uipx (rule 19a).
+#    init's <name> takes no slashes — cd into the solution dir so it finds the parent .uipx.
+cd ./MySolution
+uip api-workflow init MyApiProject --output json
+# ... edit MyApiProject/Workflow.json to add tasks ...
 
 # 2. Local smoke test
-uip api-workflow run ./MyApiProject/main.json --no-auth --output json
+uip api-workflow run ./MyApiProject/Workflow.json --no-auth --output json
 
 # 3. Authenticate (only needed for publish / deploy)
 uip login
 
 # 4. Authenticated run
-uip api-workflow run ./MyApiProject/main.json --output json
+uip api-workflow run ./MyApiProject/Workflow.json --output json
 
 # 5. Pack the solution
-uip solution pack ./MySolution ./build \
+uip solution pack . ./build \
   --name MyApiSolution \
   --version 1.0.0 \
   --output json
@@ -431,8 +517,7 @@ uip solution publish ./build/MyApiSolution.zip \
 
 The agent should not invent these — they are NOT part of the api-workflow-tool surface:
 
-- `uip api-workflow publish` <!-- uip-check-skip -->
-- `uip api-workflow init` <!-- uip-check-skip -->
+- `uip api-workflow publish` <!-- uip-check-skip --> (publish goes through `uip solution publish`)
 - `uip apw <anything>` (no alias) <!-- uip-check-skip -->
 
-Build / publish go through `uip solution pack` / `uip solution publish`. Validation is done by running with `--no-auth`.
+These DO exist (don't route around them): `uip api-workflow init` (scaffold), `uip api-workflow build` (compile one project), `uip api-workflow pack` (one-project `.nupkg`). Solution-level packaging/publishing go through `uip solution pack` / `uip solution publish`. Offline validation is `uip api-workflow validate` (or running with `--no-auth`).

--- a/skills/uipath-api-workflow/references/troubleshooting.md
+++ b/skills/uipath-api-workflow/references/troubleshooting.md
@@ -569,7 +569,7 @@ These are issues that surface only when a workflow is opened or run in **StudioW
 
 ### `Failed to parse <solution>.uipx`
 - **Cause:** Solution file is malformed JSON
-- **Fix:** Re-create with `uip solution new <name>` and re-add projects via `uip solution project add`
+- **Fix:** Re-create with `uip solution init <name>` and re-add projects via `uip solution project add`
 
 ### Generated `operate.json` or `package-descriptor.json` mismatch
 - **Cause:** Stale files committed by hand or from an older CLI version
@@ -577,7 +577,18 @@ These are issues that surface only when a workflow is opened or run in **StudioW
 
 ### `.nupkg` produced but missing workflow files
 - **Cause:** Workflow JSON not located in the project directory the packager scanned
-- **Fix:** Verify workflow files are in the project folder declared in the solution `.uipx`, alongside `project.json`
+- **Fix:** Verify `Workflow.json` is in the project folder whose `project.uiproj` is declared in the solution `.uipx`
+
+### API workflow runs/deploys fine but does NOT appear or open in Studio Web
+- **Symptom:** The workflow runs under `uip api-workflow run`, the solution packs, publishes, and deploys as an API process — but after uploading the solution to Studio Web the API project is invisible / not editable. Importing it directly fails with `Failed to import new projects at the overwrite operations`.
+- **Cause:** The project uses the **runtime-only** shape — `project.json` + `workflows/WF_*.json`, no `.uiproj`. Studio Web's import (`isProjectFolder`) only recognizes a folder as a project when it contains a `.uiproj` file; a `project.json`-only folder is rejected as `invalid_project_folder`. Every runtime gate (validate / run / pack / publish / deploy) passes on this shape, so the defect surfaces only when a human opens Studio Web. This was the Woolworths private-preview RCA root cause. Root reason it happened: the project was hand-assembled instead of scaffolded with `uip api-workflow init`, which always produces the correct shape.
+- **Fix (preferred — re-scaffold):** For each broken `Type: "Api"` project, run `uip api-workflow init <newName>` inside the solution directory and copy the old main workflow's `document`/`do` content into the new `Workflow.json`. `init` writes the correct `project.uiproj` / `entry-points.json` / `bindings_v2.json` and registers the project in the `.uipx`. Then delete the old `project.json` folder (and its `.uipx` entry).
+- **Fix (in-place conversion)** when you must keep the existing folder/`Id` (SKILL.md rule 19a, [workflow-file-format.md](workflow-file-format.md#project-structure-studio-web-editable-contract)):
+  - Add `project.uiproj` (`ProjectType: "Api"`, `MainFile: "Workflow.json"`) and `entry-points.json` (`filePath: "content/Workflow.json"`, no leading slash, `type: "Api"`). Copy `bindings_v2.json` if present.
+  - Rename the main workflow to `Workflow.json` at the project root.
+  - Edit the `.uipx` `ProjectRelativePath` from `<folder>/project.json` → `<folder>/project.uiproj`, **preserving the project `Id` and `Type`**. Do NOT use `uip solution project remove`+`add` — it mints a new `Id`.
+  - Remove the stray `project.json` / `workflows/` (a mismatched `project.json` triggers `ProjectMetadataMismatchError`).
+  - Re-pack, then confirm the project opens in Studio Web (runtime/pack success alone does not prove it).
 
 ---
 
@@ -599,10 +610,10 @@ These are issues that surface only when a workflow is opened or run in **StudioW
 
 ## Validation Pitfalls
 
-### Not re-running after a fix
+### Not re-validating after a fix
 - **Symptom:** Reported "fixed" but errors remain
-- **Cause:** Skipped re-running `uip api-workflow run --no-auth` after applying a fix
-- **Fix:** ALWAYS re-run after every edit. The CLI is the only validator — there is no `uip api-workflow validate` command.
+- **Cause:** Skipped re-running the validators after applying a fix
+- **Fix:** ALWAYS re-run after every edit. Two validators: `uip api-workflow validate <Workflow.json>` (offline static — schema + semantic checks, autonomous) then `uip api-workflow run --no-auth` (runtime — catches expression/connection errors static analysis can't). See SKILL.md rules 20–21.
 
 ### Fixing in wrong order
 - **Symptom:** Fixing one error creates more errors; thrashing

--- a/skills/uipath-api-workflow/references/workflow-file-format.md
+++ b/skills/uipath-api-workflow/references/workflow-file-format.md
@@ -184,20 +184,38 @@ A `Sequence` task groups child tasks. Most workflows have a single root `Sequenc
 
 Child tasks execute in order. `$context` flows from one to the next via `export.as`.
 
-## Project Structure (Packaging Context)
+## Project Structure (Studio Web editable contract)
 
-When part of a UiPath solution, the workflow JSON sits in a project folder with `Type: "Api"` declared in the solution `.uipx`:
+An API workflow project that must open and edit in **Studio Web** ships a specific on-disk shape. **`uip api-workflow init <name>` generates this shape for you** (and registers the project in the solution `.uipx`) — use it for new projects instead of writing these files by hand. The layout below is the contract `init` produces and what `uip solution pack` reads via `project.uiproj`; it also documents what to recreate when converting a legacy `project.json` project:
 
 ```
 <solutionDir>/
-├── <solution>.uipx          # Lists all projects with their Type
-└── <projectFolder>/
-    ├── project.json         # Project metadata
-    ├── <main-workflow>.json # Your API workflow
-    └── <other-workflow>.json
+├── <solution>.uipx                 # Projects[].Type "Api", ProjectRelativePath "<projectFolder>/project.uiproj"
+└── <projectFolder>/                # created by `uip api-workflow init <projectFolder>`
+    ├── project.uiproj              # { "ProjectType": "Api", "Name": "...", "Description": null, "MainFile": "Workflow.json" }
+    ├── Workflow.json               # the API workflow — canonical fixed name, project root
+    ├── entry-points.json           # entryPoints[0]: filePath "content/Workflow.json", type "Api"
+    ├── bindings_v2.json            # IntSvc connector bindings ({"version":"2.0","resources":[]} when none)
+    └── .local/ProjectSettings.json # NOT written by init — Studio Web creates it on first open. Do not author by hand.
 ```
 
 `uip solution pack` auto-generates `operate.json` and `package-descriptor.json` during build — do NOT commit these.
+
+### Field rules (what Studio Web enforces)
+
+| File | Field | Rule |
+|------|-------|------|
+| `.uipx` | `Projects[].ProjectRelativePath` | MUST end with `/project.uiproj`. Pointing at `project.json` → folder isn't recognized as a project. |
+| `.uipx` | `Projects[].Type` | `"Api"`. |
+| `project.uiproj` | `ProjectType` | Exactly `"Api"` (capital A). Studio Web parses this with a strict enum — `"api"` is rejected with `InvalidUiprojFileError`. |
+| `project.uiproj` | `MainFile` | `"Workflow.json"`. Studio Web technically accepts any name, but the CLI packager + solution reconcile assume `Workflow.json`. |
+| `Workflow.json` | — | Must exist at project root (the file `MainFile` points to). |
+| `entry-points.json` | `entryPoints[0].filePath` | `"content/Workflow.json"` — relative, **no leading slash**. (`/content/...` is non-canonical.) |
+| `entry-points.json` | `entryPoints[0].type` | `"Api"`. (Studio Web's schema accepts any string here, but stay consistent.) `input`/`output` may be `null` or mirror the workflow's input/output JSON schema so the designer shows parameters. |
+
+> **Why this matters — the runtime shape is a trap.** A `project.json` + `workflows/WF_*.json` layout (no `.uiproj`) runs under `uip api-workflow run`, and packs/publishes/deploys as an API process — every runtime gate passes. But Studio Web's import only recognizes a folder as a project if it contains a `.uiproj` file (`isProjectFolder`); a `project.json`-only project is rejected as `invalid_project_folder` and never appears in Studio Web. Runtime success is NOT proof of Studio Web editability. Scaffold with `uip api-workflow init` — it can't produce the wrong shape (SKILL.md rule 19a).
+
+> **Standalone (CLI-only) projects** that never open in Studio Web — run purely via `uip api-workflow run` — don't need solution registration; `uip api-workflow init <name> --skip-solution-registration` still emits the same files but skips the `.uipx` wiring. The `.uiproj` contract is required the moment the project must be editable in Studio Web or shipped in a solution uploaded to Studio Web.
 
 ## Sources
 

--- a/tests/tasks/uipath-api-workflow/package/package_solution.yaml
+++ b/tests/tasks/uipath-api-workflow/package/package_solution.yaml
@@ -2,9 +2,10 @@ task_id: skill-api-workflow-package-solution
 description: >
   Skill-guided evaluation: agent authors an API workflow and packages it into a
   deployable solution artifact via the solution packager. Tests whether the
-  skill teaches the build/publish path (rule 19 — API workflows pack via
-  `uip solution pack`, not a non-existent `uip api-workflow build`) and the
-  Phase 4 packaging step. Local-only (pack does not publish, needs no auth).
+  skill teaches the build/publish path (rule 19 — a multi-project solution is
+  packaged via `uip solution pack`, not the project-scoped `uip api-workflow
+  pack`/`build`) and the Phase 4 packaging step. Local-only (pack does not
+  publish, needs no auth).
 tags: [uipath-api-workflow, integration, mode:build, lifecycle:generate]
 
 initial_prompt: |


### PR DESCRIPTION
## What

Cherry-picks **a1aac253c** (`fix(api-workflow): align skill with the CLI's actual project surface (init/build/pack)`, originally #1744) onto `release/v1.197`.

## Why

`release/v1.197` was cut before #1744 landed on `main`, so the API Workflow skill in the release still described a stale project surface. This aligns the release's skill docs (`init`/`build`/`pack`) with the CLI's actual behavior.

## Scope

Clean, single-commit cherry-pick — api-workflow-only, applied with **no conflicts** (0 behind / 1 ahead of `release/v1.197`). Files changed (+178 / −43):
- `skills/uipath-api-workflow/SKILL.md`
- `skills/uipath-api-workflow/references/cli-reference.md`
- `skills/uipath-api-workflow/references/troubleshooting.md`
- `skills/uipath-api-workflow/references/workflow-file-format.md`
- `tests/tasks/uipath-api-workflow/package/package_solution.yaml`

Docs/skill-content + one test-task path change only. No behavioral code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)