### PR TITLE
fix(maestro-flow tests): raise debug criterion timeouts above run_debug subprocess timeout

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -30,7 +30,7 @@ success_criteria:
   - type: run_command
     description: "Flow debug runs and output contains 391 (17 * 23)"
     command: "python3 $TASK_DIR/check_calculator_flow.py"
-    timeout: 120
+    timeout: 300  # must exceed run_debug's internal subprocess timeout (240s)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -57,7 +57,7 @@ success_criteria:
   - type: run_command
     description: "Flow debug runs and transform output contains the 3 curated books"
     command: "python3 $TASK_DIR/check_reading_list.py"
-    timeout: 120
+    timeout: 300  # must exceed run_debug's internal subprocess timeout (240s)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -32,7 +32,7 @@ success_criteria:
   - type: run_command
     description: "Flow contains a Decision node and debug returns correct classification"
     command: "python3 $TASK_DIR/check_decision_flow.py"
-    timeout: 120
+    timeout: 540  # two sequential run_debug calls (240s subprocess timeout each)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -57,7 +57,7 @@ success_criteria:
   - type: run_command
     description: "Debug with --attachment completes and the uploaded file name appears in the output"
     command: "python3 $TASK_DIR/check_file_attachment_flow.py"
-    timeout: 240
+    timeout: 300  # must exceed run_debug's internal subprocess timeout (240s)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -36,7 +36,7 @@ success_criteria:
   - type: run_command
     description: "Flow contains a Switch node and debug returns correct season for quarter 2"
     command: "python3 $TASK_DIR/check_switch_flow.py"
-    timeout: 120
+    timeout: 300  # must exceed run_debug's internal subprocess timeout (240s)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -37,7 +37,7 @@ success_criteria:
   - type: run_command
     description: "Flow has Terminate + Delay nodes in parallel, terminates before delay completes"
     command: "python3 $TASK_DIR/check_terminate_flow.py"
-    timeout: 120
+    timeout: 300  # must exceed run_debug's internal subprocess timeout (240s)
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

Several `uipath-maestro-flow` eval tasks intermittently fail with what looks like environment instability, but is actually a **task-config bug**.

The `run_command` criteria that invoke `check_*.py` debug scripts had their sandbox command `timeout` set **at or below** the check script's internal `run_debug(...)` subprocess timeout. A cold, first-ever `uip maestro flow debug` (pack → upload solution to staging → provision → execute → poll to `Completed`) routinely exceeds the criterion timeout, so the eval harness `SIGKILL`s the command before the script's own timeout can fire — turning a legitimately-slow-but-successful run into a spurious `FAILURE`.

Found while investigating `skill-flow-calculator` (criterion `timeout: 120` vs `run_debug(timeout=240)`, killed at exactly 120s). A solution **was** successfully uploaded to staging during that run — proof the environment was healthy and the run simply wasn't given enough time.

## Fix

Raise each affected criterion timeout above its script's `run_debug` timeout, matching the convention already enforced by `single_node/subflow/test_check_subflow_flow.py`:

| Task | old → new | debug calls / rd timeout |
|---|---|---|
| `multi_node/calculator` | 120 → 300 | 1 × 240 |
| `multi_node/reading_list` | 120 → 300 | 1 × 240 |
| `single_node/switch` | 120 → 300 | 1 × 240 |
| `single_node/terminate` | 120 → 300 | 1 × 240 |
| `single_node/file_attachment` | 240 → 300 | 1 × 240 (was *equal*) |
| `single_node/decision` | 120 → 540 | **2** sequential × 240 |

## Verification

- Reproduced the `subflow` invariant (criterion timeout > `run_debug` subprocess timeout) across the whole suite: **30 debug-based tasks checked, 0 failures** after this change.
- `slack_http_fallback`'s 30s criterion was checked and is **not** affected — it runs the static `check_fallback` subcommand (no debug); its real debug criterion is already 360s.

## Follow-up (not in this PR)

The invariant test lives only under `single_node/subflow/`. Worth promoting into a suite-wide guard (e.g. under `_shared/`) so a new task with a too-tight timeout fails CI instead of silently flaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)