### PR TITLE
fix(tests): update stale uipath.human-in-the-loop node type refs

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -407,7 +407,7 @@ Verify a file contains (or excludes) expected strings. From `uipath-maestro-flow
   description: "Flow contains the inline HITL node type"
   path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
   includes:
-    - '"uipath.human-in-the-loop"'
+    - '"uipath.human-in-the-loop.quick-form"'
   weight: 3.0
   pass_threshold: 1.0
 ```

--- a/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
@@ -29,7 +29,7 @@ def _flow_doc(
             },
             {
                 "id": "reviewExpense",
-                "type": "uipath.human-in-the-loop",
+                "type": "uipath.human-in-the-loop.quick-form",
                 "typeVersion": "1.0",
                 "inputs": {
                     "schema": {

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -21,7 +21,7 @@ initial_prompt: |
       - Approve → Script node that logs "PO approved"
       - Reject  → End node
 
-  Use the inline quickform node (uipath.human-in-the-loop).
+  Use the inline quickform node (uipath.human-in-the-loop.quick-form).
   Set priority to High.
   Wire completed → decision node.
   Validate the flow after building.

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -1,7 +1,7 @@
 task_id: skill-flow-hitl-smoke-node-placed
 description: >
   Smoke test: agent builds a simple invoice approval flow containing an inline
-  HITL node (uipath.human-in-the-loop). Verifies the node is written directly
+  HITL node (uipath.human-in-the-loop.quick-form). Verifies the node is written directly
   into the .flow file as JSON and the flow validates.
 tags: [uipath-maestro-flow, uipath-human-in-the-loop, smoke, lifecycle:generate, shape:single-node, node:hitl]
 


### PR DESCRIPTION
Closes the remaining stale `uipath.human-in-the-loop` references not covered by #1901.

Four files still had the old bare type (without `.quick-form` suffix):

- `tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml` — prompt text told the agent to use `uipath.human-in-the-loop`, which caused it to write the old type
- `tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml` — description text same issue
- `tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py` — synthetic flow fixture used the old type; the checker's `startswith("uipath.human-in-the-loop")` still covers both subtypes so this is safe
- `tests/README.md` — doc example showed an old-style `file_contains` criteria

Skipped intentionally:
- `check_devcon_expense_approval.py:54` — `startswith("uipath.human-in-the-loop")` is a deliberate prefix match that covers both subtypes
- `skills/uipath-maestro-bpmn/validator/bpmn-spec.json` — BPMN spec entry, separate codeowner concern
- `tests/tasks/uipath-human-in-the-loop/TEST_PLAN.md` — references the skill name, not the node type

🤖 Generated with [Claude Code](https://claude.com/claude-code)