### PR TITLE
feat(ci): add nightly FOSSA dependency-scan pipeline

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,38 +43,83 @@ jobs:
   # and fails — blocking the stable npmjs publish — if FOSSA finds issues.
   # Alpha publishes are not gated. The pipeline lives in the "skills" ADO
   # project (https://dev.azure.com/uipath/skills — same convention as
-  # StudioWeb's repo-named project). Soft-skips with a loud warning until the
-  # gate is configured:
+  # StudioWeb's repo-named project).
+  #
+  # Auth is OIDC workload identity federation — no PAT, no repo secrets. The
+  # job's GitHub OIDC token (subject repo:UiPath/skills:environment:fossa-gate,
+  # stable across release tags because of the environment below) is exchanged
+  # through an Entra app registration for a short-lived Azure DevOps access
+  # token. Soft-skips with a loud warning until configured (all plain repo
+  # variables — none of these are secrets):
   #   vars.AZDO_FOSSA_PIPELINE_ID — numeric pipeline definition id, assigned
   #                                 when .pipelines/security.yml is registered
-  #   secrets.AZDO_FOSSA_PAT      — PAT with Build (read & execute) scope
+  #   vars.AZDO_FOSSA_CLIENT_ID   — Entra app registration client id. The app
+  #                                 needs a federated credential for this
+  #                                 repo's `fossa-gate` environment, and its
+  #                                 service principal must be added to the ADO
+  #                                 org with Build read & execute on the
+  #                                 skills project.
+  #   vars.AZDO_FOSSA_TENANT_ID   — Entra tenant id of that app registration
   fossa-gate:
     name: FOSSA security gate
     needs: [guard]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # Pins the OIDC subject claim to environment:fossa-gate so one federated
+    # credential covers every release tag (per-ref subjects can't wildcard).
+    environment: fossa-gate
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Run FOSSA pipeline and wait for verdict
+      - name: Check gate configuration
+        id: config
         env:
-          AZDO_PROJECT_URL: https://dev.azure.com/uipath/skills
           AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
-          AZDO_PAT: ${{ secrets.AZDO_FOSSA_PAT }}
+          AZDO_CLIENT_ID: ${{ vars.AZDO_FOSSA_CLIENT_ID }}
+          AZDO_TENANT_ID: ${{ vars.AZDO_FOSSA_TENANT_ID }}
         run: |
