### PR TITLE
fix(tests): stop troubleshoot simulations once criteria pass so the judge grades the diagnosis turn

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
@@ -83,3 +83,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
+  check_criteria: every_turn
+  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
@@ -86,3 +86,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
+  check_criteria: every_turn
+  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -96,3 +96,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
+  check_criteria: every_turn
+  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -91,3 +91,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
+  check_criteria: every_turn
+  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
@@ -104,3 +104,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
+  check_criteria: every_turn
+  stop_on_criteria_pass: true


### PR DESCRIPTION
## What this fixes

The troubleshoot scenarios' `llm_judge` grades only the last assistant turn (`include_agent_output: true`). In multi-turn simulation, the agent delivers the full diagnosis in turn 1, then the simulator asks a follow-up - cleanup of investigation files, or a look at a secondary job - and the agent's short reply to that follow-up becomes the graded "final answer". Correct diagnoses were scored 0/0.5.

False negatives in the 2026-07-21 nightly (`2026-07-21_04-29-26`):

- `skill-troubleshoot-o365-copyitem-null-driveitem` - correct turn-1 diagnosis; judge graded turn 2 ("Done - files deleted") -> 0.25 overall
- `skill-troubleshoot-rpa-is-connection-disabled-dap` - correct turn-1 diagnosis; judge graded the secondary-job turn -> 0.625 overall

Same pattern previously hit `uia-alter-if-disabled`, `uia-ambiguous-node-test`, and `uia-verify-execution-failure` (June nightlies).

## Change

Adds two keys to the simulation block of those 5 tasks (nothing else - no prompt, judge, or contract changes):

```yaml
  check_criteria: every_turn
  stop_on_criteria_pass: true
```

Success criteria are evaluated after every simulated exchange and the dialog ends with `stop_reason: criteria_passed` as soon as all pass - on the diagnosis turn, before a follow-up can replace it. If the agent instead ends a turn with a clarifying question, criteria fail and the simulation continues as before, so multi-turn clarification paths are unaffected.

## Run results

Each task run 3 times locally (`--repeats 3`, `--include-skipped` for the 3 mature-skipped UIA tasks): 15/15 SUCCESS, every dialog stopped at turn 1 with `criteria_passed`.

| Task | Rep 00 | Rep 01 | Rep 02 |
|---|---|---|---|
| o365-copyitem-null-driveitem | 0.850 | 0.925 | 0.925 |
| rpa-is-connection-disabled-dap | 1.0 | 1.0 | 1.0 |
| uia-alter-if-disabled | 1.0 | 1.0 | 1.0 |
| uia-ambiguous-node-test | 1.0 | 1.0 | 1.0 |
| uia-verify-execution-failure | 1.0 | 1.0 | 1.0 |

`excel-rr-nre-opaque` (the third 2026-07-21 failure) is deliberately not touched - it was a genuine partial-diagnosis miss, not a grading artifact.