### PR TITLE
docs(uipath-test): add Playwright redirect to description

### DIFF
--- a/skills/uipath-test/SKILL.md
+++ b/skills/uipath-test/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-test
-description: "UiPath Test Manager — manage test projects, cases, sets, executions; generate reports. For Orchestrator→uipath-platform. For test automation→uipath-rpa."
+description: "UiPath Test Manager — manage test projects, cases, sets, executions; generate reports. For Playwright test packages→uipath-test-playwright. For Orchestrator→uipath-platform. For test automation→uipath-rpa."
 allowed-tools: Bash, Read, Write, Glob, Grep
 user-invocable: true
 ---


### PR DESCRIPTION
## What

Adds a `For Playwright test packages→uipath-test-playwright` redirect to the `uipath-test` skill description.

## Why

`uipath-test-playwright` (added in #2125) is now a prefix-sibling of `uipath-test`. Both operate on Test Manager, so they're easy to confuse. This redirect sharpens plugin retrieval between:

- **`uipath-test`** — Test Manager CRUD + reporting (projects, cases, sets, executions)
- **`uipath-test-playwright`** — the Playwright pack → publish → run → fetch pipeline

Description stays well within the 1024-char cap (205 chars).

## Depends on

The redirect target skill lands in **#2125** — merge that first (or together) so the referenced skill exists.

> Note: this touches a frontmatter `description`, so the activation-gate recall-eval will run on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxT8K9YzwincpPnwAeWTjm