### PR TITLE
chore(eval): track the CLI `dev` channel instead of stale `alpha`

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -44,9 +44,11 @@ on:
         type: string
         default: ''
       cli_version:
-        description: '@uipath/cli version.'
+        description: '@uipath/cli version (dist-tag or exact). `dev` tracks
+          main and auto-updates on every push; `alpha` is a manual prerelease
+          that goes stale between cuts.'
         type: string
-        default: alpha
+        default: dev
       agent:
         description: 'Agent to run.'
         type: choice

--- a/tests/docker/Dockerfile
+++ b/tests/docker/Dockerfile
@@ -4,25 +4,27 @@ ARG CODER_EVAL_IMAGE=coder-eval-agent:latest
 FROM ${CODER_EVAL_IMAGE}
 
 ARG NPM_AUTH_TOKEN=
-ARG CLI_VERSION=alpha
+ARG CLI_VERSION=dev
 # Install the UiPath CLI shell AND pre-bake the tool plugins the eval CHECKERS
 # invoke (`uip or` → orchestrator-tool, `uip is` → integrationservice-tool,
 # `uip maestro` → maestro-tool).
 #
 # Why pre-bake (do NOT rely on the CLI's on-demand auto-install at eval time):
-# the @uipath tool plugins ship CLI-compatible builds only as `-alpha` on the
-# private GitHub Packages feed (public npm has stable releases only, no alpha
-# channel). At eval time the sandbox pins NPM_CONFIG_PREFIX to a task-local
-# `.npm-prefix` (coder_eval sandbox.py, MST-9674), so the CLI's npmrc lookup
-# misses this @uipath:registry config and on-demand auto-install falls back to
-# public npm, failing with "No compatible alpha version of '<tool>' found for
-# CLI". Installing the plugins here lands them in the global @uipath dir
-# (PLUGIN_TOOLS_DIR) so they are discovered on disk — no eval-time registry
+# at eval time the sandbox pins NPM_CONFIG_PREFIX to a task-local `.npm-prefix`
+# (coder_eval sandbox.py, MST-9674), so the CLI's npmrc lookup misses the
+# @uipath:registry config below and on-demand auto-install falls back to public
+# npm, failing with "No compatible version of '<tool>' found for the CLI's
+# <line> line". Installing the plugins here lands them in the global @uipath
+# dir (PLUGIN_TOOLS_DIR) so they are discovered on disk — no eval-time registry
 # resolution, and a feed/registry outage fails THIS build loudly instead of
 # silently scoring agents 0 on every orchestrator/IS-dependent checker.
 # `set -euo pipefail` makes any failed tool install abort the build.
-# (Fixes the recurring `check_folder_id_fresh` "No compatible alpha version of
-# '@uipath/orchestrator-tool'" failures in skill-flow-outlook-trigger-inbox.)
+#
+# CLI_VERSION=dev is a prerelease build, so the `uip tools install` calls below
+# resolve same-tag (`-dev`) tool builds. That needs the CLI's prerelease
+# tool-channel resolution fix (UiPath/cli#3083): a dev CLI without it resolves
+# tools on `stable`, finds none on its prerelease-only line, and fails these
+# installs. Land #3083 in a published `dev` build before flipping this to dev.
 RUN set -euo pipefail && \
     if [ -z "$NPM_AUTH_TOKEN" ]; then \
       echo "Error: NPM_AUTH_TOKEN must be passed as build arg"; exit 1; \


### PR DESCRIPTION
## ⚠️ Draft — hold merge until UiPath/cli#3083 is in a published `dev` build

## What & why

The platform eval installed `@uipath/cli@alpha` by default (`tests/docker/Dockerfile` `ARG CLI_VERSION`, and the `cli_version` input in `run-coder-eval.yml`). The `alpha` dist-tag is cut **manually** and had gone stale:

```
alpha:  1.197.0-alpha.20260626.7673   ← stuck since Jun 26
dev:    1.199.0-dev.7902              ← moves on every push to main
latest: 1.199.0-dev.7902
```

So the eval kept testing a two-month-old CLI and never saw `main`. `dev` auto-publishes on every push to `main`, so switching to it makes the eval track HEAD and pick up new CLI fixes automatically — no manual alpha cut.

## The change
- `Dockerfile`: `ARG CLI_VERSION=alpha` → `dev` (+ refreshed the pre-bake comment, which still described the `-alpha` feed).
- `run-coder-eval.yml`: `cli_version` default `alpha` → `dev`.

## Dependency (why it's a draft)
`dev` is a **prerelease** tag, so a `@dev` CLI is subject to the same tool-resolution bug this whole thread is about: without **UiPath/cli#3083**, a prerelease CLI resolves tools on `stable`, finds none on its prerelease-only line, and fails — which would break both the Docker image build (`uip tools install`) and eval-time auto-install.

**Merge order:**
1. Merge UiPath/cli#3083 → auto-publishes a `dev` build with the fix.
2. Then merge this → the eval installs that fixed `@dev` CLI, which resolves same-tag (`-dev`) tools.

Until then this stays a draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)