### PR TITLE
test: accept orchestrator alias in Orchestrator command-pattern checks

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
@@ -77,7 +77,7 @@ success_criteria:
   - type: command_executed
     description: "Agent did NOT hand-create the AdminDashboards folder with `uip or folders create` (the provisioning script owns creation + role union)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+create'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+create'
     min_count: 0
     max_count: 0
     weight: 2.0

--- a/tests/tasks/uipath-coded-apps/e2e_du_validation_station_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_du_validation_station_app.yaml
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created a fresh per-run folder via `uip or folders create` (isolated for cleanup)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+create\b'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+create\b'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_orchestrator_dashboard_web_app.yaml
@@ -82,7 +82,7 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip or folders create` in some form (isolated per-run folder for cleanup). Loosened from name-anchored pattern — the actual folder name is graded separately by the report.json check below, and the CLI accepts flag ordering the anchored pattern misses."
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+create\b'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+create\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-coded-apps/e2e_purchase_order_action_app.yaml
+++ b/tests/tasks/uipath-coded-apps/e2e_purchase_order_action_app.yaml
@@ -67,7 +67,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created a fresh per-run folder via `uip or folders create` (Rule #11 — non-interactive deploy, isolated for cleanup)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+create\b'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+create\b'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
+++ b/tests/tasks/uipath-governance/access-policy/identity_lookup_smoke.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent did NOT use the retired `uip or users list` path for User UUID resolution"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+list'
     min_count: 0
     max_count: 0
     weight: 1.0
@@ -73,7 +73,7 @@ success_criteria:
   - type: command_executed
     description: "Agent did NOT use the retired `uip or users current` subcommand"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+current'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+current'
     min_count: 0
     max_count: 0
     weight: 1.0

--- a/tests/tasks/uipath-platform/data-fabric/integration_folder_binding.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/integration_folder_binding.yaml
@@ -57,7 +57,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed folders to pick folder A"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/data-fabric/integration_folder_records.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/integration_folder_records.yaml
@@ -45,7 +45,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed folders to pick folder A and folder B"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
+++ b/tests/tasks/uipath-platform/llmgateway/create_validate_smoke.yaml
@@ -63,7 +63,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed Orchestrator folders for folder-key discovery"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+list'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/assets_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/assets_get_smoke.yaml
@@ -22,7 +22,7 @@ success_criteria:
   - type: command_executed
     description: "Agent did the resolve step with the --name filter (server-side, by name)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+assets\s+list.*(-n|--name)\s+["\047]?ApiBaseUrl'
+    command_pattern: 'uip\s+(or|orchestrator)\s+assets\s+list.*(-n|--name)\s+["\047]?ApiBaseUrl'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -30,7 +30,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the asset lookup to the provided folder"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+assets\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+assets\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/assets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/assets_list_smoke.yaml
@@ -17,7 +17,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed assets via uip or assets list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+assets\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+assets\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+assets\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+assets\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/buckets_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/buckets_list_smoke.yaml
@@ -21,7 +21,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed buckets via uip or buckets list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+buckets\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+buckets\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -29,7 +29,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+buckets\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+buckets\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_get_smoke.yaml
@@ -17,7 +17,7 @@ success_criteria:
   - type: command_executed
     description: "Agent fetched the folder via uip or folders get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+get\s+\S'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+get\s+\S'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/folders_list_smoke.yaml
@@ -16,7 +16,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed folders via uip or folders list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/jobs_list_smoke.yaml
@@ -18,7 +18,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed jobs via uip or jobs list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+jobs\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+jobs\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -26,7 +26,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+jobs\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+jobs\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -34,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent filtered server-side with --state Faulted (server-side filter — server has a flag for state, so client-side --output-filter is the wrong tool here)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+jobs\s+list.*--state\s+Faulted'
+    command_pattern: 'uip\s+(or|orchestrator)\s+jobs\s+list.*--state\s+Faulted'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/libraries_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/libraries_list_smoke.yaml
@@ -16,7 +16,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed libraries via uip or libraries list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+libraries\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+libraries\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/packages_list_smoke.yaml
@@ -16,7 +16,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed packages via uip or packages list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+packages\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+packages\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/processes_list_smoke.yaml
@@ -24,7 +24,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed processes via uip or processes list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+processes\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+processes\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -32,7 +32,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+processes\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+processes\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/queue_items_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/queue_items_list_smoke.yaml
@@ -17,7 +17,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed queue items via uip or queue-items list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+queue-items\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+queue-items\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+queue-items\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+queue-items\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/queues_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/queues_list_smoke.yaml
@@ -17,7 +17,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed queues via uip or queues list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+queues\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+queues\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -25,7 +25,7 @@ success_criteria:
   - type: command_executed
     description: "Agent scoped the list to a folder via --folder-key or --folder-path"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+queues\s+list.*--folder-(key|path)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+queues\s+list.*--folder-(key|path)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
+++ b/tests/tasks/uipath-platform/orchestrator/sessions_unattended_list_smoke.yaml
@@ -16,7 +16,7 @@ success_criteria:
   - type: command_executed
     description: "Agent listed unattended sessions via uip or sessions unattended list"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+sessions\s+unattended\s+list'
+    command_pattern: 'uip\s+(or|orchestrator)\s+sessions\s+unattended\s+list'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -21,7 +21,7 @@ success_criteria:
   - type: command_executed
     description: "Agent started the job with --wait-for-completion"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+jobs\s+start.*--wait-for-completion'
+    command_pattern: 'uip\s+(or|orchestrator)\s+jobs\s+start.*--wait-for-completion'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
+++ b/tests/tasks/uipath-platform/users_import_robot_smoke.yaml
@@ -34,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent called `uip or users import` (the single IS→tenant integration point)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+import'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -42,7 +42,7 @@ success_criteria:
   - type: command_executed
     description: "Agent passed --type DirectoryRobot"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import[\s\S]*--type\s+DirectoryRobot'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+import[\s\S]*--type\s+DirectoryRobot'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -50,7 +50,7 @@ success_criteria:
   - type: command_executed
     description: "Agent passed --directory-id (required for Robot — server-side Key check)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import[\s\S]*--directory-id'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+import[\s\S]*--directory-id'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
@@ -58,7 +58,7 @@ success_criteria:
   - type: command_executed
     description: "Agent passed --domain (required; 'autogen' for Robot)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import[\s\S]*--domain\s+autogen'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+import[\s\S]*--domain\s+autogen'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -66,6 +66,6 @@ success_criteria:
   - type: command_not_executed
     description: "Agent did NOT omit --type (would default to DirectoryUser → silent corruption)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+users\s+import(?!\s+--help)(?![\s\S]*--type)'
+    command_pattern: 'uip\s+(or|orchestrator)\s+users\s+import(?!\s+--help)(?![\s\S]*--type)'
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-test/link_automation_and_run.yaml
+++ b/tests/tasks/uipath-test/link_automation_and_run.yaml
@@ -33,7 +33,7 @@ success_criteria:
   - type: command_executed
     description: "Agent discovered folder key with `folders list -n <folder-name> --all`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+or\s+folders\s+list\s+-n\s+\S+'
+    command_pattern: 'uip\s+(or|orchestrator)\s+folders\s+list\s+-n\s+\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

`processes_list_smoke.yaml` failed even though the agent behaved correctly: [failed run](https://coder-evalboard.uipath-dev.com/runs/2026-07-13_04-26-06/skill-platform-orchestrator-processes-list).

The task prompt asks the agent to run `processes list` against a folder; the agent invoked `uip orchestrator processes list --folder-path "Finance/Accounting"`, the CLI **accepted** it and returned the expected `HTTP 400: Folder does not exist` — exactly the outcome the task grades for. But both `command_executed` checks failed because the regex hardcoded `uip\s+or\s+...`.

The `uip` CLI accepts both `or` (canonical, per `assets/uip-catalog-snapshot.json`) and `orchestrator` as the top-level verb. Any Orchestrator command-pattern check that only matches `or` is latently flaky: it docks an agent for picking the equally-valid alias.

## Fix

Broadened all **36 Orchestrator command patterns** across **23 task YAMLs** from `uip\s+or\s+...` to `uip\s+(or|orchestrator)\s+...`.

- Admin `--scope "OR.` permission-scope patterns are unrelated and left untouched.
- Changes are contained to the regex substring — no structural YAML edits.

## Verification

- Catalog confirms `or` is canonical and `orchestrator` is a real accepted alias.
- Diff reviewed line-by-line; all 36 patterns updated symmetrically.
- Not run through `coder-eval` in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)