### PR TITLE
docs(maestro-bpmn): clarify local metadata contract

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -59,8 +59,13 @@ Two halves make a valid Maestro `.bpmn`:
 
 ## Workflow
 
-Work the four steps quickly and author early — do not pre-read every reference
-before writing. Read a reference only when you reach the structure it covers.
+Work the four steps quickly, but keep the path matched to the user's ask. For
+discovery-only asks (for example, "show what the registry exposes" or "capture
+the template for X"), run `registry pull`, then `list` / `search`, then
+`registry get <type> --output json` for the requested types; save or report the
+raw evidence and do not scaffold a project. For authoring asks, read a reference
+only when you reach the structure it covers, get the needed templates, then
+write the first complete draft before further spelunking.
 
 1. **Discover.** `uip maestro bpmn registry pull` **once** (cached for the
    session — do not re-pull), then `list` / `search` to map intent to extension
@@ -69,16 +74,25 @@ before writing. Read a reference only when you reach the structure it covers.
    every selection with the user (use AskUserQuestion). Never fabricate an identifier.
    See [references/registry-workflow.md](references/registry-workflow.md).
 2. **Get templates.** `uip maestro bpmn registry get <type> --output json` for
-   each chosen node. Enrich `Intsvc.*` connector nodes with
-   `--connection-id`/`--object-name`.
+   each chosen registry-owned node only. Enrich `Intsvc.*` connector nodes with
+   `--connection-id`/`--object-name`. Do not call `registry get` for structural
+   gaps the registry never owns: sequence flows, gateways, events, boundary
+   events, multi-instance/loop markers, `errorMapping`/retry structure, or
+   diagrams.
 3. **Assemble.** Author directly from the complete minimal file in
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-fixtures)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already
    shows variables, the entry point, a branch, and the diagram. **Do not read the
-   validator's `test/fixtures/` to infer the pattern** — it is the top reason
-   authoring runs out of time. Add only the structural pieces your process needs
-   (extra gateways, events, boundary events, containers, multi-instance markers),
-   then generate one `BPMNShape`/`BPMNEdge` per node and flow.
+   validator's `test/fixtures/`, task fixtures, or generated package files to
+   infer authoring patterns** — fixture spelunking is the top reason authoring
+   runs out of time. Add only the structural pieces your process needs (extra
+   gateways, events, boundary events, containers, multi-instance markers,
+   expression/error mappings, retry attributes), then generate one
+   `BPMNShape`/`BPMNEdge` per node and flow. For local authoring prompts, use the
+   plain project layout `<ProjectName>/<ProjectName>.bpmn` with
+   `<ProjectName>/project.uiproj`; do not create `*Solution/`, package files, or
+   `.uipx` artifacts unless the user explicitly asks to package or operate the
+   project.
 4. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
    bundled validator — it reconstructs the canvas model and runs every
    PO.Frontend rule:

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -8,6 +8,20 @@ Use this guide when BPMN source changed and local package metadata must be refre
 - `entry-points.json`, `bindings_v2.json`, `operate.json`, and `package-descriptor.json` are derived package metadata unless a CLI contract explicitly marks a field as user-authored.
 - Connector-backed or dynamically schematized `Intsvc.*` activity and event payloads are executable only after registry-backed enrichment supplies connector metadata, connection binding references, dynamic schemas, and generated package resources. Confirmed plain connectionless HTTP follows the documented pass-2 authoring recipe instead.
 
+## Local Synthetic Project Contract
+
+When no CLI generator is available and you must author a local-only synthetic
+BPMN project, make the project executable and package-shaped before packing:
+
+- The root process must be `<bpmn:process ... isExecutable="true">`.
+- `project.uiproj` must use lowercase `"main"` pointing at the BPMN file.
+- `operate.json` must use `"main"` and `"contentType": "ProcessOrchestration"`.
+- `package-descriptor.json` must use a top-level `"content"` array with
+  `content/<file>` entries. Do not use `contentFiles`.
+
+The minimal placeholder-safe JSON shape is shown below; keep it exact apart
+from project, file, and start event names.
+
 ## Regeneration Inputs
 
 Local regeneration reads:

--- a/skills/uipath-maestro-bpmn/references/shared/project-layout.md
+++ b/skills/uipath-maestro-bpmn/references/shared/project-layout.md
@@ -59,6 +59,14 @@ For the regeneration and drift-check contract, see [local-metadata-regeneration-
 
 ## Package content
 
+A synthetic local project authored without a CLI generator must still match the
+executable and metadata contract before packing: the BPMN root process includes
+`isExecutable="true"`, `project.uiproj` has lowercase `"main"`,
+`operate.json` has `"main"` plus `"contentType": "ProcessOrchestration"`, and
+`package-descriptor.json` has top-level `"content"` entries under `content/`.
+For the exact minimal JSON, see
+[local-metadata-regeneration-guide.md](local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
+
 A Process Orchestration package content folder contains:
 
 - One or more `.bpmn` files.


### PR DESCRIPTION
Clarifies the local synthetic BPMN contract for executable processes and minimal package metadata: project.uiproj main, operate main/contentType, and package-descriptor content.

Verification: targeted coder-eval passed: https://github.com/UiPath/skills/actions/runs/29851079201

Prior targeted coder-eval pass: https://github.com/UiPath/skills/actions/runs/29843517156

Task globs: tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml