### PR TITLE
docs(uipath-maestro-flow): connector connection binding name = <connector-key> connection

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/data-fabric/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/data-fabric/impl.md
@@ -27,7 +27,7 @@ Use the exact CamelCase `Name` (e.g. `BankDetails`). For Create/Update, also run
 
 Author the standard top-level `bindings[]` pair (`ConnectionId` + `FolderKey`) per [parent impl.md § Top-level `bindings[]` shape](../impl.md#top-level-bindings-shape-cli-emitted-reference-only). Data Fabric specifics:
 
-- Connection binding `name` = the IS connection display name (not the `<CONNECTOR_KEY> connection` placeholder), since `node configure` is run with this value pre-resolved.
+- Connection binding `name` = `uipath-uipath-dataservice connection` (the `<CONNECTOR_KEY> connection` convention) — must match the definition's `connection` placeholder in the templates below. NOT the IS connection display name / email: a display-name value silently faults at debug with `102010 'Connection' has an invalid GUID value: '<bindings.uipath-uipath-dataservice connection>'`. (The display name belongs only in `bindings_v2.json`'s `displayName` and the connection resource filename.)
 - Both bindings share the same `resourceKey` = `<connectionId>`.
 
 Add one `definitions[]` entry per activity type used — copy the complete entry from the Definitions Templates section below. The `form` block is required ([parent impl.md § Critical: Connector Definition Must Include `form`](../impl.md#critical-connector-definition-must-include-form)).
@@ -199,7 +199,7 @@ Add one entry per activity type used to `definitions[]` in the `.flow` file (sib
       { "name": "operation",    "type": "string" },
       { "name": "objectName",   "type": "string", "value": "QueryEntityRecordsCurated" },
       { "name": "method",       "type": "string", "value": "POST" },
-      { "name": "connection",   "type": "string", "value": "<bindings.<IS connection Name>>" },
+      { "name": "connection",   "type": "string", "value": "<bindings.uipath-uipath-dataservice connection>" },
       { "name": "folderKey",    "type": "string", "value": "<bindings.FolderKey>" },
       { "name": "activityConfigurationVersion", "type": "string", "value": "v1" },
       { "name": "metadata", "type": "json", "body": { "telemetryData": { "connectorKey": "uipath-uipath-dataservice", "connectorName": "Query Entity Records" }, "inputMetadata": {}, "errorState": { "hasError": false } } }
@@ -264,7 +264,7 @@ Add one entry per activity type used to `definitions[]` in the `.flow` file (sib
       { "name": "operation",    "type": "string" },
       { "name": "objectName",   "type": "string", "value": "CreateEntityRecordCurated" },
       { "name": "method",       "type": "string", "value": "POST" },
-      { "name": "connection",   "type": "string", "value": "<bindings.<IS connection Name>>" },
+      { "name": "connection",   "type": "string", "value": "<bindings.uipath-uipath-dataservice connection>" },
       { "name": "folderKey",    "type": "string", "value": "<bindings.FolderKey>" },
       { "name": "activityConfigurationVersion", "type": "string", "value": "v1" },
       { "name": "metadata", "type": "json", "body": { "telemetryData": { "connectorKey": "uipath-uipath-dataservice", "connectorName": "Create Entity Record" }, "inputMetadata": {}, "errorState": { "hasError": false } } }
@@ -329,7 +329,7 @@ Add one entry per activity type used to `definitions[]` in the `.flow` file (sib
       { "name": "operation",    "type": "string" },
       { "name": "objectName",   "type": "string", "value": "UpdateEntityRecordV2" },
       { "name": "method",       "type": "string", "value": "PUT" },
-      { "name": "connection",   "type": "string", "value": "<bindings.<IS connection Name>>" },
+      { "name": "connection",   "type": "string", "value": "<bindings.uipath-uipath-dataservice connection>" },
       { "name": "folderKey",    "type": "string", "value": "<bindings.FolderKey>" },
       { "name": "activityConfigurationVersion", "type": "string", "value": "v1" },
       { "name": "metadata", "type": "json", "body": { "telemetryData": { "connectorKey": "uipath-uipath-dataservice", "connectorName": "Update Entity Record" }, "inputMetadata": {}, "errorState": { "hasError": false } } }
@@ -394,7 +394,7 @@ Add one entry per activity type used to `definitions[]` in the `.flow` file (sib
       { "name": "operation",    "type": "string" },
       { "name": "objectName",   "type": "string", "value": "DeleteEntityRecordCurated" },
       { "name": "method",       "type": "string", "value": "POST" },
-      { "name": "connection",   "type": "string", "value": "<bindings.<IS connection Name>>" },
+      { "name": "connection",   "type": "string", "value": "<bindings.uipath-uipath-dataservice connection>" },
       { "name": "folderKey",    "type": "string", "value": "<bindings.FolderKey>" },
       { "name": "activityConfigurationVersion", "type": "string", "value": "v1" },
       { "name": "metadata", "type": "json", "body": { "telemetryData": { "connectorKey": "uipath-uipath-dataservice", "connectorName": "Delete Entity Record" }, "inputMetadata": {}, "errorState": { "hasError": false } } }
@@ -459,7 +459,7 @@ Add one entry per activity type used to `definitions[]` in the `.flow` file (sib
       { "name": "operation",    "type": "string" },
       { "name": "objectName",   "type": "string", "value": "GetEntityRecordByIdCurated" },
       { "name": "method",       "type": "string", "value": "GET" },
-      { "name": "connection",   "type": "string", "value": "<bindings.<IS connection Name>>" },
+      { "name": "connection",   "type": "string", "value": "<bindings.uipath-uipath-dataservice connection>" },
       { "name": "folderKey",    "type": "string", "value": "<bindings.FolderKey>" },
       { "name": "activityConfigurationVersion", "type": "string", "value": "v1" },
       { "name": "metadata", "type": "json", "body": { "telemetryData": { "connectorKey": "uipath-uipath-dataservice", "connectorName": "Get Entity Record by ID" }, "inputMetadata": {}, "errorState": { "hasError": false } } }

--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -554,7 +554,7 @@ For every unique connection used in the flow, `node configure` appends **two ent
 | Field | Value |
 |-------|-------|
 | `id` | Unique string within the file. Descriptive (e.g. `bJiraConn`) or short random (e.g. `bKEFLMRB2`). |
-| `name` (connection binding) | The IS connection name (e.g. `"chandu.lella@uipath.com #3"`). `uip maestro flow node configure` fetches this from IS automatically — this is the supported path. The placeholder form `"<CONNECTOR_KEY> connection"` appears in the table for reference only (e.g. when inspecting a flow whose bindings have not yet been configured); it must match the definition's `model.context[].connection` placeholder (without the `<bindings.` prefix and `>` suffix). |
+| `name` (connection binding) | `"<CONNECTOR_KEY> connection"` — must match the definition's `model.context[].connection` placeholder (the `<bindings.…>` inner text). Matching is name-only (rule above). `node configure` writes it. NOT the IS connection display name / email — a display-name value silently faults at debug with `102010 'Connection' has an invalid GUID value: '<bindings.<CONNECTOR_KEY> connection>'`. |
 | `name` (folder binding) | Literal `"FolderKey"` — matches `<bindings.FolderKey>`. |
 | `type` | Always `"string"`. |
 | `resource` | Always `"Connection"` — capital C, case-sensitive. |


### PR DESCRIPTION
## Problem

A Maestro Flow using a Data Fabric (Data Service) connector node faults at `flow debug` with:

```
[102010] Integration Services invalid value in input
'Connection' has an invalid GUID value: '<bindings.uipath-uipath-dataservice connection>'
```

The connector connection binding never resolves — the raw `<bindings.…>` placeholder reaches Integration Services.

## Root cause — skill doc bug

The flow→BPMN converter resolves a connector's connection by matching the definition's `model.context[].connection` placeholder (`<bindings.<CONNECTOR_KEY> connection>`) against a top-level `bindings[]` entry **by `name`, name-only**. So the binding `name` must be the `<CONNECTOR_KEY> connection` convention.

Two docs instructed the **IS connection display name** (e.g. an email) instead:

- `connector/impl.md:557` — table row claimed binding `name` = the IS connection display name (`chandu.lella@uipath.com #3`). Self-contradictory (same sentence then says it must match the `<CONNECTOR_KEY> connection` placeholder).
- `connector/data-fabric/impl.md` — worse: an explicit rule (Step 3) *and* all 5 definition templates hardcoded `<bindings.<IS connection Name>>`. Following the doc literally produced a binding named after the connection's owner email + a rewritten definition placeholder → resolver finds no match → 102010.

## Fix

- `connector/impl.md`: correct the table row — binding `name` = `"<CONNECTOR_KEY> connection"`, matches the definition placeholder, name-only. Added the exact 102010 failure signature as a tripwire.
- `connector/data-fabric/impl.md`: correct the Step 3 rule and all 5 definition-template `connection` placeholders to `<bindings.uipath-uipath-dataservice connection>`. Clarified the display name belongs only in `bindings_v2.json`'s `displayName` and the connection resource filename.

## Validation

Reproduced on a failing devcon `BillingDisputeResolution` build (crmLookup faulted `102010`). Patched the built flow to match this fix (binding `name` → convention, reverted the definition placeholder) and re-ran `uip maestro flow debug`:

- `102010` gone, no raw `<bindings.…>` placeholder
- `crmLookup`, `erpLookup`, `merge`, `discrepancyDetection` all **Completed** (previously faulted at `crmLookup`)

No dependency on #1942 (disjoint files).
