### PR TITLE
test(maestro-bpmn): add error-handling + advanced-event structural evals

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/check_error_boundary_handler.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/check_error_boundary_handler.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Structural check for the interrupting error boundary event + recovery path.
+
+Asserts:
+  - an interrupting error boundary event (cancelActivity="true") whose
+    attachedToRef resolves to a serviceTask;
+  - its errorEventDefinition errorRef resolves to a bpmn:error with a non-empty
+    errorCode (the ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE rule is satisfied);
+  - the boundary routes to a downstream recovery node (outgoing flow);
+  - at most one catch-all (no errorRef) error boundary event per task, guarding
+    against MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK.
+Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("InvoiceServiceRecovery")
+
+    codes = {attr(e, "id"): attr(e, "errorCode") for e in root.findall("bpmn:error", NS)}
+    service_task_ids = {attr(t, "id") for t in elements(root, "serviceTask")}
+    flows = elements(root, "sequenceFlow")
+
+    error_boundaries = []
+    for be in elements(root, "boundaryEvent"):
+        if be.find("bpmn:errorEventDefinition", NS) is not None:
+            error_boundaries.append(be)
+    if not error_boundaries:
+        fail("no error boundary event (boundaryEvent with a bpmn:errorEventDefinition)")
+
+    # Guard against multiple catch-all error boundaries on the same task.
+    catch_all_by_task = {}
+    for be in error_boundaries:
+        edef = be.find("bpmn:errorEventDefinition", NS)
+        if not attr(edef, "errorRef"):
+            task = attr(be, "attachedToRef")
+            catch_all_by_task[task] = catch_all_by_task.get(task, 0) + 1
+    for task, n in catch_all_by_task.items():
+        if n > 1:
+            fail(f"task {task!r} has {n} catch-all error boundary events (MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK)")
+
+    valid = False
+    for be in error_boundaries:
+        be_id = attr(be, "id")
+        edef = be.find("bpmn:errorEventDefinition", NS)
+        ref = attr(edef, "errorRef")
+        # Batch scenario: an interrupting boundary with a configured error code.
+        if attr(be, "cancelActivity") != "true":
+            continue
+        if not ref:
+            continue  # this scenario wants a configured (non catch-all) error
+        attached = attr(be, "attachedToRef")
+        if attached not in service_task_ids:
+            fail(f"error boundary {be_id} attachedToRef {attached!r} is not a serviceTask")
+        if ref not in codes:
+            fail(f"error boundary {be_id} errorRef {ref!r} does not resolve to a declared bpmn:error")
+        if not codes[ref].strip():
+            fail(f"bpmn:error {ref!r} on boundary {be_id} has no errorCode (ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE)")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == be_id]
+        if not outgoing:
+            fail(f"error boundary {be_id} has no outgoing flow to a recovery path")
+        shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+        if be_id not in shaped:
+            fail(f"error boundary {be_id} has no BPMNShape")
+        valid = True
+    if not valid:
+        fail('no interrupting (cancelActivity="true") error boundary with a configured errorCode on a serviceTask routing to recovery')
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has an interrupting error boundary with a configured code on a serviceTask routing to recovery")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/check_error_boundary_handler.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/check_error_boundary_handler.py
@@ -3,50 +3,82 @@
 
 Asserts:
   - an interrupting error boundary event (cancelActivity="true") whose
-    attachedToRef resolves to a serviceTask;
+    attachedToRef resolves to a task-like activity (serviceTask, sendTask,
+    userTask, scriptTask, ... — registry templates host service calls on
+    different task kinds, e.g. Intsvc.UnifiedHttpRequest on bpmn:sendTask);
   - its errorEventDefinition errorRef resolves to a bpmn:error with a non-empty
     errorCode (the ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE rule is satisfied);
   - the boundary routes to a downstream recovery node (outgoing flow);
   - at most one catch-all (no errorRef) error boundary event per task, guarding
     against MULTIPLE_CATCH_ALL_BOUNDARY_EVENTS_ON_TASK.
-Reuses the shared uipath-maestro-bpmn check helpers.
+
+Element lookups are case-insensitive on the BPMN local name: registry
+xmlTemplates emit capitalized element names (bpmn:SendTask,
+bpmn:IntermediateCatchEvent, ...) while hand-authored structural BPMN uses the
+lowercase-camel spec names. Reuses the shared uipath-maestro-bpmn check helpers.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
 from _shared.bpmn_check import (  # noqa: E402
     NS,
     attr,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
     require_sequence_integrity,
 )
 
+BPMN_NS = NS["bpmn"]
+
+ACTIVITY_KINDS = {
+    "task", "servicetask", "sendtask", "receivetask", "scripttask",
+    "usertask", "businessruletask", "callactivity", "subprocess",
+}
+
+
+def els(root: ET.Element, kind: str) -> list[ET.Element]:
+    """Case-insensitive BPMN element lookup by local name."""
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [
+        el for el in root.iter()
+        if el.tag.startswith(prefix) and el.tag[len(prefix):].lower() == kl
+    ]
+
+
+def child(el: ET.Element, kind: str) -> ET.Element | None:
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    for c in el:
+        if c.tag.startswith(prefix) and c.tag[len(prefix):].lower() == kl:
+            return c
+    return None
+
 
 def main() -> None:
     path, root = parse_bpmn("InvoiceServiceRecovery")
 
-    codes = {attr(e, "id"): attr(e, "errorCode") for e in root.findall("bpmn:error", NS)}
-    service_task_ids = {attr(t, "id") for t in elements(root, "serviceTask")}
-    flows = elements(root, "sequenceFlow")
+    codes = {attr(e, "id"): attr(e, "errorCode") for e in els(root, "error")}
+    activity_ids = set()
+    for kind in ACTIVITY_KINDS:
+        for t in els(root, kind):
+            activity_ids.add(attr(t, "id"))
+    flows = els(root, "sequenceFlow")
 
-    error_boundaries = []
-    for be in elements(root, "boundaryEvent"):
-        if be.find("bpmn:errorEventDefinition", NS) is not None:
-            error_boundaries.append(be)
+    error_boundaries = [be for be in els(root, "boundaryEvent") if child(be, "errorEventDefinition") is not None]
     if not error_boundaries:
         fail("no error boundary event (boundaryEvent with a bpmn:errorEventDefinition)")
 
     # Guard against multiple catch-all error boundaries on the same task.
     catch_all_by_task = {}
     for be in error_boundaries:
-        edef = be.find("bpmn:errorEventDefinition", NS)
+        edef = child(be, "errorEventDefinition")
         if not attr(edef, "errorRef"):
             task = attr(be, "attachedToRef")
             catch_all_by_task[task] = catch_all_by_task.get(task, 0) + 1
@@ -57,7 +89,7 @@ def main() -> None:
     valid = False
     for be in error_boundaries:
         be_id = attr(be, "id")
-        edef = be.find("bpmn:errorEventDefinition", NS)
+        edef = child(be, "errorEventDefinition")
         ref = attr(edef, "errorRef")
         # Batch scenario: an interrupting boundary with a configured error code.
         if attr(be, "cancelActivity") != "true":
@@ -65,8 +97,8 @@ def main() -> None:
         if not ref:
             continue  # this scenario wants a configured (non catch-all) error
         attached = attr(be, "attachedToRef")
