### PR TITLE
test(maestro-bpmn): port multi-node composition evals from flow suite

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/calculator/calculator.yaml
@@ -1,0 +1,64 @@
+task_id: skill-bpmn-calculator
+description: >
+  Skill-guided evaluation (ported from the Flow calculator eval): agent uses the
+  uipath-maestro-bpmn skill to author a BPMN process that routes on an operator
+  variable through a multi-way exclusive gateway to one script task per
+  arithmetic operation. Exercises multi-branch exclusive-gateway routing, script
+  tasks, and BPMN DI. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "CalculatorBpmn" with the main file
+  at `CalculatorBpmn/CalculatorBpmn.bpmn` for this process:
+  - Manual start with input variables `operandA` and `operandB` (numbers) and
+    `operator` (string: "add", "subtract", "multiply", or "divide").
+  - An exclusive gateway routes on `operator` to one branch per operation.
+  - Each branch is its own script task that computes the result into a `result`
+    variable, then reaches an end event.
+
+  Requirements:
+  - Declare variables and author script-task payloads per the skill's structural
+    reference; do not hand-author uipath:* XML from prose.
+  - The exclusive gateway must have a condition on each non-default outgoing flow
+    and exactly one default flow.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "CalculatorBpmn/CalculatorBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN file contains a diagram and an exclusive gateway"
+    path: "CalculatorBpmn/CalculatorBpmn.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "exclusiveGateway"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has multi-way exclusive-gateway routing, one script task per branch, and valid DI"
+    command: "python3 $TASK_DIR/check_calculator.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/calculator/check_calculator.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/calculator/check_calculator.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Structural check for the calculator BPMN port.
+
+Enforces the ported intent: a multi-way exclusive gateway that routes on an
+operator variable to one script task per arithmetic operation, with a valid
+diagram. Grades authored XML shape, not runtime output (the BPMN skill is
+authoring-only and cannot debug/run locally).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("CalculatorBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+
+    scripts = elements(root, "scriptTask")
+    if len(scripts) < 3:
+        fail(f"expected at least 3 script tasks (one per operation), found {len(scripts)}")
+
+    gateways = one_or_more(root, "exclusiveGateway")
+    flows = elements(root, "sequenceFlow")
+
+    routed = False
+    for gw in gateways:
+        gw_id = attr(gw, "id")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == gw_id]
+        if len(outgoing) < 3:
+            continue
+        default_id = attr(gw, "default")
+        if not default_id:
+            fail(f"multi-way gateway {gw_id} has no default flow")
+        for flow in outgoing:
+            fid = attr(flow, "id")
+            has_condition = flow.find("bpmn:conditionExpression", NS) is not None
+            if fid != default_id and not has_condition:
+                fail(f"non-default flow {fid} from gateway {gw_id} has no condition")
+        routed = True
+
+    if not routed:
+        fail("no exclusive gateway with >= 3 outgoing branches (multi-way operator routing)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} routes an operator through a multi-way exclusive gateway with per-branch script tasks")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Structural check for the customer_escalation BPMN e2e port.
+
+Enforces the ported intent: two classifier script tasks feed an exclusive
+gateway whose high-touch branch is a human user task and whose default branch is
+a ticket-generating script task, plus complete, consistent package metadata.
+Grades authored XML/JSON shape, not runtime output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+PROJECT = Path.cwd() / "CustomerEscalation"
+BPMN_NAME = "CustomerEscalation.bpmn"
+REQUIRED_FILES = [
+    "project.uiproj",
+    "bindings_v2.json",
+    "entry-points.json",
+    "operate.json",
+    "package-descriptor.json",
+]
+
+
+def load_json(name: str):
+    p = PROJECT / name
+    if not p.is_file():
+        fail(f"{name} is missing")
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        fail(f"{name} is not valid JSON: {exc}")
+
+
+def main() -> None:
+    for name in REQUIRED_FILES:
+        if not (PROJECT / name).is_file():
+            fail(f"{name} is missing")
+
+    path, root = parse_bpmn("CustomerEscalation")
+
+    process = one_or_more(root, "process")[0]
+    if process.attrib.get("isExecutable") != "true":
+        fail("BPMN process must be executable")
+
+    scripts = elements(root, "scriptTask")
+    if len(scripts) < 3:
+        fail(f"expected at least 3 script tasks (2 classifiers + ticket), found {len(scripts)}")
+
+    if not elements(root, "userTask"):
+        fail("no user task authored for the escalation path")
+
+    gateways = one_or_more(root, "exclusiveGateway")
+    flows = elements(root, "sequenceFlow")
+    routed = False
+    for gw in gateways:
+        gw_id = attr(gw, "id")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == gw_id]
+        if len(outgoing) < 2:
+            continue
+        default_id = attr(gw, "default")
+        if not default_id:
+            fail(f"exclusive gateway {gw_id} has no default flow")
+        conditioned = [
+            f for f in outgoing
+            if attr(f, "id") != default_id and f.find("bpmn:conditionExpression", NS) is not None
+        ]
+        if not conditioned:
+            fail(f"exclusive gateway {gw_id} has no conditioned branch")
+        routed = True
+    if not routed:
+        fail("no exclusive gateway routing the combined escalation signal")
+
+    if len(elements(root, "endEvent")) < 2:
+        fail("expected an end event per escalation path")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+
+    # Package metadata references the BPMN file.
+    for name in ("entry-points.json", "operate.json", "package-descriptor.json"):
+        if BPMN_NAME not in json.dumps(load_json(name)):
+            fail(f"{name} must reference {BPMN_NAME}")
+
+    print(f"OK: {path} classifies, routes, escalates via a user task, and ships consistent package metadata")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
@@ -1,0 +1,85 @@
+task_id: skill-bpmn-e2e-customer-escalation
+description: >
+  Skill-guided e2e evaluation (ported from the Flow customer_escalation eval):
+  agent uses the uipath-maestro-bpmn skill to author a synthetic BPMN process
+  that classifies an inbound request with two script tasks, routes on the
+  combined signal through an exclusive gateway, and escalates via a human user
+  task on the high-touch path while a standard path generates a ticket in a
+  script task. Includes full package metadata. Authoring only, public-safe, no
+  cloud effects and no live connector.
+tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:hitl", "feature:escalation"]
+
+run_limits:
+  expected_turns: 28
+  turn_timeout: 1200
+  max_turns: 90
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Create a new local Maestro BPMN Process Orchestration project named
+  CustomerEscalation. The project must be fully synthetic and public-safe.
+
+  Model this process:
+  - Manual start accepts request variables (e.g. subject, senderDomain).
+  - A script task classifyUrgency sets an `urgent` boolean.
+  - A script task classifyVip sets a `vip` boolean.
+  - An exclusive gateway routeEscalation routes the high-touch case (urgent AND
+    vip) to a human user task named "Escalate to specialist", and all other
+    cases (default) to a script task createTicket that produces a ticket id.
+  - Each path ends at its own end event.
+
+  Model the escalation and ticketing with a user task and a script task — do NOT
+  use a live Integration Service connector; keep the whole project local and
+  self-contained.
+
+  Include BPMN DI shapes/edges for all visible elements and create the package
+  metadata files expected by the skill:
+  project.uiproj, bindings_v2.json, entry-points.json, operate.json, and
+  package-descriptor.json.
+
+  Do NOT upload, publish, deploy, debug, run a process, ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and implementation.
+  Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source file was created"
+    path: "CustomerEscalation/CustomerEscalation.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Project metadata file was created"
+    path: "CustomerEscalation/project.uiproj"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Package operate metadata was created"
+    path: "CustomerEscalation/operate.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated BPMN project has two classifier scripts, gateway routing, a user-task escalation path, a ticket script, and package references"
+    command: "python3 $TASK_DIR/check_customer_escalation.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the lifecycle local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent created only local project files and did not run or
+      request approval for BPMN debug, process run, upload, publish, or deploy
+      commands. Fail if tool calls or the final answer show any cloud-side
+      lifecycle mutation or any request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/dice_roller/check_dice_roller.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/dice_roller/check_dice_roller.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Structural check for the dice_roller BPMN port.
+
+Enforces the ported intent: a script task that produces a random value and an
+exclusive gateway that routes on the result. Grades authored XML shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+    text_content,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("DiceRollerBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+
+    scripts = one_or_more(root, "scriptTask")
+    if not any("random" in text_content(s).lower() for s in scripts):
+        fail("no script task uses randomness (expected Math.random or similar) to roll the die")
+
+    gateways = one_or_more(root, "exclusiveGateway")
+    flows = elements(root, "sequenceFlow")
+    routed = False
+    for gw in gateways:
+        gw_id = attr(gw, "id")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == gw_id]
+        if len(outgoing) < 2:
+            continue
+        default_id = attr(gw, "default")
+        if not default_id:
+            fail(f"exclusive gateway {gw_id} has no default flow")
+        conditioned = [
+            f for f in outgoing
+            if attr(f, "id") != default_id and f.find("bpmn:conditionExpression", NS) is not None
+        ]
+        if not conditioned:
+            fail(f"exclusive gateway {gw_id} has no conditioned branch on the roll result")
+        routed = True
+
+    if not routed:
+        fail("no exclusive gateway classifying the roll into two branches")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} rolls a die in a script task and classifies it through an exclusive gateway")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/dice_roller/dice_roller.yaml
@@ -1,0 +1,56 @@
+task_id: skill-bpmn-dice-roller
+description: >
+  Skill-guided evaluation (ported from the Flow dice_roller eval): agent uses the
+  uipath-maestro-bpmn skill to author a BPMN process with a script task that
+  produces a random die value and an exclusive gateway that classifies the
+  result. Exercises script-task randomness and gateway-on-result routing.
+  Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "DiceRollerBpmn" with the main file
+  at `DiceRollerBpmn/DiceRollerBpmn.bpmn` for this process:
+  - Manual start.
+  - A script task that rolls a fair six-sided die (a random integer 1..6) into a
+    `roll` variable.
+  - An exclusive gateway that classifies the roll into a high branch (>= 4) and a
+    low branch, each reaching its own end event.
+
+  Requirements:
+  - Declare variables and author the script-task payload per the skill's
+    structural reference; do not hand-author uipath:* XML from prose. The script
+    runs under Jint.
+  - The gateway must have a condition on the non-default branch and exactly one
+    default flow.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "DiceRollerBpmn/DiceRollerBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a randomness script task and an exclusive gateway on the result, with valid DI"
+    command: "python3 $TASK_DIR/check_dice_roller.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/feet_inches/check_feet_inches.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/feet_inches/check_feet_inches.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Structural check for the feet_inches BPMN port.
+
+Enforces the ported intent: a linear pipeline of >= 3 script tasks where a value
+flows through intermediate variables (variable passing). Grades authored XML
+shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+    text_content,
+)
+
+
+def _output_var_ids(script) -> set[str]:
+    ids = set()
+    for out in script.findall(".//uipath:output", NS):
+        var = out.attrib.get("var")
+        if var:
+            ids.add(var)
+    return ids
+
+
+def _input_text(script) -> str:
+    parts = []
+    for inp in script.findall(".//uipath:input", NS):
+        parts.append(text_content(inp))
+        parts.append(" ".join(inp.attrib.values()))
+    return " ".join(parts)
+
+
+def main() -> None:
+    path, root = parse_bpmn("FeetInchesBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+
+    scripts = elements(root, "scriptTask")
+    if len(scripts) < 3:
+        fail(f"expected a pipeline of at least 3 script tasks, found {len(scripts)}")
+
+    # Variable passing: some script's input references a variable id that another
+    # script declares as an output.
+    outputs = [(_output_var_ids(s), _input_text(s)) for s in scripts]
+    passed = False
+    for i, (_, in_text) in enumerate(outputs):
+        for j, (out_ids, _) in enumerate(outputs):
+            if i == j:
+                continue
+            if any(vid and vid in in_text for vid in out_ids):
+                passed = True
+                break
+        if passed:
+            break
+    if not passed:
+        fail("no downstream script task reads a variable produced by an upstream script task")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} is a sequential script-task pipeline with variable passing between nodes")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/feet_inches/feet_inches.yaml
@@ -1,0 +1,58 @@
+task_id: skill-bpmn-feet-inches
+description: >
+  Skill-guided evaluation (ported from the Flow feet_inches eval): agent uses the
+  uipath-maestro-bpmn skill to author a BPMN process as a sequential pipeline of
+  script tasks that pass a value through parse, convert, and format steps.
+  Exercises a linear script-task chain with variable passing between nodes.
+  Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "FeetInchesBpmn" with the main file
+  at `FeetInchesBpmn/FeetInchesBpmn.bpmn` for this process:
+  - Manual start with input variables `value` (number) and `direction` (string:
+    "f2i", "i2f", or "y2f").
+  - A sequential pipeline of at least three script tasks that pass data through
+    intermediate variables: one normalizes/parses the inputs, one applies the
+    conversion (feet to inches x12, inches to feet /12, or yards to feet x3), and
+    one formats the converted number into a `result` variable.
+  - A single end event.
+
+  Requirements:
+  - Each script task after the first must read a variable produced by an upstream
+    script task (variable passing through the chain).
+  - Declare variables and author script-task payloads per the skill's structural
+    reference; do not hand-author uipath:* XML from prose.
+  - The tasks form one linear path (no gateways needed).
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "FeetInchesBpmn/FeetInchesBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN is a linear script-task pipeline with variable passing and valid DI"
+    command: "python3 $TASK_DIR/check_feet_inches.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/loop_multiply/check_loop_multiply.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/loop_multiply/check_loop_multiply.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Structural check for the loop_multiply BPMN port.
+
+Enforces the ported intent: a SEQUENTIAL multi-instance marker over a script
+task, with the collection bound through uipath:loopCharacteristics. Grades
+authored XML shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("LoopMultiplyBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+    one_or_more(root, "scriptTask")
+
+    markers = root.findall(".//bpmn:multiInstanceLoopCharacteristics", NS)
+    if not markers:
+        fail("no bpmn:multiInstanceLoopCharacteristics marker authored")
+
+    sequential = [m for m in markers if m.attrib.get("isSequential") == "true"]
+    if not sequential:
+        fail("multi-instance marker must be sequential (isSequential=\"true\") for ordered accumulation")
+
+    bound = False
+    for m in sequential:
+        lc = m.find(".//uipath:loopCharacteristics", NS)
+        if lc is not None and lc.attrib.get("inputCollection") and lc.attrib.get("inputElement"):
+            bound = True
+    if not bound:
+        fail("sequential multi-instance marker missing uipath:loopCharacteristics inputCollection/inputElement binding")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} multiplies a collection through a sequential multi-instance marker")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/loop_multiply/loop_multiply.yaml
@@ -1,0 +1,66 @@
+task_id: skill-bpmn-loop-multiply
+description: >
+  Skill-guided evaluation (ported from the Flow loop_multiply eval): agent uses
+  the uipath-maestro-bpmn skill to author a BPMN process that multiplies a
+  collection of numbers using a sequential multi-instance marker over a script
+  task. Exercises the multi-instance / loop-characteristics registry gap
+  (sequential accumulation). Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:loop"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "LoopMultiplyBpmn" with the main file
+  at `LoopMultiplyBpmn/LoopMultiplyBpmn.bpmn` for this process:
+  - Manual start with a `numbers` variable holding [13, 15, 17] and a `product`
+    accumulator variable.
+  - A single script task that iterates the collection using a SEQUENTIAL
+    multi-instance marker, multiplying the running product by each item.
+  - A single end event that yields the final product.
+
+  Requirements:
+  - Apply `bpmn:multiInstanceLoopCharacteristics` with `isSequential="true"` to
+    the script task, and bind the collection through the
+    `uipath:loopCharacteristics` extension (`inputCollection` and `inputElement`)
+    per the skill's structural reference — the registry serves no template for
+    this, author it from the canvas contract.
+  - Declare variables and author the script-task payload per the skill's
+    structural reference; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "LoopMultiplyBpmn/LoopMultiplyBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses a multi-instance loop marker"
+    path: "LoopMultiplyBpmn/LoopMultiplyBpmn.bpmn"
+    includes:
+      - "multiInstanceLoopCharacteristics"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a sequential multi-instance marker with a bound collection and valid DI"
+    command: "python3 $TASK_DIR/check_loop_multiply.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/multi_city_weather/check_multi_city_weather.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/multi_city_weather/check_multi_city_weather.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Structural check for the multi_city_weather BPMN port.
+
+Enforces the ported intent: a PARALLEL multi-instance marker over a per-item
+script task, with the cities collection bound through uipath:loopCharacteristics.
+Grades authored XML shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("MultiCityWeatherBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+    one_or_more(root, "scriptTask")
+
+    markers = root.findall(".//bpmn:multiInstanceLoopCharacteristics", NS)
+    if not markers:
+        fail("no bpmn:multiInstanceLoopCharacteristics marker authored")
+
+    parallel = [m for m in markers if m.attrib.get("isSequential") == "false"]
+    if not parallel:
+        fail("multi-instance marker must be parallel (isSequential=\"false\") for per-city fan-out")
+
+    bound = False
+    for m in parallel:
+        lc = m.find(".//uipath:loopCharacteristics", NS)
+        if lc is not None and lc.attrib.get("inputCollection") and lc.attrib.get("inputElement"):
+            bound = True
+    if not bound:
+        fail("parallel multi-instance marker missing uipath:loopCharacteristics inputCollection/inputElement binding")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} classifies cities through a parallel multi-instance script task")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -1,0 +1,70 @@
+task_id: skill-bpmn-multi-city-weather
+description: >
+  Skill-guided evaluation (ported from the Flow multi_city_weather eval): agent
+  uses the uipath-maestro-bpmn skill to author a BPMN process that classifies a
+  list of cities using a PARALLEL multi-instance marker over a per-item script
+  task. Exercises the multi-instance / loop-characteristics registry gap
+  (parallel fan-out with a collection output). Authoring only — no cloud effects
+  and no live connector (the per-item work is a script task).
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:loop"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "MultiCityWeatherBpmn" with the main
+  file at `MultiCityWeatherBpmn/MultiCityWeatherBpmn.bpmn` for this process:
+  - Manual start with a `cities` variable holding ["Seattle", "Phoenix", "New
+    York"] and a `results` collection variable.
+  - A single script task that runs once per city under a PARALLEL multi-instance
+    marker: for each city it derives a temperature and classifies it as "warm"
+    (> 60F) or "cold", appending {city, temperature, verdict} to the results.
+  - A single end event.
+
+  Requirements:
+  - Model the per-item work as a script task (no live Integration Service
+    connector — keep it local and self-contained).
+  - Apply `bpmn:multiInstanceLoopCharacteristics` with `isSequential="false"` to
+    the script task, and bind the collection through the
+    `uipath:loopCharacteristics` extension (`inputCollection` and `inputElement`)
+    per the skill's structural reference — the registry serves no template for
+    this, author it from the canvas contract.
+  - Declare variables and author the script-task payload per the skill's
+    structural reference; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "MultiCityWeatherBpmn/MultiCityWeatherBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses a multi-instance loop marker"
+    path: "MultiCityWeatherBpmn/MultiCityWeatherBpmn.bpmn"
+    includes:
+      - "multiInstanceLoopCharacteristics"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has a parallel multi-instance marker with a bound cities collection and valid DI"
+    command: "python3 $TASK_DIR/check_multi_city_weather.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/reading_list/check_reading_list.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/reading_list/check_reading_list.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Structural check for the reading_list BPMN port.
+
+Enforces the ported intent: two distinct sequential script tasks - one that
+filters the catalog (difficulty/pages predicate) and one that maps survivors to
+an uppercased title + author. Grades authored XML shape.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+    text_content,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("ReadingListBpmn")
+
+    one_or_more(root, "startEvent")
+    one_or_more(root, "endEvent")
+
+    scripts = elements(root, "scriptTask")
+    if len(scripts) < 2:
+        fail(f"expected at least 2 script tasks (filter + map), found {len(scripts)}")
+
+    bodies = [text_content(s).lower() for s in scripts]
+    has_filter = any(
+        ("difficulty" in b or "pages" in b or "filter" in b) for b in bodies
+    )
+    has_map = any(("touppercase" in b or "map" in b or "toupper" in b) for b in bodies)
+    if not has_filter:
+        fail("no script task applies the filter predicate (difficulty/pages)")
+    if not has_map:
+        fail("no script task maps survivors (expected an uppercase title transform)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} curates the catalog through distinct filter and map script tasks")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/reading_list/reading_list.yaml
@@ -1,0 +1,63 @@
+task_id: skill-bpmn-reading-list
+description: >
+  Skill-guided evaluation (ported from the Flow reading_list eval): agent uses
+  the uipath-maestro-bpmn skill to author a BPMN process that curates a book
+  catalog through a filter script task then a map script task. Exercises a
+  list-processing script composition with a hardcoded collection and staged
+  transforms. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:transform"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "ReadingListBpmn" with the main file
+  at `ReadingListBpmn/ReadingListBpmn.bpmn` for this process:
+  - Manual start with a `catalog` variable holding this hardcoded list of books
+    (do not require a runtime input):
+    [
+      {"title": "Deep Learning", "author": "Goodfellow", "difficulty": 9, "pages": 800},
+      {"title": "Statistical Learning", "author": "James", "difficulty": 4, "pages": 440},
+      {"title": "Bayesian Data Analysis", "author": "Gelman", "difficulty": 8, "pages": 580},
+      {"title": "Information Theory", "author": "MacKay", "difficulty": 7, "pages": 540}
+    ]
+  - A script task that FILTERS to books with difficulty greater than 5 AND under
+    600 pages.
+  - A second script task that MAPS the survivors to only the title (uppercased)
+    and author, writing the curated list into a `readingList` variable.
+  - A single end event.
+
+  Requirements:
+  - Model filter and map as two distinct sequential script tasks (do not collapse
+    both into one).
+  - Declare variables and author script-task payloads per the skill's structural
+    reference; do not hand-author uipath:* XML from prose.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback. Do NOT pause between planning and
+  implementation. Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "ReadingListBpmn/ReadingListBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BPMN has distinct filter and map script tasks over the catalog and valid DI"
+    command: "python3 $TASK_DIR/check_reading_list.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Structural check for the wiki_pageviews BPMN e2e port.
+
+Enforces the ported intent: a fetch script task, an exclusive gateway that
+routes an invalid-article failure to an "Article not found" end, and two
+distinct success-path script tasks (filter high-traffic days, then aggregate the
+total), plus complete package metadata. Grades authored XML/JSON shape.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    one_or_more,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+    text_content,
+)
+
+PROJECT = Path.cwd() / "WikiPageviews"
+BPMN_NAME = "WikiPageviews.bpmn"
+REQUIRED_FILES = [
+    "project.uiproj",
+    "bindings_v2.json",
+    "entry-points.json",
+    "operate.json",
+    "package-descriptor.json",
+]
+
+
+def load_json(name: str):
+    p = PROJECT / name
+    if not p.is_file():
+        fail(f"{name} is missing")
+    try:
+        return json.loads(p.read_text(encoding="utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        fail(f"{name} is not valid JSON: {exc}")
+
+
+def main() -> None:
+    for name in REQUIRED_FILES:
+        if not (PROJECT / name).is_file():
+            fail(f"{name} is missing")
+
+    path, root = parse_bpmn("WikiPageviews")
+
+    process = one_or_more(root, "process")[0]
+    if process.attrib.get("isExecutable") != "true":
+        fail("BPMN process must be executable")
+
+    scripts = elements(root, "scriptTask")
+    if len(scripts) < 3:
+        fail(f"expected at least 3 script tasks (fetch + filter + aggregate), found {len(scripts)}")
+
+    bodies = [text_content(s).lower() for s in scripts]
+    if not any("500" in b or "views" in b for b in bodies):
+        fail("no script task filters high-traffic days (expected a views > 500 predicate)")
+    if not any(("reduce" in b or "sum" in b or "aggregate" in b or "+=" in b) for b in bodies):
+        fail("no script task aggregates the surviving views into a total")
+
+    gateways = one_or_more(root, "exclusiveGateway")
+    flows = elements(root, "sequenceFlow")
+    routed = False
+    for gw in gateways:
+        gw_id = attr(gw, "id")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == gw_id]
+        if len(outgoing) < 2:
+            continue
+        default_id = attr(gw, "default")
+        if not default_id:
+            fail(f"exclusive gateway {gw_id} has no default flow")
+        conditioned = [
+            f for f in outgoing
+            if attr(f, "id") != default_id and f.find("bpmn:conditionExpression", NS) is not None
+        ]
+        if not conditioned:
+            fail(f"exclusive gateway {gw_id} has no conditioned (invalid-article) branch")
+        routed = True
+    if not routed:
+        fail("no exclusive gateway routing the invalid-article failure")
+
+    if "article not found" not in Path(path).read_text(encoding="utf-8").lower():
+        fail('the invalid-article path must yield the literal "Article not found"')
+
+    if len(elements(root, "endEvent")) < 2:
+        fail("expected an end event for the error path and the success path")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+
+    for name in ("entry-points.json", "operate.json", "package-descriptor.json"):
+        if BPMN_NAME not in json.dumps(load_json(name)):
+            fail(f"{name} must reference {BPMN_NAME}")
+
+    print(f"OK: {path} fetches, routes failure, filters, aggregates, and ships consistent package metadata")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -1,0 +1,92 @@
+task_id: skill-bpmn-e2e-wiki-pageviews
+description: >
+  Skill-guided e2e evaluation (ported from the Flow wiki_pageviews eval): agent
+  uses the uipath-maestro-bpmn skill to author a synthetic BPMN process that
+  fetches daily pageviews in a script task, routes an invalid-article failure
+  through an exclusive gateway to an "Article not found" end, and on the success
+  path keeps high-traffic days (filter) then totals them (aggregate) in two
+  distinct script tasks. Includes full package metadata. Authoring only,
+  public-safe, no cloud effects and no live HTTP connector — the fetch is a
+  local script task.
+tags: [uipath-maestro-bpmn, e2e, "mode:build", "lifecycle:generate", "shape:multi-node", "node:decision", "node:transform"]
+
+run_limits:
+  expected_turns: 28
+  turn_timeout: 1200
+  max_turns: 90
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Create a new local Maestro BPMN Process Orchestration project named
+  WikiPageviews. The project must be fully synthetic and public-safe.
+
+  Model this process:
+  - Manual start accepts `article`, `date1`, `date2` variables and produces a
+    `total` result variable.
+  - A script task fetchPageviews produces a list of daily {date, views} records
+    for the range and sets a `valid` boolean (model the fetch locally in the
+    script — do NOT call a live HTTP endpoint or Integration Service connector).
+  - An exclusive gateway routes the invalid-article case (valid is false) to an
+    end event that returns the literal string "Article not found", and the valid
+    case (default) onward.
+  - On the valid path: a script task filterHighTraffic keeps only days whose
+    views exceed 500, then a distinct script task aggregateTotal sums the
+    surviving views into `total`.
+  - The valid path ends at its own end event.
+
+  Model filter and aggregate as two distinct sequential script tasks.
+
+  Include BPMN DI shapes/edges for all visible elements and create the package
+  metadata files expected by the skill:
+  project.uiproj, bindings_v2.json, entry-points.json, operate.json, and
+  package-descriptor.json.
+
+  Do NOT upload, publish, deploy, debug, run a process, ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and implementation.
+  Build the complete local project end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source file was created"
+    path: "WikiPageviews/WikiPageviews.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Package operate metadata was created"
+    path: "WikiPageviews/operate.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "The invalid-article path returns the fixed error string"
+    path: "WikiPageviews/WikiPageviews.bpmn"
+    includes:
+      - "Article not found"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated BPMN project has a fetch script, an error-routing gateway, distinct filter and aggregate scripts, and package references"
+    command: "python3 $TASK_DIR/check_wiki_pageviews.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the lifecycle local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent created only local project files and did not run or
+      request approval for BPMN debug, process run, upload, publish, deploy, or
+      any live HTTP call. Fail if tool calls or the final answer show any
+      cloud-side lifecycle mutation, live network fetch, or any request to
+      perform one.


### PR DESCRIPTION
Ports the intent of the Flow multi-node composition evals to `uipath-maestro-bpmn`, expressing each composition as structural BPMN (script tasks, gateways, multi-instance markers, user task) with a mandatory `bpmndi:BPMNDiagram`. BPMN authoring is local-only (no offline debug/run/connectors), so — like the existing `author/` and `e2e/invoice_exception_triage` tests — each port grades the **authored XML structure** via an ElementTree sidecar check (nodes, gateway conditions/defaults, multi-instance bindings, sequence-flow wiring, DI shape/edge coverage), not runtime output.

## Flow source -> BPMN port

| Flow source (multi_node/) | New BPMN test | Tier | Ported structure |
|---|---|---|---|
| calculator/calculator.yaml | multi_node/calculator/calculator.yaml | integration | Multi-way exclusive gateway routing on an operator variable -> one script task per operation |
| dice_roller/dice_roller.yaml | multi_node/dice_roller/dice_roller.yaml | integration | Script task with randomness + exclusive gateway classifying the result |
| feet_inches/feet_inches.yaml | multi_node/feet_inches/feet_inches.yaml | integration | Linear script-task pipeline with variable passing between nodes |
| loop_multiply/loop_multiply.yaml | multi_node/loop_multiply/loop_multiply.yaml | integration | Sequential multi-instance marker (isSequential="true") accumulating over a collection |
| reading_list/reading_list.yaml | multi_node/reading_list/reading_list.yaml | integration | Distinct filter then map script tasks over a hardcoded catalog |
| multi_city_weather/multi_city_weather.yaml | multi_node/multi_city_weather/multi_city_weather.yaml | integration | Parallel multi-instance marker (isSequential="false") with a per-item script task |
| customer_escalation/customer_escalation.yaml | multi_node/customer_escalation/customer_escalation.yaml | e2e | Two classifier scripts -> exclusive gateway -> user-task escalation path + ticket script, with full package metadata |
| wiki_pageviews/wiki_pageviews.yaml | multi_node/wiki_pageviews/wiki_pageviews.yaml | e2e | Local fetch script -> error-routing gateway ("Article not found") -> distinct filter + aggregate scripts, with full package metadata |
| bellevue_weather/bellevue_weather.yaml | **SKIPPED** | - | Script-computes-value + binary gateway shape already covered by dice_roller and calculator; per the batch note, chose multi_city_weather over bellevue for the weather intent |
| billing_* family | **SKIPPED** | - | Linked multi-flow scenario - out of scope for a single-BPMN-process port |

## Conventions

- `sandbox.template_sources` -> `../../../../../skills/uipath-maestro-bpmn` (5 `../` for the extra nesting level under `multi_node/`).
- `task_id: skill-bpmn-<capability>`; tags `[uipath-maestro-bpmn, <tier>, mode:build, lifecycle:generate, shape:multi-node, ...]` with `node:*`/`feature:*` from the closed vocabulary.
- Structural sidecar check weighted 5.0; e2e tests mirror `e2e/invoice_exception_triage.yaml` (package metadata files + local-only `llm_judge` guard). Check scripts reuse the shared `_shared/bpmn_check.py` helpers.
- All prompts forbid upload/publish/deploy/debug/run/pack and forbid pausing for approval ("Build the complete local project end-to-end in a single pass").
- Every check verified locally against a hand-authored valid fixture (8/8 pass).

## Passing run

Passing run: https://github.com/UiPath/skills/actions/runs/29439773441 — **8/8 PASS (linux)**, all success criteria passed with weighted score 1.000 on every task, first dispatch (no re-runs needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
