### PR TITLE
Add aged invoice case evals

### DIFF
--- a/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/build_from_sdd_aged_invoice.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/build_from_sdd_aged_invoice.yaml
@@ -1,0 +1,100 @@
+task_id: skill-case-phase-0-build-aged-invoice
+description: >
+  BUILD FROM GENERATED AGED-INVOICE SDD - an approved AgedInvoicePayment
+  sdd.md fixture derived from the PDD-seeded Phase 0 path is staged into the
+  sandbox; the skill uses it as the sole source of truth, proceeds past
+  planning/build approval stops, creates the case-management project, and
+  validates the resulting caseplan.json. Mirrors the employee expense build
+  eval for the larger aged-invoice case.
+tags:
+  - uipath-maestro-case
+  - integration
+  - lifecycle:generate
+  - mode:build
+  - shape:multi-node
+  - feature:phase-0
+  - feature:stages
+  - feature:case-exit
+  - feature:conditions
+  - feature:trigger
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "TodoWrite"]
+  sdk_options:
+    max_thinking_tokens: 10000
+
+run_limits:
+  task_timeout: 4200
+  max_turns: 170
+  turn_timeout: 3000
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  I have an approved SDD for our AgedInvoicePayment case-management solution -
+  it's saved as `sdd.md` in this folder. Build a UiPath Case Management solution
+  named "AgedInvoicePayment" containing a project also named
+  "AgedInvoicePayment" from this SDD.
+
+  Use the staged `sdd.md` as the sole source of truth. Do not redo Phase 0, do
+  not re-interview me, and do not redesign the process. This is intentionally a
+  large over-cap case that we are keeping as one Maestro case. The connector IDs
+  and resource references in the SDD are placeholders where the eval
+  environment does not have tenant-specific registry data; preserve the
+  requested task types and proceed with skeleton/placeholder resource bindings
+  when registry resolution is unavailable.
+
+  Important:
+  - The `uip` CLI is already available in the environment.
+  - Treat all hard stops after the SDD as pre-approved, including Phase 1
+    planning approval and Phase 2 publish-for-review. Choose the continue /
+    skip-publish path and keep going.
+  - Do NOT call AskUserQuestion - it is not available in this harness.
+  - If `uip maestro case registry pull` reports unauthenticated, empty, or
+    missing cache, record that state and proceed without live registry data.
+  - Skip Phase 5 and Phase 6. Do not run `uip maestro case debug` yourself and
+    do not publish to Studio Web.
+  - Finish with `uip maestro case validate AgedInvoicePayment/AgedInvoicePayment/caseplan.json --output json`
+    passing on the resulting caseplan.json.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran uip maestro case validate on the built aged-invoice case"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+case\s+validate[^\n]*AgedInvoicePayment/AgedInvoicePayment/caseplan\.json[^\n]*--output\s+json'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "uip maestro case validate passes on the generated AgedInvoicePayment caseplan.json"
+    command: "uip maestro case validate AgedInvoicePayment/AgedInvoicePayment/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "staged sdd.md preserves the PDD-derived aged-invoice design"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py sdd.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "caseplan preserves aged-invoice domain structure, primary chain, exception lanes, task-type mix, triage scoring, Payment Risk gate, and Payment Tracking child case"
+    command: "python3 $TASK_DIR/check_aged_invoice_case.py"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/check_aged_invoice_case.py
+++ b/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/check_aged_invoice_case.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""AgedInvoicePayment SDD -> case generation logical-integrity grader."""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+)
+from _shared.case_check import (  # noqa: E402
+    assert_tasks_nested,
+    find_stages,
+    find_transitions,
+    first_rule_of_condition,
+    get_case_exit_conditions,
+    iter_tasks,
+    read_caseplan,
+)
+
+
+PRIMARY_STAGE_PATTERNS = [
+    ("Intake", r"intake|registration"),
+    ("Enrichment", r"enrichment|context"),
+    ("Triage", r"triage"),
+    ("AP Review", r"ap review|accounts payable|ownership"),
+    ("Exception Resolution", r"exception resolution|resolution"),
+    ("Supplier Collaboration", r"supplier collaboration|supplier"),
+    ("Payment Risk", r"payment risk|risk"),
+    ("Approval", r"approval"),
+    ("Closure", r"closure|close"),
+]
+
+EXCEPTION_PATTERNS = {
+    "SLA Escalation": r"sla.*escalation|escalation",
+    "Automation Incident": r"automation.*incident|incident|automation failure|failed (api|rpa|automation)",
+    "Reopen": r"reopen|supplier dispute",
+    "Compliance Hold": r"compliance.*hold|payment.?risk.*hold|hold",
+}
+
+EXPECTED_CASEPLAN = os.path.join(
+    "AgedInvoicePayment",
+    "AgedInvoicePayment",
+    "caseplan.json",
+)
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def _label(node: dict) -> str:
+    return (node.get("data") or {}).get("label") or ""
+
+
+def _text(value: object) -> str:
+    return repr(value).lower()
+
+
+def _find_stage(stages: list[dict], pattern: str) -> dict | None:
+    rx = re.compile(pattern, re.I)
+    for stage in stages:
+        if rx.search(_label(stage)):
+            return stage
+    return None
+
+
+def _stage_tasks(stage: dict) -> list[dict]:
+    tasks: list[dict] = []
+    for lane in ((stage.get("data") or {}).get("tasks") or []):
+        if isinstance(lane, dict):
+            tasks.append(lane)
+        elif isinstance(lane, list):
+            tasks.extend(task for task in lane if isinstance(task, dict))
+    return tasks
+
+
+def _has_path(plan: dict, src_id: str, dst_id: str, max_hops: int = 12) -> bool:
+    if src_id == dst_id:
+        return True
+    frontier = {src_id}
+    seen = {src_id}
+    for _ in range(max_hops):
+        nxt = set()
+        for node_id in frontier:
+            for transition in find_transitions(plan, source=node_id):
+                target = transition.get("target")
+                if target == dst_id:
+                    return True
+                if target and target not in seen:
+                    seen.add(target)
+                    nxt.add(target)
+        if not nxt:
+            return False
+        frontier = nxt
+    return False
+
+
+def _read_aged_caseplan() -> dict:
+    if os.path.exists(EXPECTED_CASEPLAN):
+        return read_caseplan(EXPECTED_CASEPLAN)
+    return read_caseplan()
+
+
+def _stage_condition_text(stage: dict) -> str:
+    data = stage.get("data") or {}
+    return _text((data.get("entryConditions") or []) + (data.get("exitConditions") or []))
+
+
+def _case_exit_stage_ids(case_exits: list[dict]) -> set[str]:
+    out: set[str] = set()
+    for case_exit in case_exits:
+        rule = first_rule_of_condition(case_exit) or {}
+        if rule.get("rule") in ("selected-stage-completed", "selected-stage-exited"):
+            selected_id = rule.get("selectedStageId")
+            if selected_id:
+                out.add(selected_id)
+    return out
+
+
+def main() -> None:
+    plan = _read_aged_caseplan()
+    assert_tasks_nested(plan)
+
+    all_stages = find_stages(plan, include_exception=True)
+    primary_stages = find_stages(plan, include_exception=False)
+    if len(primary_stages) < 8:
+        _fail(
+            f"expected >=8 primary stages from the PDD's 9-stage design; "
+            f"got {len(primary_stages)}: {[_label(s) for s in primary_stages]}"
+        )
+
+    primary_nodes: dict[str, dict] = {}
+    for name, pattern in PRIMARY_STAGE_PATTERNS:
+        stage = _find_stage(primary_stages, pattern)
+        if not stage:
+            _fail(
+                f"missing primary stage family {name!r}; "
+                f"stages present: {[_label(s) for s in primary_stages]}"
+            )
+        primary_nodes[name] = stage
+
+    for (src, _), (dst, _) in zip(PRIMARY_STAGE_PATTERNS, PRIMARY_STAGE_PATTERNS[1:]):
+        if not _has_path(plan, primary_nodes[src]["id"], primary_nodes[dst]["id"]):
+            _fail(f"no transition path from {src!r} to {dst!r}; primary chain is broken")
+
+    exception_nodes: dict[str, dict] = {}
+    for name, pattern in EXCEPTION_PATTERNS.items():
+        stage = _find_stage(all_stages, pattern)
+        if not stage:
+            _fail(
+                f"missing exception lane {name!r}; stages present: "
+                f"{[_label(s) for s in all_stages]}"
+            )
+        exception_nodes[name] = stage
+
+    tasks = list(iter_tasks(plan))
+    if len(tasks) < 18:
+        _fail(f"task volume too low for aged invoice case: got {len(tasks)}, expected >=18")
+
+    types_seen = {task.get("type") for task in tasks}
+    missing_types = {
+        "api-workflow",
+        "agent",
+        "action",
+        "rpa",
+        "wait-for-timer",
+        "case-management",
+    } - types_seen
+    if missing_types:
+        _fail(
+            f"missing required task type(s) {sorted(missing_types)}; "
+            f"types seen: {sorted(t for t in types_seen if t)}"
+        )
+    if not ({"execute-connector-activity", "wait-for-connector"} & types_seen):
+        _fail(
+            "missing connector task type; expected execute-connector-activity "
+            "or wait-for-connector"
+        )
+
+    triage_text = _stage_condition_text(primary_nodes["Triage"]) + _text(_stage_tasks(primary_nodes["Triage"]))
+    if "rootcause" not in _norm(triage_text):
+        _fail("Triage stage must classify rootCause")
+    if "priorityscore" not in _norm(triage_text):
+        _fail("Triage stage must calculate priorityScore / SLA priority")
+
+    payment_risk = primary_nodes["Payment Risk"]
+    payment_risk_text = _text(payment_risk)
+    if "paymentrisk" not in _norm(payment_risk_text):
+        _fail("Payment Risk stage must carry payment-risk evidence/output")
+    if not any(task.get("type") == "agent" for task in _stage_tasks(payment_risk)):
+        _fail("Payment Risk stage must include an agent task")
+
+    approval_text = _stage_condition_text(primary_nodes["Approval"])
+    if "paymentrisk" not in _norm(approval_text) and "approved" not in approval_text:
+        _fail("Approval stage must be gated by the Payment Risk decision/result")
+
+    case_mgmt_tasks = [task for task in tasks if task.get("type") == "case-management"]
+    if not any("payment" in _text(task) and "tracking" in _text(task) for task in case_mgmt_tasks):
+        _fail("case-management task must reference the Payment Tracking child case")
+
+    case_exits = get_case_exit_conditions(plan)
+    if len(case_exits) < 2:
+        _fail(f"expected >=2 case-exit conditions; got {len(case_exits)}")
+    exit_stage_ids = _case_exit_stage_ids(case_exits)
+    if primary_nodes["Closure"]["id"] not in exit_stage_ids and not any(
+        (first_rule_of_condition(c) or {}).get("rule") == "required-stages-completed"
+        for c in case_exits
+    ):
+        _fail("case exits must close on Closure or required-stages-completed")
+
+    plan_text = _text(plan)
+    required_terms = [
+        "mock erp",
+        "outlook",
+        "servicenow",
+        "slack",
+        "sap",
+        "supplier",
+        "rootcause",
+        "priorityscore",
+        "paymenttracking",
+    ]
+    missing_terms = [term for term in required_terms if _norm(term) not in _norm(plan_text)]
+    if missing_terms:
+        _fail("caseplan lost expected aged-invoice terms: " + ", ".join(missing_terms))
+
+    print(
+        "OK: AgedInvoicePayment caseplan preserves the PDD-derived primary chain, "
+        "exception lanes, task-type mix, triage root-cause/priority scoring, "
+        "Payment Risk gate, Payment Tracking child case, and integration footprint"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/fixtures/sdd.md
@@ -1,0 +1,1017 @@
+# SDD — AgedInvoicePayment
+
+> **Case Definition Blueprint** — Aged invoice payment resolution case for a retail AP proof of value.
+
+> **Generated lightweight; complexity exceeded thresholds.**
+> Counts at generation time: 13 stages (9 primary + 4 secondary exception lanes), 25 tasks, 5 integrations (Mock ERP, Outlook, ServiceNow, Slack, SAP), 7 personas, 1 child case (Payment Tracking).
+> Review carefully before approving. This remains one Maestro case by request.
+
+---
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|---|---|
+| Case Name | AgedInvoicePayment |
+| Case Description | Coordinates aged invoice intake, context enrichment, root-cause triage, AP review, exception resolution, supplier collaboration, payment-risk review, approval, and closure for a mocked retail AP proof of value. |
+| Case Identifier | Type: constant. Prefix: AIP |
+| Priority | Choiceset: Low, Medium, High, Critical — Default: High |
+| Case-Level SLA | 30 minutes |
+| SLA Type | time-based |
+| Case App | Enabled |
+| Task-output passing | Direct |
+| Case Identifier source | `=metadata.ExternalId` |
+
+### Case-Level SLA Escalation Rules
+
+| SLA Status | Threshold | Action |
+|---|---|---|
+| At-Risk | 70% of SLA duration | Notify: UserGroup: AP Team Leads |
+| Breached | 100% of SLA duration | Notify: UserGroup: Finance Leadership |
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|---|---|---|
+| T02 | Intsvc.EventTrigger | aged_invoice_cases | Record created |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|---|---|---|---|---|
+| `required-stages-completed` | — | Case exited | Yes | Complete Rule 1 |
+| `selected-stage-completed("Closure")` | — | Case exited | No | Exit Rule 1 |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|---|---|---|---|---|---|---|
+| invoiceId | Variable | string | T02 | response.invoice_id | | Aged invoice identifier from the record-created payload |
+| supplierName | Variable | string | T02 | response.supplier_name | | Supplier name from the aged invoice payload |
+| supplierEmail | Variable | string | T02 | response.supplier_email | | Supplier contact email |
+| invoiceAmount | Variable | float | T02 | response.amount | | Invoice amount |
+| currency | Variable | string | T02 | response.currency | "AUD" | Invoice currency |
+| dueDate | Variable | datetime | T02 | response.due_date | | Due date for payment terms |
+| invoiceAgeDays | Variable | integer | T02 | response.age_days | | Number of days aged |
+| caseStatus | Variable | string | | | "Open" | Current case state |
+| enrichmentData | Variable | jsonSchema | | | | Mock ERP, PO, GRN, payment, supplier, and hold context |
+| rootCause | Variable | string | | | | Triage root-cause classification |
+| priorityScore | Variable | integer | | | 0 | Priority/SLA score calculated during triage |
+| slaTier | Variable | string | | | "Standard" | SLA tier from triage |
+| caseOwner | Variable | string | | | | AP owner assigned during AP review |
+| apDecision | Variable | string | | | | AP Review decision: Resolve, SupplierInfo, Escalate, Hold |
+| exceptionResolution | Variable | string | | | | Exception Resolution result |
+| supplierQuerySummary | Variable | string | | | | Agent-generated supplier communication summary |
+| supplierResponse | Variable | jsonSchema | | | | Evidence received from supplier |
+| paymentRiskDecision | Variable | string | | | | Payment Risk result: Clear, Hold, Reject |
+| approvalDecision | Variable | string | | | | Approval decision from Finance Manager or Treasury |
+| paymentTrackingCaseId | Variable | string | | | | Child Payment Tracking case ID |
+| closureSummary | Variable | string | | | | Final closure summary |
+| automationIncidentId | Variable | string | | | | ServiceNow incident ID for failed automation |
+| auditPostResult | Variable | string | | | | SAP/Slack/ServiceNow close-out result |
+
+---
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Intake and Registration
+
+**Type:** Stage
+**Description:** Registers a new aged-invoice case from the case-entity record and creates the initial audit trail.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `case-entered` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Register Invoice Case | api-workflow | Yes | Yes | System | — |
+| 2 | Create Initial Audit Event | execute-connector-activity | Yes | Yes | System | — |
+
+##### Task 1.1: Register Invoice Case
+
+**Type:** api-workflow
+**Description:** Calls the mock ERP API workflow to register the invoice case and normalize basic invoice metadata.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoiceMockIntegrationApi api-workflow>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Api
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| supplierName | string | `=vars.supplierName` |
+| amount | float | `=vars.invoiceAmount` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| normalizedStatus | caseStatus = "Registered" |
+
+##### Task 1.2: Create Initial Audit Event
+
+**Type:** execute-connector-activity
+**Description:** Posts an initial ServiceNow audit event for the new aged invoice case.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Register Invoice Case")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: ServiceNow Create Audit Event connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| eventType | string | "case_registered" |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Stage 2: Context Enrichment
+
+**Type:** Stage
+**Description:** Pulls invoice, supplier, PO, GRN, payment, hold, and supplier statement context from mocked enterprise systems.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Intake and Registration")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Enrich Invoice Context | api-workflow | Yes | Yes | System | — |
+| 2 | Reconcile Supplier Statement | rpa | No | Yes | System | — |
+
+##### Task 2.1: Enrich Invoice Context
+
+**Type:** api-workflow
+**Description:** Calls the Mock ERP and procurement API workflow to fetch invoice, PO, GRN, payment, hold, and supplier history.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoiceContextEnrichment api-workflow>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Api
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| context | -> enrichmentData |
+| — | caseStatus = "Enriched" |
+
+##### Task 2.2: Reconcile Supplier Statement
+
+**Type:** rpa
+**Description:** Runs an RPA workflow to simulate supplier statement extraction and match the invoice against mocked records.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Enrich Invoice Context")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoice_StatementReconciliation rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| supplierName | string | `=vars.supplierName` |
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| reconciliationStatus | -> exceptionResolution |
+
+### Stage 3: Triage
+
+**Type:** Stage
+**Description:** Classifies root cause, scores priority/SLA, and recommends the next action.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Context Enrichment")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Classify Root Cause and Priority | agent | Yes | Yes | System | — |
+| 2 | Assign AP Owner | process | Yes | Yes | AP Team Lead | — |
+
+##### Task 3.1: Classify Root Cause and Priority
+
+**Type:** agent
+**Description:** Invoice Triage Agent classifies rootCause and calculates priorityScore and slaTier from invoice, supplier, GRN, PO, and payment evidence.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: InvoiceTriageAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| enrichmentData | jsonSchema | `=vars.enrichmentData` |
+| invoiceAgeDays | integer | `=vars.invoiceAgeDays` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| rootCause | -> rootCause |
+| priorityScore | -> priorityScore |
+| slaTier | -> slaTier |
+
+##### Task 3.2: Assign AP Owner
+
+**Type:** process
+**Description:** Assigns the case to an AP Clerk or AP Team Lead based on priorityScore and rootCause.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Classify Root Cause and Priority")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AssignAgedInvoiceOwner process>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| rootCause | string | `=vars.rootCause` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| owner | -> caseOwner |
+
+### Stage 4: AP Review
+
+**Type:** Stage
+**Description:** AP reviews the triage recommendation and chooses the resolution route.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Triage")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | AP Ownership Review | action | Yes | Yes | AP Clerk | 5 min |
+| 2 | Start SLA Reminder Timer | wait-for-timer | No | Yes | System | — |
+
+##### Task 4.1: AP Ownership Review
+
+**Type:** action
+**Description:** Human action for the AP Clerk to confirm owner, root cause, next action, and whether supplier evidence is needed.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: Aged Invoice AP Review>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| rootCause | string | `=vars.rootCause` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> apDecision |
+
+##### Task 4.2: Start SLA Reminder Timer
+
+**Type:** wait-for-timer
+**Description:** Waits five minutes before SLA escalation checks.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 2 |
+
+**Timer:** Duration `PT5M`
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| — | caseStatus = "AP Review In Progress" |
+
+### Stage 5: Exception Resolution
+
+**Type:** Stage
+**Description:** Resolves internal exceptions such as missing GRN, price mismatch, duplicate invoice, approval delay, or payment hold.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("AP Review")` | `=vars.apDecision != "SupplierInfo"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | GRN Confirmation | action | No | Yes | Store/DC Receiver | 5 min |
+| 2 | Update Mock ERP Exception | rpa | Yes | Yes | System | — |
+
+##### Task 5.1: GRN Confirmation
+
+**Type:** action
+**Description:** Human action to confirm missing goods receipt or delivery discrepancy.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | `=vars.rootCause == "Missing GRN"` | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: GRN Confirmation>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| supplierName | string | `=vars.supplierName` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| resolution | -> exceptionResolution |
+
+##### Task 5.2: Update Mock ERP Exception
+
+**Type:** rpa
+**Description:** Updates the Mock ERP exception status after AP or GRN resolution.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("GRN Confirmation")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: MockERPExceptionUpdate rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| exceptionResolution | string | `=vars.exceptionResolution` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| updateStatus | caseStatus = "Exception Resolved" |
+
+### Stage 6: Supplier Collaboration
+
+**Type:** Stage
+**Description:** Contacts the supplier, interprets the response, and waits for missing evidence when supplier input is required.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Exception Resolution")` | — | No | Entry Rule 1 |
+| `selected-stage-completed("AP Review")` | `=vars.apDecision == "SupplierInfo"` | No | Entry Rule 2 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Notify Supplier via Outlook | execute-connector-activity | Yes | Yes | System | — |
+| 2 | Wait for Supplier Evidence | wait-for-connector | No | No | Supplier Contact | — |
+| 3 | Interpret Supplier Query | agent | No | Yes | System | — |
+
+##### Task 6.1: Notify Supplier via Outlook
+
+**Type:** execute-connector-activity
+**Description:** Sends an Outlook request for evidence or status clarification to the supplier contact.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Outlook Send Supplier Request connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| to | string | `=vars.supplierEmail` |
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| sentStatus | caseStatus = "Awaiting Supplier" |
+
+##### Task 6.2: Wait for Supplier Evidence
+
+**Type:** wait-for-connector
+**Description:** Waits for supplier portal or Outlook evidence for the invoice.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Notify Supplier via Outlook")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SupplierEvidenceReceived connector trigger>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| evidence | -> supplierResponse |
+
+##### Task 6.3: Interpret Supplier Query
+
+**Type:** agent
+**Description:** Supplier Query Agent summarizes supplier response, dispute reason, and recommended next action.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Wait for Supplier Evidence")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SupplierQueryAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| supplierResponse | jsonSchema | `=vars.supplierResponse` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> supplierQuerySummary |
+
+### Stage 7: Payment Risk Review
+
+**Type:** Stage
+**Description:** Assesses duplicate, tax, bank, hold, approval, and dispute risk before payment approval.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Supplier Collaboration")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Assess Payment Risk | agent | Yes | Yes | System | — |
+| 2 | Start Payment Tracking Case | case-management | No | Yes | System | — |
+
+##### Task 7.1: Assess Payment Risk
+
+**Type:** agent
+**Description:** Payment Risk Agent evaluates paymentRiskDecision from enrichmentData, supplierResponse, exceptionResolution, duplicate risk, and approval thresholds.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: PaymentRiskAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| enrichmentData | jsonSchema | `=vars.enrichmentData` |
+| supplierResponse | jsonSchema | `=vars.supplierResponse` |
+| exceptionResolution | string | `=vars.exceptionResolution` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> paymentRiskDecision |
+
+##### Task 7.2: Start Payment Tracking Case
+
+**Type:** case-management
+**Description:** Starts the Payment Tracking child case when payment follow-up needs separate tracking.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Assess Payment Risk")` | `=vars.paymentRiskDecision == "Clear"` | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Payment Tracking case-management>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| caseId | -> paymentTrackingCaseId |
+
+### Stage 8: Approval
+
+**Type:** Stage
+**Description:** Finance Manager or Treasury approves or rejects payment release after Payment Risk clears.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Payment Risk Review")` | `=vars.paymentRiskDecision == "Clear"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Payment Approval | action | Yes | Yes | Finance Manager | 5 min |
+| 2 | Post Approval Slack Update | execute-connector-activity | No | Yes | System | — |
+
+##### Task 8.1: Payment Approval
+
+**Type:** action
+**Description:** Finance Manager reviews paymentRiskDecision, priorityScore, supplier evidence, and approves payment release or hold.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: Aged Invoice Payment Approval>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| paymentRiskDecision | string | `=vars.paymentRiskDecision` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> approvalDecision |
+
+##### Task 8.2: Post Approval Slack Update
+
+**Type:** execute-connector-activity
+**Description:** Posts approval status to a Slack AP operations channel.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Payment Approval")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Slack Post Message connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| approvalDecision | string | `=vars.approvalDecision` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Stage 9: Closure
+
+**Type:** Stage
+**Description:** Updates SAP/Mock ERP, records final audit evidence, and closes the aged invoice case.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Approval")` | `=vars.approvalDecision == "Approved"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Post SAP Closure Record | execute-connector-activity | Yes | Yes | System | — |
+| 2 | Close Mock ERP Invoice | rpa | Yes | Yes | System | — |
+
+##### Task 9.1: Post SAP Closure Record
+
+**Type:** execute-connector-activity
+**Description:** Posts the final SAP closure record and payment status for audit.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SAP Post Closure connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| approvalDecision | string | `=vars.approvalDecision` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+##### Task 9.2: Close Mock ERP Invoice
+
+**Type:** rpa
+**Description:** Updates the Mock ERP invoice screen to closed for the demo.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Post SAP Closure Record")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: MockERPCloseInvoice rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> closureSummary |
+| — | caseStatus = "Closed" |
+
+### Secondary Stage: SLA Escalation
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for at-risk or breached SLA conditions.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("AP Review")` | `=vars.priorityScore >= 80` | Yes | Escalate At Risk |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Notify AP Lead")` | — | return-to-origin | No | Return After Escalation |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Notify AP Lead | execute-connector-activity | Yes | No | System | — |
+
+##### Task S1.1: Notify AP Lead
+
+**Type:** execute-connector-activity
+**Description:** Sends Slack and Outlook escalation notifications to AP Team Leads.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Secondary Stage: Automation Incident
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for failed API, RPA, connector, or agent automation.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Context Enrichment")` | `=vars.caseStatus == "AutomationFailed"` | Yes | Automation Failed |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Create ServiceNow Incident")` | — | return-to-origin | No | Return After Incident |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Create ServiceNow Incident | execute-connector-activity | Yes | Yes | Automation Support | — |
+
+##### Task S2.1: Create ServiceNow Incident
+
+**Type:** execute-connector-activity
+**Description:** Creates a ServiceNow incident for failed automation and stores automationIncidentId.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| incidentId | -> automationIncidentId |
+
+### Secondary Stage: Reopen and Supplier Dispute
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for supplier disputes or reopened invoices after closure.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Closure")` | `=vars.supplierQuerySummary == "Dispute"` | Yes | Reopen Dispute |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Summarize Supplier Dispute")` | — | return-to-origin | No | Return After Reopen |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Summarize Supplier Dispute | agent | Yes | Yes | System | — |
+
+##### Task S3.1: Summarize Supplier Dispute
+
+**Type:** agent
+**Description:** Summarizes reopened supplier dispute and recommends next best action.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> supplierQuerySummary |
+
+### Secondary Stage: Compliance and Payment Risk Hold
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for compliance holds, duplicate risk, tax risk, bank-data issues, and payment-risk holds.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Payment Risk Review")` | `=vars.paymentRiskDecision == "Hold"` | Yes | Compliance Hold |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Compliance Hold Review")` | — | return-to-origin | No | Return After Hold |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Compliance Hold Review | action | Yes | Yes | Finance Manager | 5 min |
+
+##### Task S4.1: Compliance Hold Review
+
+**Type:** action
+**Description:** Human action to release or keep a compliance and payment risk hold.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> paymentRiskDecision |
+
+---
+
+## Section 3: Personas & App Views
+
+| Persona | View / Responsibility |
+|---|---|
+| AP Clerk | AP Control Tower and AP Ownership Review |
+| AP Team Lead | SLA escalation and reassignment |
+| Procurement Officer | Price mismatch and PO exception decisions |
+| Store/DC Receiver | GRN Confirmation |
+| Finance Manager | Payment Approval and Compliance Hold Review |
+| Treasury User | Payment release oversight |
+| Automation Support | Automation Incident review |
+
+## Section 4: Integrations
+
+| Family | Resource | Purpose |
+|---|---|---|
+| API Workflow | AgedInvoiceMockIntegrationApi | Mock ERP registration and enrichment |
+| Agent | InvoiceTriageAgent | rootCause classification and priorityScore calculation |
+| Agent | PaymentRiskAgent | Payment Risk decision gate |
+| Action App | Aged Invoice AP Review | AP human decision |
+| Action App | Aged Invoice Payment Approval | Finance approval |
+| RPA | AgedInvoice_StatementReconciliation | Supplier statement reconciliation |
+| RPA | MockERPCloseInvoice | Mock ERP close-out |
+| Connector | Outlook | Supplier notification and evidence request |
+| Connector | ServiceNow | Automation incident and audit event |
+| Connector | Slack | AP escalation and approval updates |
+| Connector | SAP | Closure posting |
+| Case Management | Payment Tracking | Child case for payment follow-up |

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/finalize_from_draft_aged_invoice.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/finalize_from_draft_aged_invoice.yaml
@@ -1,0 +1,125 @@
+task_id: skill-case-phase-0-finalize-draft-aged-invoice
+description: >
+  Phase 0 FINALIZATION ONLY - an AgedInvoicePayment interview draft
+  (sdd.draft.md) seeded from the PDD-derived over-cap Phase 0 path is staged
+  into the sandbox; the skill resumes Phase 0, runs the Finalization checks,
+  and renames it to an approved sdd.md. Mirrors the employee expense
+  finalization eval, but for the larger aged-invoice case: 9 primary stages,
+  4 exception lanes, triage root-cause + priority scoring, payment-risk gate,
+  full task-type mix, and Payment Tracking child case.
+tags:
+  - uipath-maestro-case
+  - integration
+  - lifecycle:generate
+  - mode:build
+  - shape:multi-node
+  - feature:phase-0
+  - feature:stages
+  - feature:case-exit
+  - feature:conditions
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
+  sdk_options:
+    max_thinking_tokens: 10000
+
+run_limits:
+  task_timeout: 3600
+  max_turns: 150
+  turn_timeout: 2700
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  I have a draft design document for our AgedInvoicePayment case-management
+  solution - it's saved as `sdd.draft.md` in this folder. Please finalize it
+  into the final design document.
+
+  Work from what's there; the design is settled, so don't redo it or
+  re-interview me. This is intentionally a large over-cap case that we are
+  keeping as one Maestro case. The connector IDs and resource references in the
+  draft are placeholders on purpose - leave them as placeholders where needed.
+  I just need the finalized design for now, nothing built yet.
+
+success_criteria:
+  - type: file_exists
+    description: "Finalization produced the approved sdd.md"
+    path: "sdd.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "sdd.md is mechanically sound: variable mappings + lineage, per-gate rule legality, task types, entry/completion/exit conditions"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/sdd_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "sdd.md preserves the full aged-invoice design: stages, exception lanes, task mix, triage scoring, payment-risk gate, and child case"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py sdd.md"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "stopped at the finalized sdd.md - did not run ahead into a caseplan build"
+    command: "! find . -name caseplan.json -not -path '*/.venv/*' | grep -q ."
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Finalized sdd.md is domain-coherent for aged invoice payment resolution"
+    files:
+      - sdd.md
+    max_file_chars: 150000
+    include_agent_output: false
+    prompt: |
+      You are reviewing a finalized Phase-0 Solution Design Document for an
+      AGED INVOICE PAYMENT resolution case. Mechanical checks already verify
+      rule legality, variable mappings, and required keywords. Focus on DOMAIN
+      COHERENCE.
+
+      Judge:
+      - The full PDD-derived case survived as one Maestro case: roughly nine
+        primary stages from intake/registration through closure, plus the
+        exception lanes for SLA escalation, automation incident, reopen/supplier
+        dispute, and compliance/payment-risk hold.
+      - Triage genuinely classifies root cause and calculates priority/SLA
+        scoring; Payment Risk gates approval rather than being only a prose
+        mention.
+      - Task types fit the work: API workflows, agents, human actions, RPA,
+        connector activities/waits, timers, and a Payment Tracking child case.
+      - There are no major sequence inversions or dead decisions: approval must
+        follow payment risk; closure follows approval; exception lanes return or
+        terminate intentionally.
+
+      Score 1.0 if the design is coherent and faithful; 0.5 if mostly coherent
+      with minor gaps; 0.0 if it was trimmed to a stub or has major logic errors.
+    weight: 3.0
+    pass_threshold: 0.7
+
+simulation:
+  enabled: true
+  persona: |
+    You are the AP operations lead confirming an already-written
+    AgedInvoicePayment design draft.
+  goal: |
+    Get the existing sdd.draft.md finalized into an approved sdd.md. Keep the
+    agent in Phase 0 only.
+  constraints:
+    - "Use the draft as-is and finalize it; do not redo the interview."
+    - "Approve unresolved connector IDs and resource placeholders; they are intentional."
+    - "Decline or skip any optional HTML-preview offer."
+    - "If the assistant offers to plan, validate a caseplan, build, debug, or publish, tell it to stop at the approved sdd.md."
+    - "Keep replies short - one sentence or a single option pick."
+  max_turns: 10

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/fixtures/sdd.draft.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/fixtures/sdd.draft.md
@@ -1,0 +1,1017 @@
+# SDD — AgedInvoicePayment
+
+> **Case Definition Blueprint** — Aged invoice payment resolution case for a retail AP proof of value.
+
+> **Generated lightweight; complexity exceeded thresholds.**
+> Counts at generation time: 13 stages (9 primary + 4 secondary exception lanes), 25 tasks, 5 integrations (Mock ERP, Outlook, ServiceNow, Slack, SAP), 7 personas, 1 child case (Payment Tracking).
+> Review carefully before approving. This remains one Maestro case by request.
+
+---
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|---|---|
+| Case Name | AgedInvoicePayment |
+| Case Description | Coordinates aged invoice intake, context enrichment, root-cause triage, AP review, exception resolution, supplier collaboration, payment-risk review, approval, and closure for a mocked retail AP proof of value. |
+| Case Identifier | Type: constant. Prefix: AIP |
+| Priority | Choiceset: Low, Medium, High, Critical — Default: High |
+| Case-Level SLA | 30 minutes |
+| SLA Type | time-based |
+| Case App | Enabled |
+| Task-output passing | Direct |
+| Case Identifier source | `=metadata.ExternalId` |
+
+### Case-Level SLA Escalation Rules
+
+| SLA Status | Threshold | Action |
+|---|---|---|
+| At-Risk | 70% of SLA duration | Notify: UserGroup: AP Team Leads |
+| Breached | 100% of SLA duration | Notify: UserGroup: Finance Leadership |
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|---|---|---|
+| T02 | Intsvc.EventTrigger | aged_invoice_cases | Record created |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|---|---|---|---|---|
+| `required-stages-completed` | — | Case exited | Yes | Complete Rule 1 |
+| `selected-stage-completed("Closure")` | — | Case exited | No | Exit Rule 1 |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|---|---|---|---|---|---|---|
+| invoiceId | Variable | string | T02 | response.invoice_id | | Aged invoice identifier from the record-created payload |
+| supplierName | Variable | string | T02 | response.supplier_name | | Supplier name from the aged invoice payload |
+| supplierEmail | Variable | string | T02 | response.supplier_email | | Supplier contact email |
+| invoiceAmount | Variable | float | T02 | response.amount | | Invoice amount |
+| currency | Variable | string | T02 | response.currency | "AUD" | Invoice currency |
+| dueDate | Variable | datetime | T02 | response.due_date | | Due date for payment terms |
+| invoiceAgeDays | Variable | integer | T02 | response.age_days | | Number of days aged |
+| caseStatus | Variable | string | | | "Open" | Current case state |
+| enrichmentData | Variable | jsonSchema | | | | Mock ERP, PO, GRN, payment, supplier, and hold context |
+| rootCause | Variable | string | | | | Triage root-cause classification |
+| priorityScore | Variable | integer | | | 0 | Priority/SLA score calculated during triage |
+| slaTier | Variable | string | | | "Standard" | SLA tier from triage |
+| caseOwner | Variable | string | | | | AP owner assigned during AP review |
+| apDecision | Variable | string | | | | AP Review decision: Resolve, SupplierInfo, Escalate, Hold |
+| exceptionResolution | Variable | string | | | | Exception Resolution result |
+| supplierQuerySummary | Variable | string | | | | Agent-generated supplier communication summary |
+| supplierResponse | Variable | jsonSchema | | | | Evidence received from supplier |
+| paymentRiskDecision | Variable | string | | | | Payment Risk result: Clear, Hold, Reject |
+| approvalDecision | Variable | string | | | | Approval decision from Finance Manager or Treasury |
+| paymentTrackingCaseId | Variable | string | | | | Child Payment Tracking case ID |
+| closureSummary | Variable | string | | | | Final closure summary |
+| automationIncidentId | Variable | string | | | | ServiceNow incident ID for failed automation |
+| auditPostResult | Variable | string | | | | SAP/Slack/ServiceNow close-out result |
+
+---
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Intake and Registration
+
+**Type:** Stage
+**Description:** Registers a new aged-invoice case from the case-entity record and creates the initial audit trail.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `case-entered` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Register Invoice Case | api-workflow | Yes | Yes | System | — |
+| 2 | Create Initial Audit Event | execute-connector-activity | Yes | Yes | System | — |
+
+##### Task 1.1: Register Invoice Case
+
+**Type:** api-workflow
+**Description:** Calls the mock ERP API workflow to register the invoice case and normalize basic invoice metadata.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoiceMockIntegrationApi api-workflow>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Api
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| supplierName | string | `=vars.supplierName` |
+| amount | float | `=vars.invoiceAmount` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| normalizedStatus | caseStatus = "Registered" |
+
+##### Task 1.2: Create Initial Audit Event
+
+**Type:** execute-connector-activity
+**Description:** Posts an initial ServiceNow audit event for the new aged invoice case.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Register Invoice Case")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: ServiceNow Create Audit Event connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| eventType | string | "case_registered" |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Stage 2: Context Enrichment
+
+**Type:** Stage
+**Description:** Pulls invoice, supplier, PO, GRN, payment, hold, and supplier statement context from mocked enterprise systems.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Intake and Registration")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Enrich Invoice Context | api-workflow | Yes | Yes | System | — |
+| 2 | Reconcile Supplier Statement | rpa | No | Yes | System | — |
+
+##### Task 2.1: Enrich Invoice Context
+
+**Type:** api-workflow
+**Description:** Calls the Mock ERP and procurement API workflow to fetch invoice, PO, GRN, payment, hold, and supplier history.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoiceContextEnrichment api-workflow>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Api
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| context | -> enrichmentData |
+| — | caseStatus = "Enriched" |
+
+##### Task 2.2: Reconcile Supplier Statement
+
+**Type:** rpa
+**Description:** Runs an RPA workflow to simulate supplier statement extraction and match the invoice against mocked records.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Enrich Invoice Context")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AgedInvoice_StatementReconciliation rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| supplierName | string | `=vars.supplierName` |
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| reconciliationStatus | -> exceptionResolution |
+
+### Stage 3: Triage
+
+**Type:** Stage
+**Description:** Classifies root cause, scores priority/SLA, and recommends the next action.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Context Enrichment")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Classify Root Cause and Priority | agent | Yes | Yes | System | — |
+| 2 | Assign AP Owner | process | Yes | Yes | AP Team Lead | — |
+
+##### Task 3.1: Classify Root Cause and Priority
+
+**Type:** agent
+**Description:** Invoice Triage Agent classifies rootCause and calculates priorityScore and slaTier from invoice, supplier, GRN, PO, and payment evidence.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: InvoiceTriageAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| enrichmentData | jsonSchema | `=vars.enrichmentData` |
+| invoiceAgeDays | integer | `=vars.invoiceAgeDays` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| rootCause | -> rootCause |
+| priorityScore | -> priorityScore |
+| slaTier | -> slaTier |
+
+##### Task 3.2: Assign AP Owner
+
+**Type:** process
+**Description:** Assigns the case to an AP Clerk or AP Team Lead based on priorityScore and rootCause.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Classify Root Cause and Priority")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: AssignAgedInvoiceOwner process>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| rootCause | string | `=vars.rootCause` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| owner | -> caseOwner |
+
+### Stage 4: AP Review
+
+**Type:** Stage
+**Description:** AP reviews the triage recommendation and chooses the resolution route.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Triage")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | AP Ownership Review | action | Yes | Yes | AP Clerk | 5 min |
+| 2 | Start SLA Reminder Timer | wait-for-timer | No | Yes | System | — |
+
+##### Task 4.1: AP Ownership Review
+
+**Type:** action
+**Description:** Human action for the AP Clerk to confirm owner, root cause, next action, and whether supplier evidence is needed.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: Aged Invoice AP Review>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| rootCause | string | `=vars.rootCause` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> apDecision |
+
+##### Task 4.2: Start SLA Reminder Timer
+
+**Type:** wait-for-timer
+**Description:** Waits five minutes before SLA escalation checks.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 2 |
+
+**Timer:** Duration `PT5M`
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| — | caseStatus = "AP Review In Progress" |
+
+### Stage 5: Exception Resolution
+
+**Type:** Stage
+**Description:** Resolves internal exceptions such as missing GRN, price mismatch, duplicate invoice, approval delay, or payment hold.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("AP Review")` | `=vars.apDecision != "SupplierInfo"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | GRN Confirmation | action | No | Yes | Store/DC Receiver | 5 min |
+| 2 | Update Mock ERP Exception | rpa | Yes | Yes | System | — |
+
+##### Task 5.1: GRN Confirmation
+
+**Type:** action
+**Description:** Human action to confirm missing goods receipt or delivery discrepancy.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | `=vars.rootCause == "Missing GRN"` | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: GRN Confirmation>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| supplierName | string | `=vars.supplierName` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| resolution | -> exceptionResolution |
+
+##### Task 5.2: Update Mock ERP Exception
+
+**Type:** rpa
+**Description:** Updates the Mock ERP exception status after AP or GRN resolution.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("GRN Confirmation")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: MockERPExceptionUpdate rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| exceptionResolution | string | `=vars.exceptionResolution` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| updateStatus | caseStatus = "Exception Resolved" |
+
+### Stage 6: Supplier Collaboration
+
+**Type:** Stage
+**Description:** Contacts the supplier, interprets the response, and waits for missing evidence when supplier input is required.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Exception Resolution")` | — | No | Entry Rule 1 |
+| `selected-stage-completed("AP Review")` | `=vars.apDecision == "SupplierInfo"` | No | Entry Rule 2 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Notify Supplier via Outlook | execute-connector-activity | Yes | Yes | System | — |
+| 2 | Wait for Supplier Evidence | wait-for-connector | No | No | Supplier Contact | — |
+| 3 | Interpret Supplier Query | agent | No | Yes | System | — |
+
+##### Task 6.1: Notify Supplier via Outlook
+
+**Type:** execute-connector-activity
+**Description:** Sends an Outlook request for evidence or status clarification to the supplier contact.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Outlook Send Supplier Request connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| to | string | `=vars.supplierEmail` |
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| sentStatus | caseStatus = "Awaiting Supplier" |
+
+##### Task 6.2: Wait for Supplier Evidence
+
+**Type:** wait-for-connector
+**Description:** Waits for supplier portal or Outlook evidence for the invoice.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Notify Supplier via Outlook")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SupplierEvidenceReceived connector trigger>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| evidence | -> supplierResponse |
+
+##### Task 6.3: Interpret Supplier Query
+
+**Type:** agent
+**Description:** Supplier Query Agent summarizes supplier response, dispute reason, and recommended next action.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Wait for Supplier Evidence")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SupplierQueryAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| supplierResponse | jsonSchema | `=vars.supplierResponse` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> supplierQuerySummary |
+
+### Stage 7: Payment Risk Review
+
+**Type:** Stage
+**Description:** Assesses duplicate, tax, bank, hold, approval, and dispute risk before payment approval.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Supplier Collaboration")` | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Assess Payment Risk | agent | Yes | Yes | System | — |
+| 2 | Start Payment Tracking Case | case-management | No | Yes | System | — |
+
+##### Task 7.1: Assess Payment Risk
+
+**Type:** agent
+**Description:** Payment Risk Agent evaluates paymentRiskDecision from enrichmentData, supplierResponse, exceptionResolution, duplicate risk, and approval thresholds.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: PaymentRiskAgent agent>`
+**Folder Path:** `<UNRESOLVED>`
+**Binding Sub-Type:** Agent
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| enrichmentData | jsonSchema | `=vars.enrichmentData` |
+| supplierResponse | jsonSchema | `=vars.supplierResponse` |
+| exceptionResolution | string | `=vars.exceptionResolution` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> paymentRiskDecision |
+
+##### Task 7.2: Start Payment Tracking Case
+
+**Type:** case-management
+**Description:** Starts the Payment Tracking child case when payment follow-up needs separate tracking.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Assess Payment Risk")` | `=vars.paymentRiskDecision == "Clear"` | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Payment Tracking case-management>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| caseId | -> paymentTrackingCaseId |
+
+### Stage 8: Approval
+
+**Type:** Stage
+**Description:** Finance Manager or Treasury approves or rejects payment release after Payment Risk clears.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Payment Risk Review")` | `=vars.paymentRiskDecision == "Clear"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Payment Approval | action | Yes | Yes | Finance Manager | 5 min |
+| 2 | Post Approval Slack Update | execute-connector-activity | No | Yes | System | — |
+
+##### Task 8.1: Payment Approval
+
+**Type:** action
+**Description:** Finance Manager reviews paymentRiskDecision, priorityScore, supplier evidence, and approves payment release or hold.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**HITL Implementation:** Action App: `<UNRESOLVED: Aged Invoice Payment Approval>`
+**Action App ID:** `<UNRESOLVED>`
+**Deployment Folder:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| paymentRiskDecision | string | `=vars.paymentRiskDecision` |
+| priorityScore | integer | `=vars.priorityScore` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> approvalDecision |
+
+##### Task 8.2: Post Approval Slack Update
+
+**Type:** execute-connector-activity
+**Description:** Posts approval status to a Slack AP operations channel.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Payment Approval")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: Slack Post Message connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| approvalDecision | string | `=vars.approvalDecision` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Stage 9: Closure
+
+**Type:** Stage
+**Description:** Updates SAP/Mock ERP, records final audit evidence, and closes the aged invoice case.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-completed("Approval")` | `=vars.approvalDecision == "Approved"` | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `required-tasks-completed` | — | exit-only | Yes | Complete Rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Post SAP Closure Record | execute-connector-activity | Yes | Yes | System | — |
+| 2 | Close Mock ERP Invoice | rpa | Yes | Yes | System | — |
+
+##### Task 9.1: Post SAP Closure Record
+
+**Type:** execute-connector-activity
+**Description:** Posts the final SAP closure record and payment status for audit.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: SAP Post Closure connector activity>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+| approvalDecision | string | `=vars.approvalDecision` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+##### Task 9.2: Close Mock ERP Invoice
+
+**Type:** rpa
+**Description:** Updates the Mock ERP invoice screen to closed for the demo.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `selected-tasks-completed("Post SAP Closure Record")` | — | Entry Rule 1 |
+
+**Resolved Resource:** `<UNRESOLVED: MockERPCloseInvoice rpa>`
+**Folder Path:** `<UNRESOLVED>`
+
+**Inputs:**
+
+| Field | Type | Binding |
+|---|---|---|
+| invoiceId | string | `=vars.invoiceId` |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> closureSummary |
+| — | caseStatus = "Closed" |
+
+### Secondary Stage: SLA Escalation
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for at-risk or breached SLA conditions.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("AP Review")` | `=vars.priorityScore >= 80` | Yes | Escalate At Risk |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Notify AP Lead")` | — | return-to-origin | No | Return After Escalation |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Notify AP Lead | execute-connector-activity | Yes | No | System | — |
+
+##### Task S1.1: Notify AP Lead
+
+**Type:** execute-connector-activity
+**Description:** Sends Slack and Outlook escalation notifications to AP Team Leads.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| result | -> auditPostResult |
+
+### Secondary Stage: Automation Incident
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for failed API, RPA, connector, or agent automation.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Context Enrichment")` | `=vars.caseStatus == "AutomationFailed"` | Yes | Automation Failed |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Create ServiceNow Incident")` | — | return-to-origin | No | Return After Incident |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Create ServiceNow Incident | execute-connector-activity | Yes | Yes | Automation Support | — |
+
+##### Task S2.1: Create ServiceNow Incident
+
+**Type:** execute-connector-activity
+**Description:** Creates a ServiceNow incident for failed automation and stores automationIncidentId.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| incidentId | -> automationIncidentId |
+
+### Secondary Stage: Reopen and Supplier Dispute
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for supplier disputes or reopened invoices after closure.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Closure")` | `=vars.supplierQuerySummary == "Dispute"` | Yes | Reopen Dispute |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Summarize Supplier Dispute")` | — | return-to-origin | No | Return After Reopen |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Summarize Supplier Dispute | agent | Yes | Yes | System | — |
+
+##### Task S3.1: Summarize Supplier Dispute
+
+**Type:** agent
+**Description:** Summarizes reopened supplier dispute and recommends next best action.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| summary | -> supplierQuerySummary |
+
+### Secondary Stage: Compliance and Payment Risk Hold
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Interrupting:** Yes
+**Description:** Interrupting lane for compliance holds, duplicate risk, tax risk, bank-data issues, and payment-risk holds.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|---|---|---|---|
+| `selected-stage-exited("Payment Risk Review")` | `=vars.paymentRiskDecision == "Hold"` | Yes | Compliance Hold |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| `selected-tasks-completed("Compliance Hold Review")` | — | return-to-origin | No | Return After Hold |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|---|---|---|---|---|---|
+| 1 | Compliance Hold Review | action | Yes | Yes | Finance Manager | 5 min |
+
+##### Task S4.1: Compliance Hold Review
+
+**Type:** action
+**Description:** Human action to release or keep a compliance and payment risk hold.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| `current-stage-entered` | — | Entry Rule 1 |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|---|---|
+| decision | -> paymentRiskDecision |
+
+---
+
+## Section 3: Personas & App Views
+
+| Persona | View / Responsibility |
+|---|---|
+| AP Clerk | AP Control Tower and AP Ownership Review |
+| AP Team Lead | SLA escalation and reassignment |
+| Procurement Officer | Price mismatch and PO exception decisions |
+| Store/DC Receiver | GRN Confirmation |
+| Finance Manager | Payment Approval and Compliance Hold Review |
+| Treasury User | Payment release oversight |
+| Automation Support | Automation Incident review |
+
+## Section 4: Integrations
+
+| Family | Resource | Purpose |
+|---|---|---|
+| API Workflow | AgedInvoiceMockIntegrationApi | Mock ERP registration and enrichment |
+| Agent | InvoiceTriageAgent | rootCause classification and priorityScore calculation |
+| Agent | PaymentRiskAgent | Payment Risk decision gate |
+| Action App | Aged Invoice AP Review | AP human decision |
+| Action App | Aged Invoice Payment Approval | Finance approval |
+| RPA | AgedInvoice_StatementReconciliation | Supplier statement reconciliation |
+| RPA | MockERPCloseInvoice | Mock ERP close-out |
+| Connector | Outlook | Supplier notification and evidence request |
+| Connector | ServiceNow | Automation incident and audit event |
+| Connector | Slack | AP escalation and approval updates |
+| Connector | SAP | Closure posting |
+| Case Management | Payment Tracking | Child case for payment follow-up |

--- a/tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py
+++ b/tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Assert an AgedInvoicePayment SDD captures the full PDD-derived design.
+
+This is the deterministic companion to the LLM judge. It intentionally checks
+business shape, not exact prose: the design must keep the long-form aged-invoice
+case as one Maestro case with the expected primary stages, exception lanes, task
+type mix, triage scoring, payment-risk gating, and child payment tracking case.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+
+
+PRIMARY_STAGE_PATTERNS = {
+    "Intake": r"intake|registration",
+    "Enrichment": r"enrichment|context",
+    "Triage": r"triage",
+    "AP Review": r"ap review|accounts payable|ownership",
+    "Exception Resolution": r"exception resolution|resolution",
+    "Supplier Collaboration": r"supplier collaboration|supplier",
+    "Payment Risk": r"payment risk|risk",
+    "Approval": r"approval",
+    "Closure": r"closure|close",
+}
+
+EXCEPTION_PATTERNS = {
+    "SLA Escalation": r"sla.*escalation|escalation",
+    "Automation Incident": r"automation.*incident|incident|automation failure|failed (api|rpa|automation)",
+    "Reopen": r"reopen|supplier dispute",
+    "Compliance Hold": r"compliance.*hold|payment.?risk.*hold|hold",
+}
+
+TASK_TYPE_PATTERNS = {
+    "api-workflow": r"api[- ]workflow",
+    "connector": r"execute-connector-activity|wait-for-connector|connector|outlook|servicenow|slack|sap",
+    "agent": r"\bagent\b",
+    "action": r"\baction\b|hitl|human",
+    "wait-for-timer": r"wait-for-timer|\btimer\b|reminder",
+    "rpa": r"\brpa\b|robot",
+    "case-management": r"case-management|child case|sub-case|subcase|payment tracking",
+}
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read(path: str) -> str:
+    try:
+        return open(path, encoding="utf-8").read()
+    except OSError as exc:
+        _fail(f"could not read {path}: {exc}")
+
+
+def _heading_names(text: str, pattern: str) -> list[str]:
+    return [m.group(1).strip() for m in re.finditer(pattern, text, re.M)]
+
+
+def _has(text: str, pattern: str) -> bool:
+    return re.search(pattern, text, re.I | re.S) is not None
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        _fail("usage: check_aged_invoice_sdd.py <sdd.md|sdd.draft.md>")
+
+    text = _read(sys.argv[1])
+    lowered = text.lower()
+
+    primary_headings = _heading_names(text, r"^### +Stage +[0-9]+: +(.+)$")
+    if len(primary_headings) < 8:
+        _fail(
+            f"expected >=8 primary stages from the PDD's 9-stage design; "
+            f"found {len(primary_headings)}: {primary_headings}"
+        )
+
+    missing_primary = [
+        name
+        for name, pattern in PRIMARY_STAGE_PATTERNS.items()
+        if not _has(" ".join(primary_headings), pattern)
+    ]
+    if missing_primary:
+        _fail(
+            "missing primary stage family/families: "
+            + ", ".join(missing_primary)
+            + f"; headings={primary_headings}"
+        )
+
+    secondary_headings = _heading_names(
+        text, r"^### +(?:Secondary Stage|Exception Stage): +(.+)$"
+    )
+    exception_text = " ".join(secondary_headings) + "\n" + text
+    missing_exception = [
+        name
+        for name, pattern in EXCEPTION_PATTERNS.items()
+        if not _has(exception_text, pattern)
+    ]
+    if missing_exception:
+        _fail(
+            "missing exception lane(s): "
+            + ", ".join(missing_exception)
+            + f"; secondary headings={secondary_headings}"
+        )
+
+    missing_task_types = [
+        name for name, pattern in TASK_TYPE_PATTERNS.items() if not _has(text, pattern)
+    ]
+    if missing_task_types:
+        _fail("missing task-type signal(s): " + ", ".join(missing_task_types))
+
+    if not ("rootcause" in lowered or "root cause" in lowered):
+        _fail("triage must capture root-cause classification")
+    if not ("priorityscore" in lowered or "priority score" in lowered or "sla score" in lowered):
+        _fail("triage must capture priority/SLA scoring")
+    if not ("paymentrisk" in lowered or "payment risk" in lowered):
+        _fail("payment risk stage/gate is missing")
+    if not ("paymenttracking" in lowered or "payment tracking" in lowered):
+        _fail("payment tracking child case is missing")
+
+    for system in ("mock erp", "outlook", "servicenow", "slack", "sap"):
+        if system not in lowered:
+            _fail(f"missing external system/integration signal: {system}")
+
+    print(
+        "OK: AgedInvoicePayment SDD preserves the PDD-derived 9-stage design, "
+        "exception lanes, task-type mix, triage scoring, payment-risk gate, "
+        "payment tracking child case, and integration footprint"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add a Phase 0 finalize-from-draft eval for the AgedInvoicePayment case.
- Add a build-from-approved-SDD eval for the AgedInvoicePayment case.
- Add deterministic SDD and caseplan graders that check the primary stage chain, exception lanes, task mix, triage scoring, payment-risk gate, Payment Tracking child case, and integration footprint.

## Validation
- `SKILLS_REPO_PATH=/Users/abhiram.vadlapatla/Documents/Github/skills .venv/bin/coder-eval plan tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/finalize_from_draft_aged_invoice.yaml tasks/uipath-maestro-case/phase_0_build_aged_invoice/build_from_sdd_aged_invoice.yaml -e experiments/default.yaml`
- `python3 tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/fixtures/sdd.md`
- `python3 tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py tests/tasks/uipath-maestro-case/phase_0_finalize_draft_aged_invoice/fixtures/sdd.draft.md`
- `python3 -m py_compile tests/tasks/uipath-maestro-case/phase_0_to_case/aged_invoice_payment/check_aged_invoice_sdd.py tests/tasks/uipath-maestro-case/phase_0_build_aged_invoice/check_aged_invoice_case.py`
- `_shared/sdd_check.py` passes on both aged-invoice fixtures after staging each as `sdd.md` in a temp directory.
- `git diff --cached --check`

## Notes
- This PR mirrors the employee expense eval pattern for aged invoices.
- The build eval intentionally skips Phase 5 debug and Phase 6 publish; it validates the generated local caseplan.