### PR TITLE
fix(uipath-platform): run queue/trigger seed e2e under docker, not tempdir

### DIFF
--- a/tests/tasks/uipath-platform/resources/queue_progress_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/queue_progress_e2e.yaml
@@ -11,8 +11,13 @@ agent:
   type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
+# driver: docker (NOT tempdir): the seed's `uip or folders` needs
+# @uipath/orchestrator-tool, pre-baked into skills-image:latest. In tempdir the
+# CLI must auto-install it at runtime, which fails on a prerelease CLI (resolves
+# on `stable`, no stable build on its line — UiPath/cli#3083), so the seed dies
+# before the task starts. role-lifecycle-e2e runs the same seed under docker.
 sandbox:
-  driver: tempdir
+  driver: docker
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-platform/resources/trigger_api_e2e.yaml
+++ b/tests/tasks/uipath-platform/resources/trigger_api_e2e.yaml
@@ -13,8 +13,13 @@ agent:
   type: claude-code
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
+# driver: docker (NOT tempdir): the seed's `uip or folders` needs
+# @uipath/orchestrator-tool, pre-baked into skills-image:latest. In tempdir the
+# CLI must auto-install it at runtime, which fails on a prerelease CLI (resolves
+# on `stable`, no stable build on its line — UiPath/cli#3083), so the seed dies
+# before the task starts. role-lifecycle-e2e runs the same seed under docker.
 sandbox:
-  driver: tempdir
+  driver: docker
   python: {}
 
 pre_run:


### PR DESCRIPTION
## What & why

`skill-platform-queue-progress-e2e` and `skill-platform-trigger-api-e2e` fail their pre-run (`seed.py`) every run with:

```
No compatible version of '@uipath/orchestrator-tool' found for the CLI's 1.197.x line on npm or GitHub Packages.
```

Root cause is the `sandbox.driver`, not the seed. Both tasks set `driver: tempdir`, which runs on a bare host with **no pre-baked tool plugins**. `seed.py` calls `uip or folders`, so the CLI tries to auto-install `@uipath/orchestrator-tool` at runtime — which fails on the prerelease CLI the eval installs (it resolves tools on `stable`, and there's no stable build on its prerelease-only line; see UiPath/cli#3083). The pre-run dies before the task starts → score 0, deterministically.

`skill-platform-role-lifecycle-e2e` runs the **same** `seed.py` but under the default docker driver, where `orchestrator-tool` is pre-baked — and it passes. That's the tell.

## The change

Switch both tasks to `driver: docker`, so the pre-baked `skills-image:latest` provides `orchestrator-tool` and the seed's `uip or` calls resolve with no runtime install. This matches the existing convention — the `uipath-ixp` e2e tasks already use `driver: docker` for exactly this reason (`uip ixp` is pre-baked, not resolvable in tempdir).

## Why this over the CLI fix

UiPath/cli#3083 fixes the underlying prerelease resolution bug, but it only reaches these tasks after it merges **and** a fixed build is published **and** the eval installs it. This change fixes the two seed failures directly, now, with no cross-repo dependency. (#3083 is still worth landing as a real product bug.)

Verified by inspecting the 2026-07-15 run: of 778 tasks, only these two hit the error — the only two that both (a) run `seed.py`'s `uip or` in pre-run and (b) use `driver: tempdir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)