### PR TITLE
test(maestro-bpmn): port structural single-node evals from flow suite

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/parallel/fork_join/check_fork_join.py
+++ b/tests/tasks/uipath-maestro-bpmn/parallel/fork_join/check_fork_join.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Structural check for the parallel fork + synchronizing join port.
+
+Asserts a parallel gateway forks into two concurrent branches (one in, >=2 out)
+and a parallel gateway synchronizes them (>=2 in, one out), with two distinct
+branch activities between fork and join. Verifies diagram and sequence-flow
+integrity.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("ParallelSync")
+
+    gateways = one_or_more(root, "parallelGateway")
+    flows = elements(root, "sequenceFlow")
+
+    def out_flows(node_id):
+        return [f for f in flows if attr(f, "sourceRef") == node_id]
+
+    def in_flows(node_id):
+        return [f for f in flows if attr(f, "targetRef") == node_id]
+
+    forks = [gw for gw in gateways if len(out_flows(attr(gw, "id"))) >= 2]
+    joins = [gw for gw in gateways if len(in_flows(attr(gw, "id"))) >= 2]
+    if not forks:
+        fail("no parallel gateway forks into >=2 outgoing flows")
+    if not joins:
+        fail("no parallel gateway synchronizes >=2 incoming flows")
+
+    # The fork's two outgoing flows must reach two distinct downstream nodes.
+    fork = forks[0]
+    targets = {attr(f, "targetRef") for f in out_flows(attr(fork, "id"))}
+    if len(targets) < 2:
+        fail(f"fork gateway {attr(fork, 'id')} does not branch to >=2 distinct nodes")
+
+    # The join's incoming flows must originate from two distinct upstream nodes.
+    join = joins[0]
+    sources = {attr(f, "sourceRef") for f in in_flows(attr(join, "id"))}
+    if len(sources) < 2:
+        fail(f"join gateway {attr(join, 'id')} does not synchronize >=2 distinct branches")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} forks into parallel branches and synchronizes them at a join gateway")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/parallel/fork_join/fork_join.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/parallel/fork_join/fork_join.yaml
@@ -1,0 +1,67 @@
+task_id: skill-bpmn-parallel-fork-join
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  parallel gateway fork into two concurrent branches that a parallel gateway
+  synchronizes (join) before the end — the BPMN analogue of a Flow parallel-sync
+  merge. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:multi-node", "node:gateway", "feature:parallel-tasks"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `ParallelSync.bpmn` in the working directory
+  that runs two branches concurrently and synchronizes them before finishing:
+
+      start -> forkGateway ==> branchA task ==> joinGateway -> end
+                          \=> branchB task =/
+
+  Requirements:
+  - A bpmn:parallelGateway fork (one incoming, two outgoing) splits into two
+    distinct branch tasks.
+  - A bpmn:parallelGateway join (two incoming, one outgoing) synchronizes both
+    branches before a single end event. Parallel flows carry no conditions.
+  - Author the structural BPMN per the skill's structural reference (mind the
+    SUPERFLUOUS_GATEWAY and FAKE_JOIN rules — join with a gateway, not by
+    pointing two flows at one activity); do not hand-author uipath:* XML from
+    prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "ParallelSync.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a parallel gateway"
+    path: "ParallelSync.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "parallelGateway"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN forks into >=2 distinct parallel branches and synchronizes them at a join gateway, with full DI"
+    command: "python3 $TASK_DIR/check_fork_join.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/check_subprocess.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/check_subprocess.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Structural check for the subprocess / call-activity port (Flow Subflow analogue).
+
+Asserts the logic is encapsulated in a container: either an embedded
+bpmn:subProcess with its own nested start event, end event, and at least one
+inner activity, or a bpmn:callActivity. Verifies the container (and its inner
+nodes) carry diagram shapes and that all sequence flows resolve.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+INNER_ACTIVITY = ("task", "scriptTask", "serviceTask", "userTask", "businessRuleTask", "sendTask", "receiveTask")
+
+
+def main() -> None:
+    path, root = parse_bpmn("SubflowDemo")
+
+    subprocesses = elements(root, "subProcess")
+    call_activities = elements(root, "callActivity")
+    if not subprocesses and not call_activities:
+        fail("no bpmn:subProcess or bpmn:callActivity — logic is not encapsulated in a subflow")
+
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+
+    if subprocesses:
+        sp = subprocesses[0]
+        sp_id = attr(sp, "id")
+        if sp_id not in shaped:
+            fail(f"subProcess {sp_id} has no BPMNShape (invisible on the canvas)")
+        nested_start = sp.findall("bpmn:startEvent", NS)
+        nested_end = sp.findall("bpmn:endEvent", NS)
+        nested_acts = [a for k in INNER_ACTIVITY for a in sp.findall(f"bpmn:{k}", NS)]
+        if not nested_start:
+            fail(f"subProcess {sp_id} has no nested start event")
+        if not nested_end:
+            fail(f"subProcess {sp_id} has no nested end event")
+        if not nested_acts:
+            fail(f"subProcess {sp_id} has no inner activity (nothing encapsulated)")
+    else:
+        ca_id = attr(call_activities[0], "id")
+        if ca_id not in shaped:
+            fail(f"callActivity {ca_id} has no BPMNShape (invisible on the canvas)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    kind = "subProcess" if subprocesses else "callActivity"
+    print(f"OK: {path} encapsulates logic in a {kind} with a diagram shape")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
@@ -1,0 +1,76 @@
+task_id: skill-bpmn-subprocess
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to
+  encapsulate logic inside a container (an embedded bpmn:subProcess or a
+  bpmn:callActivity) — the BPMN analogue of a Flow Subflow. Authoring only — no
+  cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:subflow"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 60
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `SubflowDemo.bpmn` in the working directory
+  that takes a string and reverses it, with the reversal logic encapsulated in a
+  container rather than sitting directly in the top-level process.
+
+  Requirements:
+  - Encapsulate the logic in an embedded bpmn:subProcess (with its own nested
+    start event, an inner activity such as a scriptTask, and a nested end event)
+    OR a bpmn:callActivity.
+  - The top-level flow is: start -> container -> end.
+  - Author the structural BPMN per the skill's structural reference; do not
+    hand-author uipath:* XML from prose. If you add a scriptTask, keep it
+    Jint-safe (no Node.js/browser APIs).
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every visible node
+    (including the container and its inner nodes) and a BPMNEdge for every
+    sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "SubflowDemo.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram"
+    path: "SubflowDemo.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN encapsulates logic in a subProcess (nested start/activity/end) or callActivity, with a shape and resolvable flows"
+    command: "python3 $TASK_DIR/check_subprocess.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the lifecycle local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent created only local files and did not run or request
+      approval for BPMN debug, process run, upload, publish, pack, or deploy
+      commands. Fail if tool calls or the final answer show any cloud-side
+      lifecycle mutation or any request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/switch/check_switch.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/switch/check_switch.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Structural check for the multi-way exclusive-gateway (switch) port.
+
+Asserts a single exclusive gateway routes 3+ conditioned branches plus exactly
+one default flow — the BPMN analogue of a Flow Switch node. Verifies diagram
+and sequence-flow integrity so the file is importable on the canvas.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("SeasonLookup")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    gateways = one_or_more(root, "exclusiveGateway")
+    flows = elements(root, "sequenceFlow")
+    flows_by_source: dict[str, list] = {}
+    for flow in flows:
+        flows_by_source.setdefault(attr(flow, "sourceRef"), []).append(flow)
+
+    # Find the multi-way gateway: one exclusive gateway with >=4 outgoing flows
+    # (>=3 conditioned branches + exactly one default).
+    multiway = None
+    for gw in gateways:
+        outgoing = flows_by_source.get(attr(gw, "id"), [])
+        if len(outgoing) >= 4:
+            multiway = gw
+            break
+    if multiway is None:
+        counts = {attr(gw, "id"): len(flows_by_source.get(attr(gw, "id"), [])) for gw in gateways}
+        fail(f"no exclusive gateway with >=4 outgoing flows (a multi-way switch); found {counts}")
+
+    gw_id = attr(multiway, "id")
+    outgoing = flows_by_source.get(gw_id, [])
+    default_id = attr(multiway, "default")
+    if not default_id:
+        fail(f"multi-way gateway {gw_id} has no default flow")
+
+    conditioned = [
+        f for f in outgoing
+        if attr(f, "id") != default_id
+        and f.find("bpmn:conditionExpression", NS) is not None
+    ]
+    if len(conditioned) < 3:
+        fail(f"multi-way gateway {gw_id} has {len(conditioned)} conditioned branches; need >=3")
+
+    non_default = [f for f in outgoing if attr(f, "id") != default_id]
+    uncondition = [f for f in non_default if f.find("bpmn:conditionExpression", NS) is None]
+    if uncondition:
+        fail(f"non-default flows without a condition: {[attr(f, 'id') for f in uncondition]}")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a multi-way exclusive gateway ({len(conditioned)} conditioned + 1 default)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
@@ -1,0 +1,80 @@
+task_id: skill-bpmn-switch
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  multi-way exclusive gateway (the BPMN analogue of a Flow Switch) that maps a
+  quarter number to a season name across 3+ conditioned branches plus a default.
+  Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:switch"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `SeasonLookup.bpmn` in the working directory
+  that maps a quarter number (1, 2, 3, or 4) to the matching season using ONE
+  exclusive gateway that fans out to a separate branch per value:
+    - 1 -> "Spring"
+    - 2 -> "Summer"
+    - 3 -> "Fall"
+    - 4 -> "Winter"
+
+  Requirements:
+  - A blank start event feeds the exclusive gateway (directly or via an
+    intake node).
+  - The exclusive gateway has at least 3 conditioned outgoing branches plus
+    exactly one default branch; each branch reaches its own end event.
+  - Author the structural BPMN (definitions/process scaffold, sequence-flow
+    conditions, gateway default) per the skill's structural reference; do not
+    hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "SeasonLookup.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and an exclusive gateway"
+    path: "SeasonLookup.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "exclusiveGateway"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a multi-way exclusive gateway (3+ conditioned branches + default), full DI, resolvable flows"
+    command: "python3 $TASK_DIR/check_switch.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the lifecycle local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent created only local files and did not run or request
+      approval for BPMN debug, process run, upload, publish, pack, or deploy
+      commands. Fail if tool calls or the final answer show any cloud-side
+      lifecycle mutation or any request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/terminate/check_terminate.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/terminate/check_terminate.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Structural check for the terminate-end-event port.
+
+Asserts one branch ends in a terminate end event (bare terminateEventDefinition)
+while another branch reaches a normal end event, both fanned out from a fork
+gateway. Terminate is authorable only on end events, so a terminate definition on
+any other element is a failure. Verifies diagram and sequence-flow integrity.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("TerminateParallel")
+
+    end_events = elements(root, "endEvent")
+    if len(end_events) < 2:
+        fail(f"expected >=2 end events (one terminate branch + one normal), found {len(end_events)}")
+
+    terminating = [e for e in end_events if e.find("bpmn:terminateEventDefinition", NS) is not None]
+    normal = [e for e in end_events if e.find("bpmn:terminateEventDefinition", NS) is None]
+    if not terminating:
+        fail("no end event carries a bpmn:terminateEventDefinition")
+    if not normal:
+        fail("no plain (non-terminate) end event — the other branch must end normally")
+
+    # Terminate must live only on end events.
+    for kind in ("startEvent", "intermediateCatchEvent", "intermediateThrowEvent", "boundaryEvent"):
+        for ev in elements(root, kind):
+            if ev.find("bpmn:terminateEventDefinition", NS) is not None:
+                fail(f"terminateEventDefinition on a {kind} — only valid on end events")
+
+    # A fork gateway (parallel or exclusive) drives the two branches.
+    flows = elements(root, "sequenceFlow")
+    forks = []
+    for kind in ("parallelGateway", "exclusiveGateway", "inclusiveGateway"):
+        for gw in elements(root, kind):
+            out = [f for f in flows if attr(f, "sourceRef") == attr(gw, "id")]
+            if len(out) >= 2:
+                forks.append(gw)
+    if not forks:
+        fail("no fork gateway with >=2 outgoing flows to split the terminate and normal branches")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a terminate end event on one branch and a normal end on another")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
@@ -1,0 +1,75 @@
+task_id: skill-bpmn-terminate
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  process where one branch ends in a terminate end event (a hard stop of the
+  whole instance) while a parallel branch ends normally. Authoring only — no
+  cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:terminate"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `TerminateParallel.bpmn` in the working
+  directory that forks into two branches from a parallel gateway:
+    - Branch A reaches a terminate end event that stops the whole instance.
+    - Branch B runs a task and then reaches a normal (non-terminate) end event.
+
+  Requirements:
+  - The terminate end event carries a bare bpmn:terminateEventDefinition.
+    Terminate is valid only on end events — do not attach it to any other node.
+  - Both branches fan out from a fork gateway.
+  - Author the structural BPMN and the terminate payload per the skill's
+    structural reference; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "TerminateParallel.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a terminate event definition"
+    path: "TerminateParallel.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "terminateEventDefinition"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a terminate end event on one branch, a normal end on another, a fork, full DI, resolvable flows"
+    command: "python3 $TASK_DIR/check_terminate.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the lifecycle local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent created only local files and did not run or request
+      approval for BPMN debug, process run, upload, publish, pack, or deploy
+      commands. Fail if tool calls or the final answer show any cloud-side
+      lifecycle mutation or any request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/timer/check_timer.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/timer/check_timer.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Structural check for the intermediate timer-event port (Flow Delay analogue).
+
+Asserts an intermediate catch event carries a timer event definition with a
+valid ISO-8601 duration (or timeDate/timeCycle), sits between the start and end
+(one incoming + one outgoing flow), and has a diagram shape. Verifies overall
+diagram and sequence-flow integrity.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+ISO8601_DURATION = re.compile(r"^[=@]?P(?!$)(\d+Y)?(\d+M)?(\d+D)?(T(\d+H)?(\d+M)?(\d+S)?)?$")
+
+
+def main() -> None:
+    path, root = parse_bpmn("TimerWait")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    catches = elements(root, "intermediateCatchEvent")
+    timer_catch = None
+    for ev in catches:
+        if ev.find("bpmn:timerEventDefinition", NS) is not None:
+            timer_catch = ev
+            break
+    if timer_catch is None:
+        fail("no intermediateCatchEvent with a bpmn:timerEventDefinition")
+
+    timer_def = timer_catch.find("bpmn:timerEventDefinition", NS)
+    duration = timer_def.find("bpmn:timeDuration", NS)
+    date = timer_def.find("bpmn:timeDate", NS)
+    cycle = timer_def.find("bpmn:timeCycle", NS)
+    if duration is None and date is None and cycle is None:
+        fail("timerEventDefinition has no timeDuration/timeDate/timeCycle child")
+    if duration is not None:
+        body = (duration.text or "").strip()
+        if not ISO8601_DURATION.match(body):
+            fail(f"timeDuration {body!r} is not a valid ISO-8601 duration (week designators unsupported)")
+
+    ev_id = attr(timer_catch, "id")
+    incoming = [f for f in elements(root, "sequenceFlow") if attr(f, "targetRef") == ev_id]
+    outgoing = [f for f in elements(root, "sequenceFlow") if attr(f, "sourceRef") == ev_id]
+    if not incoming:
+        fail(f"timer event {ev_id} has no incoming sequence flow")
+    if not outgoing:
+        fail(f"timer event {ev_id} has no outgoing sequence flow")
+
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+    if ev_id not in shaped:
+        fail(f"timer event {ev_id} has no BPMNShape (invisible on the canvas)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a wired intermediate timer catch event with a valid definition")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/timer/timer.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/timer/timer.yaml
@@ -1,0 +1,62 @@
+task_id: skill-bpmn-timer
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author an
+  intermediate timer catch event (the BPMN analogue of a Flow Delay) that waits a
+  fixed ISO-8601 duration between the start and end. Authoring only — no cloud
+  effects.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:single-node", "feature:timer"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 50
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `TimerWait.bpmn` in the working directory
+  with the shape: start event -> intermediate timer catch event -> end event.
+
+  Requirements:
+  - The middle node is a bpmn:intermediateCatchEvent carrying a
+    bpmn:timerEventDefinition with a fixed ISO-8601 duration (e.g. PT15M). Week
+    designators (PnW) are unsupported.
+  - The timer event has one incoming and one outgoing sequence flow.
+  - Author the structural BPMN and the timer event-definition payload per the
+    skill's structural reference; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node (including the
+    timer event) and a BPMNEdge for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "TimerWait.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a timer event definition"
+    path: "TimerWait.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "timerEventDefinition"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a wired intermediate timer catch event with a valid ISO-8601 definition, full DI, resolvable flows"
+    command: "python3 $TASK_DIR/check_timer.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/check_transform_filter.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/check_transform_filter.py
@@ -67,7 +67,12 @@ def assert_script_task(root, source_must_match, label):
 
 def main() -> None:
     path, root = parse_bpmn("TransformFilterDemo")
