### PR TITLE
docs(connector-builder): dropdown + curation-layer authoring guide

### DIFF
--- a/skills/uipath-connector-builder/references/standard-resources.md
+++ b/skills/uipath-connector-builder/references/standard-resources.md
@@ -172,7 +172,21 @@ if a dependent path's `{token}` or a rule's `refFieldName` names nothing on the 
 escape hatch — an array of `{ actionType: show|hide|required|optional, rules: [{ type:"field",
 refFieldName:"<other>", refFieldValues:["card"], isCleared:false }] }`. Use `refFieldValues:["*"]`
 for "any value", `isCleared:true` to fire when the ref field is empty; multiple rules in one action
-are ANDed.
+are ANDed. **`--depends-on` vs `--field-actions`:** use `--depends-on` for a dependent dropdown
+(show once the parent has ANY value — it hard-codes `["*"]`); use `--field-actions` when the child
+should appear only for a SPECIFIC parent value (e.g. `refFieldValues:["task"]`).
+
+**Dropdowns on path / query params** work identically — the same flags exist on `activity param
+create`. For a **path variable** just pass `--type path`: the CLI auto-encodes it as `type:"query"`
++ `vendorType:"path"` when the variable isn't a segment of the flat internal path (element-service
+interpolates it into the vendor path — a literal `type:"path"` there would 400). Example — a `boardId`
+path-param dependent dropdown scoped by `projectId`:
+
+```
+activity param create --resource cards --method POST --name boardId --type path \
+  --reference-object boards --reference-path "/projects/{projectId}/boards" \
+  --lookup-value id --lookup-names id,name --display-pattern "{name}" --depends-on projectId
+```
 
 ## Bulk field authoring — `--fields` / `--fields-file`
 `activity create --fields '<json-array>'` (inline) or `--fields-file <path>` seeds the whole

--- a/skills/uipath-connector-builder/references/standard-resources.md
+++ b/skills/uipath-connector-builder/references/standard-resources.md
@@ -57,6 +57,28 @@ defines `GET`/`GETBYID`); a write-only activity keeps its base path. A per-metho
 is derived from the canonical resource path. Only model GETBYID for TRUE by-id endpoints,
 not a search/list-by-filter endpoint.
 
+### nested / parent-id vendor paths (mid-path `{token}`)
+A path variable is bound on TWO sides: element-side `{name}` in the internal `path`, vendor-side
+`{vendorName}` in the `vendorPath`. When a `{token}` sits **only in the vendor path** — a
+parent-scoped sub-collection like `--vendor-path /issue/{issueId}/comment` whose internal slug is the
+flat `/comments` — it CANNOT be `type:"path"`: element-service looks for the segment in the flat
+element URL, doesn't find it, and 400s **"required parameter '<name>' not found"** at request time
+(reads/writes on comments/transitions/assignee/attachments all fail). `activity create` now emits the
+right shape automatically:
+
+- **query→path (default for a vendor-only token):** internal `/comments`, param
+  `{ name:"issueId", type:"query", vendorName:"issueId", vendorType:"path" }`. Element-service takes the
+  value as a query param and interpolates it into the vendor template. This is how shipped connectors
+  (e.g. Jira `curated_add_comment`) declare parent ids. Callers pass it at run time via
+  `uip is resources run … --query issueId=<id>`.
+- **path→path (token in the internal path):** pass `--resource-path /comments/{id}` so `{id}` is a real
+  element URL segment → `type:"path"`. If the internal and vendor tokens differ in name, the param is
+  `{ name:"id", vendorName:"issueId", type:"path", vendorType:"path" }` (name↔internal, vendorName↔vendor);
+  the CLI can't auto-derive a differing pair, so author it with `activity param create`.
+
+`validate` now flags both failure modes: a `type:"path"` param whose `{name}` is missing from the
+internal path, and a `{token}` in the vendorPath with no param sending it (unbound → 404).
+
 ## metadata.events
 `{ "eventMode": ["polling"] }` — `trigger create` sets this. Full `eventMode` value set:
 [events.md](events.md) §"SR-level event metadata".
