### PR TITLE
docs(uipath-rpa): document coded workflow analyzer rules enforced by analyze/build/pack

### DIFF
--- a/skills/uipath-rpa/references/cli-reference.md
+++ b/skills/uipath-rpa/references/cli-reference.md
@@ -147,6 +147,8 @@ Rules:
 
 `uip rpa analyzer-rules list` reports the Workflow Analyzer rules **enabled** for the project — the best-practice rules `validate` and `build` enforce. Reports rules, not violations. Each rule returns `severity` (`error`/`warning`/`info`), rule ID, scope, title, and (when available) `recommendation` and `docs` URL. Prefix convention: `ST-*` = built-in Studio rule, `MA-*` = package-shipped rule.
 
+Rules with scope `Coded Workflow` run as Roslyn analyzers over the project's `.cs` files during `analyze`, `build`, and `pack` — same enforcement as the XAML-scoped rules. The four built-in ones are all Error severity; triggers and fixes: [coded/coding-guidelines.md § Coded Workflow Analyzer Rules](coded/coding-guidelines.md#coded-workflow-analyzer-rules).
+
 > **Performance:** the unscoped call enumerates every rule across every package and can take a minute or more. Narrow with `--scope` (`Activity`, `Workflow`, `Project`, or `Coded Workflow`) — scoped calls return in seconds. See `--help` for accepted scope values.
 
 ---

