### PR TITLE
fix(maestro-case-tests): tolerate non-idempotent second resources refresh in start_debug

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -451,12 +451,19 @@ def start_debug(
         "--solution-folder", solution_dir,
         "--output", "json",
     ]
+    already_refreshed = os.path.isdir(os.path.join(solution_dir, "resources"))
     r = subprocess.run(refresh_cmd, capture_output=True, text=True, timeout=refresh_timeout)
     if r.returncode != 0:
-        _fail(
-            f"solution resources refresh exit {r.returncode}\n"
-            f"stdout: {r.stdout}\nstderr: {r.stderr}"
-        )
+        # CLI 1.197-alpha: refresh is not idempotent — re-running it over its own
+        # output fails with "Node already added to the graph" (RetryWillNotFix).
+        # When the agent already refreshed, the resource docs are on disk and debug
+        # can proceed; only that exact re-refresh failure is tolerated.
+        duplicate_node = "Node already added to the graph" in (r.stdout + r.stderr)
+        if not (already_refreshed and duplicate_node):
+            _fail(
+                f"solution resources refresh exit {r.returncode}\n"
+                f"stdout: {r.stdout}\nstderr: {r.stderr}"
+            )
 
     debug_cmd = [
         "uip", "maestro", "case", "debug", project_dir,


### PR DESCRIPTION
## Why

`skill-case-e2e-expense-runnable` failed on 2026-07-16 (score 0.600, 3/4 criteria) even though the case was fully sound — `validate` passed and the structure checker passed with all bindings resolved to real tenant resources.

Root cause: on CLI `1.197.0-alpha.20260626`, `uip solution resources refresh` is **not idempotent**. The agent ran refresh during its turn (skill Rule 14), materializing resource docs under `<Solution>/resources/solution_folder/` (including the Payment Tracking child-case pair). The harness then re-ran refresh inside `start_debug`, and the second refresh failed with `Node already added to the graph` (`RetryWillNotFix`) in ResourceBuilder's ReconcileProjects — killing the e2e criterion before `case debug` ever ran.

## What

`_shared/case_check.py::start_debug` now tolerates exactly that failure: refresh exit != 0 is ignored **only when** a prior refresh output (`<solution_dir>/resources/`) already exists **and** the output contains `Node already added to the graph` — the resource docs are already on disk, so debug can proceed. Any other refresh failure still fails hard. `already_refreshed` is captured before the refresh runs, so a genuinely failed first refresh is never masked.

The underlying CLI idempotency regression should be filed against solution-tool separately; this change unblocks the eval regardless of agent refresh behavior.

## Verification

- `_shared/test_case_check.py`: 6 passed
- **Passing coder-eval run on this branch:** [run 29531223581](https://github.com/UiPath/skills/actions/runs/29531223581) — `skill-case-e2e-expense-runnable: SUCCESS`, 4/4 criteria, score **1.000**, `debug finalStatus=Completed` end-to-end (vs 3/4 / 0.600 on the failing 07-16 run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
