### PR TITLE
feat(uipath-ixp): smoke for conditional unconfirm by field semantics [ACTV-88713]

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -33,7 +33,6 @@ initial_prompt: |
 
   For a data-privacy request, roll back the confirmations on the fields that
   capture a person's name or phone number, so those go back to un-annotated.
-  Leave every other field confirmed.
 
   Important:
   - The `uip` CLI is available but is NOT connected to a live IXP tenant in this

--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -3,10 +3,12 @@ description: >
   Smoke: conditional bulk unconfirm with semantic field selection. Five fields on
   one document were confirmed earlier; the agent must roll back only the ones that
   hold a person's name or phone number (First Name, Last Name, Phone Number) and
-  leave the rest confirmed. Tests real semantic matching, not substring matching:
-  "Phone Number" must be caught (it's a phone, though it has no "name" in it) while
-  "Account Number" must NOT (shares "Number" but is not a phone), and "Signup Date"
-  is left alone.
+  leave the rest confirmed. The discrimination is carried by two substring traps —
+  fields that share a keyword with the request but are not what it asks for:
+  "Company Name" contains "name" yet is not a person's name, and "Account Number"
+  shares "Number" with "Phone Number" yet is not a phone. Both must stay confirmed,
+  so an agent that keys on the bare substrings "name"/"number" fails while a
+  semantic one passes.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
@@ -29,7 +31,7 @@ initial_prompt: |
   - Last Name — field id f-302
   - Phone Number — field id f-303
   - Account Number — field id f-304
-  - Signup Date — field id f-305
+  - Company Name — field id f-305
 
   For a data-privacy request, roll back the confirmations on the fields that
   capture a person's name or phone number, so those go back to un-annotated.
@@ -41,8 +43,9 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
-  # Targets: the three name/phone fields must be unconfirmed on the right
-  # project + document. Field ids are matched after --fields, so one combined
+  # Targets: the three name/phone fields must be unconfirmed. (Project + document
+  # are pinned for a precise match, not to test selection — there is only one of
+  # each.) Field ids are matched after --fields, so one combined
   # `--fields f-301 f-302 f-303` call or three separate calls both satisfy these.
   - type: command_executed
     description: "Unconfirmed First Name (f-301)"
@@ -60,8 +63,8 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # Phone Number carries no "name" substring — catching it proves semantic
-  # (not substring) matching.
+  # Phone field — a target. (This one is named in the prompt verbatim, so it does
+  # not test substring vs. semantic; the traps below do.)
   - type: command_executed
     description: "Unconfirmed Phone Number (f-303)"
     tool_name: "Bash"
@@ -70,11 +73,12 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # The crux: the non-name/phone fields must stay confirmed. Pattern is anchored
-  # to the `unconfirm` verb + the specific ids, so a mere mention in prose/comment
-  # can't false-match. Account Number (f-304) is the substring trap.
+  # The crux: the two substring traps must stay confirmed — Account Number (f-304,
+  # "Number" but not a phone) and Company Name (f-305, "name" but not a person's
+  # name). Pattern is anchored to the `unconfirm` verb + the specific ids, so a
+  # mere mention in prose/comment can't false-match.
   - type: command_not_executed
-    description: "Did NOT unconfirm Account Number (f-304) or Signup Date (f-305)"
+    description: "Did NOT unconfirm Account Number (f-304) or Company Name (f-305)"
     tool_name: "Bash"
     command_pattern: 'uip\s+ixp\s+labellings\s+unconfirm\b[^|;&]*(f-304|f-305)'
     weight: 3.0

--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -1,0 +1,82 @@
+task_id: skill-ixp-conditional-unconfirm-smoke
+description: >
+  Smoke: conditional bulk unconfirm with semantic field selection. Five fields on
+  one document were confirmed earlier; the agent must roll back only the ones that
+  hold a person's name or phone number (First Name, Last Name, Phone Number) and
+  leave the rest confirmed. Tests real semantic matching, not substring matching:
+  "Phone Number" must be caught (it's a phone, though it has no "name" in it) while
+  "Account Number" must NOT (shares "Number" but is not a phone), and "Signup Date"
+  is left alone.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+  Grades command shape, not wire effect.
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:execute]
+
+run_limits:
+  expected_turns: 6
+
+sandbox:
+  driver: tempdir
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
+initial_prompt: |
+  On project `crm_contacts-a7f3c1d2-ixp`, document `doc-contact-42`, these five
+  fields were all confirmed earlier:
+
+  - First Name — field id f-301
+  - Last Name — field id f-302
+  - Phone Number — field id f-303
+  - Account Number — field id f-304
+  - Signup Date — field id f-305
+
+  For a data-privacy request, roll back the confirmations on the fields that
+  capture a person's name or phone number, so those go back to un-annotated.
+  Leave every other field confirmed.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in this
+    environment. Commands will fail with auth errors — that is expected. Run each
+    command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  # Targets: the three name/phone fields must be unconfirmed on the right
+  # project + document. Field ids are matched after --fields, so one combined
+  # `--fields f-301 f-302 f-303` call or three separate calls both satisfy these.
+  - type: command_executed
+    description: "Unconfirmed First Name (f-301)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+unconfirm\s+["'']?crm_contacts-a7f3c1d2-ixp["'']?\s+["'']?doc-contact-42["'']?[^|;&]*--fields[^|;&]*f-301'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Unconfirmed Last Name (f-302)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+unconfirm\s+["'']?crm_contacts-a7f3c1d2-ixp["'']?\s+["'']?doc-contact-42["'']?[^|;&]*--fields[^|;&]*f-302'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # Phone Number carries no "name" substring — catching it proves semantic
+  # (not substring) matching.
+  - type: command_executed
+    description: "Unconfirmed Phone Number (f-303)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+unconfirm\s+["'']?crm_contacts-a7f3c1d2-ixp["'']?\s+["'']?doc-contact-42["'']?[^|;&]*--fields[^|;&]*f-303'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # The crux: the non-name/phone fields must stay confirmed. Pattern is anchored
+  # to the `unconfirm` verb + the specific ids, so a mere mention in prose/comment
+  # can't false-match. Account Number (f-304) is the substring trap.
+  - type: command_not_executed
+    description: "Did NOT unconfirm Account Number (f-304) or Signup Date (f-305)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+ixp\s+labellings\s+unconfirm\b[^|;&]*(f-304|f-305)'
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -63,8 +63,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # Phone field — a target. (This one is named in the prompt verbatim, so it does
-  # not test substring vs. semantic; the traps below do.)
   - type: command_executed
     description: "Unconfirmed Phone Number (f-303)"
     tool_name: "Bash"


### PR DESCRIPTION
## What

Adds one shape-only smoke for `uipath-ixp`: **`tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml`**.

Covers [ACTV-88713](https://uipath.atlassian.net/browse/ACTV-88713) — *"[P1] [Smoke] Conditional unconfirm."* Five fields on `doc-contact-42` were confirmed earlier; the agent must roll back only the ones capturing a person's **name or phone**, leaving the rest confirmed.

| Field | id | Expected |
|---|---|---|
| First Name | f-301 | **unconfirm** |
| Last Name | f-302 | **unconfirm** |
| Phone Number | f-303 | **unconfirm** |
| Account Number | f-304 | leave confirmed |
| Signup Date | f-305 | leave confirmed |

## Why the field set matters

It's a genuine **semantic**-matching test, not a substring match:
- **Phone Number (f-303)** must be caught — it's a phone, though it carries no "name" substring.
- **Account Number (f-304)** must **not** — it shares "Number" with Phone Number but is not a phone (the trap).

So an agent that naively matches on `name` misses f-303; one that matches on `Number` wrongly grabs f-304. Only real intent-matching passes.

## Grading

- Three `command_executed` positives — each pins project + document + one target field id after `--fields`, so a combined `--fields f-301 f-302 f-303` call **or** three separate calls both satisfy them.
- One `command_not_executed` negative (weight 3.0, the ticket's "only the right fields" crux) — anchored to the `unconfirm` verb + the non-target ids so a mention in prose/comment can't false-match. Matches the negative-guard idiom used by `per_occurrence_unconfirm` / `negative_guards`.

## Why it's not redundant

Distinct operation from the existing unconfirm smokes: `per_occurrence_unconfirm` rolls back one occurrence by index; `unconfirm_rollback` rolls back one known field. This tests **semantic multi-field selection**. Shared scaffold, materially distinct operation.

## Tier & grading

- Tier: `smoke` (`mode:operate`, `lifecycle:execute`).
- Reuses `_shared/mock_template` (offline, unauthenticated) — no new mock files.

## Validation

- **`/lint-task`: OK** — 0 issues (not a duplicate; `ixp labellings unconfirm` resolves in the catalog).
- **`coder-eval plan` (dry-run): passes** — `✓ conditional_unconfirm.yaml … 4 success criteria … All tasks are valid!`
- A full scored run was **not** executed locally (no `ANTHROPIC_API_KEY` in the authoring environment). The PR smoke gate (`smoke-skills.yml`) runs the scored task on this branch; please confirm it goes green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ACTV-88713]: https://uipath.atlassian.net/browse/ACTV-88713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