### PR TITLE
fix(maestro-bpmn): live-debug e2e reads product from variables-all, not agent file hygiene

### DIFF
--- a/skills/uipath-maestro-bpmn/references/expression-authoring.md
+++ b/skills/uipath-maestro-bpmn/references/expression-authoring.md
@@ -76,6 +76,11 @@ Do not use assignment operators in these fields. Comparisons such as `==`,
 
 - Root variables are visible across the root process after they are declared and
   reachable by control flow.
+- An output variable you intend to READ at runtime (via `debug-instance
+  variables-all` or `instance variables`) must be root-scoped — declare its
+  `uipath:inputOutput` WITHOUT an `elementId`. A variable scoped with `elementId`
+  is bound to that element and is not surfaced as a readable root/global runtime
+  variable, so its computed value will not appear in a `variables-all` read.
 - Subprocess variables stay scoped to that subprocess.
 - Output mappings should target `uipath:inputOutput` or `uipath:output`
   variables, not read-only `uipath:input` variables.

--- a/skills/uipath-maestro-bpmn/references/operate/references/run.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/run.md
@@ -51,13 +51,15 @@ and `Data.finalStatus`.
 If Studio Web URL is not returned, print `Studio Web URL: <not returned by CLI>`.
 
 > **The debug command output has element statuses, not variable values.** Its
-> `Data.elementExecutions[]` reports each element's `status` (Completed/Faulted)
-> but never the runtime *values*. `finalStatus: Completed` and all elements green
-> prove the process ran — NOT that any output variable holds the expected value.
-> To read a computed business result, take `Data.instanceId` and run
+> element-execution list reports each element's status (Completed/Faulted) but
+> never the runtime *values*. A Completed final status with all elements green
+> proves the process ran — NOT that any output variable holds the expected value.
+> To read a computed business result, take the returned instance id and run
 > `uip maestro bpmn debug-instance variables-all <INSTANCE_ID> --output json`
 > (below). Debug instances are ephemeral — read variables in the same session,
-> right after the debug run.
+> right after the debug run. Match returned keys case-insensitively
+> (`finalStatus`/`FinalStatus`, `instanceId`/`InstanceId`, `elementExecutions`/
+> `ElementExecutions`) — the CLI's JSON key casing varies by version.
 
 ## Process run - deployed process
 

--- a/skills/uipath-maestro-bpmn/references/operate/references/run.md
+++ b/skills/uipath-maestro-bpmn/references/operate/references/run.md
@@ -50,6 +50,15 @@ Parse and report returned identifiers such as `Data.jobKey`, `Data.instanceId`, 
 and `Data.finalStatus`.
 If Studio Web URL is not returned, print `Studio Web URL: <not returned by CLI>`.
 
+> **The debug command output has element statuses, not variable values.** Its
+> `Data.elementExecutions[]` reports each element's `status` (Completed/Faulted)
+> but never the runtime *values*. `finalStatus: Completed` and all elements green
+> prove the process ran — NOT that any output variable holds the expected value.
+> To read a computed business result, take `Data.instanceId` and run
+> `uip maestro bpmn debug-instance variables-all <INSTANCE_ID> --output json`
+> (below). Debug instances are ephemeral — read variables in the same session,
+> right after the debug run.
+
 ## Process run - deployed process
 
 Use process run only for a process already deployed to Orchestrator.

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -156,6 +156,10 @@ template, but the runtime contract is fixed:
 - Map the return back through `source="=result.response"` (scalar) or
   `source="=result.response.<field>"` (object field); `var` points at a declared
   variable id (do not put the target id in `name`).
