### PR TITLE
fix(uipath-solution): grade pack determinism on agent artifacts, not a grade-time re-pack

### DIFF
--- a/tests/tasks/uipath-solution/operate/check_pack_determinism.py
+++ b/tests/tasks/uipath-solution/operate/check_pack_determinism.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Guard: `uip solution pack` is structurally deterministic.
 
-Fingerprints the two packages the AGENT packed into the working directory and
-asserts they are the same once per-pack volatile values are normalized away.
+Fingerprints the packages the AGENT packed into the working directory (two or
+more — all are compared against the first) and asserts they are the same once
+per-pack volatile values are normalized away.
 Every pack regenerates fresh GUIDs (packageVersionKey, resource keys, the
 files/<guid>/ path segment) and stamps fresh zip timestamps — those are
 expected. Anything else that differs is real build nondeterminism that could

--- a/tests/tasks/uipath-solution/operate/check_pack_determinism.py
+++ b/tests/tasks/uipath-solution/operate/check_pack_determinism.py
@@ -1,26 +1,30 @@
 #!/usr/bin/env python3
 """Guard: `uip solution pack` is structurally deterministic.
 
-Packs the fixture solution twice (into isolated temp dirs, so the source is
-never mutated) and asserts the two packages are the same once per-pack volatile
-values are normalized away. Every pack regenerates fresh GUIDs (packageVersionKey,
-resource keys, the files/<guid>/ path segment) and stamps fresh zip timestamps —
-those are expected. Anything else that differs is real build nondeterminism that
-could mask regressions in other tests, so it fails.
+Fingerprints the two packages the AGENT packed into the working directory and
+asserts they are the same once per-pack volatile values are normalized away.
+Every pack regenerates fresh GUIDs (packageVersionKey, resource keys, the
+files/<guid>/ path segment) and stamps fresh zip timestamps — those are
+expected. Anything else that differs is real build nondeterminism that could
+mask regressions in other tests, so it fails.
+
+Deliberately does NOT re-run `uip solution pack` here: the grading subprocess
+resolves the CLI's tool packages from its own environment, not the agent's, so
+a grade-time pack can fail for tool-resolution reasons unrelated to determinism
+(nightly 2026-07-10: sandbox had no @uipath/solution-tool next to the CLI; the
+agent self-installed into its npm prefix, invisible to this subprocess). The
+companion `command_executed` criterion in the task YAML guarantees the agent
+really packed twice rather than copying one package.
 
 Comparison, after replacing GUIDs -> <GUID> and ISO timestamps -> <TS>:
-  - the set of entry paths must match, and
+  - the set of entry paths must match across all packages, and
   - the text of every JSON entry must match.
 Binary entries (the nested project .nupkg) are compared by normalized path only —
 their bytes carry zip timestamps and are not a determinism signal on their own."""
 
 import json
-import os
 import re
-import shutil
-import subprocess
 import sys
-import tempfile
 import zipfile
 from pathlib import Path
 
@@ -32,25 +36,20 @@ def normalize(text: str) -> str:
     return TS.sub("<TS>", GUID.sub("<GUID>", text))
 
 
