### PR TITLE
test(uipath-maestro-flow): disable skill-flow-eval-run-e2e (server-side job hang)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml.disabled
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml.disabled
@@ -1,3 +1,17 @@
+# DISABLED (2026-07-06): the eval run never completes server-side on the eval
+# tenant, so this test cannot pass regardless of the client wait/poll budget.
+# The reported symptom ("bounded poll limit reached, run still non-terminal") is
+# a secondary effect — with a longer window the run reaches a *terminal* state of
+# `failed`, with the single data point `workloadFailed` (score 0), because the
+# underlying Maestro flow job hangs and never finishes. Two live repros on
+# codereval@alpha reusing the exact built artifact:
+#   - run 206e7b5a: failed after 1322s -> "[greeting-match] Activity task timed out"
+#   - run 67071f47: failed after 1234s -> "Job f58976df... did not complete within 120 poll attempts"
+# The flow itself is trivial and correct (script: return {greeting:"Hello, "+name+"!"}),
+# and a healthy tenant runs this eval in ~40s. Bumping `--wait --timeout` / the
+# bounded poll count only changes the failure mode (still-running -> workloadFailed);
+# it cannot satisfy the score==1.0 acceptance while the job hangs. Re-enable (rename
+# back to eval_run.yaml) once Maestro eval-job execution is healthy on the eval tenant.
 task_id: skill-flow-eval-run-e2e
 description: >
   End-to-end eval lifecycle against a live Studio Web tenant. Agent scaffolds


### PR DESCRIPTION
## What

Disables the `skill-flow-eval-run-e2e` task (renamed `eval_run.yaml` → `eval_run.yaml.disabled`, the repo's established convention for temporarily removing a task from glob discovery).

## Why

The task was reported as failing on a timeout: *"The bounded poll limit of 5 additional status checks has been reached … the run has been in `running` state for well over 10 minutes beyond the 600s `--wait` window."*

I investigated whether simply bumping the timeout would fix it. **It won't** — the reported symptom is secondary. I reproduced the run twice against the live eval tenant (`codereval @ alpha.uipath.com`) reusing the exact built artifact from the failed run, with a much larger wait window. In both cases the run reached a **terminal `failed`** state — not merely "still running":

| Run | Duration | Terminal | Data point | Justification |
|-----|----------|----------|------------|---------------|
| `206e7b5a` | 1322s (~22 min) | `failed` | `workloadFailed` | `[greeting-match] Activity task timed out` |
| `67071f47` | 1234s (~20.5 min) | `failed` | `workloadFailed` | `Job f58976df… did not complete within 120 poll attempts` |

Root cause: the underlying **Maestro flow job hangs and never completes server-side**. The flow itself is trivial and correct (`script: return { greeting: "Hello, " + name + "!" }`) and passes every authoring criterion; a healthy tenant runs this eval in ~40s.

Because the hard acceptance criterion (weight 8) requires the data point to reach `Completed` with score 1.0, bumping `--wait --timeout` or the bounded poll count only changes the failure mode (*still-running* → *`workloadFailed`, score 0*) — it cannot make the test pass while the job hangs. So the correct action is to disable rather than paper over it with a larger timeout.

## Scope / safety

- Only the one task file is renamed; `check_eval_run.py` and the directory are left in place for easy re-enable.
- `uipath-maestro-flow` still has 44 `e2e` and 14 `smoke` active tasks, so no structural PR-review requirement is affected.
- The task lacks the `smoke` tag, so this was never part of the PR smoke gate — it runs in nightly/manual glob suites, which the `.disabled` extension now excludes.

## Re-enable

Rename `eval_run.yaml.disabled` back to `eval_run.yaml` once Maestro eval-job execution is healthy on the eval tenant. A tracking ticket for the server-side job hang should be filed against the Maestro eval runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)