-    assert_script_task(root, [r"\.filter\s*\(", r">=|>|greater"], "filter/comparison")
+    # Filter signal: .filter( / .filter.call( / .filter.apply( or a loop+push build.
+    assert_script_task(
+        root,
+        [r"\.filter\s*[(.]|(for|while)[\s\S]*push\s*\(", r">=|>|greater"],
+        "filter/comparison",
+    )
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)
     print(f"OK: {path} has a Jint-safe scriptTask performing a filter transform")

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/check_transform_filter.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/check_transform_filter.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Structural check for the filter-transform script-task port.
+
+Asserts a Jint-safe JavaScript script task performs a filter transform (keeping
+rows whose amount meets a threshold): scriptFormat="JavaScript", scriptVersion
+v3, a mapped input and output, no non-Jint runtime APIs, a diagram shape, and a
+source that implements a filter/comparison.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+FORBIDDEN_JS = ("require(", "fetch(", "XMLHttpRequest", "window.", "document.", "process.", "fs.")
+
+
+def assert_script_task(root, source_must_match, label):
+    tasks = elements(root, "scriptTask")
+    if len(tasks) != 1:
+        fail(f"expected exactly one scriptTask, found {len(tasks)}")
+    task = tasks[0]
+
+    if task.attrib.get("scriptFormat") != "JavaScript":
+        fail('scriptTask must set scriptFormat="JavaScript"')
+
+    script = task.find("bpmn:script", NS)
+    if script is None or not (script.text or "").strip():
+        fail("scriptTask has no bpmn:script source")
+    source = script.text or ""
+    bad = [t for t in FORBIDDEN_JS if t in source]
+    if bad:
+        fail(f"script uses non-Jint runtime APIs: {bad}")
+
+    version = task.find("bpmn:extensionElements/uipath:scriptVersion", NS)
+    if version is None or version.attrib.get("value") != "v3":
+        fail('scriptTask must declare uipath:scriptVersion value="v3"')
+
+    inputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:input", NS)
+    outputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:output", NS)
+    if not inputs:
+        fail("scriptTask maps no input into the script")
+    if not outputs:
+        fail("scriptTask maps no output out of the script")
+
+    for pattern in source_must_match:
+        if not re.search(pattern, source, re.IGNORECASE):
+            fail(f"script source does not implement a {label} transform (missing /{pattern}/)")
+
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+    if attr(task, "id") not in shaped:
+        fail(f"scriptTask {attr(task, 'id')} has no BPMNShape")
+    return task
+
+
+def main() -> None:
+    path, root = parse_bpmn("TransformFilterDemo")
+    assert_script_task(root, [r"\.filter\s*\(", r">=|>|greater"], "filter/comparison")
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a Jint-safe scriptTask performing a filter transform")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_filter/transform_filter.yaml
@@ -1,0 +1,64 @@
+task_id: skill-bpmn-transform-filter
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  Jint-safe script task that performs a filter transform (keeping rows whose
+  amount meets a threshold) — the BPMN analogue of a Flow Transform Filter node.
+  Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:single-node", "node:script", "feature:transform"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `TransformFilterDemo.bpmn` in the working
+  directory with the shape: start -> scriptTask -> end. The script task filters a
+  small static collection, keeping only rows whose `amount` is at least 100.
+
+  Requirements:
+  - The scriptTask sets scriptFormat="JavaScript" and uipath:scriptVersion v3,
+    and its Jint-safe JavaScript uses a filter operation (e.g.
+    Array.prototype.filter) with an `amount >= 100` comparison. No
+    Node.js/browser/network/filesystem APIs.
+  - Map a declared input (the collection) into the script and map the filtered
+    result to a declared output variable, per the skill's BPMN.ScriptTask
+    contract; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "TransformFilterDemo.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a JavaScript script task"
+    path: "TransformFilterDemo.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "scriptTask"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a Jint-safe scriptTask (v3, mapped I/O) implementing a filter transform, with full DI"
+    command: "python3 $TASK_DIR/check_transform_filter.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/check_transform_group_by.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/check_transform_group_by.py
@@ -67,10 +67,11 @@ def assert_script_task(root, source_must_match, label):
 
 def main() -> None:
     path, root = parse_bpmn("TransformGroupByDemo")
