### PR TITLE
uipath-rpa: make analyzer-rules list on-demand instead of an authoring prerequisite

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -113,14 +113,14 @@ For the full decision flowchart, InvokeCode extraction rules, and detailed hybri
 
 ## Capture-First Fast Path
 
-When the request is "automate this dialog/form" or "build a UI test from these manual steps" — i.e. the bulk of the work is target capture, not coding — **defer authoring-phase prerequisites until target capture is complete**. The capture surface is interactive, app-state-sensitive, and time-bound; project-context discovery and analyzer rules add nothing during capture and steal time from it.
+When the request is "automate this dialog/form" or "build a UI test from these manual steps" — i.e. the bulk of the work is target capture, not coding — **defer authoring-phase prerequisites until target capture is complete**. The capture surface is interactive, app-state-sensitive, and time-bound; project-context discovery adds nothing during capture and steals time from it.
 
 **Fast-path order for capture-first tasks.** Read [ui-automation-guide.md](references/ui-automation-guide.md) and [uia-configure-target-workflows.md](references/uia-configure-target-workflows.md) in full first (Rule 7; the second is used in step 3). Then:
 
 1. **Pre-flight Window Baseline** — list top-level windows once; decide whether to launch the app ([§ Pre-flight: Window Baseline](references/ui-automation-guide.md)).
 2. **Inventory targets from manual steps** (Test Manager test case, PDD, or written script). Each "Click X" / "Enter Y" / "Select Z" / "Verify W" step maps to one OR element. Group by screen state ([§ Capturing from Manual Test Steps](references/ui-automation-guide.md)).
 3. **Capture all targets** screen by screen via `uia-configure-target` and screen advancement ([§ Multi-Step UI Flows](references/uia-configure-target-workflows.md)).
-4. **Then enter authoring phase:** project-context discovery (the precondition above), analyzer rules (Critical Rule 3 — Authoring-phase start), write code, validate.
+4. **Then enter authoring phase:** project-context discovery (the precondition above), write code, validate.
 
 Skip this path when the task has no UI surface (data transforms, IS connector calls, headless file/email automation). Also skip it when the task HAS a UI surface but **no live app to capture against** (app not installed, no GUI, capture deferred to a developer) — there is nothing to capture, so use the § Placeholder-Selector Stub Pattern above instead. The Window Baseline does not tell you if the app is installed and has a GUI — validate that separately (e.g. look for the executable on disk) or ask the user.
 
@@ -149,12 +149,12 @@ uip rpa activities find --query log --output json > /dev/null 2>&1 &
      - **No matches** → fall back to a built-in `--template-id` and tell the user nothing was found.
    - Built-in `--template-id` keywords map without a search: `library` → `LibraryProcessTemplate`, `test automation` / `test project` → `TestAutomationProjectTemplate`, otherwise `BlankTemplate`. When `--template-package-id` is set, `--template-id` is ignored. Full decision flow: [environment-setup.md § Template selection](references/environment-setup.md).
 2a. **Pass `--target-framework` AND `--expression-language` explicitly on every `uip rpa init` — never omit them.** Both are immutable after creation (Rule 23); omitting `--target-framework` silently yields a **Windows** project. Choose framework by where the automation runs: cross-platform / non-Windows runtime (Linux, container, serverless) or Studio Web editing → **`Portable`** (Cross-platform); Windows runtime using Windows-only capabilities (Excel COM, classic Office, WPF / `PresentationFramework`, Windows-only UIA) or Studio Desktop as the edit surface → **`Windows`** (not editable in Studio Web). A request needing *both* a cross-platform runtime and a Windows-only capability is contradictory — surface it, don't silently pick. **Windows - Legacy is a last resort** (explicit ask or hard .NET 4.6.1 need; never inferred from VB.NET or non-"X" classic activities) — create it in Legacy mode, not modern `init`. No signal → `AskUserQuestion` (Windows vs Cross-platform), framed around the runtime host. `--expression-language`: default `VisualBasic`, `CSharp` only on explicit request.