@@ -107,9 +129,49 @@ Queues), `hidden` (what `--hidden` writes — the field-level key is `design.hid
 `isHidden`), `loadByDefault`, `isMultiSelect`, `enableUserOverride`, `dictionaryWidget`,
 `solutionResourceKind`, `fieldActions` (cascading show/hide based on another field's value).
 
-**reference** object (lookup dropdown): `{ "objectName": "accounts", "path": "/accounts",
-"lookupValue": "id", "lookupNames": ["name"] }` — set with `--reference '<json>'` (or `state
-patch`). `objectName` + `path` are REQUIRED (`validate` and `--reference` both enforce it).
+### Dropdowns (reference / lookup)
+A dropdown lists rows from a **List resource in this connector** — you choose which field is
+DISPLAYED and which is SENT. A dropdown can live on a **field, a path param, or a query param**, so
+the same flags exist on both `activity field create` and `activity param create`:
+
+```
+--reference-object <name>   target List resource's object name (e.g. teams)
+--reference-path <path>     its list path (e.g. /teams); use {parent} for a dependent dropdown
+--lookup-value <field>      the ONE field sent as the value (e.g. id)
+--lookup-names <csv>        display-candidate fields (e.g. id,displayName)
+--display-pattern <p>       visible label, e.g. "{displayName}" or "{name} - {id}" (combines lookupNames)
+--filter-pattern <p>        server-side type-ahead template with {filter} (optional)
+--load-by-default           populate the list on open;  --multi-select;  --enable-user-override
+```
+
+The reference points at a resource whose GET is `operation:"List"`; `lookupValue`/`lookupNames`
+name fields in that resource's returned records. Raw `--reference '<json>'` (`{objectName,path,
+lookupValue,lookupNames}`) is still accepted as an escape hatch. `objectName`+`path`+`lookupValue`
+are expected; `validate` warns if `lookupValue` is missing.
+
+**Dependent dropdowns** (child list scoped by a parent — e.g. Teams channel depends on team): put
+`{<parentName>}` in the child's `--reference-path` (must equal the parent field/param's name) and
+pass `--depends-on <parentName>`. That injects `design.isHidden` + a show/hide `fieldActions` pair,
+so the child appears only after the parent has a value and its list is filtered by the parent:
+
+```
+activity field create --resource messages --name team_id --reference-object teams \
+  --reference-path /teams --lookup-value id --lookup-names id,displayName \
+  --display-pattern "{displayName}" --load-by-default --method "POST=request,required"
+activity field create --resource messages --name channel_id --depends-on team_id \
+  --reference-object "teams::channels" --reference-path "/teams/{team_id}/channels" \
+  --lookup-value id --lookup-names id,displayName --display-pattern "{displayName}" \
+  --method "POST=request,required"
+```
+
+The parent (`team_id`) must exist as a sibling field/param on the same resource — `validate` warns
+if a dependent path's `{token}` or a rule's `refFieldName` names nothing on the resource.
+
+**Show/hide on a value** (conditional field, not a lookup): `--field-actions '<json>'` is the
+escape hatch — an array of `{ actionType: show|hide|required|optional, rules: [{ type:"field",
+refFieldName:"<other>", refFieldValues:["card"], isCleared:false }] }`. Use `refFieldValues:["*"]`
+for "any value", `isCleared:true` to fire when the ref field is empty; multiple rules in one action
+are ANDed.
 
 ## Bulk field authoring — `--fields` / `--fields-file`
 `activity create --fields '<json-array>'` (inline) or `--fields-file <path>` seeds the whole

--- a/skills/uipath-connector-builder/references/standard-resources.md
+++ b/skills/uipath-connector-builder/references/standard-resources.md
@@ -188,6 +188,38 @@ activity param create --resource cards --method POST --name boardId --type path 
   --lookup-value id --lookup-names id,name --display-pattern "{name}" --depends-on projectId
 ```
 
+## Authoring for catalogue parity — the curation layer
+Wiring dropdowns is necessary but NOT sufficient to match a catalogue connector's Studio Web UX.
+Benchmarking generated connectors vs catalogue (Gmail/Outlook/OneDrive) showed the dropdown plumbing
+reaches parity, but four things a blind build usually MISSES — do these to close the gap:
+
+1. **Static / enum-backed pickers.** Not every dropdown is backed by a live vendor list — some are a
+   fixed set of literal choices. Two cases:
+   - **Small closed choice** (writeMode, valueInputOption, operation, role/type) → use
+     `--enum '["A","B"]'` or `--enhanced-enum '[{"name":"Label","value":"V"}]'` on **`field create`
+     OR `param create`** (both support it). This renders a static combo directly — do NOT stand up a
+     helper List resource for these. (Catalogue puts `enum`/`enhancedEnum` right on the field/param.)
+   - **Large / shared / vendor-fetched set** (timezones, currencies) → author a small helper List
+     resource holding that set and point a dropdown at it (`--reference-object timezones
+     --reference-path /timezones`). The catalogue adds a `timezones` picker on every calendar /
+     send-mail activity this way.
+2. **Curated responses, not raw vendor JSON.** Don't leave an activity's output as raw vendor field
+   names. Curate it — friendly output field names + a curated subset — via per-field `responseCurated`
+   + `displayName` (e.g. `EventTitle`/`StartDateTime` instead of `subject`/`start`). Set curated
+   visibility in the `--fields-file` method map; both `responseCurated` and the kebab
+   `response-curated` spelling are accepted (normalized).
+3. **Scope pickers on list / read verbs.** A list activity should offer the folder / calendar /
+   parent **scope** as a dropdown, not just a generic `where` / `pageSize`. e.g. Get Email List →
+   an email-folder picker; Get Event List → a calendar picker.
+4. **Field completeness.** Cover the catalogue's fields, not just the obvious ones (e.g. `Importance`
+   / `ReplyTo` on send-email, `ListColumns` on SharePoint list items).
+
+**Known CLI limits (catalogue-only for now — can't reach 100% here):** there is no hierarchical
+**tree-picker** reference type (the OneDrive drive→folder→file browser) and no **merged/combined**
+picker (sheets+tables+named-ranges in one dropdown); the SR-level `type:"curated"` + `section` /
+`category` grouping isn't settable (activities still surface as standalone via
+`metadata.method.<VERB>.curated`). Don't try to hand-fake these — note them as gaps.
+
 ## Bulk field authoring — `--fields` / `--fields-file`
 `activity create --fields '<json-array>'` (inline) or `--fields-file <path>` seeds the whole
 field schema in one shot. Two shapes are accepted: an ARRAY of field objects

