### PR TITLE
fix(tests): install coder-eval from public PyPI in make install

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -10,17 +10,9 @@ help:  ## Show available commands
 	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Install coder-eval into local .venv (requires Python 3.13+; UV_INDEX_UIPATH_USERNAME/PASSWORD optional for private ml-packages feed)
+install:  ## Install coder-eval into local .venv (requires Python 3.13+)
 	uv venv --python 3.13 $(VENV)
-	@if [ -n "$$UV_INDEX_UIPATH_USERNAME" ] && [ -n "$$UV_INDEX_UIPATH_PASSWORD" ]; then \
-	  echo "Using UiPath private PyPI feed (ml-packages)."; \
-	  UV_EXTRA_INDEX_URL="https://$$UV_INDEX_UIPATH_USERNAME:$$UV_INDEX_UIPATH_PASSWORD@uipath.pkgs.visualstudio.com/_packaging/ml-packages/pypi/simple/" \
-	    uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
-	else \
-	  echo "UV_INDEX_UIPATH_USERNAME/PASSWORD not set — installing without the UiPath private PyPI feed."; \
-	  echo "Set both variables before running 'make install' if you need packages from the ml-packages feed."; \
-	  uv pip install --python $(VENV)/bin/python "coder-eval @ git+https://github.com/UiPath/coder_eval.git"; \
-	fi
+	uv pip install --python $(VENV)/bin/python coder-eval
 	@echo ""
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,6 +2,7 @@
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
 VENV := .venv
+CODER_EVAL_VERSION := $(shell tr -d '[:space:]' < .coder-eval-version)
 CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(VENV)/bin/coder-eval
 TASKS := $(shell find tasks -name '*.yaml' -type f)
 TASK_PARALLELISM ?= 1
@@ -10,9 +11,9 @@ help:  ## Show available commands
 	@grep -E '^[a-zA-Z0-9_%-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 	  awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
-install:  ## Install coder-eval into local .venv (requires Python 3.13+)
+install:  ## Install coder-eval into local .venv (pinned to .coder-eval-version; requires Python 3.13+)
 	uv venv --python 3.13 $(VENV)
-	uv pip install --python $(VENV)/bin/python coder-eval
+	uv pip install --python $(VENV)/bin/python "coder-eval==$(CODER_EVAL_VERSION)"
 	@echo ""
 	@echo "See https://github.com/UiPath/coder_eval for environment setup (.env, API keys, etc.)"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,27 +4,20 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
 
 ## Prerequisites
 
-1. **UiPath private PyPI credentials** (optional) — only needed if `coder-eval` resolves to packages on the UiPath Azure DevOps `ml-packages` feed. Export these **before** running `make install` to enable the private feed:
-   ```bash
-   export UV_INDEX_UIPATH_USERNAME=<your-ado-username>
-   export UV_INDEX_UIPATH_PASSWORD=<your-ado-pat>
-   ```
-   The Makefile composes these into `UV_EXTRA_INDEX_URL` for `uv pip install`. If either variable is empty, install continues against public PyPI only and prints a notice.
-
-2. **coder-eval** — install from GitHub (creates a local `.venv`, requires Python 3.13+):
+1. **coder-eval** — install from public PyPI (creates a local `.venv`, requires Python 3.13+):
    ```bash
    cd tests
    make install
    ```
 
-3. **uip CLI** — the UiPath CLI must be available:
+2. **uip CLI** — the UiPath CLI must be available:
    ```bash
    npm install -g @uipath/cli
    ```
 
    > **Do not add `@uipath/cli` to `sandbox.node.env_packages` in task YAMLs.** The GH smoke runner installs it globally before any task runs. Listing it in `env_packages` is redundant and, when pinned to a version, causes skew against the runner's `@latest` install.
 
-4. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
+3. **Environment setup** — API keys and other environment variables are required. See the [coder_eval README](https://github.com/UiPath/coder_eval) for environment setup (`.env`, API keys, etc.).
 
 ## Running Tests
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -4,7 +4,7 @@ Tests that verify AI agents can correctly use skills from this repository. Tests
 
 ## Prerequisites
 
-1. **coder-eval** — install from public PyPI (creates a local `.venv`, requires Python 3.13+):
+1. **coder-eval** — install from public PyPI, pinned to `.coder-eval-version` (creates a local `.venv`, requires Python 3.13+):
    ```bash
    cd tests
    make install


### PR DESCRIPTION
## What

`coder-eval` is now published on public PyPI. Simplify `tests/Makefile`'s `install` target to a plain `uv pip install coder-eval`, dropping:

- the `UV_INDEX_UIPATH_USERNAME`/`UV_INDEX_UIPATH_PASSWORD` private `ml-packages` feed branching
- the `coder-eval @ git+https://github.com/UiPath/coder_eval.git` source

Also removes the now-obsolete private-feed prerequisite from `tests/README.md`.

## Why

Follows #1969 (CI now installs coder-eval from public PyPI). The local `make install` path was still on the old git+private-feed flow.

## Scope notes

The remaining `UV_INDEX_UIPATH_PASSWORD` references in `.github/workflows/` (run-coder-eval.yml, smoke-rpa-skills.yml) are for a **NuGet/Helm feed**, not the pip `coder-eval` install — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)