### PR TITLE
test: remove Drive to Slack from path-to-ga

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml
@@ -3,7 +3,7 @@ description: >
   E2E cross-connector scenario — downloads a file from Google Drive and posts
   it into a Slack channel via the "Send File to channel" activity. Exercises
   binary file flow between two IS connectors in a single Flow.
-tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack, ipe, mode:build, path-to-ga]
+tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, connector, e2e, uipath-google-drive, uipath-salesforce-slack, ipe, mode:build]
 
 run_limits:
   expected_turns: 49


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-flow-ipe-drive-to-slack`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-maestro-flow/connector_features/drive_to_slack.yaml`

## Validation

- GitHub compare confirms this PR changes only the task YAML and removes only the tag.
- Full coder-eval run not repeated because this is a tag-only metadata change.