### PR TITLE
docs(uipath-solution): document --offset and Pagination.Total on the list commands

### DIFF
--- a/skills/uipath-solution/references/activate-and-manage.md
+++ b/skills/uipath-solution/references/activate-and-manage.md
@@ -90,16 +90,21 @@ uip solution packages list --output json
 
 # Paginate and sort
 uip solution packages list --limit 20 --sort-by "Name" --sort-order "Ascending" --output json
+uip solution packages list --limit 50 --offset 50 --output json   # page 2
 
-# Filter by name (server-side substring match on the package name)
+# Filter by name (server-side substring match on the package name, case-insensitive)
 uip solution packages list --name "Invoice" --output json
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
 | `--limit <n>` | Number of results to return | 50 |
+| `--offset <n>` | Number of results to skip (page start) | 0 |
+| `--name <pattern>` | Server-side substring match on the package name | -- |
 | `--sort-by <field>` | Sort field | -- |
 | `--sort-order <dir>` | `Ascending` or `Descending` | -- |
+
+The response's `Pagination` block reports `Total` (all matches on the server) and `HasMore`. If `HasMore` is `true`, re-run with `--offset <previous offset + Returned>` to fetch the next page — a package missing from the first page is not necessarily absent. The list is tenant-scoped: packages published on another tenant of the same organization do not appear; check the active tenant with `uip login status`.
 
 ## Step 5: Download a Package Version
 

--- a/skills/uipath-solution/references/pack-and-deploy.md
+++ b/skills/uipath-solution/references/pack-and-deploy.md
@@ -143,9 +143,12 @@ The CLI also falls back to the persistent `searchSearchDeployments22` record if 
 ```bash
 uip solution deploy list --output json
 uip solution deploy list --folder-path "Shared" --limit 20 --sort-by "Name" --sort-order "Ascending" --output json
+uip solution deploy list --limit 50 --offset 50 --output json   # page 2
 ```
 
-Options: `--folder-path`, `--limit` (default 50), `--sort-by`, `--sort-order` (`Ascending`/`Descending`).
+Options: `--folder-path`, `--limit` (default 50), `--offset` (default 0), `--sort-by`, `--sort-order` (`Ascending`/`Descending`).
+
+The response's `Pagination` block reports `Total` and `HasMore`; when `HasMore` is `true`, fetch the next page with `--offset`. Note that `--folder-path` filters client-side after the fetch, so with that flag `Returned` counts the filtered rows while `Offset`/`Total` stay server-side — page with `--offset` first, then filter.
 
 ---
 


### PR DESCRIPTION
Companion to UiPath/cli#2962, which adds real pagination to `uip solution packages list` and `uip solution deploy list`: a new `--offset` option (mapped to the Search API's `skip`) and the server total surfaced as `Pagination.Total`, with `HasMore` derived from `offset + returned < total`.

Updates the two references that document these commands' options:

- `activate-and-manage.md` (packages list): `--offset` example + option row, adds the missing `--name` row, and a paragraph telling agents to page via `--offset` when `HasMore` is true and that the list is tenant-scoped (a package published on another tenant of the same org will not appear — check `uip login status`). This came out of a field report where an agent concluded a solution didn't exist because it wasn't in the first 50 rows.
- `pack-and-deploy.md` (deploy list): `--offset` in the example and options line, plus the caveat that `--folder-path` filters client-side after the fetch while `Offset`/`Total` stay server-side.

Merge after UiPath/cli#2962 so the docs don't describe an option older CLI builds reject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)