### PR TITLE
fix(uipath-review): minimize low-code review prompts to restore skill activation [AL-504]

### DIFF
--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -27,23 +27,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -23,23 +23,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -22,23 +22,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -24,23 +24,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -24,23 +24,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
@@ -24,23 +24,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -23,23 +23,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -23,23 +23,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -24,23 +24,11 @@ pre_run:
     timeout: 30
 
 initial_prompt: |
-  A low-code UiPath agent project exists at `ReviewSol/SampleAgent`
-  inside the solution `ReviewSol`. Review the agent project and produce
-  a structured review report with Critical / Warning / Info findings.
+  A low-code UiPath agent project exists at `ReviewSol/SampleAgent` inside the
+  solution `ReviewSol`. Review the agent project for issues and save your review
+  report to `./_review_report.md` at the sandbox root.
 
-  This is a read-only review. Do NOT modify, create, or delete any
-  files inside `ReviewSol/`. Do NOT scaffold a new project. Do NOT
-  ask for approval, confirmation, or feedback.
-
-  Important — produce the review in TWO places, identical content:
-
-  1. As the chat output (the normal review surface), AND
-  2. Save the SAME report to a file at `./_review_report.md` at the
-     sandbox root (NOT inside `ReviewSol/`).
-
-  Writing the file copy first, before producing the chat report, is
-  encouraged — that way the file persists even if the chat response is
-  cut off. The file is the source of truth the test harness will check.
+  This is a read-only review — do not modify anything inside `ReviewSol/`.
 
 success_criteria:
   - type: skill_triggered


### PR DESCRIPTION
## What changed?

Simplified the `initial_prompt` in all 9 low-code `uipath-review` task YAMLs to a minimal, coded-style prompt.

**Why:** In run `2026-07-07_04-22-21`, 5 low-code guardrail review tasks failed identically — the agent **never engaged the `uipath-review` skill** (`skill_triggered=0`), which cascaded into skipping the review CLI, the guardrail-catalog fetch, and the canonical rule IDs (`LC_GUARDRAIL_RECOMMENDED`, etc.). Root cause: the verbose prompt over-specified the deliverable (Critical/Warning/Info bands, "two places", "write file first"), handing the model a complete recipe so it reviewed inline without the skill. The minimal coded-guardrail prompts triggered the skill in **4/4** runs; the verbose low-code prompt in only **1/6**. The verbose prompt also violated the repo's own test-writing rule (`Prompts: Minimal… the skill teaches those`).

The new prompt keeps the review goal, the `./_review_report.md` target, and the read-only constraint. Only `initial_prompt` text changed (+36/−144) — criteria, injects, and check scripts are untouched, and `SKILL.md` frontmatter is **not** touched, so the `activation-gate.yml` recall gate is not triggered. All 9 prompts remain byte-identical (repo convention).

## How has this been tested?

- Reproduced the original failure locally (custom finding IDs → `check_*.py` exit 1; canonical rule ID → exit 0).
- Deterministic checks: all 9 prompts byte-identical, YAML-valid, criteria counts preserved.
- Full agentic re-runs via `coder-eval` (local, live `uip` tenant auth + `anthropic_direct` routing): `audit_logging` and `content_safety` — both **0.33 FAIL before** — now score **6/6, 1.000 across 5/5 runs each** (10/10 completed runs passed, incl. `skill_triggered`). Remaining tasks share the identical prompt.

## Are there any breaking changes?

- [x] None

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AaLb6j1btoKxnw1981V8Zt