### PR TITLE
test: remove paginated reference lookup from path-to-ga

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -16,7 +16,6 @@ tags:
   - connector
   - uipath-salesforce-slack
   - feature:records
-  - path-to-ga
 
 run_limits:
   expected_turns: 30


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-flow-paginated-reference-lookup`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml`

## Validation

- GitHub compare confirms this PR changes only the task YAML and removes only the tag.
- Full coder-eval run not repeated because this is a tag-only metadata change.