### PR TITLE
test: remove Test Manager testcase lifecycle from path-to-ga

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute, path-to-ga]
+tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
   driver: tempdir


### PR DESCRIPTION
## Summary

- Removes `path-to-ga` from `skill-platform-is-testmanager-testcase-lifecycle`.
- Leaves test behavior, prompts, limits, and success criteria unchanged.

## Scope

- `tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml`

## Validation

- GitHub compare confirms this PR changes only the task YAML and removes only the tag.
- Full coder-eval run not repeated because this is a tag-only metadata change.