### PR TITLE
fix(uipath-maestro-bpmn): stop validator-copy from breaking BPMN grading

### DIFF
--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -474,6 +474,20 @@ cd skills/uipath-maestro-bpmn/validator && npm install --silent
 node validate-bpmn.mjs <file.bpmn>   # prints VALID and exits 0, or prints errors and exits 1
 ```
 
+If the skill directory is read-only (`npm install` fails), copy the validator to
+a scratch location **outside** your project/output directory (e.g. `/tmp`) and
+run it there — pass the absolute path of your `.bpmn`:
+
+```bash
+cp -r skills/uipath-maestro-bpmn/validator /tmp/bpmn-validator
+cd /tmp/bpmn-validator && npm install --silent
+node validate-bpmn.mjs <ABSOLUTE_PATH_TO_FILE.bpmn>
+```
+
+Never copy the validator into your project or output directory: it carries ~60
+fixture `.bpmn` files, and dropping them beside your file pollutes the tree that
+downstream tooling and graders scan for the single BPMN you authored.
+
 `VALID` / exit 0 means the document passes all rules. Any other output lists the
 blocking errors (gateway/condition, fake-join, superfluous-gateway, error
 end/boundary event, timer-duration, single-blank-start, variable-reference, and

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py
@@ -20,8 +20,21 @@ def fail(message: str) -> None:
     sys.exit(f"FAIL: {message}")
 
 
+# Directory components that never hold the graded project's BPMN. Agents that
+# copy the skill's bundled validator into the output tree (a common read-only
+# fallback) drag ~60 fixture .bpmn files under `validator/`; without this
+# filter discovery finds all of them and grading aborts on "multiple BPMN
+# files found". `node_modules`/`.venv`/`.git` are always vendored.
+_EXCLUDED_DIR_COMPONENTS = {"node_modules", ".venv", "venv", ".git", "validator"}
+
+
+def _is_excluded(path: str) -> bool:
+    components = re.split(r"[\\/]", path)
+    return bool(_EXCLUDED_DIR_COMPONENTS.intersection(components))
+
+
 def find_bpmn_file(name_hint: str | None = None) -> str:
-    paths = sorted(glob.glob("**/*.bpmn", recursive=True))
+    paths = sorted(p for p in glob.glob("**/*.bpmn", recursive=True) if not _is_excluded(p))
     if not paths:
         fail("no BPMN file found")
     if name_hint:


### PR DESCRIPTION
## Problem

The `skill-bpmn-script-jint-guidance` eval run **failed** (weighted score `0.167`, `FAILURE`) even though the agent's BPMN was authored correctly and passed the offline validator (`VALID`, exit 0).

Root cause is **not** the agent's authoring — it's a grader/harness fragility triggered by an agent workaround:

1. The task asks the agent to validate via the skill's bundled validator (`skills/uipath-maestro-bpmn/validator`).
2. That directory was **read-only**, so `npm install` there failed.
3. The agent's fallback was `cp -r .../validator <output>/validator`, dragging the validator's **~60 fixture `.bpmn` files** (`test/fixtures/known-good/*`, `expected-findings/*`, `samples/*`) into the graded output tree.
4. The shared grader globs `**/*.bpmn`, found **62** files, and aborted:
   `FAIL: multiple BPMN files found; expected one or hint match: [...]`

The `check_script_jint_guidance.py` grader is the only BPMN grader that calls `parse_bpmn()` **without** a `name_hint`, so it had no way to disambiguate.

## Fix

Two complementary changes:

- **Grader** (`tests/tasks/uipath-maestro-bpmn/_shared/bpmn_check.py`): exclude vendored/tooling directory components (`node_modules`, `.venv`, `venv`, `.git`, `validator`) from BPMN discovery. Every polluting path in the failure started with `validator/`, so this deterministically restores single-file discovery. Other graders in the dir pass a `name_hint` and are unaffected.
- **Skill guidance** (`skills/uipath-maestro-bpmn/references/structural-bpmn.md`): when the skill dir is read-only, copy the validator to a scratch location **outside** the project/output dir (e.g. `/tmp`) and run it there. Never copy it into the project — it carries ~60 fixtures that pollute the tree downstream tooling scans.

## Verification

Ran the patched grader from the exact failing artifacts tree (62 `.bpmn` files present):

```
=== .bpmn files present in the polluted tree ===
62
=== run patched grader from the polluted working dir ===
OK: RiskScoreScriptBpmn/RiskScoreScriptBpmn.bpmn contains a Jint-compatible BPMN script task
exit=0
```

Discovery now selects the single project BPMN and the Jint-guidance check passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)