### PR TITLE
fix(uipath-feedback): send description via --description-file, not inline multi-line arg [PILOT-6404]

### DIFF
--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -292,26 +292,32 @@ The user can adjust type, priority, or title (the title carries the area / optio
 
 ### Step 4 -- Send feedback
 
+**Never inline the multi-line description as a `--description "…"` argument.** On Windows PowerShell the native-command argument serializer mangles multi-line values (lines starting with `-` reach the CLI as options → `ValidationError`). Always pass the body through `--description-file`.
+
+1. Write the sanitized description body to a temp file using the **Write tool** (not a shell heredoc — heredocs are bash-only and fail on PowerShell). Use an absolute path in the OS temp dir, e.g. `<temp>/uip-feedback/description.md`.
+2. Invoke the CLI with `--description-file` pointing at that file:
+
 ```bash
 uip feedback send \
   --type "<bug|improvement>" \
   --title "<TITLE>" \
-  --description "$(cat <<'FEEDBACK_EOF'
-<DESCRIPTION_BODY>
-FEEDBACK_EOF
-)" \
+  --description-file "<TEMP>/uip-feedback/description.md" \
   --priority "<critical|normal|minor>" \
   --attachment <FILE1> <FILE2> \
   --output json
 ```
 
-The title's leading `[Tag]` segments (the area, plus an optional `[CLI]`/`[Skill]` marker) become Jira labels automatically -- no extra flags.
+`--description-file` reads the body from disk, so it is immune to shell quoting and works identically on PowerShell, cmd, and bash. (If the CLI predates this flag, pipe the body via stdin instead; do not inline it.)
+
+The title (`--title`) is short and single-line, so passing it inline is safe. Its leading `[Tag]` segments (the area, plus an optional `[CLI]`/`[Skill]` marker) become Jira labels automatically -- no extra flags.
 
 If an email is available from `uip login status`, include `--email "<EMAIL>"`. The CLI places it in the issue's Environment field, never in the description body.
 
 Parse the JSON output. On success, show the user a confirmation with any reference ID returned.
 
-**Fallback:** If `uip feedback send` fails (network, auth, CLI error), save the full feedback to `./feedback-report.md` using the description body and tell the user: _"Could not send automatically. The report is saved to `feedback-report.md`."_
+**Diagnose failures correctly.** A `ValidationError` that names an option you did not pass (e.g. it complains about `-` or a bullet line) is a **shell-quoting** failure, not a CLI bug — you inlined a multi-line value. Fix it by using `--description-file`; do not report the CLI as broken and do not retry the same inline invocation.
+
+**Fallback:** Only after `--description-file` genuinely fails (network, auth, real CLI error) save the full feedback to `./feedback-report.md` using the description body and tell the user: _"Could not send automatically. The report is saved to `feedback-report.md`."_
 
 Clean up temp attachments:
 


### PR DESCRIPTION
## Why

The `uipath-feedback` skill's Step 4 built the CLI call with a **bash-only heredoc** (`$(cat <<'FEEDBACK_EOF' … )`). On Windows PowerShell that syntax doesn't exist, and inlining the multi-line markdown as `--description "…"` is mangled by PS 5.1's native-argument serializer (bullet lines become options → `ValidationError`). The agent then retried five variants of the same broken pattern, misdiagnosed it as a CLI bug, and silently fell back to writing `feedback-report.md` — the feedback was never sent. This is **[PILOT-6404]**.

## What

- Step 4 now writes the sanitized description body to a temp file with the **Write tool** (no shell heredoc — cross-shell) and passes **`--description-file`**, which is immune to shell quoting on PowerShell, cmd, and bash.
- Added a note to **diagnose a shell-quoting `ValidationError` as such** instead of blaming the CLI or retrying the inline form.
- Clarified the local-file fallback is only for a genuine send failure, not a self-inflicted quoting error.

## Companion / ordering

Depends on the CLI adding `--description-file` (UiPath/cli#3129). That should merge/release first; the skill notes a stdin fallback for older CLIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PILOT-6404]: https://uipath.atlassian.net/browse/PILOT-6404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