### PR TITLE
test(uipath-maestro-case): raise expense e2e turn cap

### DIFF
--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
@@ -21,6 +21,7 @@ Mechanical only; runtime behaviour is graded by check_expense_runnable_debug.py.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -38,6 +39,9 @@ from _shared.case_check import (  # noqa: E402
 
 EXPECTED_CASEPLAN = os.path.join(
     "ExpenseReimbursementRunnable", "ExpenseReimbursementRunnable", "caseplan.json"
+)
+EXPECTED_BINDINGS_V2 = os.path.join(
+    "ExpenseReimbursementRunnable", "ExpenseReimbursementRunnable", "bindings_v2.json"
 )
 PRIMARY_STAGES = ["Submission", "Manager Approval", "Finance Approval", "Payment", "Approved"]
 TERMINAL_LANES = ["Rejected", "Withdrawn"]
@@ -89,8 +93,32 @@ def _incoming_from(plan: dict, target_id: str, sources: set[str]) -> bool:
     return any(tr.get("source") in sources for tr in find_transitions(plan, target=target_id))
 
 
+def _assert_bindings_v2_metadata(bindings: dict) -> None:
+    """Reject metadata that the eval CLI's resource refresh cannot consume."""
+    resources = bindings.get("resources")
+    if not isinstance(resources, list):
+        _fail("bindings_v2.json must contain a resources array")
+    for index, resource in enumerate(resources):
+        if not isinstance(resource, dict):
+            _fail(f"bindings_v2.json resources[{index}] must be an object")
+        metadata = resource.get("metadata") or {}
+        if not isinstance(metadata, dict):
+            _fail(f"bindings_v2.json resource {resource.get('key', index)!r} metadata must be an object")
+        unsupported = sorted(set(metadata) - {"subType"})
+        if unsupported:
+            _fail(
+                "bindings_v2.json resource "
+                f"{resource.get('key', index)!r} has unsupported metadata key(s) "
+                f"{unsupported}; only subType is supported by uip solution resources refresh"
+            )
+
+
 def main():
     plan = read_caseplan(EXPECTED_CASEPLAN if os.path.exists(EXPECTED_CASEPLAN) else None)
+    if not os.path.exists(EXPECTED_BINDINGS_V2):
+        _fail(f"missing required {EXPECTED_BINDINGS_V2}")
+    with open(EXPECTED_BINDINGS_V2, encoding="utf-8") as f:
+        _assert_bindings_v2_metadata(json.load(f))
 
     # --- trigger: Manual, so `uip maestro case debug` can start the case headlessly
     triggers = find_triggers(plan)

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/check_expense_runnable_structure.py
@@ -50,6 +50,13 @@ REQUIRED_TASK_TYPES = {
 }
 # The automated runnable variant deliberately omits these (no HITL / no live connectors).
 FORBIDDEN_TASK_TYPES = {"action", "execute-connector-activity", "wait-for-connector"}
+REQUIRED_EXTERNAL_BINDINGS = {
+    "Shared/uipath-maestro-case/NameToAgeFixed2.API Workflow": "API Workflow",
+    "Shared/uipath-maestro-flow/CountLetters CodedAgent.CountLetters": "CountLetters",
+    "Shared/uipath-agents/ProcurementProcess.ProcurementProcess": "ProcurementProcess",
+    "Shared/uipath-maestro-flow/ProjectEuler RPA.RPA Workflow": "RPA Workflow",
+    "Shared/uipath-maestro-case/CaseTest.Maestro Case": "Maestro Case",
+}
 
 
 def _fail(msg: str):
@@ -113,12 +120,35 @@ def _assert_bindings_v2_metadata(bindings: dict) -> None:
             )
 
 
+def _assert_required_external_bindings(bindings: dict) -> None:
+    """Ensure aliases from the SDD are not used as deployed resource names."""
+    resources = bindings.get("resources")
+    if not isinstance(resources, list):
+        _fail("bindings_v2.json must contain a resources array")
+    names_by_key = {
+        resource.get("key"): ((resource.get("value") or {}).get("name") or {}).get(
+            "defaultValue"
+        )
+        for resource in resources
+        if isinstance(resource, dict)
+    }
+    for key, expected_name in REQUIRED_EXTERNAL_BINDINGS.items():
+        actual_name = names_by_key.get(key)
+        if actual_name != expected_name:
+            _fail(
+                f"bindings_v2.json must bind {key!r} as deployed name "
+                f"{expected_name!r}; got {actual_name!r}"
+            )
+
+
 def main():
     plan = read_caseplan(EXPECTED_CASEPLAN if os.path.exists(EXPECTED_CASEPLAN) else None)
     if not os.path.exists(EXPECTED_BINDINGS_V2):
         _fail(f"missing required {EXPECTED_BINDINGS_V2}")
     with open(EXPECTED_BINDINGS_V2, encoding="utf-8") as f:
-        _assert_bindings_v2_metadata(json.load(f))
+        bindings = json.load(f)
+    _assert_bindings_v2_metadata(bindings)
+    _assert_required_external_bindings(bindings)
 
     # --- trigger: Manual, so `uip maestro case debug` can start the case headlessly
     triggers = find_triggers(plan)

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -57,6 +57,11 @@ initial_prompt: |
     only `subType` (or be empty). Do not add `bindingsVersion` or
     `solutionsSupport`: those fields make `uip solution resources refresh` fail
     with "Node already added to the graph" in this eval environment.
+  - The SDD resource labels are aliases. In `bindings_v2.json`, use these deployed
+    resource keys and names exactly: `NameToAgeFixed2` → `API Workflow`,
+    `CountLetters` → `CountLetters`, `ProcurementProcess` →
+    `ProcurementProcess`, `ProjectEuler` → `RPA Workflow`, and `CaseTest` →
+    `Maestro Case`. Do not substitute an SDD alias for a deployed name.
   - Treat all hard stops after the SDD as pre-approved, including Phase 1
     planning approval, Phase 2 publish-for-review, and Phase 5 debug. Choose the
     continue / skip-publish path and keep going.

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -33,7 +33,7 @@ agent:
 run_limits:
   task_timeout: 4800
   max_turns: 500
-  turn_timeout: 2700
+  turn_timeout: 4800
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -53,6 +53,10 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is already available and authenticated in the environment.
+  - For each non-connector resource, `bindings_v2.json` metadata may contain
+    only `subType` (or be empty). Do not add `bindingsVersion` or
+    `solutionsSupport`: those fields make `uip solution resources refresh` fail
+    with "Node already added to the graph" in this eval environment.
   - Treat all hard stops after the SDD as pre-approved, including Phase 1
     planning approval, Phase 2 publish-for-review, and Phase 5 debug. Choose the
     continue / skip-publish path and keep going.

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -32,7 +32,7 @@ agent:
 
 run_limits:
   task_timeout: 4800
-  max_turns: 250
+  max_turns: 500
   turn_timeout: 2700
 
 sandbox:

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
@@ -9,7 +9,10 @@ from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from check_expense_runnable_structure import _assert_bindings_v2_metadata  # noqa: E402
+from check_expense_runnable_structure import (  # noqa: E402
+    _assert_bindings_v2_metadata,
+    _assert_required_external_bindings,
+)
 
 
 class BindingsV2MetadataTests(unittest.TestCase):
@@ -73,3 +76,46 @@ class RunLimitTests(unittest.TestCase):
             if separator and name in {"task_timeout", "turn_timeout"}:
                 limits[name] = int(value.strip())
         self.assertEqual(limits["turn_timeout"], limits["task_timeout"])
+
+
+class ResourceBindingTests(unittest.TestCase):
+    def test_accepts_runnable_resource_display_names(self) -> None:
+        _assert_required_external_bindings(
+            {
+                "resources": [
+                    {
+                        "key": "Shared/uipath-maestro-case/NameToAgeFixed2.API Workflow",
+                        "value": {"name": {"defaultValue": "API Workflow"}},
+                    },
+                    {
+                        "key": "Shared/uipath-maestro-flow/CountLetters CodedAgent.CountLetters",
+                        "value": {"name": {"defaultValue": "CountLetters"}},
+                    },
+                    {
+                        "key": "Shared/uipath-agents/ProcurementProcess.ProcurementProcess",
+                        "value": {"name": {"defaultValue": "ProcurementProcess"}},
+                    },
+                    {
+                        "key": "Shared/uipath-maestro-flow/ProjectEuler RPA.RPA Workflow",
+                        "value": {"name": {"defaultValue": "RPA Workflow"}},
+                    },
+                    {
+                        "key": "Shared/uipath-maestro-case/CaseTest.Maestro Case",
+                        "value": {"name": {"defaultValue": "Maestro Case"}},
+                    },
+                ]
+            }
+        )
+
+    def test_rejects_resource_alias_in_place_of_display_name(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "API Workflow"):
+            _assert_required_external_bindings(
+                {
+                    "resources": [
+                        {
+                            "key": "Shared/uipath-maestro-case/NameToAgeFixed2.NameToAgeFixed2",
+                            "value": {"name": {"defaultValue": "NameToAgeFixed2"}},
+                        }
+                    ]
+                }
+            )

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
@@ -45,7 +46,6 @@ class BindingsV2MetadataTests(unittest.TestCase):
                     ],
                 }
             )
