### PR TITLE
feat(hooks): export UIPATH_SKILLS_VERSION at SessionStart

### DIFF
--- a/hooks/set-session-env.sh
+++ b/hooks/set-session-env.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# SessionStart step: export the agent's session id to the uip CLI.
+# SessionStart step: export the agent's session id and the skills plugin
+# version to the uip CLI.
 #
 # Reads the SessionStart payload on stdin, takes its top-level `session_id`,
 # and appends `export UIPATH_SESSION_ID='<id>'` to $CLAUDE_ENV_FILE so every
@@ -9,6 +10,11 @@
 # command stream with the skills events emitted by send-telemetry.sh: both
 # streams then carry the same session id.
 #
+# Also reads the skills/CLI co-version from version-manifest.json (same
+# "skillsVersion" field send-telemetry.sh's read_skills_version() reads) and
+# appends `export UIPATH_SKILLS_VERSION='<version>'`, so `uip feedback send`
+# can print it in the ticket's Environment block (UiPath/cli#2637, PR #1608).
+#
 # Registered SYNCHRONOUSLY in hooks.json (no "async": true): the write must
 # complete before the session's first Bash call, or early `uip` commands would
 # miss the id. Costs a few ms (grep/sed/tr only, no network, no uip call).
@@ -17,42 +23,70 @@
 # transmits nothing — whether any event carrying it is ever sent stays
 # governed by the CLI's own telemetry gate.
 #
-# Safety:
-#   - host wins: no-op when UIPATH_SESSION_ID is already set in the env;
+# Safety (applies independently to each export):
+#   - host wins: no-op when the target var is already set in the env;
 #   - idempotent: no-op when the env file already exports it;
-#   - injection-safe: $CLAUDE_ENV_FILE is sourced by the agent, so the value
-#     is stripped to [A-Za-z0-9._-] and length-capped before being written
-#     inside single quotes (agent session ids are UUIDs, so a legitimate
-#     value is never altered);
+#   - injection-safe: $CLAUDE_ENV_FILE is sourced by the agent, so each value
+#     is stripped to a safe charset and length-capped before being written
+#     inside single quotes (agent session ids are UUIDs and skills versions
+#     are dotted version strings, so a legitimate value is never altered);
 #   - never-fail: always exits 0, never blocks the session.
 
 set +e
 
-main() {
-  [ -n "$CLAUDE_ENV_FILE" ] || exit 0
-  [ -z "$UIPATH_SESSION_ID" ] || exit 0
-  if [ -f "$CLAUDE_ENV_FILE" ] \
-    && grep -q '^export UIPATH_SESSION_ID=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
-    exit 0
-  fi
-
-  # Top-level `session_id` from the SessionStart payload. The payload for this
-  # event is small and carries no tool output, and the value is hard-sanitized
-  # anyway, so a plain grep is sufficient here (no region-scoped pass needed).
-  sid="$(grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
-    | head -1 | sed 's/.*"\([^"]*\)"$/\1/' | tr -cd 'A-Za-z0-9._-' | cut -c1-64)"
-  [ -n "$sid" ] || exit 0
-
-  # If the file exists but doesn't end with a newline (another hook's partial
-  # write), appending directly would concatenate onto its last line and could
-  # break the sourced env file for the whole session — repair it first.
-  # `tail -c 1` in a $() strips a trailing newline, so "" means the file is
-  # newline-terminated.
+# append_export <env_var_name> <sanitized_value>: write
+# `export <env_var_name>='<value>'` to $CLAUDE_ENV_FILE, repairing a missing
+# trailing newline first (see the inline comment at the call site for why).
+append_export() {
   if [ -s "$CLAUDE_ENV_FILE" ] && [ -n "$(tail -c 1 "$CLAUDE_ENV_FILE" 2>/dev/null)" ]; then
     printf '\n' >> "$CLAUDE_ENV_FILE" 2>/dev/null
   fi
+  printf "export %s='%s'\n" "$1" "$2" >> "$CLAUDE_ENV_FILE" 2>/dev/null
+}
 
