### PR TITLE
test(maestro-bpmn): port resource-node and trigger evals from flow suite

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/single_node/agent_job/agent_job.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/agent_job/agent_job.yaml
@@ -1,0 +1,64 @@
+task_id: skill-bpmn-agent-job
+description: >
+  Resource-node eval: agent uses the uipath-maestro-bpmn skill to model a
+  low-code (Agent Builder) agent invocation as a bpmn:serviceTask with the
+  registry Orchestrator.StartAgentJob wrapper, binding job arguments as input and
+  capturing the agent response into a declared variable. Ports the Flow low-code
+  agent single-node test to BPMN. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:single-node", resource]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "ApproverCountAgent" with the main file at
+  ApproverCountAgent/ApproverCountAgent.bpmn. Model this process:
+  manual start -> invoke a published low-code (Agent Builder) agent that counts
+  approvers in a sentence -> end.
+
+  Requirements:
+  - Discover the agent-job extension type via the registry and author its node
+    from the registry template. Do not hand-author uipath:* XML from prose.
+  - The agent is a published Agent Builder (low-code) resource, so model the
+    invocation as a bpmn:serviceTask using the documented
+    Orchestrator.StartAgentJob wrapper (not Orchestrator.StartJob, not an
+    Integration Service execution wrapper).
+  - Bind at least one job argument as the task's request input, and capture the
+    agent response into a declared process variable (BPMN.Variables).
+  - Use synthetic placeholder resource/binding values only. Do not invent or
+    paste real tenant URLs, folder keys, connection IDs, release keys, or agent
+    names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Do not upload, publish, deploy, debug, run, or pack anything, and do not
+    pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "ApproverCountAgent/ApproverCountAgent.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent invocation uses Orchestrator.StartAgentJob with input and a declared output variable"
+    command: "python3 $TASK_DIR/check_agent_job.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/agent_job/check_agent_job.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/agent_job/check_agent_job.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Structural check for the low-code agent-job resource-node eval.
+
+Grades that the published Agent Builder invocation is a bpmn:serviceTask carrying
+the registry Orchestrator.StartAgentJob wrapper (not StartJob / not an IS
+execution wrapper), binds a request input, and captures the agent response into a
+declared process variable. Type/input/output are matched by uipath subtree search
+so the check is robust to both wrapper styles the registry template and the skill
+rules permit. Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+UIPATH_NS = "http://uipath.org/schema/bpmn"
+TYPE_TOKEN = "Orchestrator.StartAgentJob"
+
+
+def has_type(el: ET.Element, token: str) -> bool:
+    return token in ET.tostring(el, encoding="unicode")
+
+
+def uipath_children(task: ET.Element, local: str) -> list[ET.Element]:
+    return task.findall(f".//{{{UIPATH_NS}}}{local}")
+
+
+def variable_ids(root: ET.Element) -> set[str]:
+    ids: set[str] = set()
+    for var in root.findall(f".//{{{UIPATH_NS}}}variables/*"):
+        vid = var.attrib.get("id")
+        if vid:
+            ids.add(vid)
+    return ids
+
+
+def main() -> None:
+    path, root = parse_bpmn("ApproverCountAgent")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    agent_tasks = [t for t in elements(root, "serviceTask") if has_type(t, TYPE_TOKEN)]
+    if not agent_tasks:
+        fail(f"missing bpmn:serviceTask with {TYPE_TOKEN} wrapper")
+    task = agent_tasks[0]
+
+    # The flow port's discipline: a low-code agent must not be modeled as a plain
+    # RPA job or an IS execution wrapper. StartJob is not a substring of
+    # StartAgentJob, so a whole-token search is a safe wrong-wrapper guard.
+    for kind in ("userTask", "sendTask", "scriptTask", "businessRuleTask", "callActivity", "task"):
+        if any(has_type(e, TYPE_TOKEN) for e in elements(root, kind)):
+            fail(f"{TYPE_TOKEN} used on wrong BPMN wrapper: bpmn:{kind}")
+
+    if not uipath_children(task, "input"):
+        fail("agent job task should bind at least one request input (JobArguments)")
+
+    outputs = uipath_children(task, "output")
+    if not outputs:
+        fail("agent job task should capture the agent response as an output")
+    declared = variable_ids(root)
+    if not declared:
+        fail("no process variables declared (expected a BPMN.Variables mapping)")
+    output_targets = {o.attrib.get("var") or o.attrib.get("target") for o in outputs}
+    if not any(t and t in declared for t in output_targets):
+        fail(
+            f"agent job output must bind to a declared variable; "
+            f"outputs={sorted(t for t in output_targets if t)} declared={sorted(declared)}"
+        )
+
+    require_no_private_connector_values(root)
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} wires Orchestrator.StartAgentJob with bound input and output variable")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/check_event_trigger_start.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/check_event_trigger_start.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Structural check for the connector event-trigger start-event eval.
+
+Grades the Flow connector-trigger port: the process start is a bpmn:startEvent
+carrying the registry Intsvc.EventTrigger wrapper and a messageEventDefinition,
+it is genuinely the process entry (no inbound flow, no manual start), it stays a
+public-safe draft (no leaked tenant/cloud endpoint, no hand-authored generated
+package files), and the diagram is complete. Reuses the shared uipath-maestro-bpmn
+check helpers (stdlib ET, locally authored input — same trust boundary as the
+rest of the fixture corpus).
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_check import (  # noqa: E402
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+TYPE_TOKEN = "Intsvc.EventTrigger"
+
+
+def has_type(el: ET.Element, token: str) -> bool:
+    return token in ET.tostring(el, encoding="unicode")
+
+
+def main() -> None:
+    path, root = parse_bpmn("InboxTriggerBpmn")
+
+    starts = elements(root, "startEvent")
+    if not starts:
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    trigger_starts = [
+        s
+        for s in starts
+        if has_type(s, TYPE_TOKEN)
+        and s.find(f"{{{BPMN_NS}}}messageEventDefinition") is not None
+    ]
+    if not trigger_starts:
+        fail("no bpmn:startEvent with Intsvc.EventTrigger + messageEventDefinition")
+    start = trigger_starts[0]
+
+    # No manual start: the connector trigger must be the sole start (replaced,
+    # not coexisting with a manual entry).
+    non_trigger = [s for s in starts if s not in trigger_starts]
+    if non_trigger:
+        fail(f"a non-trigger (manual) start event remains: {[attr(s, 'id') for s in non_trigger]}")
+
+    start_id = attr(start, "id")
+    if any(attr(f, "targetRef") == start_id for f in elements(root, "sequenceFlow")):
+        fail("trigger start event must be the process entry (no inbound sequence flow)")
+    if not any(attr(f, "sourceRef") == start_id for f in elements(root, "sequenceFlow")):
+        fail("trigger start event must have an outgoing sequence flow")
+
+    # Draft boundary: connection binding + package metadata are CLI-owned; the
+    # agent must not hand-author the generated package files.
+    generated = [
+        name
+        for name in (
+            "bindings_v2.json",
+            "entry-points.json",
+            "operate.json",
+            "package-descriptor.json",
+        )
+        if glob.glob(f"**/{name}", recursive=True)
+    ]
+    if generated:
+        fail(f"draft trigger should not hand-author generated package files: {generated}")
+
+    require_no_private_connector_values(root)
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} starts on a public-safe connector event-trigger draft")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
@@ -1,0 +1,86 @@
+task_id: skill-bpmn-event-trigger-start
+description: >
+  Connector trigger start-event eval: agent uses the uipath-maestro-bpmn skill to
+  start a process from an Integration Service connector event (e.g. an email
+  received) using the registry Intsvc.EventTrigger wrapper on a bpmn:startEvent,
+  kept as a public-safe draft because connection binding and trigger properties
+  are CLI-owned enrichment. Ports the Flow connector-trigger inbox test to a BPMN
+  connector-trigger start event. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:single-node", connector, "feature:trigger"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "InboxTriggerBpmn" with the main file at
+  InboxTriggerBpmn/InboxTriggerBpmn.bpmn. Model a process that is started when an
+  email is received in an inbox through an Integration Service connector:
+  connector event-trigger start -> handle the message -> end.
+
+  Requirements:
+  - Discover the connector event-trigger extension type via the registry and
+    author its node from the registry template. Do not hand-author uipath:* XML
+    from prose.
+  - The process start MUST be a bpmn:startEvent carrying the Intsvc.EventTrigger
+    wrapper (with its bpmn:messageEventDefinition). There must be NO manual start
+    event.
+  - This connector trigger requires discovery, so keep it a DRAFT: connection
+    binding, the concrete connector/object, dynamic trigger schemas, and package
+    metadata are CLI-owned enrichment. Do not invent or paste connection IDs,
+    folder keys, tenant URLs, connector resource keys, generated schemas, or
+    package metadata, and do not hand-author bindings_v2.json / entry-points.json
+    / operate.json / package-descriptor.json.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validation: a well-formed-XML parse is sufficient for this draft, e.g.
+    `python3 -c "import xml.etree.ElementTree as ET; ET.parse('InboxTriggerBpmn/InboxTriggerBpmn.bpmn')"`.
+    The connector trigger legitimately stays a draft: do NOT invent a
+    connectionId / connection binding / connector key to satisfy an
+    enrichment-blocked validator, and do not loop on validation to clear that
+    CLI-owned blocker.
+  - Do not upload, publish, deploy, debug, run, or pack anything, and do not
+    pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "InboxTriggerBpmn/InboxTriggerBpmn.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Connector event-trigger start is a public-safe draft with valid structure"
+    command: "python3 $TASK_DIR/check_event_trigger_start.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "Agent kept the connector trigger local and avoided cloud-side operations"
+    weight: 2.0
+    pass_threshold: 0.7
+    include_agent_output: true
+    include_tool_calls: true
+    prompt: >
+      Pass if the agent only authored a local BPMN draft and read-only registry
+      output, and did not run or request approval for any cloud-side mutation
+      (upload, publish, deploy, debug, run, pack) and did not invent concrete
+      connection IDs, tenant URLs, or connector resource keys. Fail if tool calls
+      or the final answer show any cloud-side lifecycle mutation, a request to
+      perform one, or fabricated private connector metadata.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/http_weather/check_http_weather.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/http_weather/check_http_weather.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Structural check for the connectionless HTTP weather eval.
+
+Grades that the weather fetch is a bpmn:sendTask carrying the registry
+Intsvc.HttpExecution wrapper in manual (connectionless) mode, GET, pointed at the
+public Open-Meteo host, capturing the response into a declared variable. Mirrors
+the Flow Open-Meteo test's discipline (a real activity, not a mock) within the
+authoring-only BPMN scope. Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+UIPATH_NS = "http://uipath.org/schema/bpmn"
+TYPE_TOKEN = "Intsvc.HttpExecution"
+
+
+def has_type(el: ET.Element, token: str) -> bool:
+    return token in ET.tostring(el, encoding="unicode")
+
+
+def uipath_inputs(task: ET.Element) -> list[ET.Element]:
+    return task.findall(f".//{{{UIPATH_NS}}}input")
+
+
+def input_value(task: ET.Element, name: str) -> str:
+    for inp in uipath_inputs(task):
+        if inp.attrib.get("name") == name:
+            return inp.attrib.get("value") or (inp.text or "")
+    return ""
+
+
+def variable_ids(root: ET.Element) -> set[str]:
+    return {
+        v.attrib["id"]
+        for v in root.findall(f".//{{{UIPATH_NS}}}variables/*")
+        if v.attrib.get("id")
+    }
+
+
+def main() -> None:
+    path, root = parse_bpmn("OpenMeteoWeatherHttp")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    http_tasks = [t for t in elements(root, "sendTask") if has_type(t, TYPE_TOKEN)]
+    if not http_tasks:
+        fail(f"missing bpmn:sendTask with {TYPE_TOKEN} wrapper")
+    task = http_tasks[0]
+
+    for kind in ("serviceTask", "userTask", "scriptTask", "businessRuleTask", "task"):
+        if any(has_type(e, TYPE_TOKEN) for e in elements(root, kind)):
+            fail(f"{TYPE_TOKEN} used on wrong BPMN wrapper: bpmn:{kind}")
+
+    mode = input_value(task, "mode").lower()
+    if mode != "manual":
+        fail(f"HTTP node must be connectionless (mode=manual); found mode={mode!r}")
+
+    method = input_value(task, "method").upper()
+    if method and method != "GET":
+        fail(f"weather fetch should be a GET; found method={method!r}")
+
+    url = input_value(task, "url")
+    if "open-meteo" not in url.lower():
+        fail(f"url input must target the public Open-Meteo host; found url={url!r}")
+    if "=bindings." in url:
+        fail("connectionless HTTP url must be a literal, not a connection binding")
+
+    outputs = task.findall(f".//{{{UIPATH_NS}}}output")
+    if not outputs:
+        fail("HTTP task should capture the response as an output")
+    declared = variable_ids(root)
+    output_targets = {o.attrib.get("var") or o.attrib.get("target") for o in outputs}
+    if not any(t and t in declared for t in output_targets):
+        fail(
+            f"HTTP response output must bind to a declared variable; "
+            f"outputs={sorted(t for t in output_targets if t)} declared={sorted(declared)}"
+        )
+
+    require_no_private_connector_values(root)
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} is a connectionless manual GET to Open-Meteo with a bound output")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/http_weather/http_weather.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/http_weather/http_weather.yaml
@@ -1,0 +1,73 @@
+task_id: skill-bpmn-http-weather
+description: >
+  HTTP activity eval: agent uses the uipath-maestro-bpmn skill to model a
+  connectionless HTTP call to a public weather API (Open-Meteo) as a
+  bpmn:sendTask with the registry Intsvc.HttpExecution wrapper in manual mode,
+  capturing the response into a declared variable. Ports the Flow Open-Meteo
+  weather single-node test to a connectionless BPMN HTTP node. Authoring only —
+  no cloud effects, no live call.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:single-node", "feature:http"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "OpenMeteoWeatherHttp" with the main file at
+  OpenMeteoWeatherHttp/OpenMeteoWeatherHttp.bpmn. Model this process:
+  manual start -> HTTP GET the current weather for Bellevue from the public
+  Open-Meteo API -> end.
+
+  Requirements:
+  - Discover the HTTP-execution extension type via the registry and author its
+    node from the registry template. Do not hand-author uipath:* XML from prose.
+  - This is a connectionless (manual) HTTP call — no Integration Service
+    connection. Model it as a bpmn:sendTask using the documented
+    Intsvc.HttpExecution wrapper in manual mode with method GET and a literal
+    Open-Meteo forecast URL (host api.open-meteo.com), including latitude,
+    longitude, and current-weather query parameters.
+  - Capture the HTTP response into a declared process variable (BPMN.Variables).
+  - Do not invent or paste real tenant URLs, connection IDs, or connector keys —
+    the only external URL is the public Open-Meteo endpoint.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Do not upload, publish, deploy, debug, run, pack, or actually call the API,
+    and do not pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "OpenMeteoWeatherHttp/OpenMeteoWeatherHttp.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses the HTTP-execution wrapper and the public Open-Meteo host"
+    path: "OpenMeteoWeatherHttp/OpenMeteoWeatherHttp.bpmn"
+    includes:
+      - "Intsvc.HttpExecution"
+      - "open-meteo"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "HTTP sendTask is connectionless manual GET to Open-Meteo with a bound output variable"
+    command: "python3 $TASK_DIR/check_http_weather.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/message_catch/check_message_catch.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/message_catch/check_message_catch.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Structural check for the mid-flow receive-message (wait-for-event) eval.
+
+Grades the Flow wait-for-email port: a bpmn:intermediateCatchEvent carries the
+registry Maestro.ReceiveMessageEvent wrapper and a bpmn:messageEventDefinition,
+sits genuinely mid-flow (both an inbound and an outbound sequence flow), and the
+process start event is preserved (the wait was added, not swapped for the start).
+Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET, locally authored
+input — same trust boundary as the rest of the fixture corpus).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_check import (  # noqa: E402
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+TYPE_TOKEN = "Maestro.ReceiveMessageEvent"
+
+
+def has_type(el: ET.Element, token: str) -> bool:
+    return token in ET.tostring(el, encoding="unicode")
+
+
+def main() -> None:
+    path, root = parse_bpmn("AwaitApprovalMessage")
+
+    if not elements(root, "startEvent"):
+        fail("no start event (the manual start must be preserved)")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    catches = [
+        c
+        for c in elements(root, "intermediateCatchEvent")
+        if has_type(c, TYPE_TOKEN)
+        and c.find(f"{{{BPMN_NS}}}messageEventDefinition") is not None
+    ]
+    if not catches:
+        fail(
+            "missing bpmn:intermediateCatchEvent with Maestro.ReceiveMessageEvent "
+            "and a messageEventDefinition"
+        )
+    catch = catches[0]
+
+    # Wrong-host guard: the receive-message wait must not be modeled as a start
+    # event (which would replace, not preserve, the process start).
+    if any(has_type(s, TYPE_TOKEN) for s in elements(root, "startEvent")):
+        fail("receive-message must be a mid-flow catch event, not the start event")
+
+    catch_id = attr(catch, "id")
+    flows = elements(root, "sequenceFlow")
+    inbound = [f for f in flows if attr(f, "targetRef") == catch_id]
+    outbound = [f for f in flows if attr(f, "sourceRef") == catch_id]
+    if not inbound:
+        fail("catch event has no inbound sequence flow (not mid-flow)")
+    if not outbound:
+        fail("catch event has no outbound sequence flow (not mid-flow)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} waits mid-flow on a receive-message catch event with the start preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/message_catch/message_catch.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/message_catch/message_catch.yaml
@@ -1,0 +1,62 @@
+task_id: skill-bpmn-message-catch
+description: >
+  Intermediate catch-event eval: agent uses the uipath-maestro-bpmn skill to add
+  a mid-flow wait step that pauses the process until a message arrives, using the
+  registry Maestro.ReceiveMessageEvent wrapper on a bpmn:intermediateCatchEvent
+  while preserving the process start. Ports the Flow wait-for-email test to a
+  BPMN intermediate catch event (internal message). Authoring only — a wait only
+  resolves in a live engine, so this validates the structure locally.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "feature:trigger"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "AwaitApprovalMessage" with the main file at
+  AwaitApprovalMessage/AwaitApprovalMessage.bpmn. Model this process:
+  manual start -> prepare a request -> WAIT until an approval message is received
+  -> end.
+
+  Requirements:
+  - Discover the receive-message extension type via the registry and author its
+    node from the registry template. Do not hand-author uipath:* XML from prose.
+  - Keep a normal (manual) start event. Add the wait step MID-FLOW as a
+    bpmn:intermediateCatchEvent using the documented Maestro.ReceiveMessageEvent
+    wrapper with a bpmn:messageEventDefinition. Do not replace the start event
+    with the catch event.
+  - The catch event must sit between two steps: it has an incoming sequence flow
+    from the prior step and an outgoing sequence flow to the next step.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Do not upload, publish, deploy, debug, run, or pack anything, and do not
+    pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "AwaitApprovalMessage/AwaitApprovalMessage.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Receive-message wait is a mid-flow intermediate catch event with the start preserved"
+    command: "python3 $TASK_DIR/check_message_catch.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/rpa_job/check_rpa_job.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/rpa_job/check_rpa_job.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Structural check for the RPA-job resource-node eval.
+
+Grades the differentiator over the wrapper-presence eval: the RPA invocation is a
+bpmn:serviceTask carrying the registry Orchestrator.StartJob wrapper, it binds a
+request input, and it captures the job response into a *declared* process
+variable. Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET, same
+trust boundary as the rest of the fixture corpus — locally authored input).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_assertions import mapping_inputs, mapping_outputs, variable_ids  # noqa: E402
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+TYPE_TOKEN = "Orchestrator.StartJob"
+
+
+def has_type(task: ET.Element, token: str) -> bool:
+    return token in ET.tostring(task, encoding="unicode")
+
+
+def main() -> None:
+    path, root = parse_bpmn("InvoiceExtractionRpa")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    rpa_tasks = [t for t in elements(root, "serviceTask") if has_type(t, TYPE_TOKEN)]
+    if not rpa_tasks:
+        fail(f"missing bpmn:serviceTask with {TYPE_TOKEN} wrapper")
+    task = rpa_tasks[0]
+
+    # Wrong-wrapper guard: StartJob must not ride a non-serviceTask host.
+    for kind in ("userTask", "sendTask", "scriptTask", "businessRuleTask", "callActivity", "task"):
+        if any(has_type(e, TYPE_TOKEN) for e in elements(root, kind)):
+            fail(f"{TYPE_TOKEN} used on wrong BPMN wrapper: bpmn:{kind}")
+
+    if len(mapping_inputs(task)) < 1:
+        fail("RPA job task should bind at least one request input (JobArguments)")
+
+    outputs = mapping_outputs(task)
+    if not outputs:
+        fail("RPA job task should capture the job response as an output")
+    declared = variable_ids(root)
+    if not declared:
+        fail("no process variables declared (expected a BPMN.Variables mapping)")
+    output_targets = {o.attrib.get("var") or o.attrib.get("target") for o in outputs}
+    bound = [t for t in output_targets if t and t in declared]
+    if not bound:
+        fail(
+            f"RPA job output must bind to a declared variable; "
+            f"outputs={sorted(t for t in output_targets if t)} declared={sorted(declared)}"
+        )
+
+    require_no_private_connector_values(root)
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} wires Orchestrator.StartJob with bound input and output variable")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/rpa_job/rpa_job.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/rpa_job/rpa_job.yaml
@@ -1,0 +1,60 @@
+task_id: skill-bpmn-rpa-job
+description: >
+  Resource-node eval: agent uses the uipath-maestro-bpmn skill to model an RPA
+  job invocation as a bpmn:serviceTask with the registry Orchestrator.StartJob
+  wrapper, binding job arguments as input and capturing the job response into a
+  declared variable. Differentiates from the hitl/rpa wrapper-presence eval by
+  grading input/output variable binding. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:single-node", resource]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "InvoiceExtractionRpa" with the main file at
+  InvoiceExtractionRpa/InvoiceExtractionRpa.bpmn. Model this process:
+  manual start -> run an RPA workflow that extracts an invoice title -> end.
+
+  Requirements:
+  - Discover the RPA-job extension type via the registry and author its node
+    from the registry template. Do not hand-author uipath:* XML from prose.
+  - Model the RPA invocation as a bpmn:serviceTask using the documented
+    Orchestrator.StartJob uipath:activity wrapper.
+  - Bind at least one job argument as the task's request input, and capture the
+    job response into a declared process variable (BPMN.Variables).
+  - Use synthetic placeholder resource keys only. Do not invent or paste real
+    tenant URLs, folder keys, connection IDs, release keys, or user names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Do not upload, publish, deploy, debug, run, or pack anything, and do not
+    pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "InvoiceExtractionRpa/InvoiceExtractionRpa.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "RPA job serviceTask uses Orchestrator.StartJob with input and a declared output variable"
+    command: "python3 $TASK_DIR/check_rpa_job.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/single_node/timer_start/check_timer_start.py
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/timer_start/check_timer_start.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Structural check for the timer start-event (scheduled trigger) eval.
+
+Grades the Flow scheduled-trigger port: the process start is a bpmn:startEvent
+carrying the registry Intsvc.TimerTrigger wrapper and a bpmn:timerEventDefinition
+configured with a recurring, non-zero ISO-8601 timeCycle; there is no manual
+start; and the timer start is genuinely the process entry (no inbound flow).
+Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET, locally authored
+input — same trust boundary as the rest of the fixture corpus).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.bpmn_check import (  # noqa: E402
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+# ISO-8601 repeating interval: R[n]/ then a period or start-datetime.
+REPEATING = re.compile(r"^R\d*/")
+
+
+def child(el: ET.Element, local: str) -> ET.Element | None:
+    return el.find(f"{{{BPMN_NS}}}{local}")
+
+
+def main() -> None:
+    path, root = parse_bpmn("ScheduledReportBpmn")
+
+    starts = elements(root, "startEvent")
+    if not starts:
+        fail("no start event")
+    if not elements(root, "endEvent"):
+        fail("no end event")
+
+    timer_starts = []
+    for start in starts:
+        xml = ET.tostring(start, encoding="unicode")
+        if "Intsvc.TimerTrigger" in xml and child(start, "timerEventDefinition") is not None:
+            timer_starts.append(start)
+    if not timer_starts:
+        fail("no bpmn:startEvent with Intsvc.TimerTrigger + timerEventDefinition")
+    start = timer_starts[0]
+
+    # No manual start: every start event must be the timer start (the flow port
+    # replaced manual with scheduled — they must not coexist).
+    non_timer = [s for s in starts if s not in timer_starts]
+    if non_timer:
+        fail(f"a non-timer (manual) start event remains: {[attr(s, 'id') for s in non_timer]}")
+
+    timer_def = child(start, "timerEventDefinition")
+    cycle = child(timer_def, "timeCycle")
+    if cycle is None:
+        fail("scheduled trigger must use a bpmn:timeCycle (recurring), not timeDuration/timeDate")
+    cycle_text = (cycle.text or "").strip()
+    if not REPEATING.match(cycle_text):
+        fail(f"timeCycle must be an ISO-8601 repeating interval (R.../...); found {cycle_text!r}")
+    if not re.search(r"[1-9]", cycle_text):
+        fail(f"timeCycle has no non-zero component (never fires): {cycle_text!r}")
+
+    # The timer start must genuinely be the process entry: nothing flows into it.
+    start_id = attr(start, "id")
+    if any(attr(f, "targetRef") == start_id for f in elements(root, "sequenceFlow")):
+        fail("timer start event must be the process entry (no inbound sequence flow)")
+    if not any(attr(f, "sourceRef") == start_id for f in elements(root, "sequenceFlow")):
+        fail("timer start event must have an outgoing sequence flow")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} starts on a recurring timer schedule ({cycle_text})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/single_node/timer_start/timer_start.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/timer_start/timer_start.yaml
@@ -1,0 +1,74 @@
+task_id: skill-bpmn-timer-start
+description: >
+  Timer start-event eval: agent uses the uipath-maestro-bpmn skill to author a
+  scheduled (timer) start event that fires on a recurring hourly cycle, using the
+  registry Intsvc.TimerTrigger wrapper on a bpmn:startEvent with a
+  bpmn:timerEventDefinition. Ports the Flow scheduled-trigger smoke test to a
+  BPMN timer start event. Authoring only — a timer only fires in a live engine,
+  so this validates the structure locally.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:generate", "feature:trigger"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 45
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Create a local BPMN project named "ScheduledReportBpmn" with the main file at
+  ScheduledReportBpmn/ScheduledReportBpmn.bpmn. Model a process that is started
+  by a schedule (not a manual start) and runs every hour:
+  scheduled timer start -> a script task that assembles a report -> end.
+
+  Requirements:
+  - Discover the timer-trigger extension type via the registry and author its
+    node from the registry template. Do not hand-author uipath:* XML from prose.
+  - The process start MUST be a bpmn:startEvent carrying the Intsvc.TimerTrigger
+    wrapper and a bpmn:timerEventDefinition. There must be NO manual start event.
+  - Configure a recurring hourly schedule using a bpmn:timeCycle with a valid
+    ISO-8601 repeating interval (for example R/PT1H). Do not use a never-firing
+    interval.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file is well-formed XML with an explicit Bash command before
+    finishing, e.g.:
+    `python3 -c "import xml.etree.ElementTree as ET; ET.parse('ScheduledReportBpmn/ScheduledReportBpmn.bpmn')"`.
+  - Do not upload, publish, deploy, debug, run, or pack anything, and do not
+    pause for approval or confirmation.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was created"
+    path: "ScheduledReportBpmn/ScheduledReportBpmn.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses the timer-trigger wrapper and a timer event definition"
+    path: "ScheduledReportBpmn/ScheduledReportBpmn.bpmn"
+    includes:
+      - "Intsvc.TimerTrigger"
+      - "timerEventDefinition"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran an explicit well-formed-XML validation on the authored BPMN"
+    tool_name: "Bash"
+    command_pattern: 'python3?\s+-c\s+[\s\S]*ET\.parse\([\s\S]*ScheduledReportBpmn\.bpmn'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Timer start event is a recurring scheduled start with valid structure"
+    command: "python3 $TASK_DIR/check_timer_start.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Ports the intent of the `uipath-maestro-flow` single-node / trigger test suite to registry-driven **Maestro BPMN** equivalents. Every new test is authoring-only, public-safe (no live connections, no upload/publish/deploy/debug/run/pack), and graded by a structural ElementTree check script (well-formedness + wrapper-on-correct-host + input/output binding + diagram + sequence integrity). All 6 check scripts were verified locally against faithful sample BPMNs (pass) and mutation cases (correctly rejected); the fully-authorable shapes also pass the skill's bundled Node validator.

