### PR TITLE
feat(sprint-cut): Slack release announcement to #team-coding-agents (+ open bump PR on publish failure)

### DIFF
--- a/.github/workflows/scripts/slack-sprint-cut-notify.mjs
+++ b/.github/workflows/scripts/slack-sprint-cut-notify.mjs
@@ -1,0 +1,90 @@
+// Posts the sprint-cut announcement to Slack (chat.postMessage; mirrors
+// UiPath/cli). Driven by the real step outcomes passed in as env vars, so the
+// message reflects what actually happened. Emojis match Studio's Sprint Release
+// Bot (#dev-studio-robot): :checkbox_ticked: succeeded · :warning: failed/skipped.
+
+const SLACK_URL = "https://slack.com/api/chat.postMessage";
+
+const token = requireEnv("SLACK_BOT_TOKEN");
+const channel = requireEnv("CHANNEL_ID");
+const repo = process.env.REPO_URL || "https://github.com/UiPath/skills";
+const runUrl = process.env.RUN_ID ? `${repo}/actions/runs/${process.env.RUN_ID}` : repo;
+
+const line = requireEnv("CUT_LINE");                 // e.g. 1.199
+const version = `${line}.0`;                          // 1.199.0
+const nextVersion = `${requireEnv("NEXT_LINE")}.0`;  // 1.200.0
+
+const cutOk = process.env.CUT_OUTCOME === "success";
+const publishOk = process.env.PUBLISH_OUTCOME === "success";
+const bumpOk = process.env.BUMP_OUTCOME === "success";
+const bumpUrl = process.env.BUMP_URL || "";
+
+const branchUrl = `${repo}/tree/release/v${line}`;
+// Exact preview version is stamped by publish.yml (<version>-preview.<run>).
+// If we have it, link the precise npmjs version; else fall back to versions tab.
+const previewVersion = process.env.PREVIEW_VERSION || "";
+const npmUrl = previewVersion
+  ? `https://www.npmjs.com/package/@uipath/skills/v/${previewVersion}`
+  : "https://www.npmjs.com/package/@uipath/skills?activeTab=versions";
+const previewLabel = previewVersion
+  ? `\`@uipath/skills@${previewVersion}\``
+  : `\`@uipath/skills@${version}-preview\``;
+
+const OK = ":checkbox_ticked:";
+const WARN = ":warning:";
+
+// Branch line
+const branchLine = cutOk
+  ? `${OK} Release branch \`release/v${line}\` cut from \`main\` (version \`${version}\`, <${branchUrl}|view branch>)`
+  : `${WARN} Release branch \`release/v${line}\` cut from \`main\` FAILED (<${runUrl}|see logs>)`;
+
+// Preview package line
+let previewLine;
+if (publishOk) {
+  previewLine = `${OK} Preview package published to npmjs — ${previewLabel} (<${npmUrl}|view on npmjs>)`;
+} else if (!cutOk) {
+  previewLine = `${WARN} Preview package publish skipped`;
+} else {
+  previewLine = `${WARN} Preview package publish to npmjs FAILED — ${previewLabel} (<${runUrl}|see logs>)`;
+}
+
+// Version-bump PR line
+let bumpLine;
+if (bumpOk && bumpUrl) {
+  bumpLine = publishOk
+    ? `${OK} Version-bump PR opened: \`main\` → \`${nextVersion}\` (<${bumpUrl}|PR>)`
+    : `${OK} Version-bump PR opened anyway: \`main\` → \`${nextVersion}\` (<${bumpUrl}|PR>) — ${WARN} verify the failed publish before merging`;
+} else if (bumpOk && !bumpUrl) {
+  bumpLine = `${OK} \`main\` already on \`${nextVersion}\` — no bump PR needed`;
+} else {
+  bumpLine = `${WARN} Version-bump PR not opened — \`main\` stays on \`${version}\``;
+}
+
+const overall = cutOk && publishOk ? OK : WARN;
+const text = [
+  `${overall} *Sprint release cut — \`${line}\`*`,
+  branchLine,
+  previewLine,
+  bumpLine,
+].join("\n");
+
+const res = await fetch(SLACK_URL, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${token}`,
+    "Content-Type": "application/json; charset=utf-8",
+  },
+  body: JSON.stringify({ channel, text, unfurl_links: false }),
+});
+const data = await res.json();
+// Slack returns HTTP 200 even on logical failure — check the ok field.
+if (!res.ok || data.ok !== true) {
+  throw new Error(`Slack post failed: ${data.error || `${res.status} ${res.statusText}`}`);
+}
+console.log(`Posted sprint-cut announcement to ${channel} (ts=${data.ts}).`);
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) throw new Error(`Missing ${name} environment variable.`);
+  return v;
+}

--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -187,12 +187,13 @@ jobs:
           # doesn't return the run id, so record the newest workflow_dispatch
           # run for this branch, dispatch, then poll for the new run id and
           # `gh run watch --exit-status` it (non-zero if the run failed). If a
-          # publish fails, this step fails and the next step (main bump, gated
-          # on success()) is skipped — main only advances on a clean publish.
+          # publish fails, this step fails; the bump PR is still opened (with a
+          # warning) and the notification reports the failure — see those steps.
           #   - channel=dev     -> $LINE.0-dev.<run>     on GitHub Packages
           #   - channel=preview -> $LINE.0-preview.<run> on npmjs (--provenance)
           # Stable (`latest`) is intentionally NOT published — promote a line
           # to stable manually when it is ready (see docs/RELEASE.md).
+          RESULT_RUN_ID=""
           dispatch_and_wait() {
             channel="$1"
             before=$(gh run list --workflow publish.yml --branch "$BRANCH" \
@@ -212,13 +213,19 @@ jobs:
               echo "::error::Timed out finding the dispatched publish.yml run for channel=$channel."
               return 1
             fi
+            RESULT_RUN_ID="$run_id"
             echo "Watching publish.yml run $run_id (channel=$channel)..."
             gh run watch "$run_id" --exit-status --interval 15
           }
 
           dispatch_and_wait dev
           dispatch_and_wait preview
-          echo "Both publishes ($LINE.0-dev / $LINE.0-preview) succeeded."
+          # publish.yml stamps the preview as $LINE.0-preview.<run_number>; the
+          # notification links the exact npmjs version, so surface it here.
+          PREVIEW_RUN_NUMBER=$(gh run view "$RESULT_RUN_ID" --json number --jq '.number')
+          PREVIEW_VERSION="$LINE.0-preview.$PREVIEW_RUN_NUMBER"
+          echo "preview_version=$PREVIEW_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Both publishes ($LINE.0-dev / $PREVIEW_VERSION) succeeded."
 
       - name: Open version-bump PR against main
         id: mainbump
@@ -290,3 +297,26 @@ jobs:
             echo "- published (waited for success): DEV (GitHub Packages) + PREVIEW (npmjs) of \`@uipath/skills@${{ steps.target.outputs.cut_line }}.0\` (stable stays manual)"
             echo "- bump PR opened (-> \`${{ steps.target.outputs.next_line }}.0\`): ${{ steps.mainbump.outputs.url }} — approve + merge to advance main"
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Announce the cut on Slack (#team-coding-agents)
+        # Post the announcement regardless of earlier failures (always()), but
+        # only for a real cut (proceed, not dry_run). continue-on-error so a
+        # Slack hiccup never turns a good cut into a failed job. The message
+        # reports the real outcome of each step (branch / preview / bump PR)
+        # with Studio-style emojis; SLACK_BOT_TOKEN must belong to a bot that
+        # is a member of the channel.
+        if: always() && steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CHANNEL_ID: 'C0A2T23NJ59'   # #team-coding-agents
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          CUT_LINE: ${{ steps.target.outputs.cut_line }}
+          NEXT_LINE: ${{ steps.target.outputs.next_line }}
+          CUT_OUTCOME: ${{ steps.cutbranch.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          PREVIEW_VERSION: ${{ steps.publish.outputs.preview_version }}
+          BUMP_OUTCOME: ${{ steps.mainbump.outcome }}
+          BUMP_URL: ${{ steps.mainbump.outputs.url }}
+        run: node .github/workflows/scripts/slack-sprint-cut-notify.mjs

--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -16,11 +16,11 @@ name: Sprint Release Cut
 #      push can't trigger publish.yml (GITHUB_TOKEN recursion guard), so the
 #      dispatches are explicit. Stable (`latest`) is NOT published here —
 #      promote a line to stable MANUALLY (see docs/RELEASE.md)
-#   3. opens a PR bumping main to the NEXT line (M.(N+1).0), only after step 2
-#      succeeds; a maintainer merges it to advance main so development
-#      continues there while release/v<M.N> stabilizes. main is protected on a
-#      public repo, so the cut does NOT push to main or use a bypass credential
-#      (see docs/RELEASE.md § Automating the bump)
+#   3. opens a PR bumping main to the NEXT line (M.(N+1).0). The PR is opened
+#      even if step 2's publish failed — with a :warning: in the PR body — so
+#      main can still advance; a maintainer reviews the warning before merging.
+#      main is protected on a public repo, so the cut does NOT push to main or
+#      use a bypass credential (see docs/RELEASE.md § Automating the bump)
 #
 # No cross-repo secret is required, gated to the CLI's 14-day cadence (anchor
 # below). The cli-repo side cuts itself, in lockstep, from the same anchor.
@@ -222,11 +222,16 @@ jobs:
 
       - name: Open version-bump PR against main
         id: mainbump
-        # `success()` so this runs ONLY when the publish step above succeeded —
-        # main advances only after a clean dev + preview publish.
-        if: success() && steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
+        # Open the bump PR even if the publish step failed: gate on the branch
+        # cut (always() + cutbranch success), NOT on publish. The bump is about
+        # advancing main to the next line, which is independent of the publish;
+        # a failed publish adds a :warning: to the PR body and a maintainer
+        # decides whether to merge. (Publish failure still fails the job overall,
+        # so the failure stays visible.)
+        if: always() && steps.cutbranch.outcome == 'success' && steps.target.outputs.proceed == 'true' && github.event.inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
         run: |
           set -euo pipefail
           CUT_LINE="${{ steps.target.outputs.cut_line }}"
@@ -259,11 +264,18 @@ jobs:
             echo "main already at $NEXT_LINE.0 — no bump PR needed."
             exit 0
           fi
+          BODY="Automated sprint cut: \`release/v$CUT_LINE\` was cut. Merge to advance \`main\` to \`$NEXT_LINE.0\` so development continues on the next line. Stable \`$CUT_LINE.0\` is promoted manually — see docs/RELEASE.md."
+          if [ "${PUBLISH_OUTCOME:-}" = "success" ]; then
+            BODY="$BODY"$'\n\n'":white_check_mark: dev + preview builds published from \`release/v$CUT_LINE\`."
+          else
+            BODY="$BODY"$'\n\n'":warning: The dev/preview publish did **not** succeed (outcome: \`${PUBLISH_OUTCOME:-unknown}\`). This bump PR was opened anyway — verify the publish from the run logs before merging."
+          fi
+
           git commit -m "chore(release): bump main to $NEXT_LINE.0 after cutting $CUT_LINE"
           git push origin "HEAD:$PR_BRANCH"
           URL=$(gh pr create --head "$PR_BRANCH" --base main \
             --title "chore(release): bump main to $NEXT_LINE.0 (sprint cut)" \
-            --body "Automated sprint cut: \`release/v$CUT_LINE\` was cut and its dev + preview builds published. Merge to advance \`main\` to \`$NEXT_LINE.0\` so development continues on the next line. Stable \`$CUT_LINE.0\` is promoted manually — see docs/RELEASE.md.")
+            --body "$BODY")
           echo "url=$URL" >> "$GITHUB_OUTPUT"
           echo "Opened bump PR: $URL — approve + merge to advance main to $NEXT_LINE.0."
 


### PR DESCRIPTION
## What

Adds a Slack **announcement** to the biweekly sprint release cut, posting to **#team-coding-agents**, and makes the version-bump PR open even when the publish fails.

Two related changes to `sprint-release-cut.yml`, one coherent feature:

### 1. Announce the cut on Slack (new final step)
A final `always()` / `continue-on-error` step posts one status message reporting the **real outcome** of each step, with Studio-style emojis (`:checkbox_ticked:` succeeded · `:warning:` failed/skipped):

- Release branch cut + version + **link to the branch**
- **Preview package** published to npmjs + **link to the exact `-preview.<run>` version** (the publish step now surfaces the stamped version)
- Version-bump PR (opened / opened-anyway-with-warning / not-opened)

Mechanism mirrors UiPath/cli (`coverage-weekly.yml`): `SLACK_BOT_TOKEN` + `chat.postMessage` by channel ID. `continue-on-error` so a Slack hiccup never fails an otherwise-good cut.

### 2. Open the bump PR even if the publish fails
The bump PR advances `main` to the next line — independent of the publish. It now gates on the **branch cut** (`always() && steps.cutbranch.outcome == 'success'`) instead of publish success, and the PR body carries a `:warning:` when the publish didn't succeed. Publish failure still fails the job overall.

## Testing

The notify script (`slack-sprint-cut-notify.mjs`) was smoke-tested against a test channel with mock step outcomes across all three scenarios (success / preview-failed / branch-cut-failed) — rendering verified. The full cut path can't be run without a real cut+publish, so that wiring is verified by review.

## Prerequisite before this posts

The `SLACK_BOT_TOKEN` bot must be **invited to #team-coding-agents** (`chat.postMessage` fails with `not_in_channel` otherwise).

🤖 Generated with [Claude Code](https://claude.com/claude-code)