### PR TITLE
test(uipath-maestro-case): CM-Golden golden-rebuild live e2e task

### DIFF
--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_bindings.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_bindings.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""CM-Golden rebuild: deterministic live-binding grader.
+
+The staged SDD pins REAL tenant identities (solution folder, resource IDs,
+connection IDs, connector activity type IDs). This grader asserts the build
+resolved against them instead of emitting skeletons or placeholder stubs:
+
+  - every resource-backed task fails ``task_is_skeleton``
+  - every non-connector resource is bound by its SDD name + folder in both
+    caseplan and bindings_v2 (tenant GUIDs are discovery inputs, not runtime
+    binding fields, so their placement is deliberately not graded)
+  - both connection IDs and both activity type IDs land in caseplan.json
+  - connector tasks carry the right serviceType + connectorKey
+  - the Stage 5 connector ENTRY RULE is resolved (real webhook typeId +
+    connectionId, not the minimal stub)
+  - bindings_v2 carries both connection bindings
+
+Expectations are parsed from the task's own ``fixtures/sdd.md`` at grade
+time (not from the workspace copy the agent can edit), so re-sweeping the
+fixture after a golden-solution reinstall updates agent input and grader
+in one file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.case_check import (  # noqa: E402
+    find_caseplan,
+    iter_tasks,
+    read_caseplan,
+    task_is_skeleton,
+)
+
+EXPECTED_CASEPLAN = os.path.join("CMGoldenExpense", "CMGoldenExpense", "caseplan.json")
+FIXTURE_SDD = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "sdd.md")
+
+GUID = r"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def parse_fixture() -> dict:
+    if not os.path.exists(FIXTURE_SDD):
+        _fail(f"fixture SDD not found at {FIXTURE_SDD}")
+    with open(FIXTURE_SDD, encoding="utf-8") as f:
+        sdd = f.read()
+
+    expected: dict = {"folder": None}
+    resource_names = set(re.findall(r"\*\*Resolved Resource:\*\*\s*([^\n]+)", sdd))
+    if len(resource_names) != 5:
+        _fail(
+            "fixture parse error: expected 5 distinct Resolved Resource names; "
+            f"got {sorted(resource_names)!r}"
+        )
+    expected["resource_names"] = resource_names
+
+    conn_ids = {g.lower() for g in re.findall(rf"Connection ID[^`\n]*`{GUID}`", sdd)}
+    act_ids = {g.lower() for g in re.findall(rf"Activity Type ID[^`\n]*`{GUID}`", sdd)}
+    if len(conn_ids) != 2 or len(act_ids) != 2:
+        _fail(
+            "fixture parse error: expected 2 connection IDs and 2 activity type "
+            f"IDs in fixtures/sdd.md; got {sorted(conn_ids)} / {sorted(act_ids)}"
+        )
+    expected["connection_ids"] = conn_ids
+    expected["activity_type_ids"] = act_ids
+
+    folders = set(re.findall(r"\*\*Folder Path:\*\*\s*(\S+)", sdd))
+    if len(folders) != 1:
+        _fail(f"fixture parse error: expected exactly 1 Folder Path value; got {sorted(folders)}")
+    expected["folder"] = folders.pop()
+
+    app_names = set(re.findall(r"Action App:\s*([A-Za-z0-9_-]+)", sdd))
+    if len(app_names) != 1:
+        _fail(f"fixture parse error: expected exactly 1 Action App name; got {sorted(app_names)}")
+    expected["app_name"] = app_names.pop()
+
+    rule_block = re.search(r"\*\*Connector Rule Detail:\*\*(.*?)(?=\n#|\Z)", sdd, re.DOTALL)
+    if not rule_block:
+        _fail("fixture parse error: no 'Connector Rule Detail' block (Stage 5 entry rule)")
+    block = rule_block.group(1)
+    rule_act = re.search(rf"Activity Type ID:\s*`{GUID}`", block)
+    rule_conn = re.search(rf"Connection ID:\s*`{GUID}`", block)
+    if not rule_act or not rule_conn:
+        _fail("fixture parse error: Connector Rule Detail lacks Activity Type ID / Connection ID")
+    expected["rule_activity_id"] = rule_act.group(1).lower()
+    expected["rule_connection_id"] = rule_conn.group(1).lower()
+    return expected
+
+
+def load_artifacts() -> tuple[dict, str, str | None]:
+    """Return (plan, caseplan_text, bindings_text); texts are lowercased."""
+    caseplan_path = (
+        EXPECTED_CASEPLAN if os.path.exists(EXPECTED_CASEPLAN) else find_caseplan()
+    )
+    plan = read_caseplan(caseplan_path)
+    with open(caseplan_path, encoding="utf-8") as f:
+        caseplan_text = f.read().lower()
+
+    project_dir = os.path.dirname(caseplan_path)
+    bindings_path = os.path.join(project_dir, "bindings_v2.json")
+    bindings_text = None
+    if os.path.exists(bindings_path):
+        with open(bindings_path, encoding="utf-8") as f:
+            bindings_text = f.read().lower()
+    return plan, caseplan_text, bindings_text
+
+
+def main():
+    expected = parse_fixture()
+    plan, caseplan_text, bindings_text = load_artifacts()
+
+    # -- live connector identities present ---------------------------------
+    for kind, ids in (
+        ("connection ID", expected["connection_ids"]),
+        ("activity type ID", expected["activity_type_ids"]),
+    ):
+        absent = sorted(g for g in ids if g not in caseplan_text)
+        if absent:
+            _fail(f"{kind}(s) not found in caseplan.json: {absent}")
+    # -- no skeleton tasks ------------------------------------------------------
+    skeletons, timer_empty = [], []
+    for task in iter_tasks(plan):
+        ttype = task.get("type")
+        name = task.get("displayName") or (task.get("data") or {}).get("label") or task.get("id")
+        if ttype == "wait-for-timer":
+            if not task.get("data"):
+                timer_empty.append(name)
+        elif task_is_skeleton(task):
+            skeletons.append(f"{name} ({ttype})")
+    if skeletons:
+        _fail(f"skeleton tasks found (resource not resolved): {skeletons}")
+    if timer_empty:
+        _fail(f"wait-for-timer tasks with empty data: {timer_empty}")
+
+    # -- name/folder resource bindings + bindings_v2 -----------------------------
+    if bindings_text is None:
+        _fail("bindings_v2.json missing next to caseplan.json")
+    try:
+        bindings_doc = json.loads(bindings_text)
+    except ValueError:
+        _fail("bindings_v2.json is not valid JSON")
+    if not (bindings_doc.get("resources") or []):
+        _fail("bindings_v2.json has no resources[] entries")
+    expected_keys = {
+        f"{expected['folder']}.{name}".lower()
+        for name in expected["resource_names"] | {expected["app_name"]}
+    }
+    caseplan_keys = {
+        str(binding.get("resourceKey") or "").lower()
+        for binding in (plan.get("bindings") or [])
+    }
+    missing_caseplan_keys = sorted(expected_keys - caseplan_keys)
+    if missing_caseplan_keys:
+        _fail(f"caseplan bindings[] missing resource key(s): {missing_caseplan_keys}")
+    binding_keys = {
+        str(resource.get("key") or "").lower()
+        for resource in (bindings_doc.get("resources") or [])
+    }
+    missing_binding_keys = sorted(expected_keys - binding_keys)
+    if missing_binding_keys:
+        _fail(f"bindings_v2.json missing resource key(s): {missing_binding_keys}")
+    for kind, ids in (
+        ("connection ID", expected["connection_ids"]),
+    ):
+        absent = sorted(g for g in ids if g not in bindings_text)
+        if absent:
+            _fail(f"{kind}(s) not found in bindings_v2.json: {absent}")
+    # -- connector tasks: serviceType + connectorKey -------------------------------
+    for ttype, svc, key in (
+        ("wait-for-connector", "intsvc.waitforevent", "uipath-http-webhook"),
+        ("execute-connector-activity", "intsvc.activityexecution", "uipath-microsoft-outlook365"),
+    ):
+        matches = [t for t in iter_tasks(plan) if t.get("type") == ttype]
+        if len(matches) != 1:
+            _fail(f"expected exactly 1 {ttype} task; got {len(matches)}")
+        task_text = json.dumps(matches[0], default=str).lower()
+        if svc not in task_text:
+            _fail(f"{ttype} task missing serviceType {svc!r}")
+        if key not in task_text:
+            _fail(f"{ttype} task not bound to connector {key!r}")
+
+    # -- Stage 5 connector entry rule resolved --------------------------------------
+    stage5 = next(
+        (
+            n
+            for n in plan.get("nodes") or []
+            if "Stage" in (n.get("type") or "") and _norm((n.get("data") or {}).get("label")).startswith("stage5")
+        ),
+        None,
+    )
+    if stage5 is None:
+        _fail("Stage 5 node not found")
+    entry_text = json.dumps(
+        (stage5.get("data") or {}).get("entryConditions") or [], default=str
+    ).lower()
+    if expected["rule_activity_id"] not in entry_text:
+        _fail("Stage 5 entry rule missing the webhook activity type ID (unresolved rule)")
+    if expected["rule_connection_id"] not in entry_text:
+        _fail("Stage 5 entry rule missing the webhook connection ID (unresolved rule)")
+
+    print(
+        "OK: all resource name/folder keys, both connections, both activity "
+        "types, connector task contracts, and the Stage 5 connector entry rule "
+        "are resolved against the live tenant; no skeleton tasks"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_case.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_case.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""CM-Golden rebuild: structural topology and runtime-contract grader.
+
+Checks that the generated caseplan.json encodes the golden feature-coverage
+design, not just a structurally valid case:
+
+  - 8 stages: 7 primary + the "Stage 4 - return to origin" secondary lane
+  - condition-derived transition chain S1->S2->S3->S6 plus S2->S4 (reject
+    lane) and S7->S8
+  - exactly 1 Manual trigger (not an event trigger)
+  - 2 case-exit rules: required-stages-completed (marksCaseComplete) +
+    Stage 4 lane exit (does not mark complete)
+  - 15 tasks, per-stage task-type multisets covering all 9 task types
+  - the named Stage 2 timer is explicitly marked run-once
+  - direct task-output passing and connector activity v2 are enabled
+  - SLA escalation, timer durations, and the EXP case-identifier prefix survive
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.case_check import (  # noqa: E402
+    assert_tasks_nested,
+    find_stages,
+    find_transitions,
+    find_triggers,
+    first_rule_of_condition,
+    get_case_exit_conditions,
+    get_sla_rules,
+    iter_tasks,
+    read_caseplan,
+)
+
+EXPECTED_CASEPLAN = os.path.join("CMGoldenExpense", "CMGoldenExpense", "caseplan.json")
+
+# Stage key -> expected task-type multiset (sorted). Keys are matched as
+# normalized prefixes of the stage label ("Stage 4" matches
+# "Stage 4 - return to origin").
+STAGE_TASK_TYPES = {
+    "Stage 1": ["agent", "process", "rpa"],
+    "Stage 2": ["action", "api-workflow", "wait-for-timer", "wait-for-timer"],
+    "Stage 3": ["case-management", "execute-connector-activity", "wait-for-connector"],
+    "Stage 4": ["action"],
+    "Stage 5": ["wait-for-timer"],
+    "Stage 6": ["wait-for-timer"],
+    "Stage 7": ["wait-for-timer"],
+    "Stage 8": ["wait-for-timer"],
+}
+SECONDARY_STAGE = "Stage 4"
+EXPECTED_TRANSITIONS = [
+    ("Stage 1", "Stage 2"),
+    ("Stage 2", "Stage 3"),
+    ("Stage 2", "Stage 4"),  # reject lane: selected-stage-exited("Stage 2")
+    ("Stage 3", "Stage 6"),
+    ("Stage 7", "Stage 8"),
+]
+TIMER_DURATIONS = ["pt20s", "pt10s", "pt20m", "pt5s"]
+
+
+def _norm(s: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
+
+
+def _label(node: dict) -> str:
+    return (node.get("data") or {}).get("label") or ""
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_plan() -> dict:
+    if os.path.exists(EXPECTED_CASEPLAN):
+        return read_caseplan(EXPECTED_CASEPLAN)
+    return read_caseplan()
+
+
+def _stage_tasks(stage: dict) -> list[dict]:
+    tasks: list[dict] = []
+    for lane in ((stage.get("data") or {}).get("tasks") or []):
+        if isinstance(lane, dict):
+            tasks.append(lane)
+        elif isinstance(lane, list):
+            tasks.extend(t for t in lane if isinstance(t, dict))
+    return tasks
+
+
+def _is_secondary(node: dict) -> bool:
+    return (
+        (node.get("data") or {}).get("stageType") == "secondary"
+        or node.get("type") == "case-management:ExceptionStage"
+    )
+
+
+def main():
+    plan = _read_plan()
+    assert_tasks_nested(plan)
+
+    # -- stages -------------------------------------------------------------
+    all_stages = find_stages(plan, include_exception=True)
+    stage_by_key: dict[str, dict] = {}
+    for key in STAGE_TASK_TYPES:
+        knorm = _norm(key)
+        matches = [s for s in all_stages if _norm(_label(s)).startswith(knorm)]
+        if not matches:
+            _fail(
+                f"missing stage {key!r}; stages present: "
+                f"{[_label(s) for s in all_stages]}"
+            )
+        if len(matches) > 1:
+            _fail(f"multiple stages match {key!r}: {[_label(s) for s in matches]}")
+        stage_by_key[key] = matches[0]
+    if len(all_stages) != len(STAGE_TASK_TYPES):
+        _fail(
+            f"expected exactly {len(STAGE_TASK_TYPES)} stages, got "
+            f"{len(all_stages)}: {[_label(s) for s in all_stages]}"
+        )
+
+    # -- secondary lane -----------------------------------------------------
+    secondaries = [s for s in all_stages if _is_secondary(s)]
+    if len(secondaries) != 1 or secondaries[0] is not stage_by_key[SECONDARY_STAGE]:
+        _fail(
+            "exactly one secondary stage expected and it must be "
+            f"{SECONDARY_STAGE!r}; secondaries found: "
+            f"{[_label(s) for s in secondaries]}"
+        )
+
+    # -- trigger ------------------------------------------------------------
+    triggers = find_triggers(plan)
+    if len(triggers) != 1:
+        _fail(f"expected exactly 1 Manual trigger; got {len(triggers)}")
+    svc = (((triggers[0].get("data") or {}).get("uipath")) or {}).get("serviceType")
+    if svc == "Intsvc.EventTrigger":
+        _fail("case trigger must be Manual, not an Intsvc.EventTrigger")
+
+    # -- transitions ----------------------------------------------------------
+    for src_key, dst_key in EXPECTED_TRANSITIONS:
+        src_id = stage_by_key[src_key]["id"]
+        dst_id = stage_by_key[dst_key]["id"]
+        if not find_transitions(plan, source=src_id, target=dst_id):
+            _fail(
+                f"missing condition-derived transition {src_key!r} -> {dst_key!r} "
+                "(entry selected-stage-completed/-exited or exitToStageId)"
+            )
+
+    # -- case exits -----------------------------------------------------------
+    case_exits = get_case_exit_conditions(plan)
+    if len(case_exits) < 2:
+        _fail(f"expected >=2 case-exit rules (happy + Stage 4 lane); got {len(case_exits)}")
+    happy = False
+    lane_exit = False
+    stage4_id = stage_by_key[SECONDARY_STAGE]["id"]
+    for case_exit in case_exits:
+        rule = first_rule_of_condition(case_exit) or {}
+        name = rule.get("rule")
+        if name == "required-stages-completed" and case_exit.get("marksCaseComplete") is True:
+            happy = True
+        if (
+            name in ("selected-stage-completed", "selected-stage-exited")
+            and rule.get("selectedStageId") == stage4_id
+            and case_exit.get("marksCaseComplete") is not True
+        ):
+            lane_exit = True
+    if not happy:
+        _fail("missing case-exit 'required-stages-completed' with marksCaseComplete=true")
+    if not lane_exit:
+        _fail(
+            "missing case-exit on the 'Stage 4 - return to origin' lane "
+            "(selected-stage-completed, marksCaseComplete=false)"
+        )
+
+    # -- tasks: count + per-stage type multisets -------------------------------
+    tasks = list(iter_tasks(plan))
+    expected_total = sum(len(v) for v in STAGE_TASK_TYPES.values())
+    if len(tasks) != expected_total:
+        _fail(f"expected exactly {expected_total} tasks, got {len(tasks)}")
+    for key, expected_types in STAGE_TASK_TYPES.items():
+        got = sorted(t.get("type") or "?" for t in _stage_tasks(stage_by_key[key]))
+        if got != sorted(expected_types):
+            _fail(f"stage {key!r} task types {got} != expected {sorted(expected_types)}")
+
+    # -- run-once task contract --------------------------------------------------
+    stage2_tasks = _stage_tasks(stage_by_key["Stage 2"])
+    run_once = next(
+        (
+            task
+            for task in stage2_tasks
+            if task.get("displayName") == "Wait for timer - S2 run once"
+        ),
+        None,
+    )
+    if run_once is None or run_once.get("shouldRunOnlyOnce") is not True:
+        _fail("'Wait for timer - S2 run once' must set shouldRunOnlyOnce=true")
+
+    # -- SLA escalation ---------------------------------------------------------
+    sla_rules = get_sla_rules(plan)
+    if not sla_rules:
+        _fail("case-level metadata.slaRules missing (1h SLA with escalations)")
+    if "song.zhao@uipath.com" not in json.dumps(sla_rules, default=str).lower():
+        _fail("SLA escalation notify recipient lost")
+    sla0 = sla_rules[0] if isinstance(sla_rules, list) else sla_rules
+    if not (sla0.get("count") == 1 and sla0.get("unit") == "h"):
+        _fail(
+            "SLA duration lost: expected count=1 unit='h' (1h case SLA); got "
+            f"count={sla0.get('count')!r} unit={sla0.get('unit')!r}"
+        )
+    escalations = sla0.get("escalationRule") or []
+    esc_types = {((e.get("triggerInfo") or {}).get("type")) for e in escalations}
+    if "at-risk" not in esc_types or not esc_types & {"breached", "sla-breached"}:
+        _fail(f"SLA escalations lost: need at-risk + (sla-)breached; got {sorted(esc_types)}")
+    if not any(
+        (e.get("triggerInfo") or {}).get("atRiskPercentage") == 70 for e in escalations
+    ):
+        _fail("SLA at-risk threshold lost: no escalation with atRiskPercentage=70")
+
+    # -- runtime contracts (functional-build facts, run4-oracle-verified) --------
+    # Direct task-output passing is what makes the lowered vars.<id> gates
+    # resolve at runtime; intsvcActivityConfig v2 is the connector-task contract.
+    if (plan.get("metadata") or {}).get("caseDirectlyPassTaskOutputs") is not True:
+        _fail("metadata.caseDirectlyPassTaskOutputs must be true (SDD: task-output passing = Direct)")
+    if (plan.get("metadata") or {}).get("intsvcActivityConfig") != "v2":
+        _fail("metadata.intsvcActivityConfig must be 'v2'")
+
+    # -- content fidelity not covered by the semantic checker -------------------
+    raw = json.dumps(plan, default=str).lower()
+    missing_durations = [d for d in TIMER_DURATIONS if d not in raw]
+    if missing_durations:
+        _fail(f"timer durations lost: {missing_durations}")
+    case_identifier = (plan.get("metadata") or {}).get("caseIdentifier")
+    if case_identifier != "EXP":
+        _fail(f"metadata.caseIdentifier must be 'EXP'; got {case_identifier!r}")
+
+    print(
+        "OK: CM-Golden caseplan preserves 8 stages (1 secondary), "
+        f"{len(tasks)} tasks across all 9 types, "
+        "transition/case-exit topology, run-once contract, runtime flags, "
+        "SLA escalation, timer durations, and case identifier"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_seed.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_seed.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""CM-Golden rebuild: exact Task 1.1 literal-seed fidelity check."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.case_check import find_stages, read_caseplan  # noqa: E402
+
+
+EXPECTED_CASEPLAN = os.path.join("CMGoldenExpense", "CMGoldenExpense", "caseplan.json")
+FIXTURE_SDD = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "sdd.md")
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _read_plan() -> dict:
+    if len(sys.argv) > 1:
+        return read_caseplan(sys.argv[1])
+    if os.path.exists(EXPECTED_CASEPLAN):
+        return read_caseplan(EXPECTED_CASEPLAN)
+    return read_caseplan()
+
+
+def _expected_seed() -> dict:
+    try:
+        with open(FIXTURE_SDD, encoding="utf-8") as stream:
+            sdd = stream.read()
+    except OSError as exc:
+        _fail(f"cannot read fixture SDD {FIXTURE_SDD}: {exc}")
+    block = re.search(
+        r"##### Task 1\.1: Analyze Expense Request(.*?)(?=\n---)",
+        sdd,
+        re.DOTALL,
+    )
+    row = None if block is None else re.search(
+        r"^\|\s*expenseRequest\s*\|\s*object\s*\|\s*`(\{.*\})`",
+        block.group(1),
+        re.MULTILINE,
+    )
+    if row is None:
+        _fail("fixture parse error: Task 1.1 expenseRequest literal not found")
+    try:
+        return json.loads(row.group(1))
+    except ValueError as exc:
+        _fail(f"fixture parse error: Task 1.1 expenseRequest is invalid JSON: {exc}")
+
+
+def _stage_tasks(stage: dict) -> list[dict]:
+    tasks: list[dict] = []
+    for lane in ((stage.get("data") or {}).get("tasks") or []):
+        if isinstance(lane, dict):
+            tasks.append(lane)
+        elif isinstance(lane, list):
+            tasks.extend(task for task in lane if isinstance(task, dict))
+    return tasks
+
+
+def main():
+    plan = _read_plan()
+    matches = [
+        task
+        for stage in find_stages(plan, include_exception=True)
+        for task in _stage_tasks(stage)
+        if task.get("displayName") == "Analyze Expense Request"
+    ]
+    if len(matches) != 1:
+        _fail(f"expected one Analyze Expense Request task; got {len(matches)}")
+    inputs = {
+        item.get("name"): item
+        for item in ((matches[0].get("data") or {}).get("inputs") or [])
+        if isinstance(item, dict)
+    }
+    if "expenseRequest" not in inputs:
+        _fail("Analyze Expense Request is missing expenseRequest input")
+    seed = inputs["expenseRequest"].get("value")
+    if isinstance(seed, dict):
+        actual_seed = seed
+    elif isinstance(seed, str):
+        try:
+            actual_seed = json.loads(seed)
+        except ValueError as exc:
+            _fail(f"expenseRequest is not a JSON object: {exc}")
+    else:
+        _fail(
+            "expenseRequest must be an object or a JSON-encoded object; "
+            f"got {type(seed).__name__}"
+        )
+    if not isinstance(actual_seed, dict):
+        _fail(f"expenseRequest must decode to an object; got {type(actual_seed).__name__}")
+    if actual_seed != _expected_seed():
+        _fail("Task 1.1 expenseRequest literal does not match fixtures/sdd.md")
+    print("OK: Task 1.1 preserves the exact SDD expenseRequest object literal")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_semantics.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_semantics.py
@@ -1,0 +1,586 @@
+#!/usr/bin/env python3
+"""CM-Golden rebuild: deterministic dataflow and condition grader.
+
+The case builder lowers SDD ``vars.$xref(stage, task, output)`` expressions to
+``vars.<output-id>`` references, where task/stage IDs are minted per build.
+This checker resolves those IDs back to logical names and verifies the semantic
+contract that previously depended on an LLM judge:
+
+  - every SDD-bound task input uses the expected upstream task output
+  - every consumed ``vars.<id>`` has a real producer
+  - behavior-bearing literal inputs and action recipients survive
+  - every stage/task entry and exit condition has the expected rule + target
+  - Stage 2 reject and Stage 4 approve/reject gates use the correct output,
+    polarity, exit type, and completion behavior
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+import os
+import re
+import sys
+
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.case_check import find_stages, read_caseplan  # noqa: E402
+
+EXPECTED_CASEPLAN = os.path.join("CMGoldenExpense", "CMGoldenExpense", "caseplan.json")
+FIXTURE_SDD = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fixtures", "sdd.md")
+
+TASKS_BY_STAGE = {
+    "Stage 1": [
+        "Analyze Expense Request",
+        "Process Expense Request",
+        "Record Expense via RPA",
+    ],
+    "Stage 2": [
+        "Manager Approval",
+        "Wait for timer - S2 run once",
+        "Call Expense API",
+        "Wait for timer - S2 adhoc",
+    ],
+    "Stage 3": ["Wait for HTTP Webhook", "List Emails", "Start Child Case"],
+    "Stage 4": ["Rework Approval"],
+    "Stage 5": ["Wait for timer - S5"],
+    "Stage 6": ["Timer to be interrupted"],
+    "Stage 7": ["Wait for timer - S7"],
+    "Stage 8": ["Wait for timer - S8"],
+}
+
+VAR_REF_RE = re.compile(r"\bvars\.([A-Za-z_][A-Za-z0-9_]*)")
+GATE_RE = re.compile(
+    r"^\s*=js:\s*vars\.([A-Za-z_][A-Za-z0-9_]*)\s*"
+    r"===\s*(['\"])(approve|reject)\2\s*$"
+)
+OUTLOOK_FOLDER_ID_RE = re.compile(r"^(?:AAMk|AQMk)[A-Za-z0-9+/_=-]{28,}$")
+
+
+def _fail(msg: str):
+    sys.exit(f"FAIL: {msg}")
+
+
+def _norm(value: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", (value or "").lower())
+
+
+def _read_plan() -> dict:
+    if len(sys.argv) > 1:
+        return read_caseplan(sys.argv[1])
+    if os.path.exists(EXPECTED_CASEPLAN):
+        return read_caseplan(EXPECTED_CASEPLAN)
+    return read_caseplan()
+
+
+def _expected_recipient() -> dict:
+    try:
+        with open(FIXTURE_SDD, encoding="utf-8") as stream:
+            sdd = stream.read()
+    except OSError as exc:
+        _fail(f"cannot read fixture SDD {FIXTURE_SDD}: {exc}")
+    recipients = set(re.findall(r"\*\*Recipient:\*\*\s*Email:\s*([^\s]+)", sdd))
+    if len(recipients) != 1:
+        _fail(
+            "fixture parse error: expected one shared action recipient; "
+            f"got {sorted(recipients)!r}"
+        )
+    return {"Type": 2, "Value": recipients.pop()}
+
+
+def _stage_tasks(stage: dict) -> list[dict]:
+    tasks: list[dict] = []
+    for lane in ((stage.get("data") or {}).get("tasks") or []):
+        if isinstance(lane, dict):
+            tasks.append(lane)
+        elif isinstance(lane, list):
+            tasks.extend(task for task in lane if isinstance(task, dict))
+    return tasks
+
+
+def _index_plan(plan: dict):
+    stages = find_stages(plan, include_exception=True)
+    stage_by_key: dict[str, dict] = {}
+    stage_id_to_key: dict[str, str] = {}
+
+    for key in TASKS_BY_STAGE:
+        matches = [
+            stage
+            for stage in stages
+            if _norm((stage.get("data") or {}).get("label")).startswith(_norm(key))
+        ]
+        if len(matches) != 1:
+            labels = [(stage.get("data") or {}).get("label") for stage in matches]
+            _fail(f"expected one stage matching {key!r}; got {labels}")
+        stage = matches[0]
+        stage_by_key[key] = stage
+        stage_id = stage.get("id")
+        if not isinstance(stage_id, str) or not stage_id:
+            _fail(f"stage {key!r} has no id")
+        stage_id_to_key[stage_id] = key
+
+    task_by_logical: dict[tuple[str, str], dict] = {}
+    task_id_to_logical: dict[str, tuple[str, str]] = {}
+    for stage_key, expected_names in TASKS_BY_STAGE.items():
+        tasks = _stage_tasks(stage_by_key[stage_key])
+        actual_names = [task.get("displayName") for task in tasks]
+        if Counter(actual_names) != Counter(expected_names):
+            _fail(
+                f"stage {stage_key!r} task names {actual_names!r} "
+                f"!= expected {expected_names!r}"
+            )
+        for task in tasks:
+            logical = (stage_key, task["displayName"])
+            task_by_logical[logical] = task
+            task_id = task.get("id")
+            if not isinstance(task_id, str) or not task_id:
+                _fail(f"task {logical!r} has no id")
+            if task_id in task_id_to_logical:
+                _fail(f"duplicate task id {task_id!r}")
+            task_id_to_logical[task_id] = logical
+
+    output_by_logical: dict[tuple[str, str, str], dict] = {}
+    output_id_to_logical: dict[str, tuple[str, str, str]] = {}
+    for (stage_key, task_name), task in task_by_logical.items():
+        for output in (task.get("data") or {}).get("outputs") or []:
+            output_name = output.get("name")
+            output_id = output.get("id")
+            output_var = output.get("var")
+            if not isinstance(output_name, str) or not output_name:
+                _fail(f"task {(stage_key, task_name)!r} has an output without a name")
+            if not isinstance(output_id, str) or not output_id:
+                _fail(
+                    f"output {(stage_key, task_name, output_name)!r} has no generated id"
+                )
+            if output_var != output_id:
+                _fail(
+                    f"output {(stage_key, task_name, output_name)!r} has "
+                    f"id={output_id!r} but var={output_var!r}"
+                )
+            logical = (stage_key, task_name, output_name)
+            if logical in output_by_logical:
+                _fail(f"duplicate logical output {logical!r}")
+            if output_id in output_id_to_logical:
+                _fail(f"duplicate generated output id {output_id!r}")
+            output_by_logical[logical] = output
+            output_id_to_logical[output_id] = logical
+
+    return (
+        stage_by_key,
+        stage_id_to_key,
+        task_by_logical,
+        task_id_to_logical,
+        output_by_logical,
+        output_id_to_logical,
+    )
+
+
+def _output_id(outputs: dict, logical: tuple[str, str, str]) -> str:
+    output = outputs.get(logical)
+    if output is None:
+        _fail(f"required producer output missing: {logical!r}")
+    return output["id"]
+
+
+def _inputs(task: dict) -> dict[str, dict]:
+    found: dict[str, dict] = {}
+    for item in (task.get("data") or {}).get("inputs") or []:
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            _fail(f"task {task.get('displayName')!r} has an input without a name")
+        if name in found:
+            _fail(f"task {task.get('displayName')!r} has duplicate input {name!r}")
+        found[name] = item
+    return found
+
+
+def _input(task: dict, name: str) -> dict:
+    item = _inputs(task).get(name)
+    if item is None:
+        _fail(f"task {task.get('displayName')!r} missing input {name!r}")
+    return item
+
+
+def _assert_source(value, kind: str, producer_id: str, where: str):
+    if not isinstance(value, str):
+        _fail(f"{where} must be an expression string; got {value!r}")
+    escaped = re.escape(producer_id)
+    patterns = {
+        "direct": rf"^\s*=vars\.{escaped}\s*$",
+        "json-stringify": (
+            rf"^\s*=js:\s*JSON\.stringify\(\s*vars\.{escaped}\s*\)\s*$"
+        ),
+        "greeting": (
+            rf"^\s*=js:\s*`Hi \$\{{JSON\.stringify\(\s*vars\.{escaped}\s*\)\}}`\s*$"
+        ),
+    }
+    if not re.fullmatch(patterns[kind], value):
+        _fail(
+            f"{where} is wired as {value!r}; expected {kind} reference to "
+            f"producer id {producer_id!r}"
+        )
+
+
+def _assert_dataflow(plan: dict, tasks: dict, outputs: dict, outputs_by_id: dict):
+    expected_sources = [
+        (
+            ("Stage 1", "Process Expense Request"),
+            "ProcessExpenseRequestIn",
+            ("Stage 1", "Analyze Expense Request", "AgentExpenseRequest"),
+            "direct",
+        ),
+        (
+            ("Stage 1", "Record Expense via RPA"),
+            "RPAExpenseRequestIn",
+            ("Stage 1", "Process Expense Request", "ProcessExpenseRequestOut"),
+            "json-stringify",
+        ),
+        (
+            ("Stage 2", "Manager Approval"),
+            "Content",
+            ("Stage 1", "Analyze Expense Request", "AgentExpenseRequest"),
+            "greeting",
+        ),
+        (
+            ("Stage 2", "Manager Approval"),
+            "Comment",
+            ("Stage 1", "Record Expense via RPA", "RPAExpenseRequestOut"),
+            "json-stringify",
+        ),
+        (
+            ("Stage 2", "Call Expense API"),
+            "APIInput1",
+            ("Stage 2", "Manager Approval", "Comment"),
+            "direct",
+        ),
+        (
+            ("Stage 3", "Start Child Case"),
+            "caseInput1",
+            ("Stage 2", "Manager Approval", "Comment"),
+            "json-stringify",
+        ),
+    ]
+    expected_ref_locations: set[tuple[tuple[str, str], str]] = set()
+    for consumer, input_name, producer, kind in expected_sources:
+        producer_id = _output_id(outputs, producer)
+        value = _input(tasks[consumer], input_name).get("value")
+        _assert_source(value, kind, producer_id, f"{consumer!r} input {input_name!r}")
+        expected_ref_locations.add((consumer, input_name))
+
+    rework = tasks[("Stage 4", "Rework Approval")]
+    for field in ("Content", "Comment"):
+        value = _input(rework, field).get("value")
+        if value != "":
+            _fail(f"Rework Approval input {field!r} must be the SDD empty literal")
+
+    webhook_body = _input(tasks[("Stage 3", "Wait for HTTP Webhook")], "body").get(
+        "body"
+    )
+    if webhook_body not in ({}, None):
+        _fail(f"Wait for HTTP Webhook body must be unbound; got {webhook_body!r}")
+
+    email_inputs = _inputs(tasks[("Stage 3", "List Emails")])
+    populated_parameter_sets = []
+    for container_name in ("body", "queryParameters"):
+        item = email_inputs.get(container_name) or {}
+        parameters = item.get("body")
+        if isinstance(parameters, dict) and parameters:
+            populated_parameter_sets.append((container_name, parameters))
+    if len(populated_parameter_sets) != 1:
+        _fail(
+            "List Emails must have exactly one populated body or "
+            "queryParameters input; got "
+            f"{[name for name, _ in populated_parameter_sets]!r}"
+        )
+    container_name, email_body = populated_parameter_sets[0]
+    normalized_email_body = {_norm(str(key)): value for key, value in email_body.items()}
+    if set(normalized_email_body) != {"parentfolderid", "limit", "filter"}:
+        _fail(
+            f"List Emails {container_name} fields do not match the SDD: "
+            f"{sorted(normalized_email_body)!r}"
+        )
+    if normalized_email_body["limit"] != "10":
+        _fail(f"List Emails limit must be '10'; got {normalized_email_body['limit']!r}")
+    if normalized_email_body["filter"] != "contains(subject,'urgent')":
+        _fail(
+            "List Emails filter must be contains(subject,'urgent'); got "
+            f"{normalized_email_body['filter']!r}"
+        )
+    parent_folder = normalized_email_body["parentfolderid"]
+    if not isinstance(parent_folder, str) or (
+        _norm(parent_folder) != "inbox"
+        and OUTLOOK_FOLDER_ID_RE.fullmatch(parent_folder) is None
+    ):
+        _fail(
+            "List Emails parentFolderId must be literal 'Inbox' or a resolved "
+            f"Outlook folder reference; got {parent_folder!r}"
+        )
+
+    # No task input may quietly consume an extra task-output variable. Every
+    # cross-task reference must be one of the source contracts asserted above.
+    for logical, task in tasks.items():
+        for input_name, item in _inputs(task).items():
+            refs = set(VAR_REF_RE.findall(str(item.get("value") or "")))
+            if refs and (logical, input_name) not in expected_ref_locations:
+                _fail(
+                    f"unexpected task-output reference(s) {sorted(refs)} in "
+                    f"{logical!r} input {input_name!r}"
+                )
+            dangling = refs - set(outputs_by_id)
+            if dangling:
+                _fail(
+                    f"unproduced variable reference(s) {sorted(dangling)} in "
+                    f"{logical!r} input {input_name!r}"
+                )
+
+    variables = plan.get("variables") or {}
+    nonempty_case_vars = {
+        name: variables.get(name)
+        for name in ("inputs", "outputs", "inputOutputs")
+        if variables.get(name)
+    }
+    if nonempty_case_vars:
+        _fail(f"SDD declares no case variables; found {nonempty_case_vars!r}")
+
+    expected_recipient = _expected_recipient()
+    for logical in (
+        ("Stage 2", "Manager Approval"),
+        ("Stage 4", "Rework Approval"),
+    ):
+        recipient = (tasks[logical].get("data") or {}).get("recipient")
+        if recipient != expected_recipient:
+            _fail(
+                f"{logical!r} recipient must be {expected_recipient!r}; "
+                f"got {recipient!r}"
+            )
+
+
+def _selected_tasks(rule: dict, task_ids: dict) -> tuple[tuple[str, str], ...]:
+    ids = list(rule.get("selectedTasksIds") or [])
+    if rule.get("selectedTaskId"):
+        ids.append(rule["selectedTaskId"])
+    logical = []
+    for task_id in ids:
+        if task_id not in task_ids:
+            _fail(f"condition references unknown task id {task_id!r}")
+        logical.append(task_ids[task_id])
+    return tuple(sorted(logical))
+
+
+def _selected_stages(rule: dict, stage_ids: dict) -> tuple[str, ...]:
+    ids = list(rule.get("selectedStagesIds") or [])
+    if rule.get("selectedStageId"):
+        ids.append(rule["selectedStageId"])
+    logical = []
+    for stage_id in ids:
+        if stage_id not in stage_ids:
+            _fail(f"condition references unknown stage id {stage_id!r}")
+        logical.append(stage_ids[stage_id])
+    return tuple(sorted(logical))
+
+
+def _canonical_expression(expression, output_ids: dict):
+    if expression in (None, ""):
+        return None
+    if not isinstance(expression, str):
+        return ("invalid", repr(expression))
+    match = GATE_RE.fullmatch(expression)
+    if match is None:
+        return ("raw", re.sub(r"\s+", "", expression))
+    output_id, _, value = match.groups()
+    producer = output_ids.get(output_id)
+    if producer is None:
+        _fail(f"gate expression references unproduced variable {output_id!r}")
+    return ("equals", producer, value)
+
+
+def _condition_signature(
+    condition: dict, stage_ids: dict, task_ids: dict, output_ids: dict
+):
+    groups = condition.get("rules") or []
+    if len(groups) != 1 or not isinstance(groups[0], list) or len(groups[0]) != 1:
+        _fail(
+            f"condition {condition.get('displayName')!r} must contain exactly "
+            f"one rule; got {groups!r}"
+        )
+    rule = groups[0][0]
+    return (
+        rule.get("rule"),
+        _selected_stages(rule, stage_ids),
+        _selected_tasks(rule, task_ids),
+        _canonical_expression(rule.get("conditionExpression"), output_ids),
+        condition.get("type"),
+        condition.get("marksStageComplete"),
+    )
+
+
+def _sig(
+    rule: str,
+    *,
+    stages=(),
+    tasks=(),
+    expression=None,
+    exit_type=None,
+    marks=None,
+):
+    return (
+        rule,
+        tuple(sorted(stages)),
+        tuple(sorted(tasks)),
+        expression,
+        exit_type,
+        marks,
+    )
+
+
+def _assert_condition_set(where: str, actual_conditions: list, expected, indexes):
+    stage_ids, task_ids, output_ids = indexes
+    actual = Counter(
+        _condition_signature(condition, stage_ids, task_ids, output_ids)
+        for condition in actual_conditions
+    )
+    wanted = Counter(expected)
+    if actual != wanted:
+        _fail(f"{where} conditions differ\n  actual={actual}\n  expected={wanted}")
+
+
+def _assert_conditions(stages: dict, tasks: dict, stage_ids: dict, task_ids: dict, output_ids):
+    manager = ("Stage 2", "Manager Approval")
+    rework = ("Stage 4", "Rework Approval")
+    indexes = (stage_ids, task_ids, output_ids)
+
+    expected_stage_entries = {
+        "Stage 1": [_sig("case-entered")],
+        "Stage 2": [_sig("selected-stage-completed", stages=("Stage 1",))],
+        "Stage 3": [_sig("selected-stage-completed", stages=("Stage 2",))],
+        "Stage 4": [_sig("selected-stage-exited", stages=("Stage 2",))],
+        "Stage 5": [_sig("wait-for-connector")],
+        "Stage 6": [_sig("selected-stage-completed", stages=("Stage 3",))],
+        "Stage 7": [_sig("user-selected-stage")],
+        "Stage 8": [_sig("selected-stage-completed", stages=("Stage 7",))],
+    }
+    expected_stage_exits = {
+        "Stage 1": [_sig("required-tasks-completed", exit_type="exit-only", marks=True)],
+        "Stage 2": [
+            _sig("required-tasks-completed", exit_type="exit-only", marks=True),
+            _sig(
+                "selected-tasks-completed",
+                tasks=(manager,),
+                expression=("equals", (*manager, "Action"), "reject"),
+                exit_type="exit-only",
+                marks=False,
+            ),
+        ],
+        "Stage 3": [_sig("required-tasks-completed", exit_type="exit-only", marks=True)],
+        "Stage 4": [
+            _sig(
+                "required-tasks-completed",
+                expression=("equals", (*rework, "Action"), "reject"),
+                exit_type="exit-only",
+                marks=True,
+            ),
+            _sig(
+                "selected-tasks-completed",
+                tasks=(rework,),
+                expression=("equals", (*rework, "Action"), "approve"),
+                exit_type="return-to-origin",
+                marks=False,
+            ),
+        ],
+        "Stage 5": [_sig("required-tasks-completed", exit_type="wait-for-user", marks=True)],
+        "Stage 6": [_sig("required-tasks-completed", exit_type="exit-only", marks=True)],
+        "Stage 7": [_sig("required-tasks-completed", exit_type="exit-only", marks=True)],
+        "Stage 8": [_sig("required-tasks-completed", exit_type="exit-only", marks=True)],
+    }
+
+    for stage_key, stage in stages.items():
+        data = stage.get("data") or {}
+        _assert_condition_set(
+            f"stage {stage_key!r} entry",
+            data.get("entryConditions") or [],
+            expected_stage_entries[stage_key],
+            indexes,
+        )
+        _assert_condition_set(
+            f"stage {stage_key!r} exit",
+            data.get("exitConditions") or [],
+            expected_stage_exits[stage_key],
+            indexes,
+        )
+
+    expected_task_entries = {
+        ("Stage 1", "Analyze Expense Request"): [_sig("current-stage-entered")],
+        ("Stage 1", "Process Expense Request"): [
+            _sig(
+                "selected-tasks-completed",
+                tasks=(("Stage 1", "Analyze Expense Request"),),
+            )
+        ],
+        ("Stage 1", "Record Expense via RPA"): [
+            _sig(
+                "selected-tasks-completed",
+                tasks=(("Stage 1", "Process Expense Request"),),
+            )
+        ],
+        ("Stage 2", "Manager Approval"): [_sig("current-stage-entered")],
+        ("Stage 2", "Wait for timer - S2 run once"): [_sig("current-stage-entered")],
+        ("Stage 2", "Call Expense API"): [
+            _sig("selected-tasks-completed", tasks=(manager,))
+        ],
+        ("Stage 2", "Wait for timer - S2 adhoc"): [_sig("adhoc")],
+        ("Stage 3", "Wait for HTTP Webhook"): [_sig("current-stage-entered")],
+        ("Stage 3", "List Emails"): [
+            _sig(
+                "selected-tasks-completed",
+                tasks=(("Stage 3", "Wait for HTTP Webhook"),),
+            )
+        ],
+        ("Stage 3", "Start Child Case"): [
+            _sig(
+                "selected-tasks-completed",
+                tasks=(("Stage 3", "List Emails"),),
+            )
+        ],
+        ("Stage 4", "Rework Approval"): [_sig("current-stage-entered")],
+        ("Stage 5", "Wait for timer - S5"): [_sig("current-stage-entered")],
+        ("Stage 6", "Timer to be interrupted"): [_sig("current-stage-entered")],
+        ("Stage 7", "Wait for timer - S7"): [_sig("current-stage-entered")],
+        ("Stage 8", "Wait for timer - S8"): [_sig("runs-sequentially")],
+    }
+    for logical, task in tasks.items():
+        _assert_condition_set(
+            f"task {logical!r} entry",
+            task.get("entryConditions") or [],
+            expected_task_entries[logical],
+            indexes,
+        )
+        _assert_condition_set(
+            f"task {logical!r} exit",
+            task.get("exitConditions") or [],
+            [],
+            indexes,
+        )
+
+
+def main():
+    plan = _read_plan()
+    (
+        stages,
+        stage_ids,
+        tasks,
+        task_ids,
+        outputs,
+        output_ids,
+    ) = _index_plan(plan)
+    _assert_dataflow(plan, tasks, outputs, output_ids)
+    _assert_conditions(stages, tasks, stage_ids, task_ids, output_ids)
+
+    print(
+        "OK: CM-Golden caseplan deterministically matches SDD dataflow "
+        "sources/completeness, normalized stage/task conditions, and "
+        "reject/approve gate polarity"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/cm_golden_expense.yaml
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/cm_golden_expense.yaml
@@ -1,0 +1,123 @@
+task_id: skill-case-golden-rebuild-cm-expense
+description: >
+  GOLDEN REBUILD (live tenant) - rebuild the CM-Golden expense-reporting
+  reference case from a reverse-engineered sdd.md whose resource references
+  are REAL: the staged fixture pins the deployed solution folder, resource
+  IDs, connection IDs, and connector activity type IDs of the CM-Golden
+  golden solution on the coder-eval tenant. Unlike the phase_0_build_* tasks
+  (offline, skeleton bindings allowed), this exercises live resolution and
+  grades the resulting resource/connector bindings rather than the exact CLI
+  command sequence. Every task must be RESOLVED (no skeletons or unresolved
+  connector rules), with structural fidelity to the golden design
+  (8 stages incl. a secondary rework lane with return-to-origin, 15 tasks
+  across all 9 task types, wait-for-user / user-selected-stage handoff,
+  ad-hoc + run-once timers, SLA escalation). Stops at validate - NOT debug.
+
+  TENANT PRECONDITION: the CM-Golden golden solution must be deployed on the
+  eval tenant at the folder/IDs pinned in fixtures/sdd.md. A golden solution
+  reinstall re-mints every ID and renames the folder - re-sweep
+  fixtures/sdd.md (the ONE source both the agent and the bindings grader
+  read; the grader parses its expectations from that file at grade time).
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, resource, feature:approval-gate, feature:escalation]
+
+# Sized from measured runs: a healthy full build finishes in ~60 min, but a
+# mid-stream API-limit death (32k output-token cap, context overflow) makes
+# the harness retry with a FRESH session (no resume) - task_timeout must
+# absorb one full cold restart. Launch with CLAUDE_CODE_MAX_OUTPUT_TOKENS=64000
+# so a caseplan-sized extended-thinking response is not fatal (both failure
+# modes observed 2026-07-10).
+run_limits:
+  task_timeout: 14400
+  max_turns: 600
+  turn_timeout: 9000
+
+# The case skill delegates heavy legs (reference reading, sibling-resource
+# builds) to sub-agents; without Agent the whole build runs inline in one
+# context and dies to "Prompt is too long" (observed 2026-07-10). Extends the
+# experiment's allowed_tools - keep the base list in sync with
+# experiments/default.yaml.
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "Agent"]
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  I have an approved SDD for our CM-Golden expense-reporting case-management
+  solution - it's staged as `sdd.md` in this folder. Build a UiPath Case
+  Management solution named "CMGoldenExpense" containing a project also named
+  "CMGoldenExpense" from this SDD.
+
+  Use the staged `sdd.md` as the sole source of truth. Do not redo Phase 0,
+  do not re-interview me, and do not redesign the process. The tenant is LIVE
+  and already hosts every referenced resource: the solution folder, resource
+  IDs, connection IDs, and connector activity type IDs in the SDD are real.
+  Resolve every task and connector rule against them - skeleton or
+  placeholder bindings are NOT acceptable.
+
+  Important:
+  - The `uip` CLI is available and already authenticated against the target
+    tenant. Resolve against a FRESH registry cache - a stale local cache is
+    not acceptable.
+  - Treat all hard stops after the SDD as pre-approved, including Phase 1
+    planning approval, Phase 2 publish-for-review, and Phase 5 publish. Choose
+    the continue / skip-publish path and keep going.
+  - Do NOT call AskUserQuestion - it is not available in this harness.
+  - Do NOT publish the solution and do NOT run `uip maestro case debug`
+    (the case suspends on timers, HITL actions, and a webhook event).
+  - Finish with `uip maestro case validate CMGoldenExpense/CMGoldenExpense/caseplan.json --output json`
+    passing on the resulting caseplan.json.
+
+success_criteria:
+  - type: run_command
+    description: "uip maestro case validate passes on the generated CMGoldenExpense caseplan.json"
+    command: "uip maestro case validate CMGoldenExpense/CMGoldenExpense/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "caseplan preserves the golden topology: 8 stages, secondary rework lane, condition-derived transitions, case exits, 15 tasks across all 9 types, run-once timer, runtime flags, SLA escalation"
+    command: "python3 $TASK_DIR/check_cm_golden_case.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "every resource task and the Stage 5 connector entry rule are resolved: expected name/folder binding keys, connection/activity IDs, connector service types, and no skeleton tasks"
+    command: "python3 $TASK_DIR/check_cm_golden_bindings.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "caseplan semantically implements the SDD's dataflow and gate logic (producer ownership, globally unique output IDs, gate polarity, condition equivalence)"
+    command: "python3 $TASK_DIR/check_cm_golden_semantics.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Task 1.1 preserves the SDD's exact expenseRequest seed object (native object or JSON-encoded object)"
+    command: "python3 $TASK_DIR/check_cm_golden_seed.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run case debug or publish (case suspends; publish is out of scope)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+case\s+(debug|publish)\b'
+    weight: 1.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
@@ -1,0 +1,792 @@
+# SDD — Coding-Agent-CM-Golden-Expense-Reporting-Manual-Case
+
+**Case Definition Blueprint.** Expense-reporting case that chains an AI agent, a process orchestration, and an RPA robot to analyze and record an expense request, routes it through human approval with a rework/return-to-origin exception lane, calls an API workflow and a child case, reacts to an inbound HTTP-webhook event, and demonstrates user-selected routing and completion delays. Feature-coverage reference case.
+
+## Table of Contents
+
+1. [Case Definition](#section-1-case-definition) — Metadata, SLA, Triggers, Exit Conditions, Variables
+2. [Stages & Tasks](#section-2-stages--tasks)
+   - [Stage 1: Stage 1](#stage-1-stage-1) — 3 tasks
+   - [Stage 2: Stage 2](#stage-2-stage-2) — 4 tasks
+   - [Stage 3: Stage 3](#stage-3-stage-3) — 3 tasks
+   - [Secondary Stage: Stage 4 - return to origin](#secondary-stage-stage-4---return-to-origin) — 1 task
+   - [Stage 5: Stage 5 - connector entry](#stage-5-stage-5---connector-entry) — 1 task
+   - [Stage 6: Stage 6 - to be interrupted](#stage-6-stage-6---to-be-interrupted) — 1 task
+   - [Stage 7: Stage 7 - user select](#stage-7-stage-7---user-select) — 1 task
+   - [Stage 8: Stage 8 - delay case completion](#stage-8-stage-8---delay-case-completion) — 1 task
+3. [Personas & App Views](#section-3-personas--app-views)
+4. [Integrations](#section-4-integrations) — IS Connectors, API Workflows, Agents, Processes & RPA, Child Cases
+
+---
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|----------|-------|
+| Case Name | Coding-Agent-CM-Golden-Expense-Reporting-Manual-Case |
+| Case Description | Manages an employee expense request end to end: automated analysis (agent → process → RPA), manager approval with a rework exception lane, an API-workflow call and a child case, an event-driven stage entered by an inbound HTTP webhook, a user-selected routing stage, and a final completion-delay stage. |
+| Case Identifier | Type: constant. Prefix: `EXP` |
+| Priority | — |
+| Case-Level SLA | 1 h |
+| SLA Type | time-based |
+| Case App | Enabled |
+| Task-output passing | Direct |
+| Case Identifier source | `=metadata.ExternalId` (platform-generated) — every `caseId` task input binds to this |
+
+### Case-Level SLA Escalation Rules
+
+| SLA Status | Threshold | Action |
+|------------|-----------|--------|
+| At-Risk | 70% of SLA duration | Notify: `song.zhao@uipath.com` |
+| Breached | 100% of SLA duration | Notify: `song.zhao@uipath.com` |
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|----|-------------|--------|---------------|
+| T02 | Manual | Manual | N/A |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|------|-----|------|---------------------|--------------|
+| `required-stages-completed` | — | Case exited | Yes | Case complete rule |
+| `selected-stage-completed("Stage 4 - return to origin")` | — | Case exited | No | Case exit rule 1 |
+
+### Case Variables
+
+> None. This case declares no `In` / `Out` arguments and no case-level state. Every cross-task value flows by direct task-output reference — whole-value `<- "Stage"."Task".output` in an Inputs Binding cell, or `vars.$xref('Stage','Task','output')` inside a `=js:` expression / IF gate. The case's seed input is supplied as a literal on the first task.
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|------|----------|------|----------------|--------------|---------|-------------|
+| — | — | — | — | — | — | — |
+
+---
+
+## Section 2: Stages & Tasks
+
+**I/O bindings:** Inputs `Binding` feeds a task input (whole-value `<- "Stage"."Task".out`, a `=js:` expression, or a literal). Outputs `Binding / Value` uses `-> caseVar` (extract) or `caseVar = expr` (set); tasks that only feed downstream via direct reference self-declare their outputs and need no case-variable row.
+
+---
+
+### Stage 1: Stage 1
+
+**Type:** Stage
+**Description:** Automated analysis and recording of the expense request: an AI agent normalizes the raw request, a process orchestration processes it, and an RPA robot records the result. Runs as a strict sequential chain.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `case-entered` | — | No | Enter case |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Tasks completed rule |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Analyze Expense Request | agent | Yes | No | — | — |
+| 2 | Process Expense Request | process | Yes | No | — | — |
+| 3 | Record Expense via RPA | rpa | Yes | No | — | — |
+
+---
+
+##### Task 1.1: Analyze Expense Request
+
+**Type:** agent
+**Description:** AI agent that ingests the raw expense-request event and returns a normalized `AgentExpenseRequest` record used by the rest of the case.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Resolved Resource:** Agent
+**Folder Path:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**Resource Identity:** agentId `ccf5793f-54ab-4262-bf44-fcd09a52ed4e` (v1.0.6)
+**Binding Sub-Type:** Agent
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| expenseRequest | object | `{"CaseId":"ATH-4484403e0059","CaseTitle":"Athena E2E 20260519-015425","EmployeeName":"Athena Tester","EmployeeEmail":"song.zhao@uipath.com","Department":"QA","ExpenseType":1,"Amount":100,"Currency":"USD","Description":"Generated by CMGoldenExpenseReportingTests","SubmittedDate":"2026-05-19T01:54:25Z","Id":"c617a3ad-2553-f111-8ef3-6045bd0a4e20","eventType":"CREATED"}` (literal seed — a sample `CMGoldenExpenseRequest` CREATED event) |
+
+**Outputs:** —
+
+---
+
+##### Task 1.2: Process Expense Request
+
+**Type:** process
+**Description:** Process orchestration (agentic BPMN) that processes the normalized expense record and returns `ProcessExpenseRequestOut`.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `selected-tasks-completed("Analyze Expense Request")` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Resolved Resource:** Agentic Process
+**Folder Path:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**Resource Identity:** processOrchestrationId `7d01a11a-c8a3-41b0-b30f-f65c4d7ddbb9` (v1.0.6)
+**Binding Sub-Type:** ProcessOrchestration
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| ProcessExpenseRequestIn | object | `<- "Stage 1"."Analyze Expense Request".AgentExpenseRequest` |
+
+**Outputs:** —
+
+---
+
+##### Task 1.3: Record Expense via RPA
+
+**Type:** rpa
+**Description:** RPA robot that records the processed expense into the legacy system; input is the serialized process output.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `selected-tasks-completed("Process Expense Request")` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Resolved Resource:** RPA Workflow
+**Folder Path:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**Resource Identity:** processId `0bc08e50-b45a-401c-aec8-a720e1d190e3` (v1.0.6)
+**Binding Sub-Type:** —
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| RPAExpenseRequestIn | string | `=js:JSON.stringify(vars.$xref('Stage 1','Process Expense Request','ProcessExpenseRequestOut'))` |
+
+**Outputs:** —
+
+---
+
+### Stage 2: Stage 2
+
+**Type:** Stage
+**Description:** Human approval of the recorded expense with a divergent reject path. A manager reviews via the approval app; an API workflow logs the decision comment; timers demonstrate run-once and ad-hoc entry. A reject decision exits the stage without completing it, opening the rework lane (Stage 4).
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `selected-stage-completed("Stage 1")` | — | No | Entry from 'Stage 1' |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Tasks completed rule |
+| `selected-tasks-completed("Manager Approval")` | `=js:vars.$xref('Stage 2','Manager Approval','Action') === "reject"` | exit-only | No | Reject Exit1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Manager Approval | action | Yes | No | Reviewer | — |
+| 2 | Wait for timer - S2 run once | wait-for-timer | Yes | Yes | — | — |
+| 3 | Call Expense API | api-workflow | Yes | No | — | — |
+| 4 | Wait for timer - S2 adhoc | wait-for-timer | Yes | No | — | — |
+
+---
+
+##### Task 2.1: Manager Approval
+
+**Type:** action
+**Description:** Manager reviews the expense analysis and approves or rejects. Approve continues the case; reject diverts to the rework lane.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**HITL Implementation:** Action App: SimpleApprovalApp
+**Action App ID:** `d5102769-8bac-4afc-a727-77745c53181e` (actionDefinitionId `7ee15f07-6845-46e9-9388-7eadd30f76b6`, v1.0.6)
+**Deployment Folder:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**actionType:** —
+**Recipient:** Email: song.zhao@uipath.com
+**Priority:** — · **Task Title:** Approve expense · **Labels:** —
+
+**Input Schema:**
+
+| Field | Type | Binding | Required |
+|-------|------|---------|----------|
+| Content | String | `` =js:`Hi ${JSON.stringify(vars.$xref('Stage 1','Analyze Expense Request','AgentExpenseRequest'))}` `` | No |
+| Comment | String | `=js:JSON.stringify(vars.$xref('Stage 1','Record Expense via RPA','RPAExpenseRequestOut'))` | No |
+
+**Output Schema:** —
+
+**Actions:**
+
+| Button | Maps To | Behavior |
+|--------|---------|----------|
+| Approve | Action = "approve" | Complete task |
+| Reject | Action = "reject" | Complete task; diverts Stage 2 via Reject Exit1 |
+
+---
+
+##### Task 2.2: Wait for timer - S2 run once
+
+**Type:** wait-for-timer
+**Description:** Fixed delay demonstrating run-once behavior within the stage.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | Yes | — |
+
+**Timer:** timeDuration
+**Value:** PT20S
+
+---
+
+##### Task 2.3: Call Expense API
+
+**Type:** api-workflow
+**Description:** API workflow invoked with the approval comment; returns `APIOutput1`.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `selected-tasks-completed("Manager Approval")` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Resolved Resource:** API Workflow
+**Folder Path:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**Resource Identity:** apiWorkflowId `b9e4f81a-a2c5-4e6d-ab72-a819649c7666` (v1.0.6)
+**Binding Sub-Type:** Api
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| APIInput1 | string | `<- "Stage 2"."Manager Approval".Comment` |
+
+**Outputs:** —
+
+---
+
+##### Task 2.4: Wait for timer - S2 adhoc
+
+**Type:** wait-for-timer
+**Description:** Ad-hoc delay task — does not auto-start; started on demand from the case app.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `adhoc` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Timer:** timeDuration
+**Value:** PT10S
+
+---
+
+### Stage 3: Stage 3
+
+**Type:** Stage
+**Description:** External integrations after approval: waits for an inbound HTTP-webhook event, executes a connector activity to list emails, and starts a child case with the approval comment.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `selected-stage-completed("Stage 2")` | — | No | Entry from 'Stage 2' |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Tasks completed rule |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Wait for HTTP Webhook | wait-for-connector | Yes | No | — | — |
+| 2 | List Emails | execute-connector-activity | Yes | No | — | — |
+| 3 | Start Child Case | case-management | Yes | No | — | — |
+
+---
+
+##### Task 3.1: Wait for HTTP Webhook
+
+**Type:** wait-for-connector
+**Description:** Pauses the stage until an HTTP-webhook event is received from the bound connection.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Connector:** HTTP Webhook · **Connector Key:** `uipath-http-webhook`
+**Connection:** athena-cmgolden-expense-reporting · **Connection ID:** `6a817d24-cbbd-4389-b10d-4329214ffb8d`
+**Activity Type ID:** `773cab30-51dc-3eb4-b19d-720dfa151cc9` · **Service Type:** `Intsvc.WaitForEvent`
+**Auth Method:** — (AuthenticateAfterDeployment)
+**Account / Endpoint:** —
+**Operation:** Event (objectName `HTTP_WEBHOOK`, operation `GENERIC`, eventMode `webhooks`)
+**Trigger / Event:** HTTP Webhook event
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| body | json | — |
+
+**Outputs:** —
+
+---
+
+##### Task 3.2: List Emails
+
+**Type:** execute-connector-activity
+**Description:** Retrieves a capped list of Inbox emails whose subject contains "urgent". The result is not consumed downstream — this task exercises the `execute-connector-activity` step in the flow.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `selected-tasks-completed("Wait for HTTP Webhook")` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Connector:** Microsoft Outlook 365 · **Connector Key:** `uipath-microsoft-outlook365`
+**Connection:** is-sandboxes-test@uipathsandboxes.onmicrosoft.com · **Connection ID:** `dd657127-91f5-4568-a3a3-c024bc03fb0f`
+**Activity Type ID:** `5b154ea8-15bb-30a6-b07d-74a8cd1c1688` · **Service Type:** `Intsvc.ActivityExecution`
+**Auth Method:** OAuth2
+**Account / Endpoint:** —
+**Operation:** Get Email List (objectName `ListEmails`, GET `/ListEmails`)
+**Trigger / Event:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| parentFolderId | string | `"Inbox"` |
+| limit | string | `"10"` |
+| filter | string | `contains(subject,'urgent')` |
+
+**Outputs:** —
+
+---
+
+##### Task 3.3: Start Child Case
+
+**Type:** case-management
+**Description:** Launches the "Task agentic case" child case, passing the approval comment as input.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `selected-tasks-completed("List Emails")` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Resolved Resource:** Task agentic case
+**Folder Path:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**Resource Identity:** caseManagementId `deecae87-ce5a-4351-b777-92348aff3226` (v1.0.6)
+**Binding Sub-Type:** CaseManagement
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| caseInput1 | string | `=js:JSON.stringify(vars.$xref('Stage 2','Manager Approval','Comment'))` |
+
+**Outputs:** —
+
+---
+
+### Secondary Stage: Stage 4 - return to origin
+
+**Type:** Stage
+**Stage Kind:** secondary
+**Description:** Rework exception lane. Activates when Stage 2 exits (e.g. on reject). A second approval either sends the case back to its origin (approve) or marks the lane complete (reject).
+**Required for Case Completion:** No
+**Interrupting:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `selected-stage-exited("Stage 2")` | — | No | Entry rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "reject"` | exit-only | Yes | Stage 6 App Reject |
+| `selected-tasks-completed("Rework Approval")` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "approve"` | return-to-origin | No | Exit rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Rework Approval | action | Yes | No | Reviewer | — |
+
+---
+
+##### Task 4.1: Rework Approval
+
+**Type:** action
+**Description:** Second approval on the rework lane. Approve returns the case to origin; reject completes the lane.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**HITL Implementation:** Action App: SimpleApprovalApp
+**Action App ID:** `d5102769-8bac-4afc-a727-77745c53181e` (actionDefinitionId `7ee15f07-6845-46e9-9388-7eadd30f76b6`, v1.0.6)
+**Deployment Folder:** Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106
+**actionType:** —
+**Recipient:** Email: song.zhao@uipath.com
+**Priority:** — · **Task Title:** Rework approval · **Labels:** —
+
+**Input Schema:**
+
+| Field | Type | Binding | Required |
+|-------|------|---------|----------|
+| Content | String | "" (empty literal) | No |
+| Comment | String | "" (empty literal) | No |
+
+**Output Schema:** —
+
+**Actions:**
+
+| Button | Maps To | Behavior |
+|--------|---------|----------|
+| Approve | Action = "approve" | Complete task; stage returns to origin |
+| Reject | Action = "reject" | Complete task; stage marks complete |
+
+---
+
+### Stage 5: Stage 5 - connector entry
+
+**Type:** Stage
+**Description:** Event-driven stage entered when an HTTP-webhook event arrives, independent of the linear flow. On completion it hands off to a user-selected next stage.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `wait-for-connector` (HTTP Webhook event) | — | No | Entry rule 1 |
+
+**Connector Rule Detail:**
+- Connector: HTTP Webhook · Connector Key: `uipath-http-webhook`
+- Connection: athena-cmgolden-expense-reporting · Connection ID: `6a817d24-cbbd-4389-b10d-4329214ffb8d`
+- Activity Type ID: `773cab30-51dc-3eb4-b19d-720dfa151cc9` · Service Type: `Intsvc.WaitForEvent`
+- Event: HTTP Webhook event (objectName `HTTP_WEBHOOK`, operation `GENERIC`, eventMode `webhooks`)
+- Filter: —
+- Event Parameters: —
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | wait-for-user | Yes | Stage complete |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Wait for timer - S5 | wait-for-timer | Yes | No | — | — |
+
+---
+
+##### Task 5.1: Wait for timer - S5
+
+**Type:** wait-for-timer
+**Description:** Fixed delay after event entry, before the user-select handoff.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Timer:** timeDuration
+**Value:** PT10S
+
+---
+
+### Stage 6: Stage 6 - to be interrupted
+
+**Type:** Stage
+**Description:** Long-running timer stage entered after Stage 3, demonstrating a stage that can be interrupted. Not required for case completion.
+**Required for Case Completion:** No
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `selected-stage-completed("Stage 3")` | — | No | Entry rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Completion rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Timer to be interrupted | wait-for-timer | Yes | No | — | — |
+
+---
+
+##### Task 6.1: Timer to be interrupted
+
+**Type:** wait-for-timer
+**Description:** Long delay that can be interrupted before it elapses.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Timer:** timeDuration
+**Value:** PT20M
+
+---
+
+### Stage 7: Stage 7 - user select
+
+**Type:** Stage
+**Description:** Entered when a user selects it as the next stage from an upstream `wait-for-user` exit (Stage 5). Runs a short timer before handing to the completion-delay stage.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `user-selected-stage` | — | No | Entry rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Completion rule 1 |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Wait for timer - S7 | wait-for-timer | Yes | No | — | — |
+
+---
+
+##### Task 7.1: Wait for timer - S7
+
+**Type:** wait-for-timer
+**Description:** Fixed delay on the user-selected stage.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `current-stage-entered` | — | Entry rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Timer:** timeDuration
+**Value:** PT10S
+
+---
+
+### Stage 8: Stage 8 - delay case completion
+
+**Type:** Stage
+**Description:** Final stage that delays case completion with a short timer after the user-selected stage completes.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| `selected-stage-completed("Stage 7")` | — | No | Stage entry |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| `required-tasks-completed` | — | exit-only | Yes | Stage complete |
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Wait for timer - S8 | wait-for-timer | Yes | No | — | — |
+
+---
+
+##### Task 8.1: Wait for timer - S8
+
+**Type:** wait-for-timer
+**Description:** Short delay before case completion.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| `runs-sequentially` | — | Task entry |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+**Timer:** timeDuration
+**Value:** PT5S
+
+---
+
+## Section 3: Personas & App Views
+
+### Personas
+
+| Persona | Stage Scope | Permissions | Description |
+|---------|-------------|-------------|-------------|
+| Reviewer | Stage 2, Stage 4 - return to origin | View, Act | Approves or rejects the expense via the SimpleApprovalApp action app; drives the reject/rework routing. |
+
+### Process App Views
+
+> Case App is Enabled. No custom views are defined in the source; the default case list and case detail views apply.
+
+| App | View | Persona | Purpose | Key Components |
+|-----|------|---------|---------|----------------|
+| Case App | Case Detail | Reviewer | Review expense and act on approval tasks | Stage timeline, approval action, comment |
+
+---
+
+## Section 4: Integrations
+
+> All deployed resources below are pre-deployed in the **`Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106`** solution folder and must be resolved within it — each name is unique inside this folder. Connections are existing tenant connections bound by Connection ID: the HTTP Webhook connection `athena-cmgolden-expense-reporting` and the Outlook 365 sandbox connection `is-sandboxes-test@uipathsandboxes.onmicrosoft.com` in the parent `Shared/uipath-maestro-case` folder.
+
+### Integration Service Connectors
+
+| Connector | Connector Key | System | Connection (ID) | Auth Method | Operations Used | Used By Tasks |
+|-----------|---------------|--------|-----------------|-------------|-----------------|---------------|
+| HTTP Webhook | `uipath-http-webhook` | HTTP Webhook | athena-cmgolden-expense-reporting (`6a817d24-cbbd-4389-b10d-4329214ffb8d`) | AuthenticateAfterDeployment | Event (GENERIC) | Wait for HTTP Webhook; Stage 5 entry rule |
+| Microsoft Outlook 365 | `uipath-microsoft-outlook365` | Microsoft Outlook 365 | is-sandboxes-test@uipathsandboxes.onmicrosoft.com (`dd657127-91f5-4568-a3a3-c024bc03fb0f`) | OAuth2 | Get Email List | List Emails |
+
+#### HTTP Webhook
+
+**Operations:**
+
+| Operation | Activity Type ID | Method | Input Fields | Output Fields |
+|-----------|------------------|--------|-------------|---------------|
+| Event (GENERIC) | `773cab30-51dc-3eb4-b19d-720dfa151cc9` | EVENT | body: json | response (request_body: string, request_headers: string) |
+
+#### Microsoft Outlook 365
+
+**Operations:**
+
+| Operation | Activity Type ID | Method | Input Fields | Output Fields |
+|-----------|------------------|--------|-------------|---------------|
+| Get Email List | `5b154ea8-15bb-30a6-b07d-74a8cd1c1688` | GET | parentFolderId (required), limit, filter, unReadOnly, importance, withAttachmentsOnly, includeSubfolders, markAsRead, conversationId | email list: subject, from, receivedDateTime, isRead, … |
+
+### API Workflows
+
+| Workflow | Folder | Resource ID (+version) | Inputs → Outputs | Used By Tasks |
+|----------|--------|------------------------|------------------|---------------|
+| API Workflow | Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106 | `b9e4f81a-a2c5-4e6d-ab72-a819649c7666` (v1.0.6) | APIInput1 → APIOutput1 | Call Expense API |
+
+### Agents
+
+| Agent | Folder | Resource ID (+version) | Inputs → Outputs | Used By Tasks |
+|-------|--------|------------------------|--------------------|---------------|
+| Agent | Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106 | `ccf5793f-54ab-4262-bf44-fcd09a52ed4e` (v1.0.6) | expenseRequest → AgentExpenseRequest | Analyze Expense Request |
+
+### Processes & RPA
+
+| Resource | Type | Folder | Resource ID (+version) | Used By Tasks |
+|----------|------|--------|------------------------|---------------|
+| Agentic Process | process (ProcessOrchestration) | Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106 | `7d01a11a-c8a3-41b0-b30f-f65c4d7ddbb9` (v1.0.6) | Process Expense Request |
+| RPA Workflow | rpa | Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106 | `0bc08e50-b45a-401c-aec8-a720e1d190e3` (v1.0.6) | Record Expense via RPA |
+
+### Child Cases
+
+| Child Case | Identifier Prefix | Wait for Completion | Used By Tasks |
+|------------|-------------------|---------------------|---------------|
+| Task agentic case | CASE | — | Start Child Case |

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/test_checkers.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/test_checkers.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Offline behavioral tests for the CM-Golden deterministic graders."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent
+TOPOLOGY_CHECKER = ROOT / "check_cm_golden_case.py"
+
+
+def condition(rule_name: str, **rule_fields: object) -> dict:
+    return {"rules": [[{"rule": rule_name, **rule_fields}]]}
+
+
+def task(
+    task_id: str,
+    task_type: str,
+    display_name: str,
+    *,
+    duration: str | None = None,
+    run_once: bool = False,
+) -> dict:
+    data = {"duration": duration} if duration else {}
+    return {
+        "id": task_id,
+        "type": task_type,
+        "displayName": display_name,
+        "shouldRunOnlyOnce": run_once,
+        "data": data,
+        "entryConditions": [],
+        "exitConditions": [],
+    }
+
+
+def stage(
+    number: int,
+    tasks: list[dict],
+    *,
+    label: str | None = None,
+    secondary: bool = False,
+    entry_conditions: list[dict] | None = None,
+) -> dict:
+    data = {
+        "label": label or f"Stage {number}",
+        "tasks": [[item] for item in tasks],
+        "entryConditions": entry_conditions or [],
+        "exitConditions": [],
+    }
+    if secondary:
+        data["stageType"] = "secondary"
+    return {
+        "id": f"stage-{number}",
+        "type": "case-management:Stage",
+        "data": data,
+    }
+
+
+def expected_caseplan() -> dict:
+    stages = [
+        stage(
+            1,
+            [
+                task("task-1-agent", "agent", "Analyze Expense Request"),
+                task("task-1-process", "process", "Process Expense Request"),
+                task("task-1-rpa", "rpa", "Record Expense via RPA"),
+            ],
+        ),
+        stage(
+            2,
+            [
+                task("task-2-action", "action", "Manager Approval"),
+                task(
+                    "task-2-timer-once",
+                    "wait-for-timer",
+                    "Wait for timer - S2 run once",
+                    duration="PT20S",
+                    run_once=True,
+                ),
+                task("task-2-api", "api-workflow", "Call Expense API"),
+                task(
+                    "task-2-timer-adhoc",
+                    "wait-for-timer",
+                    "Wait for timer - S2 adhoc",
+                    duration="PT10S",
+                ),
+            ],
+            entry_conditions=[
+                condition("selected-stage-completed", selectedStageId="stage-1")
+            ],
+        ),
+        stage(
+            3,
+            [
+                task("task-3-webhook", "wait-for-connector", "Wait for HTTP Webhook"),
+                task("task-3-email", "execute-connector-activity", "List Emails"),
+                task("task-3-case", "case-management", "Start Child Case"),
+            ],
+            entry_conditions=[
+                condition("selected-stage-completed", selectedStageId="stage-2")
+            ],
+        ),
+        stage(
+            4,
+            [task("task-4-action", "action", "Rework Approval")],
+            label="Stage 4 - return to origin",
+            secondary=True,
+            entry_conditions=[
+                condition("selected-stage-exited", selectedStageId="stage-2")
+            ],
+        ),
+        stage(
+            5,
+            [
+                task(
+                    "task-5-timer",
+                    "wait-for-timer",
+                    "Wait for timer - S5",
+                    duration="PT20M",
+                )
+            ],
+            label="Stage 5 - connector entry",
+        ),
+        stage(
+            6,
+            [
+                task(
+                    "task-6-timer",
+                    "wait-for-timer",
+                    "Timer to be interrupted",
+                    duration="PT5S",
+                )
+            ],
+            label="Stage 6 - to be interrupted",
+            entry_conditions=[
+                condition("selected-stage-completed", selectedStageId="stage-3")
+            ],
+        ),
+        stage(
+            7,
+            [task("task-7-timer", "wait-for-timer", "Wait for timer - S7")],
+            label="Stage 7 - user select",
+        ),
+        stage(
+            8,
+            [task("task-8-timer", "wait-for-timer", "Wait for timer - S8")],
+            entry_conditions=[
+                condition("selected-stage-completed", selectedStageId="stage-7")
+            ],
+        ),
+    ]
+    return {
+        "metadata": {
+            "caseIdentifier": "EXP",
+            "caseDirectlyPassTaskOutputs": True,
+            "intsvcActivityConfig": "v2",
+            "caseExitRules": [
+                {
+                    **condition("required-stages-completed"),
+                    "marksCaseComplete": True,
+                },
+                {
+                    **condition(
+                        "selected-stage-completed", selectedStageId="stage-4"
+                    ),
+                    "marksCaseComplete": False,
+                },
+            ],
+            "slaRules": [
+                {
+                    "count": 1,
+                    "unit": "h",
+                    "escalationRule": [
+                        {
+                            "triggerInfo": {
+                                "type": "at-risk",
+                                "atRiskPercentage": 70,
+                            },
+                            "recipient": "song.zhao@uipath.com",
+                        },
+                        {"triggerInfo": {"type": "breached"}},
+                    ],
+                }
+            ],
+        },
+        "nodes": [
+            {
+                "id": "manual-trigger",
+                "type": "case-management:Trigger",
+                "data": {"uipath": {"serviceType": "Manual"}},
+            },
+            *stages,
+        ],
+    }
+
+
+def run_topology_checker(plan: dict) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        caseplan = (
+            Path(temporary)
+            / "CMGoldenExpense"
+            / "CMGoldenExpense"
+            / "caseplan.json"
+        )
+        caseplan.parent.mkdir(parents=True)
+        caseplan.write_text(json.dumps(plan), encoding="utf-8")
+        return subprocess.run(
+            [sys.executable, str(TOPOLOGY_CHECKER)],
+            cwd=temporary,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+
+class CMGoldenCheckerTests(unittest.TestCase):
+    def test_topology_checker_accepts_expected_structure(self) -> None:
+        result = run_topology_checker(copy.deepcopy(expected_caseplan()))
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_topology_checker_rejects_missing_stage(self) -> None:
+        plan = expected_caseplan()
+        plan["nodes"] = [
+            node
+            for node in plan["nodes"]
+            if (node.get("data") or {}).get("label") != "Stage 8"
+        ]
+
+        result = run_topology_checker(plan)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("missing stage 'Stage 8'", result.stdout + result.stderr)
+
+    def test_topology_checker_rejects_missing_task(self) -> None:
+        plan = expected_caseplan()
+        stage_1 = next(
+            node
+            for node in plan["nodes"]
+            if (node.get("data") or {}).get("label") == "Stage 1"
+        )
+        stage_1["data"]["tasks"].pop()
+
+        result = run_topology_checker(plan)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected exactly 15 tasks, got 14", result.stdout + result.stderr)
+
+    def test_topology_checker_rejects_extra_task(self) -> None:
+        plan = expected_caseplan()
+        stage_1 = next(
+            node
+            for node in plan["nodes"]
+            if (node.get("data") or {}).get("label") == "Stage 1"
+        )
+        stage_1["data"]["tasks"].append(
+            [task("unexpected-task", "agent", "Unexpected Task")]
+        )
+
+        result = run_topology_checker(plan)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("expected exactly 15 tasks, got 16", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Adds the live-tenant CM-Golden expense-reporting rebuild eval under `tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/`.

The staged SDD describes a feature-dense Case Management solution with 8 stages, 15 tasks across all 9 task types, a secondary rework lane, connector tasks, task-output dataflow, approval gates, timers, and SLA escalation.

## Why

Existing build tasks allow offline/skeleton resource bindings. This task exercises the full live resolution path and deterministically grades the generated artifacts without an LLM judge or dependence on a specific command sequence.

## Grading design

The six outcome-based criteria are:

1. `uip maestro case validate` passes.
2. The generated plan preserves the exact stage/task topology, secondary lane, transitions, runtime flags, timers, and SLA contract.
3. Resource and connector tasks resolve to the SDD's expected name/folder keys, connection IDs, activity IDs, service types, and non-skeleton task shapes.
4. Dataflow and gate semantics are correct: generated output IDs are globally unique, consumers reference the correct logical producer, and Stage 2/Stage 4 use the correct approval output and polarity. Generated identifiers are resolved by ownership; names such as `action`/`action2` are not hardcoded.
5. Task 1.1 preserves the exact `expenseRequest` seed object, graded separately at low weight.
6. Debug and publish remain forbidden because this case suspends on HITL, timers, and a webhook.

The grader no longer scores skill activation, command history, raw resource-GUID presence, imported manifests, or an LLM review.

## Checker coverage

- `check_cm_golden_case.py`: exactly 8 stages, exactly 15 tasks, per-stage task-type multisets, secondary lane, transitions, exits, trigger, run-once timer, runtime flags, SLA, durations, and case identifier.
- `check_cm_golden_bindings.py`: live name/folder bindings plus connector connection/activity/service contracts; no skeleton tasks.
- `check_cm_golden_semantics.py`: exact logical task names, output ownership/uniqueness, producer-consumer dataflow, action recipients, stage/task condition sets, and approval/rework gate polarity.
- `check_cm_golden_seed.py`: exact seed-object fidelity, accepting native or JSON-encoded objects.
- `test_checkers.py`: portable offline mutation tests proving the topology checker accepts the golden structure and rejects missing stages, missing tasks, and extra tasks.

## Tenant precondition

The CM-Golden reference solution must remain deployed at the folder and connector identities pinned in `fixtures/sdd.md` (currently v1.0.6, folder `Shared/uipath-maestro-case/CM-Golden-Expense-Reporting-106`). A reinstall requires re-sweeping that fixture.

## Validation

- Squashed to one commit on current `main`; the final tree is byte-identical to the tree exercised by the passing run.
- [GitHub Actions coder-eval run 29367011483](https://github.com/UiPath/skills/actions/runs/29367011483): **SUCCESS**, 6/6 criteria, weighted score **1.000**, 1/1 task passed.
- `uip maestro case validate` and topology, live-binding, semantic, seed, and safety criteria all passed.
- All 4 offline topology-checker mutation tests pass.
- Known-good artifact passes all 4 deterministic checker scripts.

Post-run cleanup reported one non-grading warning: it could not delete generated solution `5d988fc7-c6e1-47ee-8001-761176861572`.

🤖 Generated with [Codex](https://openai.com/codex/)
