### PR TITLE
chore(troubleshoot): promote uipath-troubleshoot to stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-solution` | Preview |
 | `uipath-tasks` | Preview |
 | `uipath-test` | In-development |
-| `uipath-troubleshoot` | Preview |
+| `uipath-troubleshoot` | Stable |
 
 **Status legend:**
 - **Stable** — Stable, production-ready surface; safe for production.

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -191,7 +191,7 @@
       "last_synced": null
     },
     "uipath-troubleshoot": {
-      "status": "preview",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null


### PR DESCRIPTION
Promote `uipath-troubleshoot` from **preview** to **stable** in `assets/skill-status.json` (single source of truth) and regenerate the README status table via `scripts/check-skill-status.py --write-readme`.

Scope: 2 files, 2 lines — status flip + generated README row. No other changes.

Base: `release/v1.197`.