### PR TITLE
feat(uipath-insights): add insights job monitoring skill

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -158,5 +158,9 @@
 /skills/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents
 /tests/tasks/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents
 
+# Insights skill (job monitoring and analytics)
+/skills/uipath-insights/ @suranabhavya @rliuup
+/tests/tasks/uipath-insights/ @suranabhavya @rliuup
+
 # Automation Discovery skill
 /skills/uipath-automation-discovery/ @uisherif

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-functions` | Preview |
 | `uipath-governance` | In-development |
 | `uipath-human-in-the-loop` | In-development |
+| `uipath-insights` | Preview |
 | `uipath-ixp` | In-development |
 | `uipath-maestro-bpmn` | In-development |
 | `uipath-maestro-case` | In-development |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -94,6 +94,14 @@
       },
       "last_synced": null
     },
+    "uipath-insights": {
+      "status": "preview",
+      "confluence": {
+        "page_id": "90824180832",
+        "url": "https://uipath.atlassian.net/wiki/spaces/CA/pages/90824180832"
+      },
+      "last_synced": null
+    },
     "uipath-ixp": {
       "status": "in-development",
       "confluence": {

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -1,0 +1,267 @@
+---
+name: uipath-insights
+description: "UiPath Insights job monitoring via `uip insights` — query job execution metrics, failure analysis, and process performance. TRIGGER: user asks about job failures, automation health, job success rates, processing times, failure reasons, process performance trends, or 'why are my jobs failing'. DO NOT TRIGGER: for Orchestrator job start/stop/logs (use uipath-platform), for root-cause analysis of specific job errors (use uipath-troubleshoot), for RPA workflow authoring (use uipath-rpa)."
+when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details'. Also 'uip insights', 'insights jobs'. NOT for starting/stopping jobs (uipath-platform), NOT for root-cause debugging of a specific job error (uipath-troubleshoot), NOT for queue metrics (not yet supported)."
+allowed-tools: Bash, Read
+---
+
+# UiPath Insights — Job Monitoring Agent Skill
+
+Insights provides analytics and monitoring for UiPath automation execution. This skill covers **job monitoring** — querying aggregated job execution data for dashboards, health checks, and failure investigation.
+
+All operations go through `uip insights jobs <subcommand> --output json`.
+
+---
+
+## Login & Tenant Setup
+
+**Default to Production. Only switch environment/org/tenant when explicitly stated in the request.**
+
+- If the request mentions no environment, use the current session (defaults to prod `cloud.uipath.com`)
+- If the request explicitly names an environment/org/tenant, check `uip login status` and re-login if needed
+
+```bash
+# Check current environment, org, and tenant
+uip login status --output json
+
+# Login to a specific environment
+uip login --authority https://alpha.uipath.com --tenant MyTenant
+
+# Switch tenant within the same environment
+uip login tenant set MyTenant
+```
+
+---
+
+## When to Use
+
+- Checking overall automation health (how many jobs ran, how many succeeded)
+- Investigating job failures (which processes fail most, what are the failure reasons)
+- Monitoring job execution trends over time (completed/uncompleted timelines)
+- Getting per-process performance breakdowns
+- Drilling into specific failure details for investigation
+
+> **Not in scope:** Starting, stopping, or managing individual jobs (use `uip or jobs` via uipath-platform). Root-cause debugging of a specific job's error (use uipath-troubleshoot). Queue item metrics, robot utilization, or dashboard CRUD (not yet available in CLI).
+
+---
+
+## Critical Rules
+
+1. **A time range is always required.** Every `uip insights jobs` command needs either `--time-range <minutes>` (relative) or both `--started-after <epoch-ms>` and `--started-before <epoch-ms>` (absolute). Without one, the command fails. Common values:
+   - `--time-range 60` — last 1 hour
+   - `--time-range 1440` — last 24 hours
+   - `--time-range 10080` — last 7 days
+   - `--time-range 43200` — last 30 days
+
+2. **Always use `--output json`.** All commands return a JSON envelope: `{ Result: "Success", Code: "<code>", Data: { ... } }`. Parse the `Data` field for the actual metrics.
+
+3. **Filter options are repeatable.** `--folder-key`, `--process-name`, and `--machine-name` can be specified multiple times to filter by several values: `--process-name "ProcessA" --process-name "ProcessB"`.
+
+4. **Empty data is normal.** If no jobs ran in the time window, the response will have `Data` with null/zero/empty fields. This is not an error.
+
+5. **Start with summary, then drill down.** For any investigation, start with `summary` to get the big picture, then use specific subcommands to investigate areas of concern.
+
+---
+
+## Command Reference
+
+All commands share these filter options:
+
+| Option | Description |
+|--------|-------------|
+| `--time-range <minutes>` | Relative time range in minutes |
+| `--started-after <epoch-ms>` | Absolute start time (Unix epoch ms) |
+| `--started-before <epoch-ms>` | Absolute end time (Unix epoch ms) |
+| `--folder-key <guid>` | Filter by folder key (repeatable) |
+| `--process-name <name>` | Filter by process name (repeatable) |
+| `--machine-name <name>` | Filter by machine name (repeatable) |
+| `--timezone-offset <minutes>` | Client timezone offset from UTC |
+
+### summary
+
+Get job KPIs: total count, successful count, and average processing time.
+
+```bash
+uip insights jobs summary --time-range 1440 --output json
+```
+
+**Key Data fields:** `jobsCount`, `successfulJobsCount`, `averageProcessingTime`
+
+**Use when:** User asks "how are my automations doing?" or "what's my job success rate?"
+
+### completed-timeline
+
+Get completed jobs over time, grouped by job state (successful, faulted, stopped, etc.).
+
+```bash
+uip insights jobs completed-timeline --time-range 1440 --output json
+```
+
+**Key Data fields:** `jobState`, `jobCountByTime`, `timestamp`
+
+**Use when:** User asks "show me job completion trends" or "when do most jobs run?"
+
+### uncompleted-timeline
+
+Get running and pending jobs over time.
+
+```bash
+uip insights jobs uncompleted-timeline --time-range 1440 --output json
+```
+
+**Key Data fields:** `jobState`, `jobCountByTime`, `timestamp`
+
+**Use when:** User asks "are there stuck jobs?" or "how many jobs are still running?"
+
+### top-failures
+
+Get processes ranked by failure count.
+
+```bash
+uip insights jobs top-failures --time-range 43200 --output json
+```
+
+**Key Data fields:** `processName`, `jobCountByTime`
+
+**Use when:** User asks "which processes fail the most?" or "what's causing failures?"
+
+### failures-by-reason
+
+Get job failures grouped by exception reason, with total job count for context.
+
+```bash
+uip insights jobs failures-by-reason --time-range 1440 --output json
+```
+
+**Key Data fields:** `processExceptionReason`, `processName`, `robotName`, `jobsCount`
+
+**Use when:** User asks "why are jobs failing?" or "what are the common error messages?"
+
+### process-details
+
+Get per-process job breakdown with counts by state.
+
+```bash
+uip insights jobs process-details --time-range 1440 --output json
+```
+
+**Key Data fields:** `processName`, `jobAggregate`
+
+**Use when:** User asks "show me per-process stats" or "which process has the most faulted jobs?"
+
+### failure-details
+
+Get detailed failure information for drill-down investigation.
+
+```bash
+uip insights jobs failure-details --time-range 1440 --output json
+```
+
+**Key Data fields:** `processName`, `machineName`, `processExceptionReason`, `startTime`, `endTime`
+
+**Use when:** User asks "show me the details of recent failures" or "which machines are failing?"
+
+---
+
+## Workflow: Investigate Job Health
+
+Follow this pattern when a user asks about automation health or job failures:
+
+```bash
+# 1. Check login
+uip login status --output json
+
+# 2. Get the big picture — how many jobs ran? how many succeeded?
+uip insights jobs summary --time-range 1440 --output json
+
+# 3. If success rate is low, find which processes fail most
+uip insights jobs top-failures --time-range 1440 --output json
+
+# 4. Find out WHY they're failing
+uip insights jobs failures-by-reason --time-range 1440 --output json
+
+# 5. Drill into specific failure details
+uip insights jobs failure-details --time-range 1440 --output json
+
+# 6. For time-based trends, check timelines
+uip insights jobs completed-timeline --time-range 10080 --output json
+```
+
+**Present findings clearly:** After gathering data, summarize for the user:
+- Total jobs vs successful jobs (derive failure rate)
+- Top failing processes by name
+- Most common failure reasons
+- Which machines are affected
+- Whether failures are trending up or down
+
+---
+
+## Workflow: Filter by Folder or Process
+
+When the user asks about a specific folder or process:
+
+```bash
+# Filter by folder
+uip insights jobs summary --time-range 1440 --folder-key "abc-123-def" --output json
+
+# Filter by process name
+uip insights jobs top-failures --time-range 43200 --process-name "Invoice_Processing" --output json
+
+# Combine filters
+uip insights jobs failures-by-reason --time-range 1440 \
+  --folder-key "abc-123-def" \
+  --process-name "Invoice_Processing" \
+  --output json
+```
+
+To discover available folder keys, use `uip or folders list --output json` (from the uipath-platform skill).
+
+---
+
+## Workflow: Absolute Time Range
+
+When the user specifies an exact date range instead of "last N hours":
+
+```bash
+# Convert dates to epoch milliseconds
+# Example: 2026-07-01 00:00:00 UTC to 2026-07-06 00:00:00 UTC
+uip insights jobs summary \
+  --started-after 1782691200000 \
+  --started-before 1783123200000 \
+  --output json
+```
+
+Compute epoch milliseconds in bash:
+```bash
+# macOS
+START=$(date -j -f "%Y-%m-%d" "2026-07-01" +%s)000
+END=$(date -j -f "%Y-%m-%d" "2026-07-06" +%s)000
+
+# Linux
+START=$(date -d "2026-07-01" +%s)000
+END=$(date -d "2026-07-06" +%s)000
+
+uip insights jobs summary --started-after "$START" --started-before "$END" --output json
+```
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Not logged in` | Auth expired | `uip login` |
+| `time range is required` | Missing `--time-range` or `--started-after`/`--started-before` | Add `--time-range 1440` (or your preferred window) |
+| `API request failed: 401` | Token doesn't have Insights access | Re-login; ensure the org has Insights enabled |
+| `API request failed: 403` | User has no folder permissions | Check folder assignments in Orchestrator Admin |
+| `API request failed: 500` | Server error (often missing time range on older deployments) | Ensure time range is provided in the request body |
+| All Data fields are null/zero | No jobs ran in the given time window | Widen the `--time-range` (try 43200 for 30 days) |
+
+---
+
+## References
+
+For deeper guidance, read these files only when needed:
+
+- [`references/jobs-commands-guide.md`](references/jobs-commands-guide.md) — Full command reference with all options, response shapes, and example outputs
+- [`references/investigation-playbook-guide.md`](references/investigation-playbook-guide.md) — Step-by-step playbooks for common investigation scenarios

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-insights
-description: "UiPath Insights job monitoring via `uip insights` — query job execution metrics, failure analysis, and process performance. TRIGGER: user asks about job failures, automation health, job success rates, processing times, failure reasons, process performance trends, or 'why are my jobs failing'. DO NOT TRIGGER: for Orchestrator job start/stop/logs (use uipath-platform), for root-cause analysis of specific job errors (use uipath-troubleshoot), for RPA workflow authoring (use uipath-rpa)."
+description: "UiPath Insights job monitoring via `uip insights` — query job execution metrics, failure analysis, and process performance. Covers job KPIs, failure reasons, completion trends, process breakdowns. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa."
 when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details'. Also 'uip insights', 'insights jobs'. NOT for starting/stopping jobs (uipath-platform), NOT for root-cause debugging of a specific job error (uipath-troubleshoot), NOT for queue metrics (not yet supported)."
 allowed-tools: Bash, Read
 ---
