### PR TITLE
fix(uipath-coded-apps): update test criteria for the uipath.json config convention

### DIFF
--- a/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
@@ -192,8 +192,8 @@ success_criteria:
   # the three config criteria below accept EITHER convention so the test grades
   # the config contract, not which skill version taught it.
   - type: run_command
-    description: "SDK config exists: uipath.json with clientId+scope fields (current convention) OR .env/.env.example with VITE_UIPATH_* (legacy)"
-    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; d=json.load(open('$F')); sys.exit(0 if 'clientId' in d and 'scope' in d else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -lE '^VITE_UIPATH_' {} + | grep -q ."
+    description: "SDK config exists: uipath.json with a scope field (current convention; clientId may be an empty placeholder or omitted entirely in test tenants, so only scope is required) OR .env/.env.example with VITE_UIPATH_* (legacy)"
+    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; d=json.load(open('$F')); sys.exit(0 if 'scope' in d else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -lE '^VITE_UIPATH_' {} + | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
@@ -4,7 +4,7 @@ description: >
   App dashboard that surfaces live Orchestrator state, from scratch. Given
   only a business goal, the agent must scaffold Vite + React, wire the
   `@uipath/uipath-typescript` SDK with subpath imports and constructor DI,
-  configure the SDK scope (uipath.json / legacy .env) to cover Jobs + Queues, configure
+  configure the uipath.json scope to cover Jobs + Queues, configure
   `vite.config.ts` correctly (Rule #9), use `getAppBase()` for any runtime
   asset URLs (Rule #10), build, pack, publish (default Web type), and
   deploy to a fresh per-run Orchestrator folder so `post_run` can clean it
@@ -189,27 +189,27 @@ success_criteria:
 
   # Skill change #1562 (Jul 6) replaced the .env/VITE_UIPATH_* SDK config with
   # uipath.json ({clientId, scope, orgName, tenantName, baseUrl, redirectUri});
-  # the three config criteria below accept EITHER convention so the test grades
-  # the config contract, not which skill version taught it.
+  # the SDK reads only the uipath.json-injected meta tags, so the three config
+  # criteria below grade uipath.json exclusively.
   - type: run_command
-    description: "SDK config exists: uipath.json with a scope field (current convention; clientId may be an empty placeholder or omitted entirely in test tenants, so only scope is required) OR .env/.env.example with VITE_UIPATH_* (legacy)"
-    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; d=json.load(open('$F')); sys.exit(0 if 'scope' in d else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -lE '^VITE_UIPATH_' {} + | grep -q ."
+    description: "SDK config exists: uipath.json with a scope field (clientId may be an empty placeholder or omitted entirely in test tenants, so only scope is required)"
+    command: "F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; d=json.load(open('$F')); sys.exit(0 if 'scope' in d else 1)\""
     timeout: 10
     expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "SDK scope covers BOTH Jobs and Queues (Rule #16 — mismatched scopes fail silently with 401/403). Reads uipath.json .scope (current) or VITE_UIPATH_SCOPE (legacy)."
-    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; s=str(json.load(open('$F')).get('scope','')); sys.exit(0 if ('OR.Jobs' in s and 'OR.Queues' in s) else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_SCOPE=.*OR\\.Jobs.*OR\\.Queues|^VITE_UIPATH_SCOPE=.*OR\\.Queues.*OR\\.Jobs\" {} + 2>/dev/null | grep -q ."
+    description: "uipath.json scope covers BOTH Jobs and Queues (Rule #16 — mismatched scopes fail silently with 401/403)"
+    command: "F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; s=str(json.load(open('$F')).get('scope','')); sys.exit(0 if ('OR.Jobs' in s and 'OR.Queues' in s) else 1)\""
     timeout: 10
     expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 
   - type: run_command
-    description: "SDK base URL uses the API subdomain (Rule #8 — api.uipath.com, not cloud.uipath.com). Reads uipath.json .baseUrl (current) or VITE_UIPATH_BASE_URL (legacy)."
-    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys,re; b=str(json.load(open('$F')).get('baseUrl','')); sys.exit(0 if re.match(r'https://([\\w-]+\\.)*api\\.uipath\\.com', b) else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_BASE_URL=https://(\\w+\\.)?api\\.uipath\\.com\" {} + 2>/dev/null | grep -q ."
+    description: "uipath.json baseUrl uses the API subdomain (Rule #8 — api.uipath.com, not cloud.uipath.com)"
+    command: "F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys,re; b=str(json.load(open('$F')).get('baseUrl','')); sys.exit(0 if re.match(r'https://([\\w-]+\\.)*api\\.uipath\\.com', b) else 1)\""
     timeout: 10
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
@@ -11,9 +11,14 @@ description: >
   up. Tests the Web-app lifecycle with deep SDK integration that no smoke
   or integration test covers.
 tags: [uipath-coded-apps, e2e, mode:build, lifecycle:setup]
+# max_turns 65→85: run 28935883495 exhausted 65 with all lifecycle criteria
+# already passed — ~14 turns went to TaskCreate/TaskUpdate ceremony and a
+# post-deploy nupkg inspection detour, and report.json (the last step) was
+# the casualty. The prompt now writes the report immediately after deploy
+# and bans task-tracking ceremony; the bump is headroom for verbose agents.
 run_limits:
   expected_turns: 45
-  max_turns: 65
+  max_turns: 85
   turn_timeout: 1200
 
 initial_prompt: |
@@ -47,17 +52,23 @@ initial_prompt: |
   This isolates the deployment so `post_run` cleanup can delete the
   folder afterwards (folder delete cascades to the coded-app deployment).
 
-  When you finish, write `report.json` at the sandbox root with:
+  IMMEDIATELY after `uip codedapp deploy` succeeds — before ANY further
+  verification, inspection, or cleanup — write `report.json` at the
+  sandbox root with:
     {
       "app_name": "<the exact app name you used>",
       "deployment_id": "<the deploymentId from .uipath/app.config.json (or its systemName if deploymentId is absent)>",
       "app_url": "<the appUrl from .uipath/app.config.json>",
       "folder": "<the codedapp-e2e-dash-<EPOCH> folder name you created>"
     }
-  The `folder` field is REQUIRED — `post_run` reads it to clean up.
+  The `folder` field is REQUIRED — `post_run` reads it to clean up. The
+  run is graded incomplete without `report.json`, no matter how well the
+  deployment went.
 
   Use `--output json` on every `uip` command. Do not prompt for
-  confirmation — this is an automated test.
+  confirmation — this is an automated test. Do NOT use task-tracking
+  tools (TaskCreate/TaskUpdate) — execute the steps directly; every
+  turn spent on bookkeeping is budget taken from the build.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
@@ -4,7 +4,7 @@ description: >
   App dashboard that surfaces live Orchestrator state, from scratch. Given
   only a business goal, the agent must scaffold Vite + React, wire the
   `@uipath/uipath-typescript` SDK with subpath imports and constructor DI,
-  configure `VITE_UIPATH_SCOPE` to cover Jobs + Queues, configure
+  configure the SDK scope (uipath.json / legacy .env) to cover Jobs + Queues, configure
   `vite.config.ts` correctly (Rule #9), use `getAppBase()` for any runtime
   asset URLs (Rule #10), build, pack, publish (default Web type), and
   deploy to a fresh per-run Orchestrator folder so `post_run` can clean it
@@ -187,25 +187,29 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # Skill change #1562 (Jul 6) replaced the .env/VITE_UIPATH_* SDK config with
+  # uipath.json ({clientId, scope, orgName, tenantName, baseUrl, redirectUri});
+  # the three config criteria below accept EITHER convention so the test grades
+  # the config contract, not which skill version taught it.
   - type: run_command
-    description: ".env or .env.example was created with VITE_UIPATH_* config (anywhere in the project tree)"
-    command: "find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -lE '^VITE_UIPATH_' {} + | grep -q ."
+    description: "SDK config exists: uipath.json with clientId+scope fields (current convention) OR .env/.env.example with VITE_UIPATH_* (legacy)"
+    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; d=json.load(open('$F')); sys.exit(0 if 'clientId' in d and 'scope' in d else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -lE '^VITE_UIPATH_' {} + | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
-    description: "VITE_UIPATH_SCOPE covers BOTH Jobs and Queues (Rule #16 — mismatched scopes fail silently with 401/403)"
-    command: "find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_SCOPE=.*OR\\.Jobs.*OR\\.Queues|^VITE_UIPATH_SCOPE=.*OR\\.Queues.*OR\\.Jobs\" {} + 2>/dev/null | grep -q ."
+    description: "SDK scope covers BOTH Jobs and Queues (Rule #16 — mismatched scopes fail silently with 401/403). Reads uipath.json .scope (current) or VITE_UIPATH_SCOPE (legacy)."
+    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys; s=str(json.load(open('$F')).get('scope','')); sys.exit(0 if ('OR.Jobs' in s and 'OR.Queues' in s) else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_SCOPE=.*OR\\.Jobs.*OR\\.Queues|^VITE_UIPATH_SCOPE=.*OR\\.Queues.*OR\\.Jobs\" {} + 2>/dev/null | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 
   - type: run_command
-    description: "VITE_UIPATH_BASE_URL uses the API subdomain (Rule #8 — api.uipath.com, not cloud.uipath.com)"
-    command: "find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_BASE_URL=https://(\\w+\\.)?api\\.uipath\\.com\" {} + 2>/dev/null | grep -q ."
+    description: "SDK base URL uses the API subdomain (Rule #8 — api.uipath.com, not cloud.uipath.com). Reads uipath.json .baseUrl (current) or VITE_UIPATH_BASE_URL (legacy)."
+    command: "( F=$(find . -name 'uipath.json' -not -path '*/node_modules/*' -print -quit) && test -n \"$F\" && python3 -c \"import json,sys,re; b=str(json.load(open('$F')).get('baseUrl','')); sys.exit(0 if re.match(r'https://([\\w-]+\\.)*api\\.uipath\\.com', b) else 1)\" ) || find . \\( -name '.env.example' -o -name '.env' -o -name '.env.local' \\) -not -path '*/node_modules/*' -exec grep -hE \"^VITE_UIPATH_BASE_URL=https://(\\w+\\.)?api\\.uipath\\.com\" {} + 2>/dev/null | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-coded-apps/integration_debug_catalog_classification.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_debug_catalog_classification.yaml
@@ -70,25 +70,25 @@ success_criteria:
   # Skill change #1562 moved SDK config from .env/VITE_UIPATH_* to uipath.json;
   # debug.md's canonical fixes now say "set baseUrl in uipath.json" / "update
   # the scope field in uipath.json". The regexes accept the current canonical
-  # phrasing, the legacy env-var names, and the specific value — but still
-  # reject vague answers ('check CORS settings', 'check your scopes').
+  # phrasing and the specific value — but still reject vague answers
+  # ('check CORS settings', 'check your scopes') and dead VITE_* env vars.
   - type: json_check
-    description: "Fault A — fix names the API hostname, the baseUrl config field, or the legacy env var (debug.md: 'Set baseUrl in uipath.json to https://api.uipath.com'). NOT just 'cloud.uipath.com' (the wrong value)."
+    description: "Fault A — fix names the API hostname or the baseUrl config field (debug.md: 'Set baseUrl in uipath.json to https://api.uipath.com'). NOT just 'cloud.uipath.com' (the wrong value)."
     path: "diagnosis.json"
     assertions:
       - expression: "faultA.fix"
         operator: regex
-        expected: "(?i)(VITE_UIPATH_BASE_URL|api\\.uipath\\.com|\\bbaseUrl\\b)"
+        expected: "(?i)(api\\.uipath\\.com|\\bbaseUrl\\b)"
     weight: 2.5
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Fault B — fix names the specific OR.Tasks scope, the uipath.json scope field, or the legacy env var (debug.md: 'Update the scope field in uipath.json with the missing scope' — Rule #16). Bare 'scope' with no config location still fails."
+    description: "Fault B — fix names the specific OR.Tasks scope or the uipath.json scope field (debug.md: 'Update the scope field in uipath.json with the missing scope' — Rule #16). Bare 'scope' with no config location still fails."
     path: "diagnosis.json"
     assertions:
       - expression: "faultB.fix"
         operator: regex
-        expected: "(?i)(VITE_UIPATH_SCOPE|OR\\.Tasks|scope[^.;]{0,60}uipath\\.json|uipath\\.json[^.;]{0,60}scope)"
+        expected: "(?i)(OR\\.Tasks|scope[^.;]{0,60}uipath\\.json|uipath\\.json[^.;]{0,60}scope)"
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-coded-apps/integration_debug_catalog_classification.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_debug_catalog_classification.yaml
@@ -39,7 +39,7 @@ initial_prompt: |
   {
     "faultA": {
       "root_cause": "<one-sentence root cause>",
-      "fix": "<the canonical fix from debug.md — name the env var / file / rule that needs to change>"
+      "fix": "<the canonical fix from debug.md — name the config field / file / rule that needs to change>"
     },
     "faultB": { "root_cause": "...", "fix": "..." },
     "faultC": { "root_cause": "...", "fix": "..." }
@@ -67,23 +67,28 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Skill change #1562 moved SDK config from .env/VITE_UIPATH_* to uipath.json;
+  # debug.md's canonical fixes now say "set baseUrl in uipath.json" / "update
+  # the scope field in uipath.json". The regexes accept the current canonical
+  # phrasing, the legacy env-var names, and the specific value — but still
+  # reject vague answers ('check CORS settings', 'check your scopes').
   - type: json_check
-    description: "Fault A — fix names the correct API subdomain or the env var being changed (debug.md: 'Use https://api.uipath.com not cloud.uipath.com'). Tight regex: agent must mention the API hostname or VITE_UIPATH_BASE_URL — NOT just 'cloud.uipath.com' (which is the wrong value, valid only for the OAuth redirect/UI host elsewhere)."
+    description: "Fault A — fix names the API hostname, the baseUrl config field, or the legacy env var (debug.md: 'Set baseUrl in uipath.json to https://api.uipath.com'). NOT just 'cloud.uipath.com' (the wrong value)."
     path: "diagnosis.json"
     assertions:
       - expression: "faultA.fix"
         operator: regex
-        expected: "(?i)(VITE_UIPATH_BASE_URL|api\\.uipath\\.com)"
+        expected: "(?i)(VITE_UIPATH_BASE_URL|api\\.uipath\\.com|\\bbaseUrl\\b)"
     weight: 2.5
     pass_threshold: 1.0
 
   - type: json_check
-    description: "Fault B — fix names the scope env var being changed or the specific OR.Tasks scope being added (debug.md: 'Mismatched scopes fail silently with 401/403' — Rule #16). Tight regex: bare 'scope' alone no longer passes; agent must name the env var or the specific OR.Tasks scope."
+    description: "Fault B — fix names the specific OR.Tasks scope, the uipath.json scope field, or the legacy env var (debug.md: 'Update the scope field in uipath.json with the missing scope' — Rule #16). Bare 'scope' with no config location still fails."
     path: "diagnosis.json"
     assertions:
       - expression: "faultB.fix"
         operator: regex
-        expected: "(?i)(VITE_UIPATH_SCOPE|OR\\.Tasks)"
+        expected: "(?i)(VITE_UIPATH_SCOPE|OR\\.Tasks|scope[^.;]{0,60}uipath\\.json|uipath\\.json[^.;]{0,60}scope)"
     weight: 2.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

Skill change #1562 replaced the `.env`/`VITE_UIPATH_*` SDK config convention with `uipath.json` (single config source, meta-tag injection) and rewrote `debug.md`'s canonical fixes to match. Two coded-apps tests still graded the old convention and failed every nightly (`2026-07-07_04-22-21`, `2026-07-08_04-20-05`) while the agent behaved correctly — the grader lagging the skill, not agent or skill defects. Post-#1562 a `VITE_UIPATH_*` `.env` is not a legacy variant but a non-functional artifact (the SDK reads only the `uipath.json`-injected meta tags), so the criteria grade `uipath.json` exclusively — no legacy fallback (review: [r3543030742](https://github.com/UiPath/skills/pull/1930#discussion_r3543030742)).

## Fixes

**`e2e_orchestrator_dashboard_web_app`**
- The three config criteria read `uipath.json` fields (`scope` covers `OR.Jobs`+`OR.Queues` — Rule #16; api-subdomain `baseUrl` — Rule #8; config-exists requires the `scope` key only, since `clientId` is legitimately an empty placeholder or omitted in test tenants).
- Turn-budget hardening after run 28935883495 exhausted `max_turns: 65` with every lifecycle criterion already passed: the prompt now writes `report.json` (also the `post_run` cleanup handle) immediately after deploy instead of last, bans task-tracking-tool ceremony (~14 turns in the failed run), and `max_turns` is 85 — even well-behaved runs live near 65.

**`integration_debug_catalog_classification`** — `debug.md`'s 401-scope fix is now "update the `scope` field in `uipath.json`", so the Fault B regex (`VITE_UIPATH_SCOPE|OR\.Tasks`) matched neither the dead env var nor the new canonical text: agents were failed for quoting the skill verbatim. Fault A/B regexes accept the `uipath.json`-era phrasing (bounded — vague answers like "check your scopes" still fail, and naming the dead `VITE_*` vars now correctly fails too).

## Verification

- **Full suite green on this branch: [51/51](https://github.com/UiPath/skills/actions/runs/28945485276)** (35 coded-apps + 16 dashboard), including both fixed tests and the hardened e2e.
- `e2e_orchestrator_dashboard_web_app`: nightly failure reproduced exactly pre-fix (0.868, same 3 criteria); post-fix criteria verified against both observed run artifacts (clientId omitted / empty) and negative configs (wrong scope, `cloud.uipath.com`); full local run **1.000 (22/22)** with zero task-tool calls and `report.json` written post-deploy.
- `integration_debug_catalog_classification`: reproduced pre-fix (0.773, Fault B — the agent's diagnosis quoted the new debug.md verbatim), post-fix **1.000 (6/6)**; regexes verified against the real `diagnosis.json`, vague answers, and dead-env-var answers.

## Follow-up (separate PR)

Nine tests pass today only because their prompts explicitly pin `.env.example`/`VITE_UIPATH_*` — they should migrate to the `uipath.json` convention so Rule-16 coverage grades what the skill actually teaches (`web_sdk_oauth_init` is the most affected: its prompt still teaches `import.meta.env` sourcing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