--- a/skills/uipath-rpa/references/coded/codedworkflow-reference.md
+++ b/skills/uipath-rpa/references/coded/codedworkflow-reference.md
@@ -54,7 +54,7 @@ var result = RunWorkflow(workflowPath, new Dictionary<string, object>
 >
 > - **Single return value** (`public string Execute(int a, int b)`) — the result is stored under the key `"Output"`. Access it as `result["Output"]`.
 > - **Multiple outputs via tuple** (`public (string a, string b) Execute()`) — each tuple member becomes a separate key: `result["a"]`, `result["b"]`. These are Out arguments.
-> - **InOut arguments** — when a parameter name appears in both the input parameters and the return tuple, it is an InOut argument. Example: `public (string a, string b) Execute(string b, int c)` — `a` is Out, `b` is InOut (same name in input and output), `c` is In.
+> - **InOut arguments** — when a parameter name appears in both the input parameters and the return tuple, it is an InOut argument. Example: `public (string a, string b) Execute(string b, int c)` — `a` is Out, `b` is InOut (same name in input and output), `c` is In. The input and output types of an InOut argument must be identical — a mismatch fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`.
 >
 > For same-project workflows, prefer the type-safe `workflows.MyWorkflow()` property — it returns the declared return type directly and avoids this dictionary lookup.
 

--- a/skills/uipath-rpa/references/coded/codedworkflow-reference.md
+++ b/skills/uipath-rpa/references/coded/codedworkflow-reference.md
@@ -54,7 +54,7 @@ var result = RunWorkflow(workflowPath, new Dictionary<string, object>
 >
 > - **Single return value** (`public string Execute(int a, int b)`) — the result is stored under the key `"Output"`. Access it as `result["Output"]`.
 > - **Multiple outputs via tuple** (`public (string a, string b) Execute()`) — each tuple member becomes a separate key: `result["a"]`, `result["b"]`. These are Out arguments.
-> - **InOut arguments** — when a parameter name appears in both the input parameters and the return tuple, it is an InOut argument. Example: `public (string a, string b) Execute(string b, int c)` — `a` is Out, `b` is InOut (same name in input and output), `c` is In. The input and output types of an InOut argument must be identical — a mismatch fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`.
+> - **InOut arguments** — when a parameter name appears in both the input parameters and the return tuple, it is an InOut argument. Example: `public (string a, string b) Execute(string b, int c)` — `a` is Out, `b` is InOut (same name in input and output), `c` is In. The input and output types of an InOut argument must be identical — a mismatch fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`/`pack`.
 >
 > For same-project workflows, prefer the type-safe `workflows.MyWorkflow()` property — it returns the declared return type directly and avoids this dictionary lookup.
 

--- a/skills/uipath-rpa/references/coded/coding-guidelines.md
+++ b/skills/uipath-rpa/references/coded/coding-guidelines.md
@@ -107,6 +107,19 @@ if (!System.Text.RegularExpressions.Regex.IsMatch(hash, @"^[0-9a-f]{40}$"))
 
 Project-local types are appropriate for **domain DTOs** that have no platform equivalent — `InvoiceLineItem`, `CustomerRecord`, `WorkItem` — and belong in Coded Source Files. The rule above applies to platform-provided types only: do not reinvent exceptions, queue-item shapes, credential handles, file-resource handles, or OR descriptors.
 
+## Coded Workflow Analyzer Rules
+
+Four built-in Workflow Analyzer rules with scope `Coded Workflow` run as Roslyn analyzers over the project's `.cs` files. All four are **Error** severity and enabled by default — a violation fails `uip rpa analyze`, `build`, and `pack`, and Studio flags the same violations as validation errors. Author to satisfy them up front:
+
+| Rule | Trigger | Fix |
+|------|---------|-----|
+| **ST-NMG-017** — Class name matches default namespace | A class declared inside the project's default namespace has the same name as that namespace (generated from the project name) — e.g. class `Invoicing` in project `Invoicing`. Applies to every class, including Coded Source Files. | Rename the class (and its file to match) — e.g. `InvoicingWorkflow` |
+| **ST-DBP-010** — Multiple `[Workflow]`/`[TestCase]` | More than one `[Workflow]` or `[TestCase]` attribute in the same **file** (the two attribute kinds count together) | One entry-point attribute per file — move each extra entry point to its own file |
+| **ST-REL-001** — Mismatched InOut argument types | An entry-point input parameter collapses into an InOut argument (its name matches a return-tuple element, or it is literally named `Output` with a single non-void return) but the input and returned types differ | Make the input parameter type and the returned type identical |
+| **ST-USG-017** — Invalid parameter modifier | `out` or `ref` modifier on a `[Workflow]`/`[TestCase]` method parameter | Use return values or tuples for outputs instead |
+
+> Older CLI versions listed these rules in `analyzer-rules list` but did not execute them headlessly — only Studio flagged the violations. Do not treat a clean `analyze`/`build` from an older CLI as proof these rules pass; fix violations at authoring time regardless.
+
 ## Best Practices
 
 ### API Discovery
@@ -145,7 +158,7 @@ if (system.PathExists(@"C:\Reports\report.pdf", PathType.File, out ILocalResourc
 
 ### Code Quality
 - **Start simple, iterate** — Create minimal working version first, then refine
-- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
+- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
 - **Only include using statements for packages in project.json** — Adding unused usings causes compile errors
 - **Match input parameter names exactly** — Execute method signature must match `--input` arguments (case-sensitive)
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments
@@ -186,6 +199,8 @@ C) <user-driven approach>
 - Never generate C# code without first searching for existing .cs files (API Discovery)
 - Never edit files without reading them first
 - Never skip the `[Workflow]` or `[TestCase]` attribute on the Execute method (Critical Rule #4)
+- Never put more than one `[Workflow]`/`[TestCase]` attribute in the same file — analyzer error ST-DBP-010 (see § Coded Workflow Analyzer Rules)
+- Never name a class the same as the project — analyzer error ST-NMG-017 (see § Coded Workflow Analyzer Rules)
 - Never forget to inherit from `CodedWorkflow` (except Coded Source Files) (Critical Rule #3)
 - Never add `using` statements for packages not in `project.json` — causes CS errors
 - Never guess service method names — verify with existing code or `uip rpa packages inspect`

--- a/skills/uipath-rpa/references/coded/coding-guidelines.md
+++ b/skills/uipath-rpa/references/coded/coding-guidelines.md
@@ -118,7 +118,7 @@ Four built-in Workflow Analyzer rules with scope `Coded Workflow` run as Roslyn 
 | **ST-REL-001** — Mismatched InOut argument types | An entry-point input parameter collapses into an InOut argument (its name matches a return-tuple element, or it is literally named `Output` with a single non-void return) but the input and returned types differ | Make the input parameter type and the returned type identical |
 | **ST-USG-017** — Invalid parameter modifier | `out` or `ref` modifier on a `[Workflow]`/`[TestCase]` method parameter | Use return values or tuples for outputs instead |
 
-> Older CLI versions listed these rules in `analyzer-rules list` but did not execute them headlessly — only Studio flagged the violations. Do not treat a clean `analyze`/`build` from an older CLI as proof these rules pass; fix violations at authoring time regardless.
+> Older CLI versions listed these rules in `analyzer-rules list` but did not execute them headlessly — only Studio flagged the violations. Do not treat a clean `analyze`/`build`/`pack` from an older CLI as proof these rules pass; fix violations at authoring time regardless.
 
 ## Best Practices
 
@@ -158,7 +158,7 @@ if (system.PathExists(@"C:\Reports\report.pdf", PathType.File, out ILocalResourc
 
 ### Code Quality
 - **Start simple, iterate** — Create minimal working version first, then refine
-- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
+- **NEVER use C# `out` or `ref` keywords in `[Workflow]` methods** — The auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`/`pack`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead
 - **Only include using statements for packages in project.json** — Adding unused usings causes compile errors
 - **Match input parameter names exactly** — Execute method signature must match `--input` arguments (case-sensitive)
 - **Escape backslashes in paths** — Use `C:\\path\\file.txt` not `C:\path\file.txt` in input arguments

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -30,7 +30,7 @@ Read: <PROJECT_DIR>/Main.xaml          # or TestCase.xaml for test projects
 **4. Add required dependencies to `project.json`** based on the Service-to-Package mapping. Edit the existing `project.json` — do NOT rewrite the entire file.
 
 **5. Add `.cs` workflow / test case / source files:**
-- Generate `.cs` files (workflows, test cases, source files)
+- Generate `.cs` files (workflows, test cases, source files) — respect the four Error-severity coded analyzer rules while authoring: [coding-guidelines.md § Coded Workflow Analyzer Rules](coding-guidelines.md#coded-workflow-analyzer-rules)
 - For each `.cs` **workflow** file, add an entry to `entryPoints` in `project.json` (**Process projects only** — Tests and Library projects do NOT use `entryPoints`). The existing scaffolded XAML entry can stay alongside.
 - For each `.cs` **test case** file, add an entry to `designOptions.fileInfoCollection` in `project.json` with `editingStatus: "InProgress"`, `testCaseType: "TestCase"`, `publishAsTestCase: true`. Test cases do NOT go in `entryPoints` regardless of project type.
 - If test project and shared setup is needed, create a `partial class CodedWorkflow` source file that implements `IBeforeAfterRun` (see before-after-hooks-template.md)
@@ -45,9 +45,9 @@ Read: <PROJECT_DIR>/Main.xaml          # or TestCase.xaml for test projects
 1. Read existing `project.json` to get project name (for namespace), `outputType`, and current entry points
 2. Create the new `.cs` file:
    - Use the project name as namespace
-   - Class name = file name (without .cs)
+   - Class name = file name (without .cs). The class name must **not** equal the project name — a class named like the project's default namespace fails analyzer rule ST-NMG-017 (Error) at `analyze`/`build`. When the natural name collides (e.g. workflow `Invoicing` in project `Invoicing`), pick a variant like `InvoicingWorkflow`
    - Inherit from `CodedWorkflow`
-   - Add `[Workflow]` attribute on the entry-point method. Method name does not have to be `Execute` — any name works. `Execute` is convention; keep it unless the user asks otherwise
+   - Add `[Workflow]` attribute on the entry-point method. Method name does not have to be `Execute` — any name works. `Execute` is convention; keep it unless the user asks otherwise. **One `[Workflow]`/`[TestCase]` attribute per file** — a second one in the same file fails analyzer rule ST-DBP-010 (Error)
    - Add appropriate `using` statements based on which activities are needed
 3. Argument direction is determined by the entry-point method signature. Single-return OutArgument is named **`"Output"`**. Tuple returns produce one OutArgument per element, named after the element. A tuple element name matching an input parameter name — or, for single returns, an input parameter literally named `"Output"` — collapses into one **`InOutArgument`**:
 
@@ -59,7 +59,9 @@ Read: <PROJECT_DIR>/Main.xaml          # or TestCase.xaml for test projects
    | Single return + `Output` input | `public string Execute(string Output, int c)` | `Output` = InOut (input named `"Output"` collides with implicit return name), `c` = In |
    | No return | `public void Execute(string input)` | `input` = In |
 
-   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
+   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
+
+   > **InOut collapse requires matching types.** When a name collision turns a parameter into an `InOutArgument` (rows 3–4 above), the input parameter type and the returned type must be identical — a mismatch (e.g. input `string b` vs tuple element `int b`) fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`.
 4. Update `project.json` (**Process projects only** — skip `entryPoints` for Tests and Library projects):
    - Add new entry to `entryPoints` array with `filePath`, unique `uniqueId`, `input`, and `output` definitions
    - If the workflow has parameters, define them in `input`/`output` with `name`, `type`, and `required`
@@ -191,7 +193,7 @@ Coded Source Files are plain `.cs` files that contain reusable classes, models, 
 1. Read existing `project.json` to get the project name (for namespace)
 2. Create the `.cs` file:
    - Use the project name as namespace
-   - Class name = file name (without .cs)
+   - Class name = file name (without .cs) — and never the project name itself (analyzer rule ST-NMG-017 applies to every class in the default namespace, source files included)
    - Add only the `using` statements the class needs (typically just `System` namespaces)
    - Do NOT inherit from `CodedWorkflow`
 3. No `project.json` changes needed

--- a/skills/uipath-rpa/references/coded/operations-guide.md
+++ b/skills/uipath-rpa/references/coded/operations-guide.md
@@ -45,7 +45,7 @@ Read: <PROJECT_DIR>/Main.xaml          # or TestCase.xaml for test projects
 1. Read existing `project.json` to get project name (for namespace), `outputType`, and current entry points
 2. Create the new `.cs` file:
    - Use the project name as namespace
-   - Class name = file name (without .cs). The class name must **not** equal the project name — a class named like the project's default namespace fails analyzer rule ST-NMG-017 (Error) at `analyze`/`build`. When the natural name collides (e.g. workflow `Invoicing` in project `Invoicing`), pick a variant like `InvoicingWorkflow`
+   - Class name = file name (without .cs). The class name must **not** equal the project name — a class named like the project's default namespace fails analyzer rule ST-NMG-017 (Error) at `analyze`/`build`/`pack`. When the natural name collides (e.g. workflow `Invoicing` in project `Invoicing`), pick a variant like `InvoicingWorkflow`
    - Inherit from `CodedWorkflow`
    - Add `[Workflow]` attribute on the entry-point method. Method name does not have to be `Execute` — any name works. `Execute` is convention; keep it unless the user asks otherwise. **One `[Workflow]`/`[TestCase]` attribute per file** — a second one in the same file fails analyzer rule ST-DBP-010 (Error)
    - Add appropriate `using` statements based on which activities are needed
@@ -59,9 +59,9 @@ Read: <PROJECT_DIR>/Main.xaml          # or TestCase.xaml for test projects
    | Single return + `Output` input | `public string Execute(string Output, int c)` | `Output` = InOut (input named `"Output"` collides with implicit return name), `c` = In |
    | No return | `public void Execute(string input)` | `input` = In |
 
-   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
+   > **NEVER use C# `out` or `ref` keywords** on `Execute` parameters — the auto-generated `*+Activity.cs` wrapper does not handle them correctly. Symptoms: analyzer error ST-USG-017 at `analyze`/`build`/`pack`, compile error `CS1620`, or runtime `Using 'out' and 'ref' modifiers is not allowed for Coded Workflows executions.` Studio regenerates the wrapper on every save, so manual fixes are reverted. Use return values or tuples for outputs instead.
 
-   > **InOut collapse requires matching types.** When a name collision turns a parameter into an `InOutArgument` (rows 3–4 above), the input parameter type and the returned type must be identical — a mismatch (e.g. input `string b` vs tuple element `int b`) fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`.
+   > **InOut collapse requires matching types.** When a name collision turns a parameter into an `InOutArgument` (rows 3–4 above), the input parameter type and the returned type must be identical — a mismatch (e.g. input `string b` vs tuple element `int b`) fails analyzer rule ST-REL-001 (Error) at `analyze`/`build`/`pack`.
 4. Update `project.json` (**Process projects only** — skip `entryPoints` for Tests and Library projects):
    - Add new entry to `entryPoints` array with `filePath`, unique `uniqueId`, `input`, and `output` definitions
    - If the workflow has parameters, define them in `input`/`output` with `name`, `type`, and `required`
@@ -193,7 +193,7 @@ Coded Source Files are plain `.cs` files that contain reusable classes, models, 
 1. Read existing `project.json` to get the project name (for namespace)
 2. Create the `.cs` file:
    - Use the project name as namespace
-   - Class name = file name (without .cs) — and never the project name itself (analyzer rule ST-NMG-017 applies to every class in the default namespace, source files included)
+   - Name each class after what it contains (for a single-class file, that matches the file name). Never use the project name as a class name — analyzer rule ST-NMG-017 applies to every class in the default namespace, source files included
    - Add only the `using` statements the class needs (typically just `System` namespaces)
    - Do NOT inherit from `CodedWorkflow`
 3. No `project.json` changes needed

--- a/skills/uipath-rpa/references/validation-guide.md
+++ b/skills/uipath-rpa/references/validation-guide.md
@@ -17,6 +17,8 @@ uip rpa analyzer-rules list --project-dir "<PROJECT_DIR>" --scope "<Activity|Wor
 
 Prefer a `--scope` matching what you're authoring — scoped calls return in seconds; unscoped can take a minute+. Apply `error` and `warning` rules; `info` rules are advisory. If you do consult the rules and then add or update a NuGet package, the package-shipped (`MA-*`) rules may have changed with the dependency set.
 
+For coded (`.cs`) workflow files, the four built-in `Coded Workflow`-scope rules (ST-NMG-017, ST-DBP-010, ST-REL-001, ST-USG-017) are all Error severity and enforced by `analyze`, `build`, and `pack` — triggers and fixes: [coded/coding-guidelines.md § Coded Workflow Analyzer Rules](coded/coding-guidelines.md#coded-workflow-analyzer-rules).
+
 Rule prefixes and full schema: [cli-reference.md § analyzer-rules list](cli-reference.md).
 
 ## Fix One Thing at a Time


### PR DESCRIPTION
## What

Documents the four `Coded Workflow`-scope Workflow Analyzer rules — **ST-NMG-017** (class named like the project's default namespace), **ST-DBP-010** (more than one `[Workflow]`/`[TestCase]` attribute per file), **ST-REL-001** (mismatched InOut argument types), **ST-USG-017** (`out`/`ref` modifiers on entry-point parameters) — in the `uipath-rpa` skill:

- `references/coded/coding-guidelines.md` — new **§ Coded Workflow Analyzer Rules** section (rule / trigger / fix table + old-CLI caveat) and two anti-pattern bullets
- `references/coded/operations-guide.md` — authoring guards: class name must not equal the project name, one entry-point attribute per file, InOut type-match note, analyzer symptom added to the `out`/`ref` prohibition
- `references/coded/codedworkflow-reference.md` — InOut type-match requirement on the argument-direction reference
- `references/validation-guide.md` + `references/cli-reference.md` — enforcement notes linking to the rule table

## Why

Companion to the UV-15226 fix (https://uipath.atlassian.net/browse/UV-15226). Previously the CLI listed these rules in `analyzer-rules list` but never executed them headlessly — `uip rpa analyze`/`build`/`pack` silently passed coded projects that Studio flags as validation errors. With the fix, the rules run as Roslyn analyzers over the project's `.cs` files during `analyze`, `build`, and `pack`; all four are Error severity, so violating coded projects now fail these verbs. Agents need the rules documented up front to author compliant code on the first attempt instead of round-tripping through failures.

Triggering PRs:
- https://github.com/UiPath/Studio/pull/28755 — WFC: evaluate Coded Workflow-scope analyzer rules in rpa analyze [UV-15226]
- https://github.com/UiPath/Studio.Common/pull/322 — JIT library: run coded workflow analyzers as a separate analysis pass (findings never served stale from the compile cache)

## Rollout note

Enforcement ships when a WorkflowCompiler build containing UiPath/Studio#28755 reaches rpa-tool / the CLI. The docs are version-free and correct on both sides of the rollout: the authoring constraints have always been enforced by Studio, and the coding-guidelines section carries an explicit caveat that older CLI versions listed these rules without executing them headlessly.

Reference-doc-only change: no new verbs (`uip rpa analyze` is already in the catalog), no task YAML or catalog impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[UV-15226]: https://uipath.atlassian.net/browse/UV-15226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