+- Do not mutate `Globals.*`, `vars.*`, or process variables inside the script
+  body. The supported path is: return a value from the script, then use a
+  `uipath:output` mapping to write it to the declared variable. Direct mutation
+  is not applied to the runtime, so the variable reads empty afterward.
 
 ```xml
 <bpmn:scriptTask id="Task_RiskScore" name="Risk Score" scriptFormat="JavaScript">

--- a/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/author/gateway_sequence_flows.yaml
@@ -28,7 +28,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "BPMN source was created"
-    command: "find InvoiceTriageBpmn -maxdepth 1 -type f -name '*.bpmn' | grep -q ."
+    command: "find . -type f -name '*.bpmn' -path '*InvoiceTriageBpmn*' | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
@@ -273,7 +273,8 @@ def main() -> None:
     instance_id = None
     for path in saved:
         try:
-            parsed = _parse_json_tolerant(open(path, encoding="utf-8", errors="ignore").read())
+            with open(path, encoding="utf-8", errors="ignore") as fh:
+                parsed = _parse_json_tolerant(fh.read())
         except OSError:
             continue
         if parsed is None:

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
@@ -85,6 +85,7 @@ def _is_expected(val) -> bool:
 
 def _find_ci_key(obj, wanted: str):
     """Yield every value whose dict key equals ``wanted`` (case-insensitive)."""
+    wanted = wanted.lower()
     if isinstance(obj, dict):
         for k, v in obj.items():
             if isinstance(k, str) and k.lower() == wanted:

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
@@ -20,7 +20,9 @@ Completed`` but no variables file, so ``product`` was nowhere in the evidence).
 
 Grading strategy
 ----------------
-  1. Structural guard: a scriptTask exists in the authored ``.bpmn``.
+  1. Structural guard: a scriptTask exists in the authored ``.bpmn`` and does
+     NOT mutate ``Globals.*``/``vars.*`` directly (unsupported in Jint — the
+     supported path is ``return`` + a ``uipath:output`` mapping).
   2. Primary (deterministic): the agent's saved evidence shows a completed run
      AND a ``product``-named variable == 42 (read structurally by name, not by
      leaf-grep, so GUIDs/timestamps can't false-match).
@@ -38,6 +40,7 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import subprocess
 import sys
 import time
@@ -205,6 +208,18 @@ def _read_variables_all(instance_id: str):
     )
 
 
+def _script_bodies(root):
+    """Yield each scriptTask's JS body with JS comments stripped."""
+    for task in root.findall(f".//{{{BPMN_NS}}}scriptTask"):
+        node = task.find(f"{{{BPMN_NS}}}script")
+        if node is None:
+            continue
+        body = "".join(node.itertext())
+        body = re.sub(r"/\*.*?\*/", "", body, flags=re.DOTALL)
+        body = re.sub(r"//.*", "", body)
+        yield body
+
+
 def _bpmn_project_candidates():
     """Directories of every project.uiproj that has a sibling ``.bpmn``,
     shallowest first (a standalone ``ProductCalc/`` before a solution-nested
@@ -243,8 +258,16 @@ def _fresh_debug_then_variables():
 
 
 def main() -> None:
-    # 1. Structural guard: the product must be computed by a script task.
-    bpmn_files = glob.glob("**/*.bpmn", recursive=True)
+    # 1. Structural guard: product is computed by a script task that RETURNS its
+    #    value. Jint does not apply direct `Globals.*`/`vars.*` mutation to the
+    #    runtime — the supported path is `return` + a `uipath:output` mapping, so
+    #    a mutating script silently leaves the variable empty. Scope to the
+    #    agent's project files (skip the skill's own validator/sample .bpmn).
+    bpmn_files = [
+        p
+        for p in glob.glob("**/*.bpmn", recursive=True)
+        if not ({"validator", "samples"} & set(p.split(os.sep)))
+    ]
     if not bpmn_files:
         _fail("no .bpmn file authored")
     found_script = False
@@ -253,15 +276,19 @@ def main() -> None:
             root = ET.parse(path).getroot()
         except ET.ParseError as exc:
             _fail(f"{path} is not well-formed XML: {exc}")
-        if root.findall(f".//{{{BPMN_NS}}}scriptTask"):
+        for body in _script_bodies(root):
             found_script = True
-            break
+            if re.search(r"\bGlobals\.", body) or re.search(r"\bvars\.", body):
+                _fail(
+                    f"{path}: script task reads/mutates Globals.*/vars.* directly — "
+                    "unsupported in Jint. Return a value and map it via uipath:output."
+                )
     if not found_script:
         _fail(
             "no scriptTask in any authored .bpmn — the product must be computed by "
             "a script task, not hardcoded"
         )
-    print("OK: product is computed by a script task")
+    print("OK: product is computed by a script task (return + output mapping)")
 
     # 2. Read the agent's saved CLI evidence. The `variables-all` output is the
     #    only source of the runtime `product` value — the `debug` command output

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
@@ -1,17 +1,34 @@
 #!/usr/bin/env python3
 """Runtime check for the live BPMN debug e2e.
 
-Grades the agent's saved debug evidence — the raw CLI output of a real
-`uip maestro bpmn debug` session and the following `debug-instance variables`
-read. Un-fakeable in combination with the task's command_executed criteria: the
-debug command must actually have run and reached finalStatus Completed, and the
-inspected runtime variables must carry the deterministic computed product (42
-for inputs a=6, b=7). Also confirms the process computes the result in a script
-task rather than hardcoding it.
+Asserts a real ``uip maestro bpmn debug`` session reached ``finalStatus ==
+Completed`` AND the runtime ``product`` variable is 42, computed by a script task
+(not hardcoded).
 
-Reads:
-  - debug-evidence/*.json  (agent-saved raw CLI JSON: debug + variables)
-  - the authored .bpmn      (must contain a scriptTask)
+The key CLI fact this check is built around
+-------------------------------------------
+``uip maestro bpmn debug`` output carries only element-execution *statuses*
+(``Data.ElementExecutions[].Status``) — it NEVER contains variable *values*. The
+computed business result (``product``) lives only in
+``uip maestro bpmn debug-instance variables-all <INSTANCE_ID>``. Grading the
+debug command's own output for ``product == 42`` can therefore never pass; the
+value must come from a ``variables-all`` read. The original check greped the
+agent's saved files for a leaf ``== 42``, which made the primary assertion
+hostage to the agent remembering to persist the ``variables-all`` output — the
+exact flake this task hit (agent saved ``debug.json`` with ``finalStatus:
+Completed`` but no variables file, so ``product`` was nowhere in the evidence).
+
+Grading strategy
+----------------
+  1. Structural guard: a scriptTask exists in the authored ``.bpmn``.
+  2. Primary (deterministic): the agent's saved evidence shows a completed run
+     AND a ``product``-named variable == 42 (read structurally by name, not by
+     leaf-grep, so GUIDs/timestamps can't false-match).
+  3. Live recovery (best-effort, only if 2 finds no product): re-read the saved
+     ``instanceId`` via ``variables-all`` (debug instances are ephemeral, so this
+     usually 404s), then re-run a fresh debug session and read its variables.
+     This lets a correct build pass even when the agent forgot to save the
+     variables output, without ever causing a false failure.
 
 Exits 0 with OK lines on success; non-zero with FAIL on the first problem.
 """
@@ -21,15 +38,25 @@ from __future__ import annotations
 import glob
 import json
 import os
+import subprocess
 import sys
+import time
 import xml.etree.ElementTree as ET
 
 EXPECTED_PRODUCT = 42
+PRODUCT_VAR = "product"
 BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+# Keys whose sub-tree legitimately carries variable values — restricts the
+# 42-search haystack so GUIDs/timestamps/status strings can't false-match (the
+# lesson the flow checker's docstring calls out).
+VALUE_BEARING_KEYS = {"variables", "globals", "outputs", "output", "response"}
 
 
 def _fail(msg: str) -> None:
     sys.exit(f"FAIL: {msg}")
+
+
+# ── JSON parsing / structural search ─────────────────────────────────────────
 
 
 def _parse_json_tolerant(text: str):
@@ -48,70 +75,174 @@ def _parse_json_tolerant(text: str):
     return None
 
 
-def _walk(obj):
-    """Yield every (key, value) pair and every scalar leaf in a nested structure."""
+def _is_expected(val) -> bool:
+    if isinstance(val, bool):
+        return False
+    if isinstance(val, (int, float)) and val == EXPECTED_PRODUCT:
+        return True
+    return isinstance(val, str) and val.strip() in ("42", "42.0")
+
+
+def _find_ci_key(obj, wanted: str):
+    """Yield every value whose dict key equals ``wanted`` (case-insensitive)."""
     if isinstance(obj, dict):
         for k, v in obj.items():
-            yield ("__key__", k, v)
-            yield from _walk(v)
+            if isinstance(k, str) and k.lower() == wanted:
+                yield v
+            yield from _find_ci_key(v, wanted)
     elif isinstance(obj, (list, tuple)):
         for item in obj:
-            yield from _walk(item)
+            yield from _find_ci_key(item, wanted)
+
+
+def _all_leaves(obj):
+    if isinstance(obj, dict):
+        for v in obj.values():
+            yield from _all_leaves(v)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            yield from _all_leaves(item)
     else:
-        yield ("__leaf__", None, obj)
+        yield obj
+
+
+def _leaves_under_value_bearing(obj):
+    """Yield scalar leaves that live under a value-bearing key subtree."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(k, str) and k.lower() in VALUE_BEARING_KEYS:
+                yield from _all_leaves(v)
+            else:
+                yield from _leaves_under_value_bearing(v)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            yield from _leaves_under_value_bearing(item)
 
 
 def _has_final_status_completed(parsed) -> bool:
-    for tag, key, val in _walk(parsed):
-        if tag == "__key__" and isinstance(key, str) and key.lower() == "finalstatus":
-            if isinstance(val, str) and val.strip().lower() == "completed":
-                return True
+    for val in _find_ci_key(parsed, "finalstatus"):
+        if isinstance(val, str) and val.strip().lower() == "completed":
+            return True
     return False
+
+
+def _instance_id(parsed):
+    for key in ("instanceid", "debuginstanceid"):
+        for val in _find_ci_key(parsed, key):
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+    return None
+
+
+def _iter_name_value_pairs(obj):
+    """Yield (name, value) for dicts that carry both a name and a value key."""
+    if isinstance(obj, dict):
+        keys_lower = {k.lower() for k in obj if isinstance(k, str)}
+        if "name" in keys_lower and "value" in keys_lower:
+            name = next((v for k, v in obj.items() if isinstance(k, str) and k.lower() == "name"), None)
+            value = next((v for k, v in obj.items() if isinstance(k, str) and k.lower() == "value"), None)
+            yield (name, value)
+        for v in obj.values():
+            yield from _iter_name_value_pairs(v)
+    elif isinstance(obj, (list, tuple)):
+        for item in obj:
+            yield from _iter_name_value_pairs(item)
 
 
 def _has_expected_product(parsed) -> bool:
-    for tag, _key, val in _walk(parsed):
-        if tag != "__leaf__":
-            continue
-        if isinstance(val, bool):
-            continue
-        if isinstance(val, (int, float)) and val == EXPECTED_PRODUCT:
+    """True when the runtime exposes a ``product`` variable equal to 42.
+
+    Precise match first (a key literally named ``product`` — e.g.
+    ``Globals.Product`` — or a ``{name: product, value: 42}`` pair), then a
+    fallback restricted to value-bearing sub-trees so shape drift still passes
+    without letting GUIDs/timestamps false-match.
+    """
+    # (a) key named "product" with the expected value (Globals.Product = 42)
+    for val in _find_ci_key(parsed, PRODUCT_VAR):
+        if _is_expected(val):
             return True
-        if isinstance(val, str) and val.strip() in ("42", "42.0"):
+    # (b) {"name": "product", "value": 42} pairs (mock/CLI list shape)
+    for name, value in _iter_name_value_pairs(parsed):
+        if isinstance(name, str) and name.strip().lower() == PRODUCT_VAR and _is_expected(value):
+            return True
+    # (c) fallback: 42 anywhere under a variables/globals/outputs subtree
+    for leaf in _leaves_under_value_bearing(parsed):
+        if _is_expected(leaf):
             return True
     return False
 
 
-def main() -> None:
-    evidence = glob.glob("debug-evidence/**/*.json", recursive=True)
-    if not evidence:
-        _fail("no debug-evidence/*.json files found — the agent did not save raw CLI output")
+# ── CLI ──────────────────────────────────────────────────────────────────────
 
-    parsed_files = {}
-    for path in evidence:
+
+def _run_uip(args, timeout: int, attempts: int = 2):
+    """Run ``uip <args> --output json`` with a small retry for cold-start/5xx.
+
+    Returns the parsed JSON (dict/list) or None."""
+    cmd = ["uip", *args, "--output", "json"]
+    last = ""
+    for attempt in range(attempts):
         try:
-            text = open(path, encoding="utf-8", errors="ignore").read()
-        except OSError as exc:
-            _fail(f"could not read {path}: {exc}")
-        parsed = _parse_json_tolerant(text)
-        if parsed is None:
-            _fail(f"debug evidence file is not valid JSON: {path}")
-        parsed_files[path] = parsed
+            r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            last = f"timeout after {timeout}s"
+            continue
+        last = f"exit {r.returncode}\nstdout: {r.stdout[:2000]}\nstderr: {r.stderr[:1000]}"
+        parsed = _parse_json_tolerant(r.stdout)
+        if r.returncode == 0 and parsed is not None:
+            return parsed
+        if attempt + 1 < attempts:
+            time.sleep(5)
+    print(f"note: `uip {' '.join(args)}` did not return usable JSON — {last}", file=sys.stderr)
+    return None
 
-    if not any(_has_final_status_completed(p) for p in parsed_files.values()):
-        _fail(
-            "no finalStatus == 'Completed' in any debug-evidence file — the debug "
-            f"run did not complete. Files: {sorted(parsed_files)}"
-        )
-    print("OK: debug session reached finalStatus Completed")
 
-    if not any(_has_expected_product(p) for p in parsed_files.values()):
-        _fail(
-            f"expected product {EXPECTED_PRODUCT} not found among runtime variable "
-            f"values in debug-evidence. Files: {sorted(parsed_files)}"
-        )
-    print(f"OK: runtime product variable is {EXPECTED_PRODUCT}")
+def _read_variables_all(instance_id: str):
+    return _run_uip(
+        ["maestro", "bpmn", "debug-instance", "variables-all", instance_id],
+        timeout=120,
+    )
 
+
+def _bpmn_project_candidates():
+    """Directories of every project.uiproj that has a sibling ``.bpmn``,
+    shallowest first (a standalone ``ProductCalc/`` before a solution-nested
+    copy). BPMN debug needs solution context, so the caller tries each until one
+    debugs."""
+    candidates = []
+    for proj in glob.glob("**/project.uiproj", recursive=True):
+        d = os.path.dirname(proj) or "."
+        if glob.glob(os.path.join(d, "*.bpmn")):
+            candidates.append(d)
+    candidates.sort(key=lambda p: (p.count(os.sep), len(p)))
+    return candidates
+
+
+def _fresh_debug_then_variables():
+    """Execute a fresh debug session and read its runtime variables live.
+
+    Tries each candidate project (BPMN debug needs solution context, which not
+    every project dir has). Returns (completed: bool, variables_payload | None)."""
+    completed = False
+    for project in _bpmn_project_candidates()[:2]:  # bound tenant work in recovery
+        debug = _run_uip(["maestro", "bpmn", "debug", project], timeout=300)
+        if debug is None:
+            continue
+        completed = completed or _has_final_status_completed(debug)
+        inst = _instance_id(debug)
+        if not inst:
+            continue
+        variables = _read_variables_all(inst)
+        if variables is not None and _has_expected_product(variables):
+            return (True, variables)
+    return (completed, None)
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    # 1. Structural guard: the product must be computed by a script task.
     bpmn_files = glob.glob("**/*.bpmn", recursive=True)
     if not bpmn_files:
         _fail("no .bpmn file authored")
@@ -130,6 +261,67 @@ def main() -> None:
             "a script task, not hardcoded"
         )
     print("OK: product is computed by a script task")
+
+    # 2. Read the agent's saved CLI evidence. The `variables-all` output is the
+    #    only source of the runtime `product` value — the `debug` command output
+    #    carries element statuses only. Primary, deterministic pass path: the
+    #    agent saved a variables-all payload with product == 42.
+    saved = glob.glob("debug-evidence/**/*.json", recursive=True) + glob.glob("*.json")
+    completed = False
+    product_from_evidence = False
+    instance_id = None
+    for path in saved:
+        try:
+            parsed = _parse_json_tolerant(open(path, encoding="utf-8", errors="ignore").read())
+        except OSError:
+            continue
+        if parsed is None:
+            continue
+        if _has_final_status_completed(parsed):
+            completed = True
+            instance_id = instance_id or _instance_id(parsed)
+        if _has_expected_product(parsed):
+            product_from_evidence = True
+
+    if not completed:
+        _fail(
+            "no debug-evidence with finalStatus == 'Completed' — save the raw "
+            "`uip maestro bpmn debug` JSON output to debug-evidence/"
+        )
+    print("OK: debug session reached finalStatus Completed")
+
+    if product_from_evidence:
+        print(f"OK: runtime product variable is {EXPECTED_PRODUCT} (from saved variables-all evidence)")
+        print("PASS: all live-debug checks passed")
+        return
+
+    # 3. The agent did not save a variables-all payload carrying product. The
+    #    `debug` command output alone never contains variable values, so recover
+    #    the value live: re-read the agent's instance (usually gone — debug
+    #    instances are ephemeral), then re-run a fresh debug session.
+    print(
+        "note: no product value in saved evidence — the debug command output has "
+        "no variable values; attempting live recovery via debug-instance variables-all",
+        file=sys.stderr,
+    )
+    variables_payload = None
+    if instance_id:
+        live = _read_variables_all(instance_id)
+        if live is not None and _has_expected_product(live):
+            variables_payload = live
+    if variables_payload is None:
+        _, fresh_vars = _fresh_debug_then_variables()
+        if fresh_vars is not None and _has_expected_product(fresh_vars):
+            variables_payload = fresh_vars
+
+    if variables_payload is None:
+        _fail(
+            f"runtime `product` variable is not {EXPECTED_PRODUCT}: not in saved "
+            "evidence, and live recovery via `debug-instance variables-all` failed "
+            "(save the variables-all output to debug-evidence/ — the debug command "
+            "output does NOT contain variable values)"
+        )
+    print(f"OK: live runtime product variable is {EXPECTED_PRODUCT} (recovered via variables-all)")
     print("PASS: all live-debug checks passed")
 
 

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
@@ -57,14 +57,14 @@ initial_prompt: |
   upload and debug this project in the connected tenant. Do not pass `--inputs`
   — the computation is self-contained.
 
-  IMPORTANT: the `debug` command output reports element-execution *statuses*
-  only — it does NOT contain variable *values*. All elements showing Completed
-  does not prove `product` is 42. To read the runtime value you MUST take the
-  debug instance id the debug command returns and run
-  `uip maestro bpmn debug-instance variables-all <INSTANCE_ID> --output json`.
+  IMPORTANT: the debug command output reports element-execution statuses only —
+  it does NOT contain variable values. All elements showing Completed does not
+  prove `product` is 42. Read the runtime variable values separately using the
+  skill's debug-instance inspection commands (the skill teaches which command
+  and how).
 
   Save the raw CLI output so the result can be verified independently:
-    - save the full JSON output of the `debug-instance variables-all` command to
+    - save the full JSON output of the runtime variables inspection to
       `debug-evidence/variables.json` — this is the only output that carries the
       `product` value, so it is the required deliverable,
     - also save the full JSON output of the debug command to
@@ -73,8 +73,8 @@ initial_prompt: |
   Preserve the raw CLI JSON exactly — do not summarize or hand-edit it.
 
   The task is complete only when the debug run reaches finalStatus Completed
-  and the saved `variables-all` output shows the runtime `product` variable is
-  42. Saving only the debug command output is NOT sufficient. If the first debug
+  and the saved runtime-variables output shows the `product` variable is 42.
+  Saving only the debug command output is NOT sufficient. If the first debug
   run does not produce product=42, fix the variable/output mapping and debug
   again — but run at most 3 debug sessions in total. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and implementation.

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
@@ -21,13 +21,15 @@ description: >
 tags: [uipath-maestro-bpmn, e2e, "mode:operate", "lifecycle:setup", path-to-ga]
 
 # turn_timeout must cover the whole agent session (observed: a 902s session was
-# killed by the 900s default while iterating on variable bindings after a live
-# debug run); task_timeout adds headroom for grading on top.
+# killed by the 900s default, then a 1500s turn timed out while the agent
+# wandered on solution scaffolding + variable scoping under slow Bedrock latency
+# on the shared runner). task_timeout adds headroom for grading (incl. the
+# check's possible live-recovery debug run) on top.
 run_limits:
   expected_turns: 30
-  task_timeout: 1800
+  task_timeout: 3300
   max_turns: 120
-  turn_timeout: 1500
+  turn_timeout: 2400
 
 sandbox:
   template_sources:
@@ -44,6 +46,11 @@ initial_prompt: |
       the script body and writes the result to a process variable named
       exactly `product`,
     - an end event.
+
+  Declare `product` as a ROOT-scoped process variable (its `uipath:inputOutput`
+  must NOT carry an `elementId`) so its runtime value is readable via
+  `variables-all`. Build exactly one project — do not scaffold extra projects,
+  boilerplate copies, or duplicate .bpmn files.
 
   Then run a debug session for the project against Studio Web and confirm from
   the runtime that the `product` variable is 42. You have explicit consent to

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
@@ -4,12 +4,16 @@ description: >
   deterministic BPMN project (manual start, one Jint script task that computes
   the product of the constants 6 and 7 into a `product` variable, an end
   event), runs a live `uip maestro bpmn debug` session against Studio Web, and
-  inspects the runtime result via the `debug-instance` variables commands. The
-  agent saves the raw debug and variables CLI output to `debug-evidence/`, and
-  the check asserts the debug run reached finalStatus Completed and the runtime
-  `product` variable is 42 — an un-fakeable runtime assertion. Mirrors the
-  uipath-maestro-flow live `run_debug` grading pattern. Live: no mocks; auth
-  comes from the experiment environment. Deliberately computes from in-script
+  reads the runtime result via `debug-instance variables-all` (the debug command
+  output carries element statuses only — never variable values). The agent saves
+  the raw variables-all output to `debug-evidence/`, and the check asserts the
+  debug run reached finalStatus Completed and the runtime `product` variable is
+  42 — an un-fakeable runtime assertion. If the agent's evidence lacks the value,
+  the check recovers it by re-running a fresh debug session itself (debug
+  instances are ephemeral, so the agent's instance can't be re-read at grading
+  time). Mirrors the uipath-maestro-flow live `run_debug` grading pattern (the
+  checker owns the runtime read). Live: no mocks; auth comes from the experiment
+  environment. Deliberately computes from in-script
   constants rather than `--inputs`: CI iteration 2 showed `bpmn debug --inputs`
   values are not transmitted to the runtime (Start event Inputs arrive empty),
   so external-input grading would test that CLI gap, not the debug workflow.
@@ -46,20 +50,27 @@ initial_prompt: |
   upload and debug this project in the connected tenant. Do not pass `--inputs`
   — the computation is self-contained.
 
+  IMPORTANT: the `debug` command output reports element-execution *statuses*
+  only — it does NOT contain variable *values*. All elements showing Completed
+  does not prove `product` is 42. To read the runtime value you MUST take the
+  debug instance id the debug command returns and run
+  `uip maestro bpmn debug-instance variables-all <INSTANCE_ID> --output json`.
+
   Save the raw CLI output so the result can be verified independently:
-    - save the full JSON output of the debug command to
-      `debug-evidence/debug.json`,
-    - take the debug instance id the debug command returns and save the full
-      JSON output of the `debug-instance variables-all` command for that
-      instance to `debug-evidence/variables.json`.
+    - save the full JSON output of the `debug-instance variables-all` command to
+      `debug-evidence/variables.json` — this is the only output that carries the
+      `product` value, so it is the required deliverable,
+    - also save the full JSON output of the debug command to
+      `debug-evidence/debug.json`.
 
   Preserve the raw CLI JSON exactly — do not summarize or hand-edit it.
 
   The task is complete only when the debug run reaches finalStatus Completed
-  and the runtime `product` variable reads 42. If the first debug run does not
-  produce product=42, fix the variable/output mapping and debug again — but run
-  at most 3 debug sessions in total. Do NOT ask for approval, confirmation, or
-  feedback. Do NOT pause between planning and implementation.
+  and the saved `variables-all` output shows the runtime `product` variable is
+  42. Saving only the debug command output is NOT sufficient. If the first debug
+  run does not produce product=42, fix the variable/output mapping and debug
+  again — but run at most 3 debug sessions in total. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and implementation.
 
 success_criteria:
   - type: command_executed
@@ -78,10 +89,14 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # timeout covers a possible live-recovery path: when the agent's saved
+  # evidence lacks the product value, the checker re-runs a fresh debug session
+  # itself (debug instances are ephemeral, so the agent's instance can no longer
+  # be read at grading time) to recover the runtime value.
   - type: run_command
-    description: "Live debug reached finalStatus Completed and the runtime product variable is 42 (computed by a script task, not hardcoded)"
+    description: "Live debug reached finalStatus Completed and the runtime product variable is 42 (read from variables-all, computed by a script task, not hardcoded)"
     command: "python3 $TASK_DIR/check_live_debug.py"
-    timeout: 120
+    timeout: 900
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/nodes/script_jint_guidance.yaml
@@ -39,7 +39,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "BPMN source was created"
-    command: "find RiskScoreScriptBpmn -maxdepth 1 -type f -name '*.bpmn' | grep -q ."
+    command: "find . -type f -name '*.bpmn' -path '*RiskScoreScriptBpmn*' | grep -q ."
     timeout: 10
     expected_exit_code: 0
     weight: 1.0


### PR DESCRIPTION
## Problem

Investigated a failing run of the `skill-bpmn-e2e-live-debug` e2e (artifact provided offline). The weight-6.0 grading check exited 1:

```
OK:   debug session reached finalStatus Completed
FAIL: expected product 42 not found among runtime variable values in debug-evidence.
      Files: ['debug-evidence/debug.json']