-        if attached not in service_task_ids:
-            fail(f"error boundary {be_id} attachedToRef {attached!r} is not a serviceTask")
+        if attached not in activity_ids:
+            fail(f"error boundary {be_id} attachedToRef {attached!r} is not a task-like activity")
         if ref not in codes:
             fail(f"error boundary {be_id} errorRef {ref!r} does not resolve to a declared bpmn:error")
         if not codes[ref].strip():
@@ -79,11 +111,11 @@ def main() -> None:
             fail(f"error boundary {be_id} has no BPMNShape")
         valid = True
     if not valid:
-        fail('no interrupting (cancelActivity="true") error boundary with a configured errorCode on a serviceTask routing to recovery')
+        fail('no interrupting (cancelActivity="true") error boundary with a configured errorCode on an activity routing to recovery')
 
     require_sequence_integrity(root)
     require_di_for_visible_elements(root)
-    print(f"OK: {path} has an interrupting error boundary with a configured code on a serviceTask routing to recovery")
+    print(f"OK: {path} has an interrupting error boundary with a configured code on an activity routing to recovery")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/error_boundary_handler.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/error_boundary_handler.yaml
@@ -1,0 +1,78 @@
+task_id: skill-bpmn-error-boundary-handler
+description: >
+  Structural error-handling eval: agent uses the uipath-maestro-bpmn skill to
+  attach an INTERRUPTING error boundary event (cancelActivity="true") with a
+  configured error code to a serviceTask, routing the caught error to a recovery
+  path. Exercises the ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE and duplicate
+  catch-all boundary rules. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `InvoiceServiceRecovery.bpmn` in the working
+  directory that recovers from a service failure with a boundary event:
+    - a manual start,
+    - a serviceTask that posts an invoice to a downstream service,
+    - an INTERRUPTING error boundary event (cancelActivity="true") attached to
+      that serviceTask, referencing a declared bpmn:error that carries an
+      errorCode,
+    - on the happy path the serviceTask flows to a normal end event; when the
+      boundary error fires, it routes to a recovery task and its own end event.
+
+  Requirements:
+  - Discover any UiPath extension node's type via the registry and author it from
+    the registry template — do not hand-author uipath:* XML from prose. Structural
+    BPMN (boundary event attachedToRef/cancelActivity, sequence flows, the
+    declared bpmn:error) comes from the skill's structural reference.
+  - The error referenced by the boundary event MUST declare an errorCode, and
+    there must be at most one catch-all (no errorRef) error boundary per task.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node (including the
+    boundary event) and a BPMNEdge for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "InvoiceServiceRecovery.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN has a diagram, an error boundary, and an interrupting cancelActivity"
+    path: "InvoiceServiceRecovery.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "boundaryEvent"
+      - 'cancelActivity="true"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Interrupting error boundary with a configured code on a serviceTask routes to recovery, fully shaped"
+    command: "python3 $TASK_DIR/check_error_boundary_handler.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/error_boundary_handler.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_boundary_handler/error_boundary_handler.yaml
@@ -2,9 +2,9 @@ task_id: skill-bpmn-error-boundary-handler
 description: >
   Structural error-handling eval: agent uses the uipath-maestro-bpmn skill to
   attach an INTERRUPTING error boundary event (cancelActivity="true") with a
-  configured error code to a serviceTask, routing the caught error to a recovery
-  path. Exercises the ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE and duplicate
-  catch-all boundary rules. Authoring only — no cloud effects.
+  configured error code to a service-call task, routing the caught error to a
+  recovery path. Exercises the ERROR_BOUNDARY_EVENT_REQUIRES_ERROR_CODE and
+  duplicate catch-all boundary rules. Authoring only — no cloud effects.
 tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
 
 run_limits:
@@ -22,12 +22,12 @@ initial_prompt: |
   Author a single Maestro BPMN file `InvoiceServiceRecovery.bpmn` in the working
   directory that recovers from a service failure with a boundary event:
     - a manual start,
-    - a serviceTask that posts an invoice to a downstream service,
+    - a task that posts an invoice to a downstream service (use the registry
+      service/HTTP node type of your choice),
     - an INTERRUPTING error boundary event (cancelActivity="true") attached to
-      that serviceTask, referencing a declared bpmn:error that carries an
-      errorCode,
-    - on the happy path the serviceTask flows to a normal end event; when the
-      boundary error fires, it routes to a recovery task and its own end event.
+      that task, referencing a declared bpmn:error that carries an errorCode,
+    - on the happy path the task flows to a normal end event; when the boundary
+      error fires, it routes to a recovery task and its own end event.
 
   Requirements:
   - Discover any UiPath extension node's type via the registry and author it from
@@ -70,7 +70,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Interrupting error boundary with a configured code on a serviceTask routes to recovery, fully shaped"
+    description: "Interrupting error boundary with a configured code on a service-call task routes to recovery, fully shaped"
     command: "python3 $TASK_DIR/check_error_boundary_handler.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/check_error_event_subprocess.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/check_error_event_subprocess.py
@@ -8,53 +8,72 @@ subprocess:
     ERROR_END_EVENT_MISSING_EXCEPTION would fire otherwise);
   - an EVENT subprocess (triggeredByEvent="true") with exactly one start event
     that is an interrupting error start (errorEventDefinition, not
-    cancelActivity/isInterrupting="false"), so it catches the thrown error;
+    isInterrupting="false"), so it catches the thrown error;
   - a DI shape for the event subprocess container.
-Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET, locally authored
-input — same trust boundary as the rest of the fixture corpus).
+
+Element lookups are case-insensitive on the BPMN local name: registry
+xmlTemplates emit capitalized element names while hand-authored structural BPMN
+uses the lowercase-camel spec names. Reuses the shared uipath-maestro-bpmn
+check helpers (stdlib ET, locally authored input — same trust boundary as the
+rest of the fixture corpus).
 """
 
 from __future__ import annotations
 
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
 from _shared.bpmn_check import (  # noqa: E402
     NS,
     attr,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
     require_sequence_integrity,
 )
 
+BPMN_NS = NS["bpmn"]
 
-def error_codes_by_id(root):
-    codes = {}
-    for err in root.findall("bpmn:error", NS):
-        codes[attr(err, "id")] = attr(err, "errorCode")
-    return codes
+
+def els(root: ET.Element, kind: str) -> list[ET.Element]:
+    """Case-insensitive BPMN element lookup by local name."""
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [
+        el for el in root.iter()
+        if el.tag.startswith(prefix) and el.tag[len(prefix):].lower() == kl
+    ]
+
+
+def children(el: ET.Element, kind: str) -> list[ET.Element]:
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [c for c in el if c.tag.startswith(prefix) and c.tag[len(prefix):].lower() == kl]
+
+
+def child(el: ET.Element, kind: str) -> ET.Element | None:
+    found = children(el, kind)
+    return found[0] if found else None
 
 
 def main() -> None:
     path, root = parse_bpmn("PaymentErrorHandling")
 
-    if not elements(root, "startEvent"):
+    if not els(root, "startEvent"):
         fail("no start event")
 
-    codes = error_codes_by_id(root)
+    codes = {attr(err, "id"): attr(err, "errorCode") for err in els(root, "error")}
 
     # 1. Error END event with a resolvable errorRef + non-empty errorCode.
     error_ends = []
-    for end in elements(root, "endEvent"):
-        edef = end.find("bpmn:errorEventDefinition", NS)
+    for end in els(root, "endEvent"):
+        edef = child(end, "errorEventDefinition")
         if edef is not None:
             error_ends.append((end, edef))
     if not error_ends:
         fail("no end event carries a bpmn:errorEventDefinition (nothing throws an error)")
-    end_ref_ok = False
     for end, edef in error_ends:
         ref = attr(edef, "errorRef")
         if not ref:
@@ -63,25 +82,22 @@ def main() -> None:
             fail(f"error end event errorRef {ref!r} does not resolve to a declared bpmn:error")
         if not codes[ref].strip():
             fail(f"bpmn:error {ref!r} referenced by the error end event has no errorCode")
-        end_ref_ok = True
-    if not end_ref_ok:
-        fail("no valid error end event")
 
     # 2. Event subprocess (triggeredByEvent) catching the error.
-    event_subs = [sp for sp in elements(root, "subProcess") if attr(sp, "triggeredByEvent") == "true"]
+    event_subs = [sp for sp in els(root, "subProcess") if attr(sp, "triggeredByEvent") == "true"]
     if not event_subs:
         fail('no event subprocess (bpmn:subProcess triggeredByEvent="true")')
     caught = False
     for sp in event_subs:
-        starts = sp.findall("bpmn:startEvent", NS)
+        starts = children(sp, "startEvent")
         if len(starts) != 1:
             fail(f"event subprocess {attr(sp, 'id')} must have exactly one start event, found {len(starts)}")
         se = starts[0]
-        se_err = se.find("bpmn:errorEventDefinition", NS)
+        se_err = child(se, "errorEventDefinition")
         if se_err is None:
             continue  # not an error-catching start; keep looking
         # Interrupting: the spec generates an interrupting error start; reject a
-        # non-interrupting one (isInterrupting/cancelActivity="false").
+        # non-interrupting one (isInterrupting="false").
         if attr(se, "isInterrupting") == "false":
             fail(f"error start event {attr(se, 'id')} is non-interrupting; an interrupting error start is required")
         # The caught error should reference a declared error (ties handler to throw).

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/check_error_event_subprocess.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/check_error_event_subprocess.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Structural check for the error-end-event + error-catching event subprocess.
+
+Asserts the process throws a configured error and catches it in an event
+subprocess:
+  - an error END event whose errorEventDefinition carries an errorRef that
+    resolves to a bpmn:error with a non-empty errorCode (the runtime-blocking
+    ERROR_END_EVENT_MISSING_EXCEPTION would fire otherwise);
+  - an EVENT subprocess (triggeredByEvent="true") with exactly one start event
+    that is an interrupting error start (errorEventDefinition, not
+    cancelActivity/isInterrupting="false"), so it catches the thrown error;
+  - a DI shape for the event subprocess container.
+Reuses the shared uipath-maestro-bpmn check helpers (stdlib ET, locally authored
+input — same trust boundary as the rest of the fixture corpus).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def error_codes_by_id(root):
+    codes = {}
+    for err in root.findall("bpmn:error", NS):
+        codes[attr(err, "id")] = attr(err, "errorCode")
+    return codes
+
+
+def main() -> None:
+    path, root = parse_bpmn("PaymentErrorHandling")
+
+    if not elements(root, "startEvent"):
+        fail("no start event")
+
+    codes = error_codes_by_id(root)
+
+    # 1. Error END event with a resolvable errorRef + non-empty errorCode.
+    error_ends = []
+    for end in elements(root, "endEvent"):
+        edef = end.find("bpmn:errorEventDefinition", NS)
+        if edef is not None:
+            error_ends.append((end, edef))
+    if not error_ends:
+        fail("no end event carries a bpmn:errorEventDefinition (nothing throws an error)")
+    end_ref_ok = False
+    for end, edef in error_ends:
+        ref = attr(edef, "errorRef")
+        if not ref:
+            fail(f"error end event {attr(end, 'id')} has no errorRef (ERROR_END_EVENT_MISSING_EXCEPTION)")
+        if ref not in codes:
+            fail(f"error end event errorRef {ref!r} does not resolve to a declared bpmn:error")
+        if not codes[ref].strip():
+            fail(f"bpmn:error {ref!r} referenced by the error end event has no errorCode")
+        end_ref_ok = True
+    if not end_ref_ok:
+        fail("no valid error end event")
+
+    # 2. Event subprocess (triggeredByEvent) catching the error.
+    event_subs = [sp for sp in elements(root, "subProcess") if attr(sp, "triggeredByEvent") == "true"]
+    if not event_subs:
+        fail('no event subprocess (bpmn:subProcess triggeredByEvent="true")')
+    caught = False
+    for sp in event_subs:
+        starts = sp.findall("bpmn:startEvent", NS)
+        if len(starts) != 1:
+            fail(f"event subprocess {attr(sp, 'id')} must have exactly one start event, found {len(starts)}")
+        se = starts[0]
+        se_err = se.find("bpmn:errorEventDefinition", NS)
+        if se_err is None:
+            continue  # not an error-catching start; keep looking
+        # Interrupting: the spec generates an interrupting error start; reject a
+        # non-interrupting one (isInterrupting/cancelActivity="false").
+        if attr(se, "isInterrupting") == "false":
+            fail(f"error start event {attr(se, 'id')} is non-interrupting; an interrupting error start is required")
+        # The caught error should reference a declared error (ties handler to throw).
+        se_ref = attr(se_err, "errorRef")
+        if se_ref and se_ref not in codes:
+            fail(f"event-subprocess start errorRef {se_ref!r} does not resolve to a declared bpmn:error")
+        caught = True
+        # 3. DI shape for the event subprocess container.
+        shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+        if attr(sp, "id") not in shaped:
+            fail(f"event subprocess {attr(sp, 'id')} has no BPMNShape (invisible on the canvas)")
+    if not caught:
+        fail("no event subprocess has an interrupting error start event catching the thrown error")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} throws a configured error end event and catches it in an interrupting error event subprocess")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/error_event_subprocess.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/error_event_subprocess/error_event_subprocess.yaml
@@ -1,0 +1,81 @@
+task_id: skill-bpmn-error-event-subprocess
+description: >
+  Structural error-handling eval: agent uses the uipath-maestro-bpmn skill to
+  author a process that throws a configured error END event and catches it in an
+  EVENT subprocess (triggeredByEvent="true") whose single interrupting error
+  start event handles it. Exercises the ERROR_END_EVENT_MISSING_EXCEPTION and
+  event-subprocess start-event rules. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:subflow"]
+
+run_limits:
+  expected_turns: 22
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `PaymentErrorHandling.bpmn` in the working
+  directory that models an error thrown by the main flow and handled by an event
+  subprocess:
+    - a manual start,
+    - a task that attempts a payment,
+    - an exclusive gateway that routes a failure to an error END event and the
+      normal case to a plain end event,
+    - the error end event must reference a declared bpmn:error that carries an
+      errorCode (an error end event with no configured exception is invalid),
+    - an EVENT subprocess (bpmn:subProcess with triggeredByEvent="true") whose
+      SINGLE start event is an INTERRUPTING error start event
+      (bpmn:errorEventDefinition) that catches that same error and runs a
+      handler task to a nested end event.
+
+  Requirements:
+  - Discover any UiPath extension node's type via the registry and author it from
+    the registry template — do not hand-author uipath:* XML from prose. Plain
+    structural BPMN (start/end events, tasks, gateway, subprocess, sequence
+    flows) comes from the skill's structural reference.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node (including the
+    event subprocess container and its nested nodes) and a BPMNEdge for every
+    sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "PaymentErrorHandling.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN declares an error, an error event definition, and an event subprocess"
+    path: "PaymentErrorHandling.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "errorEventDefinition"
+      - 'triggeredByEvent="true"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Error end event with a configured code is caught by an interrupting error event subprocess, fully shaped"
+    command: "python3 $TASK_DIR/check_error_event_subprocess.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/check_event_based_gateway.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/check_event_based_gateway.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Structural check for the event-based gateway (first-catcher-wins) race.
+
+Asserts:
+  - a bpmn:eventBasedGateway with >=2 outgoing sequence flows;
+  - every outgoing flow targets a bpmn:intermediateCatchEvent (the only valid
+    target type for an event-based gateway);
+  - among the raced catch events, at least one carries a messageEventDefinition
+    and at least one carries a timerEventDefinition;
+  - the gateway's outgoing flows all have BPMNEdges.
+Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("PaymentRace")
+
+    gateways = elements(root, "eventBasedGateway")
+    if not gateways:
+        fail("no bpmn:eventBasedGateway")
+    flows = elements(root, "sequenceFlow")
+    catch_by_id = {attr(c, "id"): c for c in elements(root, "intermediateCatchEvent")}
+    edged = {e.attrib.get("bpmnElement") for e in root.findall(".//bpmndi:BPMNEdge", NS)}
+
+    valid = False
+    for gw in gateways:
+        gw_id = attr(gw, "id")
+        outgoing = [f for f in flows if attr(f, "sourceRef") == gw_id]
+        if len(outgoing) < 2:
+            continue
+        targets = [attr(f, "targetRef") for f in outgoing]
+        non_catch = [t for t in targets if t not in catch_by_id]
+        if non_catch:
+            fail(f"event-based gateway {gw_id} routes to non-catch targets {non_catch} (must be intermediateCatchEvents)")
+        has_message = any(catch_by_id[t].find("bpmn:messageEventDefinition", NS) is not None for t in targets)
+        has_timer = any(catch_by_id[t].find("bpmn:timerEventDefinition", NS) is not None for t in targets)
+        if not has_message:
+            fail(f"event-based gateway {gw_id} has no message catch among its raced events")
+        if not has_timer:
+            fail(f"event-based gateway {gw_id} has no timer catch among its raced events")
+        for f in outgoing:
+            if attr(f, "id") not in edged:
+                fail(f"gateway outgoing flow {attr(f, 'id')} has no BPMNEdge")
+        valid = True
+    if not valid:
+        fail("no event-based gateway with >=2 outgoing flows racing a message catch and a timer catch")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} races a message catch and a timer catch behind an event-based gateway")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/check_event_based_gateway.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/check_event_based_gateway.py
@@ -3,39 +3,64 @@
 
 Asserts:
   - a bpmn:eventBasedGateway with >=2 outgoing sequence flows;
-  - every outgoing flow targets a bpmn:intermediateCatchEvent (the only valid
+  - every outgoing flow targets an intermediate catch event (the only valid
     target type for an event-based gateway);
   - among the raced catch events, at least one carries a messageEventDefinition
     and at least one carries a timerEventDefinition;
   - the gateway's outgoing flows all have BPMNEdges.
-Reuses the shared uipath-maestro-bpmn check helpers.
+
+Element lookups are case-insensitive on the BPMN local name: registry
+xmlTemplates emit capitalized element names (e.g. bpmn:IntermediateCatchEvent
+for Maestro.ReceiveMessageEvent) while hand-authored structural BPMN uses the
+lowercase-camel spec names. Reuses the shared uipath-maestro-bpmn check helpers.
 """
 
 from __future__ import annotations
 
 import os
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
 from _shared.bpmn_check import (  # noqa: E402
     NS,
     attr,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
     require_sequence_integrity,
 )
 
