### PR TITLE
chore: add alexandrujircan as uipath-ixp code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -155,9 +155,8 @@
 /tests/tasks/uipath-admin/ @sriramva-uipath @bansal-anushree @jianjunwang2 @t-hsia @ZuerWang99 @litheon @IsabellaCapriottiUIPath @uipathswapnil @ashleyetheridge @yadvender-uipath @CalinMPopa @chandhanshanth
 
 # IXP skill
-/skills/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath
-/skills/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath
-/tests/tasks/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath
+/skills/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath @alexandrujircan
+/tests/tasks/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath @alexandrujircan
 # MCP skill (UiPath AgentHub MCP server registration + tool authoring)
 /skills/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents
 /tests/tasks/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents


### PR DESCRIPTION
## What

Adds @alexandrujircan to the CODEOWNERS entries for the IXP skill:

- `/skills/uipath-ixp/`
- `/tests/tasks/uipath-ixp/`

Also removes an accidental verbatim duplicate of the `/skills/uipath-ixp/` line.

## Why

Joining the IXP skill ownership so review requests for `uipath-ixp` changes route to me.

🤖 Generated with [Claude Code](https://claude.com/claude-code)