### PR TITLE
test: remove aged invoice structural from path-to-ga

### DIFF
--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
@@ -23,7 +23,6 @@ tags:
   - feature:case-exit
   - feature:trigger
   - feature:registry
-  - path-to-ga
 
 agent:
   type: claude-code


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-case-aged-invoice-structural`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml`

## Validation

- Existing passing run: [2026-07-16_04-24-15](https://coder-evalboard.uipath-dev.com/runs/2026-07-16_04-24-15)
- GitHub compare confirms this PR changes only the task YAML and removes only the tag.