+BPMN_NS = NS["bpmn"]
+
+
+def els(root: ET.Element, kind: str) -> list[ET.Element]:
+    """Case-insensitive BPMN element lookup by local name."""
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [
+        el for el in root.iter()
+        if el.tag.startswith(prefix) and el.tag[len(prefix):].lower() == kl
+    ]
+
+
+def child(el: ET.Element, kind: str) -> ET.Element | None:
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    for c in el:
+        if c.tag.startswith(prefix) and c.tag[len(prefix):].lower() == kl:
+            return c
+    return None
+
 
 def main() -> None:
     path, root = parse_bpmn("PaymentRace")
 
-    gateways = elements(root, "eventBasedGateway")
+    gateways = els(root, "eventBasedGateway")
     if not gateways:
         fail("no bpmn:eventBasedGateway")
-    flows = elements(root, "sequenceFlow")
-    catch_by_id = {attr(c, "id"): c for c in elements(root, "intermediateCatchEvent")}
+    flows = els(root, "sequenceFlow")
+    catch_by_id = {attr(c, "id"): c for c in els(root, "intermediateCatchEvent")}
     edged = {e.attrib.get("bpmnElement") for e in root.findall(".//bpmndi:BPMNEdge", NS)}
 
     valid = False
@@ -48,8 +73,8 @@ def main() -> None:
         non_catch = [t for t in targets if t not in catch_by_id]
         if non_catch:
             fail(f"event-based gateway {gw_id} routes to non-catch targets {non_catch} (must be intermediateCatchEvents)")
-        has_message = any(catch_by_id[t].find("bpmn:messageEventDefinition", NS) is not None for t in targets)
-        has_timer = any(catch_by_id[t].find("bpmn:timerEventDefinition", NS) is not None for t in targets)
+        has_message = any(child(catch_by_id[t], "messageEventDefinition") is not None for t in targets)
+        has_timer = any(child(catch_by_id[t], "timerEventDefinition") is not None for t in targets)
         if not has_message:
             fail(f"event-based gateway {gw_id} has no message catch among its raced events")
         if not has_timer:

--- a/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/event_based_gateway.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/event_based_gateway/event_based_gateway.yaml
@@ -1,0 +1,79 @@
+task_id: skill-bpmn-event-based-gateway
+description: >
+  Structural advanced-event eval: agent uses the uipath-maestro-bpmn skill to
+  author an EVENT-BASED gateway racing a message catch against a timer catch
+  (first-catcher-wins). Exercises the event-based gateway target contract
+  (outgoing flows target intermediate catch events). Authoring only — no cloud
+  effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:gateway"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `PaymentRace.bpmn` in the working directory
+  that waits for whichever of two events fires first:
+    - a manual start,
+    - a task that submits a payment,
+    - a bpmn:eventBasedGateway with two outgoing flows,
+    - one flow to an intermediateCatchEvent carrying a bpmn:messageEventDefinition
+      (payment confirmed), the other to an intermediateCatchEvent carrying a
+      bpmn:timerEventDefinition (confirmation timeout, valid ISO-8601 duration),
+    - each catch event leads to its own follow-up task and end event.
+
+  Requirements:
+  - The event-based gateway's outgoing flows MUST target intermediate catch
+    events (that is the only valid target for an event-based gateway).
+  - Discover any UiPath extension node's type via the registry and author it from
+    the registry template — do not hand-author uipath:* XML from prose. Structural
+    BPMN (the gateway, catch events, event definitions, sequence flows) comes
+    from the skill's structural reference.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "PaymentRace.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN has a diagram, an event-based gateway, and both event definitions"
+    path: "PaymentRace.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "eventBasedGateway"
+      - "messageEventDefinition"
+      - "timerEventDefinition"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Event-based gateway races a message catch and a timer catch with full DI edges"
+    command: "python3 $TASK_DIR/check_event_based_gateway.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/structural/inclusive_gateway_forkjoin/check_inclusive_gateway_forkjoin.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/inclusive_gateway_forkjoin/check_inclusive_gateway_forkjoin.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Structural check for the inclusive (OR) gateway fork + real inclusive join.
+
+Asserts:
+  - two distinct bpmn:inclusiveGateway elements: a split (one in, >=2 out) and a
+    join (>=2 in, one out);
+  - every outgoing branch from the split carries a conditionExpression (OR-fork
+    semantics: each branch is independently gated);
+  - the join synchronizes >=2 distinct upstream branches;
+  - no gateway is superfluous (exactly one-in-one-out) — the join is a real
+    inclusive join, not a fake join onto an activity.
+Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("NotificationFanout")
+
+    gateways = elements(root, "inclusiveGateway")
+    if len(gateways) < 2:
+        fail(f"expected >=2 inclusiveGateways (a split and a join), found {len(gateways)}")
+    flows = elements(root, "sequenceFlow")
+
+    def out_flows(nid):
+        return [f for f in flows if attr(f, "sourceRef") == nid]
+
+    def in_flows(nid):
+        return [f for f in flows if attr(f, "targetRef") == nid]
+
+    splits = [g for g in gateways if len(out_flows(attr(g, "id"))) >= 2 and len(in_flows(attr(g, "id"))) == 1]
+    joins = [g for g in gateways if len(in_flows(attr(g, "id"))) >= 2 and len(out_flows(attr(g, "id"))) == 1]
+    if not splits:
+        fail("no inclusive split gateway (one incoming, >=2 outgoing)")
+    if not joins:
+        fail("no inclusive join gateway (>=2 incoming, one outgoing)")
+
+    split = splits[0]
+    join = joins[0]
+    if attr(split, "id") == attr(join, "id"):
+        fail("split and join are the same gateway; a real fork+join needs two")
+
+    # Every branch out of the split is conditioned (OR-fork).
+    for f in out_flows(attr(split, "id")):
+        if f.find("bpmn:conditionExpression", NS) is None:
+            fail(f"inclusive split branch {attr(f, 'id')} has no conditionExpression")
+
+    # Join synchronizes >=2 distinct upstream branches.
+    sources = {attr(f, "sourceRef") for f in in_flows(attr(join, "id"))}
+    if len(sources) < 2:
+        fail(f"inclusive join {attr(join, 'id')} does not synchronize >=2 distinct branches")
+
+    # No superfluous gateway (one-in-one-out) among any gateway type.
+    for kind in ("inclusiveGateway", "exclusiveGateway", "parallelGateway"):
+        for g in elements(root, kind):
+            gid = attr(g, "id")
+            if len(in_flows(gid)) == 1 and len(out_flows(gid)) == 1:
+                fail(f"{kind} {gid} has exactly one in and one out (SUPERFLUOUS_GATEWAY)")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} forks on a conditioned inclusive split and rejoins at a real inclusive join")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/inclusive_gateway_forkjoin/inclusive_gateway_forkjoin.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/inclusive_gateway_forkjoin/inclusive_gateway_forkjoin.yaml
@@ -1,0 +1,80 @@
+task_id: skill-bpmn-inclusive-gateway-forkjoin
+description: >
+  Structural advanced-event eval: agent uses the uipath-maestro-bpmn skill to
+  author an INCLUSIVE (OR) gateway fork with conditioned branches and a real
+  inclusive join. Exercises the FAKE_JOIN / SUPERFLUOUS_GATEWAY rules (join with
+  a gateway, not by pointing two flows at one activity). Authoring only — no
+  cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "node:gateway"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `NotificationFanout.bpmn` in the working
+  directory that fans out to independently-chosen channels and rejoins:
+    - a manual start,
+    - a bpmn:inclusiveGateway SPLIT (one incoming, two outgoing) where each
+      outgoing branch carries its own conditionExpression (e.g. email wanted,
+      SMS wanted) so any subset can run,
+    - each branch runs a notification task,
+    - a SECOND bpmn:inclusiveGateway JOIN (two incoming, one outgoing) that
+      synchronizes the branches,
+    - a final task and end event after the join.
+
+  Requirements:
+  - Synchronize with an inclusive JOIN gateway — do NOT point two flows at one
+    activity (that is a FAKE_JOIN), and do NOT use a one-in/one-out gateway
+    (SUPERFLUOUS_GATEWAY). Each split branch must be conditioned.
+  - Discover any UiPath extension node's type via the registry and author it from
+    the registry template — do not hand-author uipath:* XML from prose. Structural
+    BPMN (gateways, conditions, sequence flows) comes from the skill's structural
+    reference.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node and a BPMNEdge
+    for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "NotificationFanout.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN has a diagram, an inclusive gateway, and branch conditions"
+    path: "NotificationFanout.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "inclusiveGateway"
+      - "conditionExpression"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Conditioned inclusive split rejoins at a real inclusive join (no fake/superfluous gateway), fully shaped"
+    command: "python3 $TASK_DIR/check_inclusive_gateway_forkjoin.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/check_message_send_receive_pair.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/check_message_send_receive_pair.py
@@ -2,15 +2,19 @@
 """Structural check for the correlated internal-message send/receive pair.
 
 Asserts:
-  - a bpmn:intermediateThrowEvent hosting the registry Maestro.SendMessageEvent
+  - an intermediate THROW event hosting the registry Maestro.SendMessageEvent
     wrapper with a bpmn:messageEventDefinition;
-  - a bpmn:intermediateCatchEvent hosting the registry Maestro.ReceiveMessageEvent
+  - an intermediate CATCH event hosting the registry Maestro.ReceiveMessageEvent
     wrapper with a bpmn:messageEventDefinition;
   - a shared/consistent message reference between the two — the uipath:context
     `name` input value matches (the internal-message correlation key), and where
     a messageRef is present on both, it resolves to the same declared message;
   - DI shapes for both events.
-Reuses the shared uipath-maestro-bpmn check helpers.
+
+Element lookups are case-insensitive on the BPMN local name: the registry
+xmlTemplates emit capitalized element names (bpmn:IntermediateThrowEvent /
+bpmn:IntermediateCatchEvent) while hand-authored structural BPMN uses the
+lowercase-camel spec names. Reuses the shared uipath-maestro-bpmn check helpers.
 """
 
 from __future__ import annotations
