### PR TITLE
fix(maestro-case): enforce canonical registry handoff fields

### DIFF
--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -289,6 +289,15 @@ Every task entry includes at least:
 
 Additional fields are plugin-specific; read the plugin's `planning.md` before filling the entry.
 
+> **Registry handoff:** For a resolved `action` or `case-management` T-entry, translate the selected audit object into the canonical `tasks.md` labels and values:
+>
+> | Task type | `name` from | `folder-path` from | `taskTypeId` from |
+> |---|---|---|---|
+> | `action` | `selected.deploymentTitle` | `selected.deploymentFolder.fullyQualifiedName` | `selected.id` |
+> | `case-management` | `selected.name` | `selected.folders[0].fullyQualifiedName` | `selected.entityKey` |
+>
+> Before Step 5, confirm these labels and values match the `selected` object in `registry-resolved.json`.
+
 > **No shell commands in task entries.** Each task is a declarative specification. Never write `uip` invocations or any other shell commands inside a task body — the execution phase translates specs into JSON mutations.
 
 > **Record `lane: <n>` per task.** Default: increment within each stage starting at 0 — lane is FE layout only, task ordering comes from task-entry conditions. **Exception:** within a `runs-sequentially` group, tasks meant to run in parallel share the same `lane` (shared lane = parallel siblings inside the sequential group, carries execution semantics). Solo runs-sequentially tasks still get own lane.


### PR DESCRIPTION
## Summary

Add a Phase 1 planning guard for resolved Action and case-management tasks. The table maps selected registry values into the canonical tasks.md labels: name, folder-path, and taskTypeId.

## Root cause

The failed coder-eval resolved the correct Action App but omitted the canonical name and folder-path labels in tasks.md. Its tool-call trace shows that the agent read the generic references/planning.md and references/registry-discovery.md files but did not open the Action plugin planning file, despite the generic routing instruction.

Keeping the positive output contract next to generic task emission reaches the path the failed run actually read. The case-management row provides the equivalent mapping for future resolved child-case handoffs. The fixture child case is unresolved, so this PR does not claim to change unresolved-placeholder behavior.

The checker remains unchanged because name, folder-path, and taskTypeId are the canonical Phase 2 handoff fields.

Failed run: https://coder-evalboard.uipath-dev.com/runs/2026-07-17_18-00-25/skill-case-registry-handoff-action-case-sdd-only

## Validation

- python3 scripts/check-skill-status.py
- python3 scripts/check-skill-verbs.py skills/uipath-maestro-case/references/planning.md
- git diff --check

The full coder-eval scenario has not yet been rerun on this branch.