### PR TITLE
test: tag path-to-ga tasks

### DIFF
--- a/.claude/commands/generate-task.md
+++ b/.claude/commands/generate-task.md
@@ -54,7 +54,7 @@ Per the tier table in `tests/README.md`:
 
 ### 2b. Tags
 
-Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. Optional dimensions (`shape:*`, `node:*`, `resource`, `connector`, `windows`, `feature:*`) follow per `tests/README.md#tag-taxonomy`.
+Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. Optional dimensions (`shape:*`, `node:*`, `resource`, `connector`, `windows`, `feature:*`, `path-to-ga`) follow per `tests/README.md#tag-taxonomy`.
 
 - **`<skill-name>`** — always the first tag. Must match the `skills/<name>/` folder exactly (e.g. `uipath-maestro-flow`, `uipath-agents`). Never abbreviate or drop the `uipath-` prefix.
 - **`<tier>`** — `smoke`, `integration`, or `e2e`.
@@ -65,7 +65,7 @@ Required, in this order: `<skill-name>` first, then `<tier>`, then `mode:<X>`. O
 
 **Use only the closed-vocabulary values listed in `tests/README.md`.** If no value fits an optional dimension, omit it and surface it in the Phase 4 summary so the taxonomy can be extended deliberately. Never invent tag values inline.
 
-Final tag order: `[<skill-name>, <tier>, mode:X, shape:X, node:..., resource, connector, windows, feature:...]`.
+Final tag order: `[<skill-name>, <tier>, mode:X, shape:X, node:..., resource, connector, windows, feature:..., path-to-ga]`.
 
 Example:
 

--- a/.claude/commands/test-coverage.md
+++ b/.claude/commands/test-coverage.md
@@ -176,7 +176,7 @@ task_id         — unique test identifier (e.g., "skill-flow-calculator")
 description     — what the test validates
 tags            — array carrying values from the Tag Taxonomy dimensions
                   documented in tests/README.md. Form:
-                  [skill, tier, mode:X, shape:X, node:..., resource, connector, windows, feature:...]
+                  [skill, tier, mode:X, shape:X, node:..., resource, connector, windows, feature:..., path-to-ga]
                     skill      — uipath-<name>                                (required, flat)
                     tier       — smoke | integration | e2e                    (required, flat)
                     mode       — mode:{build|operate|diagnose}                  (required; see Phase 2f for mode definitions)
@@ -185,6 +185,7 @@ tags            — array carrying values from the Tag Taxonomy dimensions
                     resource   — flat boolean marker (present iff task uses a resource node) (0..1)
                     connector  — flat boolean marker (present iff task uses any connector)   (0..1)
                     windows    — flat boolean marker (present iff task requires a Windows host) (0..1)
+                    path-to-ga  — flat boolean marker for exhaustive / critical GA-path tasks (0..1)
                     feature    — feature:{http|trigger|registry|transform|approval-gate|
                                  write-back|escalation|…}                     (0..n)
                   Record every dimension; Phase 4f keys off all of them, not just tier.
@@ -336,7 +337,7 @@ For each skill that has at least one test, compute which values from the Tag Tax
 - **Mode** — now a **scored slice** (Phase 4f-mode), not a sidecar tick. Report it in the Per-Mode Coverage table, not here.
 - **Shape** — tick each of `shape:single-node`, `shape:multi-node` (applies to flow-building skills only).
 - **Node** — list values present under `node:*` for skills where that axis applies.
