### PR TITLE
test: remove IxP invoice extraction from path-to-ga

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -10,7 +10,7 @@ description: >
   verifies offline structural correctness only (`uip maestro flow validate`
   exit 0 on the generated flow).
 
-tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp, connector, feature:http, path-to-ga]
+tags: [uipath-maestro-flow, e2e, lifecycle:generate, shape:multi-node, node:ixp, connector, feature:http]
 
 initial_prompt: |
   Build a UiPath Flow that monitors a SharePoint folder for new vendor PDF


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-flow-ixp-e2e-invoice-extraction-greenfield`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml`

## Validation

- GitHub compare confirms this PR changes only the task YAML and removes only the tag.
- Full coder-eval run not repeated because this is a tag-only metadata change.