### PR TITLE
fix(maestro-flow): retry past maestro-tool plugin cold-start in flow validation

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -39,6 +39,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from typing import Any, Iterable, Sequence
 
 
@@ -53,7 +54,45 @@ from typing import Any, Iterable, Sequence
 _LAST_DEBUG_RAW: str | None = None
 
 
+# The `maestro` command group is a lazily-registered `uip` plugin
+# (`maestro-tool`, CommandPrefix "maestro"), not a core verb. The FIRST
+# `uip maestro ...` invocation in a fresh process can race plugin registration
+# and fail with "unknown command 'maestro'" before the plugin loads; the next
+# invocation succeeds once it is registered. This surfaced in the interactive
+# customer-escalation-triage eval: the grader's first post-run call
+# (`uip maestro flow validate`) cold-started and returned exit 3 /
+# "unknown command 'maestro'", while the very next call (`flow debug`, same
+# sandbox, seconds later) ran clean. Retry only on this signature so a genuine
+# validation or runtime error is still returned immediately.
+_COLD_PLUGIN_MARKER = "unknown command 'maestro'"
+
+
 # ── Public helpers ──────────────────────────────────────────────────────────
+
+
+def _run_maestro_flow(
+    args: Sequence[str],
+    *,
+    timeout: int,
+    retries: int = 3,
+    backoff_seconds: float = 2.0,
+) -> subprocess.CompletedProcess:
+    """Run ``uip maestro flow <args>`` capturing output, retrying past the
+    transient cold plugin-load error (see ``_COLD_PLUGIN_MARKER``).
+
+    Returns the ``CompletedProcess`` of the last attempt. A non-cold-start
+    failure (real validation/runtime error) is returned on the first attempt so
+    callers observe the true result without waiting out the retries."""
+    cmd = ["uip", "maestro", "flow", *args]
+    result = None
+    for attempt in range(retries):
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        combined = f"{result.stdout}\n{result.stderr}"
+        if result.returncode == 0 or _COLD_PLUGIN_MARKER not in combined:
+            return result
+        if attempt + 1 < retries:
+            time.sleep(backoff_seconds)
+    return result
 
 
 def run_debug(
@@ -71,12 +110,12 @@ def run_debug(
     ``id`` must match a ``variables.globals[]`` entry with ``direction:"in"`` and
     ``type:"file"`` — see :func:`read_flow_file_input_vars`."""
     project_dir = _find_project(project_glob)
-    cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]
+    args = ["debug", project_dir, "--output", "json"]
     if inputs is not None:
-        cmd.extend(["--inputs", json.dumps(inputs)])
+        args.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
-        cmd.extend(["--attachment", f"{var_id}={local_path}"])
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        args.extend(["--attachment", f"{var_id}={local_path}"])
+    r = _run_maestro_flow(args, timeout=timeout)
     global _LAST_DEBUG_RAW
     _LAST_DEBUG_RAW = r.stdout
     if r.returncode != 0:
@@ -89,6 +128,47 @@ def run_debug(
     if status != "Completed":
         _fail(f"Flow did not complete (finalStatus={status})\n{r.stdout}")
     return payload
+
+
+def run_validate(
+    flow_file: str | None = None,
+    *,
+    project_glob: str = "**/project.uiproj",
+    strict_bindings: bool = False,
+    timeout: int = 180,
+) -> None:
+    """Validate a generated ``.flow`` against the Flow schema via
+    ``uip maestro flow validate --output json``, retrying past the transient
+    cold plugin-load error. Exits nonzero (via ``_fail``) on any real
+    validation error, so it drops straight into a ``run_command`` criterion with
+    ``expected_exit_code: 0`` while staying resilient to the plugin cold-start
+    that a raw ``uip maestro flow validate`` command string cannot survive.
+
+    ``flow_file`` — explicit path to the ``.flow``. When omitted, the single
+    ``.flow`` under the located Flow project is used."""
+    if flow_file is None:
+        project_dir = _find_project(project_glob)
+        flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+        if not flows:
+            _fail(f"No .flow file found under {project_dir}")
+        if len(flows) > 1:
+            joined = "\n  - ".join(sorted(flows))
+            _fail(f"Multiple .flow files found — pass an explicit path:\n  - {joined}")
+        flow_file = flows[0]
+    elif not os.path.isfile(flow_file):
+        _fail(f"Flow file not found: {flow_file}")
+    args = ["validate", flow_file, "--output", "json"]
+    if strict_bindings:
+        args.append("--strict-bindings")
+    r = _run_maestro_flow(args, timeout=timeout)
+    if r.returncode != 0:
+        _fail(f"flow validate exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
+    data = _parse_json(r.stdout)
+    if data is not None:
+        result = _get_ci(data, "Result")
+        if isinstance(result, str) and result.lower() not in ("success", "valid"):
+            _fail(f"flow validate reported Result={result!r}\n{r.stdout}")
+    print(f"OK: {flow_file} validates against the Flow schema")
 
 
 def assert_flow_has_node_type(

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -6,12 +6,14 @@ real tenant run (as happened with the nested-output flattening bug).
 """
 
 import os
+import subprocess
 import sys
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import flow_check  # noqa: E402
 from flow_check import (  # noqa: E402
     assert_flow_has_any_node_type,
     assert_flow_has_api_node_targeting,
@@ -22,6 +24,7 @@ from flow_check import (  # noqa: E402
     assert_output_value,
     assert_outputs_contain,
     collect_outputs,
+    run_validate,
 )
 
 
@@ -613,3 +616,97 @@ def test_collect_outputs_pascalcase_matches_camelcase():
         }
     }
     assert sorted(map(str, collect_outputs(camel))) == sorted(map(str, collect_outputs(pascal)))
+
+
+# ── maestro-tool plugin cold-start resilience ────────────────────────────────
+
+
+_COLD_STDOUT = (
+    '{\n  "Result": "ValidationError",\n  "ErrorCode": "invalid_argument",\n'
+    '  "Message": "error: unknown command \'maestro\'",\n'
+    '  "Retry": "RetryWillNotFix"\n}'
+)
+_VALID_STDOUT = (
+    '{\n  "Result": "Success",\n  "Code": "FlowValidate",\n'
+    '  "Data": {"Status": "Valid"}\n}'
+)
+
+
+def _cp(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["uip", "maestro", "flow"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _stub_runs(monkeypatch, results):
+    """Feed ``_run_maestro_flow`` a queue of CompletedProcess results and record
+    how many subprocess invocations happened. Also stubs sleep to keep the
+    retry backoff instant under test."""
+    calls = {"n": 0}
+    queue = list(results)
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        return queue.pop(0)
+
+    monkeypatch.setattr(flow_check.subprocess, "run", fake_run)
+    monkeypatch.setattr(flow_check.time, "sleep", lambda *_: None)
+    return calls
+
+
+def test_run_maestro_flow_retries_past_cold_plugin(monkeypatch):
+    """First call cold-starts the plugin ('unknown command maestro'); the retry
+    succeeds. The success result is returned."""
+    calls = _stub_runs(monkeypatch, [_cp(3, _COLD_STDOUT), _cp(0, _VALID_STDOUT)])
+    r = flow_check._run_maestro_flow(["validate", "x.flow"], timeout=10)
+    assert r.returncode == 0
+    assert calls["n"] == 2
+
+
+def test_run_maestro_flow_does_not_retry_real_error(monkeypatch):
+    """A genuine validation error (no cold-start marker) is returned on the
+    first attempt — no wasted retries."""
+    real_err = '{\n  "Result": "ValidationError",\n  "Message": "node X missing port"\n}'
+    calls = _stub_runs(monkeypatch, [_cp(3, real_err)])
+    r = flow_check._run_maestro_flow(["validate", "x.flow"], timeout=10)
+    assert r.returncode == 3
+    assert calls["n"] == 1
+
+
+def test_run_maestro_flow_exhausts_retries(monkeypatch):
+    """A persistent cold-start marker exhausts the retry budget and returns the
+    last (failed) result rather than looping forever."""
+    calls = _stub_runs(monkeypatch, [_cp(3, _COLD_STDOUT)] * 3)
+    r = flow_check._run_maestro_flow(["validate", "x.flow"], timeout=10, retries=3)
+    assert r.returncode == 3
+    assert calls["n"] == 3
+
+
+def test_run_validate_passes_on_valid_flow(monkeypatch, tmp_path, capsys):
+    flow = tmp_path / "Sample.flow"
+    flow.write_text("{}", encoding="utf-8")
+    _stub_runs(monkeypatch, [_cp(0, _VALID_STDOUT)])
+    run_validate(str(flow))
+    assert "validates against the Flow schema" in capsys.readouterr().out
+
+
+def test_run_validate_survives_cold_plugin_then_valid(monkeypatch, tmp_path):
+    flow = tmp_path / "Sample.flow"
+    flow.write_text("{}", encoding="utf-8")
+    calls = _stub_runs(monkeypatch, [_cp(3, _COLD_STDOUT), _cp(0, _VALID_STDOUT)])
+    run_validate(str(flow))  # must not raise
+    assert calls["n"] == 2
+
+
+def test_run_validate_fails_on_validation_error(monkeypatch, tmp_path):
+    flow = tmp_path / "Sample.flow"
+    flow.write_text("{}", encoding="utf-8")
+    real_err = '{\n  "Result": "ValidationError",\n  "Message": "node X missing port"\n}'
+    _stub_runs(monkeypatch, [_cp(3, real_err)])
+    with pytest.raises(SystemExit):
+        run_validate(str(flow))
+
+
+def test_run_validate_missing_file_fails(tmp_path):
+    with pytest.raises(SystemExit):
+        run_validate(str(tmp_path / "does-not-exist.flow"))

--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""Validate a generated ``.flow`` against the Flow schema, resilient to the
+`uip` maestro-tool plugin cold-start.
+
+Drop-in ``run_command`` replacement for a raw
+``uip maestro flow validate <path> --output json`` criterion. Runs the exact
+same CLI verb via the shared harness, but retries past the transient
+"unknown command 'maestro'" plugin-load race that fails the FIRST
+``uip maestro ...`` call in a fresh grading process (see
+``flow_check._COLD_PLUGIN_MARKER``). Exits 0 when the flow validates, nonzero
+otherwise.
+
+Usage:
+    python3 validate_flow.py [<path-to.flow>]
+
+With no argument, the single ``.flow`` under the located Flow project is used.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from flow_check import run_validate  # noqa: E402
+
+
+def main() -> None:
+    flow_file = sys.argv[1] if len(sys.argv) > 1 else None
+    run_validate(flow_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -89,7 +89,12 @@ success_criteria:
 
   - type: run_command
     description: "Generated customer-escalation Flow validates without errors"
-    command: "uip maestro flow validate CustomerEscalationTriage/CustomerEscalationTriage/CustomerEscalationTriage.flow --output json"
+    # Routes the raw `uip maestro flow validate ... --output json` through the
+    # shared harness so the grader's FIRST `uip maestro` call survives the
+    # maestro-tool plugin cold-start race ("unknown command 'maestro'") that
+    # fails a bare CLI command string. Same verb, same assertion (exit 0), just
+    # retried past the transient plugin-load error.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py CustomerEscalationTriage/CustomerEscalationTriage/CustomerEscalationTriage.flow"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## What failed

The interactive **customer-escalation-triage** eval (`skill-flow-interactive-customer-escalation-triage`) failed at score **0.79**. The only failing criterion:

> **Generated customer-escalation Flow validates without errors** — `uip maestro flow validate … --output json` exited **3**:
> ```json
> { "Result": "ValidationError", "ErrorCode": "invalid_argument",
>   "Message": "error: unknown command 'maestro'", "Retry": "RetryWillNotFix" }
> ```

## Root cause — not a real defect

The flow the agent built is **valid**. Evidence:
- The agent's own in-build `uip maestro flow validate` calls all reported *"Status: Valid, no warnings"* (4×).
- The **very next** post-run criterion — the seeded Sev1/Sev3 check, which runs `uip maestro flow debug` in the same sandbox seconds later — **passed** with the correct business outcomes.
- Re-validating the exact artifact flow locally returns `Result: Success`, exit 0.

`maestro` is a **lazily-registered `uip` plugin** (`maestro-tool`, `CommandPrefix: "maestro"`), not a core verb. The **first** `uip maestro …` call in a fresh grading process can race plugin registration and fail with *"unknown command 'maestro'"* before the plugin loads. Here `flow validate` ran first and ate the cold-start; `flow debug` ran second and the plugin was ready. A raw CLI command string in a `run_command` criterion has no way to survive that transient error.

## Fix (centralized in the shared harness)

- **`flow_check.py`** — add `_run_maestro_flow`, a `uip maestro flow` runner that retries **only** on the cold-start signature (`unknown command 'maestro'`) and returns genuine validation/runtime errors immediately. `run_debug` is refactored onto it; a new public `run_validate` mirrors the raw validate criterion (exit 0 iff the flow validates) with the same resilience. Every maestro-flow e2e task inherits this.
- **`_shared/validate_flow.py`** — drop-in `run_command` entrypoint wrapping `run_validate`. Runs the same `uip maestro flow validate … --output json` verb, just resilient to the cold-start.
- **`customer_escalation_triage.yaml`** — criterion #4 now calls the shared script via `$SKILLS_REPO_PATH` (the established convention for `_shared` refs in `run_command` criteria). **Same verb, same assertion.** The separate `command_executed` criterion still verifies the agent itself runs `uip maestro flow validate`.
- **`test_flow_check.py`** — new unit tests: retry-then-succeed, no-retry-on-real-error, retry-exhaustion, and `run_validate` pass / validation-fail / missing-file paths.

## Verification

- `pytest test_flow_check.py` → **55 passed** (7 new).
- `validate_flow.py <artifact.flow>` against the real failing artifact → **exit 0**, `OK: … validates against the Flow schema` (both explicit-path and auto-locate).
- A deliberately malformed `.flow` → **exit 1**, error surfaced (no retry — real errors are never masked).

## Notes
- Two sibling tasks (`smoke/merge_parallel_sync.yaml`, `smoke/scheduled_trigger.yaml`) use the same raw `uip maestro flow validate` pattern and carry the identical latent cold-start risk. Left unchanged here to keep scope tight; they can adopt `_shared/validate_flow.py` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