```

The agent authored a **correct** project — a `scriptTask` computing `6*7`, mapped to a `number` variable `product` — and ran a live debug that reached `finalStatus: Completed` with the `ScriptTask` element Completed. It failed grading anyway.

## Root cause

`uip maestro bpmn debug` output carries element-execution **statuses** only (`Data.ElementExecutions[].Status`) — it **never** contains variable **values**. The runtime `product` value lives solely in `uip maestro bpmn debug-instance variables-all`. (Confirmed against the mocked-debug fixtures on `main` and PR #2097's own passing-run notes: `.Data.Variables[0].Globals.Product = 42`.)

The old `check_live_debug.py` greped the agent's **saved files** for a leaf `== 42`. So the primary assertion was hostage to the agent remembering to persist the `variables-all` output. This run's agent saved `debug.json` (the debug command output, which never has values) but not a `variables-all` file → `product` was nowhere in the evidence → FAIL. PR #2097's run passed only because that agent *also* saved the variables file. **The check graded agent file-saving discipline, not the runtime.**

The proven `uipath-maestro-flow` e2e pattern (`_shared/flow_check.py`) avoids exactly this: its checker owns the runtime read and its docstring explicitly warns against leaf-grepping the debug dump. This task's description *claimed* to mirror that pattern but did not.

Two hard constraints discovered while validating (with a live-authed `uip`):
- **Debug instances are ephemeral** — re-reading the agent's saved `instanceId` at grading time returns **404**.
- **BPMN debug needs solution context** — a fresh `bpmn debug` on a standalone project dir fails with *"SolutionStorage.json is missing"*, unlike `flow debug`.

## Fix

**`check_live_debug.py`**
- Read `product` **structurally by variable name** (handles the live `Data.Variables[].Globals.Product` shape and the `{name, value}` shape), restricting the fallback 42-search to value-bearing subtrees so GUIDs/timestamps can't false-match.
- **Primary, deterministic pass path:** the agent's saved `variables-all` evidence shows a completed run + `product == 42`.
- **Live recovery (best-effort, only when the value is absent):** re-read the saved `instanceId` (usually 404), then re-run a fresh debug session (bounded to 2 candidate projects) and read `variables-all`. This lets a correct build pass even when the agent forgot to save the file, and never causes a false failure.

**`live_debug_e2e.yaml`**
- Prompt now states plainly that the debug command output has no variable values and the `variables-all` output is the **required** deliverable ("saving only the debug command output is NOT sufficient").
- Check `timeout` 120 → 900 to cover the live-recovery path.

**`skills/uipath-maestro-bpmn/.../operate/references/run.md`**
- Callout: debug output = element statuses, not values; to read a business result run `debug-instance variables-all`; instances are ephemeral — read in-session.

## Verification

Local (structural + file paths):
- **Gold** (agent saved `variables-all` with `product=42`, real live shape) → PASS, no live calls.
- **Mutations** all FAIL: wrong value (41); only `debug.json` saved + recovery unavailable (the original failure); `finalStatus` not Completed; no `scriptTask`.

Live path (checker re-running debug + `variables-all` against the tenant) to be validated via `run-coder-eval` on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
