### PR TITLE
chore: bump version to 1.197.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uipath",
       "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
-      "version": "1.197.0",
+      "version": "1.197.1",
       "author": {
         "name": "UiPath"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.197.0",
+  "version": "1.197.1",
   "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.197.0",
+  "version": "1.197.1",
   "description": "UiPath skills for building, validating, deploying, and operating automations and agents from Codex.",
   "author": {
     "name": "UiPath"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/skills",
-  "version": "1.197.0",
+  "version": "1.197.1",
   "description": "UiPath agent skills for Claude Code, Codex, Cursor, Copilot, Gemini and OpenCode — RPA, UI automation, UI testing, coded agents/apps/workflows, and troubleshooting. Distributed as the UiPath Claude Code plugin.",
   "author": {
     "name": "UiPath"

--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
-  "skillsVersion": "1.197.0",
+  "skillsVersion": "1.197.1",
   "targetCli": "^1.197.0"
 }


### PR DESCRIPTION
## Summary
- Bump `package.json` to `1.197.1` (single source of truth) ahead of the next publish from `release/v1.197`
- `npm run version:sync` regenerated `version-manifest.json` (`skillsVersion: 1.197.1`, `targetCli: ^1.197.0`)
- Plugin / marketplace / Codex manifests advanced to `1.197.1` as well (`sync-version.mjs --bump-patch`) — plugin version now moves together with the package version

## Verification
- `npm run version:check` → `✓ All manifests in sync (package 1.197.1, plugin 1.197.1, targetCli ^1.197.0)` (same guard as the publish workflow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)