### PR TITLE
fix(uipath-coded-apps): inline the push-fixture project ID — drop env-var wiring

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -235,8 +235,6 @@ jobs:
           TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
           E2E_PROCESS_KEY:          ${{ secrets.E2E_PROCESS_KEY }}
           E2E_LONG_PROCESS_KEY:     ${{ secrets.E2E_LONG_PROCESS_KEY }}
-          CODED_APPS_TEST_PROJECT_ID:  ${{ secrets.CODED_APPS_TEST_PROJECT_ID }}
-          CODED_APPS_TEST_SOLUTION_ID: ${{ secrets.CODED_APPS_TEST_SOLUTION_ID }}
           TASK_GLOBS:               ${{ needs.partition.outputs.linux_globs }}
           TASK_COUNT:               ${{ needs.partition.outputs.linux_count }}
           TASK_PARALLELISM:         ${{ inputs.parallelism }}

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -428,8 +428,6 @@ jobs:
             echo "UIPATH_CLI_TENANT_NAME=$TENANT_NAME"
             echo "UIPATH_CLI_TENANT_ID=$TENANT_ID"
             echo "TRACES_SMOKE_PROCESS_KEY=${{ secrets.TRACES_SMOKE_PROCESS_KEY }}"
-            echo "CODED_APPS_TEST_PROJECT_ID=${{ secrets.CODED_APPS_TEST_PROJECT_ID }}"
-            echo "CODED_APPS_TEST_SOLUTION_ID=${{ secrets.CODED_APPS_TEST_SOLUTION_ID }}"
           } >> "$GITHUB_ENV"
           mkdir ~/.uipath
           run_uip_with_tenant "$TENANT_NAME" login status --output json
@@ -514,8 +512,6 @@ jobs:
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           TRACES_SMOKE_PROCESS_KEY: ${{ secrets.TRACES_SMOKE_PROCESS_KEY }}
-          CODED_APPS_TEST_PROJECT_ID: ${{ secrets.CODED_APPS_TEST_PROJECT_ID }}
-          CODED_APPS_TEST_SOLUTION_ID: ${{ secrets.CODED_APPS_TEST_SOLUTION_ID }}
         run: |
           python - <<'PY'
           import os
@@ -526,8 +522,6 @@ jobs:
               "AWS_BEARER_TOKEN_BEDROCK",
               "ANTHROPIC_API_KEY",
               "TRACES_SMOKE_PROCESS_KEY",
-              "CODED_APPS_TEST_PROJECT_ID",
-              "CODED_APPS_TEST_SOLUTION_ID",
           )
           values = [os.environ[name] for name in names if len(os.environ.get(name, "")) >= 8]
           if not values:

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -28,8 +28,6 @@ defaults:
         - E2E_LONG_PROCESS_KEY
         - CODEX_API_KEY
         - CODEX_BASE_URL
-        - CODED_APPS_TEST_PROJECT_ID
-        - CODED_APPS_TEST_SOLUTION_ID
       extra_mounts:
         - ~/.uipath:/.uipath:rw
 

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -28,8 +28,6 @@ defaults:
         - TRACES_SMOKE_PROCESS_KEY
         - CODEX_API_KEY
         - CODEX_BASE_URL
-        - CODED_APPS_TEST_PROJECT_ID
-        - CODED_APPS_TEST_SOLUTION_ID
       extra_mounts:
         - ~/.uipath:/.uipath:rw
 

--- a/tests/tasks/uipath-coded-apps/integration_push_ignore_resources.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_push_ignore_resources.yaml
@@ -12,6 +12,12 @@ run_limits:
   expected_turns: 15
   turn_timeout: 1200
 
+# Persistent Studio Web fixture (codereval/DefaultTenant, alpha):
+#   project "test-webapp"  02c993ea-e366-4ee5-b389-e12166e6dc2a  (inlined in the prompt below)
+#   solution               c05e7fad-1eb1-420d-02cc-08ded767500a
+# The CLI derives the solution from the project ID at runtime; the solution ID
+# is recorded here only for fixture maintenance — recreating a deleted fixture
+# project requires creating it inside this solution.
 initial_prompt: |
   Push an existing Coded App to its Studio Web project. The team's Studio
   Web side already has environment variables and third-party connector
@@ -26,12 +32,11 @@ initial_prompt: |
 
   1. `uip login status --output json` — verify login, do NOT re-login.
 
-  2. Write `.env` at the sandbox root with the project ID from the
-     `CODED_APPS_TEST_PROJECT_ID` env var (this makes push non-interactive):
+  2. Write `.env` at the sandbox root with the persistent test-fixture
+     project ID (this makes push non-interactive):
      ```
-     echo "UIPATH_PROJECT_ID=$CODED_APPS_TEST_PROJECT_ID" > .env
+     echo "UIPATH_PROJECT_ID=02c993ea-e366-4ee5-b389-e12166e6dc2a" > .env
      ```