-repo = os.environ.get("SKILLS_REPO_PATH") or str(Path(__file__).resolve().parents[4])
-solution = Path(repo) / "tests" / "fixtures" / "solutions" / "e2e-stub-solution"
-if not (solution / "e2e-stub-solution.uipx").is_file():
-    sys.exit(f"FAIL: solution fixture not found at {solution}")
-
-
-def pack_once(tag: str) -> Path:
-    work = Path(tempfile.mkdtemp(prefix=f"packdet-{tag}-"))
-    src = work / "solution"
-    shutil.copytree(solution, src)
-    out = work / "out"
-    r = subprocess.run(
-        ["uip", "solution", "pack", str(src), str(out), "--output", "json"],
-        capture_output=True, text=True, timeout=180,
+def is_solution_package(zip_path: Path) -> bool:
+    """True only for real `uip solution pack` output: it always carries the
+    solution metadata, the package manifest, and the bundled project payload
+    under files/ — a zipped source tree or hand-rolled archive doesn't."""
+    try:
+        with zipfile.ZipFile(zip_path) as z:
+            names = z.namelist()
+    except (zipfile.BadZipFile, OSError):
+        return False
+    return (
+        "solutionMetadata.json" in names
+        and "packageInfo.json" in names
+        and any(n.startswith("files/") for n in names)
     )
-    zips = list(out.glob("*.zip")) if out.is_dir() else []
-    if not zips:
-        sys.exit(f"FAIL: pack ({tag}) produced no package (exit={r.returncode}, stderr={r.stderr[-300:]})")
-    return zips[0]
 
 
 def fingerprint(zip_path: Path) -> tuple[list[str], dict]:
@@ -69,16 +68,40 @@ def fingerprint(zip_path: Path) -> tuple[list[str], dict]:
     return sorted(paths), jsons
 
 
-a_paths, a_json = fingerprint(pack_once("a"))
-b_paths, b_json = fingerprint(pack_once("b"))
+# Cwd is the sandbox working directory the agent packed into. Skip hidden dirs
+# (.git, .local investigation state) — packages land in plain output folders.
+packages = sorted(
+    p for p in Path(".").rglob("*.zip")
+    if not any(part.startswith(".") for part in p.parts) and is_solution_package(p)
+)
+if len(packages) < 2:
+    sys.exit(
+        f"FAIL: expected at least 2 packed solution packages (*.zip containing "
+        f"solutionMetadata.json) under the working directory, found "
+        f"{[str(p) for p in packages]} — the agent must pack the fixture twice "
+        f"into two separate output folders"
+    )
 
-if a_paths != b_paths:
-    only_a = sorted(set(a_paths) - set(b_paths))
-    only_b = sorted(set(b_paths) - set(a_paths))
-    sys.exit(f"FAIL: package entry lists differ (after id/timestamp normalization). only-in-a={only_a} only-in-b={only_b}")
+base_paths, base_json = fingerprint(packages[0])
 
-for name in a_json:
-    if a_json[name] != b_json.get(name):
-        sys.exit(f"FAIL: JSON entry {name!r} differs between packs after id/timestamp normalization — real nondeterminism")
+for other in packages[1:]:
+    o_paths, o_json = fingerprint(other)
+    if base_paths != o_paths:
+        only_a = sorted(set(base_paths) - set(o_paths))
+        only_b = sorted(set(o_paths) - set(base_paths))
+        sys.exit(
+            f"FAIL: package entry lists differ between {packages[0]} and {other} "
+            f"(after id/timestamp normalization). only-in-first={only_a} only-in-other={only_b}"
+        )
+    for name in base_json:
+        if base_json[name] != o_json.get(name):
+            sys.exit(
+                f"FAIL: JSON entry {name!r} differs between {packages[0]} and {other} "
+                f"after id/timestamp normalization — real nondeterminism"
+            )
 
-print(f"OK: pack is deterministic — {len(a_paths)} entries and all JSON match (GUIDs/timestamps normalized)")
+print(
+    f"OK: pack is deterministic — {len(packages)} packages "
+    f"({', '.join(str(p) for p in packages)}), {len(base_paths)} entries each, "
+    f"all JSON matches (GUIDs/timestamps normalized)"
+)

--- a/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
+++ b/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
@@ -45,9 +45,13 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+# Branch 1 is the Linux form (sh expands $TASK_DIR, hosts ship python3);
+# branch 2 is the Windows form (cmd expands %TASK_DIR%, venv ships python).
+# TASK_DIR is an env var in the run_command subprocess, so each shell expands
+# its own syntax; the checker is read-only, so the fallback re-run is harmless.
   - type: run_command
     description: "uip solution pack is structurally deterministic (file list + metadata)"
-    command: "python3 $TASK_DIR/check_pack_determinism.py"
+    command: "python3 $TASK_DIR/check_pack_determinism.py || python %TASK_DIR%/check_pack_determinism.py"
     timeout: 120
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
+++ b/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
@@ -6,6 +6,12 @@ description: >
   nondeterminism that would mask regressions in other tests. Purely local: no
   tenant, no login, no packages published. Uses the committed fixture at
   tests/fixtures/solutions/e2e-stub-solution.
+
+  Grading fingerprints the packages the agent produced; it does not re-run
+  `uip solution pack` at grade time (the grading subprocess resolves CLI tool
+  packages from its own environment — on the 2026-07-10 nightly that env had
+  no solution-tool, failing the check for reasons unrelated to determinism).
+  The command_executed criterion pins that the agent really packed twice.
 tags: [uipath-solution, integration, mode:build, lifecycle:generate, solution]
 
 agent:
@@ -31,6 +37,14 @@ initial_prompt: |
   Don't ask for approval, don't pause.
 
 success_criteria:
+  - type: command_executed
+    description: "Agent packed the solution twice with uip solution pack"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+solution\s+pack'
+    min_count: 2
+    weight: 1.5
+    pass_threshold: 1.0
+
   - type: run_command
     description: "uip solution pack is structurally deterministic (file list + metadata)"
     command: "python3 $TASK_DIR/check_pack_determinism.py"

--- a/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
+++ b/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
@@ -45,13 +45,14 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-# Branch 1 is the Linux form (sh expands $TASK_DIR, hosts ship python3);
-# branch 2 is the Windows form (cmd expands %TASK_DIR%, venv ships python).
-# TASK_DIR is an env var in the run_command subprocess, so each shell expands
-# its own syntax; the checker is read-only, so the fallback re-run is harmless.
+# runpy bootstrap (repo precedent: governance/admin tasks): TASK_DIR is an env
+# var in the run_command subprocess, and shell expansion is sh-only ($TASK_DIR
+# is literal under cmd.exe), so resolve it inside Python. Bare `python` (not
+# python3) because the sandbox venv is prepended to PATH and guarantees it on
+# both platforms — the Windows venv ships no python3.exe.
   - type: run_command
     description: "uip solution pack is structurally deterministic (file list + metadata)"
-    command: "python3 $TASK_DIR/check_pack_determinism.py || python %TASK_DIR%/check_pack_determinism.py"
+    command: "python -c \"import os,runpy;runpy.run_path(os.path.join(os.environ['TASK_DIR'],'check_pack_determinism.py'))\""
     timeout: 120
     expected_exit_code: 0
     weight: 5.0


### PR DESCRIPTION
## Problem

`skill-platform-solution-pack-determinism-integration` failed on the [2026-07-10 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-07-10_04-24-53) (one of the two failures that put uipath-solution at 20/22, below the 95% bar) **even though the agent's work was correct** — it packed twice, compared, and wrote a correct `DETERMINISTIC` verdict.

Root cause: the checker re-ran `uip solution pack` at grade time, but the grading subprocess resolves the CLI's tool packages from its own environment, not the agent's. On the nightly VM the tempdir sandbox had no `@uipath/solution-tool` next to the CLI; the agent self-installed the tools into its own npm prefix (invisible to the checker), so the checker's pack produced no package and the task scored 0.167. The checker also printed only stderr, while `--output json` errors go to stdout — so the failure message was empty.

Two latent portability bugs in the same criterion: `python3` and `$TASK_DIR` are sh-only (cmd.exe has no `python3` alias and never expands `$VAR`), so the checker could never run under the Windows tempdir driver at all.

## Fix

- **Grade the agent's artifacts instead of re-packing.** `check_pack_determinism.py` now fingerprints the packages the agent packed into the working directory (all pairwise, same GUID/timestamp normalization as before). No `uip` invocation at grade time → immune to tool-resolution drift between agent and checker environments.
- **Anti-gaming guards:** only zips carrying real packed-output markers count (`solutionMetadata.json` + `packageInfo.json` + `files/` payload — a zipped source tree or hand-rolled archive has none), and a new `command_executed` criterion requires ≥2 `uip solution pack` invocations so copying one package can't pass.
- **Cross-platform criterion command:** `python -c "import os,runpy;runpy.run_path(os.path.join(os.environ['TASK_DIR'],'check_pack_determinism.py'))"` — the repo's runpy-bootstrap precedent (governance/admin tasks), resolving `TASK_DIR` inside Python since `$VAR` expansion is sh-only. Bare `python` (not `python3`) because coder_eval prepends the sandbox venv to the `run_command` PATH and the venv guarantees `python` on both platforms — the Windows venv ships no `python3.exe`. (Per Copilot review: an earlier `cmd1 || cmd2` fallback also fired on genuine checker failures, muddying the recorded exit code.)

## Verification

- **Replay against the real 2026-07-10 nightly artifacts** (the agent's pack1/pack2 zips from the failed run): new checker exits 0, "pack is deterministic". The failed run would have passed with this grading.
- **7 synthetic checker scenarios**: identical packs pass; JSON drift fails; entry-list drift fails; single package fails; marker-less zips ignored; hidden dirs skipped + 3rd pack tolerated; corrupt zip ignored.
- **Passing coder-eval runs** (local, tempdir driver, `experiments/default.yaml`, `@uipath/cli@1.197.0-alpha.20260626.7673` — same alpha as the nightly): `status=SUCCESS`, score **1.000**, 3/3 criteria on both the initial version (run `2026-07-13_12-35-24`) and the final criterion command after review feedback (run `2026-07-13_13-02-18`, with the shell PATH deliberately minimal so `python` resolution came only from the sandbox venv injection the command relies on).
- `/lint-task`: one Low finding (gameability), fixed by the packed-output marker check; CLI verb check clean (`solution pack` in catalog).

## Notes

- Harness follow-up (not this PR): tempdir-driver sandboxes on the nightly VM expose a CLI with no `@uipath` tool packages, and `uip tools install` doesn't repair it against the alpha CLI — the agent burned ~40 turns working around it. Will raise separately with the eval-infra owners; other skills' tempdir tasks are exposed to the same drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