-3. **Phase-gated validation: analyzer rules run at AUTHORING-phase start, not session start.** Three-phase validation:
-   - **Authoring-phase start** (immediately before creating or editing any workflow file — `.cs` with `[Workflow]`/`[TestCase]`, or `.xaml`): `uip rpa analyzer-rules list --project-dir "<PROJECT_DIR>" --output json` to list the enabled Workflow Analyzer rules. Apply every `error` and `warning` rule during authoring so generated code passes `analyze` and `build` on the first attempt. Run once at this point; re-run only when project dependencies change. **DO NOT run at session start** — the call can take a minute or more (use `--scope <Activity|Workflow|Coded Workflow|Project>` to narrow if it times out, see [cli-reference.md § analyzer-rules list](references/cli-reference.md)). For capture-first tasks (target capture from manual test steps, dialog automation), this prerequisite is deferred until capture is complete — see § Capture-First Fast Path below.
-   - **Per-file** (after every create or edit): `uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Catches structural XAML, missing references, analyzer rules, schema violations. Fix one thing per iteration.
+3. **Phase-gated validation.** Two-phase validation:
+   - **Per-file** (after every create or edit): `uip rpa validate --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json` until 0 errors. Catches structural XAML, missing references, analyzer-rule violations, schema violations. Fix one thing per iteration.
    - **Project-level build** (after per-file `validate` is clean across all files in the edit session, and before declaring done): `uip rpa build "<PROJECT_DIR>" --output json` until clean. Catches what `validate` misses (unknown members, invalid enums, CacheMetadata / member resolution, attribute-form C# JIT) — full list at [validation-guide.md § Errors `build` catches that `validate` misses](references/validation-guide.md). If `build` errors, identify the offending file from the output and re-run `validate --file-path` on it.
    - **5-attempt cap per loop** — 5 attempts for each file's per-file `validate` loop; a separate 5 attempts for the project-level `build` loop. Fix one root cause per iteration.
    - **Smoke-test shortcut:** A successful `uip rpa run` substitutes for the standalone end-of-session `build` — `run` compiles internally. Prefer `run --skip-build` when `build` has just passed; see [validation-guide.md § Smoke Test](references/validation-guide.md).
+   - **Do NOT run `uip rpa analyzer-rules list` as an authoring prerequisite.** `validate` and `build` already enforce the enabled analyzer rules and report violations with rule IDs and recommendations — pre-fetching the rule list is speculative cost (the unscoped call can take a minute or more). It is an **on-demand** command: run it when the user asks about the project's best-practice/analyzer rules, or when repeated violations of the same rule family suggest authoring against the full rule set. See [validation-guide.md § On demand: List Analyzer Rules](references/validation-guide.md) and [cli-reference.md § analyzer-rules list](references/cli-reference.md).
 
    See [references/validation-guide.md](references/validation-guide.md).
 4. **ALWAYS validate files as you go AND verify the project builds before declaring done.** After every create or edit: per-file `validate` to clean. Project-level `build` runs once at the end of the edit session (or at any compile-verification gate) — not after every Edit, because `build` is project-scoped and rebuilds the entire project regardless of which file changed. `validate` clean alone is not "validated"; it cannot see member or enum errors — the project-level `build` is mandatory before declaring done. See [references/validation-guide.md](references/validation-guide.md).
@@ -209,7 +209,6 @@ uip rpa activities find --query log --output json > /dev/null 2>&1 &
 
 1. **Post-`init` prerequisite batch.** After `uip rpa init` returns, these depend only on the project existing — NOT on each other. Emit them in ONE message:
    - `Read` `project.json` + the scaffolded `Main.xaml`
-   - `uip rpa analyzer-rules list` (Rule 3 authoring-phase prerequisite)
    - `uip rpa packages install` for packages already known from the request
    - `uip rpa activities find` for activities you'll author
 
@@ -372,7 +371,7 @@ Check `expressionLanguage` in `project.json`. VB.NET uses `[brackets]` for expre
 |---------|---------|
 | `activities find --query "<keyword>"` | Discover activities by keyword |
 | `activities get-default-xaml --activity-class-name "<class>"` | Get starter XAML for an activity |
-| `analyzer-rules list --project-dir "<dir>"` | List enabled Workflow Analyzer rules — run before generating |
+| `analyzer-rules list --project-dir "<dir>"` | List enabled Workflow Analyzer rules — on demand only (user asks about project rules, or repeated violations of one rule family); `validate`/`build` enforce the rules without it |
 | `validate --file-path "<file>"` | Per-file static validation (structure, references, analyzer rules) |
 | `build "<PROJECT_DIR>"` | Compile-time validation (member names, enum values, JIT expressions) — run after `validate` is clean |
 

--- a/skills/uipath-rpa/references/environment-setup.md
+++ b/skills/uipath-rpa/references/environment-setup.md
@@ -171,7 +171,7 @@ Pass `--target-framework` and `--expression-language` here too (Rule 2a) — a t
 2. **Read the scaffolded files** — the command generates starter files. Read them before making changes so you build on valid defaults
 3. Proceed with the skill workflow using the new project root
 
-> **Batch the post-`init` prerequisites.** Step 2 here, the analyzer-rules list (SKILL.md Rule 3), `packages install` for known-needed packages, and the first `activities find` all depend only on the project existing — emit them as parallel tool calls in one message, not one per turn. They share the warmed Studio host. See SKILL.md § Call Batching.
+> **Batch the post-`init` prerequisites.** Step 2 here, `packages install` for known-needed packages, and the first `activities find` all depend only on the project existing — emit them as parallel tool calls in one message, not one per turn. They share the warmed Studio host. See SKILL.md § Call Batching.
 
 ## Edge case: requiring Studio Desktop
 

--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -33,7 +33,7 @@ When the source is a Test Manager test case, a PDD, or any written list of "Clic
 2. **Group by screen state.** Sort steps into screen batches — every step before an action that advances the UI (submit, navigate, dialog confirm) belongs to the current screen; the next batch starts after the advance.
 3. **Build the checklist** — three columns per row: `manual step → element name → screen`. Lock the count before opening the app. If the user later adds requirements, capture deltas, do not re-inventory the whole thing.
 4. **Capture screen by screen.** Pre-flight Window Baseline (above) → run `uia-configure-target` for the current screen's batch → register each element in the Object Repository before advancing → use the UIA interact CLI to advance → repeat. The "Complete-then-advance" rule from [uia-configure-target-workflows.md § Multi-Step UI Flows](uia-configure-target-workflows.md) is mandatory; never advance with elements still un-registered.
-5. **Then code.** With every checklist row registered in the Object Repository, write the `.cs` / `.xaml` workflow that calls them in step order. Authoring-phase prerequisites (analyzer rules, project context discovery) run NOW, not earlier.
+5. **Then code.** With every checklist row registered in the Object Repository, write the `.cs` / `.xaml` workflow that calls them in step order. Authoring-phase prerequisites (project context discovery) run NOW, not earlier.
 
 > Coverage check: after capture, every checklist row must have a matching `Descriptors.<App>.<Screen>.<Element>` path (coded) or Object Repository reference (XAML). Rows without a match indicate a missed capture or an obsolete manual step — reconcile before writing code.
 

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -2,23 +2,20 @@
 
 Fix-one-thing discipline, the validation iteration loop, smoke test procedure, and RPA-specific fix procedures.
 
-## Pre-generation: List Analyzer Rules
+## On demand: List Analyzer Rules
 
-Before creating or editing any workflow file (`.cs` with `[Workflow]`/`[TestCase]`, or `.xaml`), list the enabled Workflow Analyzer rules so generated code satisfies them on the first attempt instead of round-tripping through `validate` fixes:
+`validate` and `build` already enforce the project's enabled Workflow Analyzer rules — violations come back with the rule ID, severity, and recommendation, so the normal authoring loop needs **no** rule pre-fetch. Do NOT run `analyzer-rules list` as an authoring prerequisite: the unscoped call enumerates every rule across every package and can take a minute or more, and most of its output never affects the code you write.
+
+Run it **only on demand**:
+
+1. The **user asks** about the project's best-practice / analyzer rules ("what rules does this project enforce?", "list the analyzer rules", "why is UI-REL-001 firing?").
+2. **Repeated violations of the same rule family** across `validate`/`build` iterations — reading the full rule set (scoped, see below) lets you author against it instead of fixing violations one by one.
 
 ```bash
