### PR TITLE
fix(maestro-flow): retry transient 5xx/RetryLater errors in run_debug

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -39,6 +39,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from typing import Any, Iterable, Sequence
 
 
@@ -53,6 +54,34 @@ from typing import Any, Iterable, Sequence
 _LAST_DEBUG_RAW: str | None = None
 
 
+# A `uip maestro flow debug` run can die on a transient server-side error — a
+# gateway timeout / 5xx while polling the debug instance, which the CLI reports
+# as `Result:Failure`, `ErrorCode:server_error`, `Retry:RetryLater` (the CLI's
+# own Instructions say "retry once before reporting"). This is orchestration
+# infrastructure hiccuping mid-run, NOT the built flow being wrong: a single
+# 504 on GET /debug-instances/<id>/element-executions failed a whole seeded
+# check (customer-escalation-triage). Distinct from a real flow failure (a
+# `finalStatus` that completed-with-fault, or wrong outputs), which must fail
+# immediately. Retry ONLY on the transient markers below.
+_DEBUG_RETRY_MARKERS = ('"retry": "retrylater"', '"errorcode": "server_error"')
+
+
+def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
+    """True iff a failed ``flow debug`` invocation looks like a transient
+    server-side error (5xx / RetryLater) worth retrying, rather than a real
+    flow fault. Case-insensitive so CLI key casing can't slip past."""
+    if result.returncode == 0:
+        return False
+    blob = f"{result.stdout}\n{result.stderr}".lower()
+    if any(marker in blob for marker in _DEBUG_RETRY_MARKERS):
+        return True
+    # Fall back to an explicit 5xx HttpStatus in the error Context.
+    data = _parse_json(result.stdout)
+    status = _get_ci(data or {}, "Context", default={})
+    http = _get_ci(status if isinstance(status, dict) else {}, "HttpStatus")
+    return isinstance(http, int) and 500 <= http < 600
+
+
 # ── Public helpers ──────────────────────────────────────────────────────────
 
 
@@ -62,9 +91,17 @@ def run_debug(
     attachments: dict[str, str] | None = None,
     timeout: int = 240,
     project_glob: str = "**/project.uiproj",
+    retries: int = 3,
+    backoff_seconds: float = 5.0,
 ) -> dict:
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
     parsed ``Data`` payload. Exits on any step failing.
+
+    Transient server-side errors (5xx / ``RetryLater`` while polling the debug
+    instance — see :func:`_is_transient_debug_error`) are retried up to
+    ``retries`` times with ``backoff_seconds`` between attempts. A real flow
+    fault (non-transient failure, or a run that completes with the wrong
+    ``finalStatus``) fails immediately without burning retries.
 
     ``attachments`` maps a file-typed input variable ``id`` to a local file path;
     each pair is passed as ``--attachment <id>=<path>`` (repeatable). The variable
