### PR TITLE
test(maestro-bpmn): accept wiki pageviews wrapper layout

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
@@ -32,7 +32,6 @@ from _shared.bpmn_check import (  # noqa: E402
     text_content,
 )
 
-PROJECT = Path.cwd() / "WikiPageviews"
 BPMN_NAME = "WikiPageviews.bpmn"
 REQUIRED_FILES = [
     "project.uiproj",
@@ -43,8 +42,8 @@ REQUIRED_FILES = [
 ]
 
 
-def load_json(name: str):
-    p = PROJECT / name
+def load_json(project: Path, name: str):
+    p = project / name
     if not p.is_file():
         fail(f"{name} is missing")
     try:
@@ -54,11 +53,15 @@ def load_json(name: str):
 
 
 def main() -> None:
-    for name in REQUIRED_FILES:
-        if not (PROJECT / name).is_file():
-            fail(f"{name} is missing")
-
     path, root = parse_bpmn("WikiPageviews")
+    bpmn_path = Path(path)
+    if bpmn_path.name != BPMN_NAME:
+        fail(f"expected BPMN file named {BPMN_NAME}, found {bpmn_path}")
+
+    project = bpmn_path.parent
+    for name in REQUIRED_FILES:
+        if not (project / name).is_file():
+            fail(f"{name} is missing beside {BPMN_NAME}")
 
     process = one_or_more(root, "process")[0]
     if process.attrib.get("isExecutable") != "true":
@@ -106,7 +109,7 @@ def main() -> None:
     require_no_private_connector_values(root)
 
     for name in ("entry-points.json", "operate.json", "package-descriptor.json"):
-        if BPMN_NAME not in json.dumps(load_json(name)):
+        if BPMN_NAME not in json.dumps(load_json(project, name)):
             fail(f"{name} must reference {BPMN_NAME}")
 
     print(f"OK: {path} fetches, routes failure, filters, aggregates, and ships consistent package metadata")

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -50,23 +50,27 @@ initial_prompt: |
   Build the complete local project end-to-end in a single pass.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "BPMN source file was created"
-    path: "WikiPageviews/WikiPageviews.bpmn"
+    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/WikiPageviews.bpmn'), Path('WikiPageviewsSolution/WikiPageviews/WikiPageviews.bpmn')]; sys.exit(0 if any(p.is_file() for p in paths) else 'WikiPageviews.bpmn missing in direct or solution-wrapper layout')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
+  - type: run_command
     description: "Package operate metadata was created"
-    path: "WikiPageviews/operate.json"
+    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/operate.json'), Path('WikiPageviewsSolution/WikiPageviews/operate.json')]; sys.exit(0 if any(p.is_file() for p in paths) else 'operate.json missing in direct or solution-wrapper layout')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "The invalid-article path returns the fixed error string"
-    path: "WikiPageviews/WikiPageviews.bpmn"
-    includes:
-      - "Article not found"
+    command: "python3 -c \"from pathlib import Path; import sys; paths=[Path('WikiPageviews/WikiPageviews.bpmn'), Path('WikiPageviewsSolution/WikiPageviews/WikiPageviews.bpmn')]; texts=[p.read_text(encoding='utf-8') for p in paths if p.is_file()]; sys.exit(0 if any('Article not found' in t for t in texts) else 'Article not found missing from WikiPageviews.bpmn')\""
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
Fixes the wiki pageviews task contract so valid direct and CLI-init solution-wrapper BPMN layouts are accepted without weakening semantic checks.

Verification: targeted coder-eval passed: https://github.com/UiPath/skills/actions/runs/29843519334

Task glob: tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml