### PR TITLE
docs(uipath-rpa): document --profiling for advanced UI automation debugging

### DIFF
--- a/skills/uipath-rpa/references/ui-automation-guide.md
+++ b/skills/uipath-rpa/references/ui-automation-guide.md
@@ -293,6 +293,16 @@ Install the UI Library as a package dependency; its descriptors appear under **U
 
 Skipping steps 4-5 causes the next run's open-if-not-open behavior to reuse a stale window in whatever state it was left in, or -- if the selector doesn't match -- to spawn a duplicate instance.
 
+### Advanced Debugging — Profiling
+
+For advanced debugging, add `--profiling` to collect insightful per-activity execution data, timings, and before- and after-execution screenshots:
+
+```bash
+uip rpa debug start --file-path "<FILE>" --project-dir "<PROJECT_DIR>" --output json --profiling
+```
+
+Use the before-execution screenshot to confirm the application/element started in the correct state, and the after-execution one to validate the expected outcome. Each screenshot's filename is recorded in the run's `.uistat` file; the image sits in the `Screenshots` folder in the same directory as that `.uistat` file. See [debugging.md § Profiling Workflow Performance](debugging.md#profiling-workflow-performance) for details.
+
 ### Runtime Selector Failure Recovery
 
 "UI element not found", "UI element is invalid", element not on screen -- these surface at runtime, not during static validation. They occur when a selector was captured against one app state but the DOM changed by the time the activity executes.


### PR DESCRIPTION
Add an Advanced Debugging — Profiling subsection to the Running UI Automation Workflows section, covering the --profiling flag for collecting per-activity execution data, timings, and before/after screenshots. Points to debugging.md for full details and explains where screenshots live (.uistat filename + Screenshots folder).