-    # A grouping construct plus an aggregation signal.
+    # Grouping signal: reduce( / reduce.call( / "group" naming / keyed loop build,
+    # plus an aggregation signal.
     assert_script_task(
         root,
-        [r"reduce\s*\(|group", r"count|sum|average|avg|aggregate|total|\.length|push\s*\(|\+\s*1|\+="],
+        [r"reduce\s*[(.]|group|(for|while)[\s\S]*\[", r"count|sum|average|avg|aggregate|total|\.length|push\s*\(|\+\s*1|\+="],
         "group-by/aggregation",
     )
     require_sequence_integrity(root)

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/check_transform_group_by.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/check_transform_group_by.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Structural check for the group-by-transform script-task port.
+
+Asserts a Jint-safe JavaScript script task performs a group-by transform
+(grouping rows by a field and producing an aggregation): scriptFormat=
+"JavaScript", scriptVersion v3, a mapped input and output, no non-Jint runtime
+APIs, a diagram shape, and a source that implements a grouping + aggregation.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+FORBIDDEN_JS = ("require(", "fetch(", "XMLHttpRequest", "window.", "document.", "process.", "fs.")
+
+
+def assert_script_task(root, source_must_match, label):
+    tasks = elements(root, "scriptTask")
+    if len(tasks) != 1:
+        fail(f"expected exactly one scriptTask, found {len(tasks)}")
+    task = tasks[0]
+
+    if task.attrib.get("scriptFormat") != "JavaScript":
+        fail('scriptTask must set scriptFormat="JavaScript"')
+
+    script = task.find("bpmn:script", NS)
+    if script is None or not (script.text or "").strip():
+        fail("scriptTask has no bpmn:script source")
+    source = script.text or ""
+    bad = [t for t in FORBIDDEN_JS if t in source]
+    if bad:
+        fail(f"script uses non-Jint runtime APIs: {bad}")
+
+    version = task.find("bpmn:extensionElements/uipath:scriptVersion", NS)
+    if version is None or version.attrib.get("value") != "v3":
+        fail('scriptTask must declare uipath:scriptVersion value="v3"')
+
+    inputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:input", NS)
+    outputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:output", NS)
+    if not inputs:
+        fail("scriptTask maps no input into the script")
+    if not outputs:
+        fail("scriptTask maps no output out of the script")
+
+    for pattern in source_must_match:
+        if not re.search(pattern, source, re.IGNORECASE):
+            fail(f"script source does not implement a {label} transform (missing /{pattern}/)")
+
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+    if attr(task, "id") not in shaped:
+        fail(f"scriptTask {attr(task, 'id')} has no BPMNShape")
+    return task
+
+
+def main() -> None:
+    path, root = parse_bpmn("TransformGroupByDemo")
+    # A grouping construct plus an aggregation signal.
+    assert_script_task(
+        root,
+        [r"reduce\s*\(|group", r"count|sum|average|avg|aggregate|total|\.length|push\s*\(|\+\s*1|\+="],
+        "group-by/aggregation",
+    )
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a Jint-safe scriptTask performing a group-by transform")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_group_by/transform_group_by.yaml
@@ -1,0 +1,65 @@
+task_id: skill-bpmn-transform-group-by
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  Jint-safe script task that performs a group-by transform (grouping rows by a
+  field and producing an aggregation) — the BPMN analogue of a Flow Transform
+  Group By node. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:single-node", "node:script", "feature:transform"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `TransformGroupByDemo.bpmn` in the working
+  directory with the shape: start -> scriptTask -> end. The script task groups a
+  small static collection of records by a field (e.g. employees by department)
+  and computes at least one aggregation (e.g. a count per group).
+
+  Requirements:
+  - The scriptTask sets scriptFormat="JavaScript" and uipath:scriptVersion v3,
+    and its Jint-safe JavaScript groups the rows by a field and produces an
+    aggregation (e.g. Array.prototype.reduce building groups plus a count/sum).
+    No Node.js/browser/network/filesystem APIs.
+  - Map a declared input (the collection) into the script and map the grouped
+    result to a declared output variable, per the skill's BPMN.ScriptTask
+    contract; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "TransformGroupByDemo.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a JavaScript script task"
+    path: "TransformGroupByDemo.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "scriptTask"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a Jint-safe scriptTask (v3, mapped I/O) implementing a group-by transform, with full DI"
+    command: "python3 $TASK_DIR/check_transform_group_by.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/check_transform_map.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/check_transform_map.py
@@ -67,7 +67,12 @@ def assert_script_task(root, source_must_match, label):
 
 def main() -> None:
     path, root = parse_bpmn("TransformMapDemo")
