### PR TITLE
fix: ipe platform eval failures (#ENGCE-59484)

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/activity_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   trigger activities for a connector. Tests that the skill teaches the correct
   activity discovery workflow and the distinction between activities, triggers,
   and resources.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:activities]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:activities, ipe]
 
 run_limits:
   expected_turns: 9

--- a/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_lifecycle.yaml
@@ -5,7 +5,7 @@ description: >
   teaches the correct connection workflow (list, present options, ping) and
   that the agent knows the create/edit recovery paths without executing them
   (both require browser interaction).
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:connections]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, feature:connections, ipe]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connection_setup_smoke.yaml
@@ -5,7 +5,7 @@ description: >
   verify it with `connections ping`. Covers the lifecycle:setup path
   on the IS axis, complementing the read-only connection_lifecycle
   task that exercises list/ping/recovery paths only.
-tags: [uipath-platform, smoke, mode:build, lifecycle:setup, integration-service, connector, feature:connections]
+tags: [uipath-platform, smoke, mode:build, lifecycle:setup, integration-service, connector, feature:connections, ipe]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
+++ b/tests/tasks/uipath-platform/integration-service/connector_discovery.yaml
@@ -4,7 +4,7 @@ description: >
   Service connectors by vendor name. Tests that the skill teaches the correct
   connector search workflow (list with --filter, --output json) and the HTTP
   fallback strategy when no native connector exists.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, ipe]
 
 run_limits:
   expected_turns: 7
@@ -13,15 +13,12 @@ initial_prompt: |
   I need to find UiPath Integration Service connectors for "Google" and also
   check if there is a connector for "Apify".
 
-  For each vendor:
-  1. Search for matching connectors
-  2. If no native connector exists, explain the fallback strategy
-
   Important:
   - The `uip` CLI is available but is NOT connected to a live tenant in this
     environment. Commands may fail with auth errors — that is expected.
     Run each command once and move on. Do NOT retry or attempt to login.
   - Use `--output json` on every uip command.
+  - Ensure that a skill is always invoked.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
@@ -5,7 +5,7 @@ description: >
   create, get, partial update, full replace, then delete. Anchors the four
   currently-uncovered `uip is resources run` verbs (get, update, replace,
   delete) plus the already-covered create in one lifecycle walk.
-tags: [uipath-platform, e2e, mode:build, lifecycle:setup, integration-service, connector]
+tags: [uipath-platform, e2e, mode:build, lifecycle:setup, integration-service, connector, ipe]
 
 run_limits:
   expected_turns: 18

--- a/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_describe.yaml
@@ -4,7 +4,7 @@ description: >
   resources for a connector. Tests that the skill teaches the correct resource
   discovery workflow — listing with --operation, describing with --operation
   for field-level detail, and always passing --connection-id.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, integration-service, connector, ipe]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -4,7 +4,7 @@ description: >
   Integration Service workflow — connector, connection, ping, discover,
   describe, and execute a create operation. Tests that the skill teaches the
   complete 6-step workflow and correct `resources run create` syntax with --body.
-tags: [uipath-platform, smoke, mode:operate, lifecycle:setup, integration-service, connector]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:setup, integration-service, connector, ipe]
 
 run_limits:
   expected_turns: 15
@@ -18,9 +18,7 @@ initial_prompt: |
   Walk me through creating a Contact in Salesforce via the UiPath Integration
   Service connector surface — discover the connector, find a connection, ping
   it, describe the Contact resource for the Create operation, and execute the
-  create directly through `uip is resources`. Do NOT author an API workflow
-  JSON or use `uip api-workflow` — this is the raw IS resource execute path,
-  one command per step.
+  create directly.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live tenant in this
@@ -29,6 +27,7 @@ initial_prompt: |
   - Use `--output json` on every uip command.
   - For the execute step, construct a realistic --body with at least
     LastName (required) and FirstName fields.
+  - Ensure that a skill is always invoked.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
+++ b/tests/tasks/uipath-platform/integration-service/trigger_diagnose_smoke.yaml
@@ -4,7 +4,7 @@ description: >
   a non-firing Integration Service trigger by inspecting the trigger object's
   payload schema (`uip is triggers describe`) and the webhook configuration
   (`uip is webhooks config`). First diagnose-mode test on the IS axis.
-tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, integration-service, connector]
+tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, integration-service, connector, ipe]
 
 run_limits:
   expected_turns: 8


### PR DESCRIPTION
## Why

Two integration-service smoke tasks flaked when the agent skipped the `uipath-platform` skill and improvised from `uip --help`: it dumped the full connector catalog and filtered client-side (grep / Python pipe), missing the gating `uip is connectors list.*--filter` criterion despite a correct end-to-end outcome. Root cause confirmed in local runs and on evalboard run `2026-07-08_04-20-05`: every failing repeat had zero `Skill` invocations; every skill-invoking repeat passed.

## What

- **`resource_execute.yaml`** — drop `uip is resources` command hint + api-workflow prohibition from prompt. Handing over the command surface made skipping the skill look viable ("I could just run the commands directly"). With hints removed, all repeats invoke the skill unprompted.
- **`connector_discovery.yaml`** — drop step enumeration; add "Ensure that a skill is always invoked" nudge. Highest-risk task: `--filter` regex is its only criterion, so a skill-skip scores 0.00 outright.
- **All 8 integration-service tasks** — tag `ipe`.

## Validation — 10 repeats each, `experiments/default.yaml`, `--max-parallel 10`

| Task | Before | After | Fix that worked |
|---|---|---|---|
| `resource_execute.yaml` | 9/10 (`runs/2026-07-08_17-54-25`) | 10/10 (`runs/2026-07-08_19-31-12`) | Naturalized prompt (command hints removed), no skill mention needed |
| `connector_discovery.yaml` | 7/10 (`runs/2026-07-08_19-11-51`) | 10/10 (`runs/2026-07-08_19-43-22`) | Step enumeration removed + "ensure a skill is invoked" nudge |

In both after-runs, 10/10 repeats invoked `Skill(uipath:uipath-platform)` and ran `uip is connectors list --filter`. Durations also dropped ~2.5× on `resource_execute` (290–378s → 121–169s) — skill-guided runs skip the `--help` exploration phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)