### PR TITLE
test: remove deploy tenant prompt instructions

### DIFF
--- a/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
@@ -21,9 +21,7 @@ initial_prompt: |
   as `data/fixtures.json` containing `{"sample": "value"}`. The
   `data/` directory must NOT end up in the packaged output.
 
-  Take the function through scaffold → init → run locally → pack.
-  Configure `packOptions` so the `data/` directory is excluded from
-  the package. Do NOT publish, upload, or deploy.
+  Do NOT publish, upload, or deploy.
   Complete it in a single pass.
 
 success_criteria:


### PR DESCRIPTION
## Summary

- Remove the scaffold → init → local run → pack recipe from `skill-functions-deploy-tenant`.
- Remove the explicit instruction to configure `packOptions` while retaining the outcome requirement that `data/` stay out of the package.
- Keep the existing guard against publishing, uploading, or deploying.

## Why

The test prompt was prescribing workflow and configuration details that the `uipath-functions` skill should teach. Removing those hints makes the evaluation measure whether the skill can derive the correct packaging workflow and exclusion configuration from the requested outcome.

## Impact

The success criteria and task limits are unchanged. The task still verifies scaffold, init, pack, `packOptions`, package contents, and the `.nupkg` artifact; only the agent-facing prompt is less prescriptive.

## Validation

- `coder-eval plan tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml -e tests/experiments/default.yaml`
- `python scripts/check-cli-verbs.py --json tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml` (Python 3.13)
- YAML parse and assertions that both removed instructions are absent
- `git diff --check`

Full end-to-end execution was not run because it requires the configured agent/tenant environment; this change only updates prompt text.