### PR TITLE
fix(maestro-flow-skill): fix stale v1.6 node type in HITL planning docs

### DIFF
--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -1,6 +1,6 @@
 # HITL QuickForm Node — Direct JSON Reference
 
-The agent writes the `uipath.human-in-the-loop` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is available when the user explicitly requests it, or as a fallback if direct JSON writing fails — see [CLI reference: uip maestro flow hitl add](../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
+The agent writes the `uipath.human-in-the-loop.quick-form` node directly into the `.flow` file as JSON. **Direct JSON is the default.** A CLI opt-in is available when the user explicitly requests it, or as a fallback if direct JSON writing fails — see [CLI reference: uip maestro flow hitl add](../../uipath-maestro-flow/references/shared/cli-commands.md#uip-maestro-flow-hitl-add).
 
 ---
 

--- a/skills/uipath-maestro-flow/references/author/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/author/CAPABILITY.md
@@ -28,7 +28,7 @@ Every node in a `.flow` file has exactly one author. The validator enforces this
 | Triggers | `core.trigger.manual`, `core.trigger.scheduled` |
 | Control flow | `core.logic.decision`, `core.logic.switch`, `core.logic.loop`, `core.logic.merge`, `core.control.end`, `core.logic.terminate`, `core.subflow` |
 | Logic | `core.action.script`, `core.action.transform`, `core.logic.delay`, `core.logic.mock` |
-| Human-in-the-loop | `uipath.human-in-the-loop` (inline + app-task forms) |
+| Human-in-the-loop | `uipath.human-in-the-loop.quick-form` (inline form), `uipath.human-in-the-loop.coded-action-app` (app-based) |
 | Patterns | `uipath.pattern.batch-transform`, `uipath.pattern.deep-rag` |
 | Agents | `uipath.agent.autonomous` (inline; after `uip agent init --inline-in-flow`) |
 | Resource nodes | `uipath.core.rpa-workflow.*`, `uipath.core.agent.*`, `uipath.core.flow.*`, `uipath.core.agentic-process.*`, `uipath.core.api-workflow.*`, `uipath.core.human-task.*` |

--- a/skills/uipath-maestro-flow/references/author/references/planning-arch.md
+++ b/skills/uipath-maestro-flow/references/author/references/planning-arch.md
@@ -142,7 +142,7 @@ Each plugin has a `planning.md` with full selection heuristics, ports, key input
 | `core.logic.delay` | [delay](plugins/delay/planning.md) | Pause execution for a duration or until a specific date |
 | `core.action.queue.create` | [queue](plugins/queue/planning.md) | Distribute work to robots — fire-and-forget |
 | `core.action.queue.create-and-wait` | [queue](plugins/queue/planning.md) | Distribute work to robots — wait for result |
-| `uipath.human-in-the-loop` | [hitl](plugins/hitl/planning.md) | Pause flow for a human to review, approve, or fill in data — inline schema, no app required |
+| `uipath.human-in-the-loop.quick-form` | [hitl](plugins/hitl/planning.md) | Pause flow for a human to review, approve, or fill in data — inline schema, no app required |
 
 ### Control Flow
 
@@ -247,7 +247,7 @@ Use this when defining edges. Every edge requires a `sourcePort` and `targetPort
 | `uipath.connector.*` (activities) | `input` | `output`, `error` |
 | `core.action.queue.create` | `input` | `success` |
 | `core.action.queue.create-and-wait` | `input` | `success` |
-| `uipath.human-in-the-loop` | `input` | `completed` |
+| `uipath.human-in-the-loop.quick-form` | `input` | `completed` |
 | `uipath.core.human-task.{key}` | `input` | `output` |
 
 > **`error` is an implicit source port** on every action node (any node with `supportsErrorHandling: true`). Wire it whenever the flow needs to survive a failed HTTP call, script exception, transform error, agent fault, etc. — otherwise the flow faults as a whole. This is a **different mechanism** from content-based `inputs.branches` on HTTP. See [Implicit error port on action nodes](../../shared/file-format.md#implicit-error-port-on-action-nodes) for wiring, when it fires, and the decision matrix vs branches/decision/switch.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/impl.md
@@ -4,7 +4,7 @@ Two node types implement human-in-the-loop checkpoints. Choose based on whether 
 
 ---
 
-## Option 1 — `uipath.human-in-the-loop` (Inline Schema — OOTB)
+## Option 1 — `uipath.human-in-the-loop.quick-form` (Inline Schema — OOTB)
 
 This is the preferred option. No registry pull, no app publishing, no tenant dependency. Write the node directly into the `.flow` file as JSON.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/hitl/planning.md
@@ -8,16 +8,16 @@ The flow needs to pause for a human to review, approve, or fill in data. Two nod
 
 | Use case | Node type | Form source |
 | --- | --- | --- |
-| Inline form designed right now (fields + outcomes defined in the flow) | `uipath.human-in-the-loop` | Schema embedded in node inputs — no app needed |
-| Existing coded app or Action Center app | `uipath.core.human-task.{key}` | Deployed app from Orchestrator |
+| Inline form designed right now (fields + outcomes defined in the flow) | `uipath.human-in-the-loop.quick-form` | Schema embedded in node inputs — no app needed |
+| Existing coded app or Action Center app | `uipath.human-in-the-loop.coded-action-app` | Deployed app from Orchestrator |
 
-**Prefer `uipath.human-in-the-loop`** for new flows. It is an OOTB node — no registry discovery, no app publishing, no tenant dependency.
+**Prefer `uipath.human-in-the-loop.quick-form`** for new flows. It is an OOTB node — no registry discovery, no app publishing, no tenant dependency.
 
 ---
 
-## Option 1 — `uipath.human-in-the-loop` (Inline Schema — OOTB)
+## Option 1 — `uipath.human-in-the-loop.quick-form` (Inline Schema — OOTB)
 
-Node type: `uipath.human-in-the-loop`
+Node type: `uipath.human-in-the-loop.quick-form`
 Available: always — no `uip login` or registry pull required.
 
 ### When to Select
@@ -95,7 +95,7 @@ Trigger -> Process -> Decision (confidence ok?) ->
 
 In the node table:
 ```
-| hitlReview | Invoice Review | human-task | uipath.human-in-the-loop | inputs: [invoiceId, amount] outputs: [decision] outcomes: [Approve, Reject] | result, status |
+| hitlReview | Invoice Review | human-task | uipath.human-in-the-loop.quick-form | inputs: [invoiceId, amount] outputs: [decision] outcomes: [Approve, Reject] | output, status |
 ```
 
 ---


### PR DESCRIPTION
Fixes the root cause of 2/21 eval failures on release/v1.197.

The maestro-flow skill planning docs (CAPABILITY.md, planning-arch.md, hitl/planning.md, hitl/impl.md) still had `uipath.human-in-the-loop` as the node type — the old v1.6 name. When the agent builds a greenfield flow using the maestro-flow skill, it reads these docs and writes the wrong type, so `file_contains '"uipath.human-in-the-loop.quick-form"'` fails.

Changed all node type references to `uipath.human-in-the-loop.quick-form` (inline form) and `uipath.human-in-the-loop.coded-action-app` (app-based). Skill name references (uipath-human-in-the-loop package name) left unchanged.

Verified by downloading artifacts from run 28837986176: both failing flows had `"type": "uipath.human-in-the-loop"` — the agent was reading the old type from these planning docs.

Failures addressed:
- skill-hitl-e2e-gdpr-compliance-greenfield (5/6, score 0.769)
- skill-hitl-e2e-invoice-approval-greenfield-simple (5/6, score 0.810)

🤖 Generated with [Claude Code](https://claude.com/claude-code)