@@ -23,15 +27,34 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(
 from _shared.bpmn_check import (  # noqa: E402
     NS,
     attr,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
     require_sequence_integrity,
 )
 
+BPMN_NS = NS["bpmn"]
 SEND = "Maestro.SendMessageEvent"
 RECEIVE = "Maestro.ReceiveMessageEvent"
+
+
+def els(root: ET.Element, kind: str) -> list[ET.Element]:
+    """Case-insensitive BPMN element lookup by local name."""
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [
+        el for el in root.iter()
+        if el.tag.startswith(prefix) and el.tag[len(prefix):].lower() == kl
+    ]
+
+
+def child(el: ET.Element, kind: str) -> ET.Element | None:
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    for c in el:
+        if c.tag.startswith(prefix) and c.tag[len(prefix):].lower() == kl:
+            return c
+    return None
 
 
 def has_type(el: ET.Element, token: str) -> bool:
@@ -49,23 +72,23 @@ def main() -> None:
     path, root = parse_bpmn("OrderCoordination")
 
     throws = [
-        t for t in elements(root, "intermediateThrowEvent")
-        if has_type(t, SEND) and t.find("bpmn:messageEventDefinition", NS) is not None
+        t for t in els(root, "intermediateThrowEvent")
+        if has_type(t, SEND) and child(t, "messageEventDefinition") is not None
     ]
     catches = [
-        c for c in elements(root, "intermediateCatchEvent")
-        if has_type(c, RECEIVE) and c.find("bpmn:messageEventDefinition", NS) is not None
+        c for c in els(root, "intermediateCatchEvent")
+        if has_type(c, RECEIVE) and child(c, "messageEventDefinition") is not None
     ]
     if not throws:
-        fail("no bpmn:intermediateThrowEvent with Maestro.SendMessageEvent and a messageEventDefinition")
+        fail("no intermediate throw event with Maestro.SendMessageEvent and a messageEventDefinition")
     if not catches:
-        fail("no bpmn:intermediateCatchEvent with Maestro.ReceiveMessageEvent and a messageEventDefinition")
+        fail("no intermediate catch event with Maestro.ReceiveMessageEvent and a messageEventDefinition")
 
     # Wrong-host guards: the send must not be a catch, the receive must not be a throw.
-    if any(has_type(c, SEND) for c in elements(root, "intermediateCatchEvent")):
-        fail("Maestro.SendMessageEvent must be on an intermediateThrowEvent, not a catch")
-    if any(has_type(t, RECEIVE) for t in elements(root, "intermediateThrowEvent")):
-        fail("Maestro.ReceiveMessageEvent must be on an intermediateCatchEvent, not a throw")
+    if any(has_type(c, SEND) for c in els(root, "intermediateCatchEvent")):
+        fail("Maestro.SendMessageEvent must be on an intermediate throw event, not a catch")
+    if any(has_type(t, RECEIVE) for t in els(root, "intermediateThrowEvent")):
+        fail("Maestro.ReceiveMessageEvent must be on an intermediate catch event, not a throw")
 
     throw, catch = throws[0], catches[0]
 
@@ -79,12 +102,12 @@ def main() -> None:
 
     # If both declare a messageRef, they must resolve to the same declared message.
     def message_ref(el):
-        med = el.find("bpmn:messageEventDefinition", NS)
+        med = child(el, "messageEventDefinition")
         return attr(med, "messageRef")
 
     send_ref, recv_ref = message_ref(throw), message_ref(catch)
     if send_ref and recv_ref:
-        declared = {attr(m, "id") for m in root.findall("bpmn:message", NS)}
+        declared = {attr(m, "id") for m in els(root, "message")}
         if send_ref not in declared or recv_ref not in declared:
             fail(f"messageRef(s) {send_ref!r}/{recv_ref!r} do not resolve to a declared bpmn:message")
         if send_ref != recv_ref:

--- a/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/check_message_send_receive_pair.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/check_message_send_receive_pair.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Structural check for the correlated internal-message send/receive pair.
+
+Asserts:
+  - a bpmn:intermediateThrowEvent hosting the registry Maestro.SendMessageEvent
+    wrapper with a bpmn:messageEventDefinition;
+  - a bpmn:intermediateCatchEvent hosting the registry Maestro.ReceiveMessageEvent
+    wrapper with a bpmn:messageEventDefinition;
+  - a shared/consistent message reference between the two — the uipath:context
+    `name` input value matches (the internal-message correlation key), and where
+    a messageRef is present on both, it resolves to the same declared message;
+  - DI shapes for both events.
+Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+SEND = "Maestro.SendMessageEvent"
+RECEIVE = "Maestro.ReceiveMessageEvent"
+
+
+def has_type(el: ET.Element, token: str) -> bool:
+    return token in ET.tostring(el, encoding="unicode")
+
+
+def context_name(el: ET.Element) -> str:
+    for inp in el.findall(".//uipath:context/uipath:input", NS):
+        if attr(inp, "name") == "name":
+            return attr(inp, "value")
+    return ""
+
+
+def main() -> None:
+    path, root = parse_bpmn("OrderCoordination")
+
+    throws = [
+        t for t in elements(root, "intermediateThrowEvent")
+        if has_type(t, SEND) and t.find("bpmn:messageEventDefinition", NS) is not None
+    ]
+    catches = [
+        c for c in elements(root, "intermediateCatchEvent")
+        if has_type(c, RECEIVE) and c.find("bpmn:messageEventDefinition", NS) is not None
+    ]
+    if not throws:
+        fail("no bpmn:intermediateThrowEvent with Maestro.SendMessageEvent and a messageEventDefinition")
+    if not catches:
+        fail("no bpmn:intermediateCatchEvent with Maestro.ReceiveMessageEvent and a messageEventDefinition")
+
+    # Wrong-host guards: the send must not be a catch, the receive must not be a throw.
+    if any(has_type(c, SEND) for c in elements(root, "intermediateCatchEvent")):
+        fail("Maestro.SendMessageEvent must be on an intermediateThrowEvent, not a catch")
+    if any(has_type(t, RECEIVE) for t in elements(root, "intermediateThrowEvent")):
+        fail("Maestro.ReceiveMessageEvent must be on an intermediateCatchEvent, not a throw")
+
+    throw, catch = throws[0], catches[0]
+
+    # Consistent correlation reference via the context `name`.
+    send_name = context_name(throw)
+    recv_name = context_name(catch)
+    if not send_name or not recv_name:
+        fail("send/receive missing a uipath:context name (no correlation reference)")
+    if send_name != recv_name:
+        fail(f"send/receive message names differ ({send_name!r} vs {recv_name!r}); not a correlated pair")
+
+    # If both declare a messageRef, they must resolve to the same declared message.
+    def message_ref(el):
+        med = el.find("bpmn:messageEventDefinition", NS)
+        return attr(med, "messageRef")
+
+    send_ref, recv_ref = message_ref(throw), message_ref(catch)
+    if send_ref and recv_ref:
+        declared = {attr(m, "id") for m in root.findall("bpmn:message", NS)}
+        if send_ref not in declared or recv_ref not in declared:
+            fail(f"messageRef(s) {send_ref!r}/{recv_ref!r} do not resolve to a declared bpmn:message")
+        if send_ref != recv_ref:
+            fail(f"send/receive messageRefs differ ({send_ref!r} vs {recv_ref!r})")
+
+    # DI shapes for both events.
+    shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+    for ev in (throw, catch):
+        if attr(ev, "id") not in shaped:
+            fail(f"message event {attr(ev, 'id')} has no BPMNShape")
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} pairs a Maestro send and receive message event on a consistent reference {send_name!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/message_send_receive_pair.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/message_send_receive_pair/message_send_receive_pair.yaml
@@ -1,0 +1,80 @@
+task_id: skill-bpmn-message-send-receive-pair
+description: >
+  Structural advanced-event eval: agent uses the uipath-maestro-bpmn skill to
+  author a correlated internal-message pair — a Maestro.SendMessageEvent
+  (intermediateThrow) followed by a Maestro.ReceiveMessageEvent (intermediateCatch)
+  that share a consistent message reference. Exercises registry-driven authoring
+  of the Maestro internal-message wrappers. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate", "feature:trigger"]
+
+run_limits:
+  expected_turns: 20
+  max_turns: 80
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `OrderCoordination.bpmn` in the working
+  directory that signals and awaits an internal message:
+    - a manual start,
+    - a task that prepares an order packet,
+    - a Maestro.SendMessageEvent on a bpmn:intermediateThrowEvent that signals
+      the order is ready,
+    - a Maestro.ReceiveMessageEvent on a bpmn:intermediateCatchEvent that awaits
+      that same message,
+    - an end event.
+
+  Requirements:
+  - Discover the Maestro.SendMessageEvent and Maestro.ReceiveMessageEvent types
+    via the registry and author each node from its registry xmlTemplate — do not
+    hand-author uipath:* XML from prose. The send wrapper goes on an
+    intermediateThrowEvent, the receive wrapper on an intermediateCatchEvent, and
+    each carries a bpmn:messageEventDefinition.
+  - The two events MUST share a consistent message reference (the same message
+    name / correlation key) so the receive matches the send.
+  - Structural BPMN (sequence flows, the scaffold) comes from the skill's
+    structural reference. Include a bpmndi:BPMNDiagram with a BPMNShape for every
+    node (including both message events) and a BPMNEdge for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "OrderCoordination.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN has a diagram and both Maestro internal-message wrapper types"
+    path: "OrderCoordination.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "Maestro.SendMessageEvent"
+      - "Maestro.ReceiveMessageEvent"
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Send/receive wrappers on the right host events share a consistent message reference, fully shaped"
+    command: "python3 $TASK_DIR/check_message_send_receive_pair.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/check_timer_boundary_noninterrupting.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/check_timer_boundary_noninterrupting.py
@@ -8,7 +8,11 @@ host task:
   - attachedToRef resolves to a userTask;
   - a valid non-week ISO-8601 timer duration (or an expression);
   - a DI shape for the boundary event and an outgoing flow.
-Reuses the shared uipath-maestro-bpmn check helpers.
+
+Element lookups are case-insensitive on the BPMN local name: registry
+xmlTemplates emit capitalized element names (e.g. bpmn:UserTask for
+Actions.HITL) while hand-authored structural BPMN uses the lowercase-camel
+spec names. Reuses the shared uipath-maestro-bpmn check helpers.
 """
 
 from __future__ import annotations
@@ -16,30 +20,51 @@ from __future__ import annotations
 import os
 import re
 import sys
+import xml.etree.ElementTree as ET
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
 from _shared.bpmn_check import (  # noqa: E402
     NS,
     attr,
-    elements,
     fail,
     parse_bpmn,
     require_di_for_visible_elements,
     require_sequence_integrity,
 )
 
+BPMN_NS = NS["bpmn"]
+
+
+def els(root: ET.Element, kind: str) -> list[ET.Element]:
+    """Case-insensitive BPMN element lookup by local name."""
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    return [
+        el for el in root.iter()
+        if el.tag.startswith(prefix) and el.tag[len(prefix):].lower() == kl
+    ]
+
+
+def child(el: ET.Element, kind: str) -> ET.Element | None:
+    prefix = "{" + BPMN_NS + "}"
+    kl = kind.lower()
+    for c in el:
+        if c.tag.startswith(prefix) and c.tag[len(prefix):].lower() == kl:
+            return c
+    return None
+
 
 def main() -> None:
     path, root = parse_bpmn("ApprovalReminder")
 
-    user_task_ids = {attr(t, "id") for t in elements(root, "userTask")}
+    user_task_ids = {attr(t, "id") for t in els(root, "userTask")}
     if not user_task_ids:
         fail("no userTask to attach a reminder timer to")
-    flows = elements(root, "sequenceFlow")
+    flows = els(root, "sequenceFlow")
 
     timer_boundaries = [
-        be for be in elements(root, "boundaryEvent")
-        if be.find("bpmn:timerEventDefinition", NS) is not None
+        be for be in els(root, "boundaryEvent")
+        if child(be, "timerEventDefinition") is not None
     ]
     if not timer_boundaries:
         fail("no timer boundary event (boundaryEvent with a bpmn:timerEventDefinition)")
@@ -53,12 +78,10 @@ def main() -> None:
         attached = attr(be, "attachedToRef")
         if attached not in user_task_ids:
             fail(f"non-interrupting timer boundary {be_id} attachedToRef {attached!r} is not a userTask")
-        tdef = be.find("bpmn:timerEventDefinition", NS)
-        dur = tdef.find("bpmn:timeDuration", NS)
-        date = tdef.find("bpmn:timeDate", NS)
-        cycle = tdef.find("bpmn:timeCycle", NS)
+        tdef = child(be, "timerEventDefinition")
         spec = None
-        for el in (dur, date, cycle):
+        for kind in ("timeDuration", "timeDate", "timeCycle"):
+            el = child(tdef, kind)
             if el is not None and (el.text or "").strip():
                 spec = el.text.strip()
                 break

--- a/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/check_timer_boundary_noninterrupting.py
+++ b/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/check_timer_boundary_noninterrupting.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Structural check for the non-interrupting timer boundary event.
+
+Asserts a timer boundary event that reminds/escalates WITHOUT cancelling the
+host task:
+  - a boundaryEvent with a bpmn:timerEventDefinition;
+  - cancelActivity="false" (non-interrupting);
+  - attachedToRef resolves to a userTask;
+  - a valid non-week ISO-8601 timer duration (or an expression);
+  - a DI shape for the boundary event and an outgoing flow.
+Reuses the shared uipath-maestro-bpmn check helpers.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "..")))
+from _shared.bpmn_check import (  # noqa: E402
+    NS,
+    attr,
+    elements,
+    fail,
+    parse_bpmn,
+    require_di_for_visible_elements,
+    require_sequence_integrity,
+)
+
+
+def main() -> None:
+    path, root = parse_bpmn("ApprovalReminder")
+
+    user_task_ids = {attr(t, "id") for t in elements(root, "userTask")}
+    if not user_task_ids:
+        fail("no userTask to attach a reminder timer to")
+    flows = elements(root, "sequenceFlow")
+
+    timer_boundaries = [
+        be for be in elements(root, "boundaryEvent")
+        if be.find("bpmn:timerEventDefinition", NS) is not None
+    ]
+    if not timer_boundaries:
+        fail("no timer boundary event (boundaryEvent with a bpmn:timerEventDefinition)")
+
+    valid = False
+    for be in timer_boundaries:
+        be_id = attr(be, "id")
+        # Non-interrupting: cancelActivity MUST be explicitly "false".
+        if attr(be, "cancelActivity") != "false":
+            continue
+        attached = attr(be, "attachedToRef")
+        if attached not in user_task_ids:
+            fail(f"non-interrupting timer boundary {be_id} attachedToRef {attached!r} is not a userTask")
+        tdef = be.find("bpmn:timerEventDefinition", NS)
+        dur = tdef.find("bpmn:timeDuration", NS)
+        date = tdef.find("bpmn:timeDate", NS)
+        cycle = tdef.find("bpmn:timeCycle", NS)
+        spec = None
+        for el in (dur, date, cycle):
+            if el is not None and (el.text or "").strip():
+                spec = el.text.strip()
+                break
+        if spec is None:
+            fail(f"timer boundary {be_id} has no timeDuration/timeDate/timeCycle value")
+        if not (spec.startswith("=") or spec.startswith("@")):
+            if re.search(r"\dW", spec, re.IGNORECASE) or "P" in spec and re.search(r"W", spec):
+                fail(f"timer boundary {be_id} uses an unsupported ISO-8601 week designator: {spec!r}")
+            if not spec.startswith("P"):
+                fail(f"timer boundary {be_id} duration {spec!r} is not a valid ISO-8601 duration/date")
+        if not [f for f in flows if attr(f, "sourceRef") == be_id]:
+            fail(f"timer boundary {be_id} has no outgoing flow (nothing happens on the reminder)")
+        shaped = {s.attrib.get("bpmnElement") for s in root.findall(".//bpmndi:BPMNShape", NS)}
+        if be_id not in shaped:
+            fail(f"timer boundary {be_id} has no BPMNShape")
+        valid = True
+    if not valid:
+        fail('no non-interrupting (cancelActivity="false") timer boundary attached to a userTask')
+
+    require_sequence_integrity(root)
+    require_di_for_visible_elements(root)
+    print(f"OK: {path} has a non-interrupting timer boundary on a userTask that does not cancel it")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/timer_boundary_nonint.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/structural/timer_boundary_nonint/timer_boundary_nonint.yaml
@@ -1,0 +1,77 @@
+task_id: skill-bpmn-timer-boundary-noninterrupting
+description: >
+  Structural advanced-event eval: agent uses the uipath-maestro-bpmn skill to
+  attach a NON-INTERRUPTING timer boundary event (cancelActivity="false") to a
+  userTask — a reminder/escalation timer that fires without cancelling the task.
+  Exercises the boundary attachedToRef/cancelActivity contract and timer
+  duration validity. Authoring only — no cloud effects.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:generate"]
+
+run_limits:
+  expected_turns: 18
+  max_turns: 70
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+
+initial_prompt: |
+  Load and follow the uipath-maestro-bpmn skill.
+
+  Author a single Maestro BPMN file `ApprovalReminder.bpmn` in the working
+  directory:
+    - a manual start,
+    - a userTask where a human reviews and approves a request,
+    - a NON-INTERRUPTING timer boundary event (cancelActivity="false") attached
+      to that userTask with a valid ISO-8601 duration (e.g. PT1H; week
+      designators PnW are unsupported),
+    - when the userTask completes it flows to a normal end event; when the timer
+      fires it routes to a reminder task and its own end event WITHOUT cancelling
+      the userTask.
+
+  Requirements:
+  - Discover any UiPath extension node's type via the registry and author it from
+    the registry template — do not hand-author uipath:* XML from prose. Structural
+    BPMN (boundary event attachedToRef/cancelActivity, timerEventDefinition,
+    sequence flows) comes from the skill's structural reference.
+  - Include a bpmndi:BPMNDiagram with a BPMNShape for every node (including the
+    boundary event) and a BPMNEdge for every sequence flow.
+  - Validate the file locally before finishing (the bundled validator, or a
+    well-formed-XML parse plus the structural checklist).
+
+  Do NOT upload, publish, deploy, debug, run, or pack anything. Do NOT ask for
+  approval, confirmation, or feedback, and do NOT pause between planning and
+  implementation. Build the complete file end-to-end in a single pass.
+
+success_criteria:
+  - type: file_exists
+    description: "BPMN source was authored"
+    path: "ApprovalReminder.bpmn"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not run any cloud-side Maestro BPMN lifecycle command"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run|pack)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "BPMN has a diagram, a timer boundary, and a non-interrupting cancelActivity"
+    path: "ApprovalReminder.bpmn"
+    includes:
+      - "bpmndi:BPMNDiagram"
+      - "timerEventDefinition"
+      - 'cancelActivity="false"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Non-interrupting timer boundary on a userTask does not cancel it, fully shaped"
+    command: "python3 $TASK_DIR/check_timer_boundary_noninterrupting.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 4.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds 6 new `integration` coder_eval tasks for `uipath-maestro-bpmn` covering **structural error-handling and advanced events** — build-mode, locally validated (no cloud effects). New leaf dirs under `tests/tasks/uipath-maestro-bpmn/structural/`.

| # | task_id | Construct under test | Structural grade |
|---|---------|----------------------|------------------|
| 1 | `skill-bpmn-error-event-subprocess` | Error END event (errorRef→errorCode) caught by an EVENT subprocess (`triggeredByEvent="true"`, single interrupting error start) | errorRef resolves to a coded `bpmn:error`; event-subprocess single interrupting error start; subprocess DI shape |
| 2 | `skill-bpmn-error-boundary-handler` | Interrupting ERROR boundary (`cancelActivity="true"`, configured code) on a service-call task → recovery path | `attachedToRef`→task-like activity; errorCode set; guards duplicate catch-all boundaries |
| 3 | `skill-bpmn-timer-boundary-noninterrupting` | NON-INTERRUPTING timer boundary (`cancelActivity="false"`) on a userTask | timer boundary `cancelActivity="false"` + `attachedToRef`→userTask + valid non-week ISO-8601 |
| 4 | `skill-bpmn-event-based-gateway` | EVENT-BASED gateway racing a message catch vs a timer catch | `eventBasedGateway` ≥2 outgoing to intermediate catch events (one message, one timer); DI edges |
| 5 | `skill-bpmn-inclusive-gateway-forkjoin` | INCLUSIVE (OR) split with conditioned branches + real inclusive join | two `inclusiveGateway`s (split+join), conditions on split branches, no FAKE_JOIN / SUPERFLUOUS_GATEWAY |
| 6 | `skill-bpmn-message-send-receive-pair` | Correlated `Maestro.SendMessageEvent` (throw) → `Maestro.ReceiveMessageEvent` (catch) | both wrapper types on the right host events + consistent message reference; DI for both |

## How each is graded

Each task grades on deterministic side effects — no self-reports, no `llm_judge`:
- `file_exists` (1.5) + `command_not_executed` guard against cloud lifecycle (1.0) + `file_contains` on key markers (2.0)
- `run_command` structural check script (**4.0**) using `xml.etree.ElementTree` + the shared `_shared/bpmn_check.py` helpers (exact attribute asserts, DI + sequence-flow integrity).

Prompts are local-only (forbid upload/publish/deploy/debug/run/pack and pausing) and registry-driven (agent discovers any `uipath:*` node from the registry, authors structural BPMN from the skill's reference, emits full `bpmndi`).

## Local verification (why this should go green first-try)

For every task a gold `.bpmn` was hand-authored and:
1. **passes the bundled validator** (`node validate-bpmn.mjs` → `VALID`, exit 0) — all 6 green;
2. the check script **passes on the gold and fails on a targeted mutation** (removed errorRef, flipped `cancelActivity`, dropped a branch condition, mismatched message correlation, wrong host event, etc.);
3. the check passes even with the skill dir overlaid into CWD (unique name-hints disambiguate the agent's file from the skill's fixture `.bpmn`s).

`/lint-task` clean on all 6 (no self-report, strong coverage, not gameable, distinct constructs, no `env_packages`, `run_limits` top-level, CLI-verb check clean).

Passing run: https://github.com/UiPath/skills/actions/runs/29516680703 — **6/6 SUCCESS, weighted score 1.0 on every task.**

CI iterations: 2. Run 1 ([29515406602](https://github.com/UiPath/skills/actions/runs/29515406602), 4/6) exposed two check-strictness bugs, not skill gaps: registry xmlTemplates emit capitalized BPMN element names (`bpmn:IntermediateThrowEvent`) and host HTTP calls on `bpmn:sendTask` (`Intsvc.UnifiedHttpRequest`), while the checks matched lowercase names and demanded a `serviceTask` host. Fixed by case-insensitive local-name lookups + accepting any task-like activity as the boundary host (verified against the run-1 agent artifacts before re-dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
