### PR TITLE
ci(publish): dev-on-merge to GitHub Packages + preview from release branches [PILOT-6403][PILOT-6171]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,33 +1,48 @@
 name: Publish skills package
 
-# Publishing tracks:
-#   - workflow_dispatch (target: github-alpha) -> alpha prerelease to GitHub
-#     Packages (dist-tag `alpha`). Manual — no auto-publish on push to main.
-#   - workflow_dispatch (target: npmjs-preview) -> pre-release to npmjs
-#     (dist-tag `preview`, version `<base>-preview.<run_number>`). Manual.
-#     Runs through the same OIDC job as `latest`, so it carries `--provenance`.
-#   - workflow_dispatch (target: npmjs) / GitHub Release published -> stable
-#     release to npmjs (dist-tag `latest`).
+# Publishing channels (registry follows channel — see docs/RELEASE.md):
+#   - push to `main`                       -> `dev`     : GitHub Packages
+#         Auto on every merge. Version `<base>-dev.<run_number>` (never
+#         committed). No provenance — GitHub Packages does not support it.
+#   - GitHub Release published             -> `latest`  : npmjs (stable)
+#   - workflow_dispatch (channel: latest)  -> `latest`  : npmjs (stable)
+#         Committed `package.json` version. Used by sprint-release-cut.yml.
+#   - workflow_dispatch (channel: preview) -> `preview` : npmjs (pre-release)
+#         Version `<base>-preview.<run_number>`.
+#   - workflow_dispatch (channel: dev)     -> `dev`     : GitHub Packages
+#         Manual re-run of the merge publish.
 #
-# `npm install @uipath/skills` (no tag) always resolves to the last stable
-# release — never an alpha or a preview (both are pre-release versions under
-# their own dist-tags). The version line tracks the CLI minor line so the CLI
-# can pin a compatible skills package (see docs/RELEASE.md).
+# npmjs publishes (`latest`, `preview`) use OIDC trusted publishing +
+# `--provenance`. GitHub Packages publishes (`dev`) use the built-in
+# GITHUB_TOKEN and carry no provenance. `npm install @uipath/skills` (no tag,
+# from npmjs) always resolves the last stable release — `preview` and `dev`
+# are pre-release versions under their own dist-tags, so no un-tagged install
+# ever picks them. The version line tracks the CLI minor line so the CLI can
+# pin a compatible skills package.
 
 on:
+  push:
+    branches: [main]
   release:
     types: [published]
   workflow_dispatch:
     inputs:
-      target:
-        description: "Publish target"
+      channel:
+        description: "Manual publish channel"
         required: true
-        default: npmjs
+        default: preview
         type: choice
         options:
-          - npmjs
-          - npmjs-preview
-          - github-alpha
+          - preview
+          - dev
+          - latest
+
+# Serialize publishes so rapid merges don't race on the `dev` dist-tag: each
+# run stamps a unique version, the group just orders the tag moves so `dev`
+# ends on the newest run. Never cancel an in-flight publish.
+concurrency:
+  group: publish-${{ github.event_name }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -44,10 +59,15 @@ jobs:
       # Fails if version-manifest.json has drifted from package.json.
       - run: node scripts/sync-version.mjs --check
 
-  publish-alpha:
-    name: Publish alpha to GitHub Packages
+  publish-dev:
+    name: Publish dev to GitHub Packages
     needs: [guard]
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'github-alpha'
+    # Auto on every merge to main; also re-runnable via dispatch (channel=dev).
+    # The repo guard stops forks from attempting to publish on their own main.
+    if: >-
+      github.repository == 'UiPath/skills'
+      && (github.event_name == 'push'
+          || (github.event_name == 'workflow_dispatch' && github.event.inputs.channel == 'dev'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -60,31 +80,35 @@ jobs:
           registry-url: "https://npm.pkg.github.com"
           scope: "@uipath"
 
-      # Stamp a prerelease suffix: <base>-alpha.<YYYYMMDD>.<run_number>.
-      # Dot-separated so semver orders the run number numerically. Never
-      # committed — only the published tarball carries it.
-      - name: Stamp alpha version
+      # Stamp a prerelease suffix: <base>-dev.<run_number>. Dot-separated so
+      # semver orders the run number numerically. Never committed — only the
+      # published tarball carries it. sync-version.mjs rewrites the derived
+      # manifests and strips the suffix from the plugin manifests.
+      - name: Stamp dev version
         run: |
           BASE=$(node -p "require('./package.json').version")
-          DAY=$(date -u +%Y%m%d)
-          ALPHA="${BASE}-alpha.${DAY}.${{ github.run_number }}"
-          npm version "$ALPHA" --no-git-tag-version --allow-same-version
+          DEV="${BASE}-dev.${{ github.run_number }}"
+          npm version "$DEV" --no-git-tag-version --allow-same-version
           node scripts/sync-version.mjs
-          echo "Publishing $ALPHA"
+          echo "Publishing $DEV to dist-tag dev"
 
       # setup-node wrote `@uipath:registry=https://npm.pkg.github.com/` + auth;
-      # the scoped registry routes this scoped package to GitHub Packages.
-      # The built-in GITHUB_TOKEN suffices given the job's `packages: write`
-      # permission above — no dedicated secret needed.
+      # the scoped registry routes this scoped package to GitHub Packages. The
+      # built-in GITHUB_TOKEN suffices given the job's `packages: write`
+      # permission above. No --provenance: GitHub Packages does not support it.
       - name: Publish
-        run: npm publish --tag alpha
+        run: npm publish --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  publish-release:
+  publish-npmjs:
     name: Publish to npmjs (latest / preview)
     needs: [guard]
-    if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && (github.event.inputs.target == 'npmjs' || github.event.inputs.target == 'npmjs-preview'))
+    if: >-
+      github.repository == 'UiPath/skills'
+      && (github.event_name == 'release'
+          || (github.event_name == 'workflow_dispatch'
+              && (github.event.inputs.channel == 'latest' || github.event.inputs.channel == 'preview')))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -104,19 +128,15 @@ jobs:
           npm install -g npm@latest
           echo "npm $(npm --version) / node $(node --version)"
 
-      # A `release` event or target=npmjs publishes the committed version to
-      # `latest`. target=npmjs-preview stamps a `<base>-preview.<run_number>`
-      # pre-release (never committed) and targets the `preview` dist-tag. The
-      # run_number keeps each dispatch unique and semver-ordered, matching how
-      # the alpha track stamps its version. `sync-version.mjs` rewrites the
-      # derived manifests and strips the pre-release suffix from the plugin
-      # manifests (same as alpha), so only the npm tarball carries the suffix.
-      # An explicit `--tag preview` on a pre-release version never moves
-      # `latest`, so `npm install @uipath/skills` still resolves the last stable.
+      # A `release` event or channel=latest publishes the committed version to
+      # `latest`. channel=preview stamps a `<base>-preview.<run_number>`
+      # pre-release (never committed) and targets the `preview` dist-tag. An
+      # explicit `--tag preview` on a pre-release version never moves `latest`,
+      # so `npm install @uipath/skills` still resolves the last stable release.
       - name: Resolve dist-tag and stamp version
         id: dist
         run: |
-          if [ "${{ github.event.inputs.target }}" = "npmjs-preview" ]; then
+          if [ "${{ github.event.inputs.channel }}" = "preview" ]; then
             BASE=$(node -p "require('./package.json').version")
             PREVIEW="${BASE}-preview.${{ github.run_number }}"
             npm version "$PREVIEW" --no-git-tag-version --allow-same-version

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
 name: Publish skills package
 
 # Publishing channels (registry follows channel — see docs/RELEASE.md):
-#   - push to `main`                       -> `dev`     : GitHub Packages
+#   - push to `main` or `release/v*`       -> `dev`     : GitHub Packages
 #         Auto on every merge. Version `<base>-dev.<run_number>` (never
 #         committed). No provenance — GitHub Packages does not support it.
+#         The `dev` tag points to the last push from ANY of these branches.
 #   - GitHub Release published             -> `latest`  : npmjs (stable)
 #   - workflow_dispatch (channel: latest)  -> `latest`  : npmjs (stable)
 #         Committed `package.json` version. Used by sprint-release-cut.yml.
@@ -22,7 +23,10 @@ name: Publish skills package
 
 on:
   push:
-    branches: [main]
+    # Every merge to main OR a release line publishes a `dev` build to GitHub
+    # Packages. The `dev` dist-tag points to the LAST push from ANY of these
+    # branches (dist-tags ignore semver), so it can move between minor lines.
+    branches: [main, 'release/v*']
   release:
     types: [published]
   workflow_dispatch:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,18 @@
 name: Publish skills package
 
 # Publishing channels (registry follows channel — see docs/RELEASE.md):
-#   - push to `main` or `release/v*`       -> `dev`     : GitHub Packages
+#   - push to `main`                       -> `dev`     : GitHub Packages
 #         Auto on every merge. Version `<base>-dev.<run_number>` (never
 #         committed). No provenance — GitHub Packages does not support it.
-#         The `dev` tag points to the last push from ANY of these branches.
+#   - push to `release/v*`                 -> `preview` : npmjs (pre-release)
+#         Auto on every merge to a release line, mirroring UiPath/cli. Version
+#         `<base>-preview.<run_number>` (never committed), signed with
+#         `--provenance` via OIDC trusted publishing.
 #   - GitHub Release published             -> `latest`  : npmjs (stable)
 #   - workflow_dispatch (channel: latest)  -> `latest`  : npmjs (stable)
 #         Committed `package.json` version. Used by sprint-release-cut.yml.
 #   - workflow_dispatch (channel: preview) -> `preview` : npmjs (pre-release)
-#         Version `<base>-preview.<run_number>`.
 #   - workflow_dispatch (channel: dev)     -> `dev`     : GitHub Packages
-#         Manual re-run of the merge publish.
 #
 # npmjs publishes (`latest`, `preview`) use OIDC trusted publishing +
 # `--provenance`. GitHub Packages publishes (`dev`) use the built-in
@@ -23,9 +24,8 @@ name: Publish skills package
 
 on:
   push:
-    # Every merge to main OR a release line publishes a `dev` build to GitHub
-    # Packages. The `dev` dist-tag points to the LAST push from ANY of these
-    # branches (dist-tags ignore semver), so it can move between minor lines.
+    # main       -> `dev` build on GitHub Packages
+    # release/v* -> `preview` build on npmjs (mirrors UiPath/cli)
     branches: [main, 'release/v*']
   release:
     types: [published]
@@ -41,9 +41,9 @@ on:
           - dev
           - latest
 
-# Serialize publishes so rapid merges don't race on the `dev` dist-tag: each
-# run stamps a unique version, the group just orders the tag moves so `dev`
-# ends on the newest run. Never cancel an in-flight publish.
+# Serialize publishes so rapid merges don't race on a shared dist-tag: each
+# run stamps a unique version, the group just orders the tag moves. Never
+# cancel an in-flight publish.
 concurrency:
   group: publish-${{ github.event_name }}
   cancel-in-progress: false
@@ -67,10 +67,11 @@ jobs:
     name: Publish dev to GitHub Packages
     needs: [guard]
     # Auto on every merge to main; also re-runnable via dispatch (channel=dev).
+    # release/v* pushes route to preview on npmjs (publish-npmjs), not here.
     # The repo guard stops forks from attempting to publish on their own main.
     if: >-
       github.repository == 'UiPath/skills'
-      && (github.event_name == 'push'
+      && ((github.event_name == 'push' && github.ref == 'refs/heads/main')
           || (github.event_name == 'workflow_dispatch' && github.event.inputs.channel == 'dev'))
     runs-on: ubuntu-latest
     permissions:
@@ -89,9 +90,11 @@ jobs:
       # published tarball carries it. sync-version.mjs rewrites the derived
       # manifests and strips the suffix from the plugin manifests.
       - name: Stamp dev version
+        env:
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
           BASE=$(node -p "require('./package.json').version")
-          DEV="${BASE}-dev.${{ github.run_number }}"
+          DEV="${BASE}-dev.${RUN_NUMBER}"
           npm version "$DEV" --no-git-tag-version --allow-same-version
           node scripts/sync-version.mjs
           echo "Publishing $DEV to dist-tag dev"
@@ -108,9 +111,12 @@ jobs:
   publish-npmjs:
     name: Publish to npmjs (latest / preview)
     needs: [guard]
+    # release event / dispatch latest      -> `latest`  (committed version).
+    # release/v* push / dispatch preview   -> `preview` (stamped pre-release).
     if: >-
       github.repository == 'UiPath/skills'
       && (github.event_name == 'release'
+          || (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
           || (github.event_name == 'workflow_dispatch'
               && (github.event.inputs.channel == 'latest' || github.event.inputs.channel == 'preview')))
     runs-on: ubuntu-latest
@@ -118,7 +124,8 @@ jobs:
       contents: read
       # OIDC trusted publishing — no NPM_TOKEN. The npmjs trusted publisher
       # for @uipath/skills must name this repo (UiPath/skills) and workflow
-      # (publish.yml). npm exchanges this OIDC token for publish credentials.
+      # (publish.yml); it is not restricted to a single ref, so release/v*
+      # pushes publish through the same OIDC exchange as tags on main.
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -132,17 +139,23 @@ jobs:
           npm install -g npm@latest
           echo "npm $(npm --version) / node $(node --version)"
 
-      # A `release` event or channel=latest publishes the committed version to
-      # `latest`. channel=preview stamps a `<base>-preview.<run_number>`
-      # pre-release (never committed) and targets the `preview` dist-tag. An
-      # explicit `--tag preview` on a pre-release version never moves `latest`,
-      # so `npm install @uipath/skills` still resolves the last stable release.
+      # `preview` when: dispatch channel=preview, OR an auto push to a
+      # release/v* branch (mirrors UiPath/cli). Stamps `<base>-preview.<run>`
+      # (never committed). Otherwise `latest` (a GitHub Release event or
+      # channel=latest) publishes the committed version. An explicit
+      # `--tag preview` on a pre-release version never moves `latest`, so
+      # `npm install @uipath/skills` still resolves the last stable release.
       - name: Resolve dist-tag and stamp version
         id: dist
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_REF: ${{ github.ref }}
+          CHANNEL: ${{ github.event.inputs.channel }}
+          RUN_NUMBER: ${{ github.run_number }}
         run: |
-          if [ "${{ github.event.inputs.channel }}" = "preview" ]; then
+          if [ "$CHANNEL" = "preview" ] || { [ "$EVENT_NAME" = "push" ] && [[ "$PUBLISH_REF" == refs/heads/release/* ]]; }; then
             BASE=$(node -p "require('./package.json').version")
-            PREVIEW="${BASE}-preview.${{ github.run_number }}"
+            PREVIEW="${BASE}-preview.${RUN_NUMBER}"
             npm version "$PREVIEW" --no-git-tag-version --allow-same-version
             node scripts/sync-version.mjs
             echo "tag=preview" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -211,8 +211,8 @@ jobs:
           if npm view "@uipath/skills@$LINE.0" version > /dev/null 2>&1; then
             echo "@uipath/skills@$LINE.0 already on npm — skipping publish dispatch."
           else
-            gh workflow run publish.yml --ref "$TAG" -f target=npmjs
-            echo "Dispatched publish.yml (target=npmjs) at $TAG."
+            gh workflow run publish.yml --ref "$TAG" -f channel=latest
+            echo "Dispatched publish.yml (channel=latest) at $TAG."
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -20,8 +20,8 @@ All channels carry `package.json`'s version; the pre-release channels (`dev`, `p
 | Channel | Registry | Version | Cadence |
 |---------|----------|---------|---------|
 | npm `latest` | npmjs | `M.N.<release>` | per stable release — what the CLI pins |
-| npm `preview` | npmjs | `M.N.<release>-preview.<run>` | per preview dispatch (stamp never committed) |
-| npm `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per merge to `main` or `release/v*` (stamp never committed) |
+| npm `preview` | npmjs | `M.N.<release>-preview.<run>` | per merge to `release/v*`, or preview dispatch (stamp never committed) |
+| npm `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per merge to `main` (stamp never committed) |
 | plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex plugin auto-update |
 
 `sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
@@ -45,7 +45,8 @@ Registry follows channel — you pick a channel, not a registry.
 
 | Trigger | Channel | Registry | dist-tag | Version | Provenance |
 |---------|---------|----------|----------|---------|------------|
-| push to `main` or `release/v*` (every merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
+| push to `main` (every merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
+| push to `release/v*` (every merge) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
 | `workflow_dispatch` (channel: `dev`) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
 | `workflow_dispatch` (channel: `preview`) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
 | GitHub Release published | `latest` | npmjs | `latest` | `package.json` version | yes |
@@ -53,23 +54,21 @@ Registry follows channel — you pick a channel, not a registry.
 
 ¹ GitHub Packages does not support npm provenance attestations; only the npmjs channels are signed.
 
-**`dev` is the only automatic channel** — every merge to `main` or a `release/v*` branch publishes a `dev` build to GitHub Packages. `preview` and `latest` are dispatched on demand, and stable also runs when a GitHub Release is published. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release — `preview` (npmjs) and `dev` (GitHub Packages) are pre-release versions under their own dist-tags, so no un-tagged install ever picks them.
+**Two channels publish automatically** (mirroring `UiPath/cli`): every merge to `main` publishes a `dev` build to GitHub Packages, and every merge to a `release/v*` branch publishes a `preview` build to npmjs. `latest` is dispatched on demand or runs when a GitHub Release is published. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release — `preview` (npmjs) and `dev` (GitHub Packages) are pre-release versions under their own dist-tags, so no un-tagged install ever picks them. The `preview`/`dev` version suffix (`<base>-preview.<run_number>` / `<base>-dev.<run_number>`) matches the CLI's stamping scheme exactly.
 
 ### Cutting a preview
 
-Dispatch `publish.yml` on the release branch (or tag) you want to preview, with channel `preview`:
+**Every merge to a `release/v*` branch auto-publishes a preview** to npmjs (see the tracks table) — this is the normal path, mirroring `UiPath/cli`. To cut one ad hoc from any ref, dispatch with channel `preview`:
 
 ```bash
 gh workflow run publish.yml --ref release/v<minor> -f channel=preview
 ```
 
-The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to the `preview` dist-tag with `--provenance` via the same OIDC job as `latest`. Consume it with `npm install @uipath/skills@preview`. Re-dispatch to advance the `preview` tag; each run gets a unique version from `run_number`.
+Either way the job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to the `preview` dist-tag with `--provenance` via the same OIDC job as `latest`. Consume it with `npm install @uipath/skills@preview`. Each run gets a unique version from `run_number`; the `preview` tag advances to the newest one.
 
 ### The `dev` channel (GitHub Packages)
 
-Every merge to `main` **or a `release/v*` branch** publishes `@uipath/skills@<base>-dev.<run_number>` to **GitHub Packages** under the `dev` dist-tag — the internal rolling channel, replacing the retired manual `alpha` track. It uses the built-in `GITHUB_TOKEN` (`packages: write`) and carries no provenance (GitHub Packages does not support it). Consume it from the GitHub Packages registry with `npm install @uipath/skills@dev`. Publishes are serialized by a `concurrency` group so back-to-back merges don't race on the `dev` tag. Re-run a merge's publish manually with `gh workflow run publish.yml --ref <branch> -f channel=dev`.
-
-> **Cross-line `dev` tag.** The single `dev` dist-tag points to the **last push from any of these branches** — dist-tags ignore semver, so a `1.198.x-dev` build published from `release/v1.198` *after* a `1.199.x-dev` build from `main` leaves `dev` pointing at the older minor. Each version is still uniquely addressable (`@uipath/skills@1.199.0-dev.<run>`); only the floating `dev` tag is shared. If per-line isolation is ever needed, switch to line-scoped tags (`dev-1.198`).
+Every merge to `main` publishes `@uipath/skills@<base>-dev.<run_number>` to **GitHub Packages** under the `dev` dist-tag — the internal rolling channel, replacing the retired manual `alpha` track. It uses the built-in `GITHUB_TOKEN` (`packages: write`) and carries no provenance (GitHub Packages does not support it). Consume it from the GitHub Packages registry with `npm install @uipath/skills@dev`. Publishes are serialized by a `concurrency` group so back-to-back merges don't race on the `dev` tag. Re-run a merge's publish manually with `gh workflow run publish.yml --ref main -f channel=dev`. (Release lines publish `preview` to npmjs instead — see [Cutting a preview](#cutting-a-preview).)
 
 ### Registry routing
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -21,7 +21,7 @@ All channels carry `package.json`'s version; the pre-release channels (`dev`, `p
 |---------|----------|---------|---------|
 | npm `latest` | npmjs | `M.N.<release>` | per stable release — what the CLI pins |
 | npm `preview` | npmjs | `M.N.<release>-preview.<run>` | per preview dispatch (stamp never committed) |
-| npm `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per merge to `main` (stamp never committed) |
+| npm `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per merge to `main` or `release/v*` (stamp never committed) |
 | plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex plugin auto-update |
 
 `sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
@@ -45,7 +45,7 @@ Registry follows channel — you pick a channel, not a registry.
 
 | Trigger | Channel | Registry | dist-tag | Version | Provenance |
 |---------|---------|----------|----------|---------|------------|
-| push to `main` (every merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
+| push to `main` or `release/v*` (every merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
 | `workflow_dispatch` (channel: `dev`) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
 | `workflow_dispatch` (channel: `preview`) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
 | GitHub Release published | `latest` | npmjs | `latest` | `package.json` version | yes |
@@ -53,7 +53,7 @@ Registry follows channel — you pick a channel, not a registry.
 
 ¹ GitHub Packages does not support npm provenance attestations; only the npmjs channels are signed.
 
-**`dev` is the only automatic channel** — every merge to `main` publishes a `dev` build to GitHub Packages. `preview` and `latest` are dispatched on demand, and stable also runs when a GitHub Release is published. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release — `preview` (npmjs) and `dev` (GitHub Packages) are pre-release versions under their own dist-tags, so no un-tagged install ever picks them.
+**`dev` is the only automatic channel** — every merge to `main` or a `release/v*` branch publishes a `dev` build to GitHub Packages. `preview` and `latest` are dispatched on demand, and stable also runs when a GitHub Release is published. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release — `preview` (npmjs) and `dev` (GitHub Packages) are pre-release versions under their own dist-tags, so no un-tagged install ever picks them.
 
 ### Cutting a preview
 
@@ -67,7 +67,9 @@ The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-versi
 
 ### The `dev` channel (GitHub Packages)
 
-Every merge to `main` publishes `@uipath/skills@<base>-dev.<run_number>` to **GitHub Packages** under the `dev` dist-tag — the internal rolling channel, replacing the retired manual `alpha` track. It uses the built-in `GITHUB_TOKEN` (`packages: write`) and carries no provenance (GitHub Packages does not support it). Consume it from the GitHub Packages registry with `npm install @uipath/skills@dev`. Publishes are serialized by a `concurrency` group so back-to-back merges don't race on the `dev` tag. Re-run a merge's publish manually with `gh workflow run publish.yml --ref main -f channel=dev`.
+Every merge to `main` **or a `release/v*` branch** publishes `@uipath/skills@<base>-dev.<run_number>` to **GitHub Packages** under the `dev` dist-tag — the internal rolling channel, replacing the retired manual `alpha` track. It uses the built-in `GITHUB_TOKEN` (`packages: write`) and carries no provenance (GitHub Packages does not support it). Consume it from the GitHub Packages registry with `npm install @uipath/skills@dev`. Publishes are serialized by a `concurrency` group so back-to-back merges don't race on the `dev` tag. Re-run a merge's publish manually with `gh workflow run publish.yml --ref <branch> -f channel=dev`.
+
+> **Cross-line `dev` tag.** The single `dev` dist-tag points to the **last push from any of these branches** — dist-tags ignore semver, so a `1.198.x-dev` build published from `release/v1.198` *after* a `1.199.x-dev` build from `main` leaves `dev` pointing at the older minor. Each version is still uniquely addressable (`@uipath/skills@1.199.0-dev.<run>`); only the floating `dev` tag is shared. If per-line isolation is ever needed, switch to line-scoped tags (`dev-1.198`).
 
 ### Registry routing
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -15,15 +15,16 @@ The whole skills repo is published as an npm package, **`@uipath/skills`**, vers
 
 ### One version line
 
-All channels carry `package.json`'s version; only the alpha track adds a pre-release stamp:
+All channels carry `package.json`'s version; the pre-release channels (`dev`, `preview`) add a stamp that is never committed:
 
-| Channel | Version | Cadence |
-|---------|---------|---------|
-| npm `latest` | `M.N.<release>` | per stable release — what the CLI pins |
-| npm `alpha` | `M.N.<release>-alpha.<date>.<run>` | per alpha dispatch (stamp never committed) |
-| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex plugin auto-update |
+| Channel | Registry | Version | Cadence |
+|---------|----------|---------|---------|
+| npm `latest` | npmjs | `M.N.<release>` | per stable release — what the CLI pins |
+| npm `preview` | npmjs | `M.N.<release>-preview.<run>` | per preview dispatch (stamp never committed) |
+| npm `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per merge to `main` (stamp never committed) |
+| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex plugin auto-update |
 
-`sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the alpha stamp from `publish.yml` never lands in the plugin manifests. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
+`sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. The marketplace and Codex versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
 
 Run after any version change:
 
@@ -40,24 +41,33 @@ The version line mirrors the CLI's `MAJOR.MINOR` (e.g. CLI `1.197.x` → skills 
 
 ## Publishing tracks (`.github/workflows/publish.yml`)
 
-| Trigger | Registry | dist-tag | Version |
-|---------|----------|----------|---------|
-| `workflow_dispatch` (target: `github-alpha`) | GitHub Packages | `alpha` | `<base>-alpha.<YYYYMMDD>.<run_number>` |
-| `workflow_dispatch` (target: `npmjs-preview`) | npmjs | `preview` | `<base>-preview.<run_number>` |
-| GitHub Release published | npmjs | `latest` | `package.json` version |
-| `workflow_dispatch` (target: `npmjs`) | npmjs | `latest` | `package.json` version |
+Registry follows channel — you pick a channel, not a registry.
 
-All tracks are **manually triggered** — there is no auto-publish on push to `main`. Alpha and preview are dispatched on demand; stable runs when a GitHub Release is published. `npm install @uipath/skills` (no tag) always resolves to the last stable npmjs release — alphas live only under the `alpha` tag on GitHub Packages, and previews only under the `preview` tag on npmjs (both are pre-release versions, so no un-tagged install ever picks them).
+| Trigger | Channel | Registry | dist-tag | Version | Provenance |
+|---------|---------|----------|----------|---------|------------|
+| push to `main` (every merge) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
+| `workflow_dispatch` (channel: `dev`) | `dev` | GitHub Packages | `dev` | `<base>-dev.<run_number>` | no¹ |
+| `workflow_dispatch` (channel: `preview`) | `preview` | npmjs | `preview` | `<base>-preview.<run_number>` | yes |
+| GitHub Release published | `latest` | npmjs | `latest` | `package.json` version | yes |
+| `workflow_dispatch` (channel: `latest`) | `latest` | npmjs | `latest` | `package.json` version | yes |
+
+¹ GitHub Packages does not support npm provenance attestations; only the npmjs channels are signed.
+
+**`dev` is the only automatic channel** — every merge to `main` publishes a `dev` build to GitHub Packages. `preview` and `latest` are dispatched on demand, and stable also runs when a GitHub Release is published. `npm install @uipath/skills` (no tag, from npmjs) always resolves the last stable release — `preview` (npmjs) and `dev` (GitHub Packages) are pre-release versions under their own dist-tags, so no un-tagged install ever picks them.
 
 ### Cutting a preview
 
-Dispatch `publish.yml` on the release branch (or tag) you want to preview, with target `npmjs-preview`:
+Dispatch `publish.yml` on the release branch (or tag) you want to preview, with channel `preview`:
 
 ```bash
-gh workflow run publish.yml --ref release/v<minor> -f target=npmjs-preview
+gh workflow run publish.yml --ref release/v<minor> -f channel=preview
 ```
 
 The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to the `preview` dist-tag with `--provenance` via the same OIDC job as `latest`. Consume it with `npm install @uipath/skills@preview`. Re-dispatch to advance the `preview` tag; each run gets a unique version from `run_number`.
+
+### The `dev` channel (GitHub Packages)
+
+Every merge to `main` publishes `@uipath/skills@<base>-dev.<run_number>` to **GitHub Packages** under the `dev` dist-tag — the internal rolling channel, replacing the retired manual `alpha` track. It uses the built-in `GITHUB_TOKEN` (`packages: write`) and carries no provenance (GitHub Packages does not support it). Consume it from the GitHub Packages registry with `npm install @uipath/skills@dev`. Publishes are serialized by a `concurrency` group so back-to-back merges don't race on the `dev` tag. Re-run a merge's publish manually with `gh workflow run publish.yml --ref main -f channel=dev`.
 
 ### Registry routing
 
@@ -65,8 +75,8 @@ The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-versi
 
 | Job | registry | Auth |
 |-----|----------|------|
-| `publish-alpha` | GitHub Packages (`npm.pkg.github.com`) | built-in `GITHUB_TOKEN` |
-| `publish-release` | npmjs (`registry.npmjs.org`) | **OIDC trusted publishing** (no token) + signed `--provenance` |
+| `publish-dev` | GitHub Packages (`npm.pkg.github.com`) | built-in `GITHUB_TOKEN` |
+| `publish-npmjs` | npmjs (`registry.npmjs.org`) | **OIDC trusted publishing** (no token) + signed `--provenance` |
 
 ## Cutting a stable release
 
@@ -78,7 +88,7 @@ The job stamps `<base>-preview.<run_number>` (never committed), runs `sync-versi
 Steps 1–2 are automated per sprint by `sprint-release-cut.yml`. It runs **Sunday 06:00 UTC**, gated to the **14-day cadence** anchored at `2026-06-14` — the same cadence as `UiPath/cli`, but **6 hours earlier** so the skills package lands before the CLI release. It is **self-driven**: the target line is the current skills minor **+ 1**; it never reads the CLI version (skills lead, never follow), so no cross-repo secret is required. On a release Sunday it:
 
 1. cuts `release/v<minor>` from `main` at `M.N.0` (`sync-version.mjs` resets plugin/marketplace/Codex to `M.N.0` too);
-2. publishes `@uipath/skills@M.N.0` to npm `latest` — creates the GitHub Release `v<minor>.0` as the durable record, then **dispatches `publish.yml` on the tag** (`gh workflow run publish.yml --ref v<minor>.0 -f target=npmjs`). A release created with the default `GITHUB_TOKEN` does not trigger other workflows, so `release: published` would never start `publish.yml`; the explicit `workflow_dispatch` (which `GITHUB_TOKEN` *can* trigger) is what publishes. Guarded on `npm view` so a re-run doesn't re-dispatch an already-published version;
+2. publishes `@uipath/skills@M.N.0` to npm `latest` — creates the GitHub Release `v<minor>.0` as the durable record, then **dispatches `publish.yml` on the tag** (`gh workflow run publish.yml --ref v<minor>.0 -f channel=latest`). A release created with the default `GITHUB_TOKEN` does not trigger other workflows, so `release: published` would never start `publish.yml`; the explicit `workflow_dispatch` (which `GITHUB_TOKEN` *can* trigger) is what publishes. Guarded on `npm view` so a re-run doesn't re-dispatch an already-published version;
 3. opens the matching version-bump PR against `main`.
 
 Off-cadence or ad-hoc cut: dispatch manually with `minor_override` (e.g. `1.198`) to skip the gate and the auto-increment, or `dry_run` to print the plan without pushing.
@@ -91,8 +101,8 @@ Off-cadence or ad-hoc cut: dispatch manually with `minor_override` (e.g. `1.198`
 
 ## Required setup
 
-- [x] **npmjs Trusted Publishing** — configure a GitHub Actions trusted publisher on the `@uipath/skills` package (npmjs → package → Settings → Trusted Publisher): repository `UiPath/skills`, workflow `publish.yml`. No `NPM_TOKEN` secret is used — the `publish-release` job authenticates via OIDC (`id-token: write`). Do **not** set `NODE_AUTH_TOKEN`; a token makes npm bypass OIDC and (with 2FA) fail `EOTP`.
+- [x] **npmjs Trusted Publishing** — configure a GitHub Actions trusted publisher on the `@uipath/skills` package (npmjs → package → Settings → Trusted Publisher): repository `UiPath/skills`, workflow `publish.yml`. No `NPM_TOKEN` secret is used — the `publish-npmjs` job authenticates via OIDC (`id-token: write`). Do **not** set `NODE_AUTH_TOKEN`; a token makes npm bypass OIDC and (with 2FA) fail `EOTP`.
 - [x] Package name/scope confirmed: **`@uipath/skills`** (published).
 - [x] Seed version confirmed: **`1.197.0`** (current CLI minor line). The ongoing CLI↔skills lockstep is automated by `sprint-release-cut.yml` (Sunday 06:00 UTC, 6 h before the CLI's own cut, on the same 14-day cadence anchored at `2026-06-14`).
 
-> The alpha track also needs no secret — `publish-alpha` uses the built-in `GITHUB_TOKEN` with `packages: write`.
+> The `dev` channel also needs no secret — `publish-dev` uses the built-in `GITHUB_TOKEN` with `packages: write`.


### PR DESCRIPTION
**Jira:** _none — add PILOT key if tracked_

## What

Refactors `publish.yml` into a **channel-driven** model (registry follows channel) and adds **automatic `dev` publishing to GitHub Packages on every merge to `main`**, modeled on how `UiPath/cli` publishes its internal dev builds (`ci.yml` `publish` job → GitHub Packages `dev`).

## Changes

- **New `dev` channel, auto on merge.** A `push: [main]` trigger + `publish-dev` job: every merge stamps `<base>-dev.<run_number>` (never committed), runs `sync-version.mjs`, and publishes to **GitHub Packages** under the `dev` dist-tag. Consume with `npm install @uipath/skills@dev`.
- **`alpha` retired.** `dev` replaces the old manual `github-alpha` track.
- **Dispatch input `target` → `channel`.** The coupled `target` enum (`npmjs` / `npmjs-preview` / `github-alpha`) is replaced by a `channel` input (`preview` / `dev` / `latest`). Registry is derived from the channel, not chosen independently — most registry×channel combos are invalid, so this matches the CLI's event/ref-driven approach.
- **npmjs job renamed** `publish-release` → `publish-npmjs`; unchanged behavior: OIDC trusted publishing + `--provenance` for `latest` (release event or `channel=latest`) and `preview` (`channel=preview`).
- **`sprint-release-cut.yml`** dispatch updated: `-f target=npmjs` → `-f channel=latest` (same-PR, or the sprint cut breaks).
- **`docs/RELEASE.md`** updated throughout: version-line table, publishing-tracks table, new "dev channel" section, registry/job table, dispatch commands.

## Channel matrix after this PR

| Trigger | Channel | Registry | dist-tag | Provenance |
|---------|---------|----------|----------|-----------|
| push to `main` (every merge) | `dev` | GitHub Packages | `dev` | no¹ |
| dispatch `channel=dev` | `dev` | GitHub Packages | `dev` | no¹ |
| dispatch `channel=preview` | `preview` | npmjs | `preview` | yes |
| GitHub Release published | `latest` | npmjs | `latest` | yes |
| dispatch `channel=latest` | `latest` | npmjs | `latest` | yes |

¹ GitHub Packages does not support npm provenance attestations ([npm docs](https://docs.npmjs.com/generating-provenance-statements/)); only the npmjs channels are signed.

## Safety notes

- **`latest` never moves** — `dev`/`preview` are pre-release versions published under their own dist-tags on their own registries.
- **Forks can't publish** — both publish jobs are guarded on `github.repository == 'UiPath/skills'`.
- **Rapid merges are serialized** by a `concurrency` group (`cancel-in-progress: false`) so they don't race on the `dev` tag.
- **`dev` uses the built-in `GITHUB_TOKEN`** (`packages: write`) — no new secret.

## Deliberate deviation from the CLI

The CLI also moves its GitHub Packages `latest` tag to each dev build, because its internal installs resolve from GitHub Packages. Skills resolves via **npmjs** (`uip skills install` → `registry.npmjs.org`), so there's no GitHub-feed consumer of `latest` — this PR tags `dev` only. If an internal GitHub Packages consumer appears, we can add the `latest` mirror then.

## Verify after merge

First merge to `main` should publish `1.199.0-dev.<n>` to GitHub Packages under `dev`, with the `.claude-plugin` manifests still at the clean base version (suffix stripped by `sync-version.mjs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)