-    assert_script_task(root, [r"\.map\s*\(", r"touppercase|toupper"], "map/uppercase")
+    # Map signal: .map( / .map.call( / .map.apply( or an explicit loop+push build.
+    assert_script_task(
+        root,
+        [r"\.map\s*[(.]|(for|while)[\s\S]*push\s*\(", r"touppercase|toupper"],
+        "map/uppercase",
+    )
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)
     print(f"OK: {path} has a Jint-safe scriptTask performing a map/uppercase transform")

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/check_transform_map.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/check_transform_map.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Structural check for the map-transform script-task port.
+
+Asserts a Jint-safe JavaScript script task performs a map transform (uppercasing
+a field over a collection): scriptFormat="JavaScript", scriptVersion v3, a mapped
+input and output, no non-Jint runtime APIs, a diagram shape, and a source that
+implements a map/uppercase transform.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+FORBIDDEN_JS = ("require(", "fetch(", "XMLHttpRequest", "window.", "document.", "process.", "fs.")
+
+
+def assert_script_task(root, source_must_match, label):
+    tasks = elements(root, "scriptTask")
+    if len(tasks) != 1:
+        fail(f"expected exactly one scriptTask, found {len(tasks)}")
+    task = tasks[0]
+
+    if task.attrib.get("scriptFormat") != "JavaScript":
+        fail('scriptTask must set scriptFormat="JavaScript"')
+
+    script = task.find("bpmn:script", NS)
+    if script is None or not (script.text or "").strip():
+        fail("scriptTask has no bpmn:script source")
+    source = script.text or ""
+    bad = [t for t in FORBIDDEN_JS if t in source]
+    if bad:
+        fail(f"script uses non-Jint runtime APIs: {bad}")
+
+    version = task.find("bpmn:extensionElements/uipath:scriptVersion", NS)
+    if version is None or version.attrib.get("value") != "v3":
+        fail('scriptTask must declare uipath:scriptVersion value="v3"')
+
+    inputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:input", NS)
+    outputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:output", NS)
+    if not inputs:
+        fail("scriptTask maps no input into the script")
+    if not outputs:
+        fail("scriptTask maps no output out of the script")
+
+    for pattern in source_must_match:
+        if not re.search(pattern, source, re.IGNORECASE):
+            fail(f"script source does not implement a {label} transform (missing /{pattern}/)")
+
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+    if attr(task, "id") not in shaped:
+        fail(f"scriptTask {attr(task, 'id')} has no BPMNShape")
+    return task
+
+
+def main() -> None:
+    path, root = parse_bpmn("TransformMapDemo")
+    assert_script_task(root, [r"\.map\s*\(", r"touppercase|toupper"], "map/uppercase")
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a Jint-safe scriptTask performing a map/uppercase transform")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/transform_map/transform_map.yaml
@@ -1,0 +1,63 @@
+task_id: skill-bpmn-transform-map
+description: >
+  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to author a
+  Jint-safe script task that performs a map transform (uppercasing a field over a
+  collection) — the BPMN analogue of a Flow Transform Map node. Authoring only —
+  no cloud effects.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "shape:single-node", "node:script", "feature:transform"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 55
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `TransformMapDemo.bpmn` in the working
+  directory with the shape: start -> scriptTask -> end. The script task maps a
+  small static collection of people, uppercasing each `name` field.
+
+  Requirements:
+  - The scriptTask sets scriptFormat="JavaScript" and uipath:scriptVersion v3,
+    and its Jint-safe JavaScript uses a map operation (e.g. Array.prototype.map)
+    with an uppercase transformation. No Node.js/browser/network/filesystem APIs.
+  - Map a declared input (the collection) into the script and map the transformed
+    result to a declared output variable, per the skill's BPMN.ScriptTask
+    contract; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "TransformMapDemo.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file has a diagram and a JavaScript script task"
+    path: "TransformMapDemo.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "scriptTask"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a Jint-safe scriptTask (v3, mapped I/O) implementing a map/uppercase transform, with full DI"
+    command: "python3 $TASK_DIR/check_transform_map.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Ports the **intent** of structural single-node tests from the `uipath-maestro-flow` suite to `uipath-maestro-bpmn`. These are intent ports, not mechanical copies: the Flow originals target `.flow` JSON + `uip maestro flow` CLI; the BPMN ports target `.bpmn` XML authored per the BPMN skill (structural BPMN + gateway conditions from the skill's structural reference, a full `bpmndi:BPMNDiagram`, and local well-formed-XML / bundled-validator validation). There is no `uip maestro bpmn validate` command, so grading is done by stdlib-ElementTree sidecar `check_*.py` scripts modeled on the existing BPMN checks.

