### PR TITLE
test(maestro-bpmn): port brownfield-edit and connector-feature evals from flow suite

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/README.md
+++ b/tests/tasks/uipath-maestro-bpmn/README.md
@@ -19,6 +19,12 @@ authoring-only skill for producing valid, importable Maestro `.bpmn` XML.
   public-safe Maestro BPMN XML contract variants.
 - `connector/` covers Integration Service boundary behavior and registry
   discovery for connector wrapper types without cloud-side mutations.
+- `edit/` covers surgical brownfield edits on a pre-built, valid `.bpmn`
+  fixture (add / remove / update / reorder a node, add an output mapping,
+  extract a group into a subprocess). Each task ships its own fixture and
+  grades the requested edit plus preservation of untouched ids, `uipath:*`
+  payloads, and `uipath:migrationVersion` via an ElementTree diff against the
+  pristine original.
 - `e2e/` covers a multi-node authoring scenario end to end.
 - `operate-diagnose/` covers diagnostic inspection and operate-action guidance
   using mocked CLI responses, matching the operate and diagnose capabilities the

--- a/tests/tasks/uipath-maestro-bpmn/_shared/edit_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/edit_check.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Shared helpers for uipath-maestro-bpmn brownfield-edit eval checks.
+
+An edit task ships a pristine fixture `.bpmn` into the sandbox; the agent makes a
+surgical edit and the sidecar check diffs the edited file against the pristine
+original (read from the task's own `fixture/` dir via ``load_original``).
+
+The core contract these helpers enforce: elements the agent did NOT author
+(stable ids, unknown/preserve-only ``uipath:*`` payloads, ``migrationVersion``)
+must round-trip structurally identical. ``canonical`` normalizes attribute order
+and whitespace so legitimate reformatting is not flagged, while any real change
+to a preserved subtree fails the check.
+"""
+
+from __future__ import annotations
+
+import os
+import xml.etree.ElementTree as ET
+
+BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+UIPATH_NS = "http://uipath.org/schema/bpmn"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def load_original(check_file: str, basename: str) -> ET.Element:
+    """Parse the pristine fixture stored next to the check script."""
+    path = os.path.join(os.path.dirname(os.path.abspath(check_file)), "fixture", basename)
+    if not os.path.isfile(path):
+        fail(f"pristine fixture not found at {path}")
+    return ET.parse(path).getroot()
+
+
+def canonical(element: ET.Element):
+    """A hashable, order- and whitespace-normalized view of an element subtree."""
+    text = (element.text or "").strip()
+    attribs = tuple(sorted(element.attrib.items()))
+    children = tuple(canonical(child) for child in element)
+    return (local(element.tag), attribs, text, children)
+
+
+def canonical_ex(element: ET.Element, ignore: set[str] = frozenset()):
+    """Like ``canonical`` but skips child elements whose local name is in ``ignore``."""
+    text = (element.text or "").strip()
+    attribs = tuple(sorted(element.attrib.items()))
+    children = tuple(
+        canonical_ex(child, ignore) for child in element if local(child.tag) not in ignore
+    )
+    return (local(element.tag), attribs, text, children)
+
+
+def by_id(root: ET.Element, element_id: str) -> ET.Element | None:
+    for el in root.iter():
+        if el.attrib.get("id") == element_id:
+            return el
+    return None
+
+
+_by_id = by_id
+
+
+def all_ids(root: ET.Element) -> set[str]:
+    return {el.attrib["id"] for el in root.iter() if el.attrib.get("id")}
+
+
+def assert_no_orphan_di(root: ET.Element) -> None:
+    """Every DI shape/edge must reference an element that still exists — catches
+    leftover diagram interchange after a node/flow removal."""
+    ids = all_ids(root)
+    flow_ids = {fid for fid, _s, _t in flows(root)}
+    for shape in (e for e in root.iter() if local(e.tag) == "BPMNShape"):
+        ref = shape.attrib.get("bpmnElement")
+        if ref and ref not in ids:
+            fail(f"orphan BPMNShape references missing element {ref!r}")
+    for edge in (e for e in root.iter() if local(e.tag) == "BPMNEdge"):
+        ref = edge.attrib.get("bpmnElement")
+        if ref and ref not in flow_ids and ref not in ids:
+            fail(f"orphan BPMNEdge references missing flow {ref!r}")
+
+
+def assert_config_preserved(original: ET.Element, edited: ET.Element, ids: list[str]) -> None:
+    """Each listed node must keep its name/config/uipath payload; only its
+    ``bpmn:incoming``/``bpmn:outgoing`` wiring may change (edit-adjacent nodes)."""
+    ignore = {"incoming", "outgoing"}
+    for element_id in ids:
+        orig = _by_id(original, element_id)
+        new = _by_id(edited, element_id)
+        if orig is None:
+            fail(f"fixture bug: id {element_id!r} not in pristine original")
+        if new is None:
+            fail(f"node {element_id!r} is missing after the edit")
+        if canonical_ex(orig, ignore) != canonical_ex(new, ignore):
+            fail(f"node {element_id!r} config/payload changed (only its wiring may change)")
+
+
+def assert_ids_present(root: ET.Element, ids: list[str]) -> None:
+    present = {el.attrib.get("id") for el in root.iter() if el.attrib.get("id")}
+    missing = [i for i in ids if i not in present]
+    if missing:
+        fail(f"expected preserved ids missing after edit: {missing}")
+
+
+def assert_id_absent(root: ET.Element, element_id: str) -> None:
+    present = {el.attrib.get("id") for el in root.iter() if el.attrib.get("id")}
+    if element_id in present:
+        fail(f"element id {element_id!r} should have been removed but is still present")
+
+
+def assert_preserved(original: ET.Element, edited: ET.Element, ids: list[str]) -> None:
+    """Each listed element id must round-trip structurally identical."""
+    for element_id in ids:
+        orig = _by_id(original, element_id)
+        new = _by_id(edited, element_id)
+        if orig is None:
+            fail(f"fixture bug: id {element_id!r} not in pristine original")
+        if new is None:
+            fail(f"preserved element {element_id!r} is missing after the edit")
+        if canonical(orig) != canonical(new):
+            fail(f"preserved element {element_id!r} was modified (must round-trip untouched)")
+
+
+def _find_first(root: ET.Element, local_name: str) -> ET.Element | None:
+    for el in root.iter():
+        if local(el.tag) == local_name:
+            return el
+    return None
+
+
+def assert_uipath_preserved(original: ET.Element, edited: ET.Element, local_name: str) -> None:
+    """A named ``uipath:*`` payload (e.g. migrationVersion, caseManagement) must be untouched."""
+    orig = _find_first(original, local_name)
+    new = _find_first(edited, local_name)
+    if orig is None:
+        fail(f"fixture bug: no uipath:{local_name} in pristine original")
+    if new is None:
+        fail(f"uipath:{local_name} was dropped by the edit (must be preserved)")
+    if canonical(orig) != canonical(new):
+        fail(f"uipath:{local_name} payload was modified (must round-trip untouched)")
+
+
+def flows(root: ET.Element) -> list[tuple[str, str, str]]:
+    out = []
+    for el in root.iter():
+        if local(el.tag) == "sequenceFlow":
+            out.append(
+                (el.attrib.get("id", ""), el.attrib.get("sourceRef", ""), el.attrib.get("targetRef", ""))
+            )
+    return out
+
+
+def has_flow(root: ET.Element, source: str, target: str) -> bool:
+    return any(s == source and t == target for _id, s, t in flows(root))
+
+
+def flow_node_ids(root: ET.Element) -> set[str]:
+    kinds = {
+        "startEvent", "endEvent", "task", "serviceTask", "sendTask", "receiveTask",
+        "userTask", "businessRuleTask", "scriptTask", "callActivity", "subProcess",
+        "exclusiveGateway", "parallelGateway", "inclusiveGateway", "eventBasedGateway",
+    }
+    return {
+        el.attrib["id"]
+        for el in root.iter()
+        if local(el.tag) in kinds and el.attrib.get("id")
+    }
+
+
+def elements_local(root: ET.Element, local_name: str) -> list[ET.Element]:
+    return [el for el in root.iter() if local(el.tag) == local_name]

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_node/add_node.yaml
@@ -1,0 +1,60 @@
+task_id: skill-bpmn-edit-add-node
+description: >
+  Brownfield edit: insert a new script task into an existing, valid Maestro BPMN
+  between two adjacent tasks, rewiring the sequence flow and diagram while
+  preserving element ids, uipath:* payloads, and uipath:migrationVersion.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `OrderIntake.bpmn` is in the working directory. Its
+  flow is: "Validate Order" (Task_Validate) -> "Notify Customer" (Task_Notify).
+
+  Insert a new script task named "Reserve Stock" BETWEEN "Validate Order" and
+  "Notify Customer", so the order becomes
+  Validate Order -> Reserve Stock -> Notify Customer. Rewire the sequence flows
+  and update the diagram so the new node and its flows render.
+
+  Make a SURGICAL edit: preserve everything you did not author — the existing
+  element ids, the uipath:* extension payloads, uipath:migrationVersion, and the
+  process variables must round-trip untouched.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "OrderIntake.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "OrderIntake.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'uipath:migrationVersion'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "New script node inserted and wired, untouched content preserved, file still structurally sound"
+    command: "python3 $TASK_DIR/check_add_node.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_node/check_add_node.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_node/check_add_node.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Add-node edit check.
+
+A new script task must be inserted between Task_Validate and Task_Notify, the old
+direct flow rewired, and everything the agent did not author preserved.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_config_preserved,
+    assert_no_orphan_di,
+    assert_uipath_preserved,
+    elements_local,
+    fail,
+    flow_node_ids,
+    has_flow,
+    load_original,
+)
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("OrderIntake")
+    original = load_original(__file__, "OrderIntake.bpmn")
+
+    added = flow_node_ids(edited) - flow_node_ids(original)
+    inserted = [
+        i for i in added
+        if has_flow(edited, "Task_Validate", i) and has_flow(edited, i, "Task_Notify")
+    ]
+    if not inserted:
+        fail("no new node wired between Task_Validate and Task_Notify")
+
+    script_ids = {el.attrib.get("id") for el in elements_local(edited, "scriptTask")}
+    if not any(i in script_ids for i in inserted):
+        fail("the inserted node is not a bpmn:scriptTask")
+
+    if has_flow(edited, "Task_Validate", "Task_Notify"):
+        fail("original direct flow Task_Validate -> Task_Notify was not rewired")
+
+    # Preserve what the agent did not author.
+    assert_config_preserved(original, edited, ["Start_1", "Task_Validate", "Task_Notify", "End_1"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+    assert_uipath_preserved(original, edited, "variables")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: script node inserted, flow rewired, untouched content preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_node/fixture/OrderIntake.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_node/fixture/OrderIntake.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_OrderIntake" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_OrderIntake" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"order-ops","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_OrderId" name="OrderId" type="string" />
+        <uipath:inputOutput id="Var_Qty" name="Qty" type="number" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_S1</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Validate" name="Validate Order" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"orderId":"=vars.Var_OrderId"}]]></uipath:input>
+          <uipath:output name="qty" type="number" var="Var_Qty" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_S1</bpmn:incoming><bpmn:outgoing>Flow_VN</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: orderId ? 1 : 0 };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Notify" name="Notify Customer" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"qty":"=vars.Var_Qty"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_VN</bpmn:incoming><bpmn:outgoing>Flow_NE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "notified" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_NE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_S1" sourceRef="Start_1" targetRef="Task_Validate" />
+    <bpmn:sequenceFlow id="Flow_VN" sourceRef="Task_Validate" targetRef="Task_Notify" />
+    <bpmn:sequenceFlow id="Flow_NE" sourceRef="Task_Notify" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_OrderIntake">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Validate" bpmnElement="Task_Validate"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Notify" bpmnElement="Task_Notify"><dc:Bounds x="410" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="570" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_S1" bpmnElement="Flow_S1"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_VN" bpmnElement="Flow_VN"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_NE" bpmnElement="Flow_NE"><di:waypoint x="510" y="118" /><di:waypoint x="570" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_output/add_output.yaml
@@ -1,0 +1,60 @@
+task_id: skill-bpmn-edit-add-output
+description: >
+  Brownfield edit: add a new output mapping to an existing script task in a valid
+  Maestro BPMN and declare the backing variable in BPMN.Variables, without
+  disturbing the existing output, variables, or preserve-only payloads.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `Invoicing.bpmn` is in the working directory. The
+  "Calculate Total" (Task_Calc) script task returns a total and maps it to the
+  Total variable.
+
+  Add a SECOND output named "tax" to "Calculate Total": have the script also
+  return a tax value, map that output to a NEW process variable you declare in
+  the BPMN.Variables block, and have the script populate it.
+
+  Make a SURGICAL edit: the existing "total" output, the existing variables, all
+  element ids, the uipath:* extension payloads, and uipath:migrationVersion must
+  round-trip untouched.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "Invoicing.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "Invoicing.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'uipath:migrationVersion'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "New output + backing variable added, existing output/variables preserved, file still structurally sound"
+    command: "python3 $TASK_DIR/check_add_output.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_output/check_add_output.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_output/check_add_output.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Add-output edit check.
+
+A new output must be added to Task_Calc's mapping and backed by a new variable
+declared in the process BPMN.Variables block, without disturbing the existing
+output / variables / preserve-only payloads.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_assertions import mapping_outputs, variable_ids  # noqa: E402
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_no_orphan_di,
+    assert_preserved,
+    assert_uipath_preserved,
+    by_id,
+    fail,
+    load_original,
+)
+
+
+def _output_vars(task) -> set[str]:
+    return {o.attrib.get("var") or o.attrib.get("target") for o in mapping_outputs(task)}
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("Invoicing")
+    original = load_original(__file__, "Invoicing.bpmn")
+
+    orig_vars = variable_ids(original)
+    new_vars = variable_ids(edited)
+    added_vars = new_vars - orig_vars
+    if not added_vars:
+        fail("no new variable declared in BPMN.Variables")
+    if not orig_vars.issubset(new_vars):
+        fail(f"existing variables were dropped: {sorted(orig_vars - new_vars)}")
+
+    calc = by_id(edited, "Task_Calc")
+    if calc is None:
+        fail("Task_Calc is missing after the edit")
+    outs = _output_vars(calc)
+    if "Var_Total" not in outs:
+        fail("the original Task_Calc output (Var_Total) was not preserved")
+    if not (added_vars & outs):
+        fail("Task_Calc has no output wired to the newly declared variable")
+    if len(mapping_outputs(calc)) < 2:
+        fail("Task_Calc must have at least two outputs after the edit")
+
+    # Endpoints and preserve-only payloads stay untouched (variables legitimately change).
+    assert_preserved(original, edited, ["Start_1", "End_1"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: new output + variable added, existing output and payloads preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/add_output/fixture/Invoicing.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/add_output/fixture/Invoicing.bpmn
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_Invoicing" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_Invoicing" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"billing","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_Amount" name="Amount" type="number" />
+        <uipath:inputOutput id="Var_Total" name="Total" type="number" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_SC</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Calc" name="Calculate Total" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"amount":"=vars.Var_Amount"}]]></uipath:input>
+          <uipath:output name="total" type="number" var="Var_Total" source="=result.response.total" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SC</bpmn:incoming><bpmn:outgoing>Flow_CE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: { total: amount * 1.2 } };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_CE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_SC" sourceRef="Start_1" targetRef="Task_Calc" />
+    <bpmn:sequenceFlow id="Flow_CE" sourceRef="Task_Calc" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_Invoicing">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Calc" bpmnElement="Task_Calc"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="410" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_SC" bpmnElement="Flow_SC"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_CE" bpmnElement="Flow_CE"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/check_group_to_subflow.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/check_group_to_subflow.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Group-to-subflow edit check.
+
+Pick + Pack must be extracted into an embedded bpmn:subProcess (with a diagram
+shape and nested script logic), while Task_Ship stays in the main flow and the
+preserve-only payloads round-trip untouched.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_assertions import assert_has_shape  # noqa: E402
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_config_preserved,
+    assert_no_orphan_di,
+    assert_uipath_preserved,
+    elements_local,
+    fail,
+    has_flow,
+    load_original,
+    local,
+)
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("Fulfillment")
+    original = load_original(__file__, "Fulfillment.bpmn")
+
+    subs = elements_local(edited, "subProcess")
+    if not subs:
+        fail("no bpmn:subProcess was created — the group was not extracted")
+
+    # Script logic must live inside a subprocess now.
+    nested_scripts = [
+        el for sub in subs for el in sub.iter()
+        if local(el.tag) == "scriptTask" and el is not sub
+    ]
+    if not nested_scripts:
+        fail("the subprocess contains no nested script task — no logic was moved in")
+
+    # Task_Ship must remain, outside any subprocess, still reaching the end.
+    nested_ids = {el.attrib.get("id") for sub in subs for el in sub.iter() if el is not sub}
+    if "Task_Ship" in nested_ids:
+        fail("Task_Ship must stay in the main flow, not move into the subprocess")
+    if not has_flow(edited, "Task_Ship", "End_1"):
+        fail("Task_Ship no longer flows to End_1")
+
+    # The subprocess must be importable (has a diagram shape).
+    sub_id = subs[0].attrib.get("id")
+    if not sub_id:
+        fail("subprocess has no id")
+    assert_has_shape(edited, sub_id)
+
+    assert_config_preserved(original, edited, ["Task_Ship"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: Pick/Pack extracted into a subprocess, Task_Ship preserved in main flow")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/fixture/Fulfillment.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/fixture/Fulfillment.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_Fulfillment" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_Fulfillment" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"warehouse","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_OrderId" name="OrderId" type="string" />
+        <uipath:inputOutput id="Var_Label" name="Label" type="string" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_SP</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Pick" name="Pick Items" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"orderId":"=vars.Var_OrderId"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SP</bpmn:incoming><bpmn:outgoing>Flow_PP</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "picked" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Pack" name="Pack Box" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"orderId":"=vars.Var_OrderId"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_PP</bpmn:incoming><bpmn:outgoing>Flow_PS</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "packed" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Ship" name="Ship Parcel" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"orderId":"=vars.Var_OrderId"}]]></uipath:input>
+          <uipath:output name="label" type="string" var="Var_Label" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_PS</bpmn:incoming><bpmn:outgoing>Flow_SE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "label-123" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_SE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_SP" sourceRef="Start_1" targetRef="Task_Pick" />
+    <bpmn:sequenceFlow id="Flow_PP" sourceRef="Task_Pick" targetRef="Task_Pack" />
+    <bpmn:sequenceFlow id="Flow_PS" sourceRef="Task_Pack" targetRef="Task_Ship" />
+    <bpmn:sequenceFlow id="Flow_SE" sourceRef="Task_Ship" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_Fulfillment">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Pick" bpmnElement="Task_Pick"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Pack" bpmnElement="Task_Pack"><dc:Bounds x="410" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Ship" bpmnElement="Task_Ship"><dc:Bounds x="570" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="730" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_SP" bpmnElement="Flow_SP"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_PP" bpmnElement="Flow_PP"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_PS" bpmnElement="Flow_PS"><di:waypoint x="510" y="118" /><di:waypoint x="570" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_SE" bpmnElement="Flow_SE"><di:waypoint x="670" y="118" /><di:waypoint x="730" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/group_to_subflow/group_to_subflow.yaml
@@ -1,0 +1,60 @@
+task_id: skill-bpmn-edit-group-to-subflow
+description: >
+  Brownfield edit: extract a contiguous group of tasks from a valid Maestro BPMN
+  into an embedded subprocess (with its own start/end and a diagram shape),
+  keeping the remaining tail node in the main flow and behavior intact.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node", "node:subflow"]
+
+run_limits:
+  expected_turns: 26
+  max_turns: 90
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `Fulfillment.bpmn` is in the working directory. Its
+  flow is: "Pick Items" (Task_Pick) -> "Pack Box" (Task_Pack) -> "Ship Parcel"
+  (Task_Ship).
+
+  Extract "Pick Items" and "Pack Box" into a single embedded subprocess named
+  "Prepare", preserving their behavior. "Ship Parcel" must stay in the main flow
+  and still run after the subprocess. Give the subprocess its own start/end
+  events and a diagram shape so it renders.
+
+  Make a SURGICAL edit: "Ship Parcel"'s payload and id, uipath:migrationVersion,
+  and the process-level preserve-only content must round-trip untouched.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "Fulfillment.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "Fulfillment.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'bpmn:subProcess'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Group extracted into a subprocess, Ship Parcel preserved in main flow, file still structurally sound"
+    command: "python3 $TASK_DIR/check_group_to_subflow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/edit/move_node/check_move_node.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/move_node/check_move_node.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Move/reorder edit check.
+
+Task_Welcome must be reordered ahead of Task_Create, so the sequence becomes
+Start -> Task_Welcome -> Task_Create -> End, with both tasks' payloads preserved.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_config_preserved,
+    assert_no_orphan_di,
+    assert_uipath_preserved,
+    fail,
+    has_flow,
+    load_original,
+)
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("Onboarding")
+    original = load_original(__file__, "Onboarding.bpmn")
+
+    if not has_flow(edited, "Start_1", "Task_Welcome"):
+        fail("expected reordered flow Start_1 -> Task_Welcome")
+    if not has_flow(edited, "Task_Welcome", "Task_Create"):
+        fail("expected reordered flow Task_Welcome -> Task_Create")
+    if not has_flow(edited, "Task_Create", "End_1"):
+        fail("expected reordered flow Task_Create -> End_1")
+    if has_flow(edited, "Start_1", "Task_Create"):
+        fail("flow still starts with Task_Create; nodes were not reordered")
+
+    assert_config_preserved(original, edited, ["Start_1", "Task_Create", "Task_Welcome", "End_1"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+    assert_uipath_preserved(original, edited, "variables")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: nodes reordered, flows rewired, payloads preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/move_node/fixture/Onboarding.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/move_node/fixture/Onboarding.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_Onboarding" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_Onboarding" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"people-ops","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_Email" name="Email" type="string" />
+        <uipath:inputOutput id="Var_AccountId" name="AccountId" type="string" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_SC</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Create" name="Create Account" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"email":"=vars.Var_Email"}]]></uipath:input>
+          <uipath:output name="accountId" type="string" var="Var_AccountId" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SC</bpmn:incoming><bpmn:outgoing>Flow_CW</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "acct-" + email };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Welcome" name="Send Welcome" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"email":"=vars.Var_Email"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_CW</bpmn:incoming><bpmn:outgoing>Flow_WE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "welcome sent" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_WE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_SC" sourceRef="Start_1" targetRef="Task_Create" />
+    <bpmn:sequenceFlow id="Flow_CW" sourceRef="Task_Create" targetRef="Task_Welcome" />
+    <bpmn:sequenceFlow id="Flow_WE" sourceRef="Task_Welcome" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_Onboarding">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Create" bpmnElement="Task_Create"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Welcome" bpmnElement="Task_Welcome"><dc:Bounds x="410" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="570" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_SC" bpmnElement="Flow_SC"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_CW" bpmnElement="Flow_CW"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_WE" bpmnElement="Flow_WE"><di:waypoint x="510" y="118" /><di:waypoint x="570" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/move_node/move_node.yaml
@@ -1,0 +1,59 @@
+task_id: skill-bpmn-edit-move-node
+description: >
+  Brownfield edit: reorder two adjacent tasks in an existing, valid Maestro BPMN
+  by rewiring the sequence flows (BPMN has no positional move — the edit is a
+  pure rewiring), keeping both node payloads and the diagram consistent.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `Onboarding.bpmn` is in the working directory. Its
+  flow is: "Create Account" (Task_Create) -> "Send Welcome" (Task_Welcome).
+
+  Reorder the process so "Send Welcome" runs BEFORE "Create Account": the flow
+  must become Start -> Send Welcome -> Create Account -> end. Rewire the sequence
+  flows and keep the diagram edges consistent with the new order.
+
+  Make a SURGICAL edit: both tasks' names, uipath:* extension payloads, element
+  ids, uipath:migrationVersion, and the process variables must round-trip
+  untouched — only the wiring changes.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "Onboarding.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "Onboarding.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'uipath:migrationVersion'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Tasks reordered by rewiring flows, payloads preserved, file still structurally sound"
+    command: "python3 $TASK_DIR/check_move_node.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/edit/remove_node/check_remove_node.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/remove_node/check_remove_node.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Remove-node edit check.
+
+Task_Enrich must be deleted, the sequence flow healed (Task_Fetch -> Task_Route),
+orphaned DI removed, and the surrounding nodes / preserve-only payloads kept.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_config_preserved,
+    assert_id_absent,
+    assert_no_orphan_di,
+    assert_uipath_preserved,
+    fail,
+    flows,
+    has_flow,
+    load_original,
+)
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("ShipmentReview")
+    original = load_original(__file__, "ShipmentReview.bpmn")
+
+    assert_id_absent(edited, "Task_Enrich")
+    for fid, source, target in flows(edited):
+        if "Task_Enrich" in (source, target):
+            fail(f"sequence flow {fid!r} still references the removed Task_Enrich")
+
+    if not has_flow(edited, "Task_Fetch", "Task_Route"):
+        fail("flow not healed: expected a direct Task_Fetch -> Task_Route flow")
+
+    assert_config_preserved(original, edited, ["Start_1", "Task_Fetch", "Task_Route", "End_1"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+    assert_uipath_preserved(original, edited, "variables")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: Task_Enrich removed, flow healed, DI clean, untouched content preserved")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/remove_node/fixture/ShipmentReview.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/remove_node/fixture/ShipmentReview.bpmn
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_ShipmentReview" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_ShipmentReview" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"logistics","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_Tracking" name="Tracking" type="string" />
+        <uipath:inputOutput id="Var_Weight" name="Weight" type="number" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_SF</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Fetch" name="Fetch Shipment" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"tracking":"=vars.Var_Tracking"}]]></uipath:input>
+          <uipath:output name="weight" type="number" var="Var_Weight" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SF</bpmn:incoming><bpmn:outgoing>Flow_FE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: tracking.length };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Enrich" name="Enrich Shipment" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"weight":"=vars.Var_Weight"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_FE</bpmn:incoming><bpmn:outgoing>Flow_ER</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: weight * 2 };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Route" name="Route Shipment" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"weight":"=vars.Var_Weight"}]]></uipath:input>
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_ER</bpmn:incoming><bpmn:outgoing>Flow_RE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: weight > 10 ? "freight" : "parcel" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_RE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_SF" sourceRef="Start_1" targetRef="Task_Fetch" />
+    <bpmn:sequenceFlow id="Flow_FE" sourceRef="Task_Fetch" targetRef="Task_Enrich" />
+    <bpmn:sequenceFlow id="Flow_ER" sourceRef="Task_Enrich" targetRef="Task_Route" />
+    <bpmn:sequenceFlow id="Flow_RE" sourceRef="Task_Route" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_ShipmentReview">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Fetch" bpmnElement="Task_Fetch"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Enrich" bpmnElement="Task_Enrich"><dc:Bounds x="410" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Route" bpmnElement="Task_Route"><dc:Bounds x="570" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="730" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_SF" bpmnElement="Flow_SF"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_FE" bpmnElement="Flow_FE"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_ER" bpmnElement="Flow_ER"><di:waypoint x="510" y="118" /><di:waypoint x="570" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_RE" bpmnElement="Flow_RE"><di:waypoint x="670" y="118" /><di:waypoint x="730" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/remove_node/remove_node.yaml
@@ -1,0 +1,60 @@
+task_id: skill-bpmn-edit-remove-node
+description: >
+  Brownfield edit: delete a middle task from an existing, valid Maestro BPMN and
+  heal the sequence flow (source connects directly to the former successor),
+  removing orphaned diagram interchange and preserving untouched content.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `ShipmentReview.bpmn` is in the working directory.
+  Its flow is: "Fetch Shipment" (Task_Fetch) -> "Enrich Shipment" (Task_Enrich)
+  -> "Route Shipment" (Task_Route).
+
+  Remove the "Enrich Shipment" task and heal the flow so "Fetch Shipment"
+  connects directly to "Route Shipment". Remove the orphaned sequence flows and
+  the diagram shape/edges for the deleted node.
+
+  Make a SURGICAL edit: preserve everything you did not author — the remaining
+  element ids, the uipath:* extension payloads, uipath:migrationVersion, and the
+  process variables must round-trip untouched.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "ShipmentReview.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "ShipmentReview.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'uipath:migrationVersion'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Task removed, flow healed, DI clean, untouched content preserved, file still structurally sound"
+    command: "python3 $TASK_DIR/check_remove_node.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/edit/update_node/check_update_node.py
+++ b/tests/tasks/uipath-maestro-bpmn/edit/update_node/check_update_node.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Update-node edit check.
+
+The Task_Score script threshold must change from 500 to 1000, while the sibling
+Task_Format and all other content stay byte-for-byte / structurally identical.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from _shared.bpmn_check import parse_bpmn, require_di_for_visible_elements, require_sequence_integrity  # noqa: E402
+from _shared.edit_check import (  # noqa: E402
+    assert_no_orphan_di,
+    assert_preserved,
+    assert_uipath_preserved,
+    by_id,
+    fail,
+    local,
+    load_original,
+)
+
+
+def _script_text(task) -> str:
+    for child in task:
+        if local(child.tag) == "script":
+            return child.text or ""
+    return ""
+
+
+def main() -> None:
+    _path, edited = parse_bpmn("RiskScoring")
+    original = load_original(__file__, "RiskScoring.bpmn")
+
+    score = by_id(edited, "Task_Score")
+    if score is None:
+        fail("Task_Score is missing after the edit")
+    body = _script_text(score)
+    if "1000" not in body:
+        fail("Task_Score script was not updated to the new threshold 1000")
+    if "500" in body:
+        fail("Task_Score script still contains the old threshold 500")
+
+    # Sibling and endpoints must be untouched.
+    assert_preserved(original, edited, ["Task_Format", "Start_1", "End_1"])
+    assert_uipath_preserved(original, edited, "migrationVersion")
+    assert_uipath_preserved(original, edited, "caseManagement")
+    assert_uipath_preserved(original, edited, "variables")
+
+    require_sequence_integrity(edited)
+    require_di_for_visible_elements(edited)
+    assert_no_orphan_di(edited)
+    print("OK: Task_Score threshold updated, siblings untouched")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/edit/update_node/fixture/RiskScoring.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/edit/update_node/fixture/RiskScoring.bpmn
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions
+    xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL"
+    xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+    xmlns:dc="http://www.omg.org/spec/DD/20100524/DC"
+    xmlns:di="http://www.omg.org/spec/DD/20100524/DI"
+    xmlns:uipath="http://uipath.org/schema/bpmn"
+    id="Definitions_RiskScoring" targetNamespace="http://bpmn.io/schema/bpmn"
+    exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
+  <bpmn:process id="Process_RiskScoring" isExecutable="true">
+    <bpmn:extensionElements>
+      <uipath:migrationVersion version="11.5" />
+      <uipath:caseManagement version="v1"><![CDATA[{"owner":"risk-team","opaque":"preserve-only-do-not-touch"}]]></uipath:caseManagement>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="Var_Amount" name="Amount" type="number" />
+        <uipath:inputOutput id="Var_Tier" name="Tier" type="string" />
+        <uipath:inputOutput id="Var_Message" name="Message" type="string" />
+      </uipath:variables>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Start_1" name="Start"><bpmn:outgoing>Flow_SS</bpmn:outgoing></bpmn:startEvent>
+    <bpmn:scriptTask id="Task_Score" name="Score Risk" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"amount":"=vars.Var_Amount"}]]></uipath:input>
+          <uipath:output name="tier" type="string" var="Var_Tier" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SS</bpmn:incoming><bpmn:outgoing>Flow_SF</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: amount > 500 ? "high" : "low" };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Task_Format" name="Format Message" scriptFormat="JavaScript">
+      <bpmn:extensionElements>
+        <uipath:scriptVersion value="v3" />
+        <uipath:mapping version="v1">
+          <uipath:type value="BPMN.ScriptTask" version="v1" />
+          <uipath:input name="args"><![CDATA[{"tier":"=vars.Var_Tier"}]]></uipath:input>
+          <uipath:output name="message" type="string" var="Var_Message" source="=result.response" />
+        </uipath:mapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_SF</bpmn:incoming><bpmn:outgoing>Flow_FE</bpmn:outgoing>
+      <bpmn:script><![CDATA[return { response: "risk tier is " + tier };]]></bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:endEvent id="End_1" name="Done"><bpmn:incoming>Flow_FE</bpmn:incoming></bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_SS" sourceRef="Start_1" targetRef="Task_Score" />
+    <bpmn:sequenceFlow id="Flow_SF" sourceRef="Task_Score" targetRef="Task_Format" />
+    <bpmn:sequenceFlow id="Flow_FE" sourceRef="Task_Format" targetRef="End_1" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="Diagram_1">
+    <bpmndi:BPMNPlane id="Plane_1" bpmnElement="Process_RiskScoring">
+      <bpmndi:BPMNShape id="S_Start_1" bpmnElement="Start_1"><dc:Bounds x="160" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Score" bpmnElement="Task_Score"><dc:Bounds x="250" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Format" bpmnElement="Task_Format"><dc:Bounds x="410" y="78" width="100" height="80" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_End_1" bpmnElement="End_1"><dc:Bounds x="570" y="100" width="36" height="36" /></bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_SS" bpmnElement="Flow_SS"><di:waypoint x="196" y="118" /><di:waypoint x="250" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_SF" bpmnElement="Flow_SF"><di:waypoint x="350" y="118" /><di:waypoint x="410" y="118" /></bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_FE" bpmnElement="Flow_FE"><di:waypoint x="510" y="118" /><di:waypoint x="570" y="118" /></bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/edit/update_node/update_node.yaml
@@ -1,0 +1,59 @@
+task_id: skill-bpmn-edit-update-node
+description: >
+  Brownfield edit: change one script task's logic (a threshold constant) in an
+  existing, valid Maestro BPMN without restructuring the process or touching any
+  sibling node, ids, or preserve-only payloads.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "shape:multi-node"]
+
+run_limits:
+  expected_turns: 14
+  max_turns: 60
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  A valid Maestro BPMN file `RiskScoring.bpmn` is in the working directory. The
+  "Score Risk" (Task_Score) script task classifies an amount as "high" when it
+  exceeds a threshold of 500.
+
+  Update ONLY the "Score Risk" script so the threshold is 1000 instead of 500.
+  Do not restructure the process or change any other node.
+
+  Make a SURGICAL edit: the sibling "Format Message" task, all element ids, the
+  uipath:* extension payloads, uipath:migrationVersion, and the process
+  variables must round-trip untouched.
+
+  Validate the edited file locally before finishing. Do not upload, publish,
+  deploy, debug, run, or pack anything, and do not pause for approval — make the
+  edit end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The edited BPMN file is still present"
+    path: "RiskScoring.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Preserve-only payload round-tripped untouched"
+    path: "RiskScoring.bpmn"
+    includes:
+      - "preserve-only-do-not-touch"
+      - 'uipath:migrationVersion'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Score threshold updated to 1000, siblings untouched, file still structurally sound"
+    command: "python3 $TASK_DIR/check_update_node.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Ports the brownfield-**edit** family (and assesses the connector-feature family) from the `uipath-maestro-flow` test suite to `uipath-maestro-bpmn`. Each edit task ships a pre-built, validator-clean `.bpmn` fixture into the sandbox and grades a **surgical** edit: (a) the requested change happened, (b) untouched element ids / `uipath:*` payloads / `uipath:migrationVersion` round-trip structurally identical (ElementTree diff against the pristine original read from `$TASK_DIR/fixture/`), (c) the file is still structurally sound (DI + sequence integrity, no orphan diagram interchange).

All tasks are **local-only** — no upload/publish/deploy/debug/run — matching the BPMN skill's model and the existing `connector/` boundary tests. Grading uses stdlib `ElementTree` structural checks (the skill's documented validation fallback), consistent with the rest of the BPMN check corpus; it does not depend on the bundled Node validator (whose deps are gitignored). Every fixture and every "gold" correct edit was verified `VALID` against the bundled `validate-bpmn.mjs` locally, and each check was verified to FAIL on the pristine fixture and PASS on a correct edit.

## Flow source → BPMN port mapping

| Flow source (`tests/tasks/uipath-maestro-flow/`) | BPMN port / decision |
|---|---|
| `edit/add_node/add_node.yaml` | ✅ `edit/add_node/` — insert a script task between two nodes; rewire flows + DI |
| `edit/remove_node/remove_node.yaml` | ✅ `edit/remove_node/` — delete a middle task; heal the flow; drop orphaned DI |
| `edit/update_node/update_node.yaml` | ✅ `edit/update_node/` — change one script's threshold; siblings byte-identical |
| `edit/move_node/move_node.yaml` | ✅ `edit/move_node/` — recalibrated to a pure rewiring (BPMN has no positional move): reorder two adjacent tasks |
| `edit/add_output/add_output.yaml` | ✅ `edit/add_output/` — add an output mapping + declare its variable in `BPMN.Variables` |
| `edit/group_to_subflow/group_to_subflow.yaml` | ✅ `edit/group_to_subflow/` — extract a group into an embedded `bpmn:subProcess` |
| `connector_features/enum.yaml` | ⏭️ SKIPPED — enum-constrained connector fields are an Integration Service field-level feature the BPMN skill defers to the CLI; the boundary is already covered by `connector/integration_service_boundary.yaml`. No BPMN-authorable, locally-gradeable surface without live cloud. |
| `connector_features/path_params.yaml` | ⏭️ SKIPPED — same rationale: IS path parameters are CLI-owned enrichment, redundant with existing connector tests. |
| `connector_features/generate_schema.yaml` | ⏭️ SKIPPED — Flow-specific `uip is resources describe` dynamic-schema workflow; no BPMN equivalent (BPMN defers all IS payloads to the CLI). |

## New tasks (all `integration`, `mode:build`, `lifecycle:generate`, local-only)

- `skill-bpmn-edit-add-node`
- `skill-bpmn-edit-remove-node`
- `skill-bpmn-edit-update-node`
- `skill-bpmn-edit-move-node`
- `skill-bpmn-edit-add-output`
- `skill-bpmn-edit-group-to-subflow`

Shared preservation/diff helpers live in `tests/tasks/uipath-maestro-bpmn/_shared/edit_check.py`.

## Passing run

Passing run: https://github.com/UiPath/skills/actions/runs/29440348993 — **6/6 PASS (linux)**, all tasks `SUCCESS` on the first dispatch (`run-coder-eval.yml`, experiments/nightly.yaml, docker driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
