### PR TITLE
fix(troubleshoot-tests): emit raw UTF-8 in generated fixture manifests

### DIFF
--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
@@ -729,7 +729,7 @@ def apply_plan(plan: dict) -> None:
     fixtures_dir = base / "data" / "m" / "r"
     fixtures_dir.mkdir(parents=True, exist_ok=True)
     (fixtures_dir / "manifest.json").write_text(
-        json.dumps(plan["manifest"], indent=2) + "\n", encoding="utf-8"
+        json.dumps(plan["manifest"], indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
     )
     for fname, content in plan["fixtures"].items():
         (fixtures_dir / fname).write_text(content, encoding="utf-8")


### PR DESCRIPTION
`generate_scenario.py` writes fixture manifests with `json.dumps` at the default `ensure_ascii=True`, escaping every non-ASCII character to `\uXXXX`. The committed fixture corpus overwhelmingly uses raw UTF-8 (214 raw-only files vs 24 escape-only + 4 mixed) — the escapes are generator artifacts, and they make non-English fixtures (e.g. de-DE locale scenarios) unreviewable. `extract_session.py` in the same scripts folder already passes `ensure_ascii=False`.

One-word fix so future generated manifests match the corpus convention. Existing escape-bearing fixtures are left untouched (cosmetic churn, zero behavioral effect — both forms parse identically and the mock dispatcher matches on parsed values).