### PR TITLE
test(maestro-bpmn): add expression, queue/call-activity, and public-safety evals

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/expressions/computed_js/check_computed_js.py
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/computed_js/check_computed_js.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Structural check for the computed `=js:` expression eval.
+
+Grades that the authored BPMN uses a computed inline-JavaScript expression with
+the exact case-sensitive `=js:` prefix (no space after the colon) in a
+lint-sensitive field, and that every json-typed literal body parses as valid
+JSON, per references/expression-authoring.md. Reuses shared helpers (stdlib ET).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+
+def local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def collect_values(root) -> list[str]:
+    vals: list[str] = []
+    for el in root.iter():
+        for name in ("value", "source", "condition"):
+            v = el.attrib.get(name)
+            if v:
+                vals.append(v)
+        if el.text and el.text.strip():
+            vals.append(el.text.strip())
+    return vals
+
+
+def main() -> None:
+    path, root = parse_bpmn("ComputedJsBpmn")
+
+    values = collect_values(root)
+
+    # Exact, case-sensitive prefix with no space after the colon.
+    if not any("=js:" in v for v in values):
+        fail("no computed expression with the exact '=js:' prefix found")
+
+    # Reject the common malformed variants so the case-sensitivity rule is graded.
+    bad = [v for v in values if re.search(r"=(js\s*:|JS:|Js:|jS:)", v) and "=js:" not in v]
+    if bad:
+        fail(f"malformed js prefix (must be exactly '=js:', no space, lowercase): {bad}")
+
+    # Every json-typed field carrying a literal body must be valid JSON.
+    for el in root.iter():
+        if local(el.tag) in ("input", "output") and el.attrib.get("type") == "json":
+            body = (el.text or "").strip() or (el.attrib.get("value") or "").strip()
+            if body.startswith("{") or body.startswith("["):
+                try:
+                    json.loads(body)
+                except json.JSONDecodeError as exc:
+                    fail(f"json-typed value is not valid JSON: {body[:80]!r} ({exc})")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} uses a computed =js: expression with valid json-typed bodies")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/expressions/computed_js/computed_js.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/computed_js/computed_js.yaml
@@ -1,0 +1,68 @@
+task_id: skill-bpmn-expr-computed-js
+description: >
+  Expression-authoring eval: agent uses the uipath-maestro-bpmn skill to author a
+  computed inline-JavaScript expression with the exact case-sensitive `=js:`
+  prefix (no space after the colon) inside a json-typed mapping that still emits
+  valid JSON. Grades the `=js:` escape-hatch rules from
+  references/expression-authoring.md. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "ComputedJsBpmn" with the main file
+  at `ComputedJsBpmn/ComputedJsBpmn.bpmn` for this process:
+  - Manual start with two integer variables (`Offset`, `RowsPerShard`).
+  - A serviceTask whose json-typed input builds a shard-bounds payload whose
+    `startRow` and `endRow` fields are COMPUTED from those variables — use the
+    inline-JavaScript `=js:` escape hatch for the arithmetic (for example
+    `=js:vars.Offset * vars.RowsPerShard`). The json body must remain valid JSON.
+  - A single end event.
+
+  Requirements:
+  - The computed prefix is exactly `=js:` — case-sensitive, no space after the
+    colon. Use it only for the computed fields; prefer plain `=vars.<id>` where no
+    computation is needed.
+  - Any field typed `json` must contain valid JSON.
+  - Discover the activity's `uipath:*` payload via the registry
+    (`uip maestro bpmn registry`) and author it from the served template; do not
+    hand-author registry-owned XML from prose.
+  - Use synthetic placeholder values only — no tenant URLs, folder keys,
+    connection IDs, release keys, or real names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate locally by parsing the BPMN and walking the skill's structural
+    checklist. Do NOT upload, publish, deploy, debug, run, or pack anything, and
+    do NOT pause for approval — build the complete local project in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "ComputedJsBpmn/ComputedJsBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses the exact =js: computed prefix"
+    path: "ComputedJsBpmn/ComputedJsBpmn.bpmn"
+    includes:
+      - "=js:"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Computed =js: expression present and all json-typed bodies parse as JSON"
+    command: "python3 $TASK_DIR/check_computed_js.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/check_error_mapping.py
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/check_error_mapping.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Structural check for the error-mapping expression eval.
+
+Grades that the authored BPMN carries a uipath:errorMapping block whose
+condition branches on the runtime error object via `vars.error.code` (matched
+as an expression, not a baked literal), per references/expression-authoring.md.
+Reuses the shared uipath-maestro-bpmn check helpers (stdlib ElementTree).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+VARS_ERROR_RE = re.compile(r"vars\.error\.code")
+
+
+def main() -> None:
+    path, root = parse_bpmn("ErrorMappingBpmn")
+
+    mappings = root.findall(".//uipath:errorMapping", NS)
+    if not mappings:
+        fail("no uipath:errorMapping block authored")
+
+    conditions: list[str] = []
+    for mapping in mappings:
+        for err in mapping.findall("uipath:error", NS):
+            cond = err.attrib.get("condition")
+            if cond:
+                conditions.append(cond)
+    if not conditions:
+        fail("uipath:errorMapping has no uipath:error carrying a condition")
+
+    matching = [c for c in conditions if VARS_ERROR_RE.search(c)]
+    if not matching:
+        fail(f"no errorMapping condition reads vars.error.code; found: {conditions}")
+
+    # Must be a runtime expression (leading '='), not a baked literal.
+    if not any(c.strip().startswith("=") for c in matching):
+        fail(f"vars.error.code condition must be an expression (leading '='): {matching}")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} branches on vars.error.code via uipath:errorMapping")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/error_mapping.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/error_mapping/error_mapping.yaml
@@ -1,0 +1,69 @@
+task_id: skill-bpmn-expr-error-mapping
+description: >
+  Expression-authoring eval: agent uses the uipath-maestro-bpmn skill to author
+  a uipath:errorMapping block whose condition branches on the runtime error
+  object via `=vars.error.code == "..."` after a failed activity. Grades the
+  error-mapping expression shape from references/expression-authoring.md.
+  Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 75
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "ErrorMappingBpmn" with the main
+  file at `ErrorMappingBpmn/ErrorMappingBpmn.bpmn` for this process:
+  - Manual start -> a serviceTask that invokes a downstream service -> end.
+  - The serviceTask must declare error-handling metadata so that when the
+    activity fails with a service-unavailable error, the process branches on the
+    runtime error object. Model the error code on a `bpmn:error errorCode` and
+    reference it from a `uipath:errorMapping` whose condition reads the runtime
+    error via `vars.error.code` (for example
+    `=vars.error.code == "SERVICE_UNAVAILABLE"`).
+
+  Requirements:
+  - Discover any `uipath:*` activity payload via the registry
+    (`uip maestro bpmn registry`) and author it from the served template. Do not
+    hand-author registry-owned `uipath:*` XML from prose.
+  - The errorMapping condition must be a read-only expression that reads
+    `vars.error.code` — not a baked literal and no assignment operators.
+  - Use synthetic placeholder resource names only. Do not include tenant URLs,
+    folder keys, connection IDs, release keys, real process names, or real user
+    names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate locally by parsing the BPMN for well-formedness and walking the
+    skill's structural checklist. Do NOT upload, publish, deploy, debug, run, or
+    pack anything, and do NOT pause for approval, confirmation, or feedback —
+    build the complete local project end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "ErrorMappingBpmn/ErrorMappingBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN carries a uipath:errorMapping block"
+    path: "ErrorMappingBpmn/ErrorMappingBpmn.bpmn"
+    includes:
+      - "uipath:errorMapping"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "errorMapping condition branches on vars.error.code and the graph is sound"
+    command: "python3 $TASK_DIR/check_error_mapping.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/check_multiinstance_iterator.py
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/check_multiinstance_iterator.py
@@ -19,8 +19,6 @@ while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared"
 sys.path.insert(0, _d)
 
 from _shared.bpmn_check import (  # noqa: E402
-    NS,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
@@ -30,6 +28,18 @@ from _shared.bpmn_check import (  # noqa: E402
 
 ITEM_RE = re.compile(r"iterator\[0\]\.item")
 LOOPCTR_RE = re.compile(r"iterator\[0\]\.loopCounter")
+
+
+def local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def find_local(root, local_name: str) -> list:
+    """Find elements by local name, case-insensitively — the skill's
+    structural-bpmn.md documents `bpmn:SubProcess` in PascalCase while the
+    spec/fixtures use camelCase, so accept both."""
+    target = local_name.lower()
+    return [el for el in root.iter() if local(el.tag).lower() == target]
 
 
 def collect_values(root) -> list[str]:
@@ -47,14 +57,14 @@ def collect_values(root) -> list[str]:
 def main() -> None:
     path, root = parse_bpmn("MultiInstanceIteratorBpmn")
 
-    markers = root.findall(".//bpmn:multiInstanceLoopCharacteristics", NS)
+    markers = find_local(root, "multiInstanceLoopCharacteristics")
     if not markers:
         fail("no bpmn:multiInstanceLoopCharacteristics marker authored")
 
     # The marker must sit on a subProcess so subprocess-depth indexing applies.
     on_subprocess = any(
-        sp.find("bpmn:multiInstanceLoopCharacteristics", NS) is not None
-        for sp in elements(root, "subProcess")
+        any(local(child.tag).lower() == "multiinstanceloopcharacteristics" for child in sp)
+        for sp in find_local(root, "subProcess")
     )
     if not on_subprocess:
         fail(

--- a/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/check_multiinstance_iterator.py
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/check_multiinstance_iterator.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Structural check for the multi-instance iterator-depth expression eval.
+
+Grades that a multi-instance SUBPROCESS body reads the current item and loop
+index at subprocess depth — `iterator[0].item` and `iterator[0].loopCounter`
+(NOT the task-level `iterator.item`), per references/expression-authoring.md.
+Reuses the shared uipath-maestro-bpmn check helpers (stdlib ElementTree).
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+ITEM_RE = re.compile(r"iterator\[0\]\.item")
+LOOPCTR_RE = re.compile(r"iterator\[0\]\.loopCounter")
+
+
+def collect_values(root) -> list[str]:
+    vals: list[str] = []
+    for el in root.iter():
+        for name in ("value", "source", "condition", "inputCollection", "inputElement"):
+            v = el.attrib.get(name)
+            if v:
+                vals.append(v)
+        if el.text and el.text.strip():
+            vals.append(el.text.strip())
+    return vals
+
+
+def main() -> None:
+    path, root = parse_bpmn("MultiInstanceIteratorBpmn")
+
+    markers = root.findall(".//bpmn:multiInstanceLoopCharacteristics", NS)
+    if not markers:
+        fail("no bpmn:multiInstanceLoopCharacteristics marker authored")
+
+    # The marker must sit on a subProcess so subprocess-depth indexing applies.
+    on_subprocess = any(
+        sp.find("bpmn:multiInstanceLoopCharacteristics", NS) is not None
+        for sp in elements(root, "subProcess")
+    )
+    if not on_subprocess:
+        fail(
+            "multi-instance marker must sit on a bpmn:subProcess "
+            "(subprocess-depth iterator indexing uses iterator[0])"
+        )
+
+    values = collect_values(root)
+    if not any(ITEM_RE.search(v) for v in values):
+        fail("no mapping/value reads iterator[0].item (subprocess-depth item access)")
+    if not any(LOOPCTR_RE.search(v) for v in values):
+        fail("no mapping/value reads iterator[0].loopCounter")
+
+    # Guard against task-level depth leaking into the subprocess body.
+    bare_item = re.compile(r"(?<!\])iterator\.item")
+    if any(bare_item.search(v) for v in values):
+        fail("subprocess body must not use task-level iterator.item; use iterator[0].item")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} reads iterator[0].item / iterator[0].loopCounter at subprocess depth")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/multiinstance_iterator.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/expressions/multiinstance_iterator/multiinstance_iterator.yaml
@@ -1,0 +1,71 @@
+task_id: skill-bpmn-expr-multiinstance-iterator
+description: >
+  Expression-authoring eval: agent uses the uipath-maestro-bpmn skill to author
+  a multi-instance SUBPROCESS whose body reads the current item and loop index at
+  subprocess depth — `iterator[0].item` and `iterator[0].loopCounter` — not the
+  task-level `iterator.item`. Grades the iterator-depth indexing rule from
+  references/expression-authoring.md. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:loop"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "MultiInstanceIteratorBpmn" with the
+  main file at `MultiInstanceIteratorBpmn/MultiInstanceIteratorBpmn.bpmn` for
+  this process:
+  - Manual start with an `Items` collection variable.
+  - A multi-instance SUBPROCESS (`bpmn:subProcess` carrying a
+    `bpmn:multiInstanceLoopCharacteristics` marker) that iterates the collection.
+  - Inside the subprocess body, map the current item into a `CurrentLine`
+    variable and the current 0-based loop index into a `CurrentIndex` variable.
+  - A single end event.
+
+  Requirements:
+  - Because this element sits at subprocess depth, the body must read the current
+    item as `iterator[0].item` and the loop index as `iterator[0].loopCounter`
+    (the task-level `iterator.item` / `iterator.loopCounter` forms are WRONG at
+    subprocess depth). Bind the collection through the `uipath:loopCharacteristics`
+    extension (`inputCollection`, `inputElement`) per the skill's structural
+    reference — the registry serves no template for multi-instance markers, so
+    author it from the canvas contract.
+  - Declare variables and author any `uipath:*` payloads per the skill's
+    references; do not hand-author registry-owned XML from prose.
+  - Use synthetic placeholder values only — no tenant URLs, folder keys,
+    connection IDs, release keys, or real names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate locally by parsing the BPMN and walking the skill's structural
+    checklist. Do NOT upload, publish, deploy, debug, run, or pack anything, and
+    do NOT pause for approval — build the complete local project in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "MultiInstanceIteratorBpmn/MultiInstanceIteratorBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN uses a multi-instance loop marker"
+    path: "MultiInstanceIteratorBpmn/MultiInstanceIteratorBpmn.bpmn"
+    includes:
+      - "multiInstanceLoopCharacteristics"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Subprocess body reads iterator[0].item / iterator[0].loopCounter and the graph is sound"
+    command: "python3 $TASK_DIR/check_multiinstance_iterator.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/callactivity_agentic.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/callactivity_agentic.yaml
@@ -1,0 +1,63 @@
+task_id: skill-bpmn-callactivity-agentic-process
+description: >
+  Node eval: agent uses the uipath-maestro-bpmn skill to invoke a separate
+  agentic Maestro instance via Orchestrator.StartAgenticProcess, correctly hosted
+  on a bpmn:callActivity (a CallActivity invokes a SEPARATE instance) rather than
+  an in-instance serviceTask. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:call-activity"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "CallActivityAgenticBpmn" with the
+  main file at `CallActivityAgenticBpmn/CallActivityAgenticBpmn.bpmn` for this
+  process:
+  - Manual start -> invoke a published agentic process as a SEPARATE Maestro
+    instance -> end.
+
+  Requirements:
+  - Invoking a separate Maestro instance is a call activity, so model the
+    invocation with `Orchestrator.StartAgenticProcess` hosted on a
+    `bpmn:callActivity` — NOT a `bpmn:serviceTask` (a serviceTask scopes work
+    within the same instance).
+  - Discover the wrapper via the registry (`uip maestro bpmn registry`) and author
+    its `uipath:*` payload from the served template. Do not hand-author
+    registry-owned XML from prose.
+  - Use synthetic placeholder resource/binding values only. Do not invent or paste
+    real tenant URLs, folder keys, connection IDs, release keys, or process names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate locally by parsing the BPMN and walking the skill's structural
+    checklist. Do NOT upload, publish, deploy, debug, run, or pack anything, and
+    do NOT pause for approval — build the complete local project in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "CallActivityAgenticBpmn/CallActivityAgenticBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "StartAgenticProcess hosted on a bpmn:callActivity (not a serviceTask) and the graph is sound"
+    command: "python3 $TASK_DIR/check_callactivity_agentic.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/check_callactivity_agentic.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/check_callactivity_agentic.py
@@ -19,7 +19,6 @@ sys.path.insert(0, _d)
 
 from _shared.bpmn_assertions import activity_type  # noqa: E402
 from _shared.bpmn_check import (  # noqa: E402
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
@@ -30,10 +29,18 @@ from _shared.bpmn_check import (  # noqa: E402
 TYPE = "Orchestrator.StartAgenticProcess"
 
 
+def elements_ci(root, local_name: str) -> list:
+    """Find BPMN elements by local name, case-insensitively — the skill's
+    structural-bpmn.md documents `bpmn:CallActivity`/`bpmn:SubProcess` in
+    PascalCase while the spec/fixtures use camelCase, so accept both."""
+    target = local_name.lower()
+    return [el for el in root.iter() if el.tag.rsplit("}", 1)[-1].lower() == target]
+
+
 def main() -> None:
     path, root = parse_bpmn("CallActivityAgenticBpmn")
 
-    hosts = [c for c in elements(root, "callActivity") if activity_type(c) == TYPE]
+    hosts = [c for c in elements_ci(root, "callActivity") if activity_type(c) == TYPE]
     if not hosts:
         fail(f"missing bpmn:callActivity with {TYPE}")
 
@@ -48,7 +55,7 @@ def main() -> None:
         "receiveTask",
         "scriptTask",
     ):
-        offenders = [e for e in elements(root, kind) if activity_type(e) == TYPE]
+        offenders = [e for e in elements_ci(root, kind) if activity_type(e) == TYPE]
         if offenders:
             fail(f"{TYPE} must be on bpmn:callActivity (separate instance), found on bpmn:{kind}")
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/check_callactivity_agentic.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/callactivity_agentic/check_callactivity_agentic.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Structural check for the dedicated agentic call-activity node eval.
+
+Grades that `Orchestrator.StartAgenticProcess` (which invokes a SEPARATE Maestro
+instance) is hosted on a bpmn:callActivity, and never on a serviceTask or other
+in-instance host. Uses the shared bpmn_assertions activity-type helper. The
+exact-value match means the Async variant does not satisfy this check.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_assertions import activity_type  # noqa: E402
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+TYPE = "Orchestrator.StartAgenticProcess"
+
+
+def main() -> None:
+    path, root = parse_bpmn("CallActivityAgenticBpmn")
+
+    hosts = [c for c in elements(root, "callActivity") if activity_type(c) == TYPE]
+    if not hosts:
+        fail(f"missing bpmn:callActivity with {TYPE}")
+
+    # Wrong-host guard: a separate-instance invocation must not be modeled as an
+    # in-instance serviceTask / task / etc.
+    for kind in (
+        "serviceTask",
+        "sendTask",
+        "task",
+        "userTask",
+        "businessRuleTask",
+        "receiveTask",
+        "scriptTask",
+    ):
+        offenders = [e for e in elements(root, kind) if activity_type(e) == TYPE]
+        if offenders:
+            fail(f"{TYPE} must be on bpmn:callActivity (separate instance), found on bpmn:{kind}")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} hosts {TYPE} on a bpmn:callActivity")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/check_queue_create_and_wait.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/check_queue_create_and_wait.py
@@ -19,7 +19,6 @@ sys.path.insert(0, _d)
 
 from _shared.bpmn_assertions import activity_type, mapping_inputs, mapping_outputs  # noqa: E402
 from _shared.bpmn_check import (  # noqa: E402
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
@@ -30,10 +29,17 @@ from _shared.bpmn_check import (  # noqa: E402
 TYPE = "Orchestrator.CreateAndWaitForQueueItem"
 
 
+def elements_ci(root, local_name: str) -> list:
+    """Find BPMN elements by local name, case-insensitively — the skill docs use
+    both camelCase and PascalCase element names, so accept either."""
+    target = local_name.lower()
+    return [el for el in root.iter() if el.tag.rsplit("}", 1)[-1].lower() == target]
+
+
 def main() -> None:
     path, root = parse_bpmn("QueueCreateAndWaitBpmn")
 
-    hosts = [t for t in elements(root, "serviceTask") if activity_type(t) == TYPE]
+    hosts = [t for t in elements_ci(root, "serviceTask") if activity_type(t) == TYPE]
     if not hosts:
         fail(f"missing bpmn:serviceTask with {TYPE}")
 
@@ -48,7 +54,7 @@ def main() -> None:
         "receiveTask",
         "scriptTask",
     ):
-        offenders = [e for e in elements(root, kind) if activity_type(e) == TYPE]
+        offenders = [e for e in elements_ci(root, kind) if activity_type(e) == TYPE]
         if offenders:
             fail(f"{TYPE} must be on bpmn:serviceTask (synchronous wait), found on bpmn:{kind}")
 

--- a/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/check_queue_create_and_wait.py
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/check_queue_create_and_wait.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Structural check for the dedicated CreateAndWaitForQueueItem node eval.
+
+Grades that the synchronous queue wrapper `Orchestrator.CreateAndWaitForQueueItem`
+is hosted on a bpmn:serviceTask (NOT the fire-and-forget sendTask that carries
+`Orchestrator.CreateQueueItem`), binds a request input, and captures an output.
+Uses the shared bpmn_assertions activity-type / mapping helpers (stdlib ET).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_assertions import activity_type, mapping_inputs, mapping_outputs  # noqa: E402
+from _shared.bpmn_check import (  # noqa: E402
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+TYPE = "Orchestrator.CreateAndWaitForQueueItem"
+
+
+def main() -> None:
+    path, root = parse_bpmn("QueueCreateAndWaitBpmn")
+
+    hosts = [t for t in elements(root, "serviceTask") if activity_type(t) == TYPE]
+    if not hosts:
+        fail(f"missing bpmn:serviceTask with {TYPE}")
+
+    # Wrong-host guard: the synchronous wait wrapper must not sit on a
+    # fire-and-forget sendTask or any other host.
+    for kind in (
+        "sendTask",
+        "task",
+        "callActivity",
+        "userTask",
+        "businessRuleTask",
+        "receiveTask",
+        "scriptTask",
+    ):
+        offenders = [e for e in elements(root, kind) if activity_type(e) == TYPE]
+        if offenders:
+            fail(f"{TYPE} must be on bpmn:serviceTask (synchronous wait), found on bpmn:{kind}")
+
+    task = hosts[0]
+    if not mapping_inputs(task):
+        fail(f"{TYPE} serviceTask must bind at least one request input (queue item payload)")
+    if not mapping_outputs(task):
+        fail(f"{TYPE} serviceTask must capture at least one output (processed item)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    require_no_private_connector_values(root)
+    print(f"OK: {path} hosts {TYPE} on a serviceTask with bound input and captured output")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/queue_create_and_wait.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/queue_create_and_wait/queue_create_and_wait.yaml
@@ -1,0 +1,66 @@
+task_id: skill-bpmn-queue-create-and-wait
+description: >
+  Node eval: agent uses the uipath-maestro-bpmn skill to model the synchronous
+  queue wrapper Orchestrator.CreateAndWaitForQueueItem on a bpmn:serviceTask with
+  a bound request input and a captured output — distinct from the fire-and-forget
+  Orchestrator.CreateQueueItem that rides a bpmn:sendTask. Authoring only — no
+  cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a local Maestro BPMN project named "QueueCreateAndWaitBpmn" with the
+  main file at `QueueCreateAndWaitBpmn/QueueCreateAndWaitBpmn.bpmn` for this
+  process:
+  - Manual start -> enqueue a transaction item and BLOCK until it is processed,
+    then continue -> end.
+
+  Requirements:
+  - Because the process waits for the item to finish, model this as the
+    synchronous wrapper `Orchestrator.CreateAndWaitForQueueItem` hosted on a
+    `bpmn:serviceTask` — NOT the fire-and-forget `Orchestrator.CreateQueueItem`
+    (that variant rides a `bpmn:sendTask`).
+  - Discover the wrapper via the registry (`uip maestro bpmn registry`) and author
+    its `uipath:*` payload from the served template. Do not hand-author
+    registry-owned XML from prose.
+  - Bind at least one request input (the queue item payload) and capture at least
+    one output (the processed item) into a declared process variable.
+  - Use synthetic placeholder resource/binding values only. Do not invent or paste
+    real tenant URLs, folder keys, connection IDs, release keys, or queue names.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate locally by parsing the BPMN and walking the skill's structural
+    checklist. Do NOT upload, publish, deploy, debug, run, or pack anything, and
+    do NOT pause for approval — build the complete local project in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "QueueCreateAndWaitBpmn/QueueCreateAndWaitBpmn.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "CreateAndWaitForQueueItem hosted on a serviceTask with bound input + captured output"
+    command: "python3 $TASK_DIR/check_queue_create_and_wait.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/check_sanitize.py
+++ b/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/check_sanitize.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Structural check for the public-safety sanitization negative eval.
+
+The fixture ships a valid BPMN seeded with fake-but-realistic private values
+(a tenant URL, a folder key, a connection id, and person names). The agent must
+scrub every seeded value to synthetic placeholders per references/public-safety.md
+while keeping the file valid and structurally intact. This sidecar asserts NONE
+of the seeded strings survive, reuses the shared require_no_private_connector_values
+helper as a secondary tenant-host guard, and confirms the graph still parses.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+_d = os.path.dirname(os.path.abspath(__file__))
+while _d != os.path.dirname(_d) and not os.path.isdir(os.path.join(_d, "_shared")):
+    _d = os.path.dirname(_d)
+sys.path.insert(0, _d)
+
+from _shared.bpmn_check import (  # noqa: E402
+    fail,
+    find_bpmn_file,
+    parse_bpmn,
+    require_no_private_connector_values,
+    require_sequence_integrity,
+)
+
+# The exact fake-but-realistic strings seeded into the fixture. All must be gone.
+SEEDED = [
+    "acme-corp.example.uipath.com",
+    "folder-key-11111111-2222-3333-4444-555555555555",
+    "connection-id-99999999-8888-7777-6666-000000000000",
+    "Jane Doe (Contoso)",
+    "John Smith (Fabrikam)",
+]
+
+
+def main() -> None:
+    path, root = parse_bpmn("CustomerExport")
+
+    text = open(find_bpmn_file("CustomerExport"), encoding="utf-8").read()
+    leaked = [s for s in SEEDED if s in text]
+    if leaked:
+        fail(f"seeded private values still present after sanitization: {leaked}")
+
+    # Reused shared guard: no real tenant/cloud host may remain.
+    require_no_private_connector_values(root)
+    # A sanitization pass must not break the graph.
+    require_sequence_integrity(root)
+
+    # Placeholder adoption: the three seeded resource fields must be replaced by
+    # synthetic angle-bracket placeholders (e.g. <TENANT_URL>, <FOLDER_KEY>,
+    # <CONNECTION_NAME>). ElementTree unescapes &lt;/&gt;, so this is robust to
+    # however the agent XML-escaped the placeholders.
+    placeholder = re.compile(r"<[A-Z][A-Z0-9_]*>")
+    seen: set[str] = set()
+    for el in root.iter():
+        for value in list(el.attrib.values()) + ([el.text] if el.text else []):
+            seen.update(placeholder.findall(value or ""))
+    if len(seen) < 3:
+        fail(
+            "expected the seeded tenant URL, folder key, and connection id to be "
+            f"replaced by synthetic <PLACEHOLDER> tokens; found {sorted(seen)}"
+        )
+
+    print(f"OK: {path} sanitized — no seeded private data remains and the graph is intact")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/fixture/CustomerExport.bpmn
+++ b/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/fixture/CustomerExport.bpmn
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:uipath="http://uipath.org/schema/bpmn" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="x-uipath-initial-diagram" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+  <bpmn:process id="Process_1" name="CustomerExport" isExecutable="false">
+    <bpmn:extensionElements>
+      <uipath:variables version="v1">
+        <uipath:inputOutput id="vExport" name="ExportResult" type="json" elementId="Task_Export"/>
+      </uipath:variables>
+      <uipath:bindings version="v1">
+        <uipath:binding id="bFolder" name="folderKey" type="string" default="folder-key-11111111-2222-3333-4444-555555555555" resource="folder" propertyAttribute="Key"/>
+        <uipath:binding id="bConn" name="connectionId" type="string" default="connection-id-99999999-8888-7777-6666-000000000000" resource="connection" propertyAttribute="Id"/>
+      </uipath:bindings>
+    </bpmn:extensionElements>
+    <bpmn:startEvent id="Event_start">
+      <bpmn:outgoing>Flow_start_export</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:serviceTask id="Task_Export" name="Export from tenant">
+      <bpmn:extensionElements>
+        <uipath:activity version="v1">
+          <uipath:type value="Orchestrator.ExecuteApiWorkflowAsync" version="v1"/>
+          <uipath:context>
+            <uipath:input name="tenantUrl" type="string" value="https://acme-corp.example.uipath.com"/>
+            <uipath:input name="folderKey" type="string" value="=bindings.bFolder"/>
+            <uipath:input name="connectionId" type="string" value="=bindings.bConn"/>
+          </uipath:context>
+          <uipath:input name="JobArguments" type="json" target="bodyField"><![CDATA[{}]]></uipath:input>
+          <uipath:output name="ExportResult" type="json" source="=ExportResult" var="vExport"/>
+        </uipath:activity>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_start_export</bpmn:incoming>
+      <bpmn:outgoing>Flow_export_notify</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:userTask id="Task_Notify" name="Notify Jane Doe (Contoso)">
+      <bpmn:incoming>Flow_export_notify</bpmn:incoming>
+      <bpmn:outgoing>Flow_notify_escalate</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:userTask id="Task_Escalate" name="Escalate to John Smith (Fabrikam)">
+      <bpmn:incoming>Flow_notify_escalate</bpmn:incoming>
+      <bpmn:outgoing>Flow_escalate_end</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="Event_end">
+      <bpmn:incoming>Flow_escalate_end</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_start_export" sourceRef="Event_start" targetRef="Task_Export"/>
+    <bpmn:sequenceFlow id="Flow_export_notify" sourceRef="Task_Export" targetRef="Task_Notify"/>
+    <bpmn:sequenceFlow id="Flow_notify_escalate" sourceRef="Task_Notify" targetRef="Task_Escalate"/>
+    <bpmn:sequenceFlow id="Flow_escalate_end" sourceRef="Task_Escalate" targetRef="Event_end"/>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1">
+      <bpmndi:BPMNShape id="S_Event_start" bpmnElement="Event_start">
+        <dc:Bounds x="160" y="200" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Export" bpmnElement="Task_Export">
+        <dc:Bounds x="260" y="178" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Notify" bpmnElement="Task_Notify">
+        <dc:Bounds x="420" y="178" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Task_Escalate" bpmnElement="Task_Escalate">
+        <dc:Bounds x="580" y="178" width="100" height="80"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="S_Event_end" bpmnElement="Event_end">
+        <dc:Bounds x="740" y="200" width="36" height="36"/>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="E_Flow_start_export" bpmnElement="Flow_start_export">
+        <di:waypoint x="196" y="218"/>
+        <di:waypoint x="260" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_export_notify" bpmnElement="Flow_export_notify">
+        <di:waypoint x="360" y="218"/>
+        <di:waypoint x="420" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_notify_escalate" bpmnElement="Flow_notify_escalate">
+        <di:waypoint x="520" y="218"/>
+        <di:waypoint x="580" y="218"/>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="E_Flow_escalate_end" bpmnElement="Flow_escalate_end">
+        <di:waypoint x="680" y="218"/>
+        <di:waypoint x="740" y="218"/>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/sanitize_customer_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/sanitize_customer_bpmn.yaml
@@ -1,0 +1,80 @@
+task_id: skill-bpmn-safety-sanitize
+description: >
+  Public-safety negative eval: a fixture .bpmn is seeded with fake-but-realistic
+  private values (a tenant URL, a folder key, a connection id, and person names).
+  The agent must use the uipath-maestro-bpmn skill's public-safety rules to scrub
+  every private value to synthetic placeholders before the file could be shared or
+  committed, while keeping the graph valid. Grades removal of every seeded string
+  and adoption of synthetic placeholders. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 16
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: fixture
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill, and apply its public-safety
+  rules (references/public-safety.md).
+
+  A Maestro BPMN file `CustomerExport.bpmn` is in the working directory. It was
+  exported from a customer environment and still contains PRIVATE data that must
+  never be shared or committed to a public repository:
+  - a real tenant URL,
+  - a folder key,
+  - a connection id,
+  - real person names.
+
+  Sanitize the file IN PLACE so it is safe to publish, WITHOUT changing the
+  process structure (keep every element id, node, sequence flow, and diagram
+  intact):
+  - Replace the tenant URL, folder key, and connection id with the skill's
+    synthetic angle-bracket placeholders — use `<TENANT_URL>`, `<FOLDER_KEY>`,
+    and `<CONNECTION_NAME>`.
+  - Replace the person names with synthetic, non-identifying labels.
+  - The file must remain well-formed BPMN after your edit.
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything, and do NOT pause
+  for approval — sanitize the file end to end in one pass.
+
+success_criteria:
+  - type: file_exists
+    description: "The sanitized BPMN file is still present"
+    path: "CustomerExport.bpmn"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Every seeded private value was removed"
+    path: "CustomerExport.bpmn"
+    excludes:
+      - "acme-corp.example.uipath.com"
+      - "folder-key-11111111-2222-3333-4444-555555555555"
+      - "connection-id-99999999-8888-7777-6666-000000000000"
+      - "Jane Doe (Contoso)"
+      - "John Smith (Fabrikam)"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Synthetic angle-bracket placeholders adopted for folder key and connection"
+    path: "CustomerExport.bpmn"
+    includes:
+      - '&lt;FOLDER_KEY&gt;'
+      - '&lt;CONNECTION_NAME&gt;'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No seeded private data remains, no real tenant host, placeholders adopted, graph intact"
+    command: "python3 $TASK_DIR/check_sanitize.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/sanitize_customer_bpmn.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/safety/sanitize_customer_bpmn/sanitize_customer_bpmn.yaml
@@ -51,8 +51,10 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_contains
-    description: "Every seeded private value was removed"
+    description: "Every seeded private value was removed while the process structure survived"
     path: "CustomerExport.bpmn"
+    includes:
+      - "Orchestrator.ExecuteApiWorkflowAsync"
     excludes:
       - "acme-corp.example.uipath.com"
       - "folder-key-11111111-2222-3333-4444-555555555555"


### PR DESCRIPTION
## What

Adds six `integration`-tier eval tasks for the **uipath-maestro-bpmn** skill covering expression authoring (rules 5–12 of `references/expression-authoring.md`), the dedicated queue/call-activity node wrappers, and a public-safety negative test (`references/public-safety.md`).

| # | task_id | Leaf dir | Grades |
|---|---|---|---|
| 1 | `skill-bpmn-expr-error-mapping` | `expressions/error_mapping/` | `uipath:errorMapping` condition branches on `=vars.error.code == "..."` (regex on the expression, not a literal) + valid graph |
| 2 | `skill-bpmn-expr-multiinstance-iterator` | `expressions/multiinstance_iterator/` | multi-instance **subprocess** body reads `iterator[0].item` / `iterator[0].loopCounter` (subprocess-depth indexing, not task-level `iterator.item`) |
| 3 | `skill-bpmn-expr-computed-js` | `expressions/computed_js/` | exact case-sensitive `=js:` prefix in a json-typed mapping whose body stays valid JSON |
| 4 | `skill-bpmn-queue-create-and-wait` | `nodes/queue_create_and_wait/` | `Orchestrator.CreateAndWaitForQueueItem` hosted on a `bpmn:serviceTask` with bound input + captured output; wrong-host guard rejects the fire-and-forget `sendTask` variant |
| 5 | `skill-bpmn-callactivity-agentic-process` | `nodes/callactivity_agentic/` | `Orchestrator.StartAgenticProcess` hosted on a `bpmn:callActivity`; wrong-host guard fails if placed on a `serviceTask` |
| 6 | `skill-bpmn-safety-sanitize` | `safety/sanitize_customer_bpmn/` | NEGATIVE: fixture seeded with fake-but-realistic private values (tenant URL, folder key, connection id, person names); agent must scrub every one to synthetic placeholders and keep the graph valid |

## How it's graded

- Each task pairs `file_contains` content checks with a deterministic ElementTree/regex sidecar (`check_*.py`) that reuses the shared `_shared/bpmn_check.py` / `_shared/bpmn_assertions.py` helpers (activity-type, mapping, DI, sequence-integrity, and the existing `require_no_private_connector_values` guard).
- **Deterministic only** — no `llm_judge` (a prior BPMN smoke flaked on fuzzy checks), no cloud lifecycle commands. Local-only prompts forbid upload/publish/deploy/debug/run/pack and forbid pausing for approval.
- Every sidecar was validated to **pass on a hand-authored gold artifact and fail on a mutated variant** before pushing.
- Test 6's fixture is public-safe by construction: the seeded strings are obviously synthetic (`acme-corp.example.uipath.com`, `folder-key-11111111-…`, `Jane Doe (Contoso)`), so committing the fixture leaks nothing while still exercising the sanitization behavior.

## Relationship to existing tests

Tests 4 and 5 are **dedicated deep checks** (bound input/output, wrong-host guards) for two wrappers that `nodes/contract_variant_wrappers.yaml` only asserts as breadth-level *shells* — materially distinct operations, not duplicates.

## Notes

- New `node:call-activity` tag reused from `contract_variant_wrappers.yaml`; `node:loop` is in the closed vocabulary.
- No `@uipath/cli` in `env_packages`; `run_limits` is top-level; lint-task rubric applied (CLI-verb reachability clean, no Medium+ findings).

Passing run: **6/6 PASS** — https://github.com/UiPath/skills/actions/runs/29517731330 (`run-coder-eval.yml`, Linux; Windows partition empty/skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
