### PR TITLE
feat(maestro-case): reject colons in stage and SLA names

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -166,7 +166,7 @@ The generated SDD must start with:
 | Task-output passing | {Direct \| Shared} — `caseDirectlyPassTaskOutputs` (Direct = a task's outputs flow straight to downstream tasks; default Direct) |
 | Case Identifier source | {`=metadata.ExternalId` (platform-generated — the default) \| custom} — what every `caseId` task input binds to |
 
-> **Naming constraint:** Stage names and SLA titles/display names must not contain `:`. The colon is reserved by the SDD heading and task-entry syntax; replace it with a dash, parentheses, or another punctuation mark while preserving the user's wording.
+> **Case App validation contract:** Stage names must be non-empty, unique, and contain no `:`. Task names must contain no `:`. Every SLA rule and escalation needs a non-empty, target-unique title/display name with no `:`. SLA durations must be positive; minute-based SLAs must be 15–1000 minutes. Non-default SLA rows need an expression; escalations need a recipient, and at-risk escalations need a percentage.
 
 ### Case-Level SLA Escalation Rules
 
@@ -350,7 +350,7 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| {count} | {h \| d \| w \| m} | {percentage}% | {Notify: recipient or specific action} | {Notify: recipient or specific action} |
+| {count} | {min \| h \| d \| w \| m} | {percentage}% | {Notify: recipient or specific action} | {Notify: recipient or specific action} |
 
 #### Tasks
 

--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -166,6 +166,8 @@ The generated SDD must start with:
 | Task-output passing | {Direct \| Shared} — `caseDirectlyPassTaskOutputs` (Direct = a task's outputs flow straight to downstream tasks; default Direct) |
 | Case Identifier source | {`=metadata.ExternalId` (platform-generated — the default) \| custom} — what every `caseId` task input binds to |
 
+> **Naming constraint:** Stage names and SLA titles/display names must not contain `:`. The colon is reserved by the SDD heading and task-entry syntax; replace it with a dash, parentheses, or another punctuation mark while preserving the user's wording.
+
 ### Case-Level SLA Escalation Rules
 
 | SLA Status | Threshold | Action |

--- a/skills/uipath-maestro-case/references/case-schema.md
+++ b/skills/uipath-maestro-case/references/case-schema.md
@@ -104,7 +104,7 @@ Metadata and configuration for the case definition. Top-level fields (`id`, `ver
 | `metadata.caseUnifiedSchemaEnabled` | boolean? | Unified-schema flag (`true`) |
 | `metadata.caseDirectlyPassTaskOutputs` | boolean? | Passes task outputs directly through messages instead of shared variables, fixing race conditions on task outputs in cases with parallel tasks. Schema-optional, defaults `true` when absent; skill emits the T01 `directly-pass-task-outputs` value (`true` unless sdd.md requested `false`). |
 | `metadata.intsvcActivityConfig` | string? | Integration-service activity configuration payload |
-| `metadata.slaRules` | SlaRuleEntry[]? | Conditional + default SLA rules for the case. Default SLA lives here as the trailing entry with `expression: "=js:true"`. Escalations attach inside each rule's `escalationRule[]`. See §6. |
+| `metadata.slaRules` | SlaRuleEntry[]? | Conditional + default SLA rules for the case. Every rule has a non-empty target-unique `displayName` without `:`; default SLA lives here as the trailing entry with `expression: "=js:true"`. Escalations attach inside each rule's `escalationRule[]`. See §6. |
 | `metadata.caseExitRules` | CaseExitCondition[]? | Conditions that mark the case as complete |
 
 ### Case identifier (constant vs external)
@@ -182,14 +182,14 @@ No `position`, `style`, `measured`, `width`, `height`, or `zIndex` at the node l
 | Field | Type | Description |
 |-------|------|-------------|
 | `stageType` | `"primary" \| "secondary"` ? | Stage kind discriminator. Omitted on a primary stage (do NOT emit `"primary"`); set to `"secondary"` for a secondary stage, where it is the FIRST field in `data` (before `label`). See §2c. |
-| `label` | string? | Display label |
+| `label` | string? | Display label; required, unique across stages, and must not contain `:` |
 | `description` | string? | Stage description |
 | `isRequired` | boolean? | Whether the stage must complete before case exit (used by case-exit rule `required-stages-completed`) |
 | `parentElement` | `{id,type}` | Always `{ id: "root", type: "case-management:root" }`. The literal `"root"` is canvas-side — there is no `"root"` node on disk. |
 | `isInvalidDropTarget` | boolean | Always `false` (UI drag-drop flag) |
 | `isPendingParent` | boolean | Always `false` (UI drag-drop flag) |
 | `tasks` | Task[][] | 2D array: `tasks[lane][index]`. Default: one task per lane (`tasks[0][0]`, `tasks[1][0]`, …) so the FE lays them out in separate columns; lane is layout-only, sequencing comes from task-entry conditions. Exception: tasks in a `runs-sequentially` group that should execute in parallel share the same lane — there, shared lane carries execution semantics (parallel siblings inside the sequential group). Empty array `[]` when no tasks yet. |
-| `slaRules` | SlaRuleEntry[]? | Conditional + default SLA rules for this stage. Default SLA is the trailing `"=js:true"` entry. Escalations nest inside each rule. See §6. |
+| `slaRules` | SlaRuleEntry[]? | Conditional + default SLA rules for this stage. Every rule has a non-empty target-unique `displayName` without `:`; default SLA is the trailing `"=js:true"` entry. Escalations nest inside each rule. See §6. |
 | `entryConditions` | EntryCondition[]? | See §3. Not initialized on primary Stage creation — added later by the conditions plugins. (A secondary stage initializes these at creation — see §2c.) |
 | `exitConditions` | ExitCondition[]? | See §3. Not initialized on primary Stage creation — added later by the conditions plugins. (A secondary stage initializes these at creation — see §2c.) |
 | `instanceIdPrefix` | string? | Prefix for instance IDs |
@@ -443,10 +443,11 @@ Escalation `action.recipients[].scope`: `"User"` or `"UserGroup"`. `target` is t
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `expression` | string | Rule predicate. `"=js:true"` marks the default / fallback rule. |
+| `displayName` | string | Required, target-unique SLA title; must not contain `:`. |
+| `expression` | string | Rule predicate. `"=js:true"` marks the default / fallback rule. Non-default rules require a non-empty expression. |
 | `count` | number? | SLA duration count (optional — a bare escalation-only rule may omit this). |
 | `unit` | `"min" \| "h" \| "d" \| "w" \| "m"` ? | SLA duration unit (optional — paired with `count`). |
-| `escalationRule` | EscalationRule[]? | Notifications to fire at-risk or on breach. Runtime attaches escalations to whichever rule is active. |
+| `escalationRule` | EscalationRule[]? | Notifications to fire at-risk or on breach. Each escalation requires a non-empty target-unique `displayName` without `:`, at least one recipient, and an at-risk percentage when its trigger type is `at-risk`. Runtime attaches escalations to whichever rule is active. |
 
 Evaluated in array order; the first truthy expression wins. The trailing `"=js:true"` entry acts as the default.
 

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -16,9 +16,9 @@ Compose the `slaRules[]` array for each target (root or stage) in one write. Gro
 
 | T-entry kind | Required fields | Notes |
 |---|---|---|
-| Default SLA | `target`, `count`, `unit` | One per target. Emitted as the `=js:true` entry, always last. |
-| Conditional rule | `target: "root"`, `condition` (natural-language), `count`, `unit` | Root-only. Translated to `=js:<expr>` at execution; see Expression Translation below. |
-| Escalation | `target`, `attach-to: T<m>` \| `default`, `trigger-type`, `at-risk-percentage?`, `recipients[]`, `display-name?` | `attach-to` points to the T-number of the parent rule (or the default). |
+| Default SLA | `target`, `count`, `unit`, `display-name` | One per target. Emitted as the `=js:true` entry, always last. |
+| Conditional rule | `target: "root"`, `condition` (natural-language), `count`, `unit`, `display-name` | Root-only. Translated to `=js:<expr>` at execution; see Expression Translation below. |
+| Escalation | `target`, `attach-to: T<m>` \| `default`, `trigger-type`, `at-risk-percentage?`, `recipients[]`, `display-name` | `attach-to` points to the T-number of the parent rule (or the default). |
 
 ## ID generation
 
@@ -43,12 +43,14 @@ After grouping T-entries by target, compose the `slaRules` array and write it in
 ```json
 [
   {
+    "displayName": "SLA Rule 1",
     "expression": "=js:<translated-condition-1>",
     "count": <n>, "unit": "<min|h|d|w|m>",
     "escalationRule": [ <escalations with attach-to == conditional-1-T-number> ]
   },
   { "...additional conditional rules in sdd order..." },
   {
+    "displayName": "SLA Rule 2",
     "expression": "=js:true",
     "count": <default.count>, "unit": "<default.unit>",
     "escalationRule": [ <escalations with attach-to == default> ]
@@ -82,7 +84,7 @@ Emission rules:
 
 1. **Conditional rules first, in T-entry order.** Priority = sdd order (top-most wins).
 2. **Default rule (`=js:true`) last.** Always emitted when any SLA T-entry targets this node — even escalation-only cases.
-3. **Bare default rule is legal.** If a target has escalations but no default SLA T-entry, emit `{expression:"=js:true", escalationRule:[…]}` with no `count` / `unit`.
+3. **Escalation-only default rule is legal, but it still needs a title.** If a target has escalations but no default SLA T-entry, emit `{displayName:"SLA Rule 1", expression:"=js:true", escalationRule:[…]}` with no `count` / `unit`.
 4. **Always emit `escalationRule` on every rule.** Use `"escalationRule": []` when a rule has no attached escalations. Never omit the key.
 5. **Omit `slaRules` key entirely** on targets with no SLA T-entries.
 
@@ -91,7 +93,7 @@ Emission rules:
 ```json
 {
   "id": "esc_xxxxxx",
-  "displayName": "<from T-entry, optional>",
+  "displayName": "<from T-entry or deterministic fallback>",
   "action": {
     "type": "notification",
     "recipients": [
@@ -105,7 +107,9 @@ Emission rules:
 }
 ```
 
-- `displayName` omitted entirely when T-entry doesn't supply one (don't emit `undefined`). When supplied, it is the SLA title shown in the UI and MUST NOT contain `:`; reject the T-entry before writing JSON if it does.
+- `displayName` is required for every SLA rule and escalation in the current Case App contract. Use the authored value or deterministic fallback; never emit blank/undefined. It must be unique within the target and MUST NOT contain `:`; reject the T-entry before writing JSON if it does.
+- Reject a non-positive `count`; for `unit: "min"`, reject values below 15 or above 1000.
+- Reject a non-default rule with an empty expression, an escalation with no recipients, or an `at-risk` escalation without `atRiskPercentage`.
 - `atRiskPercentage` included only when `triggerInfo.type === "at-risk"`.
 - `recipients` is an array — **one entry per sdd-declared recipient**.
 

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -105,7 +105,7 @@ Emission rules:
 }
 ```
 
-- `displayName` omitted entirely when T-entry doesn't supply one (don't emit `undefined`).
+- `displayName` omitted entirely when T-entry doesn't supply one (don't emit `undefined`). When supplied, it is the SLA title shown in the UI and MUST NOT contain `:`; reject the T-entry before writing JSON if it does.
 - `atRiskPercentage` included only when `triggerInfo.type === "at-risk"`.
 - `recipients` is an array — **one entry per sdd-declared recipient**.
 
@@ -129,4 +129,3 @@ List every unresolved recipient in the completion report (per SKILL.md § Comple
 - Confirm the trailing entry's `expression === "=js:true"` when any SLA T-entry targeted this node.
 - Confirm every generated `esc_` ID appears in `id-map.json`.
 - Run `uip maestro case validate <file> --output json` after all SLA targets have been written (not per-target).
-

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -41,6 +41,7 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 | `count` | sdd.md duration number | Positive integer |
 | `unit` | sdd.md duration unit | `min` \| `h` \| `d` \| `w` \| `m` |
 | `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
+| `display-name` | sdd.md or generated fallback | Required non-empty SLA title, unique within the target, and MUST NOT contain `:`. If the SDD has no title, ask for one or use the deterministic fallback `SLA Rule {N}` and record it. |
 
 ### Conditional SLA rule
 
@@ -48,6 +49,7 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 |-------|--------|-------|
 | `expression` | sdd.md condition | Natural-language in planning; the execution phase translates. **Do not fabricate syntax during planning.** |
 | `count`, `unit` | sdd.md duration for this condition | Same units as default |
+| `display-name` | sdd.md or generated fallback | Required non-empty unique title, no `:`; use `SLA Rule {N}` only when the author supplied no title. |
 
 Rules are evaluated in insertion order — first truthy expression wins. The default SLA acts as the fallback.
 
@@ -56,11 +58,11 @@ Rules are evaluated in insertion order — first truthy expression wins. The def
 | Field | Source | Notes |
 |-------|--------|-------|
 | `trigger-type` | sdd.md | `at-risk` \| `sla-breached` |
-| `at-risk-percentage` | sdd.md | Required when `trigger-type: at-risk` (1–99) |
+| `at-risk-percentage` | sdd.md | Required when `trigger-type: at-risk`; preserve the supplied value because FE validates presence (it does not enforce a numeric range here). |
 | `recipient-scope` | sdd.md | `User` \| `UserGroup` |
 | `recipient-target` | sdd.md → resolver | Recipient UUID. When sdd gives an email or group name, run [§ Identity Resolution](#identity-resolution) — resolved UUID written inline. On resolver failure or user decline, mark `<UNRESOLVED: user-uuid for <email>>` / `<UNRESOLVED: group-uuid for <name>>`. |
 | `recipient-value` | sdd.md | Display value (typically the email for User, group name for UserGroup). |
-| `display-name` | sdd.md (optional) | SLA title shown in the UI. MUST NOT contain `:`. |
+| `display-name` | sdd.md or generated fallback | Required non-empty escalation title, unique across the target, and MUST NOT contain `:`. If omitted, use `Escalation Rule {N}` and record the fallback. |
 | `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
 | `attach-to` | sdd.md | `default` (attach to the `=js:true` rule) or `T<m>` pointing to the conditional-rule T-entry the escalation fires under. |
 
@@ -142,6 +144,7 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 ```markdown
 ## T<n>: Set default SLA for "<target>" to <duration>
 - target: "<root>" | "<stage-name>"
+- display-name: "SLA Rule 1"              # required; use authored title or SLA Rule {N}
 - count: 5
 - unit: d
 - order: after T<m>
@@ -152,6 +155,7 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 
 ```markdown
 ## T<n>: Add conditional SLA rule for root case — <condition summary>
+- display-name: "Urgent SLA"              # required; target-unique, no ':'
 - condition: "<natural-language condition from sdd.md>"
 - count: 30
 - unit: min
@@ -178,6 +182,16 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 **Recipient format:** `<target> / <value>` where `<target>` is the resolved UUID (per [§ Identity Resolution](#identity-resolution)) — or `<UNRESOLVED: …>` sentinel when the resolver failed or the user declined — and `<value>` is the display string. Unresolved recipients survive into execution; the user patches the UUID externally after the build and the completion report lists every unresolved recipient.
 
 **`attach-to: default`** is the default. Use `T<m>` when sdd.md attaches an escalation to a specific conditional SLA rule.
+
+## Frontend validation parity
+
+Before emitting SLA T-entries, reject or repair the same cases the Case App rejects:
+
+- every SLA rule has a non-empty, target-unique `display-name`;
+- every escalation has a non-empty, target-unique `display-name`;
+- every SLA `count` is positive, and minute-based values are between 15 and 1000 inclusive;
+- every non-default rule has a condition/expression;
+- every escalation has at least one recipient, and every `at-risk` escalation carries `at-risk-percentage`.
 
 ## Anti-Patterns
 

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -60,7 +60,7 @@ Rules are evaluated in insertion order — first truthy expression wins. The def
 | `recipient-scope` | sdd.md | `User` \| `UserGroup` |
 | `recipient-target` | sdd.md → resolver | Recipient UUID. When sdd gives an email or group name, run [§ Identity Resolution](#identity-resolution) — resolved UUID written inline. On resolver failure or user decline, mark `<UNRESOLVED: user-uuid for <email>>` / `<UNRESOLVED: group-uuid for <name>>`. |
 | `recipient-value` | sdd.md | Display value (typically the email for User, group name for UserGroup). |
-| `display-name` | sdd.md (optional) | |
+| `display-name` | sdd.md (optional) | SLA title shown in the UI. MUST NOT contain `:`. |
 | `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
 | `attach-to` | sdd.md | `default` (attach to the `=js:true` rule) or `T<m>` pointing to the conditional-rule T-entry the escalation fires under. |
 

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -193,6 +193,8 @@ Defines what `sdd.md` Section 1 (Case Definition) must contain.
 | Case App | optional | `Enabled` / `Disabled` — whether the in-product Case App UI is on (`metadata.caseAppEnabled`). | Default `Disabled`; record in source ledger. |
 | Task-output passing | optional | `Direct` / `Shared` — `metadata.caseDirectlyPassTaskOutputs`. `Direct` passes a task's outputs straight to downstream tasks (default). | Default `Direct`. |
 
+**Naming constraint.** Stage names and SLA titles/display names MUST NOT contain `:`. The colon is reserved by the SDD stage-heading and task-entry syntax. If the user supplies one, ask for a replacement that preserves the meaning (for example, use ` - ` or parentheses); never silently truncate or reinterpret the name.
+
 ### 1.2 Case-level SLA escalation
 
 Required when Case SLA is set. Always renders with both rows; no `—` allowed in any cell.

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -193,7 +193,19 @@ Defines what `sdd.md` Section 1 (Case Definition) must contain.
 | Case App | optional | `Enabled` / `Disabled` — whether the in-product Case App UI is on (`metadata.caseAppEnabled`). | Default `Disabled`; record in source ledger. |
 | Task-output passing | optional | `Direct` / `Shared` — `metadata.caseDirectlyPassTaskOutputs`. `Direct` passes a task's outputs straight to downstream tasks (default). | Default `Direct`. |
 
-**Naming constraint.** Stage names and SLA titles/display names MUST NOT contain `:`. The colon is reserved by the SDD stage-heading and task-entry syntax. If the user supplies one, ask for a replacement that preserves the meaning (for example, use ` - ` or parentheses); never silently truncate or reinterpret the name.
+**PO.Frontend validation parity.** Before Approve, apply the same name and SLA checks that the Case App applies:
+
+| Surface | Required checks |
+|---|---|
+| Stage label | Non-empty; unique across stages; no `:`. A non-Case-Manager stage also cannot reuse the reserved default Case Manager stage label when a Case Manager stage exists. |
+| Task display name | No `:` for materialized tasks. |
+| SLA rule title (`displayName`) | Non-empty; unique within the root or stage target; no `:`. |
+| Escalation title (`displayName`) | Non-empty; unique across escalations on the target; no `:`. |
+| SLA duration | `count > 0`; when `unit: min`, `15 ≤ count ≤ 1000`. Supported units are `min`, `h`, `d`, `w`, and `m`. |
+| Conditional SLA | Every non-default SLA rule has a non-empty expression/condition. |
+| Escalation payload | Every escalation has at least one recipient; an `at-risk` escalation has an `atRiskPercentage` value. |
+
+These are blocking authoring errors, not optional style warnings. Preserve the user's wording when repairing a name, but ask for a replacement when uniqueness or a reserved delimiter is violated; never silently suffix or truncate it.
 
 ### 1.2 Case-level SLA escalation
 

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -63,10 +63,61 @@ def _rule_token(cell: str) -> str | None:
     return m.group(1) if m else None
 
 
+def _colon_issues(text: str, source: str = "sdd.md") -> list[str]:
+    """Reject names whose literal value contains the heading/task delimiter."""
+    issues: list[str] = []
+    for line_no, line in enumerate(text.splitlines(), 1):
+        stage = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.+)", line.strip())
+        if stage:
+            # The first colon belongs to the SDD heading grammar. Any later colon
+            # is part of the authored stage label and would make FE/SDD parsing
+            # ambiguous.
+            label = re.sub(r"\s*\([^)]*\)\s*$", "", stage.group(2)).strip()
+            if ":" in label:
+                issues.append(f"naming: stage name contains ':' at {source}:{line_no}: {label!r}")
+
+        # SDDs may expose an explicit SLA title, while Phase 1 carries the same
+        # value as tasks.md `display-name` on an SLA escalation T-entry.
+        sla_title = re.match(r"^\|\s*SLA Title\s*\|\s*([^|]*)\|", line, re.I)
+        if sla_title and ":" in sla_title.group(1):
+            issues.append(f"naming: SLA title contains ':' at {source}:{line_no}")
+
+        display_name = re.match(r"^\s*-\s*display-name:\s*(.+?)\s*$", line, re.I)
+        if display_name:
+            value = display_name.group(1).strip()
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in {'\"', "'"}:
+                value = value[1:-1]
+            if ":" in value:
+                issues.append(f"naming: SLA title/display-name contains ':' at {source}:{line_no}")
+    return issues
+
+
 def main() -> None:
     path = _find_sdd()
     text = open(path, encoding="utf-8").read()
     issues: list[str] = []
+    issues.extend(_colon_issues(text, path))
+
+    # When Phase 1 has already generated tasks.md next to the SDD, validate its
+    # SLA escalation titles too. This keeps the same rule effective before JSON
+    # emission without treating colons in unrelated task names as invalid.
+    tasks_path = glob.glob("**/tasks/tasks.md", recursive=True)
+    for candidate in sorted(tasks_path):
+        tasks_text = open(candidate, encoding="utf-8").read()
+        for line_no, line in enumerate(tasks_text.splitlines(), 1):
+            if re.match(r"^##\s+T\d+.*\bSLA\b", line, re.I):
+                block = tasks_text.splitlines()[line_no:]
+                for offset, block_line in enumerate(block, line_no + 1):
+                    if block_line.startswith("## T"):
+                        break
+                    display_name = re.match(r"^\s*-\s*display-name:\s*(.+?)\s*$", block_line, re.I)
+                    if display_name:
+                        value = display_name.group(1).strip().strip('"\'')
+                        if ":" in value:
+                            issues.append(
+                                f"naming: SLA title/display-name contains ':' at {candidate}:{offset}"
+                            )
+                break
 
     # --- §Case Variables: | name | In/Out/Variable | type | srcTrig | srcFld | default | desc |
     declared: set[str] = set()

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -20,6 +20,8 @@ Checks (domain-agnostic):
      Interrupting flag, and any lane that returns to its origin
      (``return-to-origin`` exit) is marked ``Interrupting: Yes`` (you can only
      return to a stage you interrupted).
+  7. PO.Frontend name/SLA parity — stage/task/SLA/escalation names, uniqueness,
+     duration bounds, conditional expressions, recipients, and at-risk fields.
 
 Finds ``sdd.md`` under the current working directory.
 """
@@ -63,32 +65,139 @@ def _rule_token(cell: str) -> str | None:
     return m.group(1) if m else None
 
 
-def _colon_issues(text: str, source: str = "sdd.md") -> list[str]:
-    """Reject names whose literal value contains the heading/task delimiter."""
+def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
+    """Mirror the deterministic stage/task/SLA checks performed by PO.Frontend."""
     issues: list[str] = []
+    stage_names: list[str] = []
+    in_stage_sla = False
+    in_variable_sla = False
+
+    def check_duration(count_text: str, unit_text: str, line_no: int) -> None:
+        try:
+            count = float(count_text.strip())
+        except ValueError:
+            return
+        unit = unit_text.strip().lower()
+        if count <= 0:
+            issues.append(f"sla: count must be positive at {source}:{line_no}")
+        if unit == "min" and not 15 <= count <= 1000:
+            issues.append(f"sla: minute count must be between 15 and 1000 at {source}:{line_no}")
+
     for line_no, line in enumerate(text.splitlines(), 1):
-        stage = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.+)", line.strip())
+        stripped = line.strip()
+        if stripped == "#### Stage SLA":
+            in_stage_sla = True
+            in_variable_sla = False
+        elif stripped == "### Variable SLA Rules":
+            in_variable_sla = True
+            in_stage_sla = False
+        elif stripped.startswith("#"):
+            in_stage_sla = False
+            in_variable_sla = False
+
+        case_sla = re.match(r"^\|\s*Case-Level SLA\s*\|\s*([0-9]+(?:\.[0-9]+)?)\s+([A-Za-z]+)", line, re.I)
+        if case_sla:
+            check_duration(case_sla.group(1), case_sla.group(2), line_no)
+
+        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        if in_stage_sla and len(cells) >= 2 and re.fullmatch(r"\d+(?:\.\d+)?", cells[0]):
+            check_duration(cells[0], cells[1], line_no)
+        if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
+            check_duration(cells[1], cells[2], line_no)
+
+        stage = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.*)", line.strip())
         if stage:
             # The first colon belongs to the SDD heading grammar. Any later colon
             # is part of the authored stage label and would make FE/SDD parsing
             # ambiguous.
             label = re.sub(r"\s*\([^)]*\)\s*$", "", stage.group(2)).strip()
+            if not label:
+                issues.append(f"naming: stage name is missing at {source}:{line_no}")
+            else:
+                stage_names.append(label)
             if ":" in label:
                 issues.append(f"naming: stage name contains ':' at {source}:{line_no}: {label!r}")
+
+        task = re.match(r"#####\s+Task\s+[\d.]+:\s*(.+)", line.strip())
+        if task:
+            label = re.sub(r"\s*\([^)]*\)\s*$", "", task.group(1)).strip()
+            if ":" in label:
+                issues.append(f"naming: task name contains ':' at {source}:{line_no}: {label!r}")
 
         # SDDs may expose an explicit SLA title, while Phase 1 carries the same
         # value as tasks.md `display-name` on an SLA escalation T-entry.
         sla_title = re.match(r"^\|\s*SLA Title\s*\|\s*([^|]*)\|", line, re.I)
-        if sla_title and ":" in sla_title.group(1):
-            issues.append(f"naming: SLA title contains ':' at {source}:{line_no}")
-
-        display_name = re.match(r"^\s*-\s*display-name:\s*(.+?)\s*$", line, re.I)
-        if display_name:
-            value = display_name.group(1).strip()
-            if len(value) >= 2 and value[0] == value[-1] and value[0] in {'\"', "'"}:
-                value = value[1:-1]
+        if sla_title:
+            value = sla_title.group(1).strip()
+            if not value or value in {"—", "-"}:
+                issues.append(f"naming: SLA title is missing at {source}:{line_no}")
             if ":" in value:
-                issues.append(f"naming: SLA title/display-name contains ':' at {source}:{line_no}")
+                issues.append(f"naming: SLA title contains ':' at {source}:{line_no}")
+
+    duplicates = sorted({name for name in stage_names if stage_names.count(name) > 1})
+    for name in duplicates:
+        issues.append(f"naming: duplicate stage name {name!r} in {source}")
+    return issues
+
+
+def _colon_issues(text: str, source: str = "sdd.md") -> list[str]:
+    """Backward-compatible focused helper used by older checker unit tests."""
+    return [issue for issue in _sdd_frontend_issues(text, source) if "contains ':'" in issue]
+
+
+def _parse_value(value: str) -> str:
+    value = value.strip().strip('"\'')
+    return "" if value in {"", "—", "-"} else value
+
+
+def _tasks_frontend_issues(text: str, source: str) -> list[str]:
+    """Validate SLA T-entries using the same name/value invariants as FE."""
+    issues: list[str] = []
+    blocks = re.split(r"(?=^##\s+T\d+\b)", text, flags=re.M)
+    rule_names: dict[str, set[str]] = {}
+    escalation_names: dict[str, set[str]] = {}
+    for block in blocks:
+        header = re.match(r"##\s+T\d+[^\n]*", block)
+        if not header or not re.search(r"\bSLA\b|\bescalation\b", header.group(0), re.I):
+            continue
+        target_match = re.search(r"^\s*-\s*target:\s*[\"']?([^\"'\n]+)", block, re.M | re.I)
+        target = (target_match.group(1).strip() if target_match else "root")
+        is_escalation = bool(re.search(r"\bescalation\b", header.group(0), re.I))
+        display_match = re.search(r"^\s*-\s*display-name:\s*(.*?)\s*$", block, re.M | re.I)
+        display = _parse_value(display_match.group(1)) if display_match else ""
+        names = escalation_names if is_escalation else rule_names
+        names.setdefault(target, set())
+        if not display:
+            issues.append(f"naming: {'escalation' if is_escalation else 'SLA'} title is missing at {source}")
+        elif display in names[target]:
+            issues.append(f"naming: duplicate {'escalation' if is_escalation else 'SLA'} title {display!r} at {source}")
+        else:
+            names[target].add(display)
+        if ":" in display:
+            issues.append(f"naming: {'escalation' if is_escalation else 'SLA'} title contains ':' at {source}")
+
+        count_match = re.search(r"^\s*-\s*count:\s*([0-9]+(?:\.[0-9]+)?)\s*$", block, re.M | re.I)
+        unit_match = re.search(r"^\s*-\s*unit:\s*(\S+)\s*$", block, re.M | re.I)
+        if count_match:
+            count = float(count_match.group(1))
+            unit = unit_match.group(1).strip().lower() if unit_match else ""
+            if count <= 0:
+                issues.append(f"sla: count must be positive at {source}")
+            if unit == "min" and not 15 <= count <= 1000:
+                issues.append(f"sla: minute count must be between 15 and 1000 at {source}")
+
+        if re.search(r"conditional SLA rule", header.group(0), re.I):
+            condition = re.search(r"^\s*-\s*(?:condition|expression):\s*(.*?)\s*$", block, re.M | re.I)
+            if not condition or not _parse_value(condition.group(1)):
+                issues.append(f"sla: conditional rule requires an expression at {source}")
+
+        if is_escalation:
+            recipients = re.findall(r"^\s*-\s+(?:User|UserGroup):\s*.+$", block, re.M)
+            if not recipients:
+                issues.append(f"sla: escalation requires at least one recipient at {source}")
+            if re.search(r"^\s*-\s*trigger-type:\s*at-risk\s*$", block, re.M | re.I):
+                if not re.search(r"^\s*-\s*at-risk-percentage:\s*\S+", block, re.M | re.I):
+                    issues.append(f"sla: at-risk escalation requires at-risk-percentage at {source}")
     return issues
 
 
@@ -96,28 +205,14 @@ def main() -> None:
     path = _find_sdd()
     text = open(path, encoding="utf-8").read()
     issues: list[str] = []
-    issues.extend(_colon_issues(text, path))
+    issues.extend(_sdd_frontend_issues(text, path))
 
     # When Phase 1 has already generated tasks.md next to the SDD, validate its
-    # SLA escalation titles too. This keeps the same rule effective before JSON
-    # emission without treating colons in unrelated task names as invalid.
+    # SLA and escalation T-entries before JSON emission.
     tasks_path = glob.glob("**/tasks/tasks.md", recursive=True)
     for candidate in sorted(tasks_path):
         tasks_text = open(candidate, encoding="utf-8").read()
-        for line_no, line in enumerate(tasks_text.splitlines(), 1):
-            if re.match(r"^##\s+T\d+.*\bSLA\b", line, re.I):
-                block = tasks_text.splitlines()[line_no:]
-                for offset, block_line in enumerate(block, line_no + 1):
-                    if block_line.startswith("## T"):
-                        break
-                    display_name = re.match(r"^\s*-\s*display-name:\s*(.+?)\s*$", block_line, re.I)
-                    if display_name:
-                        value = display_name.group(1).strip().strip('"\'')
-                        if ":" in value:
-                            issues.append(
-                                f"naming: SLA title/display-name contains ':' at {candidate}:{offset}"
-                            )
-                break
+        issues.extend(_tasks_frontend_issues(tasks_text, candidate))
 
     # --- §Case Variables: | name | In/Out/Variable | type | srcTrig | srcFld | default | desc |
     declared: set[str] = set()
@@ -188,7 +283,7 @@ def main() -> None:
     et_idx: int | None = None
     for line in text.splitlines():
         s = line.strip()
-        m = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.+)", s)
+        m = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.*)", s)
         if m:
             cur_stage = re.sub(r"\(.*", "", m.group(2)).strip()
             has_entry.setdefault(cur_stage, False)

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -5,7 +5,7 @@ import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from sdd_check import _colon_issues  # noqa: E402
+from sdd_check import _colon_issues, _sdd_frontend_issues, _tasks_frontend_issues  # noqa: E402
 
 
 def test_stage_label_colon_is_rejected_but_heading_separator_is_allowed():
@@ -24,3 +24,54 @@ def test_sla_title_colon_is_rejected():
 
 def test_names_without_colons_are_allowed():
     assert _colon_issues("### Secondary Stage: Exception Handling") == []
+
+
+def test_stage_names_must_be_unique_and_present():
+    issues = _sdd_frontend_issues("### Stage 1: Intake\n### Stage 2: Intake\n### Secondary Stage:")
+    assert any("duplicate stage name" in issue for issue in issues)
+    assert any("stage name is missing" in issue for issue in issues)
+
+
+def test_task_names_are_checked_for_colons():
+    issues = _sdd_frontend_issues("##### Task 1.1: Review: Legal")
+    assert any("task name contains ':'" in issue for issue in issues)
+
+
+def test_sdd_sla_duration_bounds_are_checked():
+    text = """
+| Case-Level SLA | 0 d |
+#### Stage SLA
+| 1001 | min | 80% | Notify | Notify |
+"""
+    issues = _sdd_frontend_issues(text)
+    assert any("count must be positive" in issue for issue in issues)
+    assert any("minute count" in issue for issue in issues)
+
+
+def test_tasks_sla_validation_matches_frontend_contract():
+    tasks = '''
+## T01: Set default SLA for "root"
+- target: "root"
+- display-name: "Default SLA"
+- count: 10
+- unit: min
+
+## T02: Add conditional SLA rule for root case — urgent
+- target: "root"
+- display-name: "Default SLA"
+- condition: ""
+- count: 0
+- unit: d
+
+## T03: Add escalation rule for "root" — breach
+- target: "root"
+- display-name: "Notify: Manager"
+- trigger-type: at-risk
+'''
+    issues = _tasks_frontend_issues(tasks, "tasks.md")
+    assert any("minute count" in issue for issue in issues)
+    assert any("conditional rule requires" in issue for issue in issues)
+    assert any("count must be positive" in issue for issue in issues)
+    assert any("escalation title contains ':'" in issue for issue in issues)
+    assert any("requires at least one recipient" in issue for issue in issues)
+    assert any("requires at-risk-percentage" in issue for issue in issues)

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -1,0 +1,26 @@
+"""Deterministic naming guards for Phase-0/Phase-1 case authoring."""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from sdd_check import _colon_issues  # noqa: E402
+
+
+def test_stage_label_colon_is_rejected_but_heading_separator_is_allowed():
+    text = "### Stage 1: Intake\n### Stage 2: Review: Legal"
+    issues = _colon_issues(text)
+    assert len(issues) == 1
+    assert "stage name contains ':'" in issues[0]
+
+
+def test_sla_title_colon_is_rejected():
+    text = "| SLA Title | Notify: Manager |\n- display-name: \"Notify: Manager\""
+    issues = _colon_issues(text)
+    assert len(issues) == 2
+    assert all("SLA title" in issue for issue in issues)
+
+
+def test_names_without_colons_are_allowed():
+    assert _colon_issues("### Secondary Stage: Exception Handling") == []

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -18,8 +18,8 @@ def test_stage_label_colon_is_rejected_but_heading_separator_is_allowed():
 def test_sla_title_colon_is_rejected():
     text = "| SLA Title | Notify: Manager |\n- display-name: \"Notify: Manager\""
     issues = _colon_issues(text)
-    assert len(issues) == 2
-    assert all("SLA title" in issue for issue in issues)
+    assert len(issues) == 1
+    assert "SLA title contains ':'" in issues[0]
 
 
 def test_names_without_colons_are_allowed():


### PR DESCRIPTION
## Summary
- document the reserved-colon naming constraint for stage labels and SLA titles
- validate authored stage headings and SLA display names before JSON emission\n- add focused deterministic naming checks