### PR TITLE
test(uipath-platform): fix DF task hygiene — drop stale criterion, ad…

### DIFF
--- a/tests/tasks/uipath-platform/data-fabric/e2e_product_catalogue.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/e2e_product_catalogue.yaml
@@ -95,14 +95,6 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent included Id key in records update body"
-    tool_name: "Bash"
-    command_pattern: '(?s)uip\s+df\s+records\s+update.*\"Id\"'
-    min_count: 1
-    weight: 2.5
-    pass_threshold: 1.0
-
   - type: file_exists
     description: "products.csv was generated"
     path: "products.csv"

--- a/tests/tasks/uipath-platform/data-fabric/integration_filter_contract.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/integration_filter_contract.yaml
@@ -12,7 +12,7 @@ run_limits:
   turn_timeout: 600
 
 initial_prompt: |
-  There's a movie list called `CodeEvalTestEntity` already set up
+  There's a movie entity called `CodeEvalTestEntity` already set up
   with 20 rows in it. Each movie has a title, a score, an active
   flag, a release date, an email (unique per row), a free-form
   notes column, and a poster image. Please only read from it — don't

--- a/tests/tasks/uipath-platform/data-fabric/integration_filter_edge_cases.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/integration_filter_edge_cases.yaml
@@ -13,7 +13,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Set up a list `CE_FilterEdgeTest` with three columns: Title (required
+  Set up an entity `CE_FilterEdgeTest` with three columns: Title (required
   text, up to 200 chars), Score (optional whole number), Notes (optional
   long text). Then load the 10 rows from `feedback_batch.json` in the
   working directory — some rows have `Score: null`, some omit `Notes`,

--- a/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
@@ -51,12 +51,6 @@ initial_prompt: |
       with values "paid", "unpaid", "refunded". I'd like to use it on
       the `CE_SmokeExpense` list.
 
-  Important:
-  - The `uip` CLI is available but not connected to a live tenant. Commands
-    will fail — that is expected. Run each command exactly once regardless
-    of errors. Do NOT retry, do NOT attempt to login, do NOT install tools,
-    do NOT troubleshoot.
-
 success_criteria:
   - type: command_executed
     description: "Agent listed native-only entities"
@@ -196,3 +190,18 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokeExpense"
+    timeout: 120
+    fail_on_error: false
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokePaymentStatus --include-choice-sets"
+    timeout: 120
+    fail_on_error: false
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokeExpense"
+    timeout: 120
+    fail_on_error: false
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokePaymentStatus --include-choice-sets"
+    timeout: 120
+    fail_on_error: false

--- a/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/smoke_choice_relationship.yaml
@@ -201,7 +201,5 @@ pre_run:
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokeExpense"
     timeout: 120
-    fail_on_error: false
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/data-fabric/_shared/cleanup_entities_by_name.py --name-prefix CE_SmokePaymentStatus --include-choice-sets"
     timeout: 120
-    fail_on_error: false


### PR DESCRIPTION
…d smoke cleanup, prompt fixes

- e2e_product_catalogue: drop the "Id key in records update body" criterion — the CLI mandates Id in the update body (verified in `records.ts` and `--help`), so the negative-shape guard asserted absence of a thing the CLI hard-rejects without.
- smoke_choice_relationship: add pre_run/post_run cleanup for CE_SmokeExpense (entity) and CE_SmokePaymentStatus (choice set). Leftover artifacts from prior runs triggered Rule 8 in the agent, which correctly skipped `entities create` / `choice-sets create` and tanked four criteria. Cleanup runs entity-first, then CS, so the in-use reference clears before the CS delete.
- smoke_choice_relationship: remove the "CLI not connected to a live tenant, commands will fail" lines from the prompt — the eval CLI is connected, commands succeed, and the false disclaimer risks the agent silently skipping steps.
- integration_filter_contract / integration_filter_edge_cases: prompt terminology cleanup ("list" → "entity").