### PR TITLE
test(maestro-flow): add interactive escalation eval

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py
@@ -78,7 +78,7 @@ def main() -> int:
             continue
 
         r = subprocess.run(
-            ["uip", "solution", "delete", sid, "--output", "json"],
+            ["uip", "solution", "delete", sid, "--yes", "--output", "json"],
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/check_customer_escalation_triage.py
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/check_customer_escalation_triage.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Execute seeded escalation cases and verify named business outcomes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+
+_directory = os.path.dirname(os.path.abspath(__file__))
+while _directory != os.path.dirname(_directory) and not os.path.isdir(
+    os.path.join(_directory, "_shared")
+):
+    _directory = os.path.dirname(_directory)
+sys.path.insert(0, _directory)
+
+from _shared.flow_check import assert_output_nonempty, run_debug  # noqa: E402
+
+
+def normalized(value: Any) -> Any:
+    """Normalize scalar runtime values without accepting loose substrings."""
+    if isinstance(value, str):
+        text = value.strip()
+        lowered = text.casefold()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return lowered
+    return value
+
+
+def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
+    actual = assert_output_nonempty(payload, name)
+    if normalized(actual) != normalized(expected):
+        raise SystemExit(
+            f"FAIL: output {name!r}: expected {expected!r}, got {actual!r}"
+        )
+
+
+def verify_case(case: dict) -> None:
+    payload = run_debug(inputs=case["inputs"], timeout=300)
+    for name, expected in case["expected"].items():
+        assert_named_equals(payload, name, expected)
+    print(f"OK: {case['name']} produced the expected business outcomes")
+
+
+def main() -> None:
+    seed_path = Path("seed.json")
+    if not seed_path.is_file():
+        raise SystemExit("FAIL: seed.json is missing; pre_run did not complete")
+    seed = json.loads(seed_path.read_text(encoding="utf-8"))
+    cases = seed.get("cases")
+    if not isinstance(cases, list) or len(cases) != 2:
+        raise SystemExit("FAIL: seed.json must contain exactly two cases")
+    for case in cases:
+        verify_case(case)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -1,0 +1,104 @@
+task_id: skill-flow-interactive-customer-escalation-triage
+description: >
+  Interactive end-to-end Flow evaluation. A simulated support-operations
+  expert asks for a customer-escalation triage flow but withholds the company's
+  severity, engineering-handoff, and acknowledgement policies until the coding
+  agent asks relevant follow-up questions. The resulting flow must validate and
+  produce the correct business outputs for independently seeded Sev1 and Sev3
+  cases when the grader runs it.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, feature:escalation, feature:conversational]
+
+run_limits:
+  expected_turns: 45
+  max_turns: 100
+  turn_timeout: 1200
+  task_timeout: 2400
+
+agent:
+  # allowed_tools uses replace semantics. Keep the default authoring tools and
+  # allow structured questions, while simulation also supports ordinary text
+  # questions from coding agents that do not expose AskUserQuestion.
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/seed.py"
+    timeout: 30
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+# No initial_prompt: simulation mode generates the opening request from the
+# persona and goal. The policy facts below are intentionally withheld until the
+# agent asks about them, making the conversation necessary to pass the runtime
+# business-outcome checks.
+simulation:
+  enabled: true
+  persona: |
+    You are an experienced support-operations manager. You know the company's
+    customer-escalation policy in depth, but you do not know UiPath syntax or
+    implementation details. Give business answers and let the coding agent
+    choose the Flow design.
+  goal: |
+    Get a new UiPath Flow project named CustomerEscalationTriage, inside a
+    solution of the same name, that classifies an escalation and returns these
+    named outputs: severity, engineeringNeeded, responseMode, and caseKey.
+    The flow inputs are customerTier, productionDown, workaroundAvailable,
+    businessImpact, and correlationId. The completed flow must validate. Do not
+    ask the coding agent to run it; the grader supplies seeded cases and runs it.
+  constraints:
+    - "In the opening request, state the goal and input/output names, but do not volunteer any severity, engineering-handoff, or acknowledgement policy."
+    - "Only reveal a policy after the agent asks a relevant follow-up question."
+    - "Sev1 means an Enterprise customer has production unavailable and no workaround."
+    - "Sev2 means production is degraded or unavailable but a viable workaround exists."
+    - "Sev3 means informational or routine follow-up with no production impact."
+    - "Engineering is needed for Sev1 and Sev2, but not Sev3."
+    - "Customer acknowledgements must always be drafted for human review, never sent automatically; responseMode must therefore be Draft."
+    - "caseKey must preserve the incoming correlationId so downstream systems can correlate the run."
+    - "If asked a finite-choice question, choose the option matching these policies."
+    - "Keep each reply concise and internally consistent."
+    - "If asked for permission to run or debug the flow, decline and say the grader will execute it after validation."
+  max_turns: 10
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-maestro-flow skill"
+    skill_name: "uipath-maestro-flow"
+    expected_skill: "uipath-maestro-flow"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent left execution to the grader instead of running flow debug"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated customer-escalation Flow validates without errors"
+    command: "uip maestro flow validate CustomerEscalationTriage/CustomerEscalationTriage/CustomerEscalationTriage.flow --output json"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Seeded Sev1 and Sev3 runs produce the elicited severity, engineering, draft-response, and correlation outcomes"
+    command: "python3 $TASK_DIR/check_customer_escalation_triage.py"
+    timeout: 660
+    expected_exit_code: 0
+    weight: 8.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/seed.py
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/seed.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Seed isolated business inputs for the interactive escalation eval."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+
+def build_seed() -> dict:
+    run_id = uuid4().hex[:12]
+    return {
+        "run_id": run_id,
+        "cases": [
+            {
+                "name": "enterprise-production-down",
+                "inputs": {
+                    "customerTier": "Enterprise",
+                    "productionDown": True,
+                    "workaroundAvailable": False,
+                    "businessImpact": "All production users are blocked",
+                    "correlationId": f"E2E-{run_id}-SEV1",
+                },
+                "expected": {
+                    "severity": "Sev1",
+                    "engineeringNeeded": True,
+                    "responseMode": "Draft",
+                    "caseKey": f"E2E-{run_id}-SEV1",
+                },
+            },
+            {
+                "name": "informational-follow-up",
+                "inputs": {
+                    "customerTier": "Standard",
+                    "productionDown": False,
+                    "workaroundAvailable": True,
+                    "businessImpact": "Informational product question only",
+                    "correlationId": f"E2E-{run_id}-SEV3",
+                },
+                "expected": {
+                    "severity": "Sev3",
+                    "engineeringNeeded": False,
+                    "responseMode": "Draft",
+                    "caseKey": f"E2E-{run_id}-SEV3",
+                },
+            },
+        ],
+    }
+
+
+def main() -> None:
+    path = Path("seed.json")
+    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/test_customer_escalation_triage.py
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/test_customer_escalation_triage.py
@@ -1,0 +1,63 @@
+"""Focused tests for the escalation sandbox seed and output comparison."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+HERE = Path(__file__).resolve().parent
+
+
+def _load(name: str, filename: str):
+    spec = importlib.util.spec_from_file_location(name, HERE / filename)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+checker = _load("customer_escalation_checker", "check_customer_escalation_triage.py")
+seed = _load("customer_escalation_seed", "seed.py")
+
+
+def _payload(**outputs):
+    return {"Variables": {"Globals": outputs}}
+
+
+class CustomerEscalationTriageTests(unittest.TestCase):
+    def test_seed_has_isolated_sev1_and_sev3_cases(self) -> None:
+        document = seed.build_seed()
+
+        self.assertEqual(len(document["cases"]), 2)
+        self.assertEqual(document["cases"][0]["expected"]["severity"], "Sev1")
+        self.assertEqual(document["cases"][1]["expected"]["severity"], "Sev3")
+        self.assertNotEqual(
+            document["cases"][0]["inputs"]["correlationId"],
+            document["cases"][1]["inputs"]["correlationId"],
+        )
+
+    def test_named_comparison_accepts_runtime_string_booleans(self) -> None:
+        checker.assert_named_equals(
+            _payload(engineeringNeeded="true"), "engineeringNeeded", True
+        )
+        checker.assert_named_equals(
+            _payload(engineeringNeeded="false"), "engineeringNeeded", False
+        )
+
+    def test_named_comparison_is_case_insensitive_for_text(self) -> None:
+        checker.assert_named_equals(_payload(severity="SEV1"), "severity", "Sev1")
+        checker.assert_named_equals(
+            _payload(responseMode="draft"), "responseMode", "Draft"
+        )
+
+    def test_named_comparison_rejects_wrong_business_outcome(self) -> None:
+        with self.assertRaisesRegex(SystemExit, "expected 'Sev1'"):
+            checker.assert_named_equals(
+                _payload(severity="Sev3"), "severity", "Sev1"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Add an interactive `uipath-maestro-flow` coder-eval task for customer escalation triage.
- Use a simulated support-operations persona that withholds severity, engineering-handoff, and acknowledgement policies until the coding agent asks follow-up questions.
- Seed independent Sev1 and Sev3 cases and verify named business outputs through real Flow debug runs.
- Add focused unit coverage for seed isolation and runtime output normalization.
- Pass `--yes` to shared solution cleanup because current CLI deletion requires explicit confirmation.

## Why

Existing ETA coverage is primarily one-shot. This adds a concrete multi-turn evaluation that requires policy elicitation before implementation and proves the resulting Flow behavior with independently supplied runtime inputs.

## Impact

The new task exercises genuine user-agent interaction while retaining deterministic, behavior-based grading. Shared Flow teardown now remains compatible with the current CLI and removes temporary Studio Web solutions reliably.

## Validation

- `python3 -m unittest discover -s tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage -p 'test_*.py' -v` — 4/4 passed
- `coder-eval plan ...` — task valid
- CLI verb audit — passed
- Full interactive coder-eval run — 1/1 succeeded, score 1.000, 3 conversational turns
- Generated Flow validation — `Status: Valid`
- Seeded Enterprise Sev1 and informational Sev3 runtime cases — passed
- Post-run solution cleanup — deleted temporary solution successfully
