### PR TITLE
feat(coded-apps): document Validation Station subcomponents + smoke test

### DIFF
--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -318,7 +318,7 @@ Exports (from the same `@uipath/ui-widgets-validation-station` package):
 
 Must-knows (all easy to get wrong):
 
-0. **Requires a package version that exports the subcomponents** (`@uipath/ui-widgets-validation-station >= <FIRST_VERSION_WITH_SUBCOMPONENTS>`). Earlier versions export only `ValidationStation`; if the import fails at build, the installed version predates them — bump it.
+0. **Requires a package version that exports the subcomponents** (`@uipath/ui-widgets-validation-station >= 1.0.1`). Earlier versions export only `ValidationStation`.
 1. **Fetch artifacts once, share them.** Call `useBucketArtifacts` in the parent and pass the same `artifacts` object to all subcomponents. Calling it per-subcomponent re-downloads the same unchanged document once per panel.
 2. **Only `CompactFieldsForm` gets `sdk`/`data`/`folderId`.** It owns persistence. The other four can take the pre-fetched `artifacts` only.
 3. **Set `persistent: false` for static layouts.** These panels sit in a fixed grid and are never re-parented. Leaving `persistent` on makes React StrictMode's throwaway unmount call `forceDestroy()`, tearing down the underlying element so it renders **blank**. Only set `persistent: true` if you actually move a subcomponent between DOM parents.

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -10,6 +10,8 @@ Package: [`@uipath/ui-widgets-validation-station`](https://www.npmjs.com/package
 - App receives a `ContentValidationData` payload (bucket paths + document ID) — either from an Action Center task created by a DU workflow, or fetched at runtime in a web app.
 - Replaces a hand-rolled PDF viewer + field editor. Do **not** rebuild this UI from scratch — the widget already handles PDF rendering, bounding boxes, table editing, translations, and save/discard plumbing.
 
+**Two integration shapes.** The all-in-one `ValidationStation` component (standard layout, fastest — most apps want this) covers the sections below. When you need a **custom layout** — rearrange, hide, or embed individual panels (viewer, fields form, table editor, doc-type field, business rules) — the package also exports those as composable **subcomponents**. See [Compose-your-own layout: subcomponents](#compose-your-own-layout-subcomponents).
+
 If the user just wants a generic form (no DU document), use the standard Action App form pattern in [../create-action-app.md](../create-action-app.md) instead.
 
 ## Critical Rules
@@ -297,6 +299,95 @@ useEffect(() => {
 }, [isDark]);
 ```
 
+## Compose-your-own layout: subcomponents
+
+When the standard layout doesn't fit — you need to rearrange panels, hide some, or embed one piece inside your own screen — the package also exports the Validation Station as **five composable subcomponents** plus a data hook, instead of the all-in-one `ValidationStation`. Same document, same bucket artifacts, same save flows; you own the layout.
+
+Exports (from the same `@uipath/ui-widgets-validation-station` package):
+
+| Export | Kind | Role |
+|--------|------|------|
+| `useBucketArtifacts(sdk, data, folderId)` | hook | Fetches the document + extraction artifacts **once**; returns `{ artifacts, error }`. Feed `artifacts` to every subcomponent. |
+| `DocumentViewer` | component | PDF/text viewer with bounding boxes. Read-only. |
+| `CompactFieldsForm` | component | Extraction fields, editable. The **only** subcomponent that persists — give it `sdk` + `data` + `folderId` and it runs Submit / Save-draft / Report-exception (same callbacks as the monolithic widget). |
+| `CompactTableEditor` | component | Inline editor for table (line-item) fields. Edit-only. |
+| `CompactDocTypeField` | component | Document-type selector dropdown. |
+| `CompactBusinessRules` | component | Read-only evaluated business rules. |
+
+**How they link — one shared `instanceId`.** Give every subcomponent the same `instanceId` string and they share a single store: selecting a field in the form highlights it in the viewer, selecting a table field opens the table editor, clicking a rule focuses the offending field. No cross-wiring — the shared id *is* the wiring. Different ids → independent, unlinked panels.
+
+Must-knows (all easy to get wrong):
+
+0. **Requires a package version that exports the subcomponents** (`@uipath/ui-widgets-validation-station >= <FIRST_VERSION_WITH_SUBCOMPONENTS>`). Earlier versions export only `ValidationStation`; if the import fails at build, the installed version predates them — bump it.
+1. **Fetch artifacts once, share them.** Call `useBucketArtifacts` in the parent and pass the same `artifacts` object to all subcomponents. Calling it per-subcomponent re-downloads the same unchanged document once per panel.
+2. **Only `CompactFieldsForm` gets `sdk`/`data`/`folderId`.** It owns persistence. The other four can take the pre-fetched `artifacts` only.
+3. **Set `persistent: false` for static layouts.** These panels sit in a fixed grid and are never re-parented. Leaving `persistent` on makes React StrictMode's throwaway unmount call `forceDestroy()`, tearing down the underlying element so it renders **blank**. Only set `persistent: true` if you actually move a subcomponent between DOM parents.
+4. **Drop duplicated panels via `options`.** When you render `CompactBusinessRules` / `CompactDocTypeField` standalone, tell the fields form to hide its built-in copies: `options={{ hideBusinessRules: true, hideDocumentTypeField: true, emitDtoStateChanges: true }}`. (`emitDtoStateChanges` is still required for save-as-draft, same as the monolithic widget.)
+
+Same static-asset copy and `optimizeDeps.exclude` setup as the monolithic widget applies (see [Static Assets](#static-assets--vite-plugin)) — the subcomponents load the same web component under the hood. Peer versions and SDK scopes are identical too.
+
+```typescript
+import {
+  DocumentViewer,
+  CompactDocTypeField,
+  CompactFieldsForm,
+  CompactTableEditor,
+  CompactBusinessRules,
+  useBucketArtifacts,
+  ValidationStationLanguage,
+  type SaveValidatedDataResult,
+} from '@uipath/ui-widgets-validation-station';
+import type { DuFramework } from '@uipath/uipath-typescript/document-understanding';
+import { TaskType } from '@uipath/uipath-typescript/tasks';
+import type { TaskGetResponse } from '@uipath/uipath-typescript/tasks';
+import { useAuth } from '../hooks/useAuth';
+
+// `task` is already hydrated via tasks.getById(...) — see "Integration: Web App".
+function ReviewWorkspace({ task }: { task: TaskGetResponse }) {
+  const { sdk } = useAuth();
+  const data = task.data as DuFramework.ContentValidationData;
+  const { artifacts, error } = useBucketArtifacts(sdk, data, task.folderId);
+
+  if (error) return <div>Failed to load document: {error}</div>;
+  if (!artifacts) return <div>Loading document…</div>;
+
+  // One shared store for the whole screen, scoped to this document.
+  const instanceId = `review-${data.DocumentId ?? task.id}`;
+  const shared = {
+    artifacts,
+    documentId: data.DocumentId,
+    instanceId,
+    theme: 'light' as const,
+    language: ValidationStationLanguage.English,
+    persistent: false, // static grid — see must-know #3
+  };
+
+  const handleSubmit = async (result: SaveValidatedDataResult) => {
+    if (!result.success) return; // widget renders no error UI — surface it yourself
+    await task.complete({ action: 'Completed', type: TaskType.DocumentValidation });
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1.3fr 1fr', gap: 8, height: '100%' }}>
+      <DocumentViewer {...shared} style={{ height: '100%' }} />
+      <CompactDocTypeField {...shared} />
+      <CompactFieldsForm
+        {...shared}
+        sdk={sdk}
+        data={data}
+        folderId={task.folderId}
+        options={{ hideBusinessRules: true, hideDocumentTypeField: true, emitDtoStateChanges: true }}
+        onSubmitComplete={handleSubmit}
+      />
+      <CompactTableEditor {...shared} />
+      <CompactBusinessRules {...shared} />
+    </div>
+  );
+}
+```
+
+Runnable end-to-end example (task list + selection + all five subcomponents wired to Submit / Save-draft / Report-exception): the [`document-validation-subcomponents-app` sample](https://github.com/UiPath/uipath-typescript/tree/main/samples/document-validation-subcomponents-app) in the SDK repo.
+
 ## Anti-patterns
 
 - **Do not skip the `du-assets/` copy step.** PDF rendering and translations 404 silently in prod; "works on my machine" because dev serves from `node_modules`.
@@ -306,3 +397,11 @@ useEffect(() => {
 - **Do not call `completeTask` inside the `save` setter.** Always wait for `onSubmitComplete` with `success: true` — submit may fail validation, and completing early submits unvalidated data.
 - **Do not assume the widget shows an error on failure — it does not.** `onSubmitComplete`/`onSaveAsDraftComplete` with `success: false` render no UI; surface the error yourself (`showMessage`, toast, etc.).
 - **Do not treat `onReportExceptionComplete` like the save callbacks.** It receives `(documentId, reason)`, not `SaveValidatedDataResult`, and persists nothing — you must call `OrchestratorDuModule.submitExceptionReport(...)` before completing the task.
+
+Subcomponents (compose-your-own layout) only:
+
+- **Do not call `useBucketArtifacts` inside each subcomponent.** Fetch once in the parent and pass the same `artifacts` down, or you refetch the whole document per panel.
+- **Do not give more than one subcomponent `sdk`/`data`.** Only `CompactFieldsForm` persists.
+- **Do not leave `persistent` on for a static grid.** StrictMode's throwaway unmount calls `forceDestroy()` and the panel renders blank. Use `persistent: false` unless you actually re-parent the subcomponent.
+- **Do not give subcomponents different `instanceId`s** and expect them to sync — the shared id is what links the store; mismatched ids leave the panels independent.
+- **Do not render `CompactBusinessRules`/`CompactDocTypeField` standalone without hiding the form's built-in copies** (`options.hideBusinessRules` / `hideDocumentTypeField`) — you'll get each panel twice.

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -357,7 +357,7 @@ function ReviewWorkspace({ task }: { task: TaskGetResponse }) {
     artifacts,
     documentId: data.DocumentId,
     instanceId,
-    theme: 'light' as const,
+    theme: 'light' as const, // also set body class to match — see Critical Rule #4
     language: ValidationStationLanguage.English,
     persistent: false, // static grid — see must-know #3
   };

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -17,7 +17,7 @@ If the user just wants a generic form (no DU document), use the standard Action 
 ## Critical Rules
 
 1. **Peer versions are hard requirements.** Widget requires `react >= 19.2.0`, `react-dom >= 19.2.0`, `@uipath/uipath-typescript >= 1.4.1`. The Vite scaffold pins React 19.2+, but verify in `package.json` before installing.
-2. **Copy `du-assets/` into build output.** The underlying web component loads PDF.js worker, cmaps, wasm, and i18n from a sibling `du-assets/` directory resolved via `import.meta.url`. Without this, **PDF rendering and translations silently 404 in production** — no build error. See "Static assets" below.
+2. **The widget's web component loads its CSS, fonts, and assets at runtime, not at build time.** So `vite.config.ts` must *copy* those files next to the build output (for prod) and *serve them as raw CSS* in dev — use the config under "Static Assets" below. Skip it and you get 404s for PDF/fonts/styling in prod, or icons that render as their names (`warning`, `error`, `circle`) in dev. A green `npm run build` hides both — run the app to confirm.
 3. **Set `optimizeDeps.exclude: ['@uipath/du-validation-station-wc']` in `vite.config.ts`.** Vite's pre-bundler rewrites `import.meta.url` and breaks runtime asset resolution.
 4. **Body needs `light` or `dark` class** for theming. Match it to the `theme` prop. Action apps already manage this via `onInitTheme` from `CodedActionAppService.getTask()`.
 5. **`sdk` must already be initialized.** Pass the same `UiPath` instance produced by `useAuth()` (web app) or constructed in `src/uipath.ts` (action app). Do not construct a second SDK just for the widget — auth state will diverge.
@@ -37,49 +37,101 @@ Registry flag forces the public npm registry (skill default — users may have `
 
 ## Static Assets — Vite Plugin
 
-Replace `vite.config.ts` with the full file below. The plugin runs after `build` and copies the WC's `du-assets/` next to the emitted JS chunks:
+The widget (both the all-in-one `ValidationStation` and the subcomponents) wraps a web component — `@uipath/du-validation-station-wc` — that fetches its own stylesheets and fonts at runtime, so `vite.config.ts` must do two things (plus `optimizeDeps.exclude` — the WC's `import.meta.url` breaks under pre-bundling):
+
+- **Build:** copy the WC's `du-assets/`, `media/`, and raw `styles.css`/`fonts.css` next to the emitted chunks.
+- **Dev:** serve those `.css` requests as raw CSS — Vite otherwise returns a JS module, which the WC can't read (icons then render as words).
+
+**Add these to your existing `vite.config.ts` — merge them in, don't overwrite the whole file, so you keep `uipathCodedApps()` and anything else the scaffold generated:**
 
 ```typescript
 import react from '@vitejs/plugin-react';
-import { cp } from 'node:fs/promises';
+import { uipathCodedApps } from '@uipath/coded-apps-dev/vite';
+import { cp, readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { dirname, resolve } from 'node:path';
 import { defineConfig, type Plugin } from 'vite';
 
 const require = createRequire(import.meta.url);
 
+const WC_ROOT = dirname(
+  require.resolve('@uipath/du-validation-station-wc/package.json')
+);
+
+const WC_RUNTIME_CSS = ['styles.css', 'fonts.css']; // the WC fetches these as raw CSS at runtime
+
+// BUILD: copy the WC's runtime files next to the emitted chunks (it resolves them via import.meta.url).
 function copyDuValidationStationAssets(): Plugin {
-  let destDir = '';
+  let assetsDir = '';
   return {
     name: 'copy-du-validation-station-assets',
     apply: 'build',
     configResolved(config) {
-      destDir = resolve(
+      assetsDir = resolve(
         config.root,
         config.build.outDir,
         config.build.assetsDir,
-        'du-assets',
       );
     },
     async closeBundle() {
-      const wcRoot = dirname(
-        require.resolve('@uipath/du-validation-station-wc/package.json'),
-      );
-      await cp(resolve(wcRoot, 'du-assets'), destDir, { recursive: true });
+      await cp(resolve(WC_ROOT, 'du-assets'), resolve(assetsDir, 'du-assets'), {
+        recursive: true,
+      });
+      await cp(resolve(WC_ROOT, 'media'), resolve(assetsDir, 'media'), {
+        recursive: true,
+      });
+      for (const css of WC_RUNTIME_CSS) {
+        await cp(resolve(WC_ROOT, css), resolve(assetsDir, css));
+      }
+    },
+  };
+}
+
+// DEV: Vite serves .css as a JS module — return raw CSS for the WC's fetch (Sec-Fetch-Dest: empty).
+function serveDuValidationStationRawCss(): Plugin {
+  const pattern = new RegExp(
+    `/@uipath/du-validation-station-wc/(${WC_RUNTIME_CSS.join('|')})$`,
+  );
+  return {
+    name: 'serve-du-validation-station-raw-css',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        if (req.headers['sec-fetch-dest'] !== 'empty') return next();
+        const match = pattern.exec((req.url ?? '').split('?')[0]);
+        if (!match) return next();
+        readFile(resolve(WC_ROOT, match[1]), 'utf8').then((css) => {
+          res.setHeader('Content-Type', 'text/css');
+          res.end(css);
+        }, next);
+      });
     },
   };
 }
 
 export default defineConfig({
-  plugins: [react(), copyDuValidationStationAssets()],
+  plugins: [
+    react(),
+    uipathCodedApps(),
+    copyDuValidationStationAssets(),
+    serveDuValidationStationRawCss(),
+  ],
   base: './',
+  define: {
+    global: 'globalThis',
+  },
   optimizeDeps: {
+    include: ['@uipath/uipath-typescript'],
     exclude: ['@uipath/du-validation-station-wc'],
   },
 });
 ```
 
-Verify after `npm run build`: `ls dist/assets/du-assets/` must list `pdfjs/`, `cmaps/`, `wasm/`, `i18n/`. Empty or missing → plugin did not run.
+> Mirrors the widget's own `README.md` "Vite" section — re-check it if the widget version changes.
+
+**Verify (a green build isn't enough):**
+- **Build:** `dist/assets/` contains `du-assets/`, `media/`, `styles.css`, and `fonts.css`.
+- **Dev:** run the app — icons render as glyphs, not the words `warning`/`error`/`circle`.
 
 ## Key Props
 
@@ -376,6 +428,9 @@ function ReviewWorkspace({ task }: { task: TaskGetResponse }) {
         sdk={sdk}
         data={data}
         folderId={task.folderId}
+        // Keeps the built-in Submit/Report buttons. Add hideSubmitButton +
+        // hideReportAsExceptionButton (and omit enableSaveAsDraft) if you render
+        // your own toolbar — see the anti-patterns below.
         options={{ hideBusinessRules: true, hideDocumentTypeField: true, emitDtoStateChanges: true }}
         onSubmitComplete={handleSubmit}
       />
@@ -390,7 +445,8 @@ Runnable end-to-end example (task list + selection + all five subcomponents wire
 
 ## Anti-patterns
 
-- **Do not skip the `du-assets/` copy step.** PDF rendering and translations 404 silently in prod; "works on my machine" because dev serves from `node_modules`.
+- **Do the full static-asset setup and verify by running the app.** Both plugins (copy `du-assets/` + `media/` + raw CSS; serve raw CSS in dev) are required — a green `npm run build` hides a broken result because the WC loads its styles at runtime, not at build.
+- **Pick one source of action buttons — built-in or custom — never both.** The monolithic `ValidationStation` renders its own action bar (Submit, Save-draft, Discard, Report). Either rely on those built-ins (drop the controlled `save`/`discardChanges` props — the callbacks still fire), **or** drive the flows from your own toolbar via the controlled props. If you build a custom toolbar, hide the built-in buttons so they don't show twice — but note `IValidationStationOptions` only exposes `hideSubmitButton` and `hideReportAsExceptionButton`, with **no** flag for the built-in Discard or Save-draft, so a fully custom bar isn't achievable with the all-in-one widget.
 - **Do not construct a second `UiPath` SDK** for the widget. Reuse the app's authenticated instance.
 - **Do not call `setTaskData` and try to drive a custom form alongside the widget.** The widget owns the data contract end-to-end; mixing produces stale state and double saves.
 - **Do not pass a `tasks.getAll()` row straight into the widget.** `getAll()` rows omit `data` — the viewer renders empty. Hydrate with `tasks.getById(id, { taskType: TaskType.DocumentValidation }, folderId)` first.
@@ -405,3 +461,4 @@ Subcomponents (compose-your-own layout) only:
 - **Do not leave `persistent` on for a static grid.** StrictMode's throwaway unmount calls `forceDestroy()` and the panel renders blank. Use `persistent: false` unless you actually re-parent the subcomponent.
 - **Do not give subcomponents different `instanceId`s** and expect them to sync — the shared id is what links the store; mismatched ids leave the panels independent.
 - **Do not render `CompactBusinessRules`/`CompactDocTypeField` standalone without hiding the form's built-in copies** (`options.hideBusinessRules` / `hideDocumentTypeField`) — you'll get each panel twice.
+- **Do not add your own Submit / Save-draft / Report-exception controls without hiding the form's built-in buttons** (`options.hideSubmitButton` / `hideReportAsExceptionButton`, and omit the `enableSaveAsDraft` prop) — `CompactFieldsForm` ships its own action bar, so every action renders twice. The controlled `save` / `discardChanges` props still drive the flows once the built-ins are hidden. (`enableSaveAsDraft` only exposes the built-in draft button; the controlled `save={{ validate: false }}` trigger keeps working via `options.emitDtoStateChanges`. There is no flag to hide the built-in discard control — drop your own Discard button if it would duplicate.)

--- a/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
@@ -1,8 +1,3 @@
-# PENDING PUBLISH — lands together with the subcomponents doc + the npm release
-# that exports them. Until the `Compose-your-own layout` section of
-# references/widgets/validation-station.md is merged (and the package publishes
-# the subcomponents), the agent has no way to know these exports exist and this
-# eval will fail by design. Do not add to a running experiment suite before then.
 task_id: skill-coded-apps-ui-validation-station-subcomponents-smoke
 description: >
   Smoke test (mode:build): agent composes a custom Document Understanding

--- a/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
@@ -87,7 +87,7 @@ success_criteria:
 
   - type: run_command
     description: "Must-know #2 — only one subcomponent receives the `sdk` prop (only CompactFieldsForm persists). Exactly one `sdk=` JSX prop."
-    command: "test \"$(grep -oE 'sdk=' src/components/ReviewWorkspace.tsx | wc -l | tr -d ' ')\" = \"1\""
+    command: "test \"$(grep -oE 'sdk[[:space:]]*=' src/components/ReviewWorkspace.tsx | wc -l | tr -d ' ')\" = \"1\""
     timeout: 10
     expected_exit_code: 0
     weight: 2.5

--- a/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml
@@ -1,0 +1,123 @@
+# PENDING PUBLISH — lands together with the subcomponents doc + the npm release
+# that exports them. Until the `Compose-your-own layout` section of
+# references/widgets/validation-station.md is merged (and the package publishes
+# the subcomponents), the agent has no way to know these exports exist and this
+# eval will fail by design. Do not add to a running experiment suite before then.
+task_id: skill-coded-apps-ui-validation-station-subcomponents-smoke
+description: >
+  Smoke test (mode:build): agent composes a custom Document Understanding
+  review screen from the Validation Station **subcomponents** documented in
+  `references/widgets/validation-station.md §Compose-your-own layout`
+  (`DocumentViewer`, `CompactDocTypeField`, `CompactFieldsForm`,
+  `CompactTableEditor`, `CompactBusinessRules` + the `useBucketArtifacts`
+  hook) — NOT the all-in-one `<ValidationStation>`. Grades the four
+  mistakes the skill flags as easy to get wrong:
+  (1) fetch artifacts once and share them, not once per panel;
+  (2) give `sdk`/`data`/`folderId` to the fields form only, so a single
+  panel persists;
+  (3) set `persistent: false` for a static grid, or StrictMode renders it
+  blank;
+  (4) hide the fields form's built-in Business Rules / Doc Type panels when
+  rendering those standalone.
+tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
+run_limits:
+  expected_turns: 10
+  turn_timeout: 600
+
+initial_prompt: |
+  Inside a UiPath Coded Web App, build a custom document-review screen for a
+  Document Understanding validation task using the UiPath Validation Station.
+
+  The standard all-in-one Validation Station layout doesn't fit — I need a
+  custom arrangement. Put the document on the left; on the right, as separate
+  stacked panels, the document-type selector, the extraction fields, a
+  line-items table editor, and the evaluated business rules.
+
+  Selecting a field should highlight it in the document and open the right
+  editor for it. Only the fields panel saves the validated document — the rest
+  are display/edit only. Show the user a message if the save fails.
+
+  Author a single component at `src/components/ReviewWorkspace.tsx` at the
+  sandbox root. Assume the authenticated `sdk` comes from `useAuth()` and the
+  component receives an already-hydrated `task` prop (a `TaskGetResponse`
+  whose `task.data` is the `ContentValidationData` payload). Author the source
+  only — do NOT run `uip` or `npm` commands.
+
+success_criteria:
+  - type: file_exists
+    description: "src/components/ReviewWorkspace.tsx was created"
+    path: "src/components/ReviewWorkspace.tsx"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Imports from the Validation Station package"
+    command: "grep -Eq \"from ['\\\"]@uipath/ui-widgets-validation-station['\\\"]\" src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Uses all five subcomponents (composes the widget, doesn't rebuild it)"
+    command: "for n in DocumentViewer CompactDocTypeField CompactFieldsForm CompactTableEditor CompactBusinessRules; do grep -q \"$n\" src/components/ReviewWorkspace.tsx || exit 1; done"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Chose the subcomponents path — does NOT mount the all-in-one <ValidationStation> tag (ValidationStationLanguage import is fine; this targets the JSX element)"
+    command: "grep -Eq '<ValidationStation[[:space:]/>]' src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Must-know #1 — fetches artifacts once: exactly one useBucketArtifacts(...) call site (not one per panel)"
+    command: "test \"$(grep -oE 'useBucketArtifacts\\(' src/components/ReviewWorkspace.tsx | wc -l | tr -d ' ')\" = \"1\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Must-know linking — a shared instanceId ties the subcomponents to one store"
+    command: "grep -q 'instanceId' src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Must-know #2 — only one subcomponent receives the `sdk` prop (only CompactFieldsForm persists). Exactly one `sdk=` JSX prop."
+    command: "test \"$(grep -oE 'sdk=' src/components/ReviewWorkspace.tsx | wc -l | tr -d ' ')\" = \"1\""
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Must-know #3 — persistent is set false for the static grid (leaving it on makes StrictMode render the panel blank)"
+    command: "grep -Eq 'persistent:[[:space:]]*false|persistent=\\{false\\}' src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Must-know #4 — fields form hides its built-in Business Rules and Doc Type panels (rendered standalone below), so each appears once"
+    command: "grep -q 'hideBusinessRules' src/components/ReviewWorkspace.tsx && grep -q 'hideDocumentTypeField' src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Submit completion is wired (widget surfaces no error UI — host owns it)"
+    command: "grep -Eq 'onSubmitComplete' src/components/ReviewWorkspace.tsx"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary
- Add a **Compose-your-own layout: subcomponents** section to `skills/uipath-coded-apps/references/widgets/validation-station.md`, documenting the five composable Validation Station subcomponents (`DocumentViewer`, `CompactDocTypeField`, `CompactFieldsForm`, `CompactTableEditor`, `CompactBusinessRules`) plus the `useBucketArtifacts` hook, with a runnable end-to-end example.
- Cover the four easy-to-get-wrong must-knows: fetch artifacts once and share, give `sdk`/`data`/`folderId` to `CompactFieldsForm` only, set `persistent: false` for static grids (StrictMode blank-render), and hide the form's built-in Business Rules / Doc Type panels when rendering those standalone. Mirrored in the Anti-patterns section.
- Explain the shared `instanceId` store that links the subcomponents (field selection → viewer highlight → table editor → rule focus).
- Add smoke test `tests/tasks/uipath-coded-apps/ui_validation_station_subcomponents_smoke.yaml` grading an agent composing a custom DU review screen from the subcomponents.

## Verification
Ran the smoke task via the **Run Coder Eval** GitHub Action (`run-coder-eval.yml`) against this branch

<img width="1278" height="154" alt="image" src="https://github.com/user-attachments/assets/852e8102-8749-4bf1-9859-793c610d68b7" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)