### PR TITLE
docs(uipath-rpa): recommend UIA >= 26.10.0 (stable) as the minimum

### DIFF
--- a/skills/uipath-rpa/references/uia-prerequisites.md
+++ b/skills/uipath-rpa/references/uia-prerequisites.md
@@ -1,10 +1,10 @@
 # UiAutomation Prerequisites
 
 **Required package:** `UiPath.UIAutomation.Activities`
-**Minimum version (`<MIN_VERSION>`):** `26.4.1-preview`
-**Source feed:** the official UiPath NuGet feed — the same feed Studio resolves by default. Prerelease / preview builds of `UiPath.UIAutomation.Activities` are published there alongside stable releases. Installing them is a normal supported path, not a third-party workaround.
+**Minimum version (`<MIN_VERSION>`):** `26.10.0`
+**Source feed:** the official UiPath NuGet feed — the same feed Studio resolves by default.
 
-> **Prerelease required.** `<MIN_VERSION>` is a preview — stable releases of `UiPath.UIAutomation.Activities` do NOT yet ship the `uia-configure-target` skill content. Install the prerelease build explicitly. `uip rpa packages versions` MUST be invoked with `--include-prerelease` (the flag defaults to `false`), otherwise the required preview is filtered out of the listing and the agent will report "no upgrade available" against a feed that actually has it.
+> **Stable release.** `<MIN_VERSION>` is a stable GA build — it ships the `uia-configure-target` skill content and resolves from the official feed without any prerelease flag. Querying with `--include-prerelease` is still fine (it surfaces newer preview builds), but it is not needed to reach `<MIN_VERSION>`.
 
 The `uip rpa uia` CLI used by `uia-configure-target` requires `UiPath.UIAutomation.Activities` at `<MIN_VERSION>` or newer. Before configuring any target, check the installed version in `project.json` under `dependencies`.
 
@@ -17,10 +17,10 @@ Never upgrade UIA silently. Every upgrade requires explicit user consent before 
 
 | Scenario | Behavior |
 |---|---|
-| No UIA installed, request needs UIA | Ask before installing `<MIN_VERSION>`. Disclose that it is a prerelease build from the official UiPath feed. |
+| No UIA installed, request needs UIA | Ask before installing `<MIN_VERSION>` from the official UiPath feed. |
 | Major-version upgrade (e.g. `25.x` → `26.x`) | Ask. Note that breaking changes are possible across major versions. |
-| Minor-version upgrade (e.g. `26.3.x` → `26.4.x`) | Ask. Note that the minimum required for `uia-configure-target` is a preview. |
-| Patch / build upgrade within the preview band | Ask before installing the newer preview build. |
+| Minor-version upgrade (e.g. `26.4.x` → `26.10.x`) | Ask before installing the newer build. |
+| Patch / build upgrade within the `26.10.x` band | Ask before installing the newer build. |
 | Already at or above `<MIN_VERSION>` | Proceed without prompting. |
 
 If the user declines, do NOT install. Warn that `uip rpa uia` commands will fail without UIA at `<MIN_VERSION>` and fall back to indication authoring — [uia-configure-target-workflows.md](uia-configure-target-workflows.md) MUST be read IN FULL first (see § Indication Fallback). Record `UI capture: indication-only` in the plan header so downstream tasks do not route to `uia-configure-target`.
@@ -39,4 +39,4 @@ Install / upgrade (mutating — only after consent per the table above; substitu
 uip rpa packages install --packages 'id=UiPath.UIAutomation.Activities,version=<MIN_VERSION>' --project-dir "$PROJECT_DIR" --output json
 ```
 
-`packages install` accepts the beta version directly via the `version` field — no separate prerelease flag is needed once the version string is specified explicitly.
+`packages install` resolves `<MIN_VERSION>` directly via the `version` field — no prerelease flag is needed, since it is a stable release. Omit `,version=<MIN_VERSION>` to resolve the latest compatible build (which will be at or above `<MIN_VERSION>`).


### PR DESCRIPTION
## What

Bumps the `UiPath.UIAutomation.Activities` minimum in `skills/uipath-rpa/references/uia-prerequisites.md` from `26.4.1-preview` to the **`26.10.0` stable GA** build.

## Why

The `uia-configure-target` skill content now ships in a stable release, so the minimum no longer needs to point at a prerelease. Recommending a stable floor removes the prerelease friction (mandatory `--include-prerelease`, "disclose it's a preview" prompts) for the common path.

## Changes (`uia-prerequisites.md`)

- **Minimum version** → `26.10.0`.
- Replaced the **"Prerelease required"** callout with a **"Stable release"** note: `26.10.0` resolves from the official feed without any prerelease flag; `--include-prerelease` stays optional for surfacing newer previews.
- Trimmed the source-feed line (no longer needs the "prereleases are a supported path" justification).
- Updated the **upgrade-consent table** rows (minor/patch bands now reference `26.10.x`; dropped prerelease-disclosure wording).
- Updated the trailing install note — no beta/prerelease flag needed; documented the `,version=` omission to resolve latest compatible.

The consent model (never upgrade silently, plan-mode vs interactive, indication-only fallback on decline) is unchanged.

## Out of scope / follow-up

- `references/coded/operations-guide.md:409` still pins UIA at `25.10.21` inside a **coded v25.x** pinned-versions band (System 25.12.2, Testing 25.10.2, …). Bumping only UIA to 26.x there would create a cross-major mismatch in that band, so it's left untouched — flagging for a maintainer to decide whether that whole band should advance.
- `references/xaml/xaml-basics-and-rules.md:253` mentions `26.4.1-preview` only as a historical property-drift example (`InputMode`→`InteractionMode`), not a recommendation — intentionally left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)