### PR TITLE
feat(uipath-ixp): smoke for colloquial model + preprocessing mapping [ACTV-88695]

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/change_model_variant.yaml
+++ b/tests/tasks/uipath-ixp/smoke/change_model_variant.yaml
@@ -1,0 +1,44 @@
+task_id: skill-ixp-change-model-variant-smoke
+description: >
+  Smoke: agent maps two colloquial names to their canonical identifiers in a
+  single `configure-model` call — "GPT" → the only GPT variant
+  `gpt_4o_2024_05_13`, "table-mini" → `table_mini` preprocessing — instead of
+  silently picking a wrong model (e.g. a Gemini default) or the full `table`
+  option. Distinct from pick_capable_model (capability-based choice); this locks
+  in the colloquial→canonical mapping plus setting model + preprocessing at once.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+
+run_limits:
+  expected_turns: 5
+
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
+initial_prompt: |
+  In the IXP project my_invoices-f1afa9ef-ixp, switch the extraction model to
+  GPT and set preprocessing to table-mini.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
+    this environment. Commands will fail with auth errors — that is expected.
+    Run each command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  # The colloquial names resolve unambiguously from the skill's enum: "GPT" is
+  # the only GPT variant (gpt_4o_2024_05_13) and "table-mini" is table_mini (not
+  # the full `table`). Both must land on ONE configure-model call — a wrong
+  # model (gemini_*) or wrong preprocessing (table/none) fails this lookahead.
+  - type: command_executed
+    description: "Agent set model gpt_4o_2024_05_13 AND preprocessing table_mini in one `configure-model` call"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+projects\s+configure-model\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--model\s+gpt_4o_2024_05_13\b)(?=.*--preprocessing\s+table_mini\b).*'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds one shape-only smoke for `uipath-ixp`: **`tests/tasks/uipath-ixp/smoke/change_model_variant.yaml`**.

Covers [ACTV-88695](https://uipath.atlassian.net/browse/ACTV-88695) — *"[P1] [Smoke] Change model to a specific variant."* The agent must map two **colloquial** names to their canonical `configure-model` identifiers in a **single** call:

- `"GPT"` → `gpt_4o_2024_05_13` (the only GPT variant in the enum)
- `"table-mini"` → `table_mini` preprocessing (not the full `table`)

## Why it's not redundant

Distinct from the existing `pick_capable_model.yaml`, which tests **capability-based** model choice (150-page docs → `gemini_2_5_pro`, model only). This task locks in the **colloquial→canonical mapping** *and* setting model + preprocessing at once — the trap the ticket calls out ("names are colloquial … must not silently pick the wrong one"). A wrong model (`gemini_*`) or wrong preprocessing (`table`/`none`) fails the single tight lookahead.

The move/reorder tickets from the same epic (88681/88682/88683) were deliberately **not** done as smokes — their "kept clean / no duplication" outcome needs a `get-taxonomy` read-back, so they belong in integration. This PR is scoped to the one clear smoke win.

## Tier & grading

- Tier: `smoke` (`mode:build`, `lifecycle:setup`).
- Reuses the shared offline mock (`_shared/mock_template`) — no live tenant, no new mock files.
- Graded on command shape via a single `command_executed` lookahead (project id + exact model enum + exact preprocessing enum on one call).

## Validation

- **`/lint-task`: OK** — 0 issues across all axes (not a duplicate; CLI verb `ixp projects configure-model` resolves in the catalog).
- **`coder-eval plan` (dry-run): passes** — `✓ change_model_variant.yaml … All tasks are valid!`
- A full scored run was **not** executed locally (no `ANTHROPIC_API_KEY` in the authoring environment). The PR smoke gate (`smoke-skills.yml`) runs the scored task on this branch; please confirm it goes green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ACTV-88695]: https://uipath.atlassian.net/browse/ACTV-88695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