### PR TITLE
fix(uipath-maestro-flow): harden greenfield solution-selection gate

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/greenfield.md
+++ b/skills/uipath-maestro-flow/references/author/references/greenfield.md
@@ -35,7 +35,7 @@ Steps 0–6 are **logical phases**, not separate turns. A typical greenfield bui
 
 | Turn | Steps | What you emit in ONE assistant message |
 |---|---|---|
-| **T1 — Setup + discovery** | 0, 1, 2, 3 | One chained `Bash` (scaffold + register + pull + `node add` for each CLI-owned node) **+** parallel `Bash` (one `registry get` per OOTB type you'll inline) **+** parallel `Read` (plugin `impl.md`s) **+** optional `uip login status` |
+| **T1 — Setup + discovery** | 0, 1, 2, 3 | One chained `Bash` (scaffold + register + pull + `node add` for each CLI-owned node) **+** parallel `Bash` (one `registry get` per OOTB type you'll inline) **+** parallel `Read` (plugin `impl.md`s) **+** optional `uip login status`. **If existing `.uipx` solutions are present, the Step 2 gate fires first in its own turn** — resolve it before this chain. |
 | **T2 — Read + author** | 4 | One `Read` of the `.flow` **+** a batch of `Edit` calls (or one `Write` if ≥70% of nodes change). Claude Code serializes Edits on the same file, so they don't race |
 | **T3 — Finalize** | 5, 6 | One chained `Bash` (`node configure && validate && format`). On validate failure: one Edit turn, then re-chain `validate && format` |
 
@@ -75,7 +75,7 @@ When you do need it, emit `uip login status --output json` as a parallel `Bash` 
 
 > **A Flow project cannot exist outside a solution** (universal rule in [SKILL.md](../../../SKILL.md)). Scaffold or select a solution (Step 2a) BEFORE running `uip maestro flow init` (Step 2b). Skipping the solution step produces a single-nested `<Project>/<Project>.flow` layout that fails Studio Web upload and packaging. The correct layout is **always** `<Solution>/<Project>/<Project>.flow` (double-nested — see the tree after Step 2c).
 
-Check the current directory for existing `.uipx` files. If existing solutions are found, ask the user, presenting a dropdown with one option per discovered `.uipx`, a **"Create a new solution"** option, and **"Something else"** as the last option (for a custom path). If no existing solutions are found, create a new one automatically. See the dropdown question rule in [SKILL.md](../../../SKILL.md).
+Check for existing solutions with `ls *.uipx */*.uipx 2>/dev/null` (each solution is its own folder — `<Solution>/<Solution>.uipx` — so a bare `*.uipx` misses them). If any are found, **STOP before the T1 chain — do not run `uip solution init` yet** — and ask via `AskUserQuestion`, presenting a dropdown with one option per discovered `.uipx`, a **"Create a new solution"** option, and **"Something else"** as the last option. The user wanting a new solution does not let you skip this; you only learn that by asking. If none are found, create a new one automatically. See the dropdown question rule in [SKILL.md](../../../SKILL.md).
 
 - If the user specifies an existing `.uipx` file path or solution name, use that (skip to Step 2b)
 - Otherwise, create a new solution (Step 2a)


### PR DESCRIPTION
## Problem

The `skill-flow-solution-select-ask` eval fails. It drops the agent into a directory that already holds two solutions (`SolarReports/`, `TideTracker/`) and asks it to create a new Flow project. The primary graded criterion (weight 3.0) is that the agent fires `AskUserQuestion` to let the user choose a solution **before** scaffolding.

In the failing run the agent read `greenfield.md`, then went straight to `uip solution init "WeatherAlert"` — never calling `AskUserQuestion`. It produced the right end-state (a new solution), so 6/7 criteria passed, but the interactive gate — the whole point of the test — never fired. Weighted score **0.71**, `FAILURE`.

## Verdict

The test is correct; the skill instruction was weak. Two root causes in `greenfield.md`:

1. **The gate was soft prose steamrolled by the batching guidance.** The existing-`.uipx` check was a single sentence wedged before the visually dominant "**Canonical T1 chain — issue this as ONE `Bash` call**" block, which leads with `uip solution init` (create-new). The doc repeatedly pushes "collapse to 3 turns, T1 is one chained scaffold Bash," so a model treats create-new as the default and skips the gate.
2. **Discovery pointed at the wrong place.** It said "check the current directory," but a solution is a folder containing its `.uipx` (`<Solution>/<Solution>.uipx`) — confirmed by the eval fixture. A bare `ls *.uipx` finds nothing, so the gate never fires anyway.

## Changes

- Turned the check into a hard **STOP before the T1 chain**, with the correct discovery glob (`ls *.uipx */*.uipx`), a note that solutions are folders, and the explicit line that *wanting* a new solution doesn't let you skip asking — you only learn that by asking.
- Added one clause to the three-turn map's T1 row so it no longer implies Step 2 always collapses into the scaffold `Bash`: when solutions exist, the Step 2 gate fires first in its own turn.

No test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)