### PR TITLE
test(maestro-flow): remove IxP prompt instructions

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -24,14 +24,6 @@ initial_prompt: |
   - SAP: HTTP POST request to the configured endpoint, sending the extracted
     invoice fields as the request body
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors.
-
 success_criteria:
   - type: skill_triggered
     skill_name: "uipath-maestro-flow"


### PR DESCRIPTION
## Summary

- remove the `Important` instruction block from `skill-flow-ixp-e2e-invoice-extraction-greenfield`
- leave the task scenario, success criteria, and run limits unchanged

## Why

The test prompt should state the scenario without prescribing CLI availability, output flags, directory handling, validation iteration, or debug/deploy restrictions. This keeps the prompt focused on evaluating the skill's guidance.

## Validation

- `git diff --check`
- parsed the updated task with PyYAML
- verified the remote branch is one commit ahead of `main` with one changed file and 8 deletions

Full coder-eval e2e run not performed; this is a prompt-only change to a long-running test.