## Flow source → BPMN port

| Flow source (`tests/tasks/uipath-maestro-flow/`) | BPMN port | Rationale |
|---|---|---|
| `single_node/rpa/rpa.yaml` | `single_node/rpa_job/` — `Orchestrator.StartJob` on `bpmn:serviceTask` | Differentiated from existing `nodes/hitl_rpa_wrappers.yaml` (which grades wrapper *presence*) by grading job-argument **input** + response **output variable binding**. |
| `single_node/lowcode_agent/lowcode_agent.yaml` | `single_node/agent_job/` — `Orchestrator.StartAgentJob` on `bpmn:serviceTask` | Low-code (Agent Builder) flavor; robust to both registry-template and skill-rule wrapper styles. |
| `single_node/coded_agent/coded_agent.yaml` | **SKIPPED — merged** | Per `registry-workflow.md`, coded Python agents publish as `processType: Function` and use the **`Orchestrator.StartJob`** contract — structurally identical to `rpa_job`. A separate test would duplicate it. |
| `single_node/openmeteo_weather/openmeteo_weather.yaml` | `single_node/http_weather/` — `Intsvc.HttpExecution` (manual/connectionless) on `bpmn:sendTask` | Live IS connector needs a tenant connection (not public-safe/local), so ported as a connectionless HTTP GET to the public Open-Meteo host with response bound to a variable. |
| `smoke/scheduled_trigger.yaml` | `single_node/timer_start/` — `Intsvc.TimerTrigger` on `bpmn:startEvent` | Timer start event with a recurring, non-zero ISO-8601 `bpmn:timeCycle` (e.g. `R/PT1H`); no manual start. Mirrors the flow test's replace-manual-with-scheduled discipline. |
| `single_node/outlook_waitfor_email/outlook_waitfor_email.yaml` | `single_node/message_catch/` — `Maestro.ReceiveMessageEvent` on `bpmn:intermediateCatchEvent` | Mid-flow wait-for-message (internal-message flavor, login-free); manual start preserved, event added mid-flow (has inbound + outbound). |
| `single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml` | `single_node/event_trigger_start/` — `Intsvc.EventTrigger` on `bpmn:startEvent` | Connector event-received **start** trigger, kept as a public-safe **draft** (connection binding + trigger schemas are CLI-owned enrichment). Adds an `llm_judge` "stayed-local" criterion. |
| `single_node/api_workflow/api_workflow.yaml` | **SKIPPED — overlap** | `Orchestrator.ExecuteApiWorkflowAsync` is already covered by `authoring/api_workflow_task.yaml`, and the sync `ExecuteApiWorkflow` wait variant is **not in the OOTB registry** (confirmed via `uip maestro bpmn registry list`), so no differentiating variant exists to author. |
| `single_node/file_attachment/file_attachment.yaml` | **SKIPPED — N/A** | Flow's file-attachment exercises the `flow debug --attachment` operate/upload path; the BPMN skill is authoring-only with no attachment or debug-run concept in scope. |

**Net: 6 new tests, 3 skipped.**

## Conventions

- Layout: one task YAML + `check_*.py` per new leaf dir under `single_node/`; `sandbox.template_sources` → `../../../../../skills/uipath-maestro-bpmn` (5 `../` for the extra nesting level).
- Tags from the closed vocabulary: `uipath-maestro-bpmn` + tier + `mode:build` + `lifecycle:generate`, plus `shape:*`, flat `resource`/`connector` markers, and `feature:http`/`feature:trigger`.
- Behavior-graded: `file_exists`, `file_contains`, `command_not_executed` cloud-op guard, and a weight-4–5 `run_command` structural check reusing `_shared/bpmn_check.py`. No gating on `--output json`.
- No `@uipath/cli` in `env_packages`; run limits at top-level `run_limits`.

## Passing run

Passing run: https://github.com/UiPath/skills/actions/runs/29439965785 — `run-coder-eval.yml` on this branch, all 6 new tasks **6/6 PASS (linux)**, workflow conclusion `success`, first dispatch (no retries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