@@ -76,9 +113,14 @@ def run_debug(
         cmd.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
     global _LAST_DEBUG_RAW
-    _LAST_DEBUG_RAW = r.stdout
+    for attempt in range(retries):
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        _LAST_DEBUG_RAW = r.stdout
+        if r.returncode == 0 or not _is_transient_debug_error(r):
+            break
+        if attempt + 1 < retries:
+            time.sleep(backoff_seconds)
     if r.returncode != 0:
         _fail(f"flow debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}")
     data = _parse_json(r.stdout)

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -6,12 +6,14 @@ real tenant run (as happened with the nested-output flattening bug).
 """
 
 import os
+import subprocess
 import sys
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+import flow_check  # noqa: E402
 from flow_check import (  # noqa: E402
     assert_flow_has_any_node_type,
     assert_flow_has_api_node_targeting,
@@ -22,6 +24,7 @@ from flow_check import (  # noqa: E402
     assert_output_value,
     assert_outputs_contain,
     collect_outputs,
+    run_debug,
 )
 
 
@@ -613,3 +616,91 @@ def test_collect_outputs_pascalcase_matches_camelcase():
         }
     }
     assert sorted(map(str, collect_outputs(camel))) == sorted(map(str, collect_outputs(pascal)))
+
+
+# ── run_debug transient server-error retry ───────────────────────────────────
+
+
+_TRANSIENT_504 = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Failed during poll-instance-status: HTTP 504 on GET /api/v1/debug-instances/x/element-executions",\n'
+    '  "Context": {"HttpStatus": 504, "Stage": "poll-instance-status"},\n'
+    '  "ErrorCode": "server_error",\n  "Retry": "RetryLater"\n}'
+)
+_COMPLETED = (
+    '{\n  "Result": "Success",\n'
+    '  "Data": {"finalStatus": "Completed", "variables": {"globalVariables": '
+    '[{"name": "severity", "value": "Sev1"}]}}\n}'
+)
+
+
+def _cp(returncode, stdout="", stderr=""):
+    return subprocess.CompletedProcess(
+        args=["uip", "maestro", "flow", "debug"], returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+def _stub_debug(monkeypatch, results):
+    """Feed run_debug a queue of CompletedProcess results, stub sleep to be
+    instant, and stub project discovery so no real tree is needed."""
+    calls = {"n": 0}
+    queue = list(results)
+    monkeypatch.setattr(flow_check, "_find_project", lambda pattern: "/tmp/proj")
+    monkeypatch.setattr(flow_check.time, "sleep", lambda *_: None)
+
+    def fake_run(cmd, **kwargs):
+        calls["n"] += 1
+        return queue.pop(0)
+
+    monkeypatch.setattr(flow_check.subprocess, "run", fake_run)
+    return calls
+
+
+def test_run_debug_retries_transient_504_then_completes(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(1, _TRANSIENT_504), _cp(0, _COMPLETED)])
+    payload = run_debug(inputs={"x": 1})
+    assert calls["n"] == 2
+    assert flow_check._get_ci(payload, "finalStatus") == "Completed"
+
+
+def test_run_debug_does_not_retry_real_fault(monkeypatch):
+    """A run that returns exit 0 but did not complete is a real flow fault —
+    fail immediately, no retry."""
+    faulted = '{\n  "Result": "Success",\n  "Data": {"finalStatus": "Faulted"}\n}'
+    calls = _stub_debug(monkeypatch, [_cp(0, faulted)])
+    with pytest.raises(SystemExit):
+        run_debug()
+    assert calls["n"] == 1
+
+
+def test_run_debug_does_not_retry_nontransient_error(monkeypatch):
+    """A non-5xx / non-RetryLater failure (e.g. bad input) is returned on the
+    first attempt."""
+    bad = '{\n  "Result": "Failure",\n  "ErrorCode": "invalid_argument",\n  "Retry": "RetryWillNotFix"\n}'
+    calls = _stub_debug(monkeypatch, [_cp(1, bad)])
+    with pytest.raises(SystemExit):
+        run_debug()
+    assert calls["n"] == 1
+
+
+def test_run_debug_exhausts_retries_on_persistent_504(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(1, _TRANSIENT_504)] * 3)
+    with pytest.raises(SystemExit):
+        run_debug(retries=3)
+    assert calls["n"] == 3
+
+
+@pytest.mark.parametrize(
+    "cp,expected",
+    [
+        (_cp(0, _COMPLETED), False),                                   # success: never transient
+        (_cp(1, _TRANSIENT_504), True),                                # RetryLater + server_error + 504
+        (_cp(1, '{"Retry": "RetryLater"}'), True),                     # marker alone
+        (_cp(1, '{"ErrorCode": "server_error"}'), True),               # marker alone
+        (_cp(1, '{"Context": {"HttpStatus": 503}}'), True),            # 5xx via HttpStatus
+        (_cp(1, '{"ErrorCode": "invalid_argument", "Retry": "RetryWillNotFix"}'), False),
+        (_cp(1, '{"Context": {"HttpStatus": 404}}'), False),           # 4xx is not transient
+    ],
+)
+def test_is_transient_debug_error(cp, expected):
+    assert flow_check._is_transient_debug_error(cp) is expected


### PR DESCRIPTION
## Problem

`uip maestro flow debug` intermittently dies on a **transient server-side error** — a gateway timeout / 5xx while polling the debug instance. The CLI reports it as:

```json
{ "Result": "Failure",
  "Message": "Failed during poll-instance-status: HTTP 504 on GET /api/v1/debug-instances/<id>/element-executions",
  "Context": { "HttpStatus": 504, "Stage": "poll-instance-status" },
  "ErrorCode": "server_error", "Retry": "RetryLater" }
```

The CLI's own `Instructions` say *"retry once before reporting."* But the shared `run_debug` helper had **no retry**, so a single 504 failed an entire seeded e2e check. This is orchestration infrastructure hiccuping mid-run — **not** the built flow being wrong.

Surfaced while verifying a separate PR: the `customer-escalation-triage` seeded check failed on exactly this 504 ([main-branch Actions run 29776458813](https://github.com/UiPath/skills/actions/runs/29776458813)). It hits any maestro-flow e2e task's runtime check, not just that one.

## Fix

`run_debug` now retries (bounded — default 3 attempts, 5s backoff) **only** on the transient signature:
- `Retry: RetryLater`
- `ErrorCode: server_error`
- an explicit **5xx** `HttpStatus` in the error `Context`

A **real** flow fault fails immediately, no retries burned:
- a non-transient CLI failure (e.g. `invalid_argument` / `RetryWillNotFix`)
- a run that completes with the wrong `finalStatus` (e.g. `Faulted`)
- a 4xx

New helper `_is_transient_debug_error` isolates the classification (case-insensitive on CLI key casing).

## Tests

`test_flow_check.py` — 11 new assertions, all green (59 passed total):
- retry-then-complete (2 attempts)
- no-retry on real fault (`finalStatus != Completed`)
- no-retry on non-transient error (`invalid_argument`)
- retry-exhaustion on persistent 504
- detection matrix: `RetryLater` / `server_error` / 5xx → retry; 4xx / success / `RetryWillNotFix` → no retry

## Scope note

Pure test-harness resilience — no task YAML or skill changes. This is **not** the maestro-tool cold-start (that was fixed upstream in #2055, and the PR that worked around it — #2129 — is now closed as obsolete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
