### PR TITLE
test(troubleshoot): drop per-task agent type override, inherit from experiment

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
@@ -19,7 +19,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
@@ -18,7 +18,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
@@ -18,7 +18,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
   plugins:
     - type: "local"

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
@@ -8,7 +8,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
@@ -19,7 +19,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
@@ -20,7 +20,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
@@ -24,7 +24,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose, lifecycle:discover]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
@@ -16,7 +16,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
@@ -14,7 +14,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, rpa, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, integration-service, rpa, e2e, faithful-replay, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, integration-service, rpa, e2e, faithful-replay, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-troubleshoot, integration-service, rpa, e2e, faithful-replay, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -18,7 +18,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
@@ -17,7 +17,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "Agent", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-troubleshoot, orchestrator, e2e, mode:diagnose]
 
 agent:
-  type: claude-code
   allowed_tools: ["Bash", "Read", "Write", "Edit", "Glob", "Grep", "Skill", "AskUserQuestion", "TodoWrite"]
 
 run_limits:


### PR DESCRIPTION
Extracted from #1820 (which no longer carries this change). Removes the redundant `type: claude-code` line from the `agent:` block of 121 troubleshoot task YAMLs — one-line deletion per file, no other changes. Tasks inherit the agent type from the experiment config per the test-writing rules (`.claude/rules/test-writing.md` § Must-Do 3); the per-task override also blocked variant-driven runs (codex/gemini sweeps) from switching agent type cleanly.

Order-independent: behavior is identical under the current experiments, which all set `type: claude-code`.