### PR TITLE
feat: add uipath-process-mining skill (uip pm)

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -167,3 +167,7 @@
 
 # Automation Discovery skill
 /skills/uipath-automation-discovery/ @uisherif
+
+# Process Mining skill (process apps, data ingestion, dbt transformations)
+/skills/uipath-process-mining/ @UiPath/team-backendhoven
+/tests/tasks/uipath-process-mining/ @UiPath/team-backendhoven

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-mcp-servers` | In-development |
 | `uipath-planner` | Preview |
 | `uipath-platform` | Preview |
+| `uipath-process-mining` | Preview |
 | `uipath-review` | Preview |
 | `uipath-rpa` | Preview |
 | `uipath-solution` | Preview |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -158,6 +158,14 @@
       },
       "last_synced": null
     },
+    "uipath-process-mining": {
+      "status": "preview",
+      "confluence": {
+        "page_id": null,
+        "url": null
+      },
+      "last_synced": null
+    },
     "uipath-review": {
       "status": "preview",
       "confluence": {

--- a/skills/uipath-process-mining/SKILL.md
+++ b/skills/uipath-process-mining/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: uipath-process-mining
+description: "UiPath Process Mining via `uip pm` — create process apps from templates, upload event-log data, trigger ingestions, edit and run dbt SQL transformations. Covers app-types discovery, apps create/list, chunked file upload, ingestion runs + logs, ETag-safe transformation file edits, builds, build status/logs. For job execution metrics→uipath-insights, Orchestrator jobs/queues/processes→uipath-platform, root-cause of a specific error→uipath-troubleshoot, BPMN orchestration→uipath-maestro-bpmn."
+when_to_use: "User says 'process mining', 'process app', 'uip pm', 'event log', 'upload event log', 'ingest data', 'ingestion', 'dbt transformation', 'app template', 'transformation build', 'process miner'. NOT for job monitoring dashboards (uipath-insights), NOT for Orchestrator job management (uipath-platform), NOT for authoring BPMN processes (uipath-maestro-bpmn)."
+allowed-tools: Bash, Read, Write, Edit
+---
+
+# UiPath Process Mining — Process Apps Agent Skill
+
+Process Mining analyzes event logs to reconstruct and improve real business processes. This skill covers the full CLI pipeline: discover an app template → create a process app → upload data files → ingest them → inspect/edit/run the dbt SQL transformations.
+
+All operations go through `uip pm <group> <subcommand> --output json`.
+
+---
+
+## When to Use
+
+- Creating a process app from an app template (app type)
+- Uploading event-log/data files into a process app
+- Triggering and monitoring data ingestions
+- Reading, editing, and running the dbt SQL transformations of a process app
+- Re-running the transform on already-ingested data
+
+> **Not in scope:** job execution metrics (uipath-insights), Orchestrator jobs/queues (uipath-platform), dashboards or published-app analytics (no CLI surface yet).
+
+---
+
+## Login & Tenant Setup
+
+**Default to the current session. Only switch environment/org/tenant when the request names one.**
+
+```bash
+# Check current environment, org, and tenant
+uip login status --output json
+
+# Login to a specific environment
+uip login --authority https://cloud.uipath.com --tenant MyTenant
+```
+
+The tenant must have **Process Mining enabled**. If every `uip pm` command fails at the API, the tenant likely lacks Process Mining — stop and report; do not retry.
+
+---
+
+## Critical Rules
+
+1. **Pipeline order is fixed.** app-types list → apps create → files upload → ingestions create → transformations. Each step needs output from the previous one (template key/version, `AppId`, ingestion id, model path).
+
+2. **Ingestions and builds are asynchronous.** `ingestions create`, `transformations run`, and `transformations apply` return `Status: "Accepted"` immediately — that means started, not done. Poll:
+   - ingestion / apply progress: `uip pm apps list --output json` → `LastIngestion` field
+   - build progress: `uip pm transformations status <APP_ID> --output json`
+
+   Runs take minutes. A still-running ingestion/build is PENDING, not failed.
+
+3. **Always `--output json`.** Every command returns the envelope `{ Result, Code, Data }`. Parse `Data`.
+
+4. **Stage is `dev` or `published`; default `dev`.** `transformations run` supports only `dev`.
+
+5. **Transformation writes are ETag-safe.** `transformations update` fetches the remote ETag and writes with `If-Match`. On a 412 (concurrent edit): re-`get` the file, reapply the edit, retry once. Never assume the local copy is current.
+
+6. **There are no delete commands.** The CLI cannot delete apps, files, or ingestions. Do not invent `uip pm apps delete`. To fix bad data: re-upload files and re-ingest, or run `transformations apply`.
+
+7. **The data mapping must match the template model.** Build the `--data-mapping` JSON from the input tables/fields returned by `uip pm app-types get <TYPE_KEY> <VERSION> --output json`.
+
+---
+
+## Command Reference
+
+| Command | Purpose |
+|---------|---------|
+| `uip pm app-types list` | List available app templates at latest version (`AppTypeKey`, `Version`) |
+| `uip pm app-types get <key> <version>` | Full app model of a template version (input tables/fields) |
+| `uip pm apps list [--stage dev\|published]` | List process apps (`Id`, `Name`, `LastIngestion`) |
+| `uip pm apps create <name> --type <key> [--type-version <v>] [--miner directly-follows\|inductive\|bpmn] [--description <text>] [--data-mapping <json-file>]` | Create app from template; latest version resolved when `--type-version` omitted → `Data.AppId` |
+| `uip pm files upload <app-id> <file-path> [--stage] [--input-table <name>]` | Chunked upload (5 MB parts) of a data file → `{ Filename, UploadId, Size, Parts, InputTable }` |
+| `uip pm ingestions create <app-id> [--stage] [--file-format csv\|tsv] [--field-delimiter ,] [--quote-character "] [--encoding utf-8\|iso-8859-1]` | Ingest the uploaded files (async) |
+| `uip pm ingestions logs <app-id> <ingestion-id> [--stage] [--limit 100] [--offset 0]` | Ingestion run logs (paged) |
+| `uip pm transformations list <app-id> [--stage]` | dbt file tree of the app |
+| `uip pm transformations get <app-id> <path> [--stage] [--destination <local-file>]` | Read a transformation file — inline `Content`, or to disk with `--destination`; returns `ETag` |
+| `uip pm transformations update <app-id> <path> --file <local-file> [--stage]` | ETag-safe write of a transformation file |
+| `uip pm transformations run <app-id> [--model <model-path>]` | Run dbt build on dev (async); `--model` builds one model + dependents |
+| `uip pm transformations apply <app-id> [--stage]` | Re-run the full transform on already-ingested data (async) |
+| `uip pm transformations status <app-id>` | Status of current/last build |
+| `uip pm transformations logs <app-id>` | Logs of current/last build |
+
+---
+
+## Workflow: Create an App and Ingest Data
+
+```bash
+# 1. Discover templates; pick TYPE_KEY (e.g. uipath.custom) and VERSION
+uip pm app-types list --output json
+
+# 2. Fetch the template model; derive mapping.json from its input tables/fields
+uip pm app-types get <TYPE_KEY> <VERSION> --output json
+
+# 3. Create the app; save Data.AppId as APP_ID
+uip pm apps create "<APP_NAME>" --type <TYPE_KEY> --data-mapping ./mapping.json --output json
+
+# 4. Upload the event-log file(s)
+uip pm files upload <APP_ID> ./Event_log.csv --input-table Event_log --output json
+
+# 5. Trigger ingestion (async)
+uip pm ingestions create <APP_ID> --file-format csv --encoding utf-8 --output json
+
+# 6. Poll until LastIngestion reports completion; note the ingestion id
+uip pm apps list --output json
+
+# 7. Inspect ingestion logs (paged)
+uip pm ingestions logs <APP_ID> <INGESTION_ID> --limit 50 --output json
+```
+
+---
+
+## Workflow: Edit and Rebuild a dbt Transformation
+
+```bash
+# 1. Pick a model path, e.g. models/Cases.sql
+uip pm transformations list <APP_ID> --output json
+
+# 2. Download the file
+uip pm transformations get <APP_ID> <MODEL_PATH> --destination ./model.sql --output json
+
+# 3. Edit ./model.sql locally, then push back (ETag-safe)
+uip pm transformations update <APP_ID> <MODEL_PATH> --file ./model.sql --output json
+
+# 4. Build only this model and its dependents (omit --model for a full build)
+uip pm transformations run <APP_ID> --model <MODEL_PATH> --output json
+
+# 5. Poll status until complete, then read logs
+uip pm transformations status <APP_ID> --output json
+uip pm transformations logs <APP_ID> --output json
+```
+
+To re-run the full transform on data already ingested (no re-upload):
+
+```bash
+uip pm transformations apply <APP_ID> --output json
+uip pm apps list --output json   # poll LastIngestion
+```
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Not logged in` | Auth expired | `uip login` |
+| Every `uip pm` command fails at the API | Process Mining not enabled on tenant | Report; switch tenant only if the user names one |
+| `App type '<key>' not found.` | Wrong `--type` key | `uip pm app-types list --output json` |
+| `File not found: <path>` / `Local file not found: <path>` | Wrong local path | Fix the path; command exits 1 without any API call |
+| 412 on `transformations update` | Concurrent edit changed the file | Re-`get`, reapply edit, retry once |
+| Upload or ingest rejected | Another ingestion in progress | Poll `uip pm apps list` until `LastIngestion` completes, retry |
+| `error: option '--stage' argument 'X' is invalid` | Invalid stage | Only `dev` and `published` exist |
+
+---
+
+## What NOT to Do
+
+- **Don't hand-roll HTTP calls to the Process Mining API.** The CLI handles auth, chunked 5 MB blob uploads with presigned URIs, and ETag concurrency. `curl`/`fetch` will miss these.
+- **Don't treat `Status: "Accepted"` as completion.** Ingestions and builds are async — poll before asserting results or starting the next stage.
+- **Don't retry auth failures.** 401 / "Not logged in" means `uip login`, not re-running the command.
+- **Don't run `transformations run` on `published`.** Builds run on `dev` only; use `transformations apply` for published-stage re-transforms.
+- **Don't write transformation files without `transformations update`.** It is the only ETag-safe write path.
+- **Don't try to delete or recreate apps to fix data.** No delete exists — re-upload + `ingestions create`, or `transformations apply`.

--- a/tests/tasks/uipath-process-mining/e2e_app_pipeline.yaml
+++ b/tests/tasks/uipath-process-mining/e2e_app_pipeline.yaml
@@ -1,0 +1,129 @@
+task_id: skill-process-mining-e2e-app-pipeline
+description: >
+  E2E pipeline test: agent uses the uipath-process-mining skill to run the
+  full Process Mining lifecycle against a live tenant — discover an app
+  template, fetch its model, create a process app with a data mapping,
+  upload an event-log CSV, trigger an ingestion, poll for completion, and
+  inspect the dbt transformations. Requires a tenant with Process Mining
+  enabled. Read-mostly: creates one app and one ingestion, never edits
+  transformations of existing apps.
+tags: [uipath-process-mining, e2e, mode:operate]
+
+run_limits:
+  expected_turns: 40
+  max_turns: 40
+
+initial_prompt: |
+  Run a full Process Mining pipeline against the live tenant.
+
+  1. Verify login with `uip login status --output json`. Do NOT re-login —
+     use the active tenant as-is.
+  2. Discover the available process app templates and pick one (prefer a key
+     like `uipath.custom`).
+  3. Fetch the template's model and derive a minimal data mapping plus a
+     matching event-log CSV (columns like Case_ID, Activity, Timestamp)
+     with a handful of rows.
+  4. Create a process app named "CoderEval PM <random suffix>" from that
+     template with your data mapping, and confirm it appears in the app list.
+  5. Upload the event-log CSV to the new app and trigger an ingestion.
+  6. Poll until the ingestion completes (ingestions and builds are
+     asynchronous — allow several minutes), then read its logs.
+  7. List the app's transformation files and fetch the content of one model
+     file.
+
+  The task is not complete until the ingestion has finished (or you have
+  polled at least 10 minutes and report it as still pending) and a
+  transformation file's content has been fetched.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-process-mining skill and follow its
+  workflow.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent verified login status first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent discovered app templates"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+app-types\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched a template model"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+app-types\s+get\s+\S+\s+\S+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created a process app from the template with a data mapping"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+apps\s+create\s+.*--type\s+\S+[\s\S]*--data-mapping\s+\S+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent verified the app in the app list"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+apps\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent uploaded the event-log file"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+files\s+upload\s+\S+\s+\S+'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent triggered an ingestion"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+ingestions\s+create\s+\S+'
+    min_count: 1
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent read ingestion logs after polling"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+ingestions\s+logs\s+\S+\s+\S+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed the transformation files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+transformations\s+list\s+\S+'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched a transformation file's content"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+transformations\s+get\s+\S+\s+\S+'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not edit transformations (out of scope for this run)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+transformations\s+update'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-process-mining/smoke_pipeline_discovery.yaml
+++ b/tests/tasks/uipath-process-mining/smoke_pipeline_discovery.yaml
@@ -1,0 +1,50 @@
+task_id: skill-process-mining-smoke-discovery
+description: >
+  Smoke test: agent uses the uipath-process-mining skill to discover the
+  Process Mining command surface — list app templates and process apps via
+  uip pm. The prompt is goal-oriented; the agent must learn the commands
+  from the skill, not from the prompt. Auth errors are expected (no live
+  tenant) and must not trigger retries.
+tags: [uipath-process-mining, smoke, mode:operate, lifecycle:discover]
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  I want to see what Process Mining resources exist on my tenant. List the
+  available process app templates and the existing process apps (dev stage).
+
+  Use --output json on every command. The CLI is not connected to a live
+  tenant, so commands will fail with auth errors — that's expected. Run each
+  command once and move on. Do NOT retry or attempt to login.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-process-mining skill"
+    skill_name: "uipath-process-mining"
+    expected_skill: "uipath-process-mining"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed app templates"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+app-types\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed process apps"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+apps\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not attempt a login after the expected auth failures"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login(?!\s+status)'
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds the `uipath-process-mining` skill covering the new Process Mining tool in the UiPath CLI (`uip pm`, shipped in UiPath/cli#2493). The skill teaches agents the full pipeline: discover app templates (`app-types`), create process apps, upload event-log files (chunked), trigger and monitor ingestions, and read/edit/run the dbt SQL transformations (ETag-safe updates, async builds).

## Why

The `pm` command surface shipped in the CLI but had no skill, so agents had no guidance on the pipeline order, the async ingestion/build model, or the ETag concurrency rules.

## Changes

- `skills/uipath-process-mining/SKILL.md` — skill definition (frontmatter validated by `hooks/validate-skill-descriptions.sh`, terse-mode body with Critical Rules, command reference, two workflows, troubleshooting, anti-patterns)
- `assets/skill-status.json` — registered as `preview`; README status table regenerated via `scripts/check-skill-status.py --write-readme` (validator passes: 25 skills, manifest valid)
- `tests/tasks/uipath-process-mining/` — 1 smoke task (discovery, no live tenant) + 1 e2e task (full pipeline against a live Process Mining tenant)
- `CODEOWNERS` — `/skills/uipath-process-mining/` and `/tests/tasks/uipath-process-mining/` owned by @UiPath/team-backendhoven

## Notes for reviewers

- Command surface verified against `packages/pm-tool/src/commands/*.ts` in UiPath/cli (flags, choice lists, defaults, envelope codes).
- The test tasks have not yet been executed with coder-eval — the e2e task needs a tenant with Process Mining enabled. @UiPath/team-backendhoven will run them and attach passing-run claims before merge.
- Companion PR in the CLI repo backfills the tool lists and CODEOWNERS there: UiPath/cli#3001

🤖 Generated with [Claude Code](https://claude.com/claude-code)