### PR TITLE
fix(governance): compliance-pack eval fixes

### DIFF
--- a/skills/uipath-governance/SKILL.md
+++ b/skills/uipath-governance/SKILL.md
@@ -46,7 +46,7 @@ Activate on **any** governance / policy / rule intent — even when the user did
 
 ## Critical Rules
 
-1. **Classify before authoring.** First action on any governance request is to classify intent into Branch A (AOps) or Branch B (Access). Use the priors in [`references/disambiguation-guide.md`](./references/disambiguation-guide.md). Never start `create` / `update` / `delete` until classification is settled — by user wording or by the [disambiguation question](#disambiguation-question).
+1. **Classify before authoring.** First action on any governance request is to classify intent into Branch A (AOps) or Branch B (Access). Use the priors in [`references/disambiguation-guide.md`](./references/disambiguation-guide.md). Never start `create` / `update` / `delete` until classification is settled — by user wording or by the [disambiguation question](#disambiguation-question). When you ask that question, it is the whole turn: render the numbered list, then end the turn and wait — issue no `uip` call and do no branch investigation until the user answers. **Exempt: read-only information queries.** A clause / recommendation lookup ("what does ISO 42001 clause X recommend?", "what does clause X say?", "recommend for clause X") is not authoring — route it straight to [`references/compliance-pack/query/impl.md`](./references/compliance-pack/query/impl.md), which answers from `catalog get`. Do NOT classify A/B, ask the disambiguation question, or run any `state` / posture / apply command for these.
 2. **Classification lives at the top.** Mechanic libraries assume the branch is chosen. Do not let those flows ask "did you mean the other branch?" — that question belongs here.
 3. **One branch per mutation.** A single user request produces a policy on one branch only. If the user wants both, run two sequential flows with two confirmation gates.
 4. **Each mechanic owns its own Critical Rules.** Once routed, follow the branch's rules — do not relax them from this top level.
@@ -58,7 +58,7 @@ Activate on **any** governance / policy / rule intent — even when the user did
 
 ## Workflow
 
-1. **Classify the intent silently — never announce routing to the user.** Internal flow labels (AOps / Access / Compliance standard) are implementation details; the user sees only the outcome. Read [`references/disambiguation-guide.md`](./references/disambiguation-guide.md) — it lists the strong signals for each flow, the phrase patterns that need disambiguation, and the canonical worked example. If a strong signal matches, route silently. If the phrasing is ambiguous (matches AOps or Access), ask the [disambiguation question](#disambiguation-question) and wait for a digit reply. If the user replies with anything other than `1` or `2`, treat it as a re-statement of intent and re-classify. **Do not run any CLI command before classification is settled** — the disambiguation question itself does not need `uip`, and an unrelated request (platform ops, agent authoring) must redirect to a sibling skill before any setup happens here. If the request contains a standard name (`ISO 42001`), `apply standard`, `compliance posture`, `drift check`, `am I compliant`, `is my tenant compliant`, `what packs are available`, `what packs are configured`, `which standards are enabled`, `organization-wide`, or `disable standard` → route silently to the appropriate compliance standard plugin. Read `partial-apply/planning.md` for scoped requests; `coverage/impl.md` for posture checks; `catalog/impl.md` for discovery; `query/impl.md` for information queries; `full-apply/impl.md` after confirming the posture plan; `disable/impl.md` for removal; `catalog/impl.md` + `state list` for listing currently configured packs.
+1. **Classify the intent silently — never announce routing to the user.** Internal flow labels (AOps / Access / Compliance standard) are implementation details; the user sees only the outcome. Read [`references/disambiguation-guide.md`](./references/disambiguation-guide.md) — it lists the strong signals for each flow, the phrase patterns that need disambiguation, and the canonical worked example. If a strong signal matches, route silently. If the phrasing is ambiguous (matches AOps or Access), ask the [disambiguation question](#disambiguation-question) and wait for a digit reply. If the user replies with anything other than `1` or `2`, treat it as a re-statement of intent and re-classify. **Do not run any CLI command before classification is settled** — the disambiguation question itself does not need `uip`, and an unrelated request (platform ops, agent authoring) must redirect to a sibling skill before any setup happens here. If the request contains a standard name (`ISO 42001`), `apply standard`, `compliance posture`, `drift check`, `am I compliant`, `is my tenant compliant`, `what packs are available`, `what packs are configured`, `which standards are enabled`, `organization-wide`, or `disable standard` → route silently to the appropriate compliance standard plugin. Read `partial-apply/planning.md` for scoped requests; `coverage/impl.md` for posture checks; `catalog/impl.md` for discovery; `query/impl.md` for information queries — clause / recommendation lookups ("what does clause X recommend / say", "recommend for clause X") answered via `catalog get`, never from memory and never via `state`; `full-apply/impl.md` after confirming the posture plan; `disable/impl.md` for removal; `catalog/impl.md` + `state list` for listing currently configured packs.
 2. **Verify `uip` and login** *(only after classification routes to a governance flow).*
    ```bash
    which uip && uip --version
@@ -73,16 +73,27 @@ Activate on **any** governance / policy / rule intent — even when the user did
 
 ## Disambiguation Question
 
-When the user's intent fits both branches, render exactly this numbered list (no `AskUserQuestion`, no table) and wait for a digit reply:
+When the user's intent fits both branches, your entire reply is the question below — **nothing before it, nothing after it**. Emit it verbatim as your visible response AND write the identical text to any output file the user asked for (e.g. `./output.txt`). No preamble ("this is ambiguous…"), no `AskUserQuestion`, no heading, no bold, no table, no trailing narration ("I wrote this to the file…"). Surrounding prose hides the numbered list from downstream readers and is the failure mode this format prevents.
 
-```markdown
-### Which layer should this rule govern?
+Emit exactly this plain text:
 
-1. **Govern the product** — control what Studio / StudioX / Assistant / Robot / AI Trust Layer / Agent Builder *can do* (e.g. block ChatGPT inside Studio, enforce Workflow Analyzer, disable a Marketplace widget). Backed by `uip gov aops-policy`.
-2. **Govern resource/tool use** — control which Actor Processes / identities can *invoke* which child Resource as a tool (e.g. block agents tagged `Sandbox` from being called, only let the finance group trigger this Flow). Backed by `uip gov access-policy`.
+```text
+Which layer should this rule govern?
 
-Reply with the number.
+1. Govern the product — control what Studio / StudioX / Assistant / Robot / AI Trust Layer / Agent Builder can do.
+2. Govern resource/tool use — control which identities can invoke which child resources as tools.
+
+Reply with 1 or 2.
 ```
+
+**This question is the entire turn — STOP after it.** The gate exists to pause, not to get a head start:
+
+- After emitting the question (and writing the identical text to the requested output file), end the turn (`end_turn`) and wait for the user's digit.
+- Make no `uip` call; do not read further references, investigate, stage, or "pre-flight" either branch. The only tool call allowed is writing this question to the output file.
+- Do not claim you have already created, configured, or deployed anything — you have not.
+- If the reply is not `1` or `2`, re-emit the same question verbatim and stop again. Never guess a branch.
+
+Mapping (for your own routing after the reply — do NOT include in the emitted question): option 1 → `uip gov aops-policy`, option 2 → `uip gov access-policy`.
 
 The canonical ambiguous prompt is *"Block ChatGPT for my finance team using Studio."* See [`references/disambiguation-guide.md`](./references/disambiguation-guide.md#worked-example--the-canonical-ambiguous-prompt) for the worked-out reasoning of why both interpretations produce a working but different artifact.
 

--- a/skills/uipath-governance/references/compliance-pack/coverage/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/coverage/impl.md
@@ -213,9 +213,14 @@ Clauses fully covered: 9 / 15  (was 7)  ·  Suppliers 2/5 → 3/5
 Remaining gaps: ask 'What does [clause] require?'
 ```
 
-## Never cache
+## Coverage freshness — one snapshot per tenant state
 
-Always run fresh before presenting a posture plan. Coverage reflects live tenant state.
+Coverage reflects **live tenant state at the moment it runs**. Run it fresh whenever that state may have changed:
+
+- a new posture request, or
+- after any mutation (`state enable` / `state disable`) — never present a posture plan or "after" count from a snapshot taken before the mutation.
+
+Within a **single, unchanged tenant state**, take ONE snapshot and reuse it for every file and view — do NOT re-run coverage to rebuild a file or "double-check" data you already have from that same snapshot. Re-reading unchanged state is the redundant-loop anti-pattern; re-reading *changed* state is mandatory freshness. (In full apply, the post-apply "after" figures come from a single `state get`, not a second coverage run.)
 
 ## Anti-patterns
 

--- a/skills/uipath-governance/references/compliance-pack/disable/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/disable/impl.md
@@ -11,8 +11,10 @@ TENANT_ID=$(grep '^UIPATH_TENANT_ID=' ~/.uipath/.auth | cut -d'=' -f2-)
 uip gov compliance-packs state get tenant $TENANT_ID <packId> --output json
 ```
 
-Decide from the `state get` result:
-- **Confirmed inactive** — a successful response with `Data.active == false`, or a 404: reply "ISO 42001 recommended settings are not currently configured on this tenant." and stop (nothing to remove).
+Decide from the `state get` result — inspect BOTH `Data.active` and `Data.policies`, never `active` alone:
+- **Clean — nothing to remove** — a successful response with `Data.active == false` AND `Data.policies` empty, or a 404: reply "ISO 42001 recommended settings are not currently configured on this tenant." and stop.
+- **Residual policies** — `Data.active == false` but `Data.policies` is non-empty: the standard is toggled off yet leftover policy artifacts remain, so "remove settings" is NOT yet satisfied. Proceed to the disable step to purge them, then report how many were removed.
+- **Active** — `Data.active == true`: proceed to the disable step (normal removal path).
 - **State could not be read** — `state get` failed with an auth/connection error (401 / 5xx) so `active` is unknown: do NOT claim "not configured." Proceed to the disable step and report whatever error that call surfaces. (A **403** → preview gate: see [preview-gate.md](../preview-gate.md).)
 
 ## Confirmation

--- a/skills/uipath-governance/references/compliance-pack/full-apply/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/full-apply/impl.md
@@ -6,6 +6,26 @@ Applies the entire compliance standard in one command. Backend creates and deplo
 
 **Note:** This configures settings recommended by ISO 42001. Your organization's auditor determines compliance status — UiPath does not certify compliance.
 
+## Bounded execution — run once, then stop
+
+This flow is fixed-length: ~5 commands. Run each command **exactly once** and reuse its saved output. Never re-run a discovery command to "double-check", and never loop per clause or per product. The sections below (Pre-condition → Confirmation → Apply → Verify → Report) are these steps in order — do not repeat any of them.
+
+1. `catalog get <packId>` → `catalog.json` (once). Source for all name/impact lookups.
+2. `state coverage tenant $ID <packId>` → `coverage.json` (once). The single posture snapshot — parse it one time; do not re-run coverage to rebuild a file you already have.
+3. Build `posture_plan.txt` from `catalog.json` + `coverage.json` in memory — no new commands.
+4. **Guardrail — nothing to apply:** if `Summary.NewCount == 0`, write the summary files with `applyPerformed: false` and STOP. Do NOT call `state enable`.
+5. **Apply once:** `state enable tenant $ID <packId>`. One backend call configures ALL recommended settings. Do NOT loop per product/clause and do NOT run `synthesize-formdata` — that helper is partial-apply only and has no role in full apply.
+6. **Verify once:** `state get tenant $ID <packId>` — the single post-apply check.
+7. Write `report.json` and finish. After this first verify, STOP: no extra coverage, no re-synthesis, no further diagnostics.
+
+**Stop conditions** — exit immediately when any holds:
+
+- `Summary.NewCount == 0` (already fully applied).
+- One `state enable` + one `state get` already completed.
+- You have already parsed the current coverage snapshot — reuse it, never re-fetch.
+
+Automated / non-interactive run (prompt says e.g. "do not prompt for confirmation"): skip the y/n Confirmation gate and run the ordered steps directly — do not stall waiting for input.
+
 ## Pre-condition
 
 Coverage (posture analysis) has been run and presented. At least one policy has `status: "new"`.
@@ -79,6 +99,31 @@ SUMMARY
 Applied by: <UIPATH_USER from ~/.uipath/.auth>  ·  <tenantName>  ·  <date>
 Note: compliance status is determined by your auditor, not this tool.
 ```
+
+## report.json (compact run summary — write once)
+
+When the request asks for a machine-readable summary file, write exactly this shape once, at the end:
+
+```json
+{
+  "packId": "iso-42001-2023",
+  "packVersion": "<catalog Data.PackVersion>",
+  "posture": {
+    "preApplyCoverage": {
+      "notYetAppliedSettings": "<Summary.NewCount before apply>",
+      "totalSettings": "<Summary.TotalCount>"
+    },
+    "postApplyVerification": {
+      "active": "<Data.active from the single state get>",
+      "appliedSettings": "<in-place policy count after apply>",
+      "totalSettings": "<Summary.TotalCount>"
+    }
+  },
+  "applyPerformed": true
+}
+```
+
+Counts come straight from the single coverage snapshot (pre) and the single `state get` (post) — never recompute by re-running commands. `applyPerformed` is `false` only on the `NewCount == 0` guardrail path.
 
 ## Org-scope deployment (all tenants)
 

--- a/skills/uipath-governance/references/compliance-pack/partial-apply/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/partial-apply/impl.md
@@ -11,9 +11,21 @@ Synthesizes and deploys AOPS policies for the NLP-matched clause/product subset 
 - `targetClauseIds` — comma-separated ISO clauseIds matched from catalog
 - `targetProducts` — list of productIdentifiers matched from catalog
 
+## Step 0: Get the pack catalog first (required)
+
+The `synthesize-formdata` script reads `catalog.json`, so `catalog get` MUST run before Step 1. If `$SESSION_TEMP/catalog.json` does not exist yet, run it now (see `catalog/impl.md`):
+
+```bash
+uip gov compliance-packs catalog get <packId> --output json > "$SESSION_TEMP/catalog.json"
+```
+
+Do not synthesize, hand-roll formData, or default any value without this file — the catalog is the only source of which controls exist and which are org-specific.
+
 ## Step 1: Synthesize formData overrides per product
 
-Run the shipped [`synthesize-formdata`](synthesize-formdata-guide.md) script (args, exit codes, and warning handling are in that guide). For each `productIdentifier` in `targetProducts`:
+Run the shipped [`synthesize-formdata`](synthesize-formdata-guide.md) script (args, exit codes, and warning handling are in that guide) — it is the ONLY sanctioned way to build formData overrides, and it surfaces the `notEmpty` prompts in Step 1b. Do NOT hand-roll a substitute or default the values; running it is mandatory even when every org-specific value will be answered SKIP.
+
+For each `productIdentifier` in `targetProducts`:
 
 ```bash
 # Read the session dir written by catalog get — same unique dir across all tool calls.
@@ -38,9 +50,15 @@ Exit 3 = no contributions for this product in these clauses → skip it, continu
 
 ## Step 1b: Collect user-specific values (if any)
 
-After running `synthesize-formdata.mjs`, check **stderr** for `⚠` warning lines indicating settings that need org-specific values. (The script uses `console.warn` which writes to stderr, not stdout.)
+After running `synthesize-formdata`, check **stderr** for `⚠` warning lines. (The script uses `console.warn`, which writes to stderr.) Each line names the control key and its required-operator class — branch on the class, do NOT treat every `⚠` line as a value prompt:
 
-For each warned key, ask the user before proceeding:
+- **`notEmpty`** — an org-specific value the user must supply. Prompt for it (below).
+- **`exists`** — an access-policy check, not a formData value; there is nothing to type. Surface it as a manual-configuration note in the Step 4 review gate; do NOT prompt.
+- **unknown operator** — surface as a manual-configuration note; do NOT prompt.
+
+Detection is by operator class (matched from the script's structured warning), not a fixed message string — new controls with the same class are handled automatically.
+
+For each `notEmpty` key, ask the user before proceeding:
 
 ```
 Some recommended settings require values specific to your organization.
@@ -54,6 +72,8 @@ Some recommended settings require values specific to your organization.
 Accept responses:
 - Non-empty list → write the parsed array into `$SESSION_TEMP/overrides/<product>.json` at the warned key path before moving to Step 2
 - `SKIP` → leave the key absent from overrides; surface it in the AOps review gate (Step 4) as a setting that needs manual configuration, with the setting's `configLocation` from catalog
+
+**Do not proceed to Step 2 until every `notEmpty` prompt is resolved** — each answered with a value or an explicit SKIP. Never continue the apply with placeholder or default values while a required value is still outstanding. Run the `synthesize-formdata` script once per product: the warnings from that single run are the complete list — do not re-run it to re-check.
 
 **Writing collected values into overrides (example for URL list):**
 

--- a/skills/uipath-governance/references/compliance-pack/query/impl.md
+++ b/skills/uipath-governance/references/compliance-pack/query/impl.md
@@ -12,7 +12,9 @@ Pure information — no state commands, no mutations. Uses `catalog get` data on
 - "Show me all High-impact controls"
 - "What does the AI Trust Layer traceability section require?"
 
-## Command (if not already fetched)
+## Command — always answer from catalog data (required)
+
+Clause and recommendation answers MUST come from `catalog get` output — never from memory, general knowledge, or a paraphrase. Recommended settings are versioned inside the pack; only the CLI returns the authoritative values. Do not answer the question until you have catalog data in hand. Run `catalog get` now if `$SESSION_TEMP/catalog.json` does not already exist this session (reuse it if it does).
 
 ```bash
 # Read the session dir written by catalog get; run catalog get if not yet fetched this session.

--- a/tests/tasks/uipath-governance/compliance-pack/already_configured_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/already_configured_smoke.yaml
@@ -36,7 +36,7 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent ran state coverage to check current posture"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/apply_commands_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/apply_commands_smoke.yaml
@@ -38,14 +38,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent ran state coverage for posture analysis before apply"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state enable for full pack configuration"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/check_routing_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/check_routing_smoke.yaml
@@ -35,14 +35,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state coverage for posture analysis"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/disable_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/disable_smoke.yaml
@@ -32,14 +32,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent checked current pack state before disabling"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+get\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+get\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state disable to remove standard settings"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+disable\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+disable\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/disambiguation_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/disambiguation_smoke.yaml
@@ -69,3 +69,20 @@ success_criteria:
     command_pattern: 'uip\s+gov\s+access-policy\s+(create|update|delete|activate)'
     weight: 2.0
     pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Agent captured its disambiguation response to output.txt"
+    path: "output.txt"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "output.txt contains the verbatim numbered disambiguation question (deterministic, judge-independent)"
+    path: "output.txt"
+    includes:
+      - "Which layer should this rule govern?"
+      - "1. Govern the product"
+      - "2. Govern resource/tool use"
+      - "Reply with 1 or 2"
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/full_apply_e2e_live.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/full_apply_e2e_live.yaml
@@ -46,14 +46,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Step 1: Agent called catalog get for ISO 42001"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001-2023|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+["'']?(?:iso-42001-2023|\$\{?\w+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Step 2: Agent called state coverage for posture analysis"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001-2023|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001-2023|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -68,6 +68,38 @@ success_criteria:
     description: "Full apply does NOT use pack-walker.mjs (removed)"
     command_pattern: 'pack-walker\.mjs'
     weight: 1.5
+    pass_threshold: 1.0
+
+  # Bounded execution — catch the runaway command loop that timed the turn out at 900s.
+  # A correct full-apply run is ~5 commands: catalog get + coverage (once each), one
+  # state enable (+1 permitted retry), one state get verify. These caps give headroom
+  # over the happy path while failing hard on a re-read/re-synthesis loop.
+  - type: command_not_executed
+    description: "Bounded: state coverage runs at most twice (no re-read loop)"
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage'
+    max_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Bounded: state enable runs at most twice (single apply + at most one retry)"
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable'
+    max_count: 2
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Bounded: state get (verify) runs at most twice"
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+get'
+    max_count: 2
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Full apply must NOT run synthesize-formdata (partial-apply only; per-product synthesis loop is the timeout culprit)"
+    command_pattern: 'synthesize-formdata'
+    max_count: 0
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-governance/compliance-pack/gap_scan_commands_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/gap_scan_commands_smoke.yaml
@@ -32,14 +32,14 @@ initial_prompt: |
 success_criteria:
   - type: command_executed
     description: "Agent called catalog get for pack detail"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state coverage for posture analysis"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+(?:tenant|organization)\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/interactive_values_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/interactive_values_smoke.yaml
@@ -31,7 +31,9 @@ initial_prompt: |
   Capture all command output to ./output.txt
   (use `> output.txt 2>&1` for the first command, `>> output.txt 2>&1` for the rest).
 
-  If you're asked for the URL or application lists, just answer SKIP for now.
+  When the synthesize step surfaces settings needing URL or application lists,
+  answer SKIP for those. SKIP is your answer to that detected prompt — you still
+  must run the synthesize/detection step, not bypass it.
   Important:
   - uip CLI not connected — auth errors expected. Run each command once and continue.
   - Always pass --output json. Do NOT prompt for confirmation.
@@ -48,7 +50,7 @@ success_criteria:
 
   - type: command_executed
     description: "Agent invoked synthesize-formdata.mjs for Robot UIAutomation partial apply"
-    command_pattern: 'synthesize-formdata\.mjs'
+    command_pattern: 'node\s+.*synthesize-formdata\.mjs'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
@@ -57,4 +59,18 @@ success_criteria:
     description: "Command output captured to output.txt"
     path: "output.txt"
     weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "No apply before values: does NOT create a policy while org-specific values are unresolved (SKIP)"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+create'
+    max_count: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Partial apply must NOT use state enable (full-standard path)"
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable'
+    max_count: 0
+    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/org_scope_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/org_scope_smoke.yaml
@@ -41,14 +41,14 @@ success_criteria:
 
   - type: command_executed
     description: "Agent ran state coverage at tenant scope (per-tenant iteration)"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+tenant\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+coverage\s+tenant\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
     description: "Agent called state enable at tenant scope (not organization scope)"
-    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+tenant\s+\S+\s+(?:iso-42001|\$\S+)'
+    command_pattern: 'uip\s+gov\s+compliance-packs\s+state\s+enable\s+tenant\s+\S+\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/partial_apply_aitl_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/partial_apply_aitl_smoke.yaml
@@ -31,7 +31,9 @@ initial_prompt: |
   Capture all command output to ./output.txt
   (use `> output.txt 2>&1` for the first command, `>> output.txt 2>&1` for the rest).
 
-  If you're asked which AI model providers to approve, just answer SKIP for now.
+  When the synthesize step surfaces the approved AI model providers setting,
+  answer SKIP for it. SKIP is your answer to that detected prompt — you still
+  must run the synthesize/detection step, not bypass it.
   Important:
   - uip CLI not connected — auth errors expected. Run each command once and continue.
   - Always pass --output json. Do NOT prompt for confirmation.
@@ -48,7 +50,7 @@ success_criteria:
 
   - type: command_executed
     description: "Agent invoked synthesize-formdata.mjs for AI Trust Layer model governance"
-    command_pattern: 'synthesize-formdata\.mjs'
+    command_pattern: 'node\s+.*synthesize-formdata\.mjs'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/partial_apply_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/partial_apply_smoke.yaml
@@ -46,7 +46,7 @@ success_criteria:
 
   - type: command_executed
     description: "Agent invoked synthesize-formdata.mjs for AI Trust Layer partial apply"
-    command_pattern: 'synthesize-formdata\.mjs'
+    command_pattern: 'node\s+.*synthesize-formdata\.mjs'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/compliance-pack/query_clause_general_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/query_clause_general_smoke.yaml
@@ -1,8 +1,10 @@
-task_id: skill-governance-compliance-query-clause
+task_id: skill-governance-compliance-query-clause-general
 description: >
-  Skill-guided: "what does ISO 42001 compliance standard clause A.6.2.8 recommend?" must use
-  catalog get only - zero state commands, zero mutations. Tests that information-only queries
-  stay in the query plugin and never trigger apply flows.
+  Skill-guided: a general (non-tenant-scoped) clause question "what does ISO 42001
+  clause A.6.2.8 recommend?" must stay on the query path - catalog get only, zero
+  state commands, zero mutations. Companion to query_clause_smoke.yaml (which scopes
+  the same question to "my tenant"); this keeps clause-query behavior stable when no
+  tenant is named so the answer still comes from the catalog, not from memory.
 
   Platform note: uip commands fail with auth errors - expected.
 tags: [uipath-governance, smoke, mode:operate, lifecycle:discover, feature:compliance]
@@ -18,7 +20,7 @@ post_run:
     timeout: 120
 
 initial_prompt: |
-  What does ISO 42001 clause A.6.2.8 recommend for my UiPath tenant?
+  What does ISO 42001 clause A.6.2.8 recommend?
 
   Capture all command output to ./output.txt
   (use `> output.txt 2>&1` for the first command, `>> output.txt 2>&1` for the rest).
@@ -28,7 +30,7 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent called catalog get to retrieve clause recommendations"
+    description: "Agent called catalog get to retrieve clause recommendations (not answered from memory)"
     command_pattern: 'uip\s+gov\s+compliance-packs\s+catalog\s+get\s+["'']?(?:iso-42001|\$\{?\w+)'
     min_count: 1
     weight: 3.0


### PR DESCRIPTION
Re-authored port of the governance compliance-pack eval fixes onto current `main`.

## Why a new PR
The original PR (#2077) targeted `feat/governance-skills-latest`, which is unmerged and now behind main. Main has since diverged (compliance-pack now ships `.mjs` scripts + a synthesize guide), so the fixes were **re-authored against main's current files** rather than rebased — a plain rebase conflicted because the branch's fixes were written against the feat branch's older skill state.

## Fixes (six)
1. **Grading** — loosen `command_executed` pack-id regexes to accept `"$VAR"` / `${VAR}` quoting across all compliance-pack tasks (including the 5 siblings a reviewer flagged for consistency on #2077); tighten synthesize checks to require `node` execution so a `sed`/`cat` *view* no longer scores as "invoked".
2. **Disambiguation** — SKILL.md emits the numbered layer question **verbatim as the whole turn** (plain text, no narration), then ends the turn; `disambiguation_smoke` asserts it **deterministically** via `file_contains`, not judge inference.
3. **Disable** — branch on `active` AND `policies`: reconcile (disable) when toggled off but residual policies remain. (Main already had the auth-error carve-out.)
4. **Full apply** — bounded lifecycle (each command once, stop after one verify) to fix the 900s timeout; coverage freshness reworded to be state-change-aware; `report.json` schema defined; bounded `command_not_executed max_count` guardrails in the e2e task.
5. **Partial apply** — explicit Step 0 `catalog get`; class-based Step 1b (`notEmpty`→prompt, `exists`/unknown→manual note); no-apply-before-values guard; synthesize mandatory (no hand-rolled substitute).
6. **Clause query** — route read-only clause/recommendation lookups straight to `query/impl.md` via `catalog get` (exempt from A/B classify + disambiguation); `catalog get` mandatory (never answered from memory); new `query_clause_general_smoke.yaml`.

## Verification
**Not eval-verified** — `coder_eval` is an external harness and repo CI is currently blocked on a missing `coder-eval-agent` image (unrelated to this PR). Statically validated: all compliance-pack YAML parses, quoting regexes match quoted + unquoted forms, and the disambiguation test's asserted substrings are confirmed present in the skill's canonical block (drift guard).

Supersedes #2077 (which will be closed).

Generated with Claude Code