### PR TITLE
chore(uipath-maestro-flow): tag DevCon tasks with path-to-ga

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -7,7 +7,7 @@ description: >
   human-in-the-loop skills work together across the full authoring lifecycle.
   Validate-only: inline HITL nodes block on human review and cannot be `flow debug`-ged
   headlessly, so correctness is enforced via the semantic checker rather than runtime.
-tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon]
+tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon, path-to-ga]
 
 run_limits:
   expected_turns: 29

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -7,7 +7,7 @@ description: >
   human-in-the-loop skills work together across the full authoring lifecycle.
   Validate-only: inline HITL nodes block on human review and cannot be `flow debug`-ged
   headlessly, so correctness is enforced via the semantic checker rather than runtime.
-tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon, path-to-ga]
+tags: [uipath-maestro-flow, uipath-human-in-the-loop, e2e, devcon]
 
 run_limits:
   expected_turns: 29

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -4,7 +4,7 @@ description: >
   queries the BillingDisputeERP and BillingDisputeCRM entities as parallel
   branches joined by a merge, then computes an invoice overcharge; graded by
   validate plus one flow debug run against seeded tenant data.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, connector]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, connector, path-to-ga]
 
 run_limits:
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
@@ -6,7 +6,7 @@ description: >
   context handle (a uipath.agent.resource.context.index node). Graded by flow
   validate plus one flow debug run: both nodes must be present and the agent
   must return a non-empty determination.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent, path-to-ga]
 
 run_limits:
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -10,7 +10,7 @@ description: >
   are replaced by `core.control.end` nodes that RETURN the resolution as flow
   outputs instead of sending mail. Graded by flow validate, a structural check,
   and one flow debug run.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent, node:ixp, connector]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent, node:ixp, connector, path-to-ga]
 
 run_limits:
   max_turns: 200

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -4,7 +4,7 @@ description: >
   Flow that normalizes a messy invoice number and queries the BillingDisputeERP
   Data Service entity; graded by validate plus three flow debug runs over
   malformed inputs.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, connector]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, connector, path-to-ga]
 
 run_limits:
   max_turns: 120

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -5,7 +5,7 @@ description: >
   that drafts a customer-facing billing-dispute resolution email. Graded by
   flow validate plus one flow debug run: the inline agent node must be present
   and the drafted email must cite the disputed invoice number.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node, node:inline-agent, path-to-ga]
 
 run_limits:
   max_turns: 120


### PR DESCRIPTION
## Summary
- Adds `path-to-ga` to the `tags:` list on the 5 billing test tasks under `tests/tasks/uipath-maestro-flow/multi_node/`, so this GA-readiness bucket can be sliced with `--tags path-to-ga`.
- `devcon_expense_approval.yaml` is excluded — per [review feedback](https://github.com/UiPath/skills/pull/1917#issuecomment-4909352810), it's a structural-only (validate-only) test, and it's already mistagged `e2e`. Bundling it into `path-to-ga` here would conflate that pre-existing taxonomy issue with this change; fixing the `e2e`/`devcon` tagging on that file is left for a separate PR.

## ⚠️ Flag for reviewers
`path-to-ga` does **not** fit the closed tag taxonomy documented in `tests/README.md` (§ Tag Taxonomy): every existing tag maps to one of `skill` / `tier` / `mode:` / `lifecycle:` / `shape:` / `node:` / `resource` / `connector` / `windows` / `feature:`, and rule 5 says new tag values should be proposed in the PR rather than invented inline. This is a new cross-cutting dimension outside that taxonomy — flagging so reviewers can decide whether to (a) accept it as a new documented dimension, (b) fold it into an existing one, or (c) request a different approach. The tag-taxonomy lint mentioned in the README may also need updating to allow it.

## Tasks tagged
- `tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml`
- `tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml`

## Test plan
- [ ] Confirm CI's tag-taxonomy lint passes (or update it if `path-to-ga` needs to be added to the allowed vocabulary)
- [ ] `make tags TAGS="path-to-ga"` selects exactly these 5 tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
