### PR TITLE
docs(uipath-governance): compliance-pack 409 conflicts are retryable

### DIFF
--- a/skills/uipath-governance/references/compliance-pack/full-apply/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/full-apply/impl.md
@@ -158,7 +158,8 @@ Note: compliance status is determined by your auditor, not this tool.
 | Error | Action |
 |---|---|
 | Any compliance-packs call → **403 / Forbidden** | Org not enrolled in the Compliance Standards preview — stop, do not retry, run no further compliance commands. Show the opt-in message. See [preview-gate.md](../preview-gate.md). |
-| `state enable` → 4xx (non-403) | Halt. Report error verbatim. Do NOT retry. |
+| `state enable` → **409** with `"Retry": "RetryAfter10Seconds"` | Another operation holds the per-pack lock (e.g. a concurrent enable/disable) — transient. Wait ~10 seconds and retry, up to 3 attempts. Halt and report only if it persists. |
+| `state enable` → 4xx (non-403, non-409) | Halt. Report error verbatim. Do NOT retry. |
 | `state enable` → 5xx AND `"Retry": "RetryWillNotFix"` | Halt. Report error verbatim. Do NOT retry — the server explicitly flagged retrying as futile. |
 | `state enable` → 5xx (transient, no `RetryWillNotFix`) | Retry once after a short pause. If it fails again, halt and report. |
 | `Data.active != true` after enable | Unexpected — ask user to run `state get` manually and report the output. |


### PR DESCRIPTION
Companion to UiPath/cli#3086, which makes the CLI's compliance-pack HTTP 409 ("operation already in progress" — the service's per-pack lock) emit `Retry: RetryAfter10Seconds` instead of the generic `RetryWillNotFix`.

The full-apply error table told agents to halt on any 4xx (non-403), which now contradicts the envelope. This splits the 409 into its own row (wait ~10s, up to 3 attempts) and scopes the halt row to non-403/non-409.

Other references checked and unaffected: `disable/impl.md` has no retry table; `partial-apply`'s 4xx rows cover `aops-policy`/`deployment` commands whose behavior is unchanged; the preview-gate 403 guidance is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)