### PR TITLE
fix(bpmn): add quick-form and coded-action-app to uipathShortcuts

### DIFF
--- a/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
+++ b/skills/uipath-maestro-bpmn/validator/bpmn-spec.json
@@ -2401,8 +2401,12 @@
         "bpmnElement": "uipath.agent",
         "category": "uipathShortcut"
       },
-      "uipath.human-in-the-loop": {
-        "bpmnElement": "uipath.human-in-the-loop",
+      "uipath.human-in-the-loop.quick-form": {
+        "bpmnElement": "uipath.human-in-the-loop.quick-form",
+        "category": "uipathShortcut"
+      },
+      "uipath.human-in-the-loop.coded-action-app": {
+        "bpmnElement": "uipath.human-in-the-loop.coded-action-app",
         "category": "uipathShortcut"
       },
       "uipath.api-workflow": {


### PR DESCRIPTION
`bpmn-spec.json` had `uipath.human-in-the-loop` as a known shortcut but not the v1.7 subtypes. Replaces it with both new entries so the BPMN validator accepts flows using the current node types.

Validated all 31 HITL task files locally with `coder-eval plan` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)