### PR TITLE
test(connector-builder): add task-tier tests (smoke + e2e)

### DIFF
--- a/tests/tasks/uipath-connector-builder/README.md
+++ b/tests/tasks/uipath-connector-builder/README.md
@@ -1,0 +1,23 @@
+# uipath-connector-builder task tests
+
+Task-tier coverage for the `uipath-connector-builder` skill (`uip is connectors builder`).
+
+These tasks exercise the **offline authoring flow** only, which is hermetic and
+needs no tenant or login:
+
+```
+init (offline via --organization) → auth set → activity create (+ fields) → validate
+```
+
+They assert on the real generated artifacts under
+`periodic-design-<org>-<slug>/app/element/` (`element.json`,
+`standard-resources/*.json`), not on agent self-reports, and check the specific
+builder verbs ran — so a task can't pass just because `validate` was invoked.
+
+| Task | Tier | Covers |
+|------|------|--------|
+| `init-validate` | smoke | scaffold a connector shell + validate; element key is derived |
+| `oauth2-activity` | e2e | init → OAuth2 auth → CRUD activity with a typed field schema → validate |
+
+`import` / `publish` / `download` need `uip login` and a tenant, so they're out of
+scope here — those belong in a live e2e run, not the hermetic task suite.

--- a/tests/tasks/uipath-connector-builder/init-validate/init-validate.yaml
+++ b/tests/tasks/uipath-connector-builder/init-validate/init-validate.yaml
@@ -4,12 +4,16 @@ description: >
   Covers the builder init + validate happy path and asserts the generated
   element.json carries the derived design element key — the minimum a real
   build must produce.
-tags: [uipath-connector-builder, smoke, 'mode:build']
+tags: [uipath-connector-builder, smoke, 'mode:build', 'lifecycle:generate']
 
 initial_prompt: |
   Build the shell of a NEW UiPath Integration Service connector on disk for a
   fictional REST API. This is an OFFLINE build — do not log in; pass the
   organization explicitly so the element key can be derived without a session.
+
+  Before starting, load the uipath-connector-builder skill and follow its
+  workflow. Do NOT ask for approval, confirmation, or feedback. Do NOT pause
+  between steps.
 
   Connector spec:
     - Display name: Acme Widgets
@@ -19,10 +23,6 @@ initial_prompt: |
 
   After scaffolding, run the connector-builder validate step and make sure it
   passes with 0 errors.
-
-  Before starting, load the uipath-connector-builder skill and follow its
-  workflow. Do NOT ask for approval, confirmation, or feedback. Do NOT pause
-  between steps.
 
 success_criteria:
   - type: command_executed
@@ -39,6 +39,18 @@ success_criteria:
     command_pattern: 'uip\s+is\s+connectors\s+builder\s+validate'
     min_count: 1
     weight: 1.0
+    pass_threshold: 1.0
+
+  # Outcome check (not just that validate ran): re-run validate at grade time
+  # and require exit 0. The command exits non-zero when the connector is invalid
+  # (valid = errors.length === 0), so this fails a scaffold that has errors even
+  # if the agent invoked validate and the files exist.
+  - type: run_command
+    description: "validate re-run confirms a valid connector (exit 0, 0 errors)"
+    command: "uip is connectors builder validate --connector-dir periodic-design-acme-acmewidgets"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 1.5
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-connector-builder/init-validate/init-validate.yaml
+++ b/tests/tasks/uipath-connector-builder/init-validate/init-validate.yaml
@@ -1,0 +1,55 @@
+task_id: skill-connector-builder-init-validate
+description: >
+  Scaffold a new Integration Service connector shell offline and validate it.
+  Covers the builder init + validate happy path and asserts the generated
+  element.json carries the derived design element key — the minimum a real
+  build must produce.
+tags: [uipath-connector-builder, smoke, 'mode:build']
+
+initial_prompt: |
+  Build the shell of a NEW UiPath Integration Service connector on disk for a
+  fictional REST API. This is an OFFLINE build — do not log in; pass the
+  organization explicitly so the element key can be derived without a session.
+
+  Connector spec:
+    - Display name: Acme Widgets
+    - Organization slug: acme
+    - Base URL: https://api.acme.example.com
+    - Category: Developer
+
+  After scaffolding, run the connector-builder validate step and make sure it
+  passes with 0 errors.
+
+  Before starting, load the uipath-connector-builder skill and follow its
+  workflow. Do NOT ask for approval, confirmation, or feedback. Do NOT pause
+  between steps.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran builder init"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran builder validate"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+validate'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "element.json scaffolded under the derived design connector dir"
+    path: periodic-design-acme-acmewidgets/app/element/element.json
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "element.json carries the derived design element key"
+    path: periodic-design-acme-acmewidgets/app/element/element.json
+    includes: ["design-acme-acmewidgets"]
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-connector-builder/oauth2-activity/oauth2-activity.yaml
+++ b/tests/tasks/uipath-connector-builder/oauth2-activity/oauth2-activity.yaml
@@ -4,7 +4,7 @@ description: >
   with a typed field schema, and validate. Guards the recurring "shipped a
   fieldless activity" gap by asserting the standard-resource carries real fields,
   and that OAuth2 landed in element.json — not just that validate ran.
-tags: [uipath-connector-builder, e2e, 'mode:build']
+tags: [uipath-connector-builder, e2e, 'mode:build', 'lifecycle:generate']
 
 run_limits: {max_turns: 80}
 
