### PR TITLE
test: remove Functions deploy tenant from path-to-ga

### DIFF
--- a/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
+++ b/tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml
@@ -8,7 +8,7 @@ description: >
   non-interactive tenant-feed publish (pending uipath/cli#2778), so
   requiring an interactive `publish` made this task nondeterministic
   (the agent either fumbled the feed picker or exhausted its turns).
-tags: [uipath-functions, e2e, mode:build, feature:deploy, path-to-ga]
+tags: [uipath-functions, e2e, mode:build, feature:deploy]
 max_iterations: 1
 
 initial_prompt: |


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-functions-deploy-tenant`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-functions/deploy_tenant/deploy_tenant.yaml`

## Validation

- GitHub compare confirms this PR changes only the task YAML and removes only the tag.
- Full coder-eval run not repeated because this is a tag-only metadata change.