-  printf "export UIPATH_SESSION_ID='%s'\n" "$sid" >> "$CLAUDE_ENV_FILE" 2>/dev/null
+# export_session_id <payload>: UIPATH_SESSION_ID from the SessionStart
+# payload's top-level `session_id`.
+export_session_id() {
+  [ -z "$UIPATH_SESSION_ID" ] || return 0
+  if [ -f "$CLAUDE_ENV_FILE" ] \
+    && grep -q '^export UIPATH_SESSION_ID=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  # The payload for this event is small and carries no tool output, and the
+  # value is hard-sanitized anyway, so a plain grep is sufficient here (no
+  # region-scoped pass needed).
+  sid="$(printf '%s' "$1" | grep -oE '"session_id"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/' | tr -cd 'A-Za-z0-9._-' | cut -c1-64)"
+  [ -n "$sid" ] || return 0
+
+  append_export UIPATH_SESSION_ID "$sid"
+}
+
+# export_skills_version: UIPATH_SKILLS_VERSION from the "skillsVersion" field
+# of ${CLAUDE_PLUGIN_ROOT}/version-manifest.json — same source and extraction
+# as send-telemetry.sh's read_skills_version().
+export_skills_version() {
+  [ -z "$UIPATH_SKILLS_VERSION" ] || return 0
+  if [ -f "$CLAUDE_ENV_FILE" ] \
+    && grep -q '^export UIPATH_SKILLS_VERSION=' "$CLAUDE_ENV_FILE" 2>/dev/null; then
+    return 0
+  fi
+
+  ver="$(grep -oE '"skillsVersion"[[:space:]]*:[[:space:]]*"[^"]*"' \
+    "${CLAUDE_PLUGIN_ROOT:-.}/version-manifest.json" 2>/dev/null \
+    | head -1 | sed 's/.*"\([^"]*\)"$/\1/' | tr -cd 'A-Za-z0-9._-' | cut -c1-32)"
+  [ -n "$ver" ] || return 0
+
+  append_export UIPATH_SKILLS_VERSION "$ver"
+}
+
+main() {
+  [ -n "$CLAUDE_ENV_FILE" ] || exit 0
+
+  payload="$(cat)"
+  export_session_id "$payload"
+  export_skills_version
 
   exit 0
 }


### PR DESCRIPTION
## Summary
- Extends `hooks/set-session-env.sh` to also export `UIPATH_SKILLS_VERSION` (read from `version-manifest.json`'s `skillsVersion`, same source as `send-telemetry.sh`'s `read_skills_version()`), so `uip feedback send` can populate the `Skills Plugin Version` field in the ticket's Environment block (UiPath/cli#2637, PR #1608).
- Refactored the script into `append_export` / `export_session_id` / `export_skills_version` helpers so both exports share identical host-wins, idempotent, injection-safe, and never-fail behavior. No new hook entry was added — reuses the existing synchronous `SessionStart` registration in `hooks.json`.

## Verification

Simulated a SessionStart by piping a fake payload into the script with a temp `CLAUDE_ENV_FILE` and `CLAUDE_PLUGIN_ROOT` pointing at the repo root.

**Fresh write:**
```
$ echo '{"hook_event_name":"SessionStart","session_id":"abc-123-DEF_456","source":"startup"}' \
    | CLAUDE_ENV_FILE="$ENVFILE" CLAUDE_PLUGIN_ROOT="$(pwd)" bash hooks/set-session-env.sh
exit=0
--- run 1 result ---
export UIPATH_SESSION_ID='abc-123-DEF_456'
export UIPATH_SKILLS_VERSION='1.198.0'
```

**Idempotency (ran twice, same env file):**
```
exit=0
--- after 2 runs ---
export UIPATH_SESSION_ID='abc-123-DEF_456'
export UIPATH_SKILLS_VERSION='1.198.0'
--- line count ---
2
```

**Host wins (both vars pre-set in env):**
```
$ UIPATH_SESSION_ID="already-set" UIPATH_SKILLS_VERSION="already-set" ... bash hooks/set-session-env.sh
exit=0
--- host-wins result (should be empty file) ---
0
```
(env file stayed empty — script made no writes)

**Trailing-newline repair (env file missing final newline):**
```
$ printf 'export FOO=bar' > "$ENVFILE2"
$ echo '{"hook_event_name":"SessionStart","session_id":"xyz-789","source":"startup"}' | ... bash hooks/set-session-env.sh
exit=0
export FOO=bar
export UIPATH_SESSION_ID='xyz-789'
export UIPATH_SKILLS_VERSION='1.198.0'
```

**Injection safety (malicious `session_id` and `skillsVersion` containing `'; rm -rf ...`):**
```
manifest: {"skillsVersion":"1.0.0'; rm -rf /; echo pwned"}
payload session_id: abc'; rm -rf ~; echo hacked
exit=0
--- injection test result ---
export UIPATH_SESSION_ID='abcrm-rfechohacked'
export UIPATH_SKILLS_VERSION='1.0.0rm-rfechopwned'
```
Both values sanitized to a safe charset before being written inside single quotes; no shell metacharacters survive.

## Test plan
- [x] Fresh SessionStart payload produces both exports
- [x] Re-running is idempotent (no duplicate lines)
- [x] Host-set env vars are left untouched (no-op)
- [x] Trailing-newline repair still works when combined with the new export
- [x] Injected shell metacharacters in `session_id` / `skillsVersion` are stripped before being written