### PR TITLE
feat(uipath-insights): add activation prompts for skill recall

### DIFF
--- a/tests/tasks/activation/activation.yaml
+++ b/tests/tasks/activation/activation.yaml
@@ -36,7 +36,7 @@ dataset:
 
 initial_prompt: "${row.prompt}"
 
-# 22 skill_triggered criteria — one per skill. Each derives expected internally
+# 23 skill_triggered criteria — one per skill. Each derives expected internally
 # from `expected_skill == skill_name`. Heavy class imbalance (~50 yes / ~1100 no
 # per skill) means recall.yes is the meaningful gate; recall.no is trivially high.
 success_criteria:

--- a/tests/tasks/activation/activation.yaml
+++ b/tests/tasks/activation/activation.yaml
@@ -19,6 +19,7 @@ dataset:
     - uipath-feedback.jsonl
     - uipath-governance.jsonl
     - uipath-human-in-the-loop.jsonl
+    - uipath-insights.jsonl
     - uipath-ixp.jsonl
     - uipath-maestro-bpmn.jsonl
     - uipath-maestro-case.jsonl
@@ -87,6 +88,11 @@ success_criteria:
   - type: skill_triggered
     description: "uipath-human-in-the-loop activation"
     skill_name: uipath-human-in-the-loop
+    expected_skill: "${row.expected_skill}"
+    suite_thresholds: {recall.yes: 0.70}
+  - type: skill_triggered
+    description: "uipath-insights activation"
+    skill_name: uipath-insights
     expected_skill: "${row.expected_skill}"
     suite_thresholds: {recall.yes: 0.70}
   - type: skill_triggered

--- a/tests/tasks/activation/uipath-insights.jsonl
+++ b/tests/tasks/activation/uipath-insights.jsonl
@@ -1,0 +1,25 @@
+{"id": "uipath-insights-001", "prompt": "How many jobs ran in the last 24 hours?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-002", "prompt": "What's my job success rate?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-003", "prompt": "Which processes are failing the most?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-004", "prompt": "Why are my automations failing?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-005", "prompt": "Show me the failure reasons for my jobs", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-006", "prompt": "What's the average processing time for my jobs?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-007", "prompt": "Show me job completion trends for the last week", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-008", "prompt": "Are there any stuck or uncompleted jobs right now?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-009", "prompt": "Give me a breakdown of job failures by process", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-010", "prompt": "How healthy are my automations?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-011", "prompt": "Show me job metrics for the Invoice_Processing process", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-012", "prompt": "What are the most common job error messages?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-013", "prompt": "Show me per-process job details", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-014", "prompt": "How many faulted jobs were there in the last 30 days?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-015", "prompt": "Get job failure details for drill-down investigation", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-016", "prompt": "Show me which machines are having the most job failures", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-017", "prompt": "Compare job success rates this week vs last week", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-018", "prompt": "Run uip insights jobs summary for the last 24 hours", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-019", "prompt": "Check the job KPIs on my Insights dashboard", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-020", "prompt": "Show me job performance trends over the past month", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-021", "prompt": "How many jobs are still running or pending?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-022", "prompt": "Get the top failures for jobs in folder abc-123", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-023", "prompt": "What's the job timeline looking like for completed runs?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-024", "prompt": "Show me insights on automation health across all folders", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-025", "prompt": "Which processes have the highest failure rate?", "expected_skill": "uipath-insights"}

--- a/tests/tasks/activation/uipath-insights.jsonl
+++ b/tests/tasks/activation/uipath-insights.jsonl
@@ -2,7 +2,7 @@
 {"id": "uipath-insights-002", "prompt": "What's my job success rate?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-003", "prompt": "Which processes are failing the most?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-004", "prompt": "Why are my automations failing?", "expected_skill": "uipath-insights"}
-{"id": "uipath-insights-005", "prompt": "Show me the failure reasons for my jobs", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-005", "prompt": "What are the top exception types causing job failures this month?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-006", "prompt": "What's the average processing time for my jobs?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-007", "prompt": "Show me job completion trends for the last week", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-008", "prompt": "Are there any stuck or uncompleted jobs right now?", "expected_skill": "uipath-insights"}
@@ -22,4 +22,4 @@
 {"id": "uipath-insights-022", "prompt": "Get the top failures for jobs in folder abc-123", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-023", "prompt": "What's the job timeline looking like for completed runs?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-024", "prompt": "Show me insights on automation health across all folders", "expected_skill": "uipath-insights"}
-{"id": "uipath-insights-025", "prompt": "Which processes have the highest failure rate?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-025", "prompt": "Show me job metrics grouped by folder across all tenants", "expected_skill": "uipath-insights"}


### PR DESCRIPTION
PR description:
## Summary
- Add `uipath-insights.jsonl` with 25 activation prompts covering job health, failures, timelines, filters, KPIs, and process-specific queries
- Register in `activation.yaml`: dataset path + `skill_triggered` criterion

Addresses Bai Li's request to add activation recall for `uipath-insights`.

## Test plan
- [ ] Activation suite picks up `uipath-insights` prompts and reports recall