### PR TITLE
fix(tests): grade troubleshoot dialogs with include_dialog instead of last-turn-only judging

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -294,7 +294,7 @@ Every `llm_judge` criterion across all troubleshoot tasks uses the **same** prom
 - `include_reference: true` — passes `RESOLUTION.md` (the file named under `reference:` at the task root)
 - `include_agent_output: true` — passes the agent's final user-facing response
 
-That is **all** the context the judge gets. The contract: agent's final answer vs. RESOLUTION.md → score. Tool calls are deliberately excluded — the judge grades the presented diagnosis, not how it was reached.
+That is **all** the context the judge gets. The contract: agent's diagnosis (wherever it appears in the dialog) vs. RESOLUTION.md → score. Tool calls are deliberately excluded — the judge grades the presented diagnosis, not how it was reached.
 
 **Forbidden on `llm_judge`:**
 

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-null-connection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-null-connection/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
@@ -70,6 +70,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.
@@ -83,5 +84,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-  check_criteria: every_turn
-  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.
@@ -86,5 +87,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-  check_criteria: every_turn
-  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.
@@ -96,5 +97,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-  check_criteria: every_turn
-  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-no-license/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.
@@ -91,5 +92,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-  check_criteria: every_turn
-  stop_on_criteria_pass: true

--- a/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
@@ -41,6 +41,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     include_tool_calls: true
     prompt: |
@@ -104,5 +105,3 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
   max_turns: 6
-  check_criteria: every_turn
-  stop_on_criteria_pass: true


### PR DESCRIPTION
The llm_judge in simulation-mode troubleshoot tasks graded only the final dialog turn. When the simulated user keeps talking after the resolution (confirmation questions, cleanup, handoffs), the final turn is chit-chat and correct diagnoses get scored 0 - 4 false failures in the 2026-07-22 gemini nightly (healing-agent-no-license, execute-query-null-connection, agent-llm-insufficient-information, excel-rr-nre-opaque), all with the correct diagnosis verbatim in turn 1.

Fix: add `include_dialog: true` to the llm_judge criterion of the 4 affected tasks so the judge sees the whole conversation, and replace the `check_criteria: every_turn` + `stop_on_criteria_pass` workaround on the 5 tasks from #2159 with the same flag (keeps the full dialog, including post-resolution turns, gradeable). Scoped to these 9 tasks; the canonical judge block is unchanged.

Dialog sizes are safe: max full-dialog size across all 114 troubleshoot tasks in the last nightly is ~28k chars vs the 80k max_dialog_chars cap.

Passing runs (local, antigravity/gemini-3.5-flash, the agent that exposed the issue): the 4 nightly-failing tasks score 1.0 / 1.0 / 0.925 / 0.925 with include_dialog (previously 0.25-0.625), plus a repeat round 4/4 including a 2-turn dialog passing at 0.85.