### PR TITLE
fix(maestro-flow-skill): remove stale v1.6 node type from HITL plugin docs

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -24,11 +24,10 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
 ```json
 {
   "id": "hitlReview1",
-  "type": "uipath.human-in-the-loop",
+  "type": "uipath.human-in-the-loop.quick-form",
   "typeVersion": "1.0",
   "display": { "label": "Invoice Review" },
   "inputs": {
-    "type": "quick",
     "schema": {
       "schemaId": "<uuid>",
       "fields": [
@@ -120,11 +119,10 @@ Full step-by-step (app search → retrieve-configuration → resource files → 
 ```json
 {
   "id": "invoiceReview1",
-  "type": "uipath.human-in-the-loop",
+  "type": "uipath.human-in-the-loop.coded-action-app",
   "typeVersion": "<DEFINITION_VERSION>",
   "display": { "label": "Invoice Review" },
   "inputs": {
-    "type": "custom",
     "recipient": { "channels": ["ActionCenter"], "connections": {}, "assignee": { "type": "group" } },
     "app": {
       "displayName": "Invoice Approval",

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -71,7 +71,7 @@ For add, delete, and wiring procedures, see [editing-operations.md](../../editin
 - **Output fields**: `variable: "<globalName>"` (plain name, **no** `vars.` prefix). No `binding`.
 - **InOut fields**: both `binding` and `variable`, same formats as above.
 - `schemaId` (not `id`) at the schema level — generate a fresh UUID.
-- `typeVersion` — always `"1.0"` for `uipath.human-in-the-loop`. **Do not run `registry get` to derive this value; do not use `"1.1"` or any other version.** The OOTB HITL node version is stable at `1.0`.
+- `typeVersion` — always `"1.0"` for `uipath.human-in-the-loop.quick-form`. **Do not run `registry get` to derive this value; do not use `"1.1"` or any other version.** The OOTB HITL node version is stable at `1.0`.
 - No `model` block on node instances — only the definition carries it.
 
 **outputs block**: only `output` (with `properties` for output/inOut fields + `Action` outcome) and `status` (with `enum`/`default` from outcomes). No per-field `custom: true` entries.
@@ -173,6 +173,8 @@ Full step-by-step (app search → retrieve-configuration → resource files → 
   }
 }
 ```
+
+**`typeVersion`** — fill in the version returned by `uip maestro flow registry get <appKey>` for the specific deployed app. Unlike QuickForm (always `"1.0"`), AppTask version varies per app definition.
 
 **`inputs.app`**: `inputSchema` and `outputSchema` are JSON Schema objects (`{ "type": "object", "properties": { ... } }`), **not arrays**.
 

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -283,7 +283,7 @@ uip maestro flow hitl add <path/to/file.flow> \
 ### Success output
 
 ```json
-{ "Result": "Success", "Code": "HitlNodeAdded", "Data": { "NodeId": "invoiceReview1", "NodeType": "uipath.human-in-the-loop", "Label": "Invoice Review", "DefinitionAdded": true } }
+{ "Result": "Success", "Code": "HitlNodeAdded", "Data": { "NodeId": "invoiceReview1", "NodeType": "uipath.human-in-the-loop.quick-form", "Label": "Invoice Review", "DefinitionAdded": true } }
 ```
 
 After adding, wire the `completed` port to the next node — an unwired `completed` blocks the flow indefinitely. See the [Author HITL plugin reference](../author/references/plugins/hitl/impl.md) for edge format.


### PR DESCRIPTION
Cherry-pick of #1878 into `release/v1.197`.

Fixes stale v1.6 node types in `uipath-maestro-flow` HITL plugin docs:
- `hitl/impl.md`: QuickForm type → `uipath.human-in-the-loop.quick-form`, removed `inputs.type: "quick"`
- `hitl/impl.md`: AppTask type → `uipath.human-in-the-loop.coded-action-app`, removed `inputs.type: "custom"`
- `hitl/impl.md`: fix stale type name in typeVersion note, clarify AppTask version comes from registry
- `cli-commands.md`: update `NodeType` in the `hitl add` success output example

🤖 Generated with [Claude Code](https://claude.com/claude-code)