### PR TITLE
test(troubleshoot): re-enable the 143 quarantined mature replay scenarios

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-classic-movefile-source-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-classic-openapp-wrong-scope-type
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-connect-database-ace-not-registered
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Connect to Database failure where a
   Windows (64-bit) process reads an Excel workbook as a database through an ACE

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-connect-database-file-locked
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Connect to Database failure where a
   Windows process reads an Excel workbook as a database through a well-formed

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-connect-database-malformed-connstring
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Connect to Database failure where a
   Windows process reads an Excel workbook as a database through an ACE OLE DB

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-connect-database-provider-init
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Connect to Database failure that began
   right after a Windows-Legacy -> Windows migration. The LedgerExportXlsx process

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-non-query-driver-load
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Non Query failure
   where the activity targets an Oracle database via the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-non-query-out-param-size
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Non Query failure
   where a stored procedure (CommandType=StoredProcedure) is invoked over

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-non-query-unsafe-sql
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Non Query failure that
   faults on some Orchestrator runs. The activity builds its SQL by

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-query-clr-crash
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Query failure where the
   process faults on every Orchestrator run and the job terminates with exit

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-query-provider-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Query failure that
   faults on every Orchestrator run, starting right after the project was

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-query-sql-syntax-error
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Query failure that
   faults on every Orchestrator run. The activity builds its SQL by

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-query-timeout-expired
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an Execute Query failure that
   faults on every Orchestrator run because the query exceeds the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-execute-query-wrong-activity
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a StagingCleanup process that
   faults every night in Orchestrator. The Connect to Database step is

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-start-transaction-body-skip
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a NightlyReconcileTxn process that
   reports Success in Orchestrator every night, yet the reconciliation it

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-start-transaction-connection-not-propagated
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose an OrderSettlementTxn process that
   faults in Orchestrator on every run. A Start Transaction

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-start-transaction-provider-migration
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Start Transaction failure that
   faults on every Orchestrator run, starting right after the project was

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-start-transaction-silent-rollback
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a BatchLedgerPost process that
   reports Success in Orchestrator on every run, yet the ledger entries it

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-range-column-schema-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Append Range failure
   (COMException 0x800A03EC) where the source DataTable and the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-range-hidden-rows-target
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Append Range failure
   (BusinessException 'Cannot append to a range that contains hidden

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-range-variant-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Append Range failure
   (BusinessException 'must be placed inside a Use Excel File container')

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-card-excel-not-installed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Classic Excel Application
   Scope failure (BusinessException 'Error opening workbook. Make sure

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-card-rpc-race-across-scopes
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Modern Use Excel File
   failure (COMException 0x80010108 RPC_E_DISCONNECTED) where two

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-card-sensitivity-label-rejection
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Modern Use Excel File
   failure (BusinessException) where the target workbook has a

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-delete-range-invalid-syntax
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Delete Range failure
   (ArgumentException 'The range is invalid') where the activity's

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-delete-range-shift-conflict
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Delete Range failure
   (COMException 0x800A03EC 'Application-defined or object-defined

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-invokevba-code-file
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Invoke VBA failure caused by
   the external code file referenced by CodeFilePath containing bare VBA

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-invokevba-method-name
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Invoke VBA failure caused by
   EntryMethodName="ProcessInvoces" (typo, missing an "i") not matching the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-invokevba-params
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Invoke VBA failure caused by
   EntryMethodParameters being shaped wrong: the macro signature accepts two

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-invokevba-trust-access
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Invoke VBA failure caused by
   Excel's "Trust access to the VBA project object model" Trust Center setting

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-filters
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Lookup Range "value not found"
   failure caused by an active AutoFilter applied earlier in the same workflow:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-file-locked
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Lookup Range failure
   caused by the workbook being held open by another process on the robot

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-formula-cells
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Lookup Range silent miss
   caused by the target cell being the computed result of an Excel formula: the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-invalid-range
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Lookup Range failure
   caused by the Range property set to a literal empty string "" instead of

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-not-installed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Lookup Range failure
   caused by Microsoft Excel not being installed on the robot host: the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-lookup-null-reference
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Lookup Range failure
   caused by the activity being placed outside any Excel Application Scope: with

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-macro-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Execute Macro failure
   (COMException 'Cannot run the macro...') where the configured

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-macro-trust-center
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Execute Macro failure
   with the same 'Cannot run the macro...' COMException as the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-macro-vba-error
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose an Execute Macro failure
   where the macro ran but threw a VBA runtime error inside the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-host-evidence
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (System.IO.IOException: ... used by another process) where the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-nre-label
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (System.NullReferenceException from inside the activity) where the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-nre-namedrange
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure where
   the workflow references a named range (Range="MyDataRange") in the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-orphan-process
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (System.IO.IOException: ... used by another process) where a prior

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-relative-path
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (System.IO.DirectoryNotFoundException) where the workflow's

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-sheet-case
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (UiPath.Excel.BusinessException: The sheet with the name '<X>' does

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-sheet-typo
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (UiPath.Excel.BusinessException: The sheet with the name '<X>' does

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-rr-unmapped-drive
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Read Range failure
   (System.IO.DirectoryNotFoundException) where the workflow's

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-scope-addin-clash
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Classic Excel Application
   Scope failure (System.InvalidCastException on System.__ComObject,

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-scope-com-registration
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Classic Excel Application
   Scope failure (BusinessException 'Error opening workbook. Make sure

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-scope-orphan-lock
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Classic Excel Application
   Scope failure (BusinessException 'Failed opening the Excel file.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-wc-formula-semicolons
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Cell failure where
   the configured Value is a formula using semicolon separators

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-wc-loop-thrash
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Cell failure that
   emerges only after N successful iterations inside a For Each Row

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-excel-wc-scope-conflict
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Cell failure where
   a Classic Workbook `Write Cell` activity is nested inside a Modern

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-write-range-empty-source
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Range failure
   (BusinessException 'Ignore empty source is ineffective') where the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-write-range-formula-prefix
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Range failure
   (COMException 0x800A03EC 'Application-defined or object-defined

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-write-range-uninitialized-datatable
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Write Range failure
   (NullReferenceException at the activity) where the DataTable argument

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshooting-gsuite-drive-file-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose responses

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshooting-gsuite-drive-multiple-items-name-conflict
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose responses

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshooting-gsuite-invalid-or-null-input
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose responses

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-delete-outlook-mail-collection-modified
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Delete Outlook Mail Message
   failure caused by deleting inside a For Each over the live List<MailMessage>

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-delete-outlook-mail-stale-reference
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Delete Outlook Mail Message
   failure caused by a stale message reference (Branch 1 of the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-get-outlook-mail-cached-mode-desync
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Get Outlook Mail Messages
   silent shortfall (Branch 5 of get-outlook-mail-failures): the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-get-outlook-mail-filter-syntax
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Get Outlook Mail Messages
   failure caused by a malformed DASL/Jet Filter: the Filter property holds

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-get-outlook-mail-folder-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Get Outlook Mail Messages
   failure where the InvoiceMailReader process faults on every run with

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-get-outlook-mail-outlook-not-running
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Get Outlook Mail Messages
   failure where the QueueMailIntake process faults on every unattended run

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-get-outlook-mail-timeout-large-folder
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Get Outlook Mail Messages
   fault caused by a timeout enumerating a very large folder. The activity

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-move-outlook-mail-com-session-loss
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Move Outlook Mail Message
   failure that faults 100% on an unattended robot with "The operation

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-move-outlook-mail-folder-path
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Move Outlook Mail Message
   failure that faults deterministically on every run with "The specified

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-move-outlook-mail-type-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Move Outlook Mail Message
   failure caused by a modern-vs-classic type mismatch (Branch 3 of the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-send-outlook-mail-com-not-registered
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Send Outlook Mail Message
   failure at the COM layer - "Unable to cast COM object ... to interface

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-send-outlook-mail-null-input
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Send Outlook Mail Message
   failure caused by a System.NullReferenceException

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-send-outlook-mail-timeout-security-prompt
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Send Outlook Mail Message
   failure where the activity times out / hangs (System.TimeoutException

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-o365-app-scope-asset-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-o365-sharing-link-access-denied
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-o365-upload-maxfilesize
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose responses

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-python-loadscript-engine-init
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Load Python Script failure
   caused by the Python Scope being unable to initialize the Python engine on

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-python-scope-arch-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Python Scope engine-init failure
   where the scope faults at open with `One or more errors occurred. (Error

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-python-scope-path-is-file
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Python Scope failure where the
   scope faults at open with `The specified Python path is not valid:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-external-vault-failure
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Get Credential failure where
   the target asset exists in the correct folder with the right type

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-folder-scope-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the workflow's FolderPath property points to a folder that does not

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-name-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the workflow's AssetName property is misspelled ("myHiddenAset" —

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-network-connectivity
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the asset, folder, robot license, and robot roles are all correctly

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-per-robot-no-value
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Get Asset failure where the
   target asset exists in the correct folder and has the right type

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-permission-denied
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must troubleshoot a Get Credential failure where
   the activity's target asset and folder both exist correctly, but the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-robot-not-authenticated
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a Get Credential failure where
   the target asset and folder are correctly configured and the robot

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-getasset-wrong-activity-type
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Get Credential failure where
   the workflow uses the `Get Credential` activity (GetRobotCredential)

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-alter-if-disabled
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-ambiguous-node-test
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-application-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must triage a Use Application scope failure
   where the target desktop app is not running and the scope's OpenMode is set

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-healing-agent-disabled-no-consumption
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real uipath-troubleshoot investigation. A user asks
   whether the Healing Agent ran on their last job in folder Shared, whether

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-healing-agent-invalid-license
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath diagnostic investigation where the
   Healing Agent refused to recover a faulted UI Automation activity

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-node-not-found
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-out-of-screen-bounds
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation where an
   NClick activity faulted with `UiAutomationException: Cannot send input

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshooting-rpa-selector-healing-disabled
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-silent-noop-verify-missing
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-uia-verify-execution-failure
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose responses

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-web-deserialize-jsonarray-malformed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a ParseList job fault
   (Newtonsoft.Json.JsonReaderException: Unexpected character encountered while parsing value: n. Path '', line 0, position 0.) and match the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-web-deserialize-null-input
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a ReadConfig job fault
   (System.ArgumentNullException: Value cannot be null. (Parameter 'JSON string')) and match the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-web-deserialize-xml-malformed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a ParseDocument job fault
   (System.Xml.XmlException: Data at the root level is invalid. Line 1, position 1.) and match the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-web-http-connection-failure
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a CallService job fault
   (System.Net.WebException: No such host is known. (service-endpoint-unavailable.invalid:80)) and match the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-web-http-timeout
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a FetchReport job fault
   (System.Net.WebException: The operation has timed out.) and match the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-addpicture-bookmark-missing
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Word "Add Picture"
   (WordAddImage) failure where the activity is configured to insert

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-addpicture-com-interop
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Word "Add Picture"
   (WordAddImage) failure that is ENVIRONMENTAL, not a source defect.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-addpicture-image-variable
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Word "Add Picture"
   (WordAddImage) failure where the activity's Picture-to-insert

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-addpicture-missing-scope
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Word "Add Picture"
   (WordAddImage) failure where the activity is placed OUTSIDE the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-addpicture-word-crash
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshoot agent must diagnose a Word "Add Picture"
   (WordAddImage) failure where Microsoft Word (WINWORD.EXE) CRASHES on

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-text-missing-container
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Append Text failure where the
   App-Integration Append Text activity is dropped outside a Word Application

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-text-not-installed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Append Text COM startup
   failure on a server with no desktop Word: the Word Application Scope cannot

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-append-text-zero-byte-file
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Append Text failure where the
   target .docx is a 0-byte file (not a valid OpenXML package), so opening it

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-com-hang
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Export to PDF COM interop
   failure: an orphaned WINWORD.EXE (a Word instance already running on the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-missing-output-dir
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Export to PDF failure that
   surfaces only as a generic "Command Failed" because the output directory

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-output-path-format
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose an Export to PDF failure where
   the output path is built by string concatenation WITHOUT a .pdf extension

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-wrongthread-external-close
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Save Document as PDF COM
   wrong-thread fault: the export faults casting the document to

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-wrongthread-parallel
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Save Document as PDF COM
   wrong-thread fault: the export faults casting the document to

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-export-pdf-wrongthread-session0
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Save Document as PDF COM
   wrong-thread fault: the export faults casting the document to

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-read-text-doc-format
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Read Text failure where the
   standalone System > File > Word Document Read Text activity (OpenXML,

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-read-text-missing-container
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Read Text failure where the
   modern Word-pack Read Text activity is dropped outside a Use Word File /

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-read-text-protected-view
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Read Text failure where Word
   opens an email-sourced document (Mark-of-the-Web) in Protected View,

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-com-busy
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Replace Text COM-interop
   failure where WINWORD.EXE is busy (another Word instance already running on

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-file-locked
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Replace Text file-lock failure:
   a Use Word File scope with Auto Save enabled edits the same shared file on

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-headers-skipped
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Replace Text silent miss where
   the [CompanyName] placeholder in the document's header/footer is left

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-length-limit
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Replace Text failure
   where the Replace value exceeds the classic activity's hard 256-character

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-multiline-formatting
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Replace Text multi-line
   formatting issue: the Replace value is built with Environment.NewLine, so

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-replace-text-version-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a DESIGN-TIME Studio crash:
   dropping / opening the Replace Text activity throws

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-file-corrupted
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Word Application Scope failure
   where the document opens reporting "The file appears to be corrupted". The

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-file-path
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Word Application Scope
   FileNotFoundException where a relative document path (Output\OfferLetter.docx)

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-hangs
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Word Application Scope hang:
   the scope opens a password-protected document, Word blocks on a background

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-not-installed
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a classic Word Application Scope
   failure caused by Microsoft Word not being installed on the robot host: the

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-word-unknown-type
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath troubleshooting agent must diagnose a Word Application Scope load
   failure on an unattended robot whose UiPath.Word.Activities package does not

--- a/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshooting-faulted-excel-o365
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-connector-remote-token
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of an Integration Service connector-trigger failure. A
   ConnectorTriggerActivity faults with UiPath.Ipc.RemoteException wrapping

--- a/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-maestro-stuck-rpa-job
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-logon-failure-password-mismatch
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted unattended job
   whose Robot Service log shows

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-no-host-pending
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. A job is
   stuck in Pending in the Shared folder with host-family

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-no-login-pending
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. A job is
   stuck in Pending in the Shared folder with PendingReasons.ErrorCodes

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-queue-items-failing-test
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath diagnostic investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-rpa-foreground-already-running
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted AttendedReportJob job that
   failed with System.InvalidOperationException: "A foreground process is

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-rpa-foreground-misconfigured
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted ExpenseValidation
   job that failed with System.InvalidOperationException ("A foreground

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-rpa-job-killed-by-autocancel-trigger
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted LongRunningProcess job that
   ended with System.Exception: "Job stopped with an unexpected exit code:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-rpa-job-killed-by-operator-ui
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted LongRunningProcess job that
   ended with System.Exception: "Job stopped with an unexpected exit code:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-rpa-job-killed-by-watchdog-account
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   UiPath diagnostic agent must diagnose a faulted LongRunningProcess job that
   ended with System.Exception: "Job stopped with an unexpected exit code:

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-argument-null-exception
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
@@ -1,5 +1,4 @@
 task_id: skill-troubleshoot-null-reference-exception
-skip: true  # mature: 100% pass rate over recent evalboard runs (2026-07-08)
 description: >
   Faithful replay of a real UiPath troubleshooting investigation. The agent
   runs the uipath-troubleshoot skill against a uip CLI mock whose


### PR DESCRIPTION
Extracted from #1820 (which no longer carries this change). Removes the `skip: true` quarantine flag (mature: 100% pass rate) from 143 troubleshoot replay task YAMLs — one-line deletion per file, no other changes.

**Merge order: merge #1820 first.** Re-enabling these scenarios is justified by the v2 investigator's ~7-10x per-task cost reduction; re-enabling them while main still runs the v1 architecture would significantly increase nightly wall time and cost.