### PR TITLE
test(maestro-bpmn): accept singular debug input flag

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/debug/debug_workflow_mocked/debug_workflow_mocked.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/debug_workflow_mocked/debug_workflow_mocked.yaml
@@ -48,7 +48,7 @@ success_criteria:
   - type: command_executed
     description: "Agent started a debug session with inputs"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+debug\s+[\s\S]*--inputs'
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+debug\s+[\s\S]*--inputs?'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0


### PR DESCRIPTION
Fixes the mocked BPMN debug eval false failure where the agent used accepted singular --input but the criterion only matched --inputs.

Verification: targeted coder-eval passed: https://github.com/UiPath/skills/actions/runs/29843520078

Task glob: tasks/uipath-maestro-bpmn/debug/debug_workflow_mocked/debug_workflow_mocked.yaml