-          if [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_PAT" ]; then
-            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PIPELINE_ID repo variable or AZDO_FOSSA_PAT secret is missing. Register .pipelines/security.yml as a pipeline in the skills ADO project and configure them."
+          if [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_CLIENT_ID" ] || [ -z "$AZDO_TENANT_ID" ]; then
+            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PIPELINE_ID, AZDO_FOSSA_CLIENT_ID or AZDO_FOSSA_TENANT_ID repo variable is missing. Register .pipelines/security.yml as a pipeline in the skills ADO project and configure the OIDC federation (see this job's comments)."
             echo "::warning::$MSG"
             {
               echo "## ⚠️ FOSSA gate skipped (not configured)"
               echo ""
               echo "$MSG"
             } >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+            echo "enforce=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enforce=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # allow-no-subscriptions: the identity only needs Azure DevOps, not an
+      # Azure subscription.
+      - name: Azure login (OIDC)
+        if: steps.config.outputs.enforce == 'true'
+        uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZDO_FOSSA_CLIENT_ID }}
+          tenant-id: ${{ vars.AZDO_FOSSA_TENANT_ID }}
+          allow-no-subscriptions: true
+
+      - name: Run FOSSA pipeline and wait for verdict
+        if: steps.config.outputs.enforce == 'true'
+        env:
+          AZDO_PROJECT_URL: https://dev.azure.com/uipath/skills
+          AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
+        run: |
+          # Entra access token for the Azure DevOps first-party app (fixed
+          # resource id, same in every tenant); ~1h lifetime covers the 30m
+          # polling cap below.
+          AZDO_TOKEN=$(az account get-access-token \
+            --resource 499b84ac-1321-427f-aa17-267ca6975798 \
+            --query accessToken -o tsv)
+          echo "::add-mask::$AZDO_TOKEN"
 
           BODY=$(jq -n --arg ref "$GITHUB_REF" \
             '{resources: {repositories: {self: {refName: $ref}}}, templateParameters: {blockOnIssue: true}}')
-          RUN=$(curl -sSf -u ":$AZDO_PAT" -H "Content-Type: application/json" -d "$BODY" \
+          RUN=$(curl -sSf -H "Authorization: Bearer $AZDO_TOKEN" -H "Content-Type: application/json" -d "$BODY" \
             "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs?api-version=7.1")
           RUN_ID=$(echo "$RUN" | jq -r '.id')
           RUN_URL=$(echo "$RUN" | jq -r '._links.web.href')
@@ -84,7 +129,7 @@ jobs:
           # (job timeout above is the hard stop).
           for i in $(seq 1 60); do
             sleep 30
-            RUN=$(curl -sSf -u ":$AZDO_PAT" \
+            RUN=$(curl -sSf -H "Authorization: Bearer $AZDO_TOKEN" \
               "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs/$RUN_ID?api-version=7.1")
             STATE=$(echo "$RUN" | jq -r '.state')
             echo "[$i/60] state=$STATE"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,68 @@ jobs:
       # Fails if version-manifest.json has drifted from package.json.
       - run: node scripts/sync-version.mjs --check
 
+  # Queues the FOSSA pipeline (.pipelines/security.yml, registered in Azure
+  # DevOps) at this exact ref with blockOnIssue=true, waits for the verdict,
+  # and fails — blocking the stable npmjs publish — if FOSSA finds issues.
+  # Alpha publishes are not gated. Soft-skips with a loud warning until the
+  # gate is configured:
+  #   vars.AZDO_FOSSA_PROJECT     — ADO project hosting the pipeline
+  #   vars.AZDO_FOSSA_PIPELINE_ID — numeric pipeline definition id
+  #   secrets.AZDO_FOSSA_PAT      — PAT with Build (read & execute) scope
+  fossa-gate:
+    name: FOSSA security gate
+    needs: [guard]
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Run FOSSA pipeline and wait for verdict
+        env:
+          AZDO_ORG_URL: https://dev.azure.com/uipath
+          AZDO_PROJECT: ${{ vars.AZDO_FOSSA_PROJECT }}
+          AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
+          AZDO_PAT: ${{ secrets.AZDO_FOSSA_PAT }}
+        run: |
+          if [ -z "$AZDO_PROJECT" ] || [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_PAT" ]; then
+            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PROJECT / AZDO_FOSSA_PIPELINE_ID repo variables or AZDO_FOSSA_PAT secret are missing. Register .pipelines/security.yml in Azure DevOps and configure them."
+            echo "::warning::$MSG"
+            {
+              echo "## ⚠️ FOSSA gate skipped (not configured)"
+              echo ""
+              echo "$MSG"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          BODY=$(jq -n --arg ref "$GITHUB_REF" \
+            '{resources: {repositories: {self: {refName: $ref}}}, templateParameters: {blockOnIssue: true}}')
+          RUN=$(curl -sSf -u ":$AZDO_PAT" -H "Content-Type: application/json" -d "$BODY" \
+            "$AZDO_ORG_URL/$AZDO_PROJECT/_apis/pipelines/$AZDO_PIPELINE_ID/runs?api-version=7.1")
+          RUN_ID=$(echo "$RUN" | jq -r '.id')
+          RUN_URL=$(echo "$RUN" | jq -r '._links.web.href')
+          echo "Queued FOSSA run $RUN_ID at $GITHUB_REF: $RUN_URL"
+
+          # FOSSA on this repo takes a few minutes; poll every 30s, cap at 30m
+          # (job timeout above is the hard stop).
+          for i in $(seq 1 60); do
+            sleep 30
+            RUN=$(curl -sSf -u ":$AZDO_PAT" \
+              "$AZDO_ORG_URL/$AZDO_PROJECT/_apis/pipelines/$AZDO_PIPELINE_ID/runs/$RUN_ID?api-version=7.1")
+            STATE=$(echo "$RUN" | jq -r '.state')
+            echo "[$i/60] state=$STATE"
+            if [ "$STATE" = "completed" ]; then
+              RESULT=$(echo "$RUN" | jq -r '.result')
+              if [ "$RESULT" = "succeeded" ]; then
+                echo "FOSSA gate passed: $RUN_URL"
+                exit 0
+              fi
+              echo "::error::FOSSA gate failed (result: $RESULT) — release blocked. Review $RUN_URL (the FOSSA report link is in that run's fossa-report-links artifact)."
+              exit 1
+            fi
+          done
+          echo "::error::FOSSA run $RUN_ID did not complete within 30 minutes: $RUN_URL"
+          exit 1
+
   publish-alpha:
     name: Publish alpha to GitHub Packages
     needs: [guard]
@@ -77,7 +139,7 @@ jobs:
 
   publish-release:
     name: Publish stable to npmjs
-    needs: [guard]
+    needs: [guard, fossa-gate]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,10 +41,12 @@ jobs:
   # Queues the FOSSA pipeline (.pipelines/security.yml, registered in Azure
   # DevOps) at this exact ref with blockOnIssue=true, waits for the verdict,
   # and fails — blocking the stable npmjs publish — if FOSSA finds issues.
-  # Alpha publishes are not gated. Soft-skips with a loud warning until the
+  # Alpha publishes are not gated. The pipeline lives in the "skills" ADO
+  # project (https://dev.azure.com/uipath/skills — same convention as
+  # StudioWeb's repo-named project). Soft-skips with a loud warning until the
   # gate is configured:
-  #   vars.AZDO_FOSSA_PROJECT     — ADO project hosting the pipeline
-  #   vars.AZDO_FOSSA_PIPELINE_ID — numeric pipeline definition id
+  #   vars.AZDO_FOSSA_PIPELINE_ID — numeric pipeline definition id, assigned
+  #                                 when .pipelines/security.yml is registered
   #   secrets.AZDO_FOSSA_PAT      — PAT with Build (read & execute) scope
   fossa-gate:
     name: FOSSA security gate
@@ -55,13 +57,12 @@ jobs:
     steps:
       - name: Run FOSSA pipeline and wait for verdict
         env:
-          AZDO_ORG_URL: https://dev.azure.com/uipath
-          AZDO_PROJECT: ${{ vars.AZDO_FOSSA_PROJECT }}
+          AZDO_PROJECT_URL: https://dev.azure.com/uipath/skills
           AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
           AZDO_PAT: ${{ secrets.AZDO_FOSSA_PAT }}
         run: |
-          if [ -z "$AZDO_PROJECT" ] || [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_PAT" ]; then
-            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PROJECT / AZDO_FOSSA_PIPELINE_ID repo variables or AZDO_FOSSA_PAT secret are missing. Register .pipelines/security.yml in Azure DevOps and configure them."
+          if [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_PAT" ]; then
+            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PIPELINE_ID repo variable or AZDO_FOSSA_PAT secret is missing. Register .pipelines/security.yml as a pipeline in the skills ADO project and configure them."
             echo "::warning::$MSG"
             {
               echo "## ⚠️ FOSSA gate skipped (not configured)"
@@ -74,7 +75,7 @@ jobs:
           BODY=$(jq -n --arg ref "$GITHUB_REF" \
             '{resources: {repositories: {self: {refName: $ref}}}, templateParameters: {blockOnIssue: true}}')
           RUN=$(curl -sSf -u ":$AZDO_PAT" -H "Content-Type: application/json" -d "$BODY" \
-            "$AZDO_ORG_URL/$AZDO_PROJECT/_apis/pipelines/$AZDO_PIPELINE_ID/runs?api-version=7.1")
+            "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs?api-version=7.1")
           RUN_ID=$(echo "$RUN" | jq -r '.id')
           RUN_URL=$(echo "$RUN" | jq -r '._links.web.href')
           echo "Queued FOSSA run $RUN_ID at $GITHUB_REF: $RUN_URL"
@@ -84,7 +85,7 @@ jobs:
           for i in $(seq 1 60); do
             sleep 30
             RUN=$(curl -sSf -u ":$AZDO_PAT" \
-              "$AZDO_ORG_URL/$AZDO_PROJECT/_apis/pipelines/$AZDO_PIPELINE_ID/runs/$RUN_ID?api-version=7.1")
+              "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs/$RUN_ID?api-version=7.1")
             STATE=$(echo "$RUN" | jq -r '.state')
             echo "[$i/60] state=$STATE"
             if [ "$STATE" = "completed" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,114 +38,6 @@ jobs:
       # Fails if version-manifest.json has drifted from package.json.
       - run: node scripts/sync-version.mjs --check
 
-  # Queues the FOSSA pipeline (.pipelines/security.yml, registered in Azure
-  # DevOps) at this exact ref with blockOnIssue=true, waits for the verdict,
-  # and fails — blocking the stable npmjs publish — if FOSSA finds issues.
-  # Alpha publishes are not gated. The pipeline lives in the "skills" ADO
-  # project (https://dev.azure.com/uipath/skills — same convention as
-  # StudioWeb's repo-named project).
-  #
-  # Auth is OIDC workload identity federation — no PAT, no repo secrets. The
-  # job's GitHub OIDC token (subject repo:UiPath/skills:environment:fossa-gate,
-  # stable across release tags because of the environment below) is exchanged
-  # through an Entra app registration for a short-lived Azure DevOps access
-  # token. Soft-skips with a loud warning until configured (all plain repo
-  # variables — none of these are secrets):
-  #   vars.AZDO_FOSSA_PIPELINE_ID — numeric pipeline definition id, assigned
-  #                                 when .pipelines/security.yml is registered
-  #   vars.AZDO_FOSSA_CLIENT_ID   — Entra app registration client id. The app
-  #                                 needs a federated credential for this
-  #                                 repo's `fossa-gate` environment, and its
-  #                                 service principal must be added to the ADO
-  #                                 org with Build read & execute on the
-  #                                 skills project.
-  #   vars.AZDO_FOSSA_TENANT_ID   — Entra tenant id of that app registration
-  fossa-gate:
-    name: FOSSA security gate
-    needs: [guard]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-    # Pins the OIDC subject claim to environment:fossa-gate so one federated
-    # credential covers every release tag (per-ref subjects can't wildcard).
-    environment: fossa-gate
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Check gate configuration
-        id: config
-        env:
-          AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
-          AZDO_CLIENT_ID: ${{ vars.AZDO_FOSSA_CLIENT_ID }}
-          AZDO_TENANT_ID: ${{ vars.AZDO_FOSSA_TENANT_ID }}
-        run: |
-          if [ -z "$AZDO_PIPELINE_ID" ] || [ -z "$AZDO_CLIENT_ID" ] || [ -z "$AZDO_TENANT_ID" ]; then
-            MSG="FOSSA release gate NOT enforced: AZDO_FOSSA_PIPELINE_ID, AZDO_FOSSA_CLIENT_ID or AZDO_FOSSA_TENANT_ID repo variable is missing. Register .pipelines/security.yml as a pipeline in the skills ADO project and configure the OIDC federation (see this job's comments)."
-            echo "::warning::$MSG"
-            {
-              echo "## ⚠️ FOSSA gate skipped (not configured)"
-              echo ""
-              echo "$MSG"
-            } >> "$GITHUB_STEP_SUMMARY"
-            echo "enforce=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "enforce=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      # allow-no-subscriptions: the identity only needs Azure DevOps, not an
-      # Azure subscription.
-      - name: Azure login (OIDC)
-        if: steps.config.outputs.enforce == 'true'
-        uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZDO_FOSSA_CLIENT_ID }}
-          tenant-id: ${{ vars.AZDO_FOSSA_TENANT_ID }}
-          allow-no-subscriptions: true
-
-      - name: Run FOSSA pipeline and wait for verdict
-        if: steps.config.outputs.enforce == 'true'
-        env:
-          AZDO_PROJECT_URL: https://dev.azure.com/uipath/skills
-          AZDO_PIPELINE_ID: ${{ vars.AZDO_FOSSA_PIPELINE_ID }}
-        run: |
-          # Entra access token for the Azure DevOps first-party app (fixed
-          # resource id, same in every tenant); ~1h lifetime covers the 30m
-          # polling cap below.
-          AZDO_TOKEN=$(az account get-access-token \
-            --resource 499b84ac-1321-427f-aa17-267ca6975798 \
-            --query accessToken -o tsv)
-          echo "::add-mask::$AZDO_TOKEN"
-
-          BODY=$(jq -n --arg ref "$GITHUB_REF" \
-            '{resources: {repositories: {self: {refName: $ref}}}, templateParameters: {blockOnIssue: true}}')
-          RUN=$(curl -sSf -H "Authorization: Bearer $AZDO_TOKEN" -H "Content-Type: application/json" -d "$BODY" \
-            "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs?api-version=7.1")
-          RUN_ID=$(echo "$RUN" | jq -r '.id')
-          RUN_URL=$(echo "$RUN" | jq -r '._links.web.href')
-          echo "Queued FOSSA run $RUN_ID at $GITHUB_REF: $RUN_URL"
-
-          # FOSSA on this repo takes a few minutes; poll every 30s, cap at 30m
-          # (job timeout above is the hard stop).
-          for i in $(seq 1 60); do
-            sleep 30
-            RUN=$(curl -sSf -H "Authorization: Bearer $AZDO_TOKEN" \
-              "$AZDO_PROJECT_URL/_apis/pipelines/$AZDO_PIPELINE_ID/runs/$RUN_ID?api-version=7.1")
-            STATE=$(echo "$RUN" | jq -r '.state')
-            echo "[$i/60] state=$STATE"
-            if [ "$STATE" = "completed" ]; then
-              RESULT=$(echo "$RUN" | jq -r '.result')
-              if [ "$RESULT" = "succeeded" ]; then
-                echo "FOSSA gate passed: $RUN_URL"
-                exit 0
-              fi
-              echo "::error::FOSSA gate failed (result: $RESULT) — release blocked. Review $RUN_URL (the FOSSA report link is in that run's fossa-report-links artifact)."
-              exit 1
-            fi
-          done
-          echo "::error::FOSSA run $RUN_ID did not complete within 30 minutes: $RUN_URL"
-          exit 1
-
   publish-alpha:
     name: Publish alpha to GitHub Packages
     needs: [guard]
@@ -185,7 +77,7 @@ jobs:
 
   publish-release:
     name: Publish stable to npmjs
-    needs: [guard, fossa-gate]
+    needs: [guard]
     if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
     runs-on: ubuntu-latest
     permissions:

--- a/.pipelines/jobs/ci.security.fossa.yml
+++ b/.pipelines/jobs/ci.security.fossa.yml
@@ -1,0 +1,28 @@
+# FOSSA dependency scan for the skills plugin — one stage, one FOSSA project.
+# No build step: this repo is markdown + scripts with no compilation, so FOSSA
+# analyzes dependency manifests directly (root package.json and the
+# uipath-maestro-bpmn validator package.json). Scan scope is controlled by
+# fossa-skills.yml next to this file.
+parameters:
+  azureServiceConnection: ''
+  poolName: 'Security-Linux'
+  # false: findings only warn (nightly). true: `fossa test` fails the run on
+  # findings — used by the publish.yml release gate.
+  blockOnIssue: false
+
+stages:
+  - stage: Security_FOSSA
+    displayName: FOSSA
+    dependsOn: []
+    jobs:
+      - job: Skills
+        pool: ${{ parameters.poolName }}
+        steps:
+          - checkout: self
+          - template: Security/fossa.steps.yml@fossa
+            parameters:
+              OS: 'linux'
+              azureSubscription: ${{ parameters.azureServiceConnection }}
+              blockOnIssue: ${{ parameters.blockOnIssue }}
+              FOSSAFlags: '--branch "$(Build.SourceBranch)" --revision "$(Build.SourceVersion)-$(Build.BuildId)" --project "Skills" --config ".pipelines/jobs/fossa-skills.yml"'
+              FOSSATestFlags: '--revision "$(Build.SourceVersion)-$(Build.BuildId)" --project "Skills"'

--- a/.pipelines/jobs/ci.security.fossa.yml
+++ b/.pipelines/jobs/ci.security.fossa.yml
@@ -1,13 +1,6 @@
-# FOSSA dependency scan for the skills plugin — one stage, one FOSSA project.
-# No build step: this repo is markdown + scripts with no compilation, so FOSSA
-# analyzes dependency manifests directly (root package.json and the
-# uipath-maestro-bpmn validator package.json). Scan scope is controlled by
-# fossa-skills.yml next to this file.
 parameters:
   azureServiceConnection: ''
   poolName: 'Security-Linux'
-  # false: findings only warn (nightly). true: `fossa test` fails the run on
-  # findings — used by the publish.yml release gate.
   blockOnIssue: false
 
 stages:
@@ -19,17 +12,6 @@ stages:
         pool: ${{ parameters.poolName }}
         steps:
           - checkout: self
-          # Fetch the FOSSA API keys directly instead of letting the template's
-          # AzureCLI toggle steps do it: their static arguments (`@("get",
-          # "list")`, `$True`) trip the aka.ms/ado/75787 shell-argument
-          # enforcement that new ADO projects like skills get by default
-          # (AZP_75787_ENABLE_NEW_LOGIC is a locked system variable, so the
-          # documented opt-out is unavailable). skipToggleKvStep below skips
-          # the template's toggle + Key Vault steps; it consumes $(FossaApiKey)
-          # from this task instead. Relies on the vault firewall staying open
-          # (defaultAction: Allow) — if runs start failing here with a network
-          # authorization error, the vault was locked down and the agent IP
-          # needs whitelisting (the skipped toggle script used to do that).
           - task: AzureKeyVault@2
             displayName: '[FOSSA] Download secrets from devopsprodauthtokenswekv'
             inputs:

--- a/.pipelines/jobs/ci.security.fossa.yml
+++ b/.pipelines/jobs/ci.security.fossa.yml
@@ -19,10 +19,29 @@ stages:
         pool: ${{ parameters.poolName }}
         steps:
           - checkout: self
+          # Fetch the FOSSA API keys directly instead of letting the template's
+          # AzureCLI toggle steps do it: their static arguments (`@("get",
+          # "list")`, `$True`) trip the aka.ms/ado/75787 shell-argument
+          # enforcement that new ADO projects like skills get by default
+          # (AZP_75787_ENABLE_NEW_LOGIC is a locked system variable, so the
+          # documented opt-out is unavailable). skipToggleKvStep below skips
+          # the template's toggle + Key Vault steps; it consumes $(FossaApiKey)
+          # from this task instead. Relies on the vault firewall staying open
+          # (defaultAction: Allow) — if runs start failing here with a network
+          # authorization error, the vault was locked down and the agent IP
+          # needs whitelisting (the skipped toggle script used to do that).
+          - task: AzureKeyVault@2
+            displayName: '[FOSSA] Download secrets from devopsprodauthtokenswekv'
+            inputs:
+              azureSubscription: ${{ parameters.azureServiceConnection }}
+              keyVaultName: devopsprodauthtokenswekv
+              SecretsFilter: 'FossaApiKey,FossaApiIntegrationKey'
+              RunAsPreJob: false
           - template: Security/fossa.steps.yml@fossa
             parameters:
               OS: 'linux'
               azureSubscription: ${{ parameters.azureServiceConnection }}
+              skipToggleKvStep: true
               blockOnIssue: ${{ parameters.blockOnIssue }}
               FOSSAFlags: '--branch "$(Build.SourceBranch)" --revision "$(Build.SourceVersion)-$(Build.BuildId)" --project "Skills" --config ".pipelines/jobs/fossa-skills.yml"'
               FOSSATestFlags: '--revision "$(Build.SourceVersion)-$(Build.BuildId)" --project "Skills"'

--- a/.pipelines/jobs/fossa-skills.yml
+++ b/.pipelines/jobs/fossa-skills.yml
@@ -1,0 +1,13 @@
+# FOSSA scan scope for the Skills project (passed via --config).
+# Excludes:
+#   - tests: coder-eval task fixtures (pyproject.toml/package.json stubs) are
+#     eval scaffolding, not shipped code
+#   - plugins, .agents: symlinks back into the repo root / skills tree — would
+#     duplicate scan targets or cycle
+version: 3
+
+paths:
+  exclude:
+    - ./tests
+    - ./plugins
+    - ./.agents

--- a/.pipelines/jobs/fossa-skills.yml
+++ b/.pipelines/jobs/fossa-skills.yml
@@ -1,9 +1,3 @@
-# FOSSA scan scope for the Skills project (passed via --config).
-# Excludes:
-#   - tests: coder-eval task fixtures (pyproject.toml/package.json stubs) are
-#     eval scaffolding, not shipped code
-#   - plugins, .agents: symlinks back into the repo root / skills tree — would
-#     duplicate scan targets or cycle
 version: 3
 
 paths:

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -1,0 +1,62 @@
+# Dedicated security scanning pipeline. Two entry points:
+#   - nightly schedule on main (02:00 UTC, below) — warn-only, mirrors
+#     StudioWeb's .pipelines/security.yml: decoupled from regular CI so scans
+#     never delay PR/merge builds
+#   - release gate: publish.yml (GitHub Actions) queues this pipeline at the
+#     release ref with blockOnIssue=true and blocks the npmjs publish if FOSSA
+#     finds issues
+#
+# Register this file as an Azure DevOps pipeline definition. It requires:
+#   - the "UiPath" GitHub service connection (for the fossa template repository)
+#   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
+#   - access to the agent pool below and the "DevOps" universal packages feed
+# Then set AZDO_FOSSA_PROJECT / AZDO_FOSSA_PIPELINE_ID repo variables and the
+# AZDO_FOSSA_PAT secret in GitHub so publish.yml can enforce the release gate.
+
+name: $(Date:yyMMdd)$(Rev:.r)-sec
+
+trigger: none
+
+pr: none
+
+schedules:
+  - cron: "0 2 * * *"
+    displayName: Nightly security scan
+    branches:
+      include:
+        - main
+    always: true
+
+parameters:
+  - name: enableFossa
+    displayName: Run FOSSA scan
+    type: boolean
+    default: true
+  - name: azureServiceConnection
+    displayName: Azure connection pointing to Internal-Production-EA
+    type: string
+    default: 'Azure Internal-Production-EA'
+  - name: poolName
+    displayName: Agent pool
+    type: string
+    default: 'Security-Linux'
+  - name: blockOnIssue
+    displayName: Fail the run when FOSSA finds issues (release gate)
+    type: boolean
+    default: false
+
+resources:
+  repositories:
+    - repository: fossa
+      type: github
+      name: UiPath/AzurePipelinesTemplates
+      ref: refs/tags/uipath.security.fossa.3.1.1
+      endpoint: UiPath
+
+stages:
+  - ${{ if eq(parameters.enableFossa, true) }}:
+      - template: jobs/ci.security.fossa.yml
+        parameters:
+          azureServiceConnection: ${{ parameters.azureServiceConnection }}
+          poolName: ${{ parameters.poolName }}
+          blockOnIssue: ${{ parameters.blockOnIssue }}

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -9,7 +9,12 @@
 # (https://dev.azure.com/uipath/skills). The project needs:
 #   - the "github.com_UiPath" GitHub service connection (for the fossa
 #     template repository; auto-created by the ADO GitHub App integration)
-#   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
+#   - the Azure service connection below (FOSSA API key retrieval via Key
+#     Vault). Provisioned per-project by dev-sre (#dev-sre): an ARM connection
+#     named "InternalProdEAServiceConnection" backed by a
+#     "uipath-skills-202e5d15-…" app registration with a get/list secrets
+#     access policy on the devopsprodauthtokenswekv vault
+#     (Internal-Production-EA subscription)
 #   - access to the agent pool below and the "DevOps" universal packages feed
 # No GitHub-side variables or secrets are required.
 
@@ -35,7 +40,7 @@ parameters:
   - name: azureServiceConnection
     displayName: Azure connection pointing to Internal-Production-EA
     type: string
-    default: 'Azure Internal-Production-EA'
+    default: 'InternalProdEAServiceConnection'
   - name: poolName
     displayName: Agent pool
     type: string

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -1,23 +1,3 @@
-# Dedicated security scanning pipeline. Runs nightly on main (02:00 UTC,
-# below) — warn-only, mirrors StudioWeb's .pipelines/security.yml: decoupled
-# from regular CI so scans never delay PR/merge builds. Can also be queued
-# manually with blockOnIssue=true to fail the run on FOSSA findings; no
-# automated release gate is wired up currently (the publish.yml gate was
-# backed out — see this branch's history if it needs reviving).
-#
-# Register this file as a pipeline definition in the "skills" ADO project
-# (https://dev.azure.com/uipath/skills). The project needs:
-#   - the "github.com_UiPath" GitHub service connection (for the fossa
-#     template repository; auto-created by the ADO GitHub App integration)
-#   - the Azure service connection below (FOSSA API key retrieval via Key
-#     Vault). Provisioned per-project by dev-sre (#dev-sre): an ARM connection
-#     named "InternalProdEAServiceConnection" backed by a
-#     "uipath-skills-202e5d15-…" app registration with a get/list secrets
-#     access policy on the devopsprodauthtokenswekv vault
-#     (Internal-Production-EA subscription)
-#   - access to the agent pool below and the "DevOps" universal packages feed
-# No GitHub-side variables or secrets are required.
-
 name: $(Date:yyMMdd)$(Rev:.r)-sec
 
 trigger: none
@@ -56,8 +36,6 @@ resources:
       type: github
       name: UiPath/AzurePipelinesTemplates
       ref: refs/tags/uipath.security.fossa.3.1.1
-      # GitHub App connection auto-created in the skills ADO project when the
-      # pipeline was registered (Project Settings > Service connections).
       endpoint: github.com_UiPath
 
 stages:

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -50,6 +50,15 @@ parameters:
     type: boolean
     default: false
 
+variables:
+  # AzureCLI@2's shell-argument validation (aka.ms/ado/75787) hard-errors on
+  # the fossa template's static toggle args (`@("get", "list")`, `$True`) in
+  # this project — new ADO projects get the enforcement default while older
+  # projects (e.g. StudioWeb, same template/task/pool) still run legacy
+  # warning mode. The flagged arguments are template literals with no
+  # untrusted input, so downgrading back to a warning is safe.
+  AZP_75787_ENABLE_NEW_LOGIC: false
+
 resources:
   repositories:
     - repository: fossa

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -6,12 +6,13 @@
 #     release ref with blockOnIssue=true and blocks the npmjs publish if FOSSA
 #     finds issues
 #
-# Register this file as an Azure DevOps pipeline definition. It requires:
+# Register this file as a pipeline definition in the "skills" ADO project
+# (https://dev.azure.com/uipath/skills). The project needs:
 #   - the "UiPath" GitHub service connection (for the fossa template repository)
 #   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
 #   - access to the agent pool below and the "DevOps" universal packages feed
-# Then set AZDO_FOSSA_PROJECT / AZDO_FOSSA_PIPELINE_ID repo variables and the
-# AZDO_FOSSA_PAT secret in GitHub so publish.yml can enforce the release gate.
+# Then set the AZDO_FOSSA_PIPELINE_ID repo variable and the AZDO_FOSSA_PAT
+# secret in GitHub so publish.yml can enforce the release gate.
 
 name: $(Date:yyMMdd)$(Rev:.r)-sec
 

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -1,20 +1,16 @@
-# Dedicated security scanning pipeline. Two entry points:
-#   - nightly schedule on main (02:00 UTC, below) — warn-only, mirrors
-#     StudioWeb's .pipelines/security.yml: decoupled from regular CI so scans
-#     never delay PR/merge builds
-#   - release gate: publish.yml (GitHub Actions) queues this pipeline at the
-#     release ref with blockOnIssue=true and blocks the npmjs publish if FOSSA
-#     finds issues
+# Dedicated security scanning pipeline. Runs nightly on main (02:00 UTC,
+# below) — warn-only, mirrors StudioWeb's .pipelines/security.yml: decoupled
+# from regular CI so scans never delay PR/merge builds. Can also be queued
+# manually with blockOnIssue=true to fail the run on FOSSA findings; no
+# automated release gate is wired up currently (the publish.yml gate was
+# backed out — see this branch's history if it needs reviving).
 #
 # Register this file as a pipeline definition in the "skills" ADO project
 # (https://dev.azure.com/uipath/skills). The project needs:
 #   - the "UiPath" GitHub service connection (for the fossa template repository)
 #   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
 #   - access to the agent pool below and the "DevOps" universal packages feed
-# Then set the AZDO_FOSSA_PIPELINE_ID / AZDO_FOSSA_CLIENT_ID /
-# AZDO_FOSSA_TENANT_ID repo variables in GitHub so publish.yml can enforce
-# the release gate — auth is OIDC workload identity federation, no PAT
-# (setup details in publish.yml's fossa-gate job).
+# No GitHub-side variables or secrets are required.
 
 name: $(Date:yyMMdd)$(Rev:.r)-sec
 

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -50,15 +50,6 @@ parameters:
     type: boolean
     default: false
 
-variables:
-  # AzureCLI@2's shell-argument validation (aka.ms/ado/75787) hard-errors on
-  # the fossa template's static toggle args (`@("get", "list")`, `$True`) in
-  # this project — new ADO projects get the enforcement default while older
-  # projects (e.g. StudioWeb, same template/task/pool) still run legacy
-  # warning mode. The flagged arguments are template literals with no
-  # untrusted input, so downgrading back to a warning is safe.
-  AZP_75787_ENABLE_NEW_LOGIC: false
-
 resources:
   repositories:
     - repository: fossa

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -11,8 +11,10 @@
 #   - the "UiPath" GitHub service connection (for the fossa template repository)
 #   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
 #   - access to the agent pool below and the "DevOps" universal packages feed
-# Then set the AZDO_FOSSA_PIPELINE_ID repo variable and the AZDO_FOSSA_PAT
-# secret in GitHub so publish.yml can enforce the release gate.
+# Then set the AZDO_FOSSA_PIPELINE_ID / AZDO_FOSSA_CLIENT_ID /
+# AZDO_FOSSA_TENANT_ID repo variables in GitHub so publish.yml can enforce
+# the release gate — auth is OIDC workload identity federation, no PAT
+# (setup details in publish.yml's fossa-gate job).
 
 name: $(Date:yyMMdd)$(Rev:.r)-sec
 

--- a/.pipelines/security.yml
+++ b/.pipelines/security.yml
@@ -7,7 +7,8 @@
 #
 # Register this file as a pipeline definition in the "skills" ADO project
 # (https://dev.azure.com/uipath/skills). The project needs:
-#   - the "UiPath" GitHub service connection (for the fossa template repository)
+#   - the "github.com_UiPath" GitHub service connection (for the fossa
+#     template repository; auto-created by the ADO GitHub App integration)
 #   - the Azure service connection below (FOSSA API key retrieval via Key Vault)
 #   - access to the agent pool below and the "DevOps" universal packages feed
 # No GitHub-side variables or secrets are required.
@@ -50,7 +51,9 @@ resources:
       type: github
       name: UiPath/AzurePipelinesTemplates
       ref: refs/tags/uipath.security.fossa.3.1.1
-      endpoint: UiPath
+      # GitHub App connection auto-created in the skills ADO project when the
+      # pipeline was registered (Project Settings > Service connections).
+      endpoint: github.com_UiPath
 
 stages:
   - ${{ if eq(parameters.enableFossa, true) }}:


### PR DESCRIPTION
## Summary

- Add a dedicated nightly **FOSSA dependency scan** pipeline for the skills repo, decoupled from CI so scans never delay PR/merge builds
- Runs at **02:00 UTC on `main`** (`always: true`); warn-only by default, manual queue can set `blockOnIssue=true` to fail on findings
- Fetch FOSSA keys directly from Key Vault (`skipToggleKvStep: true`) to sidestep the ADO shell-argument enforcement (aka.ms/ado/75787) that the template's `AzureCLI` toggle steps trip in new projects
- No automated release gate — the `publish.yml` gate was backed out for now

## Changes

Three new files under `.pipelines/`:

- **`security.yml`** — pipeline entry point. `trigger: none` / `pr: none`, nightly `cron` schedule on `main`, and the `UiPath/AzurePipelinesTemplates` FOSSA template resource (tag `uipath.security.fossa.3.1.1`)
- **`jobs/ci.security.fossa.yml`** — single FOSSA stage/job on the `Security-Linux` pool; pulls `FossaApiKey`/`FossaApiIntegrationKey` from `devopsprodauthtokenswekv` and invokes the template's `fossa.steps.yml`
- **`jobs/fossa-skills.yml`** — scan scope; excludes `./tests`, `./plugins`, `./.agents`

> Requires the pipeline to be registered in the `skills` ADO project with the `github.com_UiPath` GitHub connection and the `InternalProdEAServiceConnection` Azure connection (Key Vault access).

## Testing

- CI-only change; validated via the pipeline definition. No repo source affected (markdown + scripts, no build step).