@@ -10,6 +10,18 @@ allowed-tools: Bash, Read
 Insights provides analytics and monitoring for UiPath automation execution. This skill covers **job monitoring** — querying aggregated job execution data for dashboards, health checks, and failure investigation.
 
 All operations go through `uip insights jobs <subcommand> --output json`.
+
+---
+
+## When to Use
+
+- Checking overall automation health (how many jobs ran, how many succeeded)
+- Investigating job failures (which processes fail most, what are the failure reasons)
+- Monitoring job execution trends over time (completed/uncompleted timelines)
+- Getting per-process performance breakdowns
+- Drilling into specific failure details for investigation
+
+> **Not in scope:** Starting, stopping, or managing individual jobs (use `uip or jobs` via uipath-platform). Root-cause debugging of a specific job's error (use uipath-troubleshoot). Queue item metrics, robot utilization, or dashboard CRUD (not yet available in CLI).
 
 ---
 
@@ -30,18 +42,6 @@ uip login --authority https://alpha.uipath.com --tenant MyTenant
 # Switch tenant within the same environment
 uip login tenant set MyTenant
 ```
-
----
-
-## When to Use
-
-- Checking overall automation health (how many jobs ran, how many succeeded)
-- Investigating job failures (which processes fail most, what are the failure reasons)
-- Monitoring job execution trends over time (completed/uncompleted timelines)
-- Getting per-process performance breakdowns
-- Drilling into specific failure details for investigation
-
-> **Not in scope:** Starting, stopping, or managing individual jobs (use `uip or jobs` via uipath-platform). Root-cause debugging of a specific job's error (use uipath-troubleshoot). Queue item metrics, robot utilization, or dashboard CRUD (not yet available in CLI).
 
 ---
 
@@ -256,6 +256,16 @@ uip insights jobs summary --started-after "$START" --started-before "$END" --out
 | `API request failed: 403` | User has no folder permissions | Check folder assignments in Orchestrator Admin |
 | `API request failed: 500` | Server error (often missing time range on older deployments) | Ensure time range is provided in the request body |
 | All Data fields are null/zero | No jobs ran in the given time window | Widen the `--time-range` (try 43200 for 30 days) |
+
+---
+
+## What NOT to Do
+
+- **Don't call `uip insights jobs` without a time range.** The server returns a 500 with a misleading success-shaped response. Always pass `--time-range` or `--started-after`/`--started-before`.
+- **Don't start, stop, or manage individual jobs.** This skill is for monitoring and analytics only. Use `uip or jobs start/stop` via uipath-platform to manage jobs.
+- **Don't construct raw API calls to the Insights endpoint.** The CLI handles auth headers (`X-UiPath-Internal-AccountName`, `X-UiPath-Internal-TenantName`), URL construction, and error handling. Hand-rolling `curl` or `fetch` calls will miss these.
+- **Don't retry on auth errors.** If `uip insights jobs` returns 401 or "Not logged in", the fix is `uip login`, not retrying the same command.
+- **Don't use this skill for root-cause debugging.** "Why did job X fail with error Y?" is a troubleshooting question — hand off to uipath-troubleshoot. This skill answers "which processes fail the most and what are the common reasons."
 
 ---
 

--- a/skills/uipath-insights/references/investigation-playbook-guide.md
+++ b/skills/uipath-insights/references/investigation-playbook-guide.md
@@ -1,0 +1,145 @@
+# Insights — Investigation Playbooks
+
+Step-by-step playbooks for common job monitoring scenarios. Each playbook shows the exact commands to run and how to interpret the results.
+
+## Playbook 1: "How healthy are my automations?"
+
+User asks about overall automation health, success rates, or general status.
+
+```bash
+# Step 1: Get the summary KPIs
+uip insights jobs summary --time-range 1440 --output json
+
+# Step 2: Interpret the results
+# - jobsCount: total jobs in the time window
+# - successfulJobsCount: jobs that completed successfully
+# - averageProcessingTime: mean execution time in seconds
+#
+# Failure rate = (jobsCount - successfulJobsCount) / jobsCount * 100
+#
+# Thresholds (rules of thumb):
+#   < 5% failure rate  → healthy
+#   5-15% failure rate → needs attention
+#   > 15% failure rate → investigate immediately
+```
+
+If the failure rate is concerning, move to Playbook 2.
+
+## Playbook 2: "Which processes are failing?"
+
+User wants to know what's breaking.
+
+```bash
+# Step 1: Get processes ranked by failure count (use 30 days for a broader view)
+uip insights jobs top-failures --time-range 43200 --output json
+
+# Step 2: Get the failure reasons
+uip insights jobs failures-by-reason --time-range 43200 --output json
+
+# Step 3: Present findings as a table:
+# | Process Name | Failure Count | Top Reason |
+# |---|---|---|
+# | Invoice_Processing | 23 | ApplicationException: File not found |
+# | Email_Parser | 15 | TimeoutException: SMTP server unreachable |
+```
+
+## Playbook 3: "Why did this specific process fail?"
+
+User asks about failures in a specific process.
+
+```bash
+# Step 1: Filter failures to that process
+uip insights jobs failures-by-reason --time-range 1440 \
+  --process-name "Invoice_Processing" --output json
+
+# Step 2: Get detailed failure info (machine, timestamps, error messages)
+uip insights jobs failure-details --time-range 1440 \
+  --process-name "Invoice_Processing" --output json
+
+# Step 3: Check if it's a recent regression with the timeline
+uip insights jobs completed-timeline --time-range 10080 \
+  --process-name "Invoice_Processing" --output json
+
+# Step 4: Present findings:
+# - Most common error reason
+# - Which machines are affected
+# - When failures started (trend direction)
+# - Recommended next steps
+```
+
+## Playbook 4: "Are there stuck or long-running jobs?"
+
+User asks about jobs that haven't completed.
+
+```bash
+# Step 1: Check uncompleted jobs
+uip insights jobs uncompleted-timeline --time-range 1440 --output json
+
+# Step 2: Get the summary to compare completed vs uncompleted
+uip insights jobs summary --time-range 1440 --output json
+
+# Step 3: If many uncompleted, check per-process breakdown
+uip insights jobs process-details --time-range 1440 --output json
+```
+
+## Playbook 5: "Compare this week vs last week"
+
+User wants to see if things are getting better or worse.
+
+```bash
+# This week (last 7 days)
+uip insights jobs summary --time-range 10080 --output json
+
+# For last week, use absolute timestamps
+# Calculate: last Monday to this Monday in epoch ms
+uip insights jobs summary \
+  --started-after <last-monday-epoch-ms> \
+  --started-before <this-monday-epoch-ms> \
+  --output json
+
+# Compare jobsCount, successfulJobsCount, and averageProcessingTime
+# between the two results
+```
+
+## Playbook 6: "Show me jobs for a specific folder"
+
+User asks about a specific Orchestrator folder.
+
+```bash
+# Step 1: Find the folder key (requires uipath-platform)
+uip or folders list --output json
+# Look for the folder's Key (GUID) in the output
+
+# Step 2: Query insights with folder filter
+uip insights jobs summary --time-range 1440 \
+  --folder-key "abc-123-def" --output json
+
+uip insights jobs top-failures --time-range 1440 \
+  --folder-key "abc-123-def" --output json
+```
+
+## Interpreting Array Data
+
+Several endpoints return parallel arrays. The same index across arrays corresponds to the same entity:
+
+```json
+{
+  "processName": ["ProcessA", "ProcessB", "ProcessC"],
+  "jobCountByTime": [[10, 5, 2]]
+}
+```
+
+This means:
+- ProcessA had 10 failures
+- ProcessB had 5 failures
+- ProcessC had 2 failures
+
+## When to Hand Off to Other Skills
+
+| Situation | Hand off to |
+|---|---|
+| User wants to start/stop/restart a specific job | `uipath-platform` (`uip or jobs start`) |
+| User wants to read the logs of a failed job | `uipath-platform` (`uip or jobs logs`) |
+| User wants to debug why a specific job error happened | `uipath-troubleshoot` |
+| User wants to find a folder key to filter by | `uipath-platform` (`uip or folders list`) |
+| User wants to fix the code that's causing failures | `uipath-rpa` or `uipath-agents` |

--- a/skills/uipath-insights/references/jobs-commands-guide.md
+++ b/skills/uipath-insights/references/jobs-commands-guide.md
@@ -1,0 +1,144 @@
+# Insights Jobs — Command Reference
+
+Complete reference for `uip insights jobs` subcommands with response shapes and examples.
+
+## Shared Options
+
+Every subcommand accepts these filter options:
+
+```
+--time-range <minutes>         Relative time range (e.g. 1440 = 24h, 43200 = 30d)
+--started-after <epoch-ms>     Absolute start time as Unix epoch milliseconds
+--started-before <epoch-ms>    Absolute end time as Unix epoch milliseconds
+--folder-key <guid>            Folder key filter (repeatable)
+--process-name <name>          Process name filter (repeatable)
+--machine-name <name>          Machine name filter (repeatable)
+--timezone-offset <minutes>    Client timezone offset from UTC
+--output <format>              Output format: json, yaml, table (always use json)
+```
+
+**Time range rule:** Either `--time-range` OR both `--started-after` and `--started-before` must be provided. Omitting both causes a validation error.
+
+**Repeatable options:** `--folder-key`, `--process-name`, and `--machine-name` can be specified multiple times:
+```bash
+uip insights jobs summary --time-range 1440 \
+  --process-name "ProcessA" \
+  --process-name "ProcessB" \
+  --output json
+```
+
+## Response Envelope
+
+All commands return:
+```json
+{
+  "Result": "Success",
+  "Code": "<CommandCode>",
+  "Data": { ... }
+}
+```
+
+On error:
+```json
+{
+  "Result": "Failure",
+  "Message": "<error description>",
+  "Instructions": "<how to fix>",
+  "ErrorCode": "unknown_error"
+}
+```
+
+## Response Data Shape
+
+All endpoints return the same `JobsResponse` shape. Fields are populated or null depending on the endpoint:
+
+```typescript
+interface JobsResponse {
+  jobState: string[] | null;
+  robotName: string[] | null;
+  processName: string[] | null;
+  jobCount: number[] | null;
+  jobCountByTime: number[][] | null;
+  folderName: string[] | null;
+  folderKey: string[] | null;
+  machineName: string[] | null;
+  hostMachineName: string[] | null;
+  machineKey: string[] | null;
+  machineStatus: string[] | null;
+  timestamp: string[] | null;
+  processExceptionType: string[] | null;
+  processExceptionReason: string[] | null;
+  startTime: string[] | null;
+  endTime: string[] | null;
+  utilizationTime: string[] | null;
+  duration: number[] | null;
+  successRate: number[] | null;
+  averageProcessingTime: number | null;
+  jobsCount: number | null;
+  successfulJobsCount: number | null;
+  jobAggregate: number[][] | null;
+  creationTime: string[] | null;
+  folderId: string[] | null;
+  jobKey: string[] | null;
+}
+```
+
+## Per-Endpoint Key Fields
+
+| Endpoint | Code | Key Data Fields |
+|----------|------|-----------------|
+| `summary` | `InsightsJobsSummary` | `jobsCount`, `successfulJobsCount`, `averageProcessingTime` |
+| `completed-timeline` | `InsightsJobsCompletedTimeline` | `jobState`, `jobCountByTime`, `timestamp` |
+| `uncompleted-timeline` | `InsightsJobsUncompletedTimeline` | `jobState`, `jobCountByTime`, `timestamp` |
+| `top-failures` | `InsightsJobsTopFailures` | `processName`, `jobCountByTime` |
+| `failures-by-reason` | `InsightsJobsFailuresByReason` | `processExceptionReason`, `processName`, `robotName`, `jobsCount` |
+| `process-details` | `InsightsJobsProcessDetails` | `processName`, `jobAggregate` |
+| `failure-details` | `InsightsJobsFailureDetails` | `processName`, `machineName`, `processExceptionReason`, `startTime`, `endTime` |
+
+## Example: Summary
+
+```bash
+$ uip insights jobs summary --time-range 1440 --output json
+{
+  "Result": "Success",
+  "Code": "InsightsJobsSummary",
+  "Data": {
+    "jobsCount": 142,
+    "successfulJobsCount": 135,
+    "averageProcessingTime": 45.7,
+    "jobState": null,
+    "processName": null,
+    ...
+  }
+}
+```
+
+Deriving metrics:
+- **Failure rate:** `(jobsCount - successfulJobsCount) / jobsCount * 100`
+- **Success rate:** `successfulJobsCount / jobsCount * 100`
+
+## Example: Top Failures with Filter
+
+```bash
+$ uip insights jobs top-failures --time-range 43200 \
+    --folder-key "a1b2c3d4-e5f6-7890-abcd-ef1234567890" \
+    --output json
+{
+  "Result": "Success",
+  "Code": "InsightsJobsTopFailures",
+  "Data": {
+    "processName": ["Invoice_Processing", "Email_Parser", "Data_Upload"],
+    "jobCountByTime": [[23, 15, 8]],
+    ...
+  }
+}
+```
+
+The `processName` array and `jobCountByTime[0]` array are parallel — index 0 of both corresponds to the same process.
+
+## API Details
+
+- **Base URL:** `{host}/{orgId}/{tenantName}/insightsrtm_/api/v1.0/InsightsJobs/{endpoint}`
+- **Method:** POST (all endpoints)
+- **Auth:** Bearer token + `X-UiPath-Internal-AccountName` + `X-UiPath-Internal-TenantName` headers
+- **The CLI handles all of this.** Do not construct raw API calls — use `uip insights jobs <subcommand>`.

--- a/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
+++ b/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
@@ -18,6 +18,13 @@ initial_prompt: |
   once and move on. Do NOT retry or attempt to login.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected: "yes"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent used --started-after with epoch milliseconds"
     tool_name: "Bash"

--- a/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
+++ b/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
@@ -21,7 +21,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-insights skill"
     skill_name: "uipath-insights"
-    expected: "yes"
+    expected_skill: "uipath-insights"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
+++ b/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
@@ -1,0 +1,43 @@
+task_id: skill-insights-smoke-absolute-time-range
+description: >
+  Smoke test: agent correctly handles absolute time ranges when the user
+  specifies exact dates instead of relative durations. The agent should
+  convert dates to epoch milliseconds and use --started-after/--started-before
+  instead of --time-range. Auth errors are expected (no live tenant).
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  Show me job metrics from July 1st 2026 to July 5th 2026 specifically.
+  I want the summary and the completed timeline for that exact date range.
+
+  Use --output json on every command. The CLI is not connected to a live tenant,
+  so commands will fail with auth errors — that's expected. Run each command
+  once and move on. Do NOT retry or attempt to login.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent used --started-after with epoch milliseconds"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--started-after\s+\d{13}'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --started-before with epoch milliseconds"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--started-before\s+\d{13}'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran at least two different subcommands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+(summary|completed-timeline)'
+    min_count: 2
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_all_commands.yaml
+++ b/tests/tasks/uipath-insights/smoke_all_commands.yaml
@@ -1,30 +1,30 @@
 task_id: skill-insights-smoke-all-commands
 description: >
-  Smoke test: agent uses the uipath-insights skill to run all seven
-  uip insights jobs subcommands. Verifies the agent knows the full command
-  surface and uses --output json and --time-range on each. Auth errors are
-  expected (no live tenant).
+  Smoke test: agent uses the uipath-insights skill to discover and run all
+  available uip insights jobs subcommands. The prompt is goal-oriented —
+  the agent must discover the full command surface from the skill, not from
+  the prompt. Auth errors are expected (no live tenant).
 tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
 
 run_limits:
   expected_turns: 10
 
 initial_prompt: |
-  I want to see all the job monitoring data available in Insights. Run each of
-  the following queries for the last 24 hours:
-  1. Jobs summary (KPIs)
-  2. Completed jobs timeline
-  3. Uncompleted jobs timeline
-  4. Top failures by process
-  5. Failures grouped by reason
-  6. Per-process job details
-  7. Failure drill-down details
+  I want a complete picture of my job monitoring data from Insights. Run every
+  available uip insights jobs subcommand for the last 24 hours.
 
-  Use --output json and --time-range 1440 on every command. The CLI is not
-  connected to a live tenant, so commands will fail with auth errors — that's
-  expected. Run each command once and move on. Do NOT retry or attempt to login.
+  Use --output json on every command. The CLI is not connected to a live tenant,
+  so commands will fail with auth errors — that's expected. Run each command
+  once and move on. Do NOT retry or attempt to login.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected: "yes"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent ran jobs summary"
     tool_name: "Bash"

--- a/tests/tasks/uipath-insights/smoke_all_commands.yaml
+++ b/tests/tasks/uipath-insights/smoke_all_commands.yaml
@@ -21,7 +21,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-insights skill"
     skill_name: "uipath-insights"
-    expected: "yes"
+    expected_skill: "uipath-insights"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-insights/smoke_all_commands.yaml
+++ b/tests/tasks/uipath-insights/smoke_all_commands.yaml
@@ -1,0 +1,82 @@
+task_id: skill-insights-smoke-all-commands
+description: >
+  Smoke test: agent uses the uipath-insights skill to run all seven
+  uip insights jobs subcommands. Verifies the agent knows the full command
+  surface and uses --output json and --time-range on each. Auth errors are
+  expected (no live tenant).
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  I want to see all the job monitoring data available in Insights. Run each of
+  the following queries for the last 24 hours:
+  1. Jobs summary (KPIs)
+  2. Completed jobs timeline
+  3. Uncompleted jobs timeline
+  4. Top failures by process
+  5. Failures grouped by reason
+  6. Per-process job details
+  7. Failure drill-down details
+
+  Use --output json and --time-range 1440 on every command. The CLI is not
+  connected to a live tenant, so commands will fail with auth errors — that's
+  expected. Run each command once and move on. Do NOT retry or attempt to login.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran jobs summary"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+summary'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran completed-timeline"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+completed-timeline'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uncompleted-timeline"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+uncompleted-timeline'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran top-failures"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failures-by-reason"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran process-details"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+process-details'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failure-details"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failure-details'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_critical_rules.yaml
+++ b/tests/tasks/uipath-insights/smoke_critical_rules.yaml
@@ -1,83 +1,56 @@
 task_id: skill-insights-smoke-critical-rules
 description: >
-  Smoke test: agent correctly follows the uipath-insights skill's critical
-  rules — always requires a time range, uses --output json, and knows the
-  boundaries of what the skill covers vs what belongs to other skills.
+  Smoke test: agent correctly follows the uipath-insights skill's boundaries.
+  Presented with four requests — one in-scope (job failures) and three
+  out-of-scope (start a job, queue metrics, root-cause a specific error).
+  The agent should run an insights command for the first and NOT run insights
+  commands for the others. Auth errors are expected (no live tenant).
 tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover, negative]
 
 run_limits:
-  expected_turns: 6
+  expected_turns: 8
 
 initial_prompt: |
-  I have four requests. For each, decide what to do based on the
-  uipath-insights skill. If the skill covers it, describe the command.
-  If not, explain why and which skill to use instead.
+  Handle each of these four requests using the appropriate approach.
+  Use --output json on every uip command. The CLI is not connected to a live
+  tenant, so commands will fail with auth errors — that's expected. Run each
+  command once and move on. Do NOT retry or attempt to login.
 
-  Request 1: Show me job failures. (No time range specified — what do you do?)
+  1. Show me job failures for the last 24 hours.
+  2. Start the "Invoice_Processing" job immediately.
+  3. Show me queue item metrics for the last 24 hours.
+  4. Why did job abc-123 fail with error "FileNotFoundException"? Debug it.
 
-  Request 2: Start the "Invoice_Processing" job immediately.
-
-  Request 3: Show me queue item metrics for the last 24 hours.
-
-  Request 4: Why did job "abc-123" fail with error "FileNotFoundException"?
-
-  Save a summary to report.json:
-  {
-    "request_1_action": "<'use_insights' or 'refuse'>",
-    "request_1_detail": "<what command or why refused>",
-    "request_2_action": "<'use_insights' or 'use_other_skill'>",
-    "request_2_skill": "<which skill if other>",
-    "request_3_action": "<'use_insights' or 'not_supported'>",
-    "request_3_detail": "<explanation>",
-    "request_4_action": "<'use_insights' or 'use_other_skill'>",
-    "request_4_skill": "<which skill if other>"
-  }
-
-  Do NOT run any uip commands. Just analyze and write the report.
+  For requests that this skill cannot handle, explain which skill or command
+  should be used instead. Do NOT attempt to run uip insights commands for
+  out-of-scope requests.
 
 success_criteria:
-  - type: file_exists
-    description: "report.json was created"
-    path: "report.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: json_check
-    description: "Agent knows insights needs a time range for request 1"
-    path: "report.json"
-    assertions:
-      - expression: "request_1_action"
-        operator: equals
-        expected: "use_insights"
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected: "yes"
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: json_check
-    description: "Agent redirects job start to another skill (uipath-platform)"
-    path: "report.json"
-    assertions:
-      - expression: "request_2_action"
-        operator: equals
-        expected: "use_other_skill"
+  - type: command_executed
+    description: "Agent ran insights jobs for the in-scope request (job failures)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+(failures-by-reason|top-failures|failure-details|summary)\s+.*--time-range'
+    min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: json_check
-    description: "Agent knows queue metrics are not yet supported in insights"
-    path: "report.json"
-    assertions:
-      - expression: "request_3_action"
-        operator: equals
-        expected: "not_supported"
+  - type: command_not_executed
+    description: "Agent did NOT run uip insights for starting a job (out of scope)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights.*start|uip\s+insights.*Invoice_Processing'
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: json_check
-    description: "Agent redirects root-cause debugging to uipath-troubleshoot"
-    path: "report.json"
-    assertions:
-      - expression: "request_4_action"
-        operator: equals
-        expected: "use_other_skill"
-    weight: 2.5
+  - type: command_not_executed
+    description: "Agent did NOT run uip insights for queue metrics (not supported)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights.*queue'
+    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_critical_rules.yaml
+++ b/tests/tasks/uipath-insights/smoke_critical_rules.yaml
@@ -29,7 +29,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-insights skill"
     skill_name: "uipath-insights"
-    expected: "yes"
+    expected_skill: "uipath-insights"
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-insights/smoke_critical_rules.yaml
+++ b/tests/tasks/uipath-insights/smoke_critical_rules.yaml
@@ -1,0 +1,83 @@
+task_id: skill-insights-smoke-critical-rules
+description: >
+  Smoke test: agent correctly follows the uipath-insights skill's critical
+  rules — always requires a time range, uses --output json, and knows the
+  boundaries of what the skill covers vs what belongs to other skills.
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover, negative]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  I have four requests. For each, decide what to do based on the
+  uipath-insights skill. If the skill covers it, describe the command.
+  If not, explain why and which skill to use instead.
+
+  Request 1: Show me job failures. (No time range specified — what do you do?)
+
+  Request 2: Start the "Invoice_Processing" job immediately.
+
+  Request 3: Show me queue item metrics for the last 24 hours.
+
+  Request 4: Why did job "abc-123" fail with error "FileNotFoundException"?
+
+  Save a summary to report.json:
+  {
+    "request_1_action": "<'use_insights' or 'refuse'>",
+    "request_1_detail": "<what command or why refused>",
+    "request_2_action": "<'use_insights' or 'use_other_skill'>",
+    "request_2_skill": "<which skill if other>",
+    "request_3_action": "<'use_insights' or 'not_supported'>",
+    "request_3_detail": "<explanation>",
+    "request_4_action": "<'use_insights' or 'use_other_skill'>",
+    "request_4_skill": "<which skill if other>"
+  }
+
+  Do NOT run any uip commands. Just analyze and write the report.
+
+success_criteria:
+  - type: file_exists
+    description: "report.json was created"
+    path: "report.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Agent knows insights needs a time range for request 1"
+    path: "report.json"
+    assertions:
+      - expression: "request_1_action"
+        operator: equals
+        expected: "use_insights"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Agent redirects job start to another skill (uipath-platform)"
+    path: "report.json"
+    assertions:
+      - expression: "request_2_action"
+        operator: equals
+        expected: "use_other_skill"
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Agent knows queue metrics are not yet supported in insights"
+    path: "report.json"
+    assertions:
+      - expression: "request_3_action"
+        operator: equals
+        expected: "not_supported"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: json_check
+    description: "Agent redirects root-cause debugging to uipath-troubleshoot"
+    path: "report.json"
+    assertions:
+      - expression: "request_4_action"
+        operator: equals
+        expected: "use_other_skill"
+    weight: 2.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_filtered_query.yaml
+++ b/tests/tasks/uipath-insights/smoke_filtered_query.yaml
@@ -1,0 +1,47 @@
+task_id: skill-insights-smoke-filtered-query
+description: >
+  Smoke test: agent uses the uipath-insights skill to query job data with
+  filters. Given a specific process name and folder, the agent should apply
+  --process-name and --folder-key filters. Tests that the agent correctly
+  uses repeatable filter options. Auth errors are expected (no live tenant).
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  I need to check the job health for a specific process called "Invoice_Processing"
+  in folder key "a1b2c3d4-e5f6-7890-abcd-ef1234567890" over the last 30 days.
+
+  Please:
+  1. Get the summary for this process in this folder
+  2. Check the failure reasons for this process
+
+  Use --output json on every command. The CLI is not connected to a live tenant,
+  so commands will fail with auth errors — that's expected. Run each command
+  once and move on. Do NOT retry or attempt to login.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent used --process-name filter"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--process-name\s+.?Invoice_Processing'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --folder-key filter"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--folder-key\s+.?a1b2c3d4'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --time-range 43200 for 30 days"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--time-range\s+43200'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_filtered_query.yaml
+++ b/tests/tasks/uipath-insights/smoke_filtered_query.yaml
@@ -25,7 +25,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-insights skill"
     skill_name: "uipath-insights"
-    expected: "yes"
+    expected_skill: "uipath-insights"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-insights/smoke_filtered_query.yaml
+++ b/tests/tasks/uipath-insights/smoke_filtered_query.yaml
@@ -22,6 +22,13 @@ initial_prompt: |
   once and move on. Do NOT retry or attempt to login.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected: "yes"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent used --process-name filter"
     tool_name: "Bash"

--- a/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
+++ b/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
@@ -26,7 +26,7 @@ success_criteria:
   - type: skill_triggered
     description: "Agent activated the uipath-insights skill"
     skill_name: "uipath-insights"
-    expected: "yes"
+    expected_skill: "uipath-insights"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
+++ b/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
@@ -23,6 +23,13 @@ initial_prompt: |
   once, note the result, and move on. Do NOT retry or attempt to login.
 
 success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected: "yes"
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: command_executed
     description: "Agent ran jobs summary to get overall KPIs"
     tool_name: "Bash"

--- a/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
+++ b/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
@@ -1,0 +1,56 @@
+task_id: skill-insights-smoke-job-health-investigation
+description: >
+  Smoke test: agent uses the uipath-insights skill to investigate automation
+  health. Given a prompt about job failures, the agent should run the right
+  sequence of uip insights jobs commands — summary first, then top-failures,
+  then failures-by-reason for drill-down. Tests that the agent follows the
+  investigation workflow and uses --output json and --time-range consistently.
+  Auth errors are expected (no live tenant).
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 8
+
+initial_prompt: |
+  Our automations seem unhealthy lately. Can you check how our jobs are doing
+  over the last 7 days? I want to know:
+  1. Overall success rate
+  2. Which processes are failing the most
+  3. What the failure reasons are
+
+  Use --output json on every command. The CLI is not connected to a live tenant,
+  so commands will fail with auth errors — that's expected. Run each command
+  once, note the result, and move on. Do NOT retry or attempt to login.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran jobs summary to get overall KPIs"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+summary\s+.*--time-range'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran top-failures to find which processes fail most"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s+.*--time-range'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failures-by-reason to get error reasons"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s+.*--time-range'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used --output json on all commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--output\s+json'
+    min_count: 3
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- Add `uipath-insights` skill for job monitoring via `uip insights jobs` (7 subcommands)
- SKILL.md with command reference, investigation workflows, critical rules, and troubleshooting
- 2 reference docs: jobs-commands-guide.md and investigation-playbook-guide.md
- 5 smoke coder_eval tests: full command surface, investigation workflow, filtered queries, critical rules/boundaries, absolute time ranges
- CODEOWNERS entry for @suranabhavya @rliuup

## Test plan
- [ ] `make test-uipath-insights` passes
- [ ] Skill frontmatter validates (name matches folder, description has TRIGGER/DO NOT TRIGGER)