### PR TITLE
Remove wiring instruction from pagination test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -29,7 +29,6 @@ initial_prompt: |
   trigger. It should send a Slack message saying "hello from coder-eval"
   to the channel named `simple` using Slack's "Send Message to Channel"
   activity.
-  Wire the trigger to the Slack node and validate the final flow file.
   For Slack, use the connection name `is-sandboxes`.
 
 success_criteria:


### PR DESCRIPTION
## Summary

- remove the explicit instruction to wire the trigger to Slack and validate the generated flow from `skill-flow-paginated-reference-lookup`
- leave the existing success criteria unchanged

## Why

The test prompt should describe the intended Slack pagination scenario without spelling out the wiring and validation steps that the skill is expected to guide.

## Impact

The evaluation continues to require a wired Slack node and a validation command through its success criteria, while providing less procedural guidance in the prompt.

## Validation

- `coder-eval plan tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml -e experiments/default.yaml` — task schema and experiment resolution passed
- `python scripts/check-cli-verbs.py --json ...` — passed with the existing informational note for the dynamic `nextPage=` pattern
- YAML parse assertion and `git diff --check` passed
- full live connector evaluation not run (prompt-only change)