-     If `$CODED_APPS_TEST_PROJECT_ID` is empty, STOP — do not retry.
 
   3. Write these two files at the sandbox root exactly as shown (the seed
      content is shared with a sibling test so parallel pushes are

--- a/tests/tasks/uipath-coded-apps/integration_push_pull_roundtrip.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_push_pull_roundtrip.yaml
@@ -15,6 +15,12 @@ run_limits:
   turn_timeout: 900
   task_timeout: 900
 
+# Persistent Studio Web fixture (codereval/DefaultTenant, alpha):
+#   project "test-webapp"  02c993ea-e366-4ee5-b389-e12166e6dc2a  (inlined in the prompt below)
+#   solution               c05e7fad-1eb1-420d-02cc-08ded767500a
+# The CLI derives the solution from the project ID at runtime; the solution ID
+# is recorded here only for fixture maintenance — recreating a deleted fixture
+# project requires creating it inside this solution.
 initial_prompt: |
   Run a Studio Web push / pull roundtrip against the currently-active
   UiPath tenant.
@@ -31,12 +37,11 @@ initial_prompt: |
 
   1. `uip login status --output json` — verify login, do NOT re-login.
 
-  2. Write `.env` at the sandbox root with the project ID from the
-     `CODED_APPS_TEST_PROJECT_ID` env var (this makes push non-interactive):
+  2. Write `.env` at the sandbox root with the persistent test-fixture
+     project ID (this makes push non-interactive):
      ```
-     echo "UIPATH_PROJECT_ID=$CODED_APPS_TEST_PROJECT_ID" > .env
+     echo "UIPATH_PROJECT_ID=02c993ea-e366-4ee5-b389-e12166e6dc2a" > .env
      ```
-     If `$CODED_APPS_TEST_PROJECT_ID` is empty, STOP — do not retry.
 
   3. Write these two files at the sandbox root exactly as shown:
 


### PR DESCRIPTION
## Summary

The two Studio Web push tests (`integration_push_pull_roundtrip`, `integration_push_ignore_resources`) read the fixture project ID from the `CODED_APPS_TEST_PROJECT_ID` env var — wired as a GH secret through `smoke.yaml`, `nightly.yaml`, `smoke-skills.yml`, and `run-coder-eval.yml`, but **absent on the ADO nightly runner**. The prompts' own empty-var guard stopped the agent at step 2, failing both tests every nightly ([Slack thread — Bai Li's diagnosis + recommendation](https://uipath-product.slack.com/archives/C0A2T23NJ59/p1783553249263849?thread_ts=1783500017.125659&cid=C0A2T23NJ59); the evalboard triage initially blamed a `.claude/settings.local.json` permission denial — a triage-LLM hallucination). Since adding runner env vars needs cross-team coordination, this inlines the ID in the repo instead, per the thread's recommendation.

## Changes

- **Two push-test prompts**: `UIPATH_PROJECT_ID=02c993ea-…` inlined directly; the "if env var empty, STOP" guard removed (nothing can be empty anymore). A comment in each task records both fixture UUIDs (project + solution, `codereval/DefaultTenant` on alpha) for fixture maintenance.
- **`nightly.yaml` / `smoke.yaml`**: `CODED_APPS_TEST_*` passthrough entries removed.
- **`run-coder-eval.yml` / `smoke-skills.yml`**: secret env wiring, `$GITHUB_ENV` exports, and log-masking entries removed.

`CODED_APPS_TEST_SOLUTION_ID` was wired but consumed by nothing: the `codedapp` CLI has no solution-ID input at all — it derives the solution from the project ID at runtime (`getProjectInfo().solutionId`). The solution UUID matters only if the fixture project ever needs recreating, so it's preserved as documentation, not wiring.

The fixture IDs are plain resource identifiers on the shared QA tenant — no auth value, safe to commit.

## Verification

- **Full suite green on this branch: [51/51](https://github.com/UiPath/skills/actions/runs/28994404432)** — and since `workflow_dispatch` runs the workflow definition from the branch, this run executed with the secret wiring already removed from `run-coder-eval.yml`: the push tests passed in CI with no `CODED_APPS_TEST_*` variables anywhere, which is exactly the ADO nightly runner's condition.
- Ran both tests locally with **both env vars explicitly unset** (the nightly-runner condition that previously failed):
- `skill-coded-apps-integration-push-ignore-resources` — **1.000 (5/5)**
- `skill-coded-apps-integration-push-pull-roundtrip` — **1.000 (9/9)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
