### PR TITLE
docs: fix broken relative links reported in UV-15217 (defect 3)

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/batch-transform/planning.md
+++ b/skills/uipath-agents/references/coded/capabilities/batch-transform/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm BatchTransform is the right mode first — see [../../../context-grounding-patterns.md](../../../context-grounding-patterns.md).
 
-For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/batch-transform/planning.md](../../lowcode/capabilities/built-in-tools/batch-transform/planning.md).
+For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/batch-transform/planning.md](../../../lowcode/capabilities/built-in-tools/batch-transform/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/coded/capabilities/batch-transform/planning.md
+++ b/skills/uipath-agents/references/coded/capabilities/batch-transform/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm BatchTransform is the right mode first — see [../../../context-grounding-patterns.md](../../../context-grounding-patterns.md).
 
-For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/batch-transform/planning.md](../../../lowcode/capabilities/built-in-tools/batch-transform/planning.md).
+For Studio Web Agent Builder → [../../../lowcode/capabilities/built-in-tools/batch-transform/planning.md](../../../lowcode/capabilities/built-in-tools/batch-transform/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/coded/capabilities/deeprag/planning.md
+++ b/skills/uipath-agents/references/coded/capabilities/deeprag/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm DeepRAG is the right mode first — see [../../../context-grounding-patterns.md](../../../context-grounding-patterns.md).
 
-For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/deeprag/planning.md](../../lowcode/capabilities/built-in-tools/deeprag/planning.md).
+For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/deeprag/planning.md](../../../lowcode/capabilities/built-in-tools/deeprag/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/coded/capabilities/deeprag/planning.md
+++ b/skills/uipath-agents/references/coded/capabilities/deeprag/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm DeepRAG is the right mode first — see [../../../context-grounding-patterns.md](../../../context-grounding-patterns.md).
 
-For Studio Web Agent Builder → [../../lowcode/capabilities/built-in-tools/deeprag/planning.md](../../../lowcode/capabilities/built-in-tools/deeprag/planning.md).
+For Studio Web Agent Builder → [../../../lowcode/capabilities/built-in-tools/deeprag/planning.md](../../../lowcode/capabilities/built-in-tools/deeprag/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/coded/embedding-in-flows.md
+++ b/skills/uipath-agents/references/coded/embedding-in-flows.md
@@ -92,7 +92,7 @@ uip maestro flow registry list --local --output json
 uip maestro flow registry get "uipath.core.agent.<resourceKey>" --local --output json
 ```
 
-The second command's `Data.Node` object is what the flow skill pastes into the flow's `definitions[]`. For the node instance shape and top-level `bindings[]` entries, see [agent/impl.md § In-solution variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--in-solution-variant).
+The second command's `Data.Node` object is what the flow skill pastes into the flow's `definitions[]`. For the node instance shape and top-level `bindings[]` entries, see the uipath-maestro-flow skill agent-plugin reference (In-solution variant).
 
 Without `--local`, `registry list`/`get` query the tenant registry (Orchestrator-published resources only) and will not surface the sibling project.
 

--- a/skills/uipath-agents/references/coded/flow-integration.md
+++ b/skills/uipath-agents/references/coded/flow-integration.md
@@ -10,7 +10,7 @@ The coded agent lives as a sibling folder inside the same solution as the flow. 
 
 - **Agent-side scaffolding:** [embedding-in-flows.md](embedding-in-flows.md)
 - **Wiring the agent's inputs:** [embedding-in-flows.md § Wiring the Agent's Inputs](embedding-in-flows.md#wiring-the-agents-inputs)
-- **Flow node JSON shape + top-level `bindings[]` + `definitions[]` entry:** [agent/impl.md § In-solution variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--in-solution-variant)
+- **Flow node JSON shape + top-level `bindings[]` + `definitions[]` entry:** uipath-maestro-flow skill, agent-plugin reference (In-solution variant)
 
 The node-type's `{key}` is the local `resource.key` minted by `uip solution project add` (written to `resources/solution_folder/process/agent/<name>.json`) and surfaced by `uip maestro flow registry list --local`.
 
@@ -36,7 +36,7 @@ Fallback discovery paths if the deploy output is unavailable or unparseable, **t
 
 If all paths return empty / 404, the deploy command's stdout JSON is authoritative — re-run the deploy and capture its output rather than chasing post-hoc discovery endpoints.
 
-For the flow node JSON shape, see [agent/impl.md § Published variant](../../../uipath-maestro-flow/references/plugins/agent/impl.md#node-instance-inside-nodes--published-variant). `model.section` is `"Published"`.
+For the flow node JSON shape, see the uipath-maestro-flow skill agent-plugin reference (Published variant). `model.section` is `"Published"`.
 
 ---
 

--- a/skills/uipath-agents/references/coded/lifecycle/build.md
+++ b/skills/uipath-agents/references/coded/lifecycle/build.md
@@ -8,7 +8,6 @@ Read **only** the reference matching the selected framework. Do NOT load other f
 
 | Framework | Reference |
 |-----------|-----------|
-| Coded Function | `../frameworks/coded-function-agents.md` + `../frameworks/agent-patterns.md` |
 | LangGraph | `../frameworks/langgraph-integration.md` |
 | LlamaIndex | `../frameworks/llamaindex-integration.md` |
 | OpenAI Agents | `../frameworks/openai-agents-integration.md` |

--- a/skills/uipath-agents/references/coded/lifecycle/setup.md
+++ b/skills/uipath-agents/references/coded/lifecycle/setup.md
@@ -14,7 +14,6 @@ Pick the framework before starting. The package installed in the Workflow determ
 
 | Agent Type | `<FRAMEWORK_PACKAGE>` | Framework config | Guide |
 |---|---|---|---|
-| Coded Function | `uipath` | `uipath.json` | [coded-function-agents.md](../frameworks/coded-function-agents.md) |
 | LangGraph | `"uipath-langchain"` | `langgraph.json` | [langgraph-integration.md](../frameworks/langgraph-integration.md) |
 | LlamaIndex | `uipath-llamaindex` | `llama_index.json` | [llamaindex-integration.md](../frameworks/llamaindex-integration.md) |
 | OpenAI Agents | `uipath-openai-agents` | `openai_agents.json` | [openai-agents-integration.md](../frameworks/openai-agents-integration.md) |

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -47,7 +47,7 @@ Use `uip codedagent <cmd>`, not `uv run uipath <cmd>`. The wrapper injects sessi
 - **Auth MUST be an interactive question only when needed and values are missing.** If the session check fails and the user did not provide all of environment / organization / tenant, your ENTIRE response must be a single direct question. Do NOT wrap it in bullet points, "Next Steps" headers, or status summaries. Just ask and stop:
 
   > What is your UiPath **environment** (cloud/staging/alpha), **organization name**, and **tenant name**?
-- **In a flow, coded agents are referenced via the [`agent`](../../../uipath-maestro-flow/references/plugins/agent/) plugin** — node type `uipath.core.agent.{key}`, `Orchestrator.StartAgentJob`. See [flow-integration.md](flow-integration.md) for the three patterns: in-solution sibling folder, Orchestrator-published, tool resource.
+- **In a flow, coded agents are referenced via the `agent` plugin (uipath-maestro-flow skill)** — node type `uipath.core.agent.{key}`, `Orchestrator.StartAgentJob`. See [flow-integration.md](flow-integration.md) for the three patterns: in-solution sibling folder, Orchestrator-published, tool resource.
 
 ## Lifecycle Stages
 

--- a/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/batch-transform/planning.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/batch-transform/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm BatchTransform is the right mode first — see [../../../../context-grounding-patterns.md](../../../../context-grounding-patterns.md).
 
-For coded agents (Python, LangGraph) → [../../../coded/capabilities/batch-transform/planning.md](../../../../coded/capabilities/batch-transform/planning.md).
+For coded agents (Python, LangGraph) → [../../../../coded/capabilities/batch-transform/planning.md](../../../../coded/capabilities/batch-transform/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/batch-transform/planning.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/batch-transform/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm BatchTransform is the right mode first — see [../../../../context-grounding-patterns.md](../../../../context-grounding-patterns.md).
 
-For coded agents (Python, LangGraph) → [../../../coded/capabilities/batch-transform/planning.md](../../../coded/capabilities/batch-transform/planning.md).
+For coded agents (Python, LangGraph) → [../../../coded/capabilities/batch-transform/planning.md](../../../../coded/capabilities/batch-transform/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/deeprag/planning.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/deeprag/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm DeepRAG is the right mode first — see [../../../../context-grounding-patterns.md](../../../../context-grounding-patterns.md).
 
-For coded agents (Python, LangGraph) → [../../../coded/capabilities/deeprag/planning.md](../../../coded/capabilities/deeprag/planning.md).
+For coded agents (Python, LangGraph) → [../../../coded/capabilities/deeprag/planning.md](../../../../coded/capabilities/deeprag/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/deeprag/planning.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/built-in-tools/deeprag/planning.md
@@ -11,7 +11,7 @@ Pick this when:
 
 Confirm DeepRAG is the right mode first — see [../../../../context-grounding-patterns.md](../../../../context-grounding-patterns.md).
 
-For coded agents (Python, LangGraph) → [../../../coded/capabilities/deeprag/planning.md](../../../../coded/capabilities/deeprag/planning.md).
+For coded agents (Python, LangGraph) → [../../../../coded/capabilities/deeprag/planning.md](../../../../coded/capabilities/deeprag/planning.md).
 
 ## Inputs You Need Before Building
 

--- a/skills/uipath-api-workflow/references/cli-reference.md
+++ b/skills/uipath-api-workflow/references/cli-reference.md
@@ -353,7 +353,7 @@ Requires `uip login`. The SDK resolves folder keys via Resource Catalog Service;
 
 **Idempotency.** Import-only by design. First run for a binding triggers `addOrUpdateResourceToSolutionAsync` (status `Added`); subsequent runs skip the binding because its key is already in the solution. Re-running is safe and a no-op when nothing changed.
 
-Lives in `solution-tool`, not `api-workflow-tool`. Full details in the [solution skill](../uipath-platform).
+Lives in `solution-tool`, not `api-workflow-tool`. Full details in the uipath-solution skill.
 
 ## `uip is resources describe`
 

--- a/skills/uipath-governance/references/cli-cheatsheet.md
+++ b/skills/uipath-governance/references/cli-cheatsheet.md
@@ -97,7 +97,7 @@ Bare `formData` object, NOT wrapped in `{ "data": ... }`. The CLI adds the wrapp
 
 ## Deployment (tenant / group / user)
 
-> **All `deployment * configure` commands are FULL REPLACE.** The submitted array rewrites the target's assignment list. Always read current state first, merge new entries in, then configure. See [policy-assign.md](policy-assign.md) for the merge-first pattern.
+> **All `deployment * configure` commands are FULL REPLACE.** The submitted array rewrites the target's assignment list. Always read current state first, merge new entries in, then configure. See `policy-assign.md` for the merge-first pattern.
 >
 > **Why this matters:** the previous `assign-tenant` / `assign-group` / `assign-user` commands had a "last deploy wins" bug — sequential single-policy calls each did a full-replace at the API. The new `configure` commands fix this by taking the full assignment list in one atomic call.
 
@@ -173,8 +173,8 @@ This skill uses only the default caller-own mode. The `--tenant-only` and `--use
 | `401 / 403` | Session expired or insufficient perms. | Halt. Ask user to `uip login`. |
 | `404` | Identifier not found. | Halt. Check IDs. (Missing `--input` paths now surface a clear filesystem error, not 404.) |
 | `409` | Duplicate policy name on create. | Halt. V1 = do NOT retry-as-update. (Critical Rule in SKILL.md) |
-| `500` | Often [missing metadata flags on update (known-issue #2)](cli-known-issues.md). | Halt. Re-read policy metadata, pass all flags. |
-| `503` with transient `Instructions` text (`template upgrade`, `connection timeout`, `backend temporarily unavailable`) | AOPS is migrating the policy's Form.io template or a dependency is flapping — typically tens of seconds to minutes. | Do NOT use the default 3s retry. Wait 30s before first retry, 60s before second. Or surface to user and offer `retry now` / `cancel`. Only halt after a third failure or if the `Instructions` text shifts to a non-transient error. See [policy-crud.md UPDATE error map](policy-crud.md#update-recipe). |
+| `500` | Often missing metadata flags on update (known-issue #2). | Halt. Re-read policy metadata, pass all flags. |
+| `503` with transient `Instructions` text (`template upgrade`, `connection timeout`, `backend temporarily unavailable`) | AOPS is migrating the policy's Form.io template or a dependency is flapping — typically tens of seconds to minutes. | Do NOT use the default 3s retry. Wait 30s before first retry, 60s before second. Or surface to user and offer `retry now` / `cancel`. Only halt after a third failure or if the `Instructions` text shifts to a non-transient error. See `policy-crud.md` UPDATE error map. |
 | `5xx` other | Server-side. | Retry once after 3s. Halt on second failure. Surface `Instructions` verbatim. |
 
 All halts write a deploy record (Apply) or patch record (Diagnose).

--- a/skills/uipath-governance/references/diagnose/references/failure-modes.md
+++ b/skills/uipath-governance/references/diagnose/references/failure-modes.md
@@ -63,7 +63,7 @@ Named failure patterns with symptom → cause → investigation → fix. Match t
    ```bash
    uip gov aops-policy deployment tenant get "$TENANT_ID" --output json
    ```
-3. Verify the product is included in the target license type (see [aops-policy-deploy-guide.md — License-type → product compatibility](../aops-policy/aops-policy-deploy-guide.md#license-type--product-compatibility)).
+3. Verify the product is included in the target license type (see [aops-policy-deploy-guide.md — License-type → product compatibility](../../aops-policy/aops-policy-deploy-guide.md#license-type--product-compatibility)).
 
 **Fix:** Cause 1 → redeploy to a license type that includes the target product. Cause 2 → deploy to the license type the affected users actually hold. Cause 3 → deploy to all relevant license types.
 
@@ -100,7 +100,7 @@ Named failure patterns with symptom → cause → investigation → fix. Match t
    uip gov access-policy list --filter "status in ('Active')" --output json
    ```
 
-**Fix:** Cause 1 → narrow selector `resourceType`/`tags`. Cause 2 → add the calling user/group to `actorRule`. Cause 3 → add the actor process type to `executableRule`. Cause 4 → adjust tags on the resource or policy. Cause 5 → see [plugins/actor/impl.md — Robot intent](../access-policy/plugins/actor/impl.md) for the User-fallback pattern.
+**Fix:** Cause 1 → narrow selector `resourceType`/`tags`. Cause 2 → add the calling user/group to `actorRule`. Cause 3 → add the actor process type to `executableRule`. Cause 4 → adjust tags on the resource or policy. Cause 5 → see [plugins/actor/impl.md — Robot intent](../../access-policy/plugins/actor/impl.md) for the User-fallback pattern.
 
 ---
 
@@ -133,7 +133,7 @@ Named failure patterns with symptom → cause → investigation → fix. Match t
    ```
 4. Verify the resource's tags in the Resource Catalog match the selector's tag filter.
 
-**Fix:** Cause 1 → broaden selector or add a new policy covering the gap. Cause 2 → update status to `Active`. Cause 3 → correct tags on resource or policy. Cause 4 → reframe deny intent as allow-only (see [plugins/tags/planning.md — Deny-to-Allow flip](../access-policy/plugins/tags/planning.md#deny-to-allow-flip)). Cause 5 → use correct enum values from [plugins/selector/impl.md](../access-policy/plugins/selector/impl.md).
+**Fix:** Cause 1 → broaden selector or add a new policy covering the gap. Cause 2 → update status to `Active`. Cause 3 → correct tags on resource or policy. Cause 4 → reframe deny intent as allow-only (see [plugins/tags/planning.md — Deny-to-Allow flip](../../access-policy/plugins/tags/planning.md#deny-to-allow-flip)). Cause 5 → use correct enum values from [plugins/selector/impl.md](../../access-policy/plugins/selector/impl.md).
 
 ---
 
@@ -165,7 +165,7 @@ Named failure patterns with symptom → cause → investigation → fix. Match t
    uip gov aops-policy deployment user get "$USER_ID" --output json
    ```
 
-**Fix:** Cause 1 → deploy a policy via [aops-policy-deploy-guide.md](../aops-policy/aops-policy-deploy-guide.md). Cause 2 → redeploy to the correct tenant. Cause 3 → use the product `name` (not label) from `product list`. Cause 4 → remove the `null` override or deploy a policy at a broader scope.
+**Fix:** Cause 1 → deploy a policy via [aops-policy-deploy-guide.md](../../aops-policy/aops-policy-deploy-guide.md). Cause 2 → redeploy to the correct tenant. Cause 3 → use the product `name` (not label) from `product list`. Cause 4 → remove the `null` override or deploy a policy at a broader scope.
 
 ---
 
@@ -198,4 +198,4 @@ Named failure patterns with symptom → cause → investigation → fix. Match t
    ```
 4. For Access — check error message in response `Data.errors`.
 
-**Fix:** Cause 1 → use `name` from `product list`. Cause 2 → fix JSON (validate with `jq`). Cause 3 → switch to `enforcement: "Allow"`. Cause 4 → add `"values": ["*"]` to selector entries. Cause 5 → choose a different name. Cause 6 → regenerate from template via [configure-aops-policy-data-guide.md](../aops-policy/configure-aops-policy-data-guide.md).
+**Fix:** Cause 1 → use `name` from `product list`. Cause 2 → fix JSON (validate with `jq`). Cause 3 → switch to `enforcement: "Allow"`. Cause 4 → add `"values": ["*"]` to selector entries. Cause 5 → choose a different name. Cause 6 → regenerate from template via [configure-aops-policy-data-guide.md](../../aops-policy/configure-aops-policy-data-guide.md).

--- a/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/guides/data-service-filter-builder-guide.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.DataService.Activities/guides/data-service-filter-builder-guide.md
@@ -60,7 +60,7 @@ xmlns:s="clr-namespace:System;assembly=System.Private.CoreLib"
 The `x:` prefix covers: `x:String`, `x:Int32`, `x:Int64`, `x:Double`, `x:Boolean`, `x:Decimal`.
 The `s:` prefix is required for: `s:DateTimeOffset`, `s:Guid`, `s:String[]`, `s:DateTime`.
 
-See [xaml-basics-and-rules.md § x: and s: namespace aliases](uipath-rpa/references/xaml/xaml-basics-and-rules.md) for the full type mapping.
+See [xaml-basics-and-rules.md § x: and s: namespace aliases](../../../xaml/xaml-basics-and-rules.md) for the full type mapping.
 
 ## Operator Reference by Field Type
 

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
@@ -488,7 +488,7 @@ Used by `ResponseOptions.FileOverwrite`.
 ## Related Activity Mappings
 
 - `Deserialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.DeserializeObject<T>(...)` in coded workflows.
-- `HTTP Request (Legacy)` is not exposed in coded workflows; use the `http` service (`IHttpService`) with `SendRequestAsync` instead. For behavioral differences versus the legacy activity, see [docs/activities/NetHttpRequest.md](UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md).
+- `HTTP Request (Legacy)` is not exposed in coded workflows; use the `http` service (`IHttpService`) with `SendRequestAsync` instead. For behavioral differences versus the legacy activity, see [docs/activities/NetHttpRequest.md](../activities/NetHttpRequest.md).
 - `Deserialize JSON Array` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.Linq.JArray.Parse(...)` in coded workflows.
 - `Serialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.SerializeObject(...)` in coded workflows.
 - `Deserialize XML` activity is not exposed as a dedicated coded API service method; use `System.Xml.Linq.XDocument.Parse(...)` in coded workflows.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/coded-api.md
@@ -488,7 +488,7 @@ Used by `ResponseOptions.FileOverwrite`.
 ## Related Activity Mappings
 
 - `Deserialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.DeserializeObject<T>(...)` in coded workflows.
-- `HTTP Request (Legacy)` is not exposed in coded workflows; use the `http` service (`IHttpService`) with `SendRequestAsync` instead. For behavioral differences versus the legacy activity, see [docs/activities/NetHttpRequest.md](../activities/NetHttpRequest.md).
+- `HTTP Request (Legacy)` is not exposed in coded workflows; use the `http` service (`IHttpService`) with `SendRequestAsync` instead. For behavioral differences versus the legacy activity, see [NetHttpRequest Activity](../activities/NetHttpRequest.md).
 - `Deserialize JSON Array` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.Linq.JArray.Parse(...)` in coded workflows.
 - `Serialize JSON` activity is not exposed as a dedicated coded API service method; use `Newtonsoft.Json.JsonConvert.SerializeObject(...)` in coded workflows.
 - `Deserialize XML` activity is not exposed as a dedicated coded API service method; use `System.Xml.Linq.XDocument.Parse(...)` in coded workflows.

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/curl-import.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/curl-import.md
@@ -12,7 +12,7 @@ Read this file completely before generating code. The workflow is: **import ? ac
 
 ### Scope of this skill
 
-This skill is concerned **only** with producing a correct `HttpRequestOptions` from a cURL command. Once the object is ready, hand it off to `http.SendRequestAsync()`. Diagnosing HTTP responses, iterating on failures, and processing response content are handled by [NetHttpRequest.md](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) and [service-discovery.md](service-discovery.md).
+This skill is concerned **only** with producing a correct `HttpRequestOptions` from a cURL command. Once the object is ready, hand it off to `http.SendRequestAsync()`. Diagnosing HTTP responses, iterating on failures, and processing response content are handled by [NetHttpRequest.md](../activities/NetHttpRequest.md) and [service-discovery.md](service-discovery.md).
 
 ## When to use
 
@@ -201,7 +201,7 @@ var response = await http.SendRequestAsync(imported.Options);
 
 ## See Also
 
-- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
-- [HttpClient Activity (Legacy)](../../UiPath.Web.Activities.Package.Design/docs/activities/HttpClient.md) — legacy HTTP activity reference
+- [NetHttpRequest Activity](../activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
+- [HttpClient Activity (Legacy)](../activities/HttpClient.md) — legacy HTTP activity reference
 - [Service Discovery](service-discovery.md) — discovering unknown service endpoints and generating working requests
 - [HTTP Request Upgrade](http-request-upgrade.md) — migrating from the legacy HTTP Request activity

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/http-request-upgrade.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/http-request-upgrade.md
@@ -1,4 +1,4 @@
-﻿# HTTP Request Upgrade — Legacy to Modern Migration
+# HTTP Request Upgrade — Legacy to Modern Migration
 
 An agent skill for migrating workflows from the legacy HTTP Request activity (RestSharp-based) to the modern NetHttpRequest activity (.NET HttpClient-based).
 
@@ -680,7 +680,7 @@ Rules:
 
 ## See Also
 
-- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
-- [HttpClient Activity (Legacy)](../../UiPath.Web.Activities.Package.Design/docs/activities/HttpClient.md) — legacy HTTP activity reference
+- [NetHttpRequest Activity](../activities/NetHttpRequest.md) — modern HTTP activity behavior spec, inputs, outputs, and defaults
+- [HttpClient Activity (Legacy)](../activities/HttpClient.md) — legacy HTTP activity reference
 - [cURL Import Skills](curl-import.md) — converting raw cURL commands to HttpRequestOptions
 - [Service Discovery](service-discovery.md) — discovering unknown service endpoints and generating working requests

--- a/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/service-discovery.md
+++ b/skills/uipath-rpa/references/activity-docs/UiPath.Web.Activities/2.5/coded/service-discovery.md
@@ -1,4 +1,4 @@
-﻿# Service Discovery
+# Service Discovery
 
 An agent skill for progressively exploring an unknown service URL and producing a working coded workflow.
 
@@ -501,6 +501,6 @@ User provides URL
 
 ## See Also
 
-- [NetHttpRequest Activity](../../UiPath.Web.Activities.Package.Design/docs/activities/NetHttpRequest.md) — HTTP activity behavior spec, inputs, outputs, and defaults
+- [NetHttpRequest Activity](../activities/NetHttpRequest.md) — HTTP activity behavior spec, inputs, outputs, and defaults
 - [cURL Import](curl-import.md) — converting raw cURL commands to HttpRequestOptions
 - [HTTP Request Upgrade](http-request-upgrade.md) — migrating from legacy HTTP Request activity


### PR DESCRIPTION
## What

Fixes the broken relative doc links reported in UV-15217 (defect 3): 14 files, 24 lines, docs only. All 8 reported claims verified against main `b775bc49` before fixing; a repo sweep of the four affected skills found no broken relative links beyond the report.

## Changes

**Mechanical path fixes (17 links):**
- `uipath-governance/references/diagnose/references/failure-modes.md` — all five `access-policy`/`aops-policy` links were one `../` short (file lives two levels deep)
- `uipath-agents` batch-transform + deeprag `planning.md` — coded↔lowcode cross-links short one `../` in both directions
- `uipath-rpa` Web.Activities `2.5/coded/*` — seven links pointed at a `UiPath.Web.Activities.Package.Design/docs/activities/` directory that never existed; targets live at `../activities/{HttpClient,NetHttpRequest}.md`
- `uipath-rpa` DataService `data-service-filter-builder-guide.md` — repo-style path replaced with the correct relative path to `xaml-basics-and-rules.md`

**Cross-skill link removal (2 clusters, per the self-contained rule):**
- `uipath-agents/references/coded/{embedding-in-flows,flow-integration,quickstart}.md` linked `uipath-maestro-flow`'s pre-restructure `references/plugins/agent/` path (the lowcode docs already use the new location — the coded ones were never updated). Broken and cross-skill; replaced with plain-text sibling-skill mentions.
- `uipath-api-workflow/references/cli-reference.md` linked `../uipath-platform` while calling it "the solution skill" (path also malformed). Resolved in favor of the text: plain-text mention of `uipath-solution`. Reviewers: please confirm this label was the intent.

## Verification

All 80 relative `.md` links in the touched files resolve after the change; zero occurrences of the stale paths remain in the repo.

**Never-written-doc removal (per line-area owner):** `coded-function-agents.md` was never written — the content became its own skill, `uipath-functions` (#1144). Per Radu Mocanu, the two lifecycle rows referencing it are removed: the `setup.md` framework-table guide link and the `build.md` read-matrix row (the latter hid the path in backticks — invisible to link checkers, found while applying the fix).

**Unmerged-pack references unlinked (per author):** the three `cli-cheatsheet.md` links (`policy-crud.md`, `policy-assign.md`, `cli-known-issues.md`) point at docs that exist only on `feat/compliance-apply-skill` (authored 2026-04-28, no PR ever opened) — the cheatsheet was extracted into main via #1342 while its companions stayed behind. Unlinked with the filenames kept as inline code: when the compliance pack merges, its own cheatsheet copy restores the links naturally. Author (Nishank Siddharth) confirmed dropping is fine; @t-hsia — flag here if you'd rather the pack land first.

With this, every claim from UV-15217 defect 3 is resolved — no known broken relative links remain in the repo.

Separately out of scope: the four skills contain ~21 *resolving* cross-skill doc links (agents→platform/maestro-flow, governance→admin, rpa→platform/solution/test). Whether those violate the self-contained rule or doc-level links are blessed is a repo-owner policy call — raised separately, not in this PR.

Ref: UV-15217 (defect 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
