### PR TITLE
fix(uipath-maestro-bpmn): raise timeouts for contract-variant-wrappers task

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/contract_variant_wrappers.yaml
@@ -9,7 +9,16 @@ tags: [uipath-maestro-bpmn, integration, "mode:build", lifecycle:generate, contr
 run_limits:
   expected_turns: 20
   max_turns: 90
-  turn_timeout: 1200
+  # 17 typed contract wrappers + full BPMN DI authored in one unbroken turn,
+  # each preceded by a slow `registry` resolve. The experiment default caps
+  # task_timeout at 1200s, which hard-kills the whole task before the BPMN
+  # lands no matter how high turn_timeout is (observed ERROR: killed mid-write
+  # at 1200s with only a start/end skeleton written). Raise BOTH: task_timeout
+  # for the end-to-end wall clock, turn_timeout for the long authoring turn.
+  # Matches the uipath-planner constraint-gate budget proven for heavy
+  # single-turn authoring.
+  task_timeout: 3600
+  turn_timeout: 2700
 initial_prompt: |
   Create a local BPMN project named "ContractVariantsBpmn".
   Use synthetic placeholder resource names only. Do not include tenant URLs,


### PR DESCRIPTION
## Problem

`skill-bpmn-contract-variant-wrappers` fails with `final_status: ERROR`, `weighted_score: 0.0`, and **empty** `success_criteria_results` — an infrastructure timeout, not a criteria miss.

Logs from the failing run:
- `TurnTimeoutError: Agent turn timed out after 1200s (iteration 1)`
- `agents.watchdog: task_timeout ... fired after 1200.0s — hard-killing subprocess`

The agent was **making steady progress, not looping**: it invoked the skill, read references, resolved several slow `registry` templates, and only began authoring the 17-node BPMN at ~12.5 min — then was hard-killed mid-write at 20 min with just a **29-line start/end skeleton** on disk.

## Root cause

The task overrode **only** `turn_timeout: 1200` but left `task_timeout` at the `experiments/default.yaml` default (**1200s**). `task_timeout` gates the whole-task wall clock, so it fired first — the `turn_timeout` bump was a no-op. The task authors 17 typed contract wrappers + full BPMN DI in one unbroken turn, each preceded by a slow `registry` resolve, and sits right at the 1200s boundary → flaky/failing.

This is the identical failure mode fixed in `tests/tasks/uipath-planner/constraint_gate/constraint_gate.yaml`.

## Fix

Raise **both** timeouts to the planner-proven heavy single-turn authoring budget:

| | before | after |
|---|---|---|
| `task_timeout` | 1200 (default) | **3600** |
| `turn_timeout` | 1200 | **2700** |

## Verification

Ran the task locally via coder-eval on this branch (`experiments/default.yaml`, `tempdir` driver):

```
Task finished: status=SUCCESS duration=1121.1s score=1.000 iterations=1
Results: 1/1 succeeded
```

Both criteria scored 1.0:
- `file_exists` — `ContractVariantsBpmn/ContractVariantsBpmn.bpmn` exists
- `run_command` — `check_contract_variant_wrappers.py` exit 0: *"OK: ... contains public-safe Maestro BPMN XML contract variants"*

Produced BPMN is fully authored (404 lines: 16 serviceTask, 8 callActivity, 2 each businessRuleTask/sendTask/receiveTask/intermediateThrowEvent/scriptTask).

🤖 Generated with [Claude Code](https://claude.com/claude-code)