### PR TITLE
fix(test-manager): set max_turns on live IS TM tasks (fixes nightly MAX_TURNS failures)

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
@@ -8,6 +8,7 @@ tags: [uipath-platform, integration, integration-service, test-manager, resource
 
 run_limits:
   expected_turns: 20
+  max_turns: 35
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
@@ -21,6 +21,7 @@ sandbox:
 
 run_limits:
   expected_turns: 18
+  max_turns: 35
   task_timeout: 1800
 
 initial_prompt: |

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
@@ -10,6 +10,7 @@ tags: [uipath-platform, integration, integration-service, test-manager, resource
 
 run_limits:
   expected_turns: 40
+  max_turns: 60
 
 sandbox:
   driver: tempdir

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
@@ -18,6 +18,7 @@ sandbox:
 
 run_limits:
   expected_turns: 28
+  max_turns: 45
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/integration-service/testmanager/_tm_shared/seed.py"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
@@ -18,6 +18,7 @@ sandbox:
 
 run_limits:
   expected_turns: 28
+  max_turns: 45
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/integration-service/testmanager/_tm_shared/seed.py"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -18,6 +18,7 @@ sandbox:
 
 run_limits:
   expected_turns: 28
+  max_turns: 45
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/integration-service/testmanager/_tm_shared/seed.py"

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
@@ -18,6 +18,7 @@ sandbox:
 
 run_limits:
   expected_turns: 28
+  max_turns: 45
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/integration-service/testmanager/_tm_shared/seed.py"


### PR DESCRIPTION
## Problem
The Test Manager integration-service tasks are failing in the nightly coder-eval suite (flagged 2026-07-07 and 07-09), dragging **uipath-platform** below the 95% public-preview bar.

## Root cause — turn budget, not the connector
The live TM tasks declare `expected_turns` (28–40) but **never set `max_turns`**, so the harness caps them at the default (~20). The multi-operation tasks can't finish in ~20 turns:

| Task | ops | expected_turns | hard cap | result |
|---|---|---|---|---|
| `execution_results` | 9 | 40 | ~20 | guaranteed MAX_TURNS |
| `requirement`/`testcase`/`testset`/`generic_records` | 5–7 | 28 | ~20 | guaranteed MAX_TURNS |
| `attachments` | 4 | 20 | ~20 | borderline |
| `execute_terminal` | execute+poll | 18 | ~20 | ok-ish |

Reproduced locally: `testcase_lifecycle` at the default → `MAX_TURNS_EXHAUSTED` (score 0.455), agent ran **0** connector commands (exhausted on discovery). Ruled out the connector: the codereval TM connection is **Enabled**, and these tasks pass when given enough turns (`requirement_lifecycle` has hit **8/8, score 1.000** locally).

## Fix
Set `max_turns` with headroom above each task's `expected_turns`:
- `execution_results` → 60
- `generic_records` / `requirement_lifecycle` / `testcase_lifecycle` / `testset_lifecycle` → 45
- `attachments` / `execute_terminal` → 35

No criteria or prompt changes. All 7 validate (`coder-eval plan`).

## Note
Per Bai Li's thread comment, coder_eval re-runs "mature" tasks whenever a task YAML changes — so this will re-run these tasks the next night and should return them to green.