### PR TITLE
ci(publish): add npmjs-preview dispatch target with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,18 @@
 name: Publish skills package
 
-# Two-track publishing:
+# Publishing tracks:
 #   - workflow_dispatch (target: github-alpha) -> alpha prerelease to GitHub
 #     Packages (dist-tag `alpha`). Manual — no auto-publish on push to main.
-#   - GitHub Release published -> stable release to npmjs (dist-tag `latest`).
+#   - workflow_dispatch (target: npmjs-preview) -> pre-release to npmjs
+#     (dist-tag `preview`, version `<base>-preview.<run_number>`). Manual.
+#     Runs through the same OIDC job as `latest`, so it carries `--provenance`.
+#   - workflow_dispatch (target: npmjs) / GitHub Release published -> stable
+#     release to npmjs (dist-tag `latest`).
 #
 # `npm install @uipath/skills` (no tag) always resolves to the last stable
-# release, never an alpha. The version line tracks the CLI minor line so the
-# CLI can pin a compatible skills package (see docs/RELEASE.md).
+# release — never an alpha or a preview (both are pre-release versions under
+# their own dist-tags). The version line tracks the CLI minor line so the CLI
+# can pin a compatible skills package (see docs/RELEASE.md).
 
 on:
   release:
@@ -21,6 +26,7 @@ on:
         type: choice
         options:
           - npmjs
+          - npmjs-preview
           - github-alpha
 
 permissions:
@@ -76,9 +82,9 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   publish-release:
-    name: Publish stable to npmjs
+    name: Publish to npmjs (latest / preview)
     needs: [guard]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'npmjs')
+    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.target == 'npmjs' || github.event.inputs.target == 'npmjs-preview'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -98,6 +104,30 @@ jobs:
           npm install -g npm@latest
           echo "npm $(npm --version) / node $(node --version)"
 
+      # A `release` event or target=npmjs publishes the committed version to
+      # `latest`. target=npmjs-preview stamps a `<base>-preview.<run_number>`
+      # pre-release (never committed) and targets the `preview` dist-tag. The
+      # run_number keeps each dispatch unique and semver-ordered, matching how
+      # the alpha track stamps its version. `sync-version.mjs` rewrites the
+      # derived manifests and strips the pre-release suffix from the plugin
+      # manifests (same as alpha), so only the npm tarball carries the suffix.
+      # An explicit `--tag preview` on a pre-release version never moves
+      # `latest`, so `npm install @uipath/skills` still resolves the last stable.
+      - name: Resolve dist-tag and stamp version
+        id: dist
+        run: |
+          if [ "${{ github.event.inputs.target }}" = "npmjs-preview" ]; then
+            BASE=$(node -p "require('./package.json').version")
+            PREVIEW="${BASE}-preview.${{ github.run_number }}"
+            npm version "$PREVIEW" --no-git-tag-version --allow-same-version
+            node scripts/sync-version.mjs
+            echo "tag=preview" >> "$GITHUB_OUTPUT"
+            echo "Publishing $PREVIEW to dist-tag preview"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+            echo "Publishing $(node -p "require('./package.json').version") to dist-tag latest"
+          fi
+
       # No auth token and no setup-node registry-url — a token would make npm
       # use token auth and bypass OIDC. We only pin the scoped package to
       # npmjs; credentials come from the OIDC exchange. `--provenance` attaches
@@ -106,4 +136,4 @@ jobs:
       - name: Publish to npmjs (OIDC trusted publishing)
         run: |
           npm config set @uipath:registry https://registry.npmjs.org/
-          npm publish --access public --provenance --tag latest
+          npm publish --access public --provenance --tag ${{ steps.dist.outputs.tag }}

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -43,10 +43,21 @@ The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.197.x` → skills 
 | Trigger | Registry | dist-tag | Version |
 |---------|----------|----------|---------|
 | `workflow_dispatch` (target: `github-alpha`) | GitHub Packages | `alpha` | `<base>-alpha.<YYYYMMDD>.<run_number>` |
+| `workflow_dispatch` (target: `npmjs-preview`) | npmjs | `preview` | `<base>-preview.<run_number>` |
 | GitHub Release published | npmjs | `latest` | `package.json` version |
 | `workflow_dispatch` (target: `npmjs`) | npmjs | `latest` | `package.json` version |
 
-Both tracks are **manually triggered** — there is no auto-publish on push to `main`. Alpha is dispatched on demand; stable runs when a GitHub Release is published. `npm install @uipath/skills` (no tag) always resolves to the last stable npmjs release — alphas live only under the `alpha` tag on GitHub Packages.
+All tracks are **manually triggered** — there is no auto-publish on push to `main`. Alpha and preview are dispatched on demand; stable runs when a GitHub Release is published. `npm install @uipath/skills` (no tag) always resolves to the last stable npmjs release — alphas live only under the `alpha` tag on GitHub Packages, and previews only under the `preview` tag on npmjs (both are pre-release versions, so no un-tagged install ever picks them).
+
+### Cutting a preview
+
+Dispatch `publish.yml` on the release branch (or tag) you want to preview, with target `npmjs-preview`:
+
+```bash
+gh workflow run publish.yml --ref release/v<minor> -f target=npmjs-preview
+```
+
+The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to the `preview` dist-tag with `--provenance` via the same OIDC job as `latest`. Consume it with `npm install @uipath/skills@preview`. Re-dispatch to advance the `preview` tag; each run gets a unique version from `run_number`.
 
 ### Registry routing
 


### PR DESCRIPTION
**Jira:** _none — add PILOT key if tracked_

## What

Adds a third `workflow_dispatch` target, **`npmjs-preview`**, to `.github/workflows/publish.yml`. It reuses the existing OIDC `publish-release` job, so previews now carry **`--provenance`** like stable releases.

## Why

The `1.197.0-preview.0` preview on npm was published **manually** (`npm publish --tag preview`) and has **no provenance attestation**. There was no CI path for previews — only `alpha` (GitHub Packages) and `latest` (npmjs). This adds a proper CI preview track so future previews are reproducible and signed, with no manual `npm login`/2FA.

## How to use

```bash
gh workflow run publish.yml --ref release/v1.198 -f target=npmjs-preview
```

The job:
1. Reads the base version from `package.json`,
2. Stamps `<base>-preview.<run_number>` (never committed — same throwaway stamp as the `alpha` track),
3. Runs `sync-version.mjs` (strips the suffix from the plugin manifests, like alpha),
4. Publishes with `npm publish --access public --provenance --tag preview`.

Consume with `npm install @uipath/skills@preview`.

## Notes

- **`latest` is protected** — an explicit `--tag preview` on a pre-release version never moves `latest`.
- **Version uses `run_number`, not a fixed `.0`** — npm forbids republishing the same version, so a fixed suffix would fail on the second dispatch. `run_number` is monotonic and mirrors the alpha track.
- **`docs/RELEASE.md`** updated: preview row in the publishing-tracks table + a "Cutting a preview" section.

## Verify before relying on it

The npmjs Trusted Publisher for `@uipath/skills` is scoped to repo `UiPath/skills` + workflow `publish.yml`. Previews run through that same workflow, so OIDC should work — the first dispatch is the real test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)