### PR TITLE
fix(rpa): match Given-When-Then via regex, accept any DisplayName prefix

### DIFF
--- a/tests/tasks/uipath-rpa/xaml_test_case.yaml
+++ b/tests/tasks/uipath-rpa/xaml_test_case.yaml
@@ -60,13 +60,16 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
-    description: "Test case uses the canonical Given-When-Then sub-sequence structure"
+  - type: file_check
+    description: "Test case uses the Given-When-Then sub-sequence structure (with or without the '... ' prefix)"
     path: "LoginTests/TestLoginSuccess.xaml"
-    includes:
-      - '"... Given"'
-      - '"... When"'
-      - '"... Then"'
+    patterns:
+      - pattern: 'DisplayName="[^"]*\bGiven\b'
+        must_match: true
+      - pattern: 'DisplayName="[^"]*\bWhen\b'
+        must_match: true
+      - pattern: 'DisplayName="[^"]*\bThen\b'
+        must_match: true
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
The xaml_test_case Given-When-Then criterion used literal file_contains matching on `"... Given"`/`"... When"`/`"... Then"`, which only passed for the canonical `... ` prefix. Valid variants such as `DisplayName="Login success Given"` failed despite being correct.

Switch to file_check with regex patterns matching the keyword as a whole word anywhere in the DisplayName value, so any prefix (or none) passes. Same weight (2.0) and pass_threshold (1.0) — all three keywords required.

It looks like the structure for the displayed name changed:

```
    <Sequence DisplayName="Login success Given" sap2010:WorkflowViewState.IdRef="Sequence_2" />
    <Sequence DisplayName="Login success When" sap2010:WorkflowViewState.IdRef="Sequence_3" />
    <Sequence DisplayName="Login success Then" sap2010:WorkflowViewState.IdRef="Sequence_4">
```