All tasks are **authoring-only and local** — prompts forbid upload/publish/deploy/debug/run/pack and forbid pausing for approval. Tests whose Flow origin was `e2e` also carry the "stayed local" `llm_judge` criterion (copied in spirit from `e2e/invoice_exception_triage.yaml`).

## Flow source to BPMN port

| Flow source (`tests/tasks/uipath-maestro-flow/`) | New BPMN test | Rationale |
|---|---|---|
| `single_node/switch/switch.yaml` | `single_node/switch/switch.yaml` | Multi-way (3+ conditioned branch) exclusive gateway + default |
| `single_node/delay/delay.yaml` | `single_node/timer/timer.yaml` | Intermediate timer catch event with ISO-8601 duration |
| `single_node/terminate/terminate.yaml` | `single_node/terminate/terminate.yaml` | Terminate end event on one branch; normal end on another; fork gateway |
| `single_node/subflow/subflow.yaml` | `single_node/subprocess/subprocess.yaml` | Embedded `subProcess` (nested start/activity/end) or `callActivity` |
| `single_node/transform_map/transform_map.yaml` | `single_node/transform_map/transform_map.yaml` | Jint-safe scriptTask performing a map/uppercase transform |
| `single_node/transform_filter/transform_filter.yaml` | `single_node/transform_filter/transform_filter.yaml` | Jint-safe scriptTask performing a filter transform |
| `single_node/transform_group_by/transform_group_by.yaml` | `single_node/transform_group_by/transform_group_by.yaml` | Jint-safe scriptTask performing a group-by transform |
| `smoke/merge_parallel_sync.yaml` | `parallel/fork_join/fork_join.yaml` | Parallel gateway fork + synchronizing join |
| `single_node/decision/decision.yaml` | **SKIPPED** | Exclusive-gateway decision intent already covered by `smoke/author_validate.yaml` (start to exclusive gateway with 2 conditioned branches to ends) and `author/gateway_sequence_flows.yaml` (exclusive + default + conditions) |

