### PR TITLE
test(maestro-bpmn): clarify live debug script output mapping

### DIFF
--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -156,6 +156,9 @@ template, but the runtime contract is fixed:
 - Map the return back through `source="=result.response"` (scalar) or
   `source="=result.response.<field>"` (object field); `var` points at a declared
   variable id (do not put the target id in `name`).
+- Do not mutate `Globals.*`, `vars.*`, or process variables inside the script
+  body. The supported path is: return a value from the script, then use a
+  `uipath:output` mapping to write it to the declared variable.
 
 ```xml
 <bpmn:scriptTask id="Task_RiskScore" name="Risk Score" scriptFormat="JavaScript">

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/check_live_debug.py
@@ -2,16 +2,17 @@
 """Runtime check for the live BPMN debug e2e.
 
 Grades the agent's saved debug evidence — the raw CLI output of a real
-`uip maestro bpmn debug` session and the following `debug-instance variables`
+`uip maestro bpmn debug` session and the following `debug-instance variables-all`
 read. Un-fakeable in combination with the task's command_executed criteria: the
 debug command must actually have run and reached finalStatus Completed, and the
-inspected runtime variables must carry the deterministic computed product (42
-for inputs a=6, b=7). Also confirms the process computes the result in a script
-task rather than hardcoding it.
+inspected runtime variables must carry the deterministic computed product (42)
+on the runtime variable named/id'd `product`. Also confirms the process computes
+the result in a script task and maps the script return through the supported
+BPMN.ScriptTask output contract.
 
 Reads:
   - debug-evidence/*.json  (agent-saved raw CLI JSON: debug + variables)
-  - the authored .bpmn      (must contain a scriptTask)
+  - the authored .bpmn      (must contain a mapped scriptTask)
 
 Exits 0 with OK lines on success; non-zero with FAIL on the first problem.
 """
@@ -21,11 +22,14 @@ from __future__ import annotations
 import glob
 import json
 import os
+import re
 import sys
 import xml.etree.ElementTree as ET
 
 EXPECTED_PRODUCT = 42
 BPMN_NS = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+UIPATH_NS = "http://uipath.com/schema/bpmn"
+NS = {"bpmn": BPMN_NS, "uipath": UIPATH_NS}
 
 
 def _fail(msg: str) -> None:
@@ -61,6 +65,17 @@ def _walk(obj):
         yield ("__leaf__", None, obj)
 
 
+def _walk_paths(obj, path=()):
+    """Yield (path, value) for every node in a nested JSON-like structure."""
+    yield (path, obj)
+    if isinstance(obj, dict):
+        for key, value in obj.items():
+            yield from _walk_paths(value, (*path, str(key)))
+    elif isinstance(obj, (list, tuple)):
+        for index, value in enumerate(obj):
+            yield from _walk_paths(value, (*path, str(index)))
+
+
 def _has_final_status_completed(parsed) -> bool:
     for tag, key, val in _walk(parsed):
         if tag == "__key__" and isinstance(key, str) and key.lower() == "finalstatus":
@@ -69,16 +84,111 @@ def _has_final_status_completed(parsed) -> bool:
     return False
 
 
+def _is_expected_product_value(value) -> bool:
+    if isinstance(value, bool):
+        return False
+    if isinstance(value, (int, float)):
+        return value == EXPECTED_PRODUCT
+    if isinstance(value, str):
+        return value.strip() in ("42", "42.0")
+    return False
+
+
 def _has_expected_product(parsed) -> bool:
-    for tag, _key, val in _walk(parsed):
-        if tag != "__leaf__":
-            continue
-        if isinstance(val, bool):
-            continue
-        if isinstance(val, (int, float)) and val == EXPECTED_PRODUCT:
+    """Find value 42 specifically attached to a runtime variable named product."""
+    product_record_keys = {
+        "product",
+        "globals.product",
+        "variables.product",
+        "root.product",
+    }
+    name_keys = {"id", "name", "key", "variable", "variableid", "variablename", "path"}
+    value_keys = {"value", "currentvalue", "runtimevalue", "rawvalue"}
+
+    for path, value in _walk_paths(parsed):
+        normalized_path = ".".join(p.lower() for p in path)
+        if normalized_path in product_record_keys and _is_expected_product_value(value):
             return True
-        if isinstance(val, str) and val.strip() in ("42", "42.0"):
+        if path and path[-1].lower() == "product" and _is_expected_product_value(value):
             return True
+        if (
+            path
+            and path[-1].lower() == "product"
+            and isinstance(value, dict)
+            and any(_is_expected_product_value(leaf) for _, leaf in _walk_paths(value))
+        ):
+            return True
+
+        if not isinstance(value, dict):
+            continue
+
+        names = {
+            str(record_value).strip().lower()
+            for record_key, record_value in value.items()
+            if record_key.replace("_", "").lower() in name_keys
+            and isinstance(record_value, (str, int, float))
+        }
+        if not (names & product_record_keys or "product" in names):
+            continue
+
+        for record_key, record_value in value.items():
+            if record_key.replace("_", "").lower() in value_keys and _is_expected_product_value(record_value):
+                return True
+        if any(_is_expected_product_value(leaf) for _, leaf in _walk_paths(value)):
+            return True
+    return False
+
+
+def _text(element: ET.Element | None) -> str:
+    if element is None:
+        return ""
+    return "".join(element.itertext())
+
+
+def _strip_js_comments(script: str) -> str:
+    script = re.sub(r"/\*.*?\*/", "", script, flags=re.DOTALL)
+    return re.sub(r"//.*", "", script)
+
+
+def _root_product_variable(root: ET.Element) -> ET.Element | None:
+    process = root.find("bpmn:process", NS)
+    if process is None:
+        return None
+    for variable in process.findall("bpmn:extensionElements/uipath:variables/*", NS):
+        local_name = variable.tag.rsplit("}", 1)[-1]
+        if (
+            local_name == "inputOutput"
+            and variable.attrib.get("id") == "product"
+            and variable.attrib.get("name") == "product"
+        ):
+            return variable
+    return None
+
+
+def _script_maps_product(root: ET.Element) -> bool:
+    for task in root.findall(f".//{{{BPMN_NS}}}scriptTask"):
+        script_format = task.attrib.get("scriptFormat", "")
+        if script_format.lower() != "javascript":
+            continue
+        version = task.find("bpmn:extensionElements/uipath:scriptVersion", NS)
+        if version is None or version.attrib.get("value") != "v3":
+            continue
+        mapping_type = task.find("bpmn:extensionElements/uipath:mapping/uipath:type", NS)
+        if mapping_type is None or mapping_type.attrib.get("value") != "BPMN.ScriptTask":
+            continue
+        outputs = task.findall("bpmn:extensionElements/uipath:mapping/uipath:output", NS)
+        if not any(
+            output.attrib.get("var") == "product"
+            and output.attrib.get("source") == "=result.response"
+            for output in outputs
+        ):
+            continue
+        body = _strip_js_comments(_text(task.find("bpmn:script", NS)))
+        if "Globals." in body or "vars." in body:
+            _fail("script body tries to mutate/read process variables directly; use output mapping")
+        if not ("return" in body and "response" in body and "6" in body and "7" in body and "*" in body):
+            _fail("script body should compute 6 * 7 and return it as { response: ... }")
+        return True
     return False
 
 
@@ -107,29 +217,31 @@ def main() -> None:
 
     if not any(_has_expected_product(p) for p in parsed_files.values()):
         _fail(
-            f"expected product {EXPECTED_PRODUCT} not found among runtime variable "
-            f"values in debug-evidence. Files: {sorted(parsed_files)}"
+            f"expected runtime variable 'product' with value {EXPECTED_PRODUCT} not "
+            f"found in debug-evidence. Files: {sorted(parsed_files)}"
         )
     print(f"OK: runtime product variable is {EXPECTED_PRODUCT}")
 
     bpmn_files = glob.glob("**/*.bpmn", recursive=True)
     if not bpmn_files:
         _fail("no .bpmn file authored")
-    found_script = False
+    found_script_mapping = False
+    found_product_variable = False
     for path in bpmn_files:
         try:
             root = ET.parse(path).getroot()
         except ET.ParseError as exc:
             _fail(f"{path} is not well-formed XML: {exc}")
-        if root.findall(f".//{{{BPMN_NS}}}scriptTask"):
-            found_script = True
-            break
-    if not found_script:
+        found_product_variable = found_product_variable or _root_product_variable(root) is not None
+        found_script_mapping = found_script_mapping or _script_maps_product(root)
+    if not found_product_variable:
+        _fail("no root inputOutput variable with id='product' and name='product'")
+    if not found_script_mapping:
         _fail(
-            "no scriptTask in any authored .bpmn — the product must be computed by "
-            "a script task, not hardcoded"
+            "no BPMN.ScriptTask output mapping writes source='=result.response' "
+            "to var='product'"
         )
-    print("OK: product is computed by a script task")
+    print("OK: product is computed by a script task output mapping")
     print("PASS: all live-debug checks passed")
 
 

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
@@ -1,8 +1,9 @@
 task_id: skill-bpmn-e2e-live-debug
 description: >
   First Maestro BPMN eval that EXECUTES a process. The agent authors a tiny,
-  deterministic BPMN project (manual start, one Jint script task that computes
-  the product of the constants 6 and 7 into a `product` variable, an end
+  deterministic BPMN project (manual start, one Jint script task that returns
+  the product of the constants 6 and 7, maps `result.response` into a root
+  inputOutput variable whose id and name are both exactly `product`, an end
   event), runs a live `uip maestro bpmn debug` session against Studio Web, and
   inspects the runtime result via the `debug-instance` variables commands. The
   agent saves the raw debug and variables CLI output to `debug-evidence/`, and
@@ -36,15 +37,20 @@ initial_prompt: |
   Author a minimal Maestro BPMN project named "ProductCalc" with its main file
   at `ProductCalc/ProductCalc.bpmn` for this process:
     - a manual start event (no input variables),
+    - one root mutable variable whose id and name are both exactly `product`,
     - a single Jint script task that multiplies the constants 6 and 7 inside
-      the script body and writes the result to a process variable named
-      exactly `product`,
+      the script body, returns the scalar result using the BPMN.ScriptTask
+      v3 contract (`return { response: ... }`), and maps the output with
+      `source="=result.response"` and `var="product"`,
     - an end event.
 
   Then run a debug session for the project against Studio Web and confirm from
   the runtime that the `product` variable is 42. You have explicit consent to
   upload and debug this project in the connected tenant. Do not pass `--inputs`
   — the computation is self-contained.
+  Do not try to assign `Globals.product`, `vars.product`, or any other process
+  variable directly inside the script body; script results become process
+  variables only through the BPMN.ScriptTask output mapping.
 
   Save the raw CLI output so the result can be verified independently:
     - save the full JSON output of the debug command to


### PR DESCRIPTION
Clarifies the live debug eval and script guidance around supported Jint return-to-output mapping instead of direct Globals/vars mutation. Focused coder-eval to run: live_debug_e2e plus script task guidance tasks.