-
     def test_rejects_solutions_support_metadata(self) -> None:
         with self.assertRaisesRegex(SystemExit, "solutionsSupport"):
             _assert_bindings_v2_metadata(
@@ -60,3 +60,16 @@ class BindingsV2MetadataTests(unittest.TestCase):
                     ],
                 }
             )
+
+
+class RunLimitTests(unittest.TestCase):
+    def test_turn_timeout_covers_the_full_e2e_task_budget(self) -> None:
+        task_yaml = Path(__file__).with_name("expense_runnable_e2e.yaml").read_text(
+            encoding="utf-8"
+        )
+        limits = {}
+        for line in task_yaml.splitlines():
+            name, separator, value = line.strip().partition(":")
+            if separator and name in {"task_timeout", "turn_timeout"}:
+                limits[name] = int(value.strip())
+        self.assertEqual(limits["turn_timeout"], limits["task_timeout"])

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/test_check_expense_runnable_structure.py
@@ -1,0 +1,62 @@
+"""Unit tests for the ExpenseReimbursementRunnable structural checker."""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from check_expense_runnable_structure import _assert_bindings_v2_metadata  # noqa: E402
+
+
+class BindingsV2MetadataTests(unittest.TestCase):
+    def test_accepts_documented_bindings_v2_metadata_shape(self) -> None:
+        _assert_bindings_v2_metadata(
+            {
+                "version": "2.0",
+                "resources": [
+                    {
+                        "resource": "process",
+                        "key": "Shared/Example/API Workflow",
+                        "metadata": {"subType": "Api"},
+                    },
+                    {
+                        "resource": "process",
+                        "key": "Shared/Example/RPA Workflow",
+                        "metadata": {},
+                    },
+                ],
+            }
+        )
+
+    def test_rejects_bindings_version_metadata(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "bindingsVersion"):
+            _assert_bindings_v2_metadata(
+                {
+                    "version": "2.0",
+                    "resources": [
+                        {
+                            "resource": "process",
+                            "key": "Shared/Example/API Workflow",
+                            "metadata": {"subType": "Api", "bindingsVersion": "2.2"},
+                        }
+                    ],
+                }
+            )
+
+    def test_rejects_solutions_support_metadata(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "solutionsSupport"):
+            _assert_bindings_v2_metadata(
+                {
+                    "version": "2.0",
+                    "resources": [
+                        {
+                            "resource": "process",
+                            "key": "Shared/Example/API Workflow",
+                            "metadata": {"subType": "Api", "solutionsSupport": "true"},
+                        }
+                    ],
+                }
+            )


### PR DESCRIPTION
## Summary
- Raise the expense runnable E2E task turn budget from 250 to 500.
- Preserve the full SDD-to-95-task planning, build, validation, and debug workflow without changing task semantics or timeouts.

## Why
The observed workflow can exceed the former 250-turn limit before it reaches runtime validation. In a fresh run with the new limit, the agent used 291 assistant turns and did not exhaust its turn budget.

## Validation
- `coder-eval plan tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml -e tests/experiments/default.yaml`
- `coder-eval run tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml -e tests/experiments/default.yaml --stream minimal`
  - Reached 291 assistant turns with `max_turns_exhausted: false`.
  - 3/4 criteria passed; the remaining debug criterion stopped on tenant configuration: `409 Cannot find a personal robot configured`, not a turn limit.
- YAML parse/assertion confirms `run_limits.max_turns: 500`.
- `git diff --check`