## Conventions matched
- `sandbox.template_sources` `type: template_dir` to `../../../../../skills/uipath-maestro-bpmn` (5 `../`: these tasks nest one level deeper than the existing `author/`-style tests).
- `task_id: skill-bpmn-<capability>`, required tags `[uipath-maestro-bpmn, <tier>, mode:build, lifecycle:generate, ...]` plus `shape:*` / `node:*` / `feature:*` from values already in the repo.
- Behavior-graded: `file_exists` + `file_contains` + a weighted (5.0) `run_command` sidecar that parses the `.bpmn` with ElementTree and asserts structure. No `command_executed` on `--output json`.
- No `@uipath/cli` in `env_packages`.

## Local verification
- Each sidecar check was run against a hand-authored valid fixture (all pass) and malformed variants (all fail) before committing.
- `/lint-task` on all 8 new YAMLs: **8 OK, 0 Critical/High/Medium/Low**.

## Passing run

Passing run: https://github.com/UiPath/skills/actions/runs/29440506110 — all 8 tasks SUCCESS, score 1.000 each (run-coder-eval.yml, Linux/docker).

CI iterations: 2. Iteration 1 (https://github.com/UiPath/skills/actions/runs/29439726077) was 6/8: `transform_map` and `transform_filter` failed because the agents wrote the Jint-friendly `Array.prototype.map.call(...)` / `.filter.call(...)` idiom that the strict `\.map\s*\(` regexes rejected — a check-authoring issue, fixed by broadening the operation-signal patterns to accept `.call`/`.apply` and loop+push idioms (verified against the actual failing artifacts and negatives before re-dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
