### PR TITLE
fix(uipath-maestro-bpmn): scope validator fixtures as test-only

### DIFF
--- a/skills/uipath-maestro-bpmn/validator/README.md
+++ b/skills/uipath-maestro-bpmn/validator/README.md
@@ -8,6 +8,14 @@ PO.Frontend `Node[] / Edge[] / CanvasState` model from the parse tree, and runs
 (`VARIABLE_DOES_NOT_EXIST`, including element-local `result.X`, and the
 flow-order `VARIABLE_NOT_SET` warning) and an optional connection-liveness ping.
 
+> **Authoring scope:** everything under `test/fixtures/` is validator test data,
+> not authoring material. **Do not read the fixtures to infer the BPMN pattern**
+> — it is the top reason authoring runs out of time. Author from the complete
+> minimal file in
+> [../references/structural-bpmn.md](../references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-fixtures)
+> instead. This README documents the validator and its test suite; run the
+> validator (below) as your check, and leave the corpus to CI.
+
 ## Usage
 
 ```bash
@@ -50,8 +58,10 @@ npm test   # runs all three suites below; green = no drift from the frontend
 3. **Integration over real `.bpmn` files** (`test/integration.test.mjs`): every
    file in `test/fixtures/` is a real, externally-validated artifact (backend
    BpmnParser/Worker/Athena/V2-E2E TestData, and PO.Frontend editor mocks),
-   bundled so the suite is self-contained in CI. `fixtures/known-good/` must
-   produce **zero** ERROR-severity findings; `fixtures/expected-findings/` assert
+   bundled so the suite is self-contained in CI. These files exist to exercise
+   the rule engine — they are **not** authoring templates; see the authoring-scope
+   note at the top before reaching for one as an example. `fixtures/known-good/`
+   must produce **zero** ERROR-severity findings; `fixtures/expected-findings/` assert
    the exact ERROR codes the frontend would also raise (each verified by reading
    the file). Set `MAESTRO_BPMN_TESTDATA` / `MAESTRO_BPMN_FRONTEND_MOCKS` to also
    sweep a live corpus during development.


### PR DESCRIPTION
## Problem

The `uipath-maestro-bpmn` skill tells the authoring agent, in two places, **not** to read the bundled validator's `test/fixtures/`:

- `SKILL.md:78` — "**Do not read the validator's `test/fixtures/` to infer the pattern** — it is the top reason authoring runs out of time."
- `references/structural-bpmn.md:67` — same instruction, "those are validator test data."

But `validator/README.md` (listed as a reference in SKILL.md, so the agent reads it) contradicted that by advertising the same fixtures as gold-standard examples:

> every file in `test/fixtures/` is a real, externally-validated artifact … `fixtures/known-good/` must produce **zero** ERROR-severity findings

That framing reads as an invitation to use the fixtures as authoring templates — the exact behavior the other two files forbid.

## What this does

Aligns the README with the prohibitions without weakening its accuracy about the test corpus:

- Adds an **Authoring scope** callout after the intro, pointing to the inline minimal skeleton in `structural-bpmn.md` and clarifying the README documents the validator/test suite (run the validator as the check; leave the corpus to CI).
- Adds a reminder at the fixture description that these files exist to exercise the rule engine and are **not** authoring templates.

No behavior change to the validator or its tests — docs only.

## Why

Surfaced while root-causing eval run `skill-bpmn-gateway-sequence-flows`, which timed out at 900s. The turn was spent almost entirely in model generation (~762s across five extended-thinking blocks, zero Write); the agent read `validator/README.md`, then globbed and read a `known-good` fixture late in the turn — the forbidden time-sink — before the watchdog fired. This PR removes the contradiction that steered it there.

Scope note: this is the one change defensible independent of that single test. The larger share of the timeout is a model analysis-paralysis behavior (the same 10-node plan re-derived three times) that a fix here won't fully resolve; not addressing that here to avoid overfitting to one run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)