### PR TITLE
test(maestro-case): cover inline resource creation

### DIFF
--- a/tests/tasks/uipath-maestro-case/create_missing_agent/check_create_missing_agent.py
+++ b/tests/tasks/uipath-maestro-case/create_missing_agent/check_create_missing_agent.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Verify inline agent creation, validation, registration, and case I/O wiring."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CASE_TASK_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CASE_TASK_ROOT))
+
+from _shared.case_check import (  # noqa: E402
+    assert_tasks_nested,
+    assert_validate_passes,
+    find_tasks_of_type,
+    read_caseplan,
+    task_is_skeleton,
+)
+
+CASE_NAME = "CreateMissingAgentCase"
+RESOURCE_NAME = "InlineGreetingAgentQ74"
+CASEPLAN = Path(CASE_NAME) / CASE_NAME / "caseplan.json"
+SOLUTION = Path(CASE_NAME) / f"{CASE_NAME}.uipx"
+SIBLING = Path(CASE_NAME) / RESOURCE_NAME
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def load_json(path: Path) -> dict:
+    if not path.is_file():
+        fail(f"missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def one(items: list[dict], what: str) -> dict:
+    if len(items) != 1:
+        fail(f"expected exactly one {what}, got {len(items)}")
+    return items[0]
+
+
+def case_variable(plan: dict, name: str) -> dict:
+    variables = plan.get("variables") or {}
+    matches = [
+        item
+        for group in ("inputs", "outputs", "inputOutputs")
+        for item in variables.get(group) or []
+        if item.get("name") == name
+    ]
+    return one(matches, f"case variable named {name!r}")
+
+
+def resolve_binding(plan: dict, reference: object, property_name: str) -> dict:
+    prefix = "=bindings."
+    if not isinstance(reference, str) or not reference.startswith(prefix):
+        fail(f"task data.{property_name} is not a binding reference: {reference!r}")
+    binding_id = reference[len(prefix) :]
+    matches = [b for b in plan.get("bindings") or [] if b.get("id") == binding_id]
+    binding = one(matches, f"binding {binding_id!r}")
+    if binding.get("propertyAttribute") != property_name:
+        fail(
+            f"binding {binding_id!r} propertyAttribute is "
+            f"{binding.get('propertyAttribute')!r}, expected {property_name!r}"
+        )
+    return binding
+
+
+def assert_case_wiring(plan: dict) -> None:
+    task = one(find_tasks_of_type(plan, "agent"), "agent task")
+    if task_is_skeleton(task):
+        fail("agent task is an unresolved skeleton")
+
+    data = task.get("data") or {}
+    name_binding = resolve_binding(plan, data.get("name"), "name")
+    folder_binding = resolve_binding(plan, data.get("folderPath"), "folderPath")
+    expected_key = f"solution_folder.{RESOURCE_NAME}"
+    for binding in (name_binding, folder_binding):
+        if binding.get("resource") != "process":
+            fail(f"inline agent binding resource is {binding.get('resource')!r}")
+        if binding.get("resourceSubType") != "Agent":
+            fail(
+                "inline agent binding resourceSubType is "
+                f"{binding.get('resourceSubType')!r}"
+            )
+        if binding.get("resourceKey") != expected_key:
+            fail(
+                f"inline agent resourceKey is {binding.get('resourceKey')!r}, "
+                f"expected {expected_key!r}"
+            )
+    if name_binding.get("default") != RESOURCE_NAME:
+        fail(f"name binding default is {name_binding.get('default')!r}")
+    if folder_binding.get("default") != "":
+        fail(
+            "inline sibling folderPath must be the co-located empty string, got "
+            f"{folder_binding.get('default')!r}"
+        )
+
+    customer_var = case_variable(plan, "customerName")
+    greeting_var = case_variable(plan, "greeting")
+    customer_id = customer_var.get("id")
+    greeting_id = greeting_var.get("id")
+    if not customer_id or not greeting_id:
+        fail("customerName/greeting case variables must each have an id")
+
+    input_row = one(
+        [row for row in data.get("inputs") or [] if row.get("name") == "customerName"],
+        "customerName task input",
+    )
+    if input_row.get("type") != "string":
+        fail(f"customerName task input type is {input_row.get('type')!r}")
+    if input_row.get("value") != f"=vars.{customer_id}":
+        fail(
+            f"customerName input is {input_row.get('value')!r}, "
+            f"expected '=vars.{customer_id}'"
+        )
+
+    output_row = one(
+        [row for row in data.get("outputs") or [] if row.get("name") == "greeting"],
+        "greeting task output",
+    )
+    if output_row.get("type") != "string":
+        fail(f"greeting task output type is {output_row.get('type')!r}")
+    if output_row.get("source") != "=greeting":
+        fail(f"greeting output source is {output_row.get('source')!r}")
+    if output_row.get("var") != greeting_id:
+        fail(
+            f"greeting output var is {output_row.get('var')!r}, "
+            f"expected case variable id {greeting_id!r}"
+        )
+    if output_row.get("originalVar") != "greeting":
+        fail("greeting extraction is missing originalVar='greeting'")
+
+
+def assert_sibling_contract() -> None:
+    project = load_json(SIBLING / "project.uiproj")
+    if project.get("ProjectType") != "Agent":
+        fail(f"sibling ProjectType is {project.get('ProjectType')!r}, expected 'Agent'")
+    if not list(SIBLING.rglob("agent.json")):
+        fail(f"no agent.json found under {SIBLING}")
+
+    entry_points = load_json(SIBLING / "entry-points.json")
+    entry = one(entry_points.get("entryPoints") or [], "agent entry point")
+    input_schema = entry.get("input") or {}
+    output_schema = entry.get("output") or {}
+    input_props = input_schema.get("properties") or {}
+    output_props = output_schema.get("properties") or {}
+    if (input_props.get("customerName") or {}).get("type") != "string":
+        fail("agent entry point does not expose customerName:string")
+    if "customerName" not in (input_schema.get("required") or []):
+        fail("agent entry point does not require customerName")
+    if (output_props.get("greeting") or {}).get("type") != "string":
+        fail("agent entry point does not expose greeting:string")
+
+    solution = load_json(SOLUTION)
+    projects = solution.get("Projects") or []
+    expected_suffix = f"{RESOURCE_NAME}/project.uiproj"
+    matches = [
+        project
+        for project in projects
+        if str(project.get("ProjectRelativePath", "")).replace("\\", "/").endswith(expected_suffix)
+    ]
+    registered = one(matches, f"solution project ending in {expected_suffix!r}")
+    if registered.get("Type") != "Agent":
+        fail(f"registered sibling Type is {registered.get('Type')!r}")
+
+    audit_path = Path("tasks/registry-resolved.json")
+    audit_text = audit_path.read_text().lower() if audit_path.is_file() else ""
+    if RESOURCE_NAME.lower() not in audit_text or '"local"' not in audit_text:
+        fail("registry-resolved.json does not record the local inline agent")
+
+
+def assert_sibling_validates() -> None:
+    result = subprocess.run(
+        ["uip", "agent", "validate", str(SIBLING), "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode != 0:
+        fail(
+            f"inline agent validation exit {result.returncode}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        fail(f"inline agent validation returned invalid JSON: {exc}")
+    data = payload.get("Data") or {}
+    if payload.get("Result") != "Success" or data.get("Status") != "Valid":
+        fail(f"inline agent validation did not report Valid: {payload!r}")
+
+
+def main() -> None:
+    plan = read_caseplan(str(CASEPLAN))
+    assert_tasks_nested(plan)
+    assert_validate_passes(str(CASEPLAN))
+    assert_case_wiring(plan)
+    assert_sibling_contract()
+    assert_sibling_validates()
+    print(
+        "OK: missing agent created inline, customerName:string -> "
+        "greeting:string is wired, and the sibling agent validates"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/create_missing_agent/create_missing_agent.yaml
+++ b/tests/tasks/uipath-maestro-case/create_missing_agent/create_missing_agent.yaml
@@ -1,0 +1,106 @@
+task_id: skill-case-create-missing-agent-inline-e2e
+description: >
+  Build a one-task Case Management project whose referenced agent is absent
+  from both the tenant and solution registries. Exercises the Rule 17 create
+  gate, Agent-tool delegation to the agent skill, sibling registration, a
+  pinned string input/output contract, case binding, and validation of both
+  the case and sibling agent project.
+tags:
+  - uipath-maestro-case
+  - e2e
+  - lifecycle:generate
+  - mode:build
+  - shape:single-node
+  - resource
+  - feature:registry
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite", "Agent"]
+  sdk_options:
+    max_thinking_tokens: 12000
+
+run_limits:
+  expected_turns: 180
+  task_timeout: 4800
+  max_turns: 260
+  turn_timeout: 3600
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  Build the approved `sdd.md` staged in this workspace as a UiPath Case
+  Management solution. The resource name is intentionally unique: exercise
+  the normal create-on-missing workflow and create the selected agent as an
+  in-solution sibling rather than substituting a similarly named tenant
+  resource or fabricating an identity.
+
+  Continue through planning, prototyping, implementation, and full case
+  validation. Do not debug, publish, upload, or deploy the solution. A case
+  with a sibling project cannot be exercised through case debug; the test
+  harness will verify the built sibling project and its wiring locally.
+
+  The `uip` CLI is available and authenticated. Before starting, load the
+  uipath-maestro-case skill and follow its workflow, including its interactive
+  create and phase gates.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-maestro-case skill"
+    skill_name: "uipath-maestro-case"
+    expected_skill: "uipath-maestro-case"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Case skill delegated the selected inline build through the Agent tool"
+    tool_name: "Agent"
+    require_success: true
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated case validates"
+    command: "uip maestro case validate CreateMissingAgentCase/CreateMissingAgentCase/caseplan.json --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Inline agent exists, validates, is registered, and is wired to the case"
+    command: "python3 $TASK_DIR/check_create_missing_agent.py"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+simulation:
+  enabled: true
+  persona: |
+    You are the solution designer who approved this tiny greeting case and
+    wants its missing agent built as an in-solution sibling.
+  goal: |
+    Build the case and its low-code greeting agent with customerName:string
+    wired into the agent and greeting:string wired back into the case.
+  constraints:
+    - "At the empty-registry gate, choose Create missing resources inline."
+    - "At the build-selection prompt, select InlineGreetingAgentQ74."
+    - "Choose Low-code when asked for the agent kind."
+    - "Approve the generated tasks.md plan without requesting design changes."
+    - "At the Phase 2 review gate, choose Skip publish and continue."
+    - "If asked to reconcile the pinned customerName/greeting contract, approve the minimal repair."
+    - "At the Phase 5 gate, choose Skip to Publish; do not run debug for a solution with a sibling project."
+    - "At the Phase 6 gate, choose Done. Never publish, upload, or deploy."
+    - "Do not choose placeholders, rename the resource, or add more I/O."
+    - "Keep replies short: one sentence or the requested option selection."
+  max_turns: 20
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/create_missing_agent/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/create_missing_agent/fixtures/sdd.md
@@ -1,0 +1,130 @@
+# SDD — CreateMissingAgentCase
+
+**Case Definition Blueprint** · Build one missing agent inline and wire a minimal string contract through the case.
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|----------|-------|
+| Case Name | CreateMissingAgentCase |
+| Case Description | Sends a customer name to a tiny inline greeting agent and stores its greeting. |
+| Case Identifier | Type: constant. Prefix: CMA |
+| Priority | Choiceset: Low, Medium, High — Default: Medium |
+| Case-Level SLA | — |
+| SLA Type | — |
+| Case App | Disabled |
+| Task-output passing | Direct |
+
+### Case-Level SLA Escalation Rules
+
+> None.
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|----|--------------|--------|---------------|
+| T02 | Manual | User-initiated | N/A |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|------|-----|------|---------------------|--------------|
+| required-stages-completed | — | Case exited | Yes | Complete Rule 1 |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|------|----------|------|----------------|--------------|---------|-------------|
+| customerName | Variable | string | | | "Ada" | Name sent from the case to the agent. |
+| greeting | Variable | string | | | | Greeting returned by the agent. |
+
+---
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Greet Customer
+
+**Type:** Stage
+**Description:** Invoke the inline greeting agent.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| case-entered | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|----------------------|--------------|
+| required-tasks-completed | — | exit-only | Yes | Complete Rule 1 |
+
+#### Stage SLA
+
+> None.
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Generate Greeting | agent | Yes | Yes | system | — |
+
+##### Task 1.1: Generate Greeting
+
+**Type:** agent
+**Description:** Return a short greeting that includes the supplied customer name. No tools, connectors, or external data are needed.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| current-stage-entered | — | Entry Rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | Yes | — |
+
+###### Process / Agent / RPA / API Workflow Task Detail
+
+**Resolved Resource:** InlineGreetingAgentQ74
+**Folder Path:** <UNRESOLVED>
+**Resource Identity:** <UNRESOLVED>
+**Binding Sub-Type:** Agent
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| customerName | string | =vars.customerName |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|-------|------------------|
+| greeting | -> greeting |
+
+---
+
+## Section 3: Personas & App Views
+
+### Personas
+
+> None. The task is automated.
+
+### App Views
+
+> None. Case App is disabled.
+
+---
+
+## Section 4: Integrations
+
+### Agents
+
+| Agent | Folder | Resource ID (+version) | Inputs → Outputs | Used By Tasks |
+|-------|--------|------------------------|------------------|---------------|
+| InlineGreetingAgentQ74 | <UNRESOLVED> | <UNRESOLVED> | customerName → greeting | Generate Greeting |

--- a/tests/tasks/uipath-maestro-case/create_missing_api_workflow/check_create_missing_api_workflow.py
+++ b/tests/tasks/uipath-maestro-case/create_missing_api_workflow/check_create_missing_api_workflow.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Verify inline API creation, validation, registration, and case I/O wiring."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+CASE_TASK_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(CASE_TASK_ROOT))
+
+from _shared.case_check import (  # noqa: E402
+    assert_tasks_nested,
+    assert_validate_passes,
+    find_tasks_of_type,
+    read_caseplan,
+    task_is_skeleton,
+)
+
+CASE_NAME = "CreateMissingApiWorkflowCase"
+RESOURCE_NAME = "InlineGreetingApiQ74"
+SOLUTION = Path(CASE_NAME) / f"{CASE_NAME}.uipx"
+SIBLING = Path(CASE_NAME) / RESOURCE_NAME
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def load_json(path: Path) -> dict:
+    if not path.is_file():
+        fail(f"missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as exc:
+        fail(f"invalid JSON in {path}: {exc}")
+
+
+def one(items: list[dict], what: str) -> dict:
+    if len(items) != 1:
+        fail(f"expected exactly one {what}, got {len(items)}")
+    return items[0]
+
+
+def resolve_caseplan(solution: dict) -> Path:
+    case_project = one(
+        [
+            project
+            for project in solution.get("Projects") or []
+            if project.get("Type") == "CaseManagement"
+        ],
+        "CaseManagement solution project",
+    )
+    relative_path = case_project.get("ProjectRelativePath")
+    if not isinstance(relative_path, str) or not relative_path:
+        fail("CaseManagement project is missing ProjectRelativePath")
+    project_path = Path(CASE_NAME) / Path(relative_path.replace("\\", "/"))
+    if project_path.name != "project.uiproj":
+        fail(
+            "CaseManagement ProjectRelativePath must end in project.uiproj, got "
+            f"{relative_path!r}"
+        )
+    return project_path.parent / "caseplan.json"
+
+
+def case_variable(plan: dict, name: str) -> dict:
+    variables = plan.get("variables") or {}
+    matches = [
+        item
+        for group in ("inputs", "outputs", "inputOutputs")
+        for item in variables.get(group) or []
+        if item.get("name") == name
+    ]
+    return one(matches, f"case variable named {name!r}")
+
+
+def resolve_binding(plan: dict, reference: object, property_name: str) -> dict:
+    prefix = "=bindings."
+    if not isinstance(reference, str) or not reference.startswith(prefix):
+        fail(f"task data.{property_name} is not a binding reference: {reference!r}")
+    binding_id = reference[len(prefix) :]
+    matches = [b for b in plan.get("bindings") or [] if b.get("id") == binding_id]
+    binding = one(matches, f"binding {binding_id!r}")
+    if binding.get("propertyAttribute") != property_name:
+        fail(
+            f"binding {binding_id!r} propertyAttribute is "
+            f"{binding.get('propertyAttribute')!r}, expected {property_name!r}"
+        )
+    return binding
+
+
+def assert_case_wiring(plan: dict) -> None:
+    task = one(find_tasks_of_type(plan, "api-workflow"), "api-workflow task")
+    if task_is_skeleton(task):
+        fail("api-workflow task is an unresolved skeleton")
+
+    data = task.get("data") or {}
+    name_binding = resolve_binding(plan, data.get("name"), "name")
+    folder_binding = resolve_binding(plan, data.get("folderPath"), "folderPath")
+    expected_key = f"solution_folder.{RESOURCE_NAME}"
+    for binding in (name_binding, folder_binding):
+        if binding.get("resource") != "process":
+            fail(f"inline API binding resource is {binding.get('resource')!r}")
+        if binding.get("resourceSubType") != "Api":
+            fail(
+                "inline API binding resourceSubType is "
+                f"{binding.get('resourceSubType')!r}"
+            )
+        if binding.get("resourceKey") != expected_key:
+            fail(
+                f"inline API resourceKey is {binding.get('resourceKey')!r}, "
+                f"expected {expected_key!r}"
+            )
+    if name_binding.get("default") != RESOURCE_NAME:
+        fail(f"name binding default is {name_binding.get('default')!r}")
+    if folder_binding.get("default") != "":
+        fail(
+            "inline sibling folderPath must be the co-located empty string, got "
+            f"{folder_binding.get('default')!r}"
+        )
+
+    customer_var = case_variable(plan, "customerName")
+    greeting_in_var = case_variable(plan, "greetingIn")
+    customer_id = customer_var.get("id")
+    greeting_in_id = greeting_in_var.get("id")
+    if not customer_id or not greeting_in_id:
+        fail("customerName/greetingIn case variables must each have an id")
+
+    input_row = one(
+        [row for row in data.get("inputs") or [] if row.get("name") == "customerName"],
+        "customerName task input",
+    )
+    if input_row.get("type") != "string":
+        fail(f"customerName task input type is {input_row.get('type')!r}")
+    if input_row.get("value") != f"=vars.{customer_id}":
+        fail(
+            f"customerName input is {input_row.get('value')!r}, "
+            f"expected '=vars.{customer_id}'"
+        )
+
+    output_row = one(
+        [row for row in data.get("outputs") or [] if row.get("name") == "greeting"],
+        "greeting task output",
+    )
+    if output_row.get("type") != "string":
+        fail(f"greeting task output type is {output_row.get('type')!r}")
+    if output_row.get("source") != "=greeting":
+        fail(f"greeting output source is {output_row.get('source')!r}")
+    if output_row.get("var") != greeting_in_id:
+        fail(
+            f"greeting output var is {output_row.get('var')!r}, "
+            f"expected greetingIn case variable id {greeting_in_id!r}"
+        )
+    if output_row.get("originalVar") != "greeting":
+        fail("greeting extraction is missing originalVar='greeting'")
+
+
+def assert_sibling_contract(solution: dict) -> Path:
+    project = load_json(SIBLING / "project.uiproj")
+    if project.get("ProjectType") != "Api":
+        fail(f"sibling ProjectType is {project.get('ProjectType')!r}, expected 'Api'")
+    workflow_files = list(SIBLING.rglob("Workflow.json"))
+    workflow = Path(one([{"path": str(p)} for p in workflow_files], "Workflow.json")["path"])
+
+    entry_points = load_json(SIBLING / "entry-points.json")
+    entry = one(entry_points.get("entryPoints") or [], "API workflow entry point")
+    input_schema = entry.get("input") or {}
+    output_schema = entry.get("output") or {}
+    input_props = input_schema.get("properties") or {}
+    output_props = output_schema.get("properties") or {}
+    if (input_props.get("customerName") or {}).get("type") != "string":
+        fail("API entry point does not expose customerName:string in the flat schema")
+    if "customerName" not in (input_schema.get("required") or []):
+        fail("API entry point does not require customerName")
+    if (output_props.get("greeting") or {}).get("type") != "string":
+        fail("API entry point does not expose greeting:string in the flat schema")
+
+    projects = solution.get("Projects") or []
+    expected_suffix = f"{RESOURCE_NAME}/project.uiproj"
+    matches = [
+        project
+        for project in projects
+        if str(project.get("ProjectRelativePath", "")).replace("\\", "/").endswith(expected_suffix)
+    ]
+    registered = one(matches, f"solution project ending in {expected_suffix!r}")
+    if registered.get("Type") != "Api":
+        fail(f"registered sibling Type is {registered.get('Type')!r}")
+
+    audit_path = Path("tasks/registry-resolved.json")
+    audit_text = audit_path.read_text().lower() if audit_path.is_file() else ""
+    if RESOURCE_NAME.lower() not in audit_text or '"local"' not in audit_text:
+        fail("registry-resolved.json does not record the local inline API workflow")
+    return workflow
+
+
+def assert_workflow_valid(workflow: Path) -> None:
+    result = subprocess.run(
+        ["uip", "api-workflow", "validate", str(workflow), "--output", "json"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        fail(
+            f"uip api-workflow validate exit {result.returncode}\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+    if "valid" not in result.stdout.lower():
+        fail(f"API workflow validation did not report Valid: {result.stdout[:1000]}")
+
+
+def load_and_validate_case() -> tuple[dict, dict]:
+    solution = load_json(SOLUTION)
+    caseplan = resolve_caseplan(solution)
+    plan = read_caseplan(str(caseplan))
+    assert_tasks_nested(plan)
+    assert_validate_passes(str(caseplan))
+    return plan, solution
+
+
+def main() -> None:
+    plan, solution = load_and_validate_case()
+    if sys.argv[1:] == ["--case-only"]:
+        print(
+            "OK: discovered CaseManagement project from the solution and "
+            "validated its caseplan"
+        )
+        return
+    if sys.argv[1:]:
+        fail("usage: check_create_missing_api_workflow.py [--case-only]")
+    assert_case_wiring(plan)
+    workflow = assert_sibling_contract(solution)
+    assert_workflow_valid(workflow)
+    print(
+        "OK: missing API workflow created inline, customerName:string -> "
+        "greeting:string -> greetingIn:string is wired, and the sibling API "
+        "workflow validates"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-case/create_missing_api_workflow/create_missing_api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/create_missing_api_workflow/create_missing_api_workflow.yaml
@@ -1,0 +1,107 @@
+task_id: skill-case-create-missing-api-workflow-inline-e2e
+description: >
+  Build a one-task Case Management project whose referenced API workflow is
+  absent from both the tenant and solution registries. Exercises the Rule 17
+  create gate, Agent-tool delegation to the API-workflow skill, sibling
+  registration, a pinned string input/output contract, case binding,
+  and validation of both the case and sibling API workflow project.
+tags:
+  - uipath-maestro-case
+  - e2e
+  - lifecycle:generate
+  - mode:build
+  - shape:single-node
+  - resource
+  - feature:registry
+  - feature:api-workflow
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite", "Agent"]
+  sdk_options:
+    max_thinking_tokens: 12000
+
+run_limits:
+  expected_turns: 180
+  task_timeout: 4800
+  max_turns: 260
+  turn_timeout: 3600
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: fixtures
+
+initial_prompt: |
+  Build the approved `sdd.md` staged in this workspace as a UiPath Case
+  Management solution. The resource name is intentionally unique: exercise
+  the normal create-on-missing workflow and create the selected API workflow
+  as an in-solution sibling rather than substituting a similarly named tenant
+  resource or fabricating an identity.
+
+  Continue through planning, prototyping, implementation, and full case
+  validation. Do not debug, publish, upload, or deploy the solution. A case
+  with a sibling project cannot be exercised through case debug; the test
+  harness will verify the built sibling project and its wiring locally.
+
+  The `uip` CLI is available and authenticated. Before starting, load the
+  uipath-maestro-case skill and follow its workflow, including its interactive
+  create and phase gates.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-maestro-case skill"
+    skill_name: "uipath-maestro-case"
+    expected_skill: "uipath-maestro-case"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Case skill delegated the selected inline build through the Agent tool"
+    tool_name: "Agent"
+    require_success: true
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated case validates"
+    command: "python3 $TASK_DIR/check_create_missing_api_workflow.py --case-only"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Inline API workflow exists, validates, is registered, and is wired to the case"
+    command: "python3 $TASK_DIR/check_create_missing_api_workflow.py"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+simulation:
+  enabled: true
+  persona: |
+    You are the solution designer who approved this tiny greeting case and
+    wants its missing API workflow built as an in-solution sibling.
+  goal: |
+    Build the case and pure-compute greeting API with customerName:string
+    wired into the workflow and its greeting:string output wired to the
+    greetingIn:string case variable.
+  constraints:
+    - "At the empty-registry gate, choose Create missing resources inline."
+    - "At the build-selection prompt, select InlineGreetingApiQ74."
+    - "Approve the generated tasks.md plan without requesting design changes."
+    - "At the Phase 2 review gate, choose Skip publish and continue."
+    - "If asked to reconcile the pinned API customerName/greeting contract and the greetingIn case destination, approve the minimal repair."
+    - "At the Phase 5 gate, choose Skip to Publish; do not run debug for a solution with a sibling project."
+    - "At the Phase 6 gate, choose Done. Never publish, upload, or deploy."
+    - "Do not choose placeholders, rename the resource, add connectors, or add more I/O."
+    - "Keep replies short: one sentence or the requested option selection."
+  max_turns: 20
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-case/create_missing_api_workflow/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/create_missing_api_workflow/fixtures/sdd.md
@@ -1,0 +1,130 @@
+# SDD — CreateMissingApiWorkflowCase
+
+**Case Definition Blueprint** · Build one missing API workflow inline and wire a minimal string contract through the case.
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|----------|-------|
+| Case Name | CreateMissingApiWorkflowCase |
+| Case Description | Sends a customer name to a tiny inline API workflow and stores its greeting. |
+| Case Identifier | Type: constant. Prefix: CMW |
+| Priority | Choiceset: Low, Medium, High — Default: Medium |
+| Case-Level SLA | — |
+| SLA Type | — |
+| Case App | Disabled |
+| Task-output passing | Direct |
+
+### Case-Level SLA Escalation Rules
+
+> None.
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|----|--------------|--------|---------------|
+| T02 | Manual | User-initiated | N/A |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Marks Case Complete | Display Name |
+|------|-----|------|---------------------|--------------|
+| required-stages-completed | — | Case exited | Yes | Complete Rule 1 |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|------|----------|------|----------------|--------------|---------|-------------|
+| customerName | Variable | string | | | "Ada" | Name sent from the case to the API workflow. |
+| greetingIn | Variable | string | | | | Greeting returned by the API workflow. |
+
+---
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Greet Customer
+
+**Type:** Stage
+**Description:** Invoke the inline greeting API workflow.
+**Required for Case Completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|-------------|--------------|
+| case-entered | — | No | Entry Rule 1 |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|----------------------|--------------|
+| required-tasks-completed | — | exit-only | Yes | Complete Rule 1 |
+
+#### Stage SLA
+
+> None.
+
+#### Tasks
+
+| # | Task Name | Type | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|----------|---------------|---------|-----|
+| 1 | Generate Greeting | api-workflow | Yes | Yes | system | — |
+
+##### Task 1.1: Generate Greeting
+
+**Type:** api-workflow
+**Description:** Return the string "Hello, " followed by the supplied customer name. This is a pure computation with no connectors or external data.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| current-stage-entered | — | Entry Rule 1 |
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | Yes | — |
+
+###### Process / Agent / RPA / API Workflow Task Detail
+
+**Resolved Resource:** InlineGreetingApiQ74
+**Folder Path:** <UNRESOLVED>
+**Resource Identity:** <UNRESOLVED>
+**Binding Sub-Type:** Api
+**Dispatch / Operation:** —
+
+**Inputs:**
+
+| Field | Type | Binding |
+|-------|------|---------|
+| customerName | string | =vars.customerName |
+
+**Outputs:**
+
+| Field | Binding / Value |
+|-------|------------------|
+| greeting | -> greetingIn |
+
+---
+
+## Section 3: Personas & App Views
+
+### Personas
+
+> None. The task is automated.
+
+### App Views
+
+> None. Case App is disabled.
+
+---
+
+## Section 4: Integrations
+
+### API Workflows
+
+| Workflow | Folder | Resource ID (+version) | Inputs → Outputs | Used By Tasks |
+|----------|--------|------------------------|------------------|---------------|
+| InlineGreetingApiQ74 | <UNRESOLVED> | <UNRESOLVED> | customerName → greeting | Generate Greeting |


### PR DESCRIPTION
## Summary
- add an E2E task for creating a missing low-code agent as an in-solution sibling
- add an E2E task for creating a missing pure-compute API workflow as an in-solution sibling
- pin and verify `customerName:string` input and `greeting:string` output wiring across the case/resource boundary
- require `Agent`-tool delegation, sibling registration, local registry audit, and valid case bindings
- validate both sibling projects locally instead of running case debug, which cannot execute a solution containing sibling projects
- discover the generated API case project from the solution manifest instead of assuming its folder matches the case name

## Validation
- `coder-eval 0.8.3 plan` for both task YAMLs
- `scripts/check-cli-verbs.py --json` for both task YAMLs
- Python compilation for both deterministic checkers
- YAML parse and `git diff --check`
- agent coder-eval passed with score `1.000`: [run 29621632043](https://github.com/UiPath/skills/actions/runs/29621632043)
- API case-project discovery and full checker passed against the artifact from [run 29622427925](https://github.com/UiPath/skills/actions/runs/29622427925), whose generated case project was named `CreateMissingApiWorkflowCaseProject`
- local API coder-eval `0.8.3`: case-project discovery/validation passed; full checker correctly failed because the generated output mapping omitted load-bearing `originalVar: "greeting"`

## Live E2E status
The revised agent task passes end to end. The API task now tolerates valid Case Management project folder names by resolving the single `CaseManagement` project from the solution manifest. Its latest local run remains red on a separate skill-output defect: the generated greeting extraction omitted `originalVar`, even though case validation passed. The grader intentionally retains this assertion because the skill contract marks `originalVar` as load-bearing.