### PR TITLE
test(maestro-case): registry-handoff checker requires exact-name match present, not all-exact

### DIFF
--- a/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/check_registry_handoff.py
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/check_registry_handoff.py
@@ -105,10 +105,14 @@ for resource_name, expected in EXPECTED.items():
         # registry-resolved.json records a normalized/trimmed audit shape, not the raw cache
         # object — compare on stable identity (name + id), never deep-equality.
         assert recorded, f"{resource_name} audit recorded no matches"
-        assert all(
+        # Discovery search is substring-based, so `matches` may carry near-name candidates
+        # alongside the exact hit. Correctness is proven by `selected` below (exact-name +
+        # live id); here we only require the exact-name match to be PRESENT among the
+        # recorded candidates, not that every candidate is exact.
+        assert any(
             str(m.get(name_field, "")).strip().casefold() == resource_name.casefold()
             for m in recorded
-        ), f"{resource_name} audit recorded a non-exact-name match"
+        ), f"{resource_name} audit recorded no exact-name match"
         assert (
             isinstance(selected, dict)
             and str(selected.get(name_field, "")).strip().casefold() == resource_name.casefold()

--- a/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/check_registry_handoff.py
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/check_registry_handoff.py
@@ -92,9 +92,13 @@ for name, expected in EXPECTED.items():
     # byte copy of the whole cache set.
     recorded = entry.get("matches") or []
     assert recorded, f"{name} audit recorded no matches"
-    assert all(
+    # The skill's discovery search is substring-based, so `matches` may carry near-name
+    # candidates (e.g. a `<name>V2` sibling) alongside the exact hit. Correctness is proven
+    # by `selected` below (exact-name + live entityKey); here we only require the exact-name
+    # match to be PRESENT among the recorded candidates, not that every candidate is exact.
+    assert any(
         str(m.get("name", "")).strip().casefold() == name.casefold() for m in recorded
-    ), f"{name} audit recorded a non-exact-name match"
+    ), f"{name} audit recorded no exact-name match"
     assert isinstance(selected, dict), f"missing selected result for {name}"
     assert (
         str(selected.get("name", "")).strip().casefold() == name.casefold()

--- a/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/check_registry_handoff.py
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/check_registry_handoff.py
@@ -84,9 +84,13 @@ for name, expected in EXPECTED.items():
     # (name + entityKey), never deep-equality against the raw cache object.
     recorded = entry.get("matches") or []
     assert recorded, f"{name} audit recorded no matches"
-    assert all(
+    # The skill's discovery search is substring-based, so `matches` may carry near-name
+    # candidates (e.g. a `<name>V2` sibling) alongside the exact hit. Correctness is proven
+    # by `selected` below (exact-name + live entityKey); here we only require the exact-name
+    # match to be PRESENT among the recorded candidates, not that every candidate is exact.
+    assert any(
         str(m.get("name", "")).strip().casefold() == name.casefold() for m in recorded
-    ), f"{name} audit recorded a non-exact-name match"
+    ), f"{name} audit recorded no exact-name match"
 
     selected = entry.get("selected")
     assert isinstance(selected, dict), f"missing selected result for {name}"


### PR DESCRIPTION
## Summary

Fixes the `skill-case-registry-handoff-stale-runnable` false failure on the 2026-07-16 nightly (introduced by #2032). The agent behaved correctly — it discarded the stale registry cache and re-resolved the runnable tasks to the live exact entries — but the deterministic checker rejected the result on an over-strict audit-shape assertion.

## Root cause

All three registry-handoff checkers asserted that **every** entry in the audit's `matches` array is an exact-name match:

```python
assert all(str(m.get("name","")).strip().casefold() == name.casefold() for m in recorded)
```

But the skill's registry discovery search is **substring-based** (`references/registry-discovery.md`: `if '<name>' in name`). On any tenant that also contains a near-name sibling (e.g. `FinancialPostingFunctionV2`), a correctly-behaving agent records that sibling in `matches` alongside the exact hit, and `all(...)` fails — even though the re-resolution the test exists to verify succeeded.

Board traceback:

```
File ".../registry_handoff_stale_runnable/check_registry_handoff.py", line 87
    assert all( ... )
AssertionError: FinancialPostingFunction audit recorded a non-exact-name match
```

The task was **added in #2032 but never behaviorally executed** (not in that PR's Test Coverage table; behavioral runs for the runnable-branch tasks were deferred), so the brittleness went undetected until the first nightly.

## Fix

Relax `all(...)` → `any(...)` in all three handoff checkers: require the exact-name match to be **present** among the recorded candidates, tolerating extra substring candidates. Correctness stays fully enforced by the existing `selected` assertions (exact-name + live `entityKey`, not the stale identity, not a debug-solution deploy). This also aligns the test with the repo's "grade behavior, not audit-log shape" rule.

Files (identical one-line change + comment in each):
- `registry_handoff_stale_runnable/check_registry_handoff.py`
- `registry_handoff_sdd_only/check_registry_handoff.py`
- `registry_handoff_action_case_sdd_only/check_registry_handoff.py`

## Verification

Deterministic A/B against a seeded cache that reproduces the exact board scenario (`matches` = exact hit + substring sibling):

| Scenario | old (`all`) | new (`any`) |
|---|---|---|
| Correct re-resolution, `matches` has exact + substring sibling (board case) | exit 1 (reproduces `non-exact-name match`) | **exit 0** |
| Audit missing the exact-name match (genuinely wrong) | exit 1 | exit 1 (`no exact-name match`) |

A full live `coder-eval run` was not executed locally: this is a live-tenant test and the available tenant does not contain `FinancialPostingFunction` / `EmailDrafter`, so a local run aborts at the checker precondition regardless of this change. The next nightly (resourced tenant) confirms end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)