### PR TITLE
test(uipath-test): accept objectlabel list as label-verification alternative in requirement export smoke [TMHUB-32267]

### DIFF
--- a/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
+++ b/tests/tasks/uipath-test/requirement_list_export_smoke.yaml
@@ -49,9 +49,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Complete list command: `uip tm requirements list --project-key HEALTH --labels eval-export`"
+    description: "Label-scoped verification list: `uip tm requirements list --project-key HEALTH --labels eval-export` OR `uip tm objectlabel list --project-key HEALTH --object-type Requirement --filter eval-export`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--labels\s+["\x27]?eval-export)uip\s+tm\s+requirements?\s+list\s'
+    command_pattern: '(?=.*--project-key\s+HEALTH)(?:(?=.*--labels\s+["\x27]?eval-export)uip\s+tm\s+requirements?\s+list\s|(?=.*--object-type\s+Requirement)(?=.*--filter\s+["\x27]?eval-export)uip\s+tm\s+objectlabel\s+list\b)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Jira

[TMHUB-32267](https://uipath.atlassian.net/browse/TMHUB-32267)

## Why

The `skill-test-requirement-list-export-smoke` eval failed a run at 0.78: the agent confirmed the applied label via `uip tm objectlabel list --project-key HEALTH --object-type Requirement --filter eval-export --output json` instead of the expected `uip tm requirements list --labels` command, and the weight-2.0 list criterion matched 0/1. Both are correct server-side verifications of the tag, so the criterion should accept either.

## What

Single criterion change in `tests/tasks/uipath-test/requirement_list_export_smoke.yaml`: the list `command_pattern` is now an OR of the two surfaces —

- `uip tm requirements list --project-key HEALTH --labels eval-export`
- `uip tm objectlabel list --project-key HEALTH --object-type Requirement --filter eval-export`

Either branch still requires the HEALTH project scope and must name the `eval-export` label explicitly (per review, a label-less `--object-ids <uuid>` dump does not qualify). The `--output json` tightening of this file's patterns stays in #1761; expect a one-hunk conflict between the two PRs on this criterion — resolve by keeping the OR pattern and adding the `(?=.*--output\s+json)` lookahead to its shared prefix.

## Validation

- Regex validated against 9 positive/negative cases, including the exact commands from the failed run transcript (the `--filter eval-export` form matches; a label-less `--object-ids` dump, `objectlabel add`, missing label scope, wrong object type, wrong project, and `list-by-test-execution` are rejected).
- Both verbs confirmed present in `assets/uip-catalog-snapshot.json` and their flags checked against uip `1.197.0-alpha` help.
- `/lint-task` verdict: Low (two pre-existing advisories on the xlsx existence check; nothing introduced by this change).
- Full coder-eval rerun pending — the run mutates the HEALTH project on the shared eval tenant, so leaving that to a nightly/approved run.

Replaces #1909 (was stacked on `test/uipath-test-steps-execution-coverage`; retargeted to main per review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TMHUB-32267]: https://uipath.atlassian.net/browse/TMHUB-32267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