### PR TITLE
feat(uipath-test-playwright): Playwright pack→publish→run→fetch skill

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -145,6 +145,10 @@
 /skills/uipath-test/ @vaishalisharma-uipath @amoluipath @ganeshborle
 /tests/tasks/uipath-test/ @vaishalisharma-uipath @amoluipath @ganeshborle
 
+# Test — Playwright external test runner (pack → publish → run → fetch)
+/skills/uipath-test-playwright/ @vaishalisharma-uipath @amoluipath @ganeshborle
+/tests/tasks/uipath-test-playwright/ @vaishalisharma-uipath @amoluipath @ganeshborle
+
 
 # Tasks skill (Action Center Operate)
 /skills/uipath-tasks/ @UiPath/ActionCenterDev

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-solution` | Preview |
 | `uipath-tasks` | Preview |
 | `uipath-test` | In-development |
+| `uipath-test-playwright` | In-development |
 | `uipath-troubleshoot` | Preview |
 
 **Status legend:**

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -198,6 +198,14 @@
       },
       "last_synced": null
     },
+    "uipath-test-playwright": {
+      "status": "in-development",
+      "confluence": {
+        "page_id": null,
+        "url": null
+      },
+      "last_synced": null
+    },
     "uipath-troubleshoot": {
       "status": "preview",
       "confluence": {

--- a/skills/uipath-test-playwright/SKILL.md
+++ b/skills/uipath-test-playwright/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: uipath-test-playwright
+description: "UiPath external Playwright test runner: pack a `playwright.config.{ts,js}` project via `uip tm pack`, upload to Orchestrator so Test Manager auto-creates Test Cases, run, poll, fetch report.json + trace.zip. TM CRUD→uipath-test. Studio/XAML→uipath-rpa."
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
+user-invocable: true
+---
+
+# UiPath External Test Runner
+
+Drive the full **pack → publish → auto-create → run → poll → fetch** pipeline for a customer Playwright project on UiPath. One prompt, branching dialog, recoverable mid-pipeline.
+
+Packaging uses `uip tm pack` (single-source `content/testCases.json`, V2 package format). On upload, Test Manager ingests that blob and **auto-creates the Test Cases** — no manual create/link loop.
+
+## When to Use This Skill
+
+- User says "run my Playwright project on UiPath", "demo the Playwright integration", "execute these Playwright tests via Test Manager"
+- User has a Playwright project (`playwright.config.{ts,js,mjs}`) and wants it to flow through Orchestrator + Test Manager
+- User asks to fetch `report.json` / `trace.zip` artefacts from a Playwright run
+
+**Do NOT use for:**
+- Generic Test Manager CRUD (list/create/update test cases/sets/projects without a Playwright pack) → `uipath-test`
+- Studio coded workflows or XAML test cases → `uipath-rpa`
+- Pure Orchestrator package operations → `uipath-platform`
+
+## Critical Rules
+
+1. **Never run `uip login` against a non-`*.uipath.com` URL.** The CLI rejects it (`cli/packages/auth/src/config.ts`). For a non-cloud Orch the user must populate `~/.uipath/.auth` (dotenv-format file: `KEY=VALUE` per line) with `UIPATH_URL`, `UIPATH_ACCESS_TOKEN`, `UIPATH_ORGANIZATION_ID`, `UIPATH_TENANT_ID`. The CLI walks up from cwd looking for any `.uipath/.auth`, falling back to `~/.uipath/.auth`. Detect via `uip login status --output json`; do NOT auto-retry login.
+2. **Always pass `--output json` to `uip` commands.** Free-form output is for humans; this skill must parse. See `references/cli-commands.md` for the exact JSON shape each command returns.
+3. **Never modify the customer's Playwright source.** Pack verbatim. If discovery is wrong, fix the packager; don't edit customer code.
+4. **Bump `--package-version` between source changes.** Orchestrator caches packages by `(name, version)` and silently returns the old payload otherwise. (Note the flag is `--package-version`, not `--version` — `-V/--version` prints the CLI version.)
+5. **Pack with `uip tm pack`; let Test Manager auto-create the Test Cases on upload.** `tm pack --tmh-project <KEY>` embeds `content/testCases.json`. On `uip or packages upload`, Orchestrator fires `package.uploaded` and TM ingests that blob — creating Test Cases and hydrating the six `PW_` label facets (File / Path / Project / Suite / Tag / Annotation). Do **NOT** manually `tm testcases create` + `link-automation` per test — that path is superseded. Use `--no-create-test-cases` only for publish-only (no TM Test Cases).
+6. **One Playwright test = one Test Case; project is NOT part of identity.** `tm pack` dedupes each test×project row into a single test carrying a `projects[]` array; TM records the browser as a `PW_Project` facet. Never split per browser or append `[<project>]` to names. `uniqueId` is a deterministic UUID v5 of `(packageName, filePath, titleChain)`, stable across re-packs — so a re-upload updates the same Test Cases instead of duplicating.
+7. **V2 test packages require Orchestrator flag `AllowTestAutomationPackagesWithV1Metadata` ON**, or upload is rejected. The package's `operate.json` carries `targetRuntime: "playwright-javascript"` (the serverless-pod discriminator) and `contentType: "tests"`.
+8. **Set a default Orchestrator folder on the TM project before any `run`.** `uip tm project set-default-folder --project-key <KEY> --folder-key <FOLDER_KEY> --output json`; `tm testsets run` fails without it. Resolve folders via `uip or folders list -n <name> --all --output json` (`.Data[].Key` is the folder UUID).
+9. **Checkpoint state after every major step.** Write `<outputDir>/.demo-state.json`. A 4MB upload that completed must not redo because a later step hiccupped. See `references/state-resume.md` for the schema.
+10. **Surface `tm wait` timeouts to the user, do not auto-fail.** A 30-min poll cap doesn't mean the run failed — it means it's still going on Orch. Offer to extend or skip-to-fetch.
+
+## Inputs
+
+Parse the user's prompt for these. Anything missing, ask in **one** consolidated text reply (not five separate prompts):
+
+| Input | Required | Default |
+|---|---|---|
+| `projectPath` | yes | — |
+| `tmProjectKey` | yes | — (e.g. `DEMO`) |
+| `version` | no | `1.0.0` for first run, else patch-bump from `state.version` |
+| `packageName` | no | basename of `projectPath` |
+| `outputDir` | no | `<projectPath>/.uipath` |
+
+Then ask via **AskUserQuestion** (multi-choice — these are decision branches, not free text):
+
+- **Q1: Auto-create TM Test Cases?** Yes (recommended) / No (publish-only)
+- **Q2: Run which?** All N / Subset (let me pick) / None (just create Test Cases) — only asked if Q1 = Yes
+
+For subset selection, do NOT use AskUserQuestion (multi-choice doesn't scale beyond ~5 options). Print a numbered table and accept free-text reply: `1,3,5` or `DEMO:23,DEMO:25` or `all`.
+
+## Workflow
+
+### Phase 0 — Pre-flight (always)
+
+Verify all three before any pack/upload. Fail fast; tell the user which to fix and stop.
+
+```bash
+# 1. uip on PATH
+command -v uip >/dev/null 2>&1 || { echo "uip not on PATH"; exit 1; }
+
+# 2. Authenticated
+uip login status --output json | jq -e '.Data.Status == "Logged in"' >/dev/null \
+  || { echo "Not authenticated. See SKILL.md Critical Rule #1."; exit 1; }
+
+# 3. Project looks like Playwright
+ls "$PROJECT_PATH"/playwright.config.{ts,js,mjs} 2>/dev/null | head -1 | grep -q . \
+  || { echo "$PROJECT_PATH is not a Playwright project."; exit 1; }
+```
+
+**`uip` install.** If `command -v uip` fails, the skill cannot run. Install the published CLI: `npm i -g @uipath/cli`. Tell the user to install it (don't auto-install). `tm pack` requires a CLI build that ships the command.
+
+Resolve / create the TM project:
+
+```bash
+uip tm project list --filter "$TM_PROJECT_KEY" --output json
+# If no row matches ProjectKey == TM_PROJECT_KEY → create it:
+uip tm project create --name "$TM_PROJECT_KEY" --project-key "$TM_PROJECT_KEY" --output json
+```
+
+Resolve a folder and set it as the project default (**required before any `run`** — Critical Rule #8):
+
+```bash
+uip or folders list --all --output json   # .Data[].Key = folder UUID, .Data[].Name
+uip tm project set-default-folder --project-key "$TM_PROJECT_KEY" --folder-key "$FOLDER_KEY" --output json
+```
+- Single folder → auto-pick. Multiple → AskUserQuestion (≤4 options; else numbered table + free-text). Save to `state.folderKey`.
+
+### Phase 1 — Pack
+
+```bash
+uip tm pack \
+  --project-path "$PROJECT_PATH" \
+  --type playwright \
+  --tmh-project "$TM_PROJECT_KEY" \
+  --name "$PACKAGE_NAME" \
+  --package-version "$VERSION" \
+  --output "$OUTPUT_DIR" \
+  --output json
+```
+
+Verify `success == true`. Compute `nupkgPath = "$OUTPUT_DIR/$PACKAGE_NAME.$VERSION.nupkg"`; save to state. Skip this phase if `state.nupkgPath` exists on disk for the current version.
+
+Preview the tests the package will register (source of truth = the embedded single-source file):
+
+```bash
+unzip -p "$NUPKG_PATH" content/testCases.json | jq '.testCases | length, .testCases[].displayName'
+```
+
+Each `testCases[]` entry is one logical test: `{ uniqueId, filePath, line, displayName, describePath[], projects[], tags[], annotations[] }`. `projects[]` lists the browsers; it is NOT part of identity (Critical Rule #6).
+
+### Phase 2 — Publish
+
+```bash
+uip or packages upload "$NUPKG_PATH" --output json
+```
+
+Verify `.Result == "Success"`. Save `state.uploadedAt`. Skip if `state.uploadedAt` is set for the current `(packageName, version)`.
+
+On success, Orchestrator's `package.uploaded` event drives Test Manager to ingest `content/testCases.json` and **auto-create the Test Cases** in `$TM_PROJECT_KEY` (unless the package was packed with `--no-create-test-cases`). Upload requires the Orchestrator flag `AllowTestAutomationPackagesWithV1Metadata` (Critical Rule #7) — a `V1Metadata`/`descriptor`-rejection error means it is OFF; see `references/troubleshooting.md`.
+
+**Branch on Q1 = No (publish-only):** the user opted out of TM Test Cases. Re-pack in Phase 1 with `--no-create-test-cases` and omit `--tmh-project`, upload, print `{packageName, version}`, **stop**.
+
+### Phase 3 — Confirm auto-created Test Cases (only if Q1 = Yes)
+
+TM ingestion runs asynchronously off the upload event; **retry with backoff** until the count matches the package:
+
+```bash
+# Retry up to 5 times (2s, 4s, 8s, 16s, 32s) until count >= expected.
+uip tm testcases list --project-key "$TM_PROJECT_KEY" --filter "$PACKAGE_NAME" --output json
+```
+
+Each row is one auto-created Test Case; capture `.Data[].ObjKey` (e.g. `DEMO:23`) — that is the `--test-case-key` value. Cross-check the count against `content/testCases.json` (Phase 1). If short after 5 retries, surface the diff (which `displayName`s are missing) and stop — do NOT hand-create the missing ones.
+
+Save the `{ displayName → ObjKey }` mapping to `state.testCaseMap`.
+
+> Do NOT run `tm testcases create` / `link-automation` here. TM created and linked the automation on ingestion (Critical Rule #5).
+
+### Phase 4 — Subset selection (only if Q1 = Yes)
+
+If Q2 = None → skip Phases 5–7. Print: "Package $PACKAGE_NAME:$VERSION uploaded; TM created N Test Cases in $TM_PROJECT_KEY. Stopped before execution as requested."
+
+If Q2 = All → set `selectedKeys = all values from state.testCaseMap`, skip to Phase 5.
+
+If Q2 = Subset → print numbered table:
+```
+  #   Key         Test Case
+  1   DEMO:23     Google Search Bar > should have a visible search bar
+  2   DEMO:24     auth > should reject expired token
+  ...
+```
+Ask (free text, not AskUserQuestion): "Type indices or keys to run (`1,3,5` or `DEMO:23,DEMO:25`), or `all`." Parse into `selectedKeys`; reject unknown indices/keys with a clear error and re-ask.
+
+### Phase 5 — Test set + run
+
+Create the per-run test set (named for sortability and bulk-cleanup later), add the selected cases, run it:
+
+```bash
+TEST_SET_NAME="_pw_run_$(date -u +%Y%m%d-%H%M%S)"
+
+TEST_SET_KEY=$(uip tm testsets create \
+  --project-key "$TM_PROJECT_KEY" \
+  --name "$TEST_SET_NAME" \
+  --description "Auto-created by uipath-test-playwright for $PACKAGE_NAME:$VERSION" \
+  --output json | jq -r '.Data.ObjKey')
+
+uip tm testcases add \
+  --test-set-key "$TEST_SET_KEY" \
+  --test-case-keys "$(IFS=,; echo "${selectedKeys[*]}")" \
+  --output json
+
+EXECUTION_ID=$(uip tm testsets run \
+  --test-set-key "$TEST_SET_KEY" \
+  --execution-type automated \
+  --output json | jq -r '.Data.ExecutionId')
+```
+
+Print the count: "Running N Test Cases via test set `$TEST_SET_KEY`." Save `state.testSetKey`, `state.testSetName`, `state.executionId`.
+
+### Phase 6 — Wait, summarize, fetch artefacts
+
+```bash
+uip tm wait \
+  --execution-id "$EXECUTION_ID" \
+  --project-key "$TM_PROJECT_KEY" \
+  --test-set-key "$TEST_SET_KEY" \
+  --timeout 1800 \
+  --output json
+```
+
+On timeout, do **not** fail. AskUserQuestion: A) extend timeout 30 min B) skip to fetch in-progress C) print execution URL and stop.
+
+```bash
+uip tm executions testcaselogs list \
+  --execution-id "$EXECUTION_ID" \
+  --project-key "$TM_PROJECT_KEY" \
+  --output json
+```
+
+Print a compact table: `TestCase | Status | Duration`. Highlight failures.
+
+```bash
+ARTEFACTS_DIR="$OUTPUT_DIR/artefacts/$EXECUTION_ID"
+mkdir -p "$ARTEFACTS_DIR"
+
+uip tm result download --execution-id "$EXECUTION_ID" --test-set-key "$TEST_SET_KEY" --result-path "$ARTEFACTS_DIR" --output json
+uip tm attachment download --execution-id "$EXECUTION_ID" --test-set-key "$TEST_SET_KEY" --result-path "$ARTEFACTS_DIR" --output json
+```
+
+After download, run `find "$ARTEFACTS_DIR" -type f` and list per-testcase artefacts. For failed cases, point at the trace:
+> Open the trace: `npx playwright show-trace <path-to-trace.zip>`
+
+### Phase 7 — Final summary
+
+```
+PIPELINE: DONE
+  TM project   : DEMO
+  Test set     : _pw_run_20260426-103015 (DEMO:142)
+  Execution    : 550e8400-e29b-41d4-a716-446655440000
+  Status       : Failed (1 of 12 cases)
+  Artefacts    : /abs/path/.uipath/artefacts/550e8400-.../
+  Failed case  : auth › login should reject expired token
+                 Trace: /.../trace.zip
+                 Run:   npx playwright show-trace /.../trace.zip
+```
+
+## Reference Navigation
+
+- **Exact CLI commands and JSON shapes** → `references/cli-commands.md`
+- **Failure modes and fixes** → `references/troubleshooting.md`
+- **State checkpointing and resume recipes** → `references/state-resume.md`
+
+## Anti-patterns — Don't Do This
+
+- **Do not** manually `tm testcases create` + `link-automation` per test. `tm pack` + upload makes TM auto-create the Test Cases (Critical Rule #5). Manual creation duplicates and drifts from the package's `uniqueId`s.
+- **Do not** create one Test Case per Playwright `(test, project)` pair, and do not append `[<project>]` to names. One test = one Test Case; browser is a `PW_Project` label facet (Critical Rule #6).
+- **Do not** use `--version` for the package version — that flag prints the CLI version. Use `--package-version`.
+- **Do not** call `uip tm testcases run` for the pipeline — that starts an ad-hoc single-case execution. Group the selection into a test set and use `tm testsets run` so results land under one execution.
+- **Do not** run before setting the project's default Orchestrator folder — `tm testsets run` fails without it (Critical Rule #8).
+- **Do not** assume the test set already exists. Always create a per-run `_pw_run_<ts>` set.
+- **Do not** auto-delete the test set after the run. The user may want to drill in via TM UI. Document cleanup in the final summary instead.
+- **Do not** retry `uip login` if `login status` fails. Login is browser-interactive; tell the user to run it themselves.

--- a/skills/uipath-test-playwright/references/cli-commands.md
+++ b/skills/uipath-test-playwright/references/cli-commands.md
@@ -1,0 +1,234 @@
+# CLI commands reference
+
+Exact `uip` invocations used by `uipath-test-playwright`, with the JSON shape returned by `--output json` and the field(s) the skill must parse.
+
+> **Always pass `--output json`.** All shapes below assume that flag.
+>
+> **Noun/verb naming:** Test Manager resources are **plural** (`testcases`, `testsets`, `executions`, `project`). Test-set membership verbs live under `testcases` (`testcases add` / `testcases remove`), not under `testsets`. Execution is `testsets run`, not `execute`.
+
+## Auth
+
+### `uip login status`
+
+```bash
+uip login status --output json
+```
+
+Returns:
+```json
+{ "Result": "Success", "Code": "LogIn", "Data": { "Status": "Logged in" | "Logged out", "Organization": "...", "Tenant": "..." } }
+```
+
+**Parse:** `.Data.Status` — must equal `"Logged in"`. If not, fail pre-flight.
+
+## External-test packager
+
+### `uip tm pack`
+
+Packages an external (non-Studio) test project — Playwright today — into a UiPath **V2 test package** (`.nupkg`). All per-test richness rides in one CLI-owned file, `content/testCases.json`, which Orchestrator forwards opaquely to Test Manager on the `package.uploaded` event.
+
+```bash
+uip tm pack \
+  --project-path "$PROJECT_PATH" \
+  --type playwright \
+  --tmh-project "$TM_PROJECT_KEY" \
+  --name "$PACKAGE_NAME" \
+  --package-version "$VERSION" \
+  --output "$OUTPUT_DIR" \
+  --output json
+```
+
+| Flag | Required | Notes |
+|---|---|---|
+| `--project-path <path>` | yes | Test project root. |
+| `--type <type>` | yes | Framework; validated against the registry (today: `playwright`). |
+| `--tmh-project <projectKey>` | yes* | TM project the auto-created Test Cases land in. **Required when create-test-cases is on (the default)** — the CLI refuses to pack otherwise. |
+| `-n, --name <name>` | no | Default: project folder name. |
+| `--package-version <v>` | no | Default `1.0.0`. Named `--package-version` to avoid colliding with the CLI's `-V/--version`. |
+| `-o, --output <dir>` | no | Default `.uipath`. |
+| `--author <author>` | no | Default `UiPath`. |
+| `--description <desc>` | no | Default `<name> — <SubType> test package`. |
+| `--no-create-test-cases` | no | Opt OUT of TM auto-creating Test Cases; per-test label metadata is still embedded. Drops the `--tmh-project` requirement. |
+| `--dry-run` | no | Preview discovered tests, emit nothing. |
+
+Returns:
+```json
+{ "success": true, "message": "...", "packageName": "e2e-playwright", "outputPath": ".uipath/e2e-playwright.1.0.0.nupkg", "testCount": 12 }
+```
+
+**Parse:** `.success == true`. The emitted nupkg is at `$OUTPUT_DIR/$PACKAGE_NAME.$VERSION.nupkg` (deterministic).
+
+**Discovery** shells out to the customer's own resolver (`playwright test --list --reporter=json`) — no AST/glob fallback. `--list` emits one row per test×project, deduped into one test with a `projects[]` array (project is an execution parameter, not identity).
+
+### Inspecting the package (single source of truth)
+
+```bash
+unzip -p "$NUPKG_PATH" content/testCases.json | jq '.testCases'
+```
+
+`content/testCases.json` (schemaVersion `2.0`):
+```json
+{
+  "schemaVersion": "2.0",
+  "testCases": [
+    {
+      "uniqueId": "c411e822-3417-5c5a-92b4-66ad0700beb2",
+      "filePath": "content/tests/google-search-bar.spec.ts",
+      "line": 4,
+      "displayName": "Google Search Bar > should have a visible search bar",
+      "describePath": ["Google Search Bar"],
+      "projects": ["chromium", "firefox", "webkit"],
+      "tags": [],
+      "annotations": []
+    }
+  ],
+  "packageName": "e2e-playwright",
+  "packageVersion": "1.0.0",
+  "subType": "Playwright",
+  "subTypeOptions": { "package": "@playwright/test", "version": "1.x" },
+  "testManagerOptions": { "createTestCases": true, "projectKey": "DEMO" },
+  "allProjects": ["chromium", "firefox", "webkit"]
+}
+```
+
+**Parse:** `.testCases[]`. `uniqueId` is a deterministic UUID v5 of `(packageName, filePath, titleChain)` — stable across re-packs, so a re-upload updates the same TM Test Cases. `content/entry-points.json` carries only `{ filePath, uniqueId, type }` (no richness) — do NOT use it as the test list.
+
+## Orchestrator
+
+### `uip or folders list`
+
+```bash
+uip or folders list --all --output json          # or: -n <folder-name> --all
+```
+
+Returns:
+```json
+{ "Result": "Success", "Data": [ { "Key": "f0...", "Name": "Shared", "Path": "Shared" } ] }
+```
+
+**Parse:** `.Data[].Key` (folder UUID). Save the chosen one to `state.folderKey` and set it as the TM project default (`tm project set-default-folder`).
+
+### `uip or packages upload`
+
+```bash
+uip or packages upload "$NUPKG_PATH" --output json
+```
+
+Returns:
+```json
+{ "Result": "Success", "Code": "PackageUploaded", "Data": { "Status": "Package uploaded successfully" } }
+```
+
+**Parse:** `.Result == "Success"`. On success Orchestrator emits `package.uploaded`; Test Manager ingests `content/testCases.json` and auto-creates the Test Cases. Requires the Orchestrator flag `AllowTestAutomationPackagesWithV1Metadata` — a V2 test package is rejected at upload if it is OFF.
+
+## Test Manager — Project
+
+### `uip tm project list` / `create` / `set-default-folder`
+
+```bash
+uip tm project list --filter "$TM_PROJECT_KEY" --output json
+uip tm project create --name "$NAME" --project-key "$KEY" --output json
+uip tm project set-default-folder --project-key "$KEY" --folder-key "$FOLDER_KEY" --output json
+```
+
+`list` returns `.Data[]` with `ProjectKey`, `Name`. Match `ProjectKey == TM_PROJECT_KEY`; if empty, `create`. `set-default-folder` is mandatory before any `run` (else `tm testsets run` fails).
+
+## Test Manager — Test cases
+
+### `uip tm testcases list`
+
+```bash
+uip tm testcases list --project-key "$TM_PROJECT_KEY" --filter "$PACKAGE_NAME" --output json
+```
+
+Returns:
+```json
+{ "Result": "Success", "Data": [ { "ObjKey": "DEMO:23", "Id": "b1...uuid", "Name": "Google Search Bar > should have a visible search bar" } ] }
+```
+
+**Parse:** `.Data[].ObjKey` (format `PROJECT_KEY:NUMBER`) is the `--test-case-key` value. `.Data[].Id` (UUID) is the `--test-case-id` value used by `run`. `--filter` is a substring search; tighten with an exact `.Name` match in jq if needed.
+
+Use this to **confirm the Test Cases TM auto-created after upload** — retry with backoff until the count matches `content/testCases.json`.
+
+### `uip tm testcases list-automations` *(diagnostic only)*
+
+```bash
+uip tm testcases list-automations --project-key "$TM_PROJECT_KEY" --folder-key "$FOLDER_KEY" --output json
+```
+
+Lists automation entry points TM sees in an Orchestrator folder (optional `--package-name`). The skill does **not** need this for the normal flow — Test Cases are auto-created on upload. Useful only to debug ingestion (did TM see the package's entry points?).
+
+### `uip tm testcases add` / `remove` (test-set membership)
+
+```bash
+uip tm testcases add    --test-set-key "$TEST_SET_KEY" --test-case-keys "DEMO:23,DEMO:24" --output json
+uip tm testcases remove --test-set-key "$TEST_SET_KEY" --test-case-keys "DEMO:23"         --output json
+```
+
+`--test-case-keys` is **plural**, comma-separated (`PROJECT_KEY:NUMBER`). These verbs live under `testcases`, not `testsets`.
+
+## Test Manager — Test sets
+
+### `uip tm testsets create`
+
+```bash
+uip tm testsets create --project-key "$TM_PROJECT_KEY" --name "$TEST_SET_NAME" --description "..." --output json
+```
+
+Returns `.Data.ObjKey` (format `PROJECT_KEY:NUMBER`) — pass to `testcases add` and `testsets run`.
+
+### `uip tm testsets run`
+
+```bash
+uip tm testsets run --test-set-key "$TEST_SET_KEY" --execution-type automated --output json
+```
+
+Optional `--execution-type <automated|manual|mixed|none>` (default `automated`), `--input-path <FILE>` for parameter overrides. **Requires a default Orchestrator folder on the project** (`tm project set-default-folder`).
+
+Returns:
+```json
+{ "Result": "Success", "Data": { "ExecutionId": "550e8400-e29b-41d4-a716-446655440000", "Status": "Running" } }
+```
+
+**Parse:** `.Data.ExecutionId` — save to state; used by `tm wait`, `tm executions testcaselogs list`, `tm result download`, `tm attachment download`.
+
+### `uip tm testsets list` (cleanup)
+
+```bash
+uip tm testsets list --project-key "$TM_PROJECT_KEY" --filter "_pw_run_" --output json
+uip tm testsets delete --test-set-key "$TEST_SET_KEY" --output json
+```
+
+## Test Manager — Wait + results
+
+### `uip tm wait`
+
+```bash
+uip tm wait --execution-id "$EXECUTION_ID" --project-key "$TM_PROJECT_KEY" --test-set-key "$TEST_SET_KEY" --timeout 1800 --output json
+```
+
+Polls until terminal. On timeout returns `Result: "Failure"` with a TimedOut message. **Do not auto-fail** — see SKILL.md Phase 6.
+
+### `uip tm executions testcaselogs list`
+
+```bash
+uip tm executions testcaselogs list --execution-id "$EXECUTION_ID" --project-key "$TM_PROJECT_KEY" --output json
+```
+
+Nested subcommand path (NOT `tm execution list-testcaselogs`). Returns per-test-case rows; display `TestCase`, `Status` (`Passed`/`Failed`), `Duration`. Optional `--only-failed`, `--filter`, `--limit`, `--offset`.
+
+### `uip tm result download`
+
+```bash
+uip tm result download --execution-id "$EXECUTION_ID" --test-set-key "$TEST_SET_KEY" --result-path "$ARTEFACTS_DIR" --output json
+```
+
+Writes JUnit XML to `$ARTEFACTS_DIR`. Optional `--project-key`.
+
+### `uip tm attachment download`
+
+```bash
+uip tm attachment download --execution-id "$EXECUTION_ID" --test-set-key "$TEST_SET_KEY" --result-path "$ARTEFACTS_DIR" --output json
+```
+
+Writes per-testcase attachments to `$ARTEFACTS_DIR/<testcase-name>/`. Common Playwright attachments: `report.json`, `trace.zip`, `error-context.md`, screenshots. Optional flags: `--only-failed`, `--test-case-name <name>` (repeatable, substring).

--- a/skills/uipath-test-playwright/references/state-resume.md
+++ b/skills/uipath-test-playwright/references/state-resume.md
@@ -1,0 +1,118 @@
+# State checkpointing and resume
+
+The `uipath-test-playwright` skill writes progress to `<outputDir>/.demo-state.json` after each major step. A re-run resumes mid-pipeline by reading this file and skipping completed phases.
+
+> **Why:** A 4MB `or packages upload` that completed must not redo because a later phase hiccupped. Pipelines die on retried-from-zero runs.
+
+## Schema
+
+```json
+{
+  "version": 1,
+  "projectPath": "/abs/path/to/project",
+  "tmProjectKey": "DEMO",
+  "packageName": "e2e-playwright",
+  "packageVersion": "1.0.5",
+  "outputDir": "/abs/path/to/project/.uipath",
+  "folderKey": "f0f0f0f0-0000-0000-0000-000000000001",
+
+  "nupkgPath": "/abs/path/to/project/.uipath/e2e-playwright.1.0.5.nupkg",
+  "packedAt": "2026-04-26T10:30:00Z",
+
+  "uploadedAt": "2026-04-26T10:30:30Z",
+
+  "confirmedAt": "2026-04-26T10:31:00Z",
+  "testCaseMap": {
+    "auth > should login": "DEMO:23",
+    "auth > should reject expired": "DEMO:24"
+  },
+
+  "selectedKeys": ["DEMO:23", "DEMO:24"],
+
+  "testSetKey": "DEMO:142",
+  "testSetName": "_pw_run_20260426-103200",
+
+  "executionId": "550e8400-e29b-41d4-a716-446655440000",
+  "executionStartedAt": "2026-04-26T10:32:15Z",
+  "terminalStatus": "Failed",
+  "terminalAt": "2026-04-26T10:42:00Z",
+
+  "artefactsPath": "/abs/path/to/project/.uipath/artefacts/550e8400-.../"
+}
+```
+
+`testCaseMap` maps each test's `displayName` to the `ObjKey` of the Test Case **TM auto-created on upload** — the skill does not create or link Test Cases itself.
+
+## Phase → state-key gating
+
+The skill skips a phase if its output keys are present in state. Drop the relevant keys to redo a phase.
+
+| Phase | Reads from state | Writes to state | Skip condition |
+|---|---|---|---|
+| 0. Pre-flight | — | `tmProjectKey`, `folderKey` | Always runs (cheap); also sets project default folder |
+| 1. Pack | `packageName`, `packageVersion`, `outputDir` | `nupkgPath`, `packedAt` | `nupkgPath` exists on disk for current `(name, version)` |
+| 2. Publish | `nupkgPath` | `uploadedAt` | `uploadedAt` set for current `(name, version)` |
+| 3. Confirm auto-created Test Cases | `tmProjectKey`, `packageName` | `testCaseMap`, `confirmedAt` | `confirmedAt > uploadedAt` AND `testCaseMap` count == package `testCount` |
+| 4. Subset selection | `testCaseMap` | `selectedKeys` | `selectedKeys` non-empty |
+| 5. Test set + run | `selectedKeys`, `tmProjectKey` | `testSetKey`, `testSetName`, `executionId`, `executionStartedAt` | `executionId` set |
+| 6. Wait + fetch | `executionId`, `testSetKey`, `outputDir` | `terminalStatus`, `terminalAt`, `artefactsPath` | `terminalAt` set AND `artefactsPath` directory has files |
+
+## Resume recipes
+
+### Redo only the test execution (keep package + auto-created Test Cases)
+
+```bash
+jq 'del(.testSetKey, .testSetName, .executionId, .executionStartedAt, .terminalStatus, .terminalAt, .artefactsPath)' \
+  "$OUTPUT_DIR/.demo-state.json" > "$OUTPUT_DIR/.demo-state.json.tmp" \
+  && mv "$OUTPUT_DIR/.demo-state.json.tmp" "$OUTPUT_DIR/.demo-state.json"
+```
+
+### Redo upload + everything downstream (keep packed nupkg)
+
+```bash
+jq 'del(.uploadedAt, .confirmedAt, .testCaseMap, .selectedKeys, .testSetKey, .testSetName, .executionId, .executionStartedAt, .terminalStatus, .terminalAt, .artefactsPath)' \
+  "$OUTPUT_DIR/.demo-state.json" > "$OUTPUT_DIR/.demo-state.json.tmp" \
+  && mv "$OUTPUT_DIR/.demo-state.json.tmp" "$OUTPUT_DIR/.demo-state.json"
+```
+
+### Start fresh
+
+```bash
+rm "$OUTPUT_DIR/.demo-state.json"
+# Optionally also remove old artefacts and packed nupkg:
+rm -rf "$OUTPUT_DIR/artefacts" "$OUTPUT_DIR"/*.nupkg
+```
+
+### Bump version (treat as a new package)
+
+```bash
+NEW_VERSION="1.0.6"
+jq --arg v "$NEW_VERSION" '
+  .packageVersion = $v
+  | del(.nupkgPath, .packedAt, .uploadedAt, .confirmedAt, .selectedKeys, .testSetKey, .testSetName, .executionId, .executionStartedAt, .terminalStatus, .terminalAt, .artefactsPath)
+' "$OUTPUT_DIR/.demo-state.json" > "$OUTPUT_DIR/.demo-state.json.tmp" \
+  && mv "$OUTPUT_DIR/.demo-state.json.tmp" "$OUTPUT_DIR/.demo-state.json"
+```
+
+`testCaseMap` is intentionally **kept** across version bumps. `uniqueId` is stable across re-packs, so re-uploading the bumped version updates the **same** TM Test Cases (no duplicates); Phase 3 just re-confirms the map.
+
+## Idempotency rules
+
+- **`testCaseMap` is keyed by `displayName`, not by version.** A `--package-version` bump re-uploads the same tests; because `uniqueId` is deterministic, TM updates the existing Test Cases and the `displayName → ObjKey` mapping still holds.
+- **`testSetName` is per-run** (`_pw_run_<ts>`). Each fresh execution creates a new test set so historical runs stay distinct in TM.
+- **`executionId` is per-run.** Once set, the run is committed; clearing it triggers a brand new execution against the existing test set.
+- **`artefactsPath` is per-execution** (`<outputDir>/artefacts/<executionId>/`). Different execution IDs never collide.
+
+## Cleanup recommendations
+
+Per-run test sets named `_pw_run_<ts>` accumulate over time. Periodically clean them with:
+
+```bash
+uip tm testsets list --project-key "$TM_PROJECT_KEY" --filter "_pw_run_" --output json \
+  | jq -r '.Data[] | select(.Name | startswith("_pw_run_")) | .ObjKey' \
+  | while read key; do
+      uip tm testsets delete --test-set-key "$key" --output json
+    done
+```
+
+Do not auto-cleanup as part of the skill — the user may want to drill into TM UI on the just-finished run.

--- a/skills/uipath-test-playwright/references/troubleshooting.md
+++ b/skills/uipath-test-playwright/references/troubleshooting.md
@@ -1,0 +1,174 @@
+# Troubleshooting
+
+Failure modes the `uipath-test-playwright` skill encounters, with diagnosis and fix.
+
+## Pre-flight failures
+
+### `uip` not on PATH
+
+**Symptom:** `command -v uip` returns non-zero in pre-flight.
+
+**Cause:** CLI not installed in this environment.
+
+**Fix:** Tell the user to install the published CLI: `npm i -g @uipath/cli`. `tm pack` requires a CLI build that ships the command.
+
+### Auth check fails
+
+**Symptom:** `uip login status --output json` returns `.Data.Status != "Logged in"`.
+
+**Causes and fixes:**
+
+| Hostname in `state.uipUrl` | Fix |
+|---|---|
+| `*.uipath.com` (cloud / staging) | `uip login --interactive` and let the user complete the browser flow |
+| `localhost` or custom | Cannot use `uip login` (the CLI rejects non-`uipath.com` hostnames in `cli/packages/auth/src/config.ts:142-150`). Tell the user to manually populate `~/.uipath/.auth` (dotenv-format `KEY=VALUE` lines) with `UIPATH_URL`, `UIPATH_ACCESS_TOKEN`, `UIPATH_ORGANIZATION_ID`, `UIPATH_TENANT_ID`. CLI walks up from cwd first, falling back to `~/.uipath/.auth`. |
+| Token expired | Same fix as above (cloud → `uip login --interactive`; local → refresh token) |
+
+**Never auto-retry login** from the skill — it requires browser interaction.
+
+### Project doesn't look like Playwright
+
+**Symptom:** No `playwright.config.{ts,js,mjs}` at the supplied `projectPath`.
+
+**Fix:** Stop. Ask the user to confirm the path. Playwright config is the only reliable Playwright-project marker.
+
+## Pack phase
+
+### `tm pack` refuses: `--tmh-project` required
+
+**Symptom:** `tm pack` exits before emitting anything, complaining a TM project key is required.
+
+**Cause:** Create-test-cases is ON by default; the CLI enforces `--tmh-project` at pack time (friendlier than failing post-upload).
+
+**Fix:** Pass `--tmh-project <TM_PROJECT_KEY>`. If the user genuinely wants no TM Test Cases, pass `--no-create-test-cases` and drop `--tmh-project`.
+
+### `playwright --list` exits non-zero
+
+**Symptom:** `tm pack` errors with a Playwright list failure.
+
+**Cause:** Customer's `playwright.config.ts` has a runtime error (broken import, type error in `defineConfig`, etc.). Discovery uses the customer's own resolver — there is no fallback.
+
+**Fix:** Print the error verbatim and stop. Customer-side issue; do not edit their source.
+
+### Duplicate `uniqueId` collision
+
+**Symptom:** `tm pack` fails loudly reporting two tests collapse to the same id.
+
+**Cause:** Two tests share file + full title chain but sit on different source lines. `uniqueId` = UUID v5 of `(packageName, filePath, titleChain)`, so they collide — packing fails rather than silently shipping fewer tests.
+
+**Fix:** Tell the user to disambiguate the duplicated test title (or its `describe` chain). Do not edit their source yourself.
+
+### Empty test discovery
+
+**Symptom:** `tm pack` succeeds but reports 0 tests (`testCount: 0`).
+
+**Causes:** `testMatch` in `playwright.config.ts` matches no files; or all projects are setup-only.
+
+**Fix:** Surface the count and ask the user to confirm. Do not auto-bail — they may be testing the packager itself.
+
+## Publish phase
+
+### Upload rejected: V2 metadata / descriptor error
+
+**Symptom:** `uip or packages upload` fails with a descriptor / `V1Metadata` rejection (not an auth error).
+
+**Cause:** `tm pack` emits a **V2 new-format** test package. Orchestrator rejects V2 test packages at upload unless the feature flag `AllowTestAutomationPackagesWithV1Metadata` is ON.
+
+**Fix:** Enable `AllowTestAutomationPackagesWithV1Metadata` on the Orchestrator tenant. This is an environment prerequisite, not something the skill can work around — surface it and stop.
+
+### Upload 401 / 403
+
+**Symptom:** `uip or packages upload` returns an auth error.
+
+**Causes:** Token lacks Orchestrator scope; or wrong tenant selected (token for tenant A, package uploaded to tenant B's URL).
+
+**Fix:** `uip login tenant set <name>` or re-login with `--tenant <name>`.
+
+### Upload 413 / size limit
+
+**Symptom:** Large nupkg rejected by Orch.
+
+**Fix:** Trim `node_modules` from the customer's project before pack (the packager already excludes `node_modules`, `dist`, `.git`, `.uipath`, `test-results`, `playwright-report` — verify this happened for this project).
+
+## Ingestion phase (TM auto-creates Test Cases)
+
+### Test Cases don't appear after upload
+
+**Symptom:** `tm testcases list --filter <packageName>` returns fewer rows than `content/testCases.json` (or none).
+
+**Causes:**
+- Ingestion runs asynchronously off the `package.uploaded` event — TM hasn't caught up yet.
+- The package was packed with `--no-create-test-cases`, so nothing is created.
+- `--tmh-project` at pack time pointed at a different TM project than you're listing.
+- The upload's tenant differs from the TM project's tenant.
+
+**Fix:**
+1. Retry `tm testcases list` with backoff (5×, 2s/4s/8s/16s/32s).
+2. Confirm the package was packed **without** `--no-create-test-cases` and with the correct `--tmh-project`.
+3. If still short after the loop, surface which `displayName`s are missing and stop. Do **not** hand-create the missing Test Cases — that drifts from the package's `uniqueId`s and duplicates on the next upload.
+
+### Debugging ingestion with `list-automations`
+
+To check whether Orchestrator surfaced the package's automation entry points to TM at all:
+
+```bash
+uip tm testcases list-automations --project-key "$TM_PROJECT_KEY" --folder-key "$FOLDER_KEY" --output json
+```
+
+Empty here means Orchestrator hasn't propagated the package to the folder yet, or the folder doesn't use the tenant feed. This is diagnostic only — the normal flow never needs it.
+
+## Execute phase
+
+### `tm testsets run` fails: no default folder
+
+**Symptom:** `testsets run` errors that the project has no default folder / execution target.
+
+**Cause:** `tm testsets run` (like `tm testcases run`) requires a default Orchestrator folder on the TM project.
+
+**Fix:** Set it once before running: `uip tm project set-default-folder --project-key "$TM_PROJECT_KEY" --folder-key "$FOLDER_KEY" --output json`. Get folder keys with `uip or folders list --all --output json` (`.Data[].Key`).
+
+### `tm testsets run` 404
+
+**Symptom:** Test set key not found.
+
+**Cause:** Wrong tenant, or the test set was deleted between create and run.
+
+**Fix:** `uip tm testsets list --project-key <KEY>` to verify the key exists.
+
+### `tm testsets run` succeeds but reports 0 cases run
+
+**Symptom:** Execution starts but `executions testcaselogs list` returns empty.
+
+**Causes:** Test set has no test cases (forgot `tm testcases add`); or the selected keys weren't valid `ObjKey`s.
+
+**Fix:** `uip tm testsets list-testcases --test-set-key <KEY>` to confirm membership; re-add via `uip tm testcases add --test-set-key <KEY> --test-case-keys <...>`.
+
+## Wait phase
+
+### `tm wait` times out
+
+**Symptom:** Returns `Result: "Failure"` with a TimedOut message after 1800s.
+
+**Cause:** Execution still running on Orch — large suite, pod startup delay, browser install at runtime.
+
+**Fix:** Do **not** auto-fail. AskUserQuestion: extend timeout 30 min, skip to fetch in-progress, or print execution URL and stop. Most failures here are recoverable.
+
+## Fetch phase
+
+### `tm attachment download` returns no files
+
+**Symptom:** Command succeeds but `find $ARTEFACTS_DIR -type f` is empty.
+
+**Causes:** Handler pod hasn't written attachments yet (race between execution-complete and pod upload); or the executor failed before producing artefacts (e.g. `npm install` failure inside the pod).
+
+**Fix:**
+1. Re-run `attachment download` once after a 30s wait.
+2. If still empty, fall back to `tm executions testcaselogs list --output json` and surface the log text — the per-testcase `Message`/`Status` indicates executor-side failure.
+
+### Downloaded `trace.zip` rejected by `playwright show-trace`
+
+**Symptom:** "newer Playwright version required" error.
+
+**Cause:** The pod ran a Playwright version newer than the local user's installed `playwright-core`.
+
+**Fix:** Tell the user to bump local Playwright (`npm i -g playwright@latest`) or use the project's pinned viewer (`npx playwright show-trace ...`).


### PR DESCRIPTION
## What

Adds the **`uipath-test-playwright`** skill — drives the full **pack → publish → auto-create → run → poll → fetch** pipeline for a customer Playwright project on UiPath.

## Design

- **Packaging via `uip tm pack`** (single-source `content/testCases.json`, V2 package format), aligned to the current packaging design in [UiPath/cli#2623](https://github.com/UiPath/cli/pull/2623).
- **Test Manager auto-creates the Test Cases on upload** from the embedded blob — the skill no longer runs a manual `testcases create` + `link-automation` loop.
- **Identity:** one Playwright test = one Test Case (browser is a `PW_Project` label facet, not a separate case); `uniqueId` is a deterministic UUID v5.
- Execution uses the current Test Manager CLI surface (plural `testcases` / `testsets` / `executions` verbs; `testsets run`; `executions testcaselogs list`).
- Recoverable mid-pipeline via `<outputDir>/.demo-state.json`.

## Naming

Named under the `uipath-test*` prefix (rather than the original `uipath-external-test`) to cluster with the Test Manager skills and drop the now-removed `external-test` CLI verb.

## Housekeeping

- Registered in `assets/skill-status.json` as **in-development**
- Added CODEOWNERS entry (Test skill area)
- Regenerated the README status table

## Caveat

`uip tm pack` ships via the still-**draft** [UiPath/cli#2623](https://github.com/UiPath/cli/pull/2623). The documented flags and `testCases.json` schema track that PR's current state and may need reconciliation before/when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxT8K9YzwincpPnwAeWTjm