-uip rpa analyzer-rules list --project-dir "<PROJECT_DIR>" --output json
+uip rpa analyzer-rules list --project-dir "<PROJECT_DIR>" --scope "<Activity|Workflow|Coded Workflow|Project>" --output json
 ```
 
-Apply every rule whose `severity` is `error` or `warning` during authoring. `info` rules are advisory.
-
-**When to run:**
-1. Once at the start of every task that will generate or edit a workflow file.
-2. Re-run after adding or updating a NuGet package — package-shipped rules (`MA-*`) change with the dependency set.
-
-**When NOT to run:**
-1. Pure read-only / Q&A tasks that do not produce or modify workflow files.
-2. Edits that only touch non-workflow files (`project.json`, docs, plain `.cs` source files without workflow attributes).
+Prefer a `--scope` matching what you're authoring — scoped calls return in seconds; unscoped can take a minute+. Apply `error` and `warning` rules; `info` rules are advisory. If you do consult the rules and then add or update a NuGet package, the package-shipped (`MA-*`) rules may have changed with the dependency set.
 
 Rule prefixes and full schema: [cli-reference.md § analyzer-rules list](cli-reference.md).
 


### PR DESCRIPTION
## What

Demotes `uip rpa analyzer-rules list` from a **mandatory authoring-phase prerequisite** to an **on-demand** command in `uipath-rpa`:

- **`SKILL.md`** — Critical Rule 3 reframed from three-phase to two-phase validation (per-file `validate` + project-level `build`), with an explicit "do NOT pre-fetch the rule list" bullet; removed from the Capture-First flow, the post-`init` call-batching list, and the Key CLI Commands table (now marked on-demand).
- **`references/validation-guide.md`** — "Pre-generation: List Analyzer Rules" becomes "On demand: List Analyzer Rules": run it only when the user asks about the project's best-practice/analyzer rules, or when repeated violations of the same rule family suggest authoring against the full (scoped) rule set.
- **`references/environment-setup.md`**, **`references/ui-automation-guide.md`** — same cleanup in the batching note and capture-first step.

The command's reference documentation (`cli-reference.md § analyzer-rules list`) and the Task Navigation entry ("List project best-practice / analyzer rules") are untouched — it stays fully documented and discoverable when a user asks for it.

## Why

`validate` and `build` already enforce the enabled analyzer rules and report violations with rule IDs and recommendations, so pre-fetching the rule list is speculative cost on every authoring task: the unscoped call enumerates every rule across every package and can take a minute or more, and most of the output never influences the generated code. This was one of the wall-clock/token line items in the PILOT-6197 authoring-cost report ("feed analyzer constraints into the step that needs them, don't front-load them").

## Related issues

- **[UV-15204](https://uipath.atlassian.net/browse/UV-15204)** — "[RPA] [CLI] analyzer-rules step makes coding-agent workflow generation 3-4x slower — 7-8 min vs ~2 min when skipped" (CodingAgents, Queued). This PR is the skill-side mitigation: the step is no longer in the default authoring loop at all.
- **Known caveat — [UV-15226](https://uipath.atlassian.net/browse/UV-15226)** — "`uip rpa analyze` does not report Coded Workflow analyzer rules (e.g. ST-NMG-017) that Studio flags as validation errors" (Queued). This PR's premise ("validate/build enforce the rules, so skip the pre-fetch") holds for XAML authoring; for **coded workflows** there is a gap until UV-15226 is fixed, since some ST-NMG rules surface neither from the CLI validate/build path nor, now, from a pre-fetched rule list. The on-demand escape hatch (run the scoped list when the same rule family keeps biting, or when Studio flags errors the CLI missed) is the interim path for that case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[UV-15204]: https://uipath.atlassian.net/browse/UV-15204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