-- **Resource / Connector / Windows** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`, `windows`) for skills where they apply.
+- **Resource / Connector / Windows / Path-to-GA** — flat boolean markers; report count of tasks carrying each (`resource`, `connector`, `windows`, `path-to-ga`) for skills where they apply.
 - **Feature** — list `feature:*` tags present vs a reasonable "expected" set for this skill (derived from SKILL.md — e.g. `uipath-human-in-the-loop` should exercise `feature:approval-gate`, `feature:write-back`, `feature:escalation`; `uipath-maestro-flow` should exercise `feature:registry`, `feature:transform`, `feature:http`, …). If the skill's vocabulary is open, list what's present without the ✗ column.
 
 This is structured data for the per-skill report (see template below). It is NOT folded into the weighted overall score — adding it on top of Components/Steps would double-count (a missing edit-scenario test already shows up as a workflow-step gap).

--- a/.github/workflows/path-to-ga-approval.yml
+++ b/.github/workflows/path-to-ga-approval.yml
@@ -1,0 +1,87 @@
+name: Path-to-GA Approval
+
+# Content-sensitive gate for the high-signal `path-to-ga` tag. This check passes
+# for ordinary PRs, and only blocks when a PR adds the tag to task/test YAML.
+# Keep this on pull_request_target and do not checkout PR code: the job only
+# reads GitHub API metadata from the trusted base-repo workflow.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gate:
+    name: path-to-ga approval
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # GitHub logins whose latest PR review may approve new path-to-ga tags.
+      # Sherif: sherifmak / uisherif
+      # Bai Li: bai-uipath
+      # Tomasz Religa: uipreliga
+      # Rocky Madden: rockymadden
+      APPROVERS: sherifmak,uisherif,bai-uipath,uipreliga,rockymadden
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Require allowlisted approval for path-to-ga additions
+        run: |
+          set -euo pipefail
+
+          if [ -z "${PR_NUMBER:-}" ]; then
+            echo "No pull request context; nothing to gate."
+            exit 0
+          fi
+
+          echo "Inspecting PR #$PR_NUMBER for path-to-ga task tag additions."
+
+          pr_json="$(gh api "repos/$REPO/pulls/$PR_NUMBER")"
+          head_sha="$(printf '%s' "$pr_json" | jq -r '.head.sha')"
+
+          additions="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER/files" --paginate \
+              --jq '.[] | select(.filename | test("^tests/tasks/.*\\.ya?ml(\\.disabled)?$")) | .patch // ""' |
+            grep -E '^\+[^+].*(^|[^[:alnum:]_-])path-to-ga([^[:alnum:]_-]|$)' || true
+          )"
+
+          if [ -z "$additions" ]; then
+            echo "No path-to-ga additions under tests/tasks/**/*.yaml."
+            exit 0
+          fi
+
+          echo "Detected path-to-ga additions that require an allowlisted approval:"
+          printf '%s\n' "$additions"
+
+          latest_approvals="$(
+            gh api "repos/$REPO/pulls/$PR_NUMBER/reviews" --paginate |
+            jq -r --arg head_sha "$head_sha" '
+              reduce (.[] | select(.state != "COMMENTED")) as $review ({};
+                .[$review.user.login] = {
+                  state: $review.state,
+                  commit_id: $review.commit_id
+                }
+              )
+              | to_entries[]
+              | select(.value.state == "APPROVED" and .value.commit_id == $head_sha)
+              | .key
+            '
+          )"
+
+          IFS=',' read -r -a approvers <<< "$APPROVERS"
+          for approver in "${approvers[@]}"; do
+            if printf '%s\n' "$latest_approvals" | grep -Fxq "$approver"; then
+              echo "path-to-ga addition approved by allowlisted reviewer: $approver"
+              exit 0
+            fi
+          done
+
+          echo "::error::This PR adds path-to-ga to task/test YAML and needs approval on the current head commit from one of: $APPROVERS"
+          exit 1

--- a/tests/README.md
+++ b/tests/README.md
@@ -106,6 +106,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 | **resource** | flat, present iff applicable | Marks tasks that exercise any resource-node type (`coded-agent`, `lowcode-agent`, `api-workflow`, `rpa`). The specific resource is implied by the file path / `task_id`. |
 | **connector** | flat, present iff applicable | Marks tasks that use any IS connector. The specific connector is in the YAML body / file path. |
 | **windows** | flat, present iff applicable | Marks tasks that require a Windows host (e.g. RPA `.xaml`/`.cs` projects that need Studio Helm). Used by `smoke-rpa-skills.yml` to route the task to a `windows-latest` runner; Linux/macOS smoke runs skip it. |
+| **path-to-ga** | flat, optional | Marks exhaustive, difficult, currently blocked, or historically fragile tasks that represent must-pass scenarios on the path to GA. | `path-to-ga` |
 | **feature** | `feature:X`, repeatable | Cross-cutting capability orthogonal to node/resource/connector. Closed vocabulary: `http`, `trigger`, `registry`, `transform`, `eval`, `approval-gate`, `write-back`, `escalation`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`, `conversational`. Do not invent leaf names like `feature:ceql-where` or directory-name markers like `feature:connector-feature` — those duplicate the file path. |
 
 ### Rules
