### PR TITLE
fix(uipath-platform): stop traces feedback e2e from timing out

### DIFF
--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -20,7 +20,7 @@ run_limits:
 initial_prompt: |
   Run a feedback round-trip on a real trace:
   - Start one job for process `$TRACES_SMOKE_PROCESS_KEY`, wait for it to finish, and save the result to job.json
-  - Fetch the trace spans for that job with `uip traces spans get --job-key ...` and save to spans.json
+  - Fetch the trace spans for that job and save to spans.json
   - Create positive feedback on the trace and save the response to feedback_create.json
   - Fetch the feedback record back by ID and save to feedback_get.json
 

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -10,15 +10,23 @@ tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces, feedback
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
+# Starts a real job and waits for its trace to land, so wall-clock runs long.
+# The default 900s ceiling isn't enough — a single job-completion poll can take
+# ~5min on a busy tenant. Match the slower data-fabric e2e tasks.
 run_limits:
   expected_turns: 16
+  turn_timeout: 1800
 
 initial_prompt: |
   Run a feedback round-trip on a real trace:
-  - Start a job for process `$TRACES_SMOKE_PROCESS_KEY` and save the result to job.json
-  - Fetch the LLM trace spans for that job and save to spans.json
+  - Start one job for process `$TRACES_SMOKE_PROCESS_KEY`, wait for it to finish, and save the result to job.json
+  - Fetch the trace spans for that job with `uip traces spans get --job-key ...` and save to spans.json
   - Create positive feedback on the trace and save the response to feedback_create.json
   - Fetch the feedback record back by ID and save to feedback_get.json
+
+  Use the one job you started above — don't start extra jobs or hunt across
+  other jobs for specific span types. Any span the job emits is fine; the root
+  span works.
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## What & why

The `skill-platform-traces-feedback-e2e` task failed by hitting the **default 900s** turn ceiling (score 0). Two causes:

1. **Real job latency** — the task starts a live job and waits for its trace. In the failing run one `uip or jobs get` poll loop alone ran ~325s (job stayed pending), plus two `--wait-for-completion --timeout 120` starts.
2. **Prompt sent the agent hunting** — it said "fetch the **LLM** trace spans," so the agent scanned jobs across all folders for `agentRun`/`LlmRun` spans and started several different agent processes. But `check_traces_feedback_e2e.py` falls back to the **root span (`ParentId=null`) of any job**, so LLM-specific spans were never required — the hunting just multiplied the job waits.

## The change
- `run_limits.turn_timeout: 1800` — matches the slower data-fabric e2e tasks (which set 600–1500s); the default 900s isn't enough for a real job round-trip.
- Reworded `initial_prompt`: start **one** job, "trace spans" instead of "LLM trace spans", and an explicit note that any span (root included) is fine and not to start extra jobs.

Success criteria and the check script are unchanged — the required commands (`uip traces spans get --job-key`, `feedback create --positive --trace-id`, `feedback get`) still match.

Note: the two sibling seed-failure tasks (`queue-progress`, `trigger-api`) failed for a separate reason — a CLI tool-resolution bug fixed in UiPath/cli#3083 — not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)