### PR TITLE
fix(maestro-flow-tests): correct false-fail in slack_channel_description grader

### DIFF
--- a/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
@@ -76,6 +76,8 @@ success_criteria:
   # a node targets the Slack connector AND flow debug retrieves the channel
   # description into the OUTPUT (the Bellevue office address). Supersedes a static
   # connector-key grep, which a flow that never executes would still pass.
+  # THIS is the authoritative proof the correct channel was targeted — a wrong or
+  # unresolved channel fails here regardless of what the static check below reports.
   - type: run_command
     description: "Flow debug runs; Slack connector executed and output has the channel description"
     command: "python3 $TASK_DIR/check_channel_description.py"
@@ -84,19 +86,31 @@ success_criteria:
     weight: 5.0
     pass_threshold: 1.0
 
-  # The channel #office-bellevue is a withheld requirement the persona reveals
-  # only when asked which channel. The debug check above already proves the right
+  # The channel #office-bellevue is a withheld requirement the persona reveals only
+  # when asked which channel. The runtime debug check above already PROVES the right
   # channel was read (its description IS the Bellevue office address); this static
-  # check separately grades the elicitation. Scored on its own (partial credit) —
-  # a flow that legitimately encodes the channel as an ID rather than its name
-  # should not hard-fail the whole task.
+  # check separately reports whether a specific channel was elicited and wired in.
+  #
+  # The Slack "Get Channel Info" activity (/ConversationsInfo/{conversationsInfoId})
+  # is keyed by channel ID, so a correct flow resolves "#office-bellevue" -> its
+  # channel ID (e.g. C0B50H7DE2F) and stores the ID — the human-readable name
+  # legitimately never survives into the .flow. A bare `office-bellevue` substring
+  # grep therefore FALSE-FAILS every correct implementation. So we pass on EITHER:
+  #   (a) the flow still names #office-bellevue (e.g. kept on a node label), OR
+  #   (b) the connector node has a resolved Slack channel ID hardwired into the
+  #       conversationsInfoId path parameter (a specific channel, not a run-time
+  #       input the persona explicitly forbade). Case (b) is not coupled to any one
+  #       workspace's ID — it matches the Slack channel-ID shape, and the runtime
+  #       check above confirms it's the *correct* channel.
+  # Non-gating (pass_threshold 0): a legitimate ID-based encoding must never
+  # hard-fail the whole task — see the block comment; scored for signal only.
   - type: run_command
     description: "Flow targets the #office-bellevue channel (elicited from the user)"
-    command: "python3 -c \"import glob,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(0 if 'office-bellevue' in open(flows[0]).read().lower() else 'flow does not reference the #office-bellevue channel')\""
+    command: "python3 -c \"import glob,re,sys; flows=glob.glob('**/*.flow',recursive=True); t=(open(flows[0]).read() if flows else ''); sys.exit('no .flow file found') if not flows else sys.exit(0 if ('office-bellevue' in t.lower() or re.search(r'conversationsInfoId[^A-Za-z0-9]+C[A-Z0-9]{6,}', t)) else 'flow neither names #office-bellevue nor hardwires a resolved Slack channel ID')\""
     timeout: 15
     expected_exit_code: 0
     weight: 3.0
-    pass_threshold: 1.0
+    pass_threshold: 0
 
   # The project name is a WITHHELD, COSMETIC requirement (persona reveals it only
   # if asked what to name it) — the flow behaves identically whatever it's called.


### PR DESCRIPTION
## Problem

`slack_channel_description_simulated` is a new task (added 2026-07-16 in #2027). On an early run the agent built a **correct, working** flow but the task still scored **FAILURE** (weighted 0.75) — three of four criteria passed; only **"Flow targets the #office-bellevue channel"** failed and hard-gated the result:

```python
sys.exit(0 if 'office-bellevue' in open(flows[0]).read().lower() else '...')
```

This is a literal substring grep for `office-bellevue` in the `.flow` file, wired as a **hard gate** (`pass_threshold: 1.0`). The Slack **Get Channel Info** activity (`/ConversationsInfo/{conversationsInfoId}`) is keyed by **channel ID**, so a correct flow resolves `#office-bellevue` → its channel ID (e.g. `C0B50H7DE2F`) and stores the ID. When the agent stores only the ID — the natural, expected encoding for this activity — the human-readable name never appears in the `.flow` and the grep fails. The check would pass **only** if an agent incidentally left the name as cosmetic text (e.g. a node label), so it is unreliable and agent-behavior-dependent.

**This is not a regression** — the criterion has been this name-grep + hard-gate since the task's first commit; the check was never valid for an ID-only flow.

The behavior contradicts the criterion's own comment:
> *"a flow that legitimately encodes the channel as an ID rather than its name should not hard-fail the whole task."*

The intent was partial-credit / non-gating, but `pass_threshold: 1.0` made it a hard gate — the opposite. (The sibling project-name criterion already got this right with `pass_threshold: 0`.)

In the run that surfaced this, the agent had correctly: clarified the ambiguous ask, elicited `#office-bellevue`, resolved it to its channel ID, hardwired it for unattended runs, validated, and produced the right output live. The authoritative runtime check (`check_channel_description.py` — runs `uip maestro flow debug` and asserts the Bellevue office address is in the output) **passed**, proving the correct channel was targeted.

## Fix

On the channel criterion only:

1. **Recognize correct ID-based flows.** Pass on **either** the channel name surviving in the flow **or** a resolved Slack channel ID hardwired into the `conversationsInfoId` path parameter. The pattern matches the Slack channel-ID *shape* — it is **not** coupled to any one workspace's ID.
2. **Make it non-gating** (`pass_threshold: 1.0` → `0`), matching the sibling project-name criterion. Correctness gating stays with criterion [1] (live `flow debug`), which is robust; a static text heuristic should not hard-fail a task — that brittleness is what caused this.

```diff
-    command: "...sys.exit(0 if 'office-bellevue' in open(flows[0]).read().lower() else '...')"
+    command: "...sys.exit(0 if ('office-bellevue' in t.lower() or re.search(r'conversationsInfoId[^A-Za-z0-9]+C[A-Z0-9]{6,}', t)) else '...')"
-    pass_threshold: 1.0
+    pass_threshold: 0
```

Comments updated to explain the ID-keyed rationale.

## Verification

- ✅ YAML parses (PyYAML)
- ✅ Decoded command runs **exit 0** against the actual failing run's flow artifact
- ✅ Negative control (channel left as a runtime input, which the persona forbade) still **exits 1**; a *wrong* hardwired channel is caught by the gating runtime check
- ✅ `lint-task` verdict **OK**
- ✅ `scripts/check-cli-verbs.py` clean (exit 0)

Replaying that run against the fixed grader: **all four criteria pass → SUCCESS**.

## Scope

Grader-only change; no skill content, no other tasks touched. The antipattern (grepping a human-readable value that a correct flow resolves to an opaque ID) is isolated to this task — no sibling in the #2027 batch shares it. This was a **test bug**, not a skill or agent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
