### PR TITLE
docs(uipath-solution): document --nuget-sources-config-path for pack and restore

### DIFF
--- a/skills/uipath-solution/references/pack-and-deploy.md
+++ b/skills/uipath-solution/references/pack-and-deploy.md
@@ -45,6 +45,7 @@ uip solution restore ./MySolution --output json
 |--------|-------------|---------|
 | `<solutionPath>` | Solution directory (containing a `.uipx`) or a `.uis` file (required) | -- |
 | `--login-validity <minutes>` | Minimum minutes left on the access token before the CLI refreshes it before restore starts | 10 |
+| `--nuget-sources-config-path <path>` | Local `NuGet.config` that sets the package sources used for resolution | -- |
 
 `restore` resolves dependencies on disk and does **not** produce a package. It needs an authenticated session (`uip login`) to reach private Orchestrator feeds. `pack` already restores internally, so this step is an **optimization, not a requirement** — its value is in CI, where running `login → restore → pack` fails fast on a missing or unreachable feed before the heavier pack step runs. Skip it for a plain local pack.
 
@@ -65,8 +66,11 @@ uip solution pack ./MySolution ./output --name "MySolution" --version "2.0.0" --
 | `<output-path>` | Directory where the .zip will be written (required positional, no default — omitting it errors with `missing required argument 'output-path'`) | -- |
 | `--name <name>` | Override the package name | Name from `.uipx` |
 | `--version <version>` | Set the package version | `1.0.0` |
+| `--nuget-sources-config-path <path>` | Local `NuGet.config` that sets the package sources used for resolution | -- |
 
 The output is a `.zip` file named `<name>.<version>.zip` written under `<output-path>/` (e.g., `MySolution.2.0.0.zip`). Run `solution resources refresh` first (from inside the solution dir, or with `--solution-folder <path>`) to ensure the solution's artefact files and debug overwrites are up to date — they're bundled into the package.
+
+**Controlling package sources.** In offline or air-gapped environments, or when packages must be resolved from specific feeds, pass `--nuget-sources-config-path <path>` pointing at a local `NuGet.config`. Both `pack` and `restore` accept the flag; the sources declared in that file determine where each project's dependencies are resolved from, giving you precise control over feed selection.
 
 ## Step 2: Publish to the Solution Feed
 


### PR DESCRIPTION
Documents the new `--nuget-sources-config-path` flag on `uip solution pack` and `uip solution restore` in the uipath-solution skill.

Requested in review of UiPath/cli#2876 (the PR that adds the flag). Mirrors how the uipath-rpa skill documents the same flag.

**What changed** (`skills/uipath-solution/references/pack-and-deploy.md`):
- Added `--nuget-sources-config-path` to the restore (Step 0) and pack (Step 1) option tables.
- Added a short note on pointing it at a local `NuGet.config` to control package sources — for offline/air-gapped builds, or when packages must come from specific feeds.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)