@@ -64,6 +64,19 @@ success_criteria:
     command_pattern: 'uip\s+is\s+connectors\s+builder\s+validate'
     min_count: 1
     weight: 1.0
+    pass_threshold: 1.0
+
+  # Outcome check (not just that validate ran): re-run validate at grade time and
+  # require a fully clean report. The prompt demands 0 errors AND 0 warnings, but
+  # the command only exits non-zero on errors (valid = errors.length === 0) — a
+  # warnings-only connector still exits 0 — so we grep the summary for the clean
+  # "0 error(s), 0 warning(s)" line to enforce both.
+  - type: run_command
+    description: "validate re-run reports a clean connector (0 errors and 0 warnings)"
+    command: "uip is connectors builder validate --connector-dir periodic-design-acme-acmewidgets | grep -q '0 error(s), 0 warning(s)'"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: file_contains

--- a/tests/tasks/uipath-connector-builder/oauth2-activity/oauth2-activity.yaml
+++ b/tests/tasks/uipath-connector-builder/oauth2-activity/oauth2-activity.yaml
@@ -1,0 +1,81 @@
+task_id: skill-connector-builder-oauth2-activity-e2e
+description: >
+  Full offline authoring loop: init, configure OAuth2 auth, add a CRUD activity
+  with a typed field schema, and validate. Guards the recurring "shipped a
+  fieldless activity" gap by asserting the standard-resource carries real fields,
+  and that OAuth2 landed in element.json — not just that validate ran.
+tags: [uipath-connector-builder, e2e, 'mode:build']
+
+run_limits: {max_turns: 80}
+
+initial_prompt: |
+  Author a NEW UiPath Integration Service connector end to end, on disk. This is
+  an OFFLINE build — do not log in; pass the organization explicitly.
+
+  Before starting, load the uipath-connector-builder skill and follow its
+  workflow. Do NOT ask for approval, confirmation, or feedback. Do NOT pause
+  between steps.
+
+  Connector spec:
+    - Display name: Acme Widgets
+    - Organization slug: acme
+    - Base URL: https://api.acme.example.com
+
+  Authentication — OAuth2 authorization code:
+    - Authorize URL: https://api.acme.example.com/oauth/authorize
+    - Token URL: https://api.acme.example.com/oauth/token
+    - Scopes: read write
+
+  Activity — a "contacts" CRUD activity supporting GET and POST. Give it a real
+  request/response field schema of id (string), email (string), and name
+  (string). It must NOT be a fieldless raw-JSON passthrough.
+
+  Finish by running validate and making sure it passes with 0 errors and 0
+  warnings.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent ran builder init"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+init'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent configured auth via auth set"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+auth\s+set'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created the activity via activity create"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+activity\s+create'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran builder validate"
+    tool_name: Bash
+    command_pattern: 'uip\s+is\s+connectors\s+builder\s+validate'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "OAuth2 auth + derived key landed in element.json"
+    path: periodic-design-acme-acmewidgets/app/element/element.json
+    includes: ["oauth2", "design-acme-acmewidgets"]
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "contacts standard-resource carries the typed field schema (not fieldless)"
+    path: periodic-design-acme-acmewidgets/app/element/standard-resources/contacts.json
+    includes: ["fields", "email", "name"]
+    weight: 2.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds the first task-tier tests for `uipath-connector-builder` under `tests/tasks/uipath-connector-builder/`:

- `init-validate` (**smoke**) — scaffold a connector shell offline + `validate`.
- `oauth2-activity` (**e2e**) — `init` → OAuth2 auth → a CRUD `contacts` activity with a typed field schema → `validate`.
- `README.md` — scope + the offline-flow rationale.

## Why

ENGCE-59831 (epic ENGCE-58546), sibling of ENGCE-59828 (activation, PR #2149). Activation only proves the skill *fires*; these prove it produces *correct* `uip is connectors builder` output. Before this the skill had zero pass-rate coverage on the eval board.

## How

Both tasks exercise the **hermetic offline flow** (`init` offline via `--organization` → `auth set` → `activity create` + fields → `validate`) — no tenant or login needed. Assertions check the **real generated artifacts** (`element.json` element key + `oauth2`, `standard-resources/contacts.json` field schema) and the **specific builder verbs** ran — not agent self-reports and not a bare `validate` call. `oauth2-activity` specifically guards the recurring "shipped a fieldless activity" gap by asserting the standard-resource carries real fields. `import`/`publish`/`download` need login + a tenant, so they're out of scope for this suite.

## Test plan

- `coder-eval plan` (CI-pinned `0.8.5`) on both tasks → **valid** (4 and 6 criteria).
- Verified the underlying flow by hand with the real CLI: `init` (offline) → `auth set --auth-type oauth2` → `activity create --name contacts --methods GET,POST --fields …` → `validate` → **`PASS: 0 error(s), 0 warning(s)`**, producing exactly the asserted files (`periodic-design-acme-acmewidgets/app/element/element.json` with `authentication.type=oauth2` + key `design-acme-acmewidgets`, and `standard-resources/contacts.json` with `fields: [id, email, name]`).

Not run: the full coder-eval agent loop (no Anthropic/Bedrock backend configured locally). The deterministic criteria are grounded in the by-hand CLI run above.

Draft until a full agent run confirms the end-to-end pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)