@@ -113,7 +114,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 1. **Required on every task: `skill` + `tier` + `mode:*` + `lifecycle:*`.** These drive `make` targets, coverage, and evalboard dashboards.
 2. **One value per singular dimension** (`tier`, `mode`, `shape`). A task doesn't have two tiers.
 3. **`node:` and `feature:` are repeatable.** A flow exercising decision and switch nodes gets both `node:decision` and `node:switch`.
-4. **`connector`, `resource`, and `windows` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
+4. **`connector`, `resource`, `windows`, and `path-to-ga` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
 5. **Use only the vocabularies above.** Propose new values in the PR — do not invent tags inline. New values should apply to at least two tasks in practice.
 6. **Don't repeat the skill name as a feature tag.** Don't tag a flow task with `rpa` (bare) or `uipath-rpa` as a feature.
 
@@ -129,6 +130,7 @@ tags: [uipath-maestro-flow, e2e, mode:build, shape:multi-node, node:decision, co
 - `make tags TAGS="smoke windows"` → Windows-only smoke tasks (the slice `smoke-rpa-skills.yml` runs on `windows-latest`).
 - `make tags TAGS="integration connector"` → connector coverage across skills.
 - `make tags TAGS="e2e mode:build"` → end-to-end build tasks across skills.
+- `make tags TAGS="path-to-ga"` → GA-critical exhaustive, blocked, or historically fragile tasks.
 - `make tags TAGS="mode:diagnose"` → diagnosis-mode coverage across skills.
 - Evalboard: `where tag == "connector"` → pass-rate across all connector-using tasks.
 - Evalboard: `where tag == "shape:multi-node"` → composite-flow reliability.

--- a/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_mcp_server_tool/inline_mcp_server_tool.yaml
@@ -7,7 +7,7 @@ description: >
   `$resourceType: "mcp"` (distinct from `$resourceType: "tool"`) with
   the documented sparse shape, and that a `uipath.agent.resource.mcp.*`
   flow node is wired to the autonomous agent node's `tool` handle.
-tags: [uipath-agents, e2e-blocked, mode:build, low-code, inline-flow]
+tags: [uipath-agents, e2e-blocked, mode:build, low-code, inline-flow, path-to-ga]
 skip: true
 # Skipped for now — wiring an inline MCP server tool into the flow is not yet
 # reliable on the run tenant. Re-enable once the inline MCP flow-node path works.

--- a/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
@@ -8,7 +8,7 @@ description: >
   non-interactive tenant-feed publish (pending uipath/cli#2778), so
   requiring an interactive `publish` made this task nondeterministic
   (the agent either fumbled the feed picker or exhausted its turns).
-tags: [uipath-functions, e2e, mode:build, feature:deploy]
+tags: [uipath-functions, e2e, mode:build, feature:deploy, path-to-ga]
 max_iterations: 1
 
 initial_prompt: |

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -8,7 +8,7 @@ description: >
   designing schema, adding HITL node, wiring all handles, and validating the
   authored .flow file. Real business use case. Full Discover -> Plan -> Build -> Verify loop.
   Does not deploy or run the flow.
-tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write-back]
+tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write-back, path-to-ga]
 
 run_limits:
   expected_turns: 19

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -9,7 +9,7 @@ description: >
   authoring path: credentials from ~/.uipath/.auth, solution context resolution,
   app search, retrieve-configuration, resource file writing, debug overwrites,
   node JSON with inputs.type=custom. Does not deploy or execute the flow.
