### PR TITLE
feat(maestro-bpmn): add BPMN SDD Phase 0 and intake

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -45,8 +45,11 @@ For `.flow` JSON use `uipath-maestro-flow`; for XAML/coded workflows use
 
 Choose one authoring route before registry discovery. These routes preserve the
 existing direct-prose and existing-file behavior while adding an SDD handoff.
+Resolve the SDD location before choosing the route: search the caller's explicit
+SDD path first, then `./sdd.md`. Treat the SDD as absent only when neither path
+exists.
 
-| Input at the requested path | Route |
+| Resolved input | Route |
 | --- | --- |
 | Existing `.bpmn` | Use the surgical edit flow above. Preserve unknown payloads and stable IDs; do not run Phase 0. |
 | Supplied `sdd.md` | Read [SDD semantic intake](references/sdd-input.md), skip Phase 0, refresh connection inventory exactly once with `uip is connections list --all-folders`, then take its complete semantic model through the existing registry, structural BPMN, BPMNDI, and validator workflow. |

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-maestro-bpmn
-description: "UiPath Maestro BPMN / Process Orchestration: author (registry-driven), validate, package, operate, and diagnose .bpmn projects. For .flow use uipath-maestro-flow; for case plans use uipath-maestro-case."
+description: "UiPath Maestro BPMN / Process Orchestration: author (registry-driven), validate, package, operate, and diagnose .bpmn projects; consume BPMN SDD sdd.md input or run Phase 0 when a new BPMN request has no SDD. For .flow use uipath-maestro-flow; for case plans use uipath-maestro-case."
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -41,6 +41,41 @@ For `.flow` JSON use `uipath-maestro-flow`; for XAML/coded workflows use
 `uipath-rpa`; for Python agents use `uipath-agents`; for Case plans use
 `uipath-maestro-case`.
 
+### SDD input routing
+
+Choose one authoring route before registry discovery. These routes preserve the
+existing direct-prose and existing-file behavior while adding an SDD handoff.
+
+| Input at the requested path | Route |
+| --- | --- |
+| Existing `.bpmn` | Use the surgical edit flow above. Preserve unknown payloads and stable IDs; do not run Phase 0. |
+| Supplied `sdd.md` | Read [SDD semantic intake](references/sdd-input.md), skip Phase 0, refresh connection inventory exactly once with `uip is connections list --all-folders`, then take its complete semantic model through the existing registry, structural BPMN, BPMNDI, and validator workflow. |
+| Prose with an explicit direct-authoring request | Keep the direct prose-to-BPMN route: clarify the process shape, then use the existing registry-driven workflow below without creating an SDD. |
+| No `sdd.md` and no existing `.bpmn` | Run [BPMN Phase 0](references/phase-0-interview.md) to create `sdd.draft.md`; wait for explicit approval before creating `sdd.md` or beginning registry authoring. |
+
+The BPMN SDD is a portable semantic handoff, not a serialized BPMN artifact.
+Use this skill's own [SDD template](assets/templates/sdd-template.md) and
+[SDD generation rules](references/sdd-generation-rules.md). It contains no
+registry XML or BPMNDI. A required unresolved resource blocks executable BPMN,
+but does not block SDD review: retain its intent and unresolved marker until a
+later registry discovery can resolve it. SDD approval confirms business shape;
+it does not silently confirm a different discovered technical resource.
+
+When an approved SDD advances to executable authoring, create a complete local
+project as defined in [project layout](references/shared/project-layout.md):
+the BPMN source and
+`project.uiproj`, plus the required package metadata files `bindings_v2.json`,
+`entry-points.json`, `operate.json`, and `package-descriptor.json`. Keep the
+metadata references aligned with the BPMN file and its actual start event.
+
+Every supplied-SDD executable path refreshes the connection inventory exactly
+once with `uip is connections list --all-folders`, before choosing registry
+resources. Do this even when the SDD says the resource is resolved or appears
+not to use a connection: a stale inventory must never silently validate a
+technical binding. Discovery does not authorize usage: add a connection binding
+only when the selected registry template contract requires that connection and
+the discovered candidate matches the SDD intent.
+
 ## The model
 
 Two halves make a valid Maestro `.bpmn`:
@@ -48,7 +83,7 @@ Two halves make a valid Maestro `.bpmn`:
 1. **`uipath:*` payloads — registry-owned.** Each node's extension XML
    (`uipath:activity` / `uipath:event` / `uipath:mapping`, its `context`,
    `input`, `output`, and `bindingInfo`) comes from
-   `uip maestro bpmn registry get <type>`'s `xmlTemplate`. **Never hand-author a
+   `uip maestro bpmn registry get <extensionType>`'s `xmlTemplate`. **Never hand-author a
    `uipath:*` element from prose.**
 2. **Structural BPMN — spec/canvas-owned.** The registry emits no
    `<bpmn:definitions>`/`<bpmn:process>`, no sequence flows, no gateway
@@ -59,27 +94,36 @@ Two halves make a valid Maestro `.bpmn`:
 
 ## Workflow
 
-Work the four steps quickly and author early — do not pre-read every reference
+Work the five steps quickly and author early — do not pre-read every reference
 before writing. Read a reference only when you reach the structure it covers.
 
