### PR TITLE
uipath-maestro-flow: authoring guards (script body, edge id) + raise devcon e2e turn_timeouts

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -218,7 +218,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 **Critical:** for `sourcePort: "error"`, also set `inputs.errorHandlingEnabled: true` on the source node. Without the flag, Studio Web hides the source handle and `uip maestro flow validate` fails.
 
-**Edge ID:** any unique string that starts with a letter or `_`, never a digit (no bare UUID). CLI uses `xy-edge__<sourceNodeId><sourcePort>-<targetNodeId><targetPort>`.
+**Edge ID:** use `xy-edge__<SOURCE_NODE_ID><SOURCE_PORT>-<TARGET_NODE_ID><TARGET_PORT>` — unique per edge, never a leading digit.
 
 See each plugin's `planning.md` or [file-format.md — Standard ports](../../shared/file-format.md) for port names by node type.
 

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -204,7 +204,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 ```json
 {
-  "id": "<UNIQUE_EDGE_ID>",
+  "id": "edge_<SOURCE_NODE_ID>_<SOURCE_PORT>_<TARGET_NODE_ID>_<TARGET_PORT>",
   "sourceNodeId": "<SOURCE_NODE_ID>",
   "sourcePort": "<SOURCE_PORT>",
   "targetNodeId": "<TARGET_NODE_ID>",
@@ -218,7 +218,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 **Critical:** for `sourcePort: "error"`, also set `inputs.errorHandlingEnabled: true` on the source node. Without the flag, Studio Web hides the source handle and `uip maestro flow validate` fails.
 
-**Edge ID:** use `xy-edge__<SOURCE_NODE_ID><SOURCE_PORT>-<TARGET_NODE_ID><TARGET_PORT>` — unique per edge, never a leading digit.
+**Edge ID:** `edge_<SOURCE_NODE_ID>_<SOURCE_PORT>_<TARGET_NODE_ID>_<TARGET_PORT>`.
 
 See each plugin's `planning.md` or [file-format.md — Standard ports](../../shared/file-format.md) for port names by node type.
 

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -204,7 +204,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 ```json
 {
-  "id": "xy-edge__<SOURCE_NODE_ID><SOURCE_PORT>-<TARGET_NODE_ID><TARGET_PORT>",
+  "id": "<UNIQUE_EDGE_ID>",
   "sourceNodeId": "<SOURCE_NODE_ID>",
   "sourcePort": "<SOURCE_PORT>",
   "targetNodeId": "<TARGET_NODE_ID>",
@@ -218,7 +218,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 **Critical:** for `sourcePort: "error"`, also set `inputs.errorHandlingEnabled: true` on the source node. Without the flag, Studio Web hides the source handle and `uip maestro flow validate` fails.
 
-**Edge ID:** use the CLI form `xy-edge__<sourceNodeId><sourcePort>-<targetNodeId><targetPort>`. Must start with a letter or `_`, never a digit (no bare UUID).
+**Edge ID:** any unique string that starts with a letter or `_`, never a digit (no bare UUID). CLI uses `xy-edge__<sourceNodeId><sourcePort>-<targetNodeId><targetPort>`.
 
 See each plugin's `planning.md` or [file-format.md — Standard ports](../../shared/file-format.md) for port names by node type.
 

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -204,7 +204,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 ```json
 {
-  "id": "<UNIQUE_EDGE_ID>",
+  "id": "xy-edge__<SOURCE_NODE_ID><SOURCE_PORT>-<TARGET_NODE_ID><TARGET_PORT>",
   "sourceNodeId": "<SOURCE_NODE_ID>",
   "sourcePort": "<SOURCE_PORT>",
   "targetNodeId": "<TARGET_NODE_ID>",
@@ -218,7 +218,7 @@ Use `Edit` to add an edge object to the `edges` array:
 
 **Critical:** for `sourcePort: "error"`, also set `inputs.errorHandlingEnabled: true` on the source node. Without the flag, Studio Web hides the source handle and `uip maestro flow validate` fails.
 
-**Edge ID:** generate a UUID (matches CLI behavior) or use `e-<sourceNodeId>-<targetNodeId>` if uniqueness across the flow is guaranteed. Short, hand-picked names risk collision when the same source/target pair gets a second edge later.
+**Edge ID:** use the CLI form `xy-edge__<sourceNodeId><sourcePort>-<targetNodeId><targetPort>`. Must start with a letter or `_`, never a digit (no bare UUID).
 
 See each plugin's `planning.md` or [file-format.md — Standard ports](../../shared/file-format.md) for port names by node type.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
@@ -30,12 +30,15 @@ See [Action Node Structure — Adding and editing procedures](../../../../shared
 
 ## Script rules
 
-1. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.{nodeId}.output`.
-2. **`$vars` is a global** — use it directly: `return { upper: $vars.input1.toUpperCase() }`
-3. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints.
-4. **No `console.log`** — `console` is not available. Use `return { debug: value }` to inspect values.
-5. **No external calls** — use the HTTP node or a connector node for API calls.
-6. **30-second timeout** — long-running computations will be killed.
+1. **Top-level body — no `function main()` wrapper.** Node runs the script text directly; a wrapper is never called → `output` null. Read inputs via `$vars.<node>.output`; end with top-level `return {…}`. Not a coded Function: no `main`, no injected args.
+   - Correct: `const n = $vars.ixp1.output.field; return { n };`
+   - Wrong: `function main({ ixp1 }) { … }`
+2. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.{nodeId}.output`.
+3. **`$vars` is a global** — use it directly: `return { upper: $vars.input1.toUpperCase() }`
+4. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints.
+5. **No `console.log`** — `console` is not available. Use `return { debug: value }` to inspect values.
+6. **No external calls** — use the HTTP node or a connector node for API calls.
+7. **30-second timeout** — long-running computations will be killed.
 
 ## Common patterns
 
@@ -83,6 +86,7 @@ Property access is **case-sensitive** — these casings resolve: `.FullName`, `.
 | Error | Cause | Fix |
 | --- | --- | --- |
 | Script did not return a value | Missing `return` statement | Add `return { ... }` |
+| `output` is `null` but script has a `return` | `return` is inside an uncalled `function main(){}` wrapper | Remove wrapper; code + `return` at top level (rule 1) |
 | Return value is not an object | Returned a scalar (`return 42`) | Wrap in object: `return { value: 42 }` |
 | `$vars.nodeId` is undefined | Upstream node not connected or wrong ID | Check edges and node IDs |
 | Timeout after 30s | Script too expensive | Simplify logic or split into multiple scripts |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
@@ -33,7 +33,7 @@ See [Action Node Structure — Adding and editing procedures](../../../../shared
 1. **Top-level body — no `function main()` wrapper.** Node runs the `script` text directly (as a function body); a wrapper is never called → `output` null. Read workflow variables via `$vars.<variableId>` and upstream node outputs via `$vars.<nodeId>.output`; end with top-level `return {…}`. Not a coded Function: no `main`, no injected args.
    - Correct: `const n = $vars.ixp1.output.field; return { n };`
    - Wrong: `function main({ ixp1 }) { … }`
-2. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.{nodeId}.output`.
+2. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.<nodeId>.output`.
 3. **`$vars` is a global** — use it directly: `return { upper: $vars.customerName.toUpperCase() }`
 4. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints.
 5. **No `console.log`** — `console` is not available. Use `return { debug: value }` to inspect values.

--- a/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/script/impl.md
@@ -30,11 +30,11 @@ See [Action Node Structure — Adding and editing procedures](../../../../shared
 
 ## Script rules
 
-1. **Top-level body — no `function main()` wrapper.** Node runs the script text directly; a wrapper is never called → `output` null. Read inputs via `$vars.<node>.output`; end with top-level `return {…}`. Not a coded Function: no `main`, no injected args.
+1. **Top-level body — no `function main()` wrapper.** Node runs the `script` text directly (as a function body); a wrapper is never called → `output` null. Read workflow variables via `$vars.<variableId>` and upstream node outputs via `$vars.<nodeId>.output`; end with top-level `return {…}`. Not a coded Function: no `main`, no injected args.
    - Correct: `const n = $vars.ixp1.output.field; return { n };`
    - Wrong: `function main({ ixp1 }) { … }`
 2. **Must `return` an object** — `return { key: value }`, not a bare scalar. The return value becomes `$vars.{nodeId}.output`.
-3. **`$vars` is a global** — use it directly: `return { upper: $vars.input1.toUpperCase() }`
+3. **`$vars` is a global** — use it directly: `return { upper: $vars.customerName.toUpperCase() }`
 4. **JavaScript ES2020 (Jint engine)** — see [variables-and-expressions.md](../../../../shared/variables-and-expressions.md) for supported features and Jint constraints.
 5. **No `console.log`** — `console` is not available. Use `return { debug: value }` to inspect values.
 6. **No external calls** — use the HTTP node or a connector node for API calls.

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -8,8 +8,8 @@ tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node
 
 run_limits:
   max_turns: 120
-  turn_timeout: 1200
-  task_timeout: 2400
+  turn_timeout: 2400
+  task_timeout: 3600
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -14,7 +14,7 @@ tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node
 
 run_limits:
   max_turns: 200
-  turn_timeout: 1800
+  turn_timeout: 3600
   task_timeout: 5400
 
 post_run:

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -8,8 +8,8 @@ tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:execute, shape:multi-node
 
 run_limits:
   max_turns: 120
-  turn_timeout: 1200
-  task_timeout: 2400
+  turn_timeout: 2400
+  task_timeout: 3600
 
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"


### PR DESCRIPTION
Three hardening changes for the maestro-flow devcon e2e flows — two skill corrections that fix silent runtime failures, plus a test-timeout bump.

## 1. Script node runs top-level body, not `function main()`

Maestro `core.action.script` executes the `script` string directly. Agents carry a coded-Functions prior and wrap logic in `function main(args){}`, which is only defined, never called — node returns nothing, `$vars.<node>.output` is `null`, downstream fails.

`plugins/script/impl.md`: rule 1 (top-level body, no wrapper, read `$vars.<node>.output`, top-level `return`) + a debug row.

## 2. Edge id must be an NCName — no bare UUID

The edge `id` is emitted as the BPMN `<sequenceFlow id>`, an XML NCName — it cannot start with a digit. The skill said "generate a UUID"; ~62% of UUIDs start with a hex digit → invalid `sequenceFlow` id → the edge is silently dropped at runtime (validate still passes; the target node never fires).

Proven by controlled debug: flipping only an edge id's first char (digit → letter) turned a dead node→node edge live.

`editing-operations-json.md`: drop the UUID advice; use `edge_<SOURCE_NODE_ID>_<SOURCE_PORT>_<TARGET_NODE_ID>_<TARGET_PORT>` (letter-leading XML NCName, unique by construction). Example placeholder updated to match.

## 3. Raise turn_timeout on devcon e2e flows that overran

Multi-node build turns exceed the default 1200s under model latency (measured: invoice-lookup ~1719s, discrepancy-detector ~1427s, dispute-resolution ~2189s), causing TurnTimeout ERRORs unrelated to the task/skill so grading never runs.

- `billing_invoice_lookup`, `billing_discrepancy_detector`: turn 1200→2400, task 2400→3600
- `billing_dispute_resolution`: turn 1800→3600 (heaviest, 10-node); task_timeout stays 5400
- resolution-writer / dispute-analyst build fast (<800s) — left at 1200.

## Follow-ups (not here)

- flow-core: sanitize non-NCName `sequenceFlow` ids on `.flow`→bpmn (defense-in-depth) and/or `validate` warns on digit-leading edge ids.
- IxP nested-output traversal guidance for script nodes.