-tags: [uipath-human-in-the-loop, e2e, brown-field, apptask]
+tags: [uipath-human-in-the-loop, e2e, brown-field, apptask, path-to-ga]
 skip: true
 # Blocked: requires live tenant with a deployed Action App and ~/.uipath/.auth
 # credentials. Cannot be run in tempdir sandbox without real infrastructure.
@@ -68,4 +68,3 @@ success_criteria:
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
@@ -23,6 +23,7 @@ tags:
   - feature:case-exit
   - feature:trigger
   - feature:registry
+  - path-to-ga
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
@@ -3,7 +3,7 @@ description: >
   E2E cross-connector scenario — downloads a file from Google Drive and posts
   it into a Slack channel via the "Send File to channel" activity. Exercises
   binary file flow between two IS connectors in a single Flow.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack, ipe, mode:build]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack, ipe, mode:build, path-to-ga]
 
 run_limits:
   expected_turns: 49
@@ -38,4 +38,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -16,6 +16,7 @@ tags:
   - connector
   - uipath-salesforce-slack
   - feature:records
+  - path-to-ga
 
 run_limits:
   expected_turns: 30

--- a/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml.disabled
+++ b/tests/tasks/uipath-maestro-flow/evaluate/eval_run/eval_run.yaml.disabled
@@ -23,7 +23,7 @@ description: >
   the data point scores 1.0 (deterministic agent + deterministic evaluator).
   Tests the full Author → Operate → Evaluate handoff in the
   uipath-maestro-flow skill.
-tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute, feature:eval]
+tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:execute, feature:eval, path-to-ga]
 
 run_limits:
   max_turns: 90

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -10,7 +10,7 @@ description: >
   verifies offline structural correctness only (`uip maestro flow validate`
   exit 0 on the generated flow).
 
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp, connector, feature:http]
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp, connector, feature:http, path-to-ga]
 
 initial_prompt: |
   Build a UiPath Flow that monitors a SharePoint folder for new vendor PDF

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -8,7 +8,7 @@ description: >
   skill honors an explicit agent request instead of substituting a deterministic
   Function. Exercises agent resource node discovery and wiring for coded (vs
   low-code) agents.
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource]
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:single-node, resource, path-to-ga]
 
 run_limits:
   expected_turns: 35

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, integration-service, test-manager, resources, execute, path-to-ga]
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, integration-service, test-manager, resources, execute, path-to-ga]
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Summary

Adds the `path-to-ga` marker to the selected exhaustive / GA-critical task coverage and documents the marker in the task tag taxonomy.

Tagged tasks include:
- `skill-flow-coded-agent`
- `skill-flow-eval-run-e2e`
- `skill-platform-is-testmanager-generic-records`
- `skill-platform-is-testmanager-testcase-lifecycle`
- `skill-functions-deploy-tenant`
- the previously selected HITL, IxP, connector, case, and inline MCP scenarios

## Notes

- Rebases cleanly on the latest `origin/main`.
- Leaves the existing upstream billing `path-to-ga` tasks from #1917 intact.
- `skill-flow-eval-run-e2e` is currently in a `.yaml.disabled` file, but is tagged so it is covered if re-enabled.

## Validation

- `git diff --check origin/main..HEAD`
- Verified all dashboard task ids map to the tagged YAML files.
- Verified `rg -l "path-to-ga" tests/tasks` reports 17 tagged task files on the updated branch.

## Path-to-GA Approval Gate

This PR also adds `.github/workflows/path-to-ga-approval.yml`, a content-sensitive required-check candidate:

- passes for ordinary PRs
- detects added `path-to-ga` lines under `tests/tasks/**/*.yaml` / `.yaml.disabled`
- requires approval on the current PR head from one of: `sherifmak`, `uisherif`, `bai-uipath`, `uipreliga`, `rockymadden`
- uses `pull_request_target` without checking out PR code; it only reads PR file patches and review metadata via the GitHub API

After this workflow lands on `main`, add the required status check named `path-to-ga approval` to the existing `main` ruleset. Do not add it before merge: `pull_request_target` workflows are loaded from the base branch, so the check would not run on this PR before the workflow exists on `main`.
