### PR TITLE
feat(hooks): accept Autopilot/Delegate tool names in telemetry gate

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -75,8 +75,8 @@ plugin; everything else exits silently. A call qualifies when:
 |------|----------------|
 | `Skill` | skill name starts with `uipath:` / `uipath-` |
 | `Agent` / `spawn_agent` | spawned type is a UiPath agent (`uipath:` / `uipath-`) or a built-in/generic type (Claude's `general-purpose`, `Explore`, `Plan`, `claude`, `claude-code-guide`, `statusline-setup`, `fork`, or Codex's `default`) — **not** other plugins' (`<plugin>:<name>`) or user-defined custom agents. Claude spawns via `Agent` + `tool_input.subagent_type`; Codex via `spawn_agent` + `tool_input.agent_type` |
-| `Bash` / `PowerShell` | command invokes the `uip` CLI or `rpa-tool` |
-| `Edit` / `Write` / `Read` / `Glob` / `Grep` | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
+| `Bash` / `PowerShell` (Autopilot / Delegate: `ExecuteBashCommand` / `ExecutePowershellCommand`) | command invokes the `uip` CLI or `rpa-tool` |
+| `Edit` / `Write` / `Read` / `Glob` / `Grep` (Autopilot / Delegate: `ReadFile` / `WriteFile` / `EditFile` / `LsDirectory`) | path targets `.cs` (coded workflows), `.flow`, `.xaml`, `.uipx`, `.bpmn`, `agent.json`, `caseplan.json`, `project.json`, `app.config.json`, `action-schema.json` |
 
 ## How it works
 
@@ -225,6 +225,19 @@ signals. The cross-agent handling itself changes no keys; the current key set
 is **schema v2** (see the [field table](#properties-sent-by-the-hook)). Events
 are distinguished by agent through the CLI-stamped client/`source` context, not
 a hook field.
+
+**UiPath Autopilot / Delegate** honor `hooks.json` with the same envelope and
+lifecycle events, but name their shell and file tools differently. Attribution
+is gated on both spellings:
+
+| Tool role | Claude Code | Autopilot / Delegate |
+|-----------|-------------|----------------------|
+| Shell command | `Bash` / `PowerShell` | `ExecuteBashCommand` / `ExecutePowershellCommand` |
+| File read/write/edit/list | `Read` / `Write` / `Edit` / `Glob` / `Grep` | `ReadFile` / `WriteFile` / `EditFile` / `LsDirectory` |
+
+Their `tool_input` still carries `command` / `file_path`, so the `uip`-command
+and file-extension attribution and the `uipSubcommand` / `fileExtension`
+derivation work unchanged once the renamed tool names are gated. No key changes.
 
 ### Added by the CLI
 

--- a/hooks/send-telemetry.ps1
+++ b/hooks/send-telemetry.ps1
@@ -43,15 +43,21 @@
 #                            (resolvedModel)
 #
 # CROSS-AGENT: registered as a PostToolUse hook, this also runs under other
-# coding agents that honor hooks.json (e.g. Codex). Codex's envelope matches
-# Claude's (hook_event_name, tool_name, tool_use_id, session_id,
-# permission_mode, tool_input/{command,file_path}), so Bash-`uip` and file
-# attribution work unchanged. Differences handled / accepted: agent spawns use
-# `spawn_agent` + tool_input.agent_type (see Test-UipathCall + extraction);
-# Codex omits duration_ms / effort.level (-> durationMs null, effortLevel "")
-# and serializes tool_response as a JSON STRING, not an object, so success /
-# interrupted / resolvedModel are absent and outcome is ok|unknown only.
-# Only derived, low-cardinality, PII-free values ever leave the machine.
+# coding agents that honor hooks.json (e.g. Codex, UiPath Autopilot / Delegate).
+# Codex's envelope matches Claude's (hook_event_name, tool_name, tool_use_id,
+# session_id, permission_mode, tool_input/{command,file_path}), so Bash-`uip`
+# and file attribution work unchanged. Differences handled / accepted: agent
+# spawns use `spawn_agent` + tool_input.agent_type (see Test-UipathCall +
+# extraction); Codex omits duration_ms / effort.level (-> durationMs null,
+# effortLevel "") and serializes tool_response as a JSON STRING, not an object,
+# so success / interrupted / resolvedModel are absent and outcome is ok|unknown
+# only. UiPath Autopilot / Delegate keep the same envelope but rename the shell
+# and file tools — ExecuteBashCommand / ExecutePowershellCommand (vs Bash /
+# PowerShell) and ReadFile / WriteFile / EditFile / LsDirectory (vs Read / Write
+# / Edit / Glob / Grep); their tool_input still carries command / file_path, so
+# the same attribution + derivation fire once those names are gated (see
+# Test-UipathCall + Get-DerivedFields). Only derived, low-cardinality, PII-free
+# values ever leave the machine.
 #
 # Non-blocking by contract: registered as an async hook in hooks.json
 # ("async": true) on every event EXCEPT SessionEnd, so Claude Code runs it in
@@ -125,11 +131,11 @@ function Test-UipathCall([string]$Tool, [string]$Skill, [string]$SubagentType, [
       if (@('general-purpose', 'Explore', 'Plan', 'claude', 'claude-code-guide', 'statusline-setup', 'fork', 'default') -ccontains $SubagentType) { return $true }
       break
     }
-    { $_ -cin @('Bash', 'PowerShell') } {
+    { $_ -cin @('Bash', 'PowerShell', 'ExecuteBashCommand', 'ExecutePowershellCommand') } {
       if ($Command -cmatch '(^|[\\";|&(\s])(uip|rpa-tool)\s' -or $Command -cmatch '\$UIP\b') { return $true }
       break
     }
-    { $_ -cin @('Edit', 'Write', 'Read', 'Glob', 'Grep') } {
+    { $_ -cin @('Edit', 'Write', 'Read', 'Glob', 'Grep', 'ReadFile', 'WriteFile', 'EditFile', 'LsDirectory') } {
       if ($FilePath -imatch '\.(cs|flow|xaml|uipx|bpmn)$' -or $FilePath -imatch '(^|[/\\])(agent|caseplan|project|app\.config|action-schema)\.json$') { return $true }
       break
     }
@@ -148,7 +154,7 @@ function Get-DerivedFields([string]$Tool, [string]$Skill, [string]$Command, [str
       $derived.skillName = $Skill
       break
     }
-    { $_ -cin @('Bash', 'PowerShell') } {
+    { $_ -cin @('Bash', 'PowerShell', 'ExecuteBashCommand', 'ExecutePowershellCommand') } {
       # e.g. "solution publish" from "uip solution publish --output json".
       $m = [regex]::Match($Command, '(uip|\$UIP)\s+[a-z][a-z-]*(\s+[a-z][a-z-]*)?')
       if ($m.Success) {
@@ -156,7 +162,7 @@ function Get-DerivedFields([string]$Tool, [string]$Skill, [string]$Command, [str
       }
       break
     }
-    { $_ -cin @('Edit', 'Write', 'Read', 'Glob', 'Grep') } {
+    { $_ -cin @('Edit', 'Write', 'Read', 'Glob', 'Grep', 'ReadFile', 'WriteFile', 'EditFile', 'LsDirectory') } {
       $m = [regex]::Match($FilePath, '\.[A-Za-z0-9]+$')
       if ($m.Success) { $derived.fileExt = $m.Value }
       if ($FilePath -clike '*agent.json') { $derived.fileExt = 'agent.json' }

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -39,15 +39,21 @@
 #                            (resolvedModel)
 #
 # CROSS-AGENT: registered as a PostToolUse hook, this also runs under other
-# coding agents that honor hooks.json (e.g. Codex). Codex's envelope matches
-# Claude's (hook_event_name, tool_name, tool_use_id, session_id,
-# permission_mode, tool_input/{command,file_path}), so Bash-`uip` and file
-# attribution work unchanged. Differences handled / accepted: agent spawns use
-# `spawn_agent` + tool_input.agent_type (see is_uipath_call + outkey); Codex
-# omits duration_ms / effort.level (-> durationMs null, effortLevel "") and
-# serializes tool_response as a JSON STRING, not an object, so success /
-# interrupted / resolvedModel are absent and outcome is ok|unknown only.
-# Only derived, low-cardinality, PII-free values ever leave the machine.
+# coding agents that honor hooks.json (e.g. Codex, UiPath Autopilot / Delegate).
+# Codex's envelope matches Claude's (hook_event_name, tool_name, tool_use_id,
+# session_id, permission_mode, tool_input/{command,file_path}), so Bash-`uip`
+# and file attribution work unchanged. Differences handled / accepted: agent
+# spawns use `spawn_agent` + tool_input.agent_type (see is_uipath_call +
+# outkey); Codex omits duration_ms / effort.level (-> durationMs null,
+# effortLevel "") and serializes tool_response as a JSON STRING, not an object,
+# so success / interrupted / resolvedModel are absent and outcome is ok|unknown
+# only. UiPath Autopilot / Delegate keep the same envelope but rename the shell
+# and file tools — ExecuteBashCommand / ExecutePowershellCommand (vs Bash /
+# PowerShell) and ReadFile / WriteFile / EditFile / LsDirectory (vs Read / Write
+# / Edit / Glob / Grep); their tool_input still carries command / file_path, so
+# the same attribution + derivation fire once those names are gated (see
+# is_uipath_call + derive_fields). Only derived, low-cardinality, PII-free
+# values ever leave the machine.
 #
 # TWIN SCRIPT: hooks/send-telemetry.ps1 is the PowerShell twin of this file —
 # any behavioral change here MUST be mirrored there in the same PR (see
@@ -247,11 +253,11 @@ is_uipath_call() {
         general-purpose|Explore|Plan|claude|claude-code-guide|statusline-setup|fork|default) return 0 ;;
       esac
       ;;
-    Bash|PowerShell)
+    Bash|PowerShell|ExecuteBashCommand|ExecutePowershellCommand)
       printf '%s' "$command" \
         | grep -Eq '(^|[\\"[:space:];|&(])(uip|rpa-tool)[[:space:]]|\$UIP\b' && return 0
       ;;
-    Edit|Write|Read|Glob|Grep)
+    Edit|Write|Read|Glob|Grep|ReadFile|WriteFile|EditFile|LsDirectory)
       printf '%s' "$file_path" \
         | grep -Eiq '\.(cs|flow|xaml|uipx|bpmn)$|(^|[/\\])(agent|caseplan|project|app\.config|action-schema)\.json$' && return 0
       ;;
@@ -269,13 +275,13 @@ derive_fields() {
     Skill)
       skill_name="$skill"
       ;;
-    Bash|PowerShell)
+    Bash|PowerShell|ExecuteBashCommand|ExecutePowershellCommand)
       # e.g. "solution publish" from "uip solution publish --output json".
       uip_subcommand="$(printf '%s' "$command" \
         | grep -oE '(uip|\$UIP)[[:space:]]+[a-z][a-z-]*([[:space:]]+[a-z][a-z-]*)?' \
         | head -1 | sed -E 's/^(uip|\$UIP)[[:space:]]+//')"
       ;;
-    Edit|Write|Read|Glob|Grep)
+    Edit|Write|Read|Glob|Grep|ReadFile|WriteFile|EditFile|LsDirectory)
       file_ext="$(printf '%s' "$file_path" | grep -oE '\.[A-Za-z0-9]+$' | head -1)"
       case "$file_path" in
         *agent.json)    file_ext="agent.json" ;;

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -211,6 +211,69 @@ def test_v2_key_set_has_no_env_fields_or_legacy_session_id():
     assert "sessionSource" not in event
 
 
+# ── Autopilot / Delegate tool-name tests ───────────────────────────────────
+# UiPath Autopilot / Delegate honor hooks.json with the same envelope but rename
+# the shell and file tools (ExecuteBashCommand / ExecutePowershellCommand,
+# ReadFile / WriteFile / EditFile / LsDirectory). tool_input still carries
+# command / file_path, so attribution + derivation must fire on the renamed
+# names exactly as for Claude's Bash / Read / Write / Edit.
+
+
+def test_autopilot_execute_bash_command_uip_maps_to_tool_use():
+    event = run_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "ExecuteBashCommand",
+            "tool_input": {"command": "uip solution publish --output json"},
+            "tool_response": {"success": True},
+        }
+    )
+    assert event["eventName"] == "tool-use"
+    assert event["toolName"] == "ExecuteBashCommand"
+    assert event["uipSubcommand"] == "solution publish"
+    assert event["outcome"] == "ok"
+
+
+def test_autopilot_execute_powershell_command_uip_maps_to_tool_use():
+    event = run_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "ExecutePowershellCommand",
+            "tool_input": {"command": "uip pack --output json"},
+            "tool_response": {"success": True},
+        }
+    )
+    assert event["eventName"] == "tool-use"
+    assert event["uipSubcommand"] == "pack"
+
+
+def test_autopilot_write_file_uipath_ext_maps_to_tool_use():
+    event = run_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "WriteFile",
+            "tool_input": {"file_path": "/proj/Process/Main.xaml"},
+            "tool_response": {"success": True},
+        }
+    )
+    assert event["eventName"] == "tool-use"
+    assert event["toolName"] == "WriteFile"
+    assert event["fileExtension"] == ".xaml"
+
+
+def test_autopilot_read_file_agent_json_maps_to_tool_use():
+    event = run_hook(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "ReadFile",
+            "tool_input": {"file_path": "/proj/agent.json"},
+            "tool_response": {"success": True},
+        }
+    )
+    assert event["eventName"] == "tool-use"
+    assert event["fileExtension"] == "agent.json"
+
+
 # ── drop-path tests ────────────────────────────────────────────────────────
 
 
@@ -221,6 +284,38 @@ def test_non_uipath_tool_call_is_dropped():
                 "hook_event_name": "PostToolUse",
                 "tool_name": "Bash",
                 "tool_input": {"command": "ls -la"},
+            },
+            expect_drop=True,
+        )
+        is None
+    )
+
+
+def test_autopilot_shell_without_uip_is_dropped():
+    """The `uip` matcher is anchored, NOT a bare substring — a command that
+    merely contains the letters 'uip' (e.g. 'equipment') must not attribute.
+    Guards against loosening the gate to a substring match, which would
+    over-attribute unrelated commands under the renamed Autopilot tools."""
+    assert (
+        run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "ExecuteBashCommand",
+                "tool_input": {"command": "echo equipment inventory"},
+            },
+            expect_drop=True,
+        )
+        is None
+    )
+
+
+def test_autopilot_read_file_non_uipath_ext_is_dropped():
+    assert (
+        run_hook(
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "ReadFile",
+                "tool_input": {"file_path": "/proj/notes.txt"},
             },
             expect_drop=True,
         )


### PR DESCRIPTION
## What

Teach the skills telemetry hook (`send-telemetry.sh` / `.ps1`) to attribute tool calls made by **UiPath Autopilot / Delegate**, which honor `hooks.json` with the same payload envelope and lifecycle events as Claude Code but rename their shell and file tools:

| Tool role | Claude Code | Autopilot / Delegate |
|-----------|-------------|----------------------|
| Shell command | `Bash` / `PowerShell` | `ExecuteBashCommand` / `ExecutePowershellCommand` |
| File read/write/edit/list | `Read` / `Write` / `Edit` / `Glob` / `Grep` | `ReadFile` / `WriteFile` / `EditFile` / `LsDirectory` |

Their `tool_input` still carries `command` / `file_path`, so once the renamed names are gated the existing `uip`-command attribution, file-extension attribution, and `uipSubcommand` / `fileExtension` derivation all fire unchanged. No schema/key changes (still v2).

Based on a working local patch under the Delegate plugin (`.../UiPath/Delegate/LocalPlugins/uipath/hooks`).

## Changes

- **`hooks/send-telemetry.sh`** — add the renamed names to the `is_uipath_call` gate and `derive_fields`; extend the cross-agent header comment.
- **`hooks/send-telemetry.ps1`** — the same change in the twin (`Test-UipathCall` / `Get-DerivedFields`), kept behaviorally identical per the CLAUDE.md twin rule.
- **`TELEMETRY.md`** — document the rename in the trigger table and cross-agent section.
- **`tests/scripts/test_send_telemetry_hook.py`** — parametrized tests (both twins) for the new tool names, plus an over-attribution guard.

## Deliberate deviation from the local patch

The local working patch also **loosened** the `uip` command matcher from the anchored pattern to a bare `(uip|rpa-tool|$UIP)` substring. This PR does **not** replicate that, because it:
- over-attributes any command merely containing the letters `uip` (e.g. `equipment`);
- breaks `$UIP` env-var detection (`$` becomes an end-anchor in ERE);
- contradicts the documented region-scoping / no-over-attribution design.

Adding the tool-name aliases alone is sufficient: Autopilot/Delegate carry the same `uip …` strings the existing anchored matcher already matches. A regression test (`test_autopilot_shell_without_uip_is_dropped`) locks this in.

## Verification

Smoke-tested **both twins** locally with Autopilot-shaped payloads (stubbed `uip` on `PATH`); output is byte-identical across `.sh` (bash) and `.ps1` (PowerShell):
- `ExecuteBashCommand` / `ExecutePowershellCommand` + `uip …` → emitted with correct `uipSubcommand`.
- `WriteFile` / `ReadFile` / `LsDirectory` on `.xaml` / `agent.json` / `.flow` → emitted with correct `fileExtension`.
- `EditFile` on `notes.txt` and `ExecuteBashCommand "echo equipment inventory"` → correctly dropped.

CI (`test-helpers.yml`) runs `test_send_telemetry_hook.py` over both twins on ubuntu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