--- a/skills/uipath-connector-builder/references/standard-resources.md
+++ b/skills/uipath-connector-builder/references/standard-resources.md
@@ -125,9 +125,10 @@ the field's request/response side.
 
 **design** object (`--design-position primary|secondary|none`, `--component`, `--hidden`):
 `position`, `component` (FolderPicker, Button, Connectors, Resources, Fields, Processes,
-Queues), `hidden` (what `--hidden` writes — the field-level key is `design.hidden`, NOT
-`isHidden`), `loadByDefault`, `isMultiSelect`, `enableUserOverride`, `dictionaryWidget`,
-`solutionResourceKind`, `fieldActions` (cascading show/hide based on another field's value).
+Queues), `isHidden` (what `--hidden` writes — the key shipped connectors use; a dependent
+dropdown's `--depends-on` writes the same key), `loadByDefault`, `isMultiSelect`,
+`enableUserOverride`, `dictionaryWidget`, `solutionResourceKind`, `fieldActions` (cascading
+show/hide based on another field's value).
 
 ### Dropdowns (reference / lookup)
 A dropdown lists rows from a **List resource in this connector** — you choose which field is


### PR DESCRIPTION
## What
Adds the **dropdown / reference-lookup** authoring docs and a new **"Authoring for catalogue parity —
the curation layer"** section to the connector-builder skill's `standard-resources.md`.

## Why
Dogfooding the connector builder against the top 9 catalogue connectors showed that wiring dropdowns
gets you part-way, but catalogue parity needs a curation layer that blind builds miss. These docs teach
it. (Companion CLI PR: UiPath/cli#2985, which adds the flags these docs describe.)

## What's in it (4 doc commits, `standard-resources.md` only)
- Dropdowns (reference/lookup), dependent dropdowns, show/hide (`--depends-on`, `--field-actions`).
- `--hidden` writes `design.isHidden`; dropdowns on path/query params; `--type path` auto-encode;
  `depends-on` vs `field-actions`.
- **Curation layer:** static/enum pickers via `--enum`/`--enhanced-enum` on a field OR param (no fake
  helper-list for small closed choices), helper List for large sets, curated responses, scope pickers on
  list verbs, field completeness — plus honest notes on the CLI's hard limits (no tree/merged picker).

## Blast radius
Docs-only, one file. Rebased onto `main` (the connector-builder skill base is in `main`); the diff is
exactly these 4 commits (+115/−6 in `standard-resources.md`).

## Test plan
Docs change — reviewed for coherence against the CLI behavior it describes (the companion CLI PR ships
the `param --enum`, dead-dropdown validate, and nested-path fixes referenced here). Both source and the
installed skill copy were kept in sync during the dogfood run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
