### PR TITLE
fix(test): raise e2e_01 task_timeout to 2400s

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -13,6 +13,7 @@ tags: [uipath-human-in-the-loop, e2e, green-field, invoice, approval-gate, write
 run_limits:
   expected_turns: 19
   max_turns: 60
+  task_timeout: 2400
   turn_timeout: 2400
 
 initial_prompt: |


### PR DESCRIPTION
`e2e_01` mentions SharePoint and SAP in the prompt. The agent does real connector registry lookups for both, which burns most of the 1200s nightly default before the HITL node is ever placed. The flow produced has no HITL node and no edges — score 0.0, timeout.

Root cause: `turn_timeout: 2400` was already set (per-turn) but `task_timeout` was missing, so the 1200s nightly default applied to the whole task.

Fix: add `task_timeout: 2400` to match the per-turn limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)