### PR TITLE
test(uipath-maestro-flow): withhold sentence from coded-agent task prompt, inject at debug time

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/check_coded_agent_flow.py
@@ -1,32 +1,65 @@
 #!/usr/bin/env python3
-"""ApproverCountAgent: a coded-agent node executes; output holds the count (3).
+"""ApproverCountAgent: a coded-agent node analyzes an unseen sentence; output is 3.
 
-The prompt explicitly asks for a coded AGENT on a free-text task. The skill must
-honor that request: scaffold an Agent project (ProjectType: "Agent" — LangGraph /
-LlamaIndex / OpenAI Agents) producing a uipath.core.agent.<key> node, NOT downgrade
-it to a coded Function (ProjectType: "Function", uipath.core.function.<key>) that
-regexes the wording or hardcodes the answer because the task looks deterministic.
-The node-type assert below fails on a Function — a correct count from the wrong
-node kind does not satisfy an explicit agent request.
+The prompt explicitly asks for a coded AGENT on a free-text task and deliberately
+does NOT disclose the sentence — the flow declares a string input variable, and
+this checker injects the sentence at debug time via ``--inputs``. The agent must
+identify each person mentioned, classify their stance (approved / requested
+changes / recused), and return the approval count, so a deterministic Function
+that regexes known wording or hardcodes the answer is not a viable design.
+
+The skill must honor the agent request: scaffold an Agent project (ProjectType:
+"Agent" — LangGraph / LlamaIndex / OpenAI Agents) producing a
+uipath.core.agent.<key> node, NOT downgrade it to a coded Function (ProjectType:
+"Function", uipath.core.function.<key>). The node-type assert below fails on a
+Function — a correct count from the wrong node kind does not satisfy an explicit
+agent request.
 """
 
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_node_type,
     assert_output_value,
+    find_project_dir,
+    read_flow_input_vars,
     run_debug,
 )
+
+# Known only to this checker — never shown to the agent under test.
+SENTENCE = (
+    "The proposal went to Dana, Marco, Priya, Lena and Sam for review. "
+    "Dana, Priya and Sam each signed off, Marco asked for changes, "
+    "and Lena recused herself."
+)
+EXPECTED = 3  # Dana, Priya, Sam signed off; Marco and Lena did not.
 
 
 def main():
     assert_flow_has_node_type(["uipath.core.agent"])
-    payload = run_debug(timeout=240)
-    # Dana, Priya, Sam signed off → 3 approvers (Marco and Lena did not).
-    assert_output_value(payload, 3)
-    print("OK: Coded-agent node present; output contains 3")
+
+    project_dir = find_project_dir()
+    in_vars = read_flow_input_vars(project_dir)
+    if not in_vars:
+        sys.exit(
+            "FAIL: Flow declares no input variables; "
+            "expected a string input for the sentence"
+        )
+    var = in_vars[0]
+    if len(in_vars) > 1:
+        var = next(
+            (v for v in in_vars if re.search(r"sentence|text|summary|input", v, re.I)),
+            in_vars[0],
+        )
+
+    print(f"Injecting sentence into input variable {var!r}")
+    payload = run_debug(inputs={var: SENTENCE}, timeout=300)
+
+    assert_output_value(payload, EXPECTED)
+    print(f"OK: Coded-agent node present; output contains {EXPECTED}")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -2,8 +2,11 @@ task_id: skill-flow-coded-agent
 description: >
   Create a UiPath Flow that uses an ApproverCount coded agent to count, from a
   free-text sentence describing each reviewer's stance, how many people approved
-  a proposal and return that integer. The prompt explicitly asks for a coded
-  agent on a natural-language task, so the resulting flow node must be
+  a proposal and return that integer. The sentence is deliberately withheld from
+  the prompt and injected by the check script at debug time via --inputs, so the
+  agent cannot hardcode the answer or fit a regex to known text — a deterministic
+  Function is not a viable design. The prompt explicitly asks for a coded agent
+  on a natural-language task, so the resulting flow node must be
   uipath.core.agent (an Agent project), not uipath.core.function — verifying the
   skill honors an explicit agent request instead of substituting a deterministic
   Function. Exercises agent resource node discovery and wiring for coded (vs
@@ -16,10 +19,11 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project named "ApproverCountAgent" that uses a coded
-  agent named "ApproverCount" to read the sentence "The proposal went to Dana,
-  Marco, Priya, Lena and Sam for review. Dana, Priya and Sam each signed off,
-  Marco asked for changes, and Lena recused herself." and return how many of
-  them approved the proposal as an integer.
+  agent named "ApproverCount" to analyze a sentence describing the outcome of
+  a proposal review round. The flow takes the sentence as a string input
+  variable. The agent must identify each person mentioned, determine whether
+  they approved, requested changes, or recused themselves, and return the
+  number of people who approved as an integer flow output.
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
@@ -38,7 +42,7 @@ success_criteria:
   - type: run_command
     description: "Flow has an agent node and debug returns the approver count"
     command: "python3 $TASK_DIR/check_coded_agent_flow.py"
-    timeout: 300
+    timeout: 360
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

The `skill-flow-coded-agent` e2e task failed nightly at 0.375: the agent under test built a **Coded Function** (`uipath.core.function.<key>` node, registered under `resources/solution_folder/process/function/`) instead of the explicitly requested **coded agent** (`uipath.core.agent.<key>`).

Transcript analysis (nightly on Bedrock + a local baseline re-run on the direct API — identical outcome) shows the root cause: the review sentence was embedded verbatim in `initial_prompt`, so the agent classified the task as deterministic, fitted a regex/hardcoded function to the visible text, and substituted a Function for the requested agent — even after noticing the resource registered as `type: "function"`.

## Change

- **`coded_agent.yaml`** — `initial_prompt` no longer discloses the sentence. It states the contract instead: the flow takes the sentence as a string input variable; the agent must identify each person, classify their stance (approved / requested changes / recused), and return the approval count as an integer output. `description` documents the mechanism; check-criterion timeout 300→360 (debug now includes a live LLM call).
- **`check_coded_agent_flow.py`** — now owns the sentence (never shown to the agent under test). Keeps the `uipath.core.agent` node-type gate, then discovers the declared input variable (`read_flow_input_vars`) and runs `run_debug(inputs={var: SENTENCE})`, asserting the count (3). Follows the `calculator` task's inject-at-debug-time precedent.

With the text unseen, a hardcoded/regex Function is no longer a viable design — the deterministic-substitution rationalization is removed at its root.

## Verification

- `/lint-task` on the YAML: clean (one optional Low hardening note — a future follow-up could inject a second, differently-phrased sentence).
- Local run before the change (`coder-eval`, `experiments/default.yaml`): FAILURE 0.375, `uipath.core.function.<uuid>` node — deterministic reproduction of the nightly.
- Local run after the change: the skill now builds a genuine **LangGraph coded agent** (LLM stance classification via `UiPathAzureChatOpenAI` structured output), registers it under `process/agent/`, and wires a `uipath.core.agent.<key>` node with `sentence` in / `approverCount` out. The node-type gate and input discovery **pass**.
- The debug-output half remains red on a **platform limitation**, reproduced manually outside the harness: `flow debug` cannot start an in-solution coded agent's job (incident `170007` — "The job's associated process could not be found"; the debug session auto-uploads the solution to Studio Web but never provisions the sibling agent as a runnable process). Consistent with the task's `path-to-ga` tag — the execution half has no green path until the platform supports it. Follow-up options (split criteria vs. published-agent scenario) intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)