### PR TITLE
fix(maestro-case): document sequential task entry normalization

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -371,9 +371,11 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 **Entry Condition:**
 
-> **Valid WHEN rule types for task entry (strict subset of Key Rule 3):** `current-stage-entered` (default — fires when the containing stage is entered; typical for first task or any task with no sibling gate), `selected-tasks-completed("TaskA", "TaskB")` (fires when specific sibling tasks in the same stage complete), `wait-for-connector` (waits for a connector event), `adhoc` (user-triggered from the case app — task does not auto-start), `runs-sequentially` (sequential ordering within the stage; parallel task sets remain allowed, and the entry rule—not lane placement—carries the sequencing intent). Other rule types from Key Rule 3 are NOT valid here.
+> **Valid WHEN rule types for task entry (strict subset of Key Rule 3):** `current-stage-entered` (fires when the containing stage is entered; use for ungated event/condition-driven tasks, not for the first task in a sequential run), `selected-tasks-completed("TaskA", "TaskB")` (explicit sibling gate, fan-in, branch convergence, or non-immediate dependency), `wait-for-connector` (waits for a connector event), `adhoc` (user-triggered from the case app — task does not auto-start), `runs-sequentially` (sequential ordering within the stage; parallel task sets remain allowed, and the entry rule—not lane placement—carries the sequencing intent). Other rule types from Key Rule 3 are NOT valid here.
 >
 > Each row is a separate entry condition. List multiple rows when a task can be entered through more than one path. Author a `current-stage-entered` row for any ungated task — including connector tasks (`execute-connector-activity`, `wait-for-connector`) — that should start when its stage is entered.
+>
+> **Sequential normalization:** for a plain top-to-bottom task run, write `runs-sequentially` as the only Entry Condition row on every task in that run, including the first task. Do not model the run as `current-stage-entered` plus `selected-tasks-completed("<previous>")`; Studio Web classifies that as condition/event-driven, not Sequential.
 
 | WHEN | IF | Display Name |
 |------|-----|--------------|

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -46,6 +46,8 @@ The Case App selector has three distinct modes:
 
 `adhoc` is task-entry-only. It is never a stage entry rule and never a substitute for `wait-for-connector`.
 
+For generated SDDs, a plain immediate-predecessor chain should already be authored as `runs-sequentially`. If a task row says `selected-tasks-completed("<previous task>")`, preserve it only when the SDD is intentionally expressing a condition/event-driven sibling gate, branch convergence, or non-immediate dependency.
+
 ## Ordering
 
 Task entry conditions are created **after** all tasks in the stage have been added (so `selected-tasks-ids` can resolve).

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -459,12 +459,14 @@ Defines per-task detail blocks. Every task opens with an **Entry Condition** blo
 | Rule | When to use |
 |---|---|
 | `current-stage-entered` | First event-driven task in stage, or any ungated task (including connector tasks) that should start when its stage is entered. A first task in a sequential chain uses `runs-sequentially` instead. When a task has multiple entry rows, render this one first. |
-| `selected-tasks-completed("<Task>")` | Sibling-gated task (e.g., after upstream task in same stage). Multiple tasks comma-separated inside the parens. |
+| `selected-tasks-completed("<Task>")` | Explicit sibling gate, fan-in, branch convergence, or conditional handoff where this task should start only after named sibling task(s) complete. Multiple tasks comma-separated inside the parens. Do not use it merely to express the next step in a simple top-to-bottom task list; use `runs-sequentially` for that UI mode. |
 | `wait-for-connector` | Async connector callback. Pair with `conditionExpression` to gate on **case state** (`vars.X`); the event payload is not accessible (no `event` namespace). **In-rule extract-then-gate (extract + same-rule `=js:vars.caseVar` gate) does NOT work at runtime** — case-backend evaluates the gate before the extract populates the case var. To condition on payload content: extract `response.field -> caseVar` on the connector rule and place the case-state gate on a DOWNSTREAM stage-entry / task-entry condition. |
 | `adhoc` | Manual fire from the case app. Optional gating expression. |
 | `runs-sequentially` | Tasks that should run top-to-bottom in their stage declaration order. The frontend toggle writes this as the task's only entry rule; it is not represented by a lane. |
 
 Multiple entry conditions render as multiple rows (DNF outer-OR). When `current-stage-entered` is among them, render it first.
+
+**Sequential normalization rule.** When a contiguous set of tasks in one stage is described as a plain ordered workflow with no branch condition, fan-in, alternate trigger, or manually launched task between them, author **each task in that run** with exactly one `runs-sequentially` Entry Condition row. This includes the first task: do not write `current-stage-entered` for the first item and `selected-tasks-completed("<previous>")` for later items. That explicit chain is valid backend logic, but Studio Web classifies it as condition/event-driven rather than Sequential. Break the run at tasks that are `adhoc`, `wait-for-connector` entry-triggered by an external event, condition-gated, or intentionally dependent on non-immediate sibling task(s).
 
 ### `action` task — required cells
 


### PR DESCRIPTION
## What Changed

This PR tightens the `uipath-maestro-case` SDD/task-entry guidance so simple in-stage top-to-bottom task runs are authored as `runs-sequentially`, which is the marker Studio Web uses for the Sequential task mode.

Updated:
- `uipath-maestro-case/references/sdd-generation-rules.md`
- `uipath-maestro-case/assets/templates/sdd-template.md`
- `uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md`

## Problem

A generated case can be behaviorally ordered but still appear as event/condition-driven in Studio Web if the SDD expresses a plain task sequence as:

- first task: `current-stage-entered`
- later tasks: `selected-tasks-completed("<previous task>")`

That is valid backend gating, but it does not match the frontend Sequential selector. Studio Web classifies those tasks as condition/event-driven because Sequential is represented by the task-entry rule `runs-sequentially`.

## Root Cause

The skill already documented `runs-sequentially` in lower-level implementation guidance, but the SDD/template layer still left room for a generator to encode a plain immediate-predecessor chain as explicit entry conditions. Phase 1 then preserved that SDD literally into `tasks.md`, and Phase 3 implemented the explicit conditions correctly, producing the wrong Studio Web task mode.

## Decision

Normalize simple ordered in-stage task runs at the SDD-generation boundary: every task in a contiguous plain top-to-bottom run should get exactly one `runs-sequentially` Entry Condition row, including the first task.

`selected-tasks-completed` remains valid for intentional sibling gates, fan-in, branch convergence, conditional handoffs, and non-immediate dependencies. `current-stage-entered` remains valid for ungated event/condition-driven tasks that should start when the stage is entered.

## Behavioral Contract

After this change, future generated SDDs should preserve the frontend task-mode semantics:

- Sequential run: `runs-sequentially` only, on each task in declaration order.
- Event/condition-driven task: explicit authored condition such as `current-stage-entered`, `selected-tasks-completed`, or `wait-for-connector`.
- Adhoc/manual task: `adhoc` only, not mixed with sequential or event-entry rules.

The planning guidance also makes clear that a generated SDD should only preserve `selected-tasks-completed("<previous task>")` when it is intentionally modeling a condition/event-driven sibling gate rather than a plain ordered step.

## File Changes and Rationale

| File | Change | Why |
|---|---|---|
| `uipath-maestro-case/references/sdd-generation-rules.md` | Adds the sequential normalization rule and narrows when `selected-tasks-completed` should be used. | This is the primary authoring rule used by SDD generation. |
| `uipath-maestro-case/assets/templates/sdd-template.md` | Updates the Entry Condition template guidance to call out the Studio Web classification consequence. | Prevents future generated SDDs from encoding simple sequences in the event/condition-driven style. |
| `uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md` | Adds planner guidance to preserve predecessor gates only when intentionally condition/event-driven. | Keeps Phase 1 aligned with the corrected SDD intent. |

## Test Evidence

- `git diff --check origin/main...HEAD` passed.
- Verified the issue on the downstream CardTransactionDispute case by changing the generated artifacts to `runs-sequentially`, then running `uip maestro case validate ... --output json`; result was `Status: Valid`.
- Republished the downstream CardTransactionDispute solution after resource refresh to confirm the corrected caseplan remained uploadable.

## Known Limitations

This PR updates the skill guidance and template only. It does not add a new coder-eval regression task; that can be added separately if we want automated coverage for generated task-mode classification.

## Rollback Plan

Revert this commit. That restores the prior guidance, where plain ordered task runs could again be authored as explicit `current-stage-entered` plus `selected-tasks-completed` chains.