-1. **Discover.** `uip maestro bpmn registry pull` **once** (cached for the
+1. **Route.** Use [SDD input routing](#sdd-input-routing). A supplied approved
+   `sdd.md` is parsed by [SDD semantic intake](references/sdd-input.md) before
+   discovery; no-SDD Phase 0 stops at the approved `sdd.md`. The direct prose
+   route starts at discovery.
+2. **Discover.** `uip maestro bpmn registry pull` **once** (cached for the
    session — do not re-pull), then `list` / `search` to map intent to extension
-   types; `uip is connections list --all-folders` for live connections (always
-   `--all-folders` — a folder-scoped list silently misses connections). Confirm
-   every selection with the user (use AskUserQuestion). Never fabricate an identifier.
-   See [references/registry-workflow.md](references/registry-workflow.md).
-2. **Get templates.** `uip maestro bpmn registry get <type> --output json` for
+   types. On every supplied-SDD executable path, refresh live connections
+   **exactly once** with `uip is connections list --all-folders`, even when the
+   resource looks resolved; a folder-scoped list silently misses connections.
+   Do not bind an inventory result unless the selected registry template
+   requires it and the connection matches the declared resource intent.
+   Confirm every selection with the user (use AskUserQuestion). Never fabricate
+   an identifier. See [references/registry-workflow.md](references/registry-workflow.md).
+3. **Get templates.** `uip maestro bpmn registry get <extensionType> --output json` for
    each chosen node. Enrich `Intsvc.*` connector nodes with
    `--connection-id`/`--object-name`.
-3. **Assemble.** Author directly from the complete minimal file in
+4. **Assemble.** Author directly from the complete minimal file in
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-fixtures)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already
    shows variables, the entry point, a branch, and the diagram. **Do not read the
    validator's `test/fixtures/` to infer the pattern** — it is the top reason
    authoring runs out of time. Add only the structural pieces your process needs
    (extra gateways, events, boundary events, containers, multi-instance markers),
-   then generate one `BPMNShape`/`BPMNEdge` per node and flow.
-4. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
+   then generate one `BPMNShape`/`BPMNEdge` per node and flow. For a new project,
+   also produce the five local package files named in the greenfield SDD contract
+   above.
+5. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
    bundled validator — it reconstructs the canvas model and runs every
    PO.Frontend rule:
 
@@ -166,6 +210,10 @@ and honestly surfaced to the user as gaps when asked.
 | Discover → template → bind → assemble loop | [references/registry-workflow.md](references/registry-workflow.md) |
 | Structural BPMN, event matrix, boundary events, containers, multi-instance, diagram, validation | [references/structural-bpmn.md](references/structural-bpmn.md) |
 | Runtime expressions, `vars.`/`bindings.`/`iterator.`, `=js:` (Jint) syntax | [references/expression-authoring.md](references/expression-authoring.md) |
+| Generate an SDD when none was supplied | [references/phase-0-interview.md](references/phase-0-interview.md) |
+| Consume a supplied SDD as BPMN semantics | [references/sdd-input.md](references/sdd-input.md) |
+| BPMN SDD semantic constraints | [references/sdd-generation-rules.md](references/sdd-generation-rules.md) |
+| BPMN SDD document shape | [assets/templates/sdd-template.md](assets/templates/sdd-template.md) |
 | CLI conventions and the side-effect boundary | [references/cli-conventions.md](references/cli-conventions.md) |
 | Keeping content public-safe | [references/public-safety.md](references/public-safety.md) |
 | Bundled offline validator (every PO.Frontend rule) | [validator/README.md](validator/README.md) |

--- a/skills/uipath-maestro-bpmn/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-bpmn/assets/templates/sdd-template.md
@@ -1,0 +1,85 @@
+# <Process name> — BPMN Solution Design Document
+
+## 1. Process identity
+
+| Field | Value |
+| --- | --- |
+| Process name | <Human-readable name> |
+| Logical process ID | `<stable-kebab-id>` |
+| Business objective | <Outcome the process delivers> |
+| Scope | <Included and excluded work> |
+| Implementation readiness | `Reviewable` \| `Executable` \| `Blocked` |
+
+## 2. Participants and triggers
+
+| Logical ID | Participant or trigger | Role in the process | Input or event |
+| --- | --- | --- | --- |
+| `<participant-id>` | <person, system, or lane> | <responsibility> | <what starts or informs work> |
+
+State the start trigger, its payload, and whether the process is manually,
+message, timer, or event initiated.
+
+## 3. Process graph
+
+### Nodes
+
+Use stable logical IDs. A logical ID is the future BPMN element identity, not a
+display label or registry key.
+
+| Logical ID | BPMN kind | Name | Inputs | Outputs | Resource intent |
+| --- | --- | --- | --- | --- | --- |
+| `<node-id>` | <start event, task, gateway, event, subprocess, end event> | <display name> | <variables or event payload> | <variables or event payload> | <none or resource-intent-id> |
+
+### Sequence flows
+
+| Logical flow ID | From node | To node | Condition | Default path |
+| --- | --- | --- | --- | --- |
+| `<flow-id>` | `<source-node-id>` | `<target-node-id>` | <condition or `Always`> | `Yes` \| `No` |
+
+Every gateway outgoing flow has either a condition or an explicit default path.
+A default flow is unconditional (`Always`); it never also carries a condition.
+
+## 4. Data and variables
+
+| Variable ID | Type | Source | Consumers | Purpose |
+| --- | --- | --- | --- | --- |
+| `<variable-id>` | <string, number, boolean, object, array> | <trigger or node ID> | <node, event, or condition-flow IDs> | <meaning> |
+
+Record event payloads, error data, and any variable whose producer or consumer
+is outside the main sequence flow.
+
+## 5. Events, subprocesses, and loops
+
+| Logical ID | Structure | Attachment or parent | Trigger or iteration rule | Exit behavior |
+| --- | --- | --- | --- | --- |
+| `<structure-id>` | <boundary event, event subprocess, embedded subprocess, loop> | <node or process ID> | <event or collection rule> | <continue, interrupt, retry, terminate> |
+
+Write `None` when this process has no exception event, subprocess, or loop.
+
+## 6. Resource intent
+
+Describe only the business intent needed for later registry discovery. Do not
+place registry payloads, candidate lists, or diagram coordinates in this SDD.
+
+| Resource intent ID | Used by node | Intended capability | Intended resource name | Connection or folder intent | Required | Resolution |
+| --- | --- | --- | --- | --- | --- | --- |
+| `<resource-intent-id>` | `<node-id>` | <human review, API, RPA, agent, connector> | <known name or `UNRESOLVED`> | <known path/name or `UNRESOLVED`> | `Yes` \| `No` | `Resolved` \| `UNRESOLVED` |
+
+## 7. Exception and event behavior
+
+For every exception, describe its source, event or condition, affected node,
+and recovery or terminal path. Include explicit business error outcomes that
+must be visible to a caller.
+
+## 8. Implementation readiness
+
+| Check | Status | Evidence or blocker |
+| --- | --- | --- |
+| Graph is complete | <Ready or blocker> | <start/end, flow, and gateway review> |
+| Variable lineage is complete | <Ready or blocker> | <producer and consumer review> |
+| Required resources are resolved | <Ready or blocker> | <resource intent IDs> |
+| Executable BPMN may be authored | <Yes or No> | <reason> |
+
+Required unresolved resources may remain in a reviewable SDD. They make the
+implementation readiness `Blocked` and prevent executable BPMN authoring until
+the registry resolves them.

--- a/skills/uipath-maestro-bpmn/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-bpmn/assets/templates/sdd-template.md
@@ -41,9 +41,9 @@ A default flow is unconditional (`Always`); it never also carries a condition.
 
 ## 4. Data and variables
 
-| Variable ID | Type | Source | Consumers | Purpose |
-| --- | --- | --- | --- | --- |
-| `<variable-id>` | <string, number, boolean, object, array> | <trigger or node ID> | <node, event, or condition-flow IDs> | <meaning> |
+| Variable ID | Type | Scope | Source | Consumers | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `<variable-id>` | <string, number, boolean, object, array> | <process or subprocess ID> | <trigger or node ID> | <node, event, or condition-flow IDs> | <meaning> |
 
 Record event payloads, error data, and any variable whose producer or consumer
 is outside the main sequence flow.

--- a/skills/uipath-maestro-bpmn/references/phase-0-interview.md
+++ b/skills/uipath-maestro-bpmn/references/phase-0-interview.md
@@ -1,0 +1,44 @@
+# BPMN Phase 0 interview
+
+Use Phase 0 only when the request is prose and neither an existing `.bpmn` nor
+a supplied `sdd.md` is available. Its output is a reviewable BPMN SDD, not
+registry discovery or a partially authored BPMN file.
+
+Before the interview, read the BPMN SDD template and generation rules from this
+skill. Create `sdd.draft.md` at the requested working path before asking for
+registry information or writing a BPMN file. Do not run registry discovery
+before registry authoring begins after SDD approval.
+
+## Interview sequence
+
+1. **Listen.** Capture the requested outcome, trigger, actors, inputs, and any
+   stated success or failure outcome. Reuse clear facts; label assumptions.
+2. **Sketch.** Write the smallest complete draft graph in `sdd.draft.md` with
+   stable logical node and flow IDs, an initial variable inventory, and known
+   resource intent.
+3. **Ask.** Ask only shape-changing questions: a missing start or end outcome,
+   branch condition, ownership boundary, exception event, subprocess, loop,
+   data producer, or required resource intent. Do not turn Phase 0 into a
+   registry interview.
+4. **Resolve.** Incorporate answers, make unresolved resource intent explicit,
+   and check graph completeness and variable lineage. Leave unknown required
+   resource details as `UNRESOLVED`; never fabricate a key, ID, or connection.
+5. **Approve.** Present the complete `sdd.draft.md` for explicit approval.
+   Request that approval with `AskUserQuestion` when it is available so the
+   approval is a resumable checkpoint, not the end of the agent turn.
+   Do not rename, replace, or create `sdd.md` until the user explicitly
+   approves the SDD. After approval, promote the exact reviewed content to
+   `sdd.md`; only then may registry authoring start.
+
+## Approval and resumption
+
+- Approval of the SDD is separate from later confirmation of a discovered
+  technical resource. If discovery finds a different candidate, preserve the
+  SDD intent and ask for the normal resource-selection confirmation.
+- If `sdd.draft.md` already exists and `sdd.md` does not, resume from the
+  draft. Ask only for unresolved shape-changing decisions, then request
+  explicit approval.
+- Never overwrite a supplied `sdd.md`. It enters semantic intake directly and
+  skips Phase 0.
+- A reviewable SDD may contain required unresolved resources. It cannot advance
+  to executable BPMN until those resources are resolved.

--- a/skills/uipath-maestro-bpmn/references/phase-0-interview.md
+++ b/skills/uipath-maestro-bpmn/references/phase-0-interview.md
@@ -24,8 +24,8 @@ before registry authoring begins after SDD approval.
    and check graph completeness and variable lineage. Leave unknown required
    resource details as `UNRESOLVED`; never fabricate a key, ID, or connection.
 5. **Approve.** Present the complete `sdd.draft.md` for explicit approval.
-   Request that approval with `AskUserQuestion` when it is available so the
-   approval is a resumable checkpoint, not the end of the agent turn.
+   Use the host's supported user-input mechanism when available so approval is a
+   resumable checkpoint, not the end of the agent turn.
    Do not rename, replace, or create `sdd.md` until the user explicitly
    approves the SDD. After approval, promote the exact reviewed content to
    `sdd.md`; only then may registry authoring start.

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -169,7 +169,7 @@ auth, schema, or enrichment decision is missing).
 ## OOTB extension types (29, login-free)
 
 These are the built-in types `registry pull` returns without login. Discover the
-exact template for any of them with `registry get <type>`.
+exact template for any of them with `registry get <extensionType>`.
 
 | Extension type | Host element | Tag |
 | --- | --- | --- |

--- a/skills/uipath-maestro-bpmn/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-bpmn/references/sdd-generation-rules.md
@@ -32,7 +32,8 @@ default behavior is ambiguous.
 
 ## 3. Preserve data lineage
 
-- Declare trigger inputs and process variables with compatible types.
+- Declare trigger inputs and process variables with compatible types and explicit
+  process or subprocess scope.
 - For each consumed variable, record the trigger or node that produces it.
 - For each output, record every downstream node, event, flow condition, or end
   outcome that consumes it. A flow ID is the consumer when its condition reads

--- a/skills/uipath-maestro-bpmn/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-bpmn/references/sdd-generation-rules.md
@@ -1,0 +1,69 @@
+# BPMN SDD generation rules
+
+Use these rules only for the portable BPMN Solution Design Document. The SDD is
+a semantic contract between process design and BPMN authoring. The SDD does not include registry XML; it does not include BPMNDI. Registry templates,
+resource identifiers, and diagram coordinates are later implementation inputs.
+
+## 1. Establish stable logical IDs
+
+- Give the process, every node, every sequence flow, every variable, and every
+  resource intent a stable, human-readable logical ID.
+- Keep display names separate from IDs. Renaming a label must not force a graph
+  identity change.
+- Use node IDs in flow endpoints, variable producers/consumers, event
+  attachments, and resource intent ownership.
+
+## 2. Translate confirmed behavior into a graph
+
+- Start from the confirmed trigger and identify every business outcome.
+- Add a node for each observable activity, decision, event, subprocess, loop,
+  or end state. Do not hide a decision inside a task description.
+- Add one sequence flow for every transition. Name flows so a reviewer can
+  trace conditions through gateways without inferring direction.
+- Write a condition for every conditional gateway path and mark exactly one
+  default path when the business design requires fallback behavior. A default
+  flow is unconditional (`Always`); never mark a conditional flow as default.
+
+### Graph integrity
+
+The graph has integrity only when it has a declared start, reachable outcomes,
+valid flow endpoints, no orphan node, and no gateway path whose condition or
+default behavior is ambiguous.
+
+## 3. Preserve data lineage
+
+- Declare trigger inputs and process variables with compatible types.
+- For each consumed variable, record the trigger or node that produces it.
+- For each output, record every downstream node, event, flow condition, or end
+  outcome that consumes it. A flow ID is the consumer when its condition reads
+  the variable.
+- State transformations and decision inputs explicitly. A gateway condition
+  cannot rely on an undeclared value.
+
+## 4. Capture resources as intent, not implementation
+
+- Attach a resource-intent ID to every node that needs a registry-owned
+  extension type, connection, process, app, agent, or queue.
+- Preserve the known intended name and folder/connection hint. Mark unknown
+  fields `UNRESOLVED`; do not invent an identifier or select a look-alike.
+- Mark each intent `Required` or `No`. A required unresolved resource can be
+  reviewed in the SDD, but blocks executable BPMN until discovery resolves it.
+- Do not promote a discovered candidate to resolved status unless it matches
+  the SDD intent and is confirmed where the normal registry workflow requires
+  confirmation.
+
+## 5. Describe non-linear behavior explicitly
+
+- Record boundary events, event subprocesses, and errors with their attachment,
+  trigger, interrupting behavior, and return or terminal route.
+- Record subprocess parentage and loop collection, cardinality, completion, or
+  retry rules. Do not imply a loop from plural wording.
+- Keep exception paths visible in the flow table and name their end behavior.
+
+## 6. Set readiness honestly
+
+The SDD is ready for review when its graph and data lineage are complete, even
+if resource discovery is pending. It is ready for executable authoring only
+when every required resource intent is resolved. The next skill stage resolves
+resources with the existing registry workflow, authors structural BPMN and
+BPMNDI, then runs the bundled validator.

--- a/skills/uipath-maestro-bpmn/references/sdd-input.md
+++ b/skills/uipath-maestro-bpmn/references/sdd-input.md
@@ -1,0 +1,75 @@
+# Supplied BPMN SDD semantic intake
+
+Use this path when a supplied `sdd.md` is the source for a new BPMN project.
+Skip Phase 0: the SDD already represents the reviewed business shape. Do not
+rewrite it, invent missing semantics, or make it conform by silently dropping a
+node, flow, condition, variable, event, subprocess, loop, or resource intent.
+
+## 1. Extract one semantic model
+
+Read the SDD and extract:
+
+- process identity, objective, and implementation readiness;
+- participants and start trigger;
+- logical nodes and their BPMN kind, inputs, outputs, and resource intent;
+- logical flows, gateway conditions, and default paths;
+- variables with types, producers, and consumers (including a flow ID when its
+  condition reads the variable);
+- events, exception behavior, subprocess declarations, and loop rules; and
+- every resource intent, including required status and unresolved markers.
+
+Use the SDD logical IDs as the plan's source IDs. Keep an explicit mapping
+only when a valid BPMN identifier must be normalized; do not replace an SDD
+identity with a registry key.
+
+Treat the declared graph as an invariant: preserve each flow's source and
+target, not only its ID. Do not insert a synthetic gateway, merge, node, or
+flow to satisfy a style preference or a speculative validator concern. If the
+declared graph is actually invalid, stop and ask a focused question instead of
+silently changing its topology.
+
+## 2. Validate semantics before registry discovery
+
+Check graph completeness before registry discovery:
+
+- one declared start and at least one reachable end outcome;
+- every flow endpoint names a declared node;
+- every non-terminal node has its intended incoming and outgoing behavior;
+- every gateway path has an explicit condition or default path, and no default
+  path also carries a condition;
+- every variable consumer has a compatible producer; and
+- every event, subprocess, and loop has the declared parent, trigger, and exit
+  behavior.
+
+Ask a focused question when the supplied SDD is ambiguous. Do not use registry
+results to fill a business-logic gap.
+
+## 3. Resolve implementation resources
+
+After semantic intake passes, refresh the live connection inventory **exactly
+once** with `uip is connections list --all-folders` before choosing registry
+resources. This is mandatory on every supplied-SDD executable path, even when
+the SDD marks a resource resolved or none of its resources appear to need a
+connection. Then follow the existing [registry workflow](registry-workflow.md):
+pull once, list or search each required extension type, and retrieve the
+selected template with `registry get`. Inventory membership is not permission to
+bind a connection: use one only when the selected template requires it and it
+matches the SDD resource intent. A supplied resolved resource intent is
+the business selection; if discovery would change it, request the normal
+confirmation rather than substituting a candidate.
+
+For a required unresolved resource, retain the SDD's intended name and mark the
+implementation blocked. It does not block SDD review, but it blocks executable
+BPMN: do not emit a placeholder registry wrapper or claim the file can run.
+
+## 4. Reuse the existing BPMN authoring machinery
+
+Use the extracted semantic model to drive the existing structural guidance in
+[structural BPMN](structural-bpmn.md), the registry-owned XML templates, and
+the mandatory BPMNDI shape/edge generation. Create the complete local project
+described in [project layout](shared/project-layout.md): `project.uiproj`,
+`bindings_v2.json`, `entry-points.json`, `operate.json`, and
+`package-descriptor.json` alongside the BPMN source. Keep their references
+consistent with the BPMN filename and the actual root start event. Then run the
+bundled validator as the final local check. The SDD itself never gains registry
+XML or BPMNDI.

--- a/skills/uipath-maestro-bpmn/references/sdd-input.md
+++ b/skills/uipath-maestro-bpmn/references/sdd-input.md
@@ -13,8 +13,8 @@ Read the SDD and extract:
 - participants and start trigger;
 - logical nodes and their BPMN kind, inputs, outputs, and resource intent;
 - logical flows, gateway conditions, and default paths;
-- variables with types, producers, and consumers (including a flow ID when its
-  condition reads the variable);
+- variables with types, process or subprocess scopes, producers, and consumers
+  (including a flow ID when its condition reads the variable);
 - events, exception behavior, subprocess declarations, and loop rules; and
 - every resource intent, including required status and unresolved markers.
 
@@ -37,7 +37,8 @@ Check graph completeness before registry discovery:
 - every non-terminal node has its intended incoming and outgoing behavior;
 - every gateway path has an explicit condition or default path, and no default
   path also carries a condition;
-- every variable consumer has a compatible producer; and
+- every variable consumer has a compatible producer in a valid declared scope;
+  and
 - every event, subprocess, and loop has the declared parent, trigger, and exit
   behavior.
 

--- a/tests/tasks/uipath-maestro-bpmn/_shared/mock_template/mocks/uip
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/mock_template/mocks/uip
@@ -44,6 +44,8 @@ patterns before generic ones. A passthrough rule with `match: "docsai ask"`
 is the typical way to proxy open-ended natural-language commands.
 """
 
+from __future__ import annotations
+
 import hashlib
 import json
 import os

--- a/tests/tasks/uipath-maestro-bpmn/sdd_contract/check_skill_contract.py
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_contract/check_skill_contract.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Verify the BPMN skill's SDD routing and handoff contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[4]
+SKILL = ROOT / "skills/uipath-maestro-bpmn/SKILL.md"
+TEMPLATE = ROOT / "skills/uipath-maestro-bpmn/assets/templates/sdd-template.md"
+RULES = ROOT / "skills/uipath-maestro-bpmn/references/sdd-generation-rules.md"
+INTERVIEW = ROOT / "skills/uipath-maestro-bpmn/references/phase-0-interview.md"
+INTAKE = ROOT / "skills/uipath-maestro-bpmn/references/sdd-input.md"
+
+
+def fail(message: str) -> None:
+    print(f"FAIL: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def read_required(path: Path) -> str:
+    if not path.is_file():
+        fail(f"missing required skill-owned file: {path.relative_to(ROOT)}")
+    return path.read_text(encoding="utf-8")
+
+
+def require_text(label: str, text: str, *phrases: str) -> None:
+    normalized_text = " ".join(text.lower().split())
+    missing = [
+        phrase
+        for phrase in phrases
+        if " ".join(phrase.lower().split()) not in normalized_text
+    ]
+    if missing:
+        fail(f"{label} is missing required contract text: {', '.join(missing)}")
+
+
+def require_order(label: str, text: str, *phrases: str) -> None:
+    cursor = 0
+    for phrase in phrases:
+        found = text.lower().find(phrase.lower(), cursor)
+        if found < 0:
+            fail(f"{label} does not preserve required order: {' -> '.join(phrases)}")
+        cursor = found + len(phrase)
+
+
+def main() -> int:
+    skill = read_required(SKILL)
+    template = read_required(TEMPLATE)
+    rules = read_required(RULES)
+    interview = read_required(INTERVIEW)
+    intake = read_required(INTAKE)
+
+    require_text(
+        "SKILL.md input routing",
+        skill,
+        "Existing `.bpmn`",
+        "surgical edit",
+        "Supplied `sdd.md`",
+        "skip Phase 0",
+        "No `sdd.md`",
+        "Phase 0",
+        "explicit direct-authoring",
+        "direct prose-to-BPMN",
+    )
+    require_order(
+        "SKILL.md input routing",
+        skill,
+        "Existing `.bpmn`",
+        "Supplied `sdd.md`",
+        "Prose with an explicit direct-authoring request",
+        "No `sdd.md`",
+    )
+    require_text(
+        "SKILL.md frontmatter activation",
+        skill.split("---", 2)[1],
+        "SDD",
+        "Phase 0",
+    )
+    require_text(
+        "SKILL.md supplied-SDD connection refresh",
+        skill,
+        "supplied-SDD",
+        "uip is connections list --all-folders",
+        "exactly once",
+        "Discovery does not authorize usage",
+    )
+    require_text(
+        "SKILL.md unresolved-resource policy",
+        skill,
+        "required unresolved resource",
+        "blocks executable BPMN",
+        "does not block SDD review",
+    )
+    require_text(
+        "SKILL.md supplied-SDD package contract",
+        skill,
+        "project.uiproj",
+        "bindings_v2.json",
+        "entry-points.json",
+        "operate.json",
+        "package-descriptor.json",
+        "references/shared/project-layout.md",
+    )
+    require_text(
+        "SKILL.md reference navigation",
+        skill,
+        "assets/templates/sdd-template.md",
+        "references/sdd-generation-rules.md",
+        "references/phase-0-interview.md",
+        "references/sdd-input.md",
+    )
+
+    require_text(
+        "Phase 0 interview",
+        interview,
+        "sdd.draft.md",
+        "explicit approval",
+        "AskUserQuestion",
+        "sdd.md",
+        "before registry",
+    )
+    require_order(
+        "Phase 0 interview",
+        interview,
+        "Listen",
+        "Sketch",
+        "Ask",
+        "Resolve",
+        "Approve",
+    )
+
+    require_text(
+        "SDD semantic intake",
+        intake,
+        "skip Phase 0",
+        "process identity",
+        "nodes",
+        "flows",
+        "conditions",
+        "variables",
+        "events",
+        "subprocess",
+        "loop",
+        "resource intent",
+        "graph completeness",
+        "before registry",
+        "registry",
+        "Inventory membership is not permission",
+        "BPMNDI",
+        "validator",
+        "project.uiproj",
+        "bindings_v2.json",
+        "entry-points.json",
+        "operate.json",
+        "package-descriptor.json",
+        "uip is connections list --all-folders",
+        "exactly once",
+    )
+    require_text(
+        "SDD generation rules",
+        rules,
+        "stable logical IDs",
+        "graph integrity",
+        "data lineage",
+        "default flow is unconditional",
+        "flow ID is the consumer",
+        "unresolved",
+        "does not include registry XML",
+        "does not include BPMNDI",
+    )
+
+    for forbidden in ("uipath:", "<bpmn:", "bpmndi"):
+        if forbidden in template.lower():
+            fail(f"SDD template must not contain {forbidden!r}")
+
+    print("OK: BPMN SDD routing, Phase 0, intake, and handoff contract is present")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tasks/uipath-maestro-bpmn/sdd_contract/check_skill_contract.py
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_contract/check_skill_contract.py
@@ -13,6 +13,14 @@ TEMPLATE = ROOT / "skills/uipath-maestro-bpmn/assets/templates/sdd-template.md"
 RULES = ROOT / "skills/uipath-maestro-bpmn/references/sdd-generation-rules.md"
 INTERVIEW = ROOT / "skills/uipath-maestro-bpmn/references/phase-0-interview.md"
 INTAKE = ROOT / "skills/uipath-maestro-bpmn/references/sdd-input.md"
+DELEGATE_E2E = (
+    ROOT
+    / "tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/delegate_loan_origination_sdd.yaml"
+)
+DELEGATE_FIXTURE = (
+    ROOT
+    / "tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/fixtures/sdd.md"
+)
 
 
 def fail(message: str) -> None:
@@ -52,6 +60,8 @@ def main() -> int:
     rules = read_required(RULES)
     interview = read_required(INTERVIEW)
     intake = read_required(INTAKE)
+    delegate_e2e = read_required(DELEGATE_E2E)
+    delegate_fixture = read_required(DELEGATE_FIXTURE)
 
     require_text(
         "SKILL.md input routing",
@@ -64,6 +74,8 @@ def main() -> int:
         "Phase 0",
         "explicit direct-authoring",
         "direct prose-to-BPMN",
+        "explicit SDD path first",
+        "`./sdd.md`",
     )
     require_order(
         "SKILL.md input routing",
@@ -118,10 +130,12 @@ def main() -> int:
         interview,
         "sdd.draft.md",
         "explicit approval",
-        "AskUserQuestion",
+        "resumable checkpoint",
         "sdd.md",
         "before registry",
     )
+    if "AskUserQuestion" in interview:
+        fail("Phase 0 reference must use platform-neutral approval wording")
     require_order(
         "Phase 0 interview",
         interview,
@@ -141,6 +155,7 @@ def main() -> int:
         "flows",
         "conditions",
         "variables",
+        "scope",
         "events",
         "subprocess",
         "loop",
@@ -170,6 +185,29 @@ def main() -> int:
         "unresolved",
         "does not include registry XML",
         "does not include BPMNDI",
+    )
+    require_text(
+        "Skills-owned SDD variable contract",
+        template,
+        "Variable ID",
+        "Type",
+        "Scope",
+        "Source",
+        "Consumers",
+    )
+    require_text(
+        "Delegate compatibility E2E",
+        delegate_e2e,
+        "Delegate-generated",
+        "skip Phase 0",
+        "check_loan_origination_sdd.py",
+    )
+    require_text(
+        "Delegate compatibility fixture",
+        delegate_fixture,
+        "N_VALIDATION_RESULT",
+        "Scope",
+        "<UNRESOLVED: active-tenant human task must be selected downstream>",
     )
 
     for forbidden in ("uipath:", "<bpmn:", "bpmndi"):

--- a/tests/tasks/uipath-maestro-bpmn/sdd_contract/sdd_contract.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_contract/sdd_contract.yaml
@@ -1,0 +1,22 @@
+task_id: skill-bpmn-sdd-contract
+description: >
+  Static contract coverage for the independently owned BPMN SDD routing,
+  Phase 0 interview, and supplied-SDD intake guidance.
+tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, feature:eval]
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+initial_prompt: |
+  Verify the checked-out uipath-maestro-bpmn skill's SDD contract. Do not
+  modify the repository or run any cloud-side operation.
+
+success_criteria:
+  - type: run_command
+    description: "BPMN SDD routing and handoff contract is present"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-bpmn/sdd_contract/check_skill_contract.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/delegate_loan_origination_sdd.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/delegate_loan_origination_sdd.yaml
@@ -1,0 +1,87 @@
+task_id: skill-bpmn-sdd-delegate-loan-origination
+description: >
+  Cross-repository compatibility evaluation: the uipath-maestro-bpmn skill
+  consumes a captured Delegate-generated loan-origination SDD, resolves its
+  resource intent, and builds a validator-clean local BPMN project.
+tags: [uipath-maestro-bpmn, e2e, mode:build, lifecycle:generate, shape:multi-node, node:decision, node:hitl, feature:registry, feature:approval-gate]
+
+run_limits:
+  expected_turns: 36
+  max_turns: 100
+  task_timeout: 2400
+  turn_timeout: 1800
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: fixtures
+    - type: template_dir
+      path: ../sdd_loan_origination/mocks
+      mount_point: mocks
+  mock_path_dirs: [mocks]
+
+initial_prompt: |
+  Build a complete local UiPath Maestro BPMN project from the approved `sdd.md`
+  in this folder. This file is the captured clean output of Delegate's BPMN SDD
+  profile. The main BPMN file must be
+  `LoanOriginationBpmn/LoanOriginationBpmn.bpmn`.
+
+  This is a supplied SDD: skip Phase 0, do not create `sdd.draft.md`, and preserve
+  every declared logical node, flow ID, source, and target exactly. Resolve the
+  underwriter resource only through the mocked `uip` registry responses on PATH.
+  The exact matching mocked Loan Underwriting Review result is pre-approved for
+  this evaluation; do not substitute a candidate. Pull the registry once, list
+  or search extension types, and run
+  `uip is connections list --all-folders` exactly once. Discovery does not
+  authorize usage: the fetched templates declare no connection contract, so keep
+  `bindings_v2.json` resources empty and do not add a `bindings.*` expression.
+
+  Create `project.uiproj`, `operate.json`, `entry-points.json`,
+  `bindings_v2.json`, and `package-descriptor.json`. Include BPMNDI for every
+  visible node and flow, and run the bundled validator until it exits zero.
+  Do not inspect mocks or validator internals. Do not ask for approval. Do not
+  upload, publish, deploy, debug, run, or make any cloud-side change.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent pulled the mocked BPMN registry"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+registry\s+pull'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved registry-owned node templates"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+registry\s+get'
+    min_count: 3
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Loan origination BPMN source was created"
+    path: LoanOriginationBpmn/LoanOriginationBpmn.bpmn
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated BPMN preserves the Delegate SDD and validates locally"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/check_loan_origination_sdd.py"
+    timeout: 240
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent kept the scenario local and avoided lifecycle mutations"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run)'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_delegate_loan_origination/fixtures/sdd.md
@@ -1,0 +1,90 @@
+# Loan Origination Solution Design Document
+
+## 1. Process Overview
+
+| Field | Value |
+|---|---|
+| Process name | Loan origination |
+| Process ID | loan-origination |
+| Scope | Validate a submitted loan application, determine eligibility, and route eligible applications for underwriter review. |
+| Intended outcome | Record an approved or rejected loan outcome. |
+| In scope | Manual application start, validation, eligibility, underwriter review, and final outcome. |
+| Out of scope | Loan funding, payment servicing, and customer notification delivery. |
+
+## 2. Participants and Triggers
+
+| Participant ID | Name | Responsibility | Lane or pool intent |
+|---|---|---|---|
+| P_APPLICANT | Applicant | Starts the application. | Applicant |
+| P_UNDERWRITER | Underwriter | Reviews eligible applications. | Underwriting |
+
+| Trigger ID | Trigger type | Description | Initial data or event | Source intent |
+|---|---|---|---|---|
+| T_MANUAL_APPLICATION | Manual start | An applicant submits a loan application. | applicationId, applicantName, requestedAmount | Loan application intake |
+
+## 3. Process Graph
+
+### Nodes
+
+| Node ID | Node type | Name | Purpose | Participant | Resource intent |
+|---|---|---|---|---|---|
+| N_START | Start event | Manual loan application start | Begin the process when an applicant submits an application. | P_APPLICANT | Manual start form or intake trigger. |
+| N_VALIDATE_APPLICATION | Script task | Validate application | Validate required application data and calculate eligibility inputs. | System | Scripted validation using application data. |
+| N_VALIDATION_RESULT | Exclusive gateway | Application valid? | Route valid applications to eligibility and invalid applications to rejection. | System | Gateway evaluates validationStatus. |
+| N_ELIGIBILITY | Exclusive gateway | Eligible? | Route valid applications by the eligibility decision. | System | Gateway evaluates eligibilityDecision. |
+| N_HUMAN_REVIEW | User task | Underwriter review | Let an underwriter approve or reject an eligible application. | P_UNDERWRITER | UiPath human review task with application data. |
+| N_REVIEW_DECISION | Exclusive gateway | Review approved? | Route the recorded underwriter outcome. | System | Gateway evaluates reviewOutcome. |
+| N_APPROVED | End event | Loan approved | End the process with an approved outcome. | System | Outcome recording. |
+| N_REJECTED | End event | Loan rejected | End the process with a rejected outcome. | System | Outcome recording. |
+
+### Sequence flows
+
+| Flow ID | Source Node ID | Target Node ID | Condition | Default |
+|---|---|---|---|---|
+| F_START_VALIDATE | N_START | N_VALIDATE_APPLICATION | Always | No |
+| F_VALIDATE_RESULT | N_VALIDATE_APPLICATION | N_VALIDATION_RESULT | Always | No |
+| F_VALID_APPLICATION | N_VALIDATION_RESULT | N_ELIGIBILITY | validationStatus == "valid" | No |
+| F_INVALID_APPLICATION | N_VALIDATION_RESULT | N_REJECTED | Always | Yes |
+| F_ELIGIBLE | N_ELIGIBILITY | N_HUMAN_REVIEW | eligibilityDecision == "eligible" | No |
+| F_INELIGIBLE | N_ELIGIBILITY | N_REJECTED | Always | Yes |
+| F_REVIEW_DECISION | N_HUMAN_REVIEW | N_REVIEW_DECISION | Always | No |
+| F_REVIEW_APPROVED | N_REVIEW_DECISION | N_APPROVED | reviewOutcome == "approved" | No |
+| F_REVIEW_REJECTED | N_REVIEW_DECISION | N_REJECTED | Always | Yes |
+
+### Subprocesses and loops
+
+No subprocesses or loops are declared for this process.
+
+## 4. Data and Variables
+
+| Variable | Type | Scope | Producer | Consumers | Source or default |
+|---|---|---|---|---|---|
+| applicationId | String | Process | T_MANUAL_APPLICATION | N_VALIDATE_APPLICATION, N_HUMAN_REVIEW | Submitted application identifier. |
+| applicantName | String | Process | T_MANUAL_APPLICATION | N_HUMAN_REVIEW | Submitted applicant name. |
+| requestedAmount | Number | Process | T_MANUAL_APPLICATION | N_VALIDATE_APPLICATION, N_HUMAN_REVIEW | Submitted requested amount. |
+| validationStatus | String | Process | N_VALIDATE_APPLICATION | F_VALID_APPLICATION, F_INVALID_APPLICATION | `valid` or `invalid`. |
+| eligibilityDecision | String | Process | N_VALIDATE_APPLICATION | F_ELIGIBLE, F_INELIGIBLE | `eligible` or `ineligible`. |
+| reviewOutcome | String | Process | N_HUMAN_REVIEW | F_REVIEW_APPROVED, F_REVIEW_REJECTED | `approved` or `rejected`. |
+
+## 5. UiPath Resource Intent
+
+This UiPath resource intent records the required behavior without fabricating a
+tenant-specific identity.
+
+| Node ID | UiPath activity or resource intent | Required | Required inputs | Expected outputs | Resolved identity | Status |
+|---|---|---|---|---|---|---|
+| N_VALIDATE_APPLICATION | Script task for application validation and eligibility calculation. | Yes | applicationId, requestedAmount | validationStatus, eligibilityDecision | `BPMN.ScriptTask` extension type, resolved from the active registry. | Resolved; revalidate the registry template downstream. |
+| N_HUMAN_REVIEW | Human review task assigned to an underwriter. | Yes | applicationId, applicantName, requestedAmount | reviewOutcome | `<UNRESOLVED: active-tenant human task must be selected downstream>` | Blocked for executable implementation. |
+
+## 6. Exception and Event Behavior
+
+| Event or exception ID | Triggering node or flow | Behavior | Recovery or outcome | Affected data |
+|---|---|---|---|---|
+| E_INVALID_APPLICATION | N_VALIDATE_APPLICATION | Set validationStatus to `invalid` and end with a rejected outcome. | Loan rejected. | validationStatus |
+| E_REVIEW_REJECTED | F_REVIEW_REJECTED | Record the underwriter rejection. | Loan rejected. | reviewOutcome |
+
+## 7. Implementation Readiness
+
+| Blocker ID | Readiness item | Status | Owner or decision needed | Resolution path |
+|---|---|---|---|---|
+| R_UNDERWRITER_ASSIGNMENT | Confirm the tenant-specific assignment mechanism for the human review task. | Open | Implementation owner | Revalidate against the active tenant before executable BPMN generation. |

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/check_loan_origination_sdd.py
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/check_loan_origination_sdd.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Grade declaration-complete BPMN projection from either supported SDD shape."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from _shared.bpmn_assertions import (  # noqa: E402
+    BPMNDI_NS,
+    BPMN_NS,
+    UIPATH_NS,
+    assert_package_lifecycle,
+    fail,
+    load_bpmn,
+)
+
+
+PROJECT = Path("LoanOriginationBpmn")
+BPMN_NAME = "LoanOriginationBpmn.bpmn"
+BPMN = PROJECT / BPMN_NAME
+
+
+def compact(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "", value.lower())
+
+
+def clean_cell(value: str) -> str:
+    return re.sub(r"[`*_]", "", value).strip()
+
+
+def header_key(value: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", clean_cell(value).lower()).strip()
+
+
+def parse_markdown_tables(text: str) -> list[list[dict[str, str]]]:
+    lines = text.splitlines()
+    tables: list[list[dict[str, str]]] = []
+    index = 0
+    while index + 1 < len(lines):
+        if not lines[index].lstrip().startswith("|") or not re.match(
+            r"^\s*\|?(?:\s*:?-+:?\s*\|)+\s*$", lines[index + 1]
+        ):
+            index += 1
+            continue
+        headers = [header_key(cell) for cell in lines[index].strip().strip("|").split("|")]
+        index += 2
+        rows: list[dict[str, str]] = []
+        while index < len(lines) and lines[index].lstrip().startswith("|"):
+            cells = [clean_cell(cell) for cell in lines[index].strip().strip("|").split("|")]
+            if len(cells) == len(headers):
+                rows.append(dict(zip(headers, cells)))
+            index += 1
+        if rows:
+            tables.append(rows)
+    return tables
+
+
+def table_with(tables: list[list[dict[str, str]]], *required: tuple[str, ...]):
+    for table in tables:
+        keys = set(table[0])
+        if all(any(header_key(alias) in keys for alias in aliases) for aliases in required):
+            return table
+    fail(f"supplied SDD is missing a required semantic table: {required}")
+
+
+def cell(row: dict[str, str], *aliases: str) -> str:
+    for alias in aliases:
+        value = row.get(header_key(alias))
+        if value is not None:
+            return value
+    fail(f"SDD row is missing one of these columns: {aliases}")
+
+
+def supplied_sdd() -> Path:
+    candidates = [Path("sdd.md"), *sorted(Path(".").glob("*SDD.md"))]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    fail("supplied SDD fixture is missing")
+
+
+def bpmn_kind(value: str) -> str:
+    normalized = header_key(value)
+    mappings = (
+        ("start event", "startEvent"),
+        ("end event", "endEvent"),
+        ("script task", "scriptTask"),
+        ("user task", "userTask"),
+        ("service task", "serviceTask"),
+        ("business rule task", "businessRuleTask"),
+        ("exclusive gateway", "exclusiveGateway"),
+        ("inclusive gateway", "inclusiveGateway"),
+        ("parallel gateway", "parallelGateway"),
+        ("event based gateway", "eventBasedGateway"),
+        ("subprocess", "subProcess"),
+        ("call activity", "callActivity"),
+        ("task", "task"),
+    )
+    for phrase, tag in mappings:
+        if phrase in normalized:
+            return tag
+    fail(f"unsupported BPMN kind in supplied SDD: {value!r}")
+
+
+def semantic_model(text: str):
+    tables = parse_markdown_tables(text)
+    node_rows = table_with(
+        tables,
+        ("Logical ID", "Node ID"),
+        ("BPMN kind", "Node type"),
+        ("Name",),
+    )
+    flow_rows = table_with(
+        tables,
+        ("Logical flow ID", "Flow ID"),
+        ("From node", "Source Node ID"),
+        ("To node", "Target Node ID"),
+        ("Condition",),
+        ("Default path", "Default"),
+    )
+    variable_rows = table_with(
+        tables,
+        ("Variable ID", "Variable"),
+        ("Type",),
+        ("Source", "Producer"),
+        ("Consumers",),
+    )
+
+    nodes = {
+        cell(row, "Logical ID", "Node ID"): {
+            "kind": bpmn_kind(cell(row, "BPMN kind", "Node type")),
+            "name": cell(row, "Name"),
+        }
+        for row in node_rows
+    }
+    flows = {
+        cell(row, "Logical flow ID", "Flow ID"): {
+            "source": cell(row, "From node", "Source Node ID"),
+            "target": cell(row, "To node", "Target Node ID"),
+            "condition": cell(row, "Condition"),
+            "default": cell(row, "Default path", "Default").lower() == "yes",
+        }
+        for row in flow_rows
+    }
+    variables = {
+        cell(row, "Variable ID", "Variable"): cell(row, "Type").split()[0].lower()
+        for row in variable_rows
+    }
+    if not nodes or not flows or not variables:
+        fail("supplied SDD semantic model is empty")
+    return nodes, flows, variables
+
+
+def find_logical_element(root, logical_id: str, expected_kind: str):
+    token = compact(logical_id)
+    candidates = root.findall(f".//{{{BPMN_NS}}}{expected_kind}")
+    for element in candidates:
+        if token in compact(element.attrib.get("id", "")) or token in compact(
+            element.attrib.get("name", "")
+        ):
+            return element
+    fail(f"missing {expected_kind} for SDD logical node {logical_id!r}")
+
+
+def find_logical_flow(root, logical_id: str):
+    token = compact(logical_id)
+    for flow in root.findall(f".//{{{BPMN_NS}}}sequenceFlow"):
+        if token in compact(flow.attrib.get("id", "")):
+            return flow
+    fail(f"missing sequence flow for SDD logical flow {logical_id!r}")
+
+
+def require_variables(root, expected: dict[str, str]) -> None:
+    variables = root.findall(f".//{{{UIPATH_NS}}}variables/*")
+    for logical_id, expected_type in expected.items():
+        token = compact(logical_id)
+        matched = next(
+            (
+                variable
+                for variable in variables
+                if token in compact(variable.attrib.get("id", ""))
+                or token in compact(variable.attrib.get("name", ""))
+            ),
+            None,
+        )
+        if matched is None:
+            fail(f"missing declared SDD variable {logical_id!r}")
+        actual_type = matched.attrib.get("type", "").lower()
+        if compact(actual_type) != compact(expected_type):
+            fail(
+                f"SDD variable {logical_id!r} must have type {expected_type!r}, "
+                f"got {actual_type or '<missing>'!r}"
+            )
+
+
+def extension_types(element) -> set[str]:
+    return {
+        type_element.attrib["value"]
+        for type_element in element.findall(f".//{{{UIPATH_NS}}}type")
+        if type_element.attrib.get("value")
+    }
+
+
+def require_flow_semantics(
+    declared_flows: dict[str, dict[str, object]],
+    generated_flows: dict[str, object],
+    generated_nodes: dict[str, object],
+    declared_variables: dict[str, str],
+) -> None:
+    variable_tokens = {compact(variable): variable for variable in declared_variables}
+    for logical_id, declaration in declared_flows.items():
+        flow = generated_flows[logical_id]
+        source = generated_nodes[str(declaration["source"])]
+        target = generated_nodes[str(declaration["target"])]
+        if flow.attrib.get("sourceRef") != source.attrib["id"]:
+            fail(f"{logical_id!r} does not preserve its SDD source node")
+        if flow.attrib.get("targetRef") != target.attrib["id"]:
+            fail(f"{logical_id!r} does not preserve its SDD target node")
+
+        expression = flow.find(f"{{{BPMN_NS}}}conditionExpression")
+        condition = str(declaration["condition"])
+        if bool(declaration["default"]):
+            if source.attrib.get("default") != flow.attrib["id"]:
+                fail(f"{logical_id!r} is declared default but its gateway does not reference it")
+            if expression is not None:
+                fail(f"default flow {logical_id!r} must be unconditional")
+        elif condition.lower() == "always":
+            if expression is not None:
+                fail(f"unconditional flow {logical_id!r} unexpectedly has a condition")
+        else:
+            if expression is None or not (expression.text or "").strip():
+                fail(f"conditional SDD flow {logical_id!r} has no BPMN conditionExpression")
+            declared_refs = [
+                variable
+                for token, variable in variable_tokens.items()
+                if token and token in compact(condition)
+            ]
+            if not declared_refs:
+                fail(f"SDD condition for {logical_id!r} references no declared variable")
+            generated_condition = compact(expression.text or "")
+            missing = [
+                variable
+                for variable in declared_refs
+                if compact(variable) not in generated_condition
+            ]
+            if missing:
+                fail(f"condition for {logical_id!r} dropped SDD variables: {missing}")
+
+
+def require_di(root, nodes: dict[str, object], flows: dict[str, object]) -> None:
+    shapes = {
+        shape.attrib.get("bpmnElement")
+        for shape in root.findall(f".//{{{BPMNDI_NS}}}BPMNShape")
+    }
+    edges = {
+        edge.attrib.get("bpmnElement")
+        for edge in root.findall(f".//{{{BPMNDI_NS}}}BPMNEdge")
+    }
+    for logical_id, node in nodes.items():
+        if node.attrib["id"] not in shapes:
+            fail(f"missing BPMNDI shape for SDD node {logical_id!r}")
+    for logical_id, flow in flows.items():
+        if flow.attrib["id"] not in edges:
+            fail(f"missing BPMNDI edge for SDD flow {logical_id!r}")
+
+
+def require_registry_calls() -> None:
+    call_log = Path("mocks/.calls.jsonl")
+    if not call_log.is_file():
+        fail("mock uip call log is missing; registry discovery did not use the dispatcher")
+    calls = [json.loads(line).get("args", "") for line in call_log.read_text().splitlines()]
+    required = [
+        "maestro bpmn registry pull",
+        "maestro bpmn registry get BPMN.Variables",
+        "maestro bpmn registry get BPMN.ScriptTask",
+        "maestro bpmn registry get Actions.HITL",
+        "is connections list --all-folders",
+    ]
+    missing = [pattern for pattern in required if not any(pattern in call for call in calls)]
+    if missing:
+        fail(f"registry discovery did not make required mocked calls: {missing}")
+    connection_calls = [call for call in calls if "is connections list --all-folders" in call]
+    if len(connection_calls) != 1:
+        fail(
+            "supplied-SDD discovery must refresh all-folder connections exactly once; "
+            f"observed {len(connection_calls)} calls"
+        )
+    if not any(
+        "maestro bpmn registry list" in call or "maestro bpmn registry search" in call
+        for call in calls
+    ):
+        fail("registry discovery must list or search extension types")
+
+
+def require_no_unrelated_connection_binding(bpmn_text: str) -> None:
+    bindings_path = PROJECT / "bindings_v2.json"
+    bindings = json.loads(bindings_path.read_text(encoding="utf-8"))
+    resources = bindings.get("resources", [])
+    if resources:
+        fail(
+            "this SDD declares ScriptTask and HITL templates with no connection "
+            f"contract; bindings_v2.json must stay empty, got {len(resources)} resource(s)"
+        )
+    if "bindings." in bpmn_text:
+        fail("BPMN references an unrelated connection binding absent from the SDD")
+
+
+def require_validator_clean() -> None:
+    skills_root = os.environ.get("SKILLS_REPO_PATH")
+    if not skills_root:
+        fail("SKILLS_REPO_PATH is required to run the bundled validator")
+    validator = Path(skills_root) / "skills/uipath-maestro-bpmn/validator"
+    install = subprocess.run(
+        ["npm", "install", "--silent"],
+        cwd=validator,
+        capture_output=True,
+        text=True,
+        timeout=180,
+        check=False,
+    )
+    if install.returncode:
+        fail(f"bundled validator dependencies failed to install: {install.stderr.strip()}")
+    result = subprocess.run(
+        ["node", "validate-bpmn.mjs", str(BPMN.resolve())],
+        cwd=validator,
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if result.returncode:
+        fail(f"bundled validator failed:\n{result.stdout}{result.stderr}")
+    if "VALID" not in result.stdout:
+        fail(f"bundled validator did not report VALID:\n{result.stdout}{result.stderr}")
+
+
+def main() -> int:
+    if Path("sdd.draft.md").exists():
+        fail("supplied SDD must bypass Phase 0; found sdd.draft.md")
+    if not BPMN.is_file():
+        fail(f"missing generated BPMN: {BPMN}")
+
+    declared_nodes, declared_flows, declared_variables = semantic_model(
+        supplied_sdd().read_text(encoding="utf-8")
+    )
+    undeclared_endpoints = {
+        endpoint
+        for flow in declared_flows.values()
+        for endpoint in (str(flow["source"]), str(flow["target"]))
+        if endpoint not in declared_nodes
+    }
+    if undeclared_endpoints:
+        fail(f"supplied SDD flows reference undeclared nodes: {sorted(undeclared_endpoints)}")
+
+    root = load_bpmn(str(BPMN))
+    bpmn_text = BPMN.read_text(encoding="utf-8")
+    if "unresolved" in bpmn_text.lower():
+        fail("generated executable BPMN still contains an unresolved resource marker")
+
+    nodes = {
+        logical_id: find_logical_element(root, logical_id, str(declaration["kind"]))
+        for logical_id, declaration in declared_nodes.items()
+    }
+    flows = {logical_id: find_logical_flow(root, logical_id) for logical_id in declared_flows}
+    require_flow_semantics(declared_flows, flows, nodes, declared_variables)
+    require_variables(root, declared_variables)
+
+    for logical_id, declaration in declared_nodes.items():
+        if declaration["kind"] == "scriptTask" and "BPMN.ScriptTask" not in extension_types(
+            nodes[logical_id]
+        ):
+            fail(f"script task {logical_id!r} must use the registry-owned BPMN.ScriptTask wrapper")
+        if declaration["kind"] == "userTask" and "Actions.HITL" not in extension_types(
+            nodes[logical_id]
+        ):
+            fail(f"user task {logical_id!r} must use the registry-owned Actions.HITL wrapper")
+
+    require_di(root, nodes, flows)
+    starts = [node for logical_id, node in nodes.items() if declared_nodes[logical_id]["kind"] == "startEvent"]
+    if len(starts) != 1:
+        fail(f"expected one root start event from this SDD fixture, got {len(starts)}")
+    assert_package_lifecycle(PROJECT, BPMN_NAME, starts[0].attrib["id"])
+    require_no_unrelated_connection_binding(bpmn_text)
+    require_registry_calls()
+    require_validator_clean()
+
+    print(
+        "OK: every supplied SDD declaration produced a registry-backed, "
+        "validator-clean BPMN project"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/check_loan_origination_sdd.py
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/check_loan_origination_sdd.py
@@ -129,6 +129,7 @@ def semantic_model(text: str):
         tables,
         ("Variable ID", "Variable"),
         ("Type",),
+        ("Scope",),
         ("Source", "Producer"),
         ("Consumers",),
     )
@@ -150,7 +151,10 @@ def semantic_model(text: str):
         for row in flow_rows
     }
     variables = {
-        cell(row, "Variable ID", "Variable"): cell(row, "Type").split()[0].lower()
+        cell(row, "Variable ID", "Variable"): {
+            "type": cell(row, "Type").split()[0].lower(),
+            "scope": cell(row, "Scope"),
+        }
         for row in variable_rows
     }
     if not nodes or not flows or not variables:
@@ -177,9 +181,10 @@ def find_logical_flow(root, logical_id: str):
     fail(f"missing sequence flow for SDD logical flow {logical_id!r}")
 
 
-def require_variables(root, expected: dict[str, str]) -> None:
+def require_variables(root, expected: dict[str, dict[str, str]]) -> None:
     variables = root.findall(f".//{{{UIPATH_NS}}}variables/*")
-    for logical_id, expected_type in expected.items():
+    parents = {child: parent for parent in root.iter() for child in parent}
+    for logical_id, declaration in expected.items():
         token = compact(logical_id)
         matched = next(
             (
@@ -192,11 +197,34 @@ def require_variables(root, expected: dict[str, str]) -> None:
         )
         if matched is None:
             fail(f"missing declared SDD variable {logical_id!r}")
+        expected_type = declaration["type"]
         actual_type = matched.attrib.get("type", "").lower()
         if compact(actual_type) != compact(expected_type):
             fail(
                 f"SDD variable {logical_id!r} must have type {expected_type!r}, "
                 f"got {actual_type or '<missing>'!r}"
+            )
+
+        owner = parents.get(matched)
+        while owner is not None and owner.tag not in {
+            f"{{{BPMN_NS}}}process",
+            f"{{{BPMN_NS}}}subProcess",
+        }:
+            owner = parents.get(owner)
+        if owner is None:
+            fail(f"SDD variable {logical_id!r} has no BPMN process or subprocess scope")
+
+        expected_scope = compact(declaration["scope"])
+        if expected_scope == "process":
+            if owner.tag != f"{{{BPMN_NS}}}process":
+                fail(f"SDD variable {logical_id!r} must be process scoped")
+        elif owner.tag != f"{{{BPMN_NS}}}subProcess" or not any(
+            expected_scope in compact(owner.attrib.get(attribute, ""))
+            for attribute in ("id", "name")
+        ):
+            fail(
+                f"SDD variable {logical_id!r} must be scoped to subprocess "
+                f"{declaration['scope']!r}"
             )
 
 
@@ -212,7 +240,7 @@ def require_flow_semantics(
     declared_flows: dict[str, dict[str, object]],
     generated_flows: dict[str, object],
     generated_nodes: dict[str, object],
-    declared_variables: dict[str, str],
+    declared_variables: dict[str, dict[str, str]],
 ) -> None:
     variable_tokens = {compact(variable): variable for variable in declared_variables}
     for logical_id, declaration in declared_flows.items():

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/fixtures/sdd.md
@@ -47,12 +47,12 @@ The process starts manually with an application ID and requested amount.
 
 ## 4. Data and variables
 
-| Variable ID | Type | Source | Consumers | Purpose |
-| --- | --- | --- | --- | --- |
-| `application-id` | string | `start-application` | `validate-application`, `underwriter-review` | Identifies the application. |
-| `requested-amount` | number | `start-application` | `validate-application`, `underwriter-review` | Records the requested loan amount. |
-| `application-valid` | boolean | `validate-application` | `assess-eligibility`, `application-rejected` | States whether required application data is valid. |
-| `review-decision` | string | `underwriter-review` | `route-review-decision`, `application-approved`, `application-rejected` | States the underwriter's outcome. |
+| Variable ID | Type | Scope | Source | Consumers | Purpose |
+| --- | --- | --- | --- | --- | --- |
+| `application-id` | string | process | `start-application` | `validate-application`, `underwriter-review` | Identifies the application. |
+| `requested-amount` | number | process | `start-application` | `validate-application`, `underwriter-review` | Records the requested loan amount. |
+| `application-valid` | boolean | process | `validate-application` | `assess-eligibility`, `application-rejected` | States whether required application data is valid. |
+| `review-decision` | string | process | `underwriter-review` | `route-review-decision`, `application-approved`, `application-rejected` | States the underwriter's outcome. |
 
 ## 5. Events, subprocesses, and loops
 

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/fixtures/sdd.md
@@ -1,0 +1,80 @@
+# Loan Origination — BPMN Solution Design Document
+
+## 1. Process identity
+
+| Field | Value |
+| --- | --- |
+| Process name | Loan Origination |
+| Logical process ID | `loan-origination` |
+| Business objective | Validate a loan application, route eligible applications to an underwriter, and record an approved or rejected outcome. |
+| Scope | Manual applications only; no document extraction, funding, or post-approval servicing. |
+| Implementation readiness | `Executable` |
+
+## 2. Participants and triggers
+
+| Logical ID | Participant or trigger | Role in the process | Input or event |
+| --- | --- | --- | --- |
+| `loan-applicant` | Loan applicant | Starts a manual application | application ID and requested amount |
+| `underwriter` | Underwriter | Reviews eligible applications | application details and validation result |
+
+The process starts manually with an application ID and requested amount.
+
+## 3. Process graph
+
+### Nodes
+
+| Logical ID | BPMN kind | Name | Inputs | Outputs | Resource intent |
+| --- | --- | --- | --- | --- | --- |
+| `start-application` | start event | Start Application | application ID, requested amount | application ID, requested amount | none |
+| `validate-application` | script task | Validate Application | application ID, requested amount | application valid | none |
+| `assess-eligibility` | exclusive gateway | Assess Eligibility | application valid | none | none |
+| `underwriter-review` | user task | Underwriter Review | application ID, requested amount | review decision | `loan-underwriter-review` |
+| `route-review-decision` | exclusive gateway | Route Review Decision | review decision | none | none |
+| `application-approved` | end event | Application Approved | review decision | none | none |
+| `application-rejected` | end event | Application Rejected | application valid or review decision | none | none |
+
+### Sequence flows
+
+| Logical flow ID | From node | To node | Condition | Default path |
+| --- | --- | --- | --- | --- |
+| `flow-start-validate` | `start-application` | `validate-application` | Always | No |
+| `flow-validate-eligibility` | `validate-application` | `assess-eligibility` | Always | No |
+| `flow-eligible-review` | `assess-eligibility` | `underwriter-review` | `=js:vars.applicationValid === true` | No |
+| `flow-ineligible-rejected` | `assess-eligibility` | `application-rejected` | Always | Yes |
+| `flow-review-decision` | `underwriter-review` | `route-review-decision` | Always | No |
+| `flow-approved` | `route-review-decision` | `application-approved` | `=js:vars.reviewDecision === "Approved"` | No |
+| `flow-review-rejected` | `route-review-decision` | `application-rejected` | Always | Yes |
+
+## 4. Data and variables
+
+| Variable ID | Type | Source | Consumers | Purpose |
+| --- | --- | --- | --- | --- |
+| `application-id` | string | `start-application` | `validate-application`, `underwriter-review` | Identifies the application. |
+| `requested-amount` | number | `start-application` | `validate-application`, `underwriter-review` | Records the requested loan amount. |
+| `application-valid` | boolean | `validate-application` | `assess-eligibility`, `application-rejected` | States whether required application data is valid. |
+| `review-decision` | string | `underwriter-review` | `route-review-decision`, `application-approved`, `application-rejected` | States the underwriter's outcome. |
+
+## 5. Events, subprocesses, and loops
+
+None.
+
+## 6. Resource intent
+
+| Resource intent ID | Used by node | Intended capability | Intended resource name | Connection or folder intent | Required | Resolution |
+| --- | --- | --- | --- | --- | --- | --- |
+| `loan-underwriter-review` | `underwriter-review` | human review | Loan Underwriting Review | Shared/Loan Operations; action app `loan-underwriting-review`, version `1`, action `ReviewApplication`, key `loan-operations` | Yes | Resolved |
+
+## 7. Exception and event behavior
+
+An invalid application follows the eligibility gateway's default rejected path.
+An underwriter decision other than `Approved` follows the review gateway's
+default rejected path.
+
+## 8. Implementation readiness
+
+| Check | Status | Evidence or blocker |
+| --- | --- | --- |
+| Graph is complete | Ready | One manual start, two explicit outcomes, and all gateway paths are declared. |
+| Variable lineage is complete | Ready | Every gateway input has a declared producer. |
+| Required resources are resolved | Ready | `loan-underwriter-review` is resolved by the approved mocked registry result. |
+| Executable BPMN may be authored | Yes | All required resource intent is resolved. |

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/loan_origination_sdd.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/loan_origination_sdd.yaml
@@ -1,0 +1,96 @@
+task_id: skill-bpmn-sdd-loan-origination
+description: >
+  End-to-end SDD-consumer evaluation: the uipath-maestro-bpmn skill bypasses
+  Phase 0 for a supplied loan-origination SDD, resolves its declared resource
+  intent through mocked registry responses, and builds a validator-clean local
+  BPMN project.
+tags: [uipath-maestro-bpmn, e2e, mode:build, lifecycle:generate, shape:multi-node, node:decision, node:hitl, feature:registry, feature:approval-gate]
+
+run_limits:
+  expected_turns: 36
+  max_turns: 100
+  task_timeout: 2400
+  turn_timeout: 1800
+
+sandbox:
+  driver: tempdir
+  python: {}
+  template_sources:
+    - type: template_dir
+      path: ../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../_shared/mock_template
+    - type: template_dir
+      path: fixtures
+    - type: template_dir
+      path: mocks
+      mount_point: mocks
+  mock_path_dirs: [mocks]
+
+initial_prompt: |
+  Build a complete local UiPath Maestro BPMN project from the approved `sdd.md`
+  in this folder. The main BPMN file must be
+  `LoanOriginationBpmn/LoanOriginationBpmn.bpmn`.
+
+  This is a supplied SDD: skip Phase 0, do not create `sdd.draft.md`, and preserve
+  every declared logical node, flow ID, source, and target exactly. Do not insert
+  synthetic merge gateways or flows. Resolve its resource intent
+  only through the mocked `uip` registry responses on PATH. The exact matching
+  mocked Loan Underwriting Review result is pre-approved for this evaluation;
+  use it to revalidate or resolve the SDD's human-review intent and do not
+  substitute a candidate. Before assembly, perform the full
+  registry discovery flow: pull the registry once, list or search extension
+  types, and run `uip is connections list --all-folders` even though this HITL
+  resource has no connection binding. Discovery does not authorize usage: the
+  fetched templates declare no connection contract, so keep `bindings_v2.json`
+  resources empty and do not add a `bindings.*` expression.
+
+  Create these local package metadata files next to the BPMN: `project.uiproj`,
+  `operate.json`, `entry-points.json`, `bindings_v2.json`, and
+  `package-descriptor.json`. Make their BPMN references point to
+  `LoanOriginationBpmn.bpmn` and its actual start event. Include BPMNDI for every
+  visible node and flow, and run the bundled validator until it exits zero.
+  Author early from `references/structural-bpmn.md` and the fetched templates.
+  Do not inspect validator internals, its test fixtures, its samples, or the
+  moddle descriptor before authoring; use the validator only to check the file.
+  Do not inspect `mocks/` directly. Do not ask for approval, confirmation, or
+  feedback. Do not upload, publish, deploy, debug, run, or make any cloud-side
+  change.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent pulled the mocked BPMN registry"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+registry\s+pull'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved registry-owned node templates"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+registry\s+get'
+    min_count: 3
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Loan origination BPMN source was created"
+    path: LoanOriginationBpmn/LoanOriginationBpmn.bpmn
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated BPMN preserves the SDD graph, resource shells, BPMNDI, and validator cleanliness"
+    command: "python3 $TASK_DIR/check_loan_origination_sdd.py"
+    timeout: 240
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent kept the scenario local and avoided lifecycle mutations"
+    tool_name: Bash
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run)'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/connections-list.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/connections-list.json
@@ -1,0 +1,11 @@
+{
+  "Status": true,
+  "Data": [
+    {
+      "Id": "connection-loan-operations",
+      "Name": "Loan Operations Connection",
+      "Folder": "Shared/Loan Operations",
+      "Connector": "Actions"
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-actions-hitl.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-actions-hitl.json
@@ -1,0 +1,19 @@
+{
+  "Status": true,
+  "Data": {
+    "ExtensionType": {
+      "extensionType": "Actions.HITL",
+      "bpmnElement": "bpmn:UserTask",
+      "extensionTag": "uipath:activity",
+      "requiresDiscovery": true,
+      "resolvedResource": {
+        "name": "Loan Underwriting Review",
+        "appId": "loan-underwriting-review",
+        "appVersion": "1",
+        "actions": "ReviewApplication",
+        "key": "loan-operations"
+      },
+      "xmlTemplate": "<bpmn:UserTask id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:activity version=\"v1\">\n      <uipath:type value=\"Actions.HITL\" version=\"v1\" />\n      <uipath:context>\n        <uipath:input name=\"appId\" value=\"{appId}\" />\n        <uipath:input name=\"appVersion\" value=\"{appVersion}\" />\n        <uipath:input name=\"actions\" value=\"{actions}\" />\n        <uipath:input name=\"key\" value=\"{key}\" />\n        <uipath:input name=\"taskTitle\" value=\"{taskTitle}\" />\n      </uipath:context>\n      <uipath:input name=\"HitlTaskArguments\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n      <uipath:output name=\"Process response\" type=\"Actions.HITL\" var=\"{varId}\" />\n    </uipath:activity>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:UserTask>"
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-bpmn-script-task.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-bpmn-script-task.json
@@ -1,0 +1,14 @@
+{
+  "Status": true,
+  "Data": {
+    "ExtensionType": {
+      "extensionType": "BPMN.ScriptTask",
+      "bpmnElement": "bpmn:ScriptTask",
+      "extensionTag": "uipath:mapping",
+      "inputPattern": "scriptArgs",
+      "inputName": "args",
+      "inputTarget": "bodyField",
+      "xmlTemplate": "<bpmn:ScriptTask id=\"{id}\" name=\"{name}\" scriptFormat=\"JavaScript\">\n  <bpmn:extensionElements>\n    <uipath:scriptVersion value=\"v3\" />\n    <uipath:mapping version=\"v1\">\n      <uipath:type value=\"BPMN.ScriptTask\" version=\"v1\" />\n      <uipath:input name=\"args\" type=\"json\" target=\"bodyField\"><![CDATA[{}]]></uipath:input>\n    </uipath:mapping>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:ScriptTask>"
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-bpmn-variables.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/get-bpmn-variables.json
@@ -1,0 +1,11 @@
+{
+  "Status": true,
+  "Data": {
+    "ExtensionType": {
+      "extensionType": "BPMN.Variables",
+      "bpmnElement": "bpmn:Task",
+      "extensionTag": "uipath:mapping",
+      "xmlTemplate": "<bpmn:Task id=\"{id}\" name=\"{name}\">\n  <bpmn:extensionElements>\n    <uipath:mapping version=\"v1\">\n      <uipath:type value=\"BPMN.Variables\" version=\"v1\" />\n    </uipath:mapping>\n  </bpmn:extensionElements>\n  <bpmn:incoming>{incomingEdge}</bpmn:incoming>\n  <bpmn:outgoing>{outgoingEdge}</bpmn:outgoing>\n</bpmn:Task>"
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/manifest.json
@@ -1,0 +1,62 @@
+{
+  "version": 2,
+  "_doc": "Deterministic public-safe registry responses for the loan-origination SDD consumer. Specific registry get rules must precede generic discovery rules.",
+  "rules": [
+    {
+      "match": "maestro bpmn registry get Actions.HITL",
+      "file": "get-actions-hitl.json",
+      "exit_code": 0
+    },
+    {
+      "match": "maestro bpmn registry get BPMN.ScriptTask",
+      "file": "get-bpmn-script-task.json",
+      "exit_code": 0
+    },
+    {
+      "match": "maestro bpmn registry get BPMN.Variables",
+      "file": "get-bpmn-variables.json",
+      "exit_code": 0
+    },
+    {
+      "match": "is connections list --all-folders",
+      "file": "connections-list.json",
+      "exit_code": 0
+    },
+    {
+      "match": "maestro bpmn registry pull",
+      "file": "registry-pull.json",
+      "exit_code": 0
+    },
+    {
+      "match": "maestro bpmn registry list",
+      "file": "registry-list.json",
+      "exit_code": 0
+    },
+    {
+      "match": "maestro bpmn registry search",
+      "file": "registry-search.json",
+      "exit_code": 0
+    }
+  ],
+  "expected_calls": [
+    {
+      "pattern": "maestro bpmn registry pull",
+      "min": 1,
+      "description": "Syncs the BPMN registry once."
+    },
+    {
+      "pattern": "maestro bpmn registry get BPMN.ScriptTask",
+      "min": 1,
+      "description": "Retrieves the script-task wrapper."
+    },
+    {
+      "pattern": "maestro bpmn registry get Actions.HITL",
+      "min": 1,
+      "description": "Retrieves the approved human-review wrapper."
+    }
+  ],
+  "unmocked_default": {
+    "response": "{\"Status\": true, \"Data\": {}}\n",
+    "exit_code": 0
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-list.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-list.json
@@ -1,0 +1,30 @@
+{
+  "Status": true,
+  "Data": {
+    "ExtensionTypes": [
+      {
+        "ExtensionType": "BPMN.Variables",
+        "Label": "BPMN Variables",
+        "BpmnElement": "bpmn:Task",
+        "ExtensionTag": "uipath:mapping",
+        "RequiresDiscovery": "No"
+      },
+      {
+        "ExtensionType": "BPMN.ScriptTask",
+        "Label": "Execute script",
+        "BpmnElement": "bpmn:ScriptTask",
+        "ExtensionTag": "uipath:mapping",
+        "RequiresDiscovery": "No"
+      },
+      {
+        "ExtensionType": "Actions.HITL",
+        "Label": "Loan Underwriting Review",
+        "BpmnElement": "bpmn:UserTask",
+        "ExtensionTag": "uipath:activity",
+        "RequiresDiscovery": "Yes"
+      }
+    ],
+    "Connectors": [],
+    "Processes": []
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-pull.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-pull.json
@@ -1,0 +1,7 @@
+{
+  "Status": true,
+  "Data": {
+    "registryVersion": "loan-origination-mock-v1",
+    "message": "Registry cache synchronized."
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-search.json
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_loan_origination/mocks/responses/registry-search.json
@@ -1,0 +1,26 @@
+{
+  "Status": true,
+  "Data": [
+    {
+      "ExtensionType": "BPMN.Variables",
+      "Label": "BPMN Variables",
+      "BpmnElement": "bpmn:Task",
+      "ExtensionTag": "uipath:mapping",
+      "RequiresDiscovery": "No"
+    },
+    {
+      "ExtensionType": "BPMN.ScriptTask",
+      "Label": "Execute script",
+      "BpmnElement": "bpmn:ScriptTask",
+      "ExtensionTag": "uipath:mapping",
+      "RequiresDiscovery": "No"
+    },
+    {
+      "ExtensionType": "Actions.HITL",
+      "Label": "Loan Underwriting Review",
+      "BpmnElement": "bpmn:UserTask",
+      "ExtensionTag": "uipath:activity",
+      "RequiresDiscovery": "Yes"
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/sdd_phase0_loan_origination/check_phase0.py
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_phase0_loan_origination/check_phase0.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Verify BPMN Phase 0 promotes an approved semantic SDD and stops."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def require(pattern: str, text: str, label: str) -> None:
+    if not re.search(pattern, text, flags=re.IGNORECASE | re.DOTALL | re.MULTILINE):
+        fail(f"approved sdd.md is missing {label}")
+
+
+def main() -> int:
+    sdd = Path("sdd.md")
+    if not sdd.is_file():
+        fail("Phase 0 did not promote the approved draft to sdd.md")
+    draft = Path("sdd.draft.md")
+    if draft.exists() and draft.read_bytes() != sdd.read_bytes():
+        fail("approved sdd.md is not the exact reviewed draft content")
+    if list(Path(".").rglob("*.bpmn")):
+        fail("Phase 0 ran ahead into BPMN authoring")
+
+    text = sdd.read_text(encoding="utf-8")
+    for heading in (
+        "Process identity",
+        "Participants and triggers",
+        "Process graph",
+        "Data and variables",
+        "Resource intent",
+        "Implementation readiness",
+    ):
+        require(rf"^##\s+\d*\.?\s*{re.escape(heading)}", text, heading)
+
+    for concept in (
+        "start event",
+        "script task",
+        "exclusive gateway",
+        "user task",
+        "end event",
+        "applicationId",
+        "requestedAmount",
+        "validationStatus",
+        "eligibilityDecision",
+        "reviewOutcome",
+    ):
+        require(re.escape(concept), text, concept)
+
+    require(r"valid.*eligible.*underwriter", text, "valid/eligible review route")
+    require(r"invalid.*reject|reject.*invalid", text, "invalid rejection route")
+    require(r"ineligible.*reject|reject.*ineligible", text, "ineligible rejection route")
+    require(r"reviewOutcome.*approv", text, "underwriter approval condition")
+    require(r"reviewOutcome.*reject", text, "underwriter rejection condition")
+    require(r"UNRESOLVED", text, "unresolved human-task resource intent")
+    require(r"Blocked|Reviewable", text, "honest implementation readiness")
+
+    if re.search(r"<uipath:|<bpmn:|bpmndi:", text, flags=re.IGNORECASE):
+        fail("semantic SDD contains executable registry XML or BPMNDI")
+
+    print("OK: BPMN Phase 0 promoted an approved semantic SDD and stopped before implementation")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tasks/uipath-maestro-bpmn/sdd_phase0_loan_origination/phase0_loan_origination.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/sdd_phase0_loan_origination/phase0_loan_origination.yaml
@@ -1,0 +1,72 @@
+task_id: skill-bpmn-sdd-phase0-loan-origination
+description: >
+  End-to-end Phase 0 evaluation: a prose loan-origination request becomes a
+  reviewable sdd.draft.md, explicit simulated approval promotes the exact design
+  to sdd.md, and the skill stops before registry discovery or BPMN authoring.
+tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, shape:multi-node, node:decision, node:hitl, feature:phase-0, feature:approval-gate]
+
+agent:
+  type: claude-code
+  permission_mode: acceptEdits
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
+  sdk_options:
+    max_thinking_tokens: 10000
+
+run_limits:
+  task_timeout: 1200
+  max_turns: 80
+  turn_timeout: 900
+
+initial_prompt: |
+  Design a UiPath Maestro BPMN solution for a simple loan-origination process.
+  An applicant manually submits applicationId, applicantName, and requestedAmount.
+  A script validates the application and produces validationStatus plus
+  eligibilityDecision. Invalid applications are rejected. Valid but ineligible
+  applications are rejected. Eligible applications go to an Underwriter human
+  review task, which produces reviewOutcome and ends approved or rejected.
+
+  I want a reviewable BPMN SDD first. Create the Phase 0 draft, show me the
+  complete business shape for approval, and do not discover registry resources
+  or create a .bpmn project yet. The tenant-specific human-review resource is
+  intentionally unresolved at this stage.
+
+success_criteria:
+  - type: run_command
+    description: "Explicit approval promoted the BPMN SDD and Phase 0 stopped cleanly"
+    command: "python3 $TASK_DIR/check_phase0.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Phase 0 did not begin registry discovery"
+    tool_name: Bash
+    command_pattern: 'uip\s+maestro\s+bpmn\s+registry'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Phase 0 did not make a cloud-side lifecycle mutation"
+    tool_name: Bash
+    command_pattern: 'uip\s+maestro\s+bpmn\s+(upload|publish|deploy|debug|run)'
+    weight: 1.0
+    pass_threshold: 1.0
+
+simulation:
+  enabled: true
+  persona: |
+    You are the lending-operations owner for the compact loan-origination process
+    in the opening message. You know its trigger, inputs, validation and
+    eligibility decisions, underwriter review, and approved/rejected outcomes.
+  goal: |
+    Review the Phase 0 BPMN SDD. Answer any shape-changing question consistently,
+    then explicitly approve the complete draft so the designer can promote it
+    to sdd.md. Stay in the conversation until the designer confirms that sdd.md
+    exists, while preventing registry discovery or BPMN authoring.
+  constraints:
+    - "Answer concisely and decisively; do not add systems, actors, or branches beyond the opening process."
+    - "The underwriter human-task resource remains UNRESOLVED until later tenant discovery."
+    - "When the complete draft is presented, explicitly say it is approved and should be promoted to sdd.md."
+    - "After approval, wait for confirmation that sdd.md was written; then say Phase 0 is complete and implementation must stop for now."
+  max_turns: 30


### PR DESCRIPTION
## TL;DR

Adds the independently owned **Skills BPMN** SDD experience: Phase 0 when a new BPMN request has no SDD, and semantic intake when an approved `sdd.md` is supplied. This is the second BPMN copy, symmetric with the existing Skills Case Phase 0 and consumer; no Delegate source is imported or pinned.

## Decisions

| Decision | Result |
|---|---|
| Ownership | Skills owns its BPMN template, rules, Phase 0, and intake |
| Compatibility | Consume semantic `sdd.md`; do not require source/file parity with Delegate |
| Phase 0 | Listen → sketch → ask → resolve → approve; promote the exact reviewed draft |
| Supplied SDD | Skip Phase 0 and preserve every declared node, flow endpoint, variable, event, loop, and resource intent |
| Input discovery | Search the caller's explicit SDD path first, then `./sdd.md` |
| Resource safety | Inventory is evidence, not authorization; required unresolved resources block executable BPMN |
| Existing routes | Preserve direct prose authoring and surgical existing-`.bpmn` editing |

## Changes

- adds the Skills-owned BPMN SDD template, generation rules, Phase 0 interview, and supplied-SDD intake
- maps the SDD semantic model—including process/subprocess variable scope—into the existing registry discovery, structural BPMN, BPMNDI, packaging, and validator machinery
- adds static contract, Phase 0, and registry-backed loan-origination E2E tasks
- adds semantic artifact checks for graph endpoints, conditions/defaults, variables, registry wrappers, BPMNDI, package metadata, connection use, and validator status

## Validation

- skill contract and 24-skill manifest checks passed
- all four coder-eval task definitions passed dry-run planning
- Phase 0 E2E: **1/1 passed** with exact reviewed-content promotion and no registry/BPMN/cloud commands
- Skills-owned supplied-SDD E2E: **5/5 passed**, score **1.000**
- exact Delegate-generated SDD E2E: **5/5 passed**, score **1.000**, validator exit 0, no unrelated connection binding
- commits that exact Delegate output as a repeatable compatibility task; all four SDD task definitions pass `coder-eval 0.8.5 plan`
- static contract, type/scope parsing, process/subprocess scope placement, and `git diff --check` pass
- broad smoke: **10/12 passed (83.3%)**, below the 95% gate; `skill-bpmn-script-jint-guidance` failed and `skill-bpmn-smoke-registry-discovery` exhausted turns
- no upload, publish, deploy, debug, run, or other cloud-side mutation was performed

## Companion stack

- Delegate Case 1/2: UiPath/Autopilot#4389
- Delegate BPMN 2/2: UiPath/Autopilot#4392

The PR remains draft while the two broad-smoke failures are triaged.
