### PR TITLE
ci(smoke-rpa): install uip CLI + RPA tools from GitHub Packages @dev

### DIFF
--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -133,39 +133,63 @@ jobs:
             --password "${{ secrets.UV_INDEX_UIPATH_PASSWORD }}" \
             --store-password-in-clear-text
 
-      # Install from public npm. The `--@uipath:registry=` flag forces
-      # the `@uipath` scope to public npm even if some `.npmrc` (runner
-      # image, user-level, or setup-node config) maps it elsewhere —
-      # notably the internal GitHub Packages feed, which carries
-      # divergent `1.0.0-alpha.*` prereleases under the same scope.
-      # Plain `--registry=` does NOT bypass scope mappings; only the
-      # scope-specific override does.
+      # Install from GitHub Packages `@dev` — the live prerelease train
+      # published on every push to `cli/main`. Public npm mirrors the same
+      # releases ~2 weeks later, so pulling `@latest` from public npm made
+      # RPA-Windows tasks exercise a stale CLI that could miss freshly
+      # renamed/added verbs. `@dev` keeps this runner in lockstep with the
+      # Linux smoke image, which builds from the same `@dev` tag (see
+      # smoke-skills.yml and tests/docker/Dockerfile).
       #
-      # Pin `@uipath/rpa-tool` to the `^0.9` line (currently 0.9.1) to
-      # avoid silently picking up `1.0.0-alpha.*` if `latest` ever
-      # shifts. `@uipath/cli` and `@uipath/rpa-legacy-tool` stay on
-      # `latest` (only the rpa-tool line has the alpha divergence).
+      # The `@uipath` scope is mapped to npm.pkg.github.com via a temp npmrc
+      # (token from GH_PAT, read:packages). EVERY package is pinned to the
+      # explicit `@dev` dist-tag: the same feed also carries a FROZEN `alpha`
+      # tag (1.197.0-alpha.*) and the public `latest` line — never rely on
+      # `latest`/unspecified here, which could resolve to a stale line. The
+      # npmrc is written and deleted inside this step so the token never
+      # lingers on the runner.
       #
-      # `npm install -g` runs from a fresh tempdir so any future
-      # workspace-aware `package.json` at the repo root cannot pull
-      # the install into a workspace context. `npm install -g` lands
-      # under `<npm-prefix>/@uipath/`, where uipcli's ToolManager
-      # discovers tools, so `uip rpa …` / `uip rpa-legacy …` resolve
-      # without triggering auto-install.
-      - name: Install uip CLI + RPA tools (public npm, rpa-tool >=0.9)
+      # Tools are installed with raw `npm install -g @uipath/<tool>@dev`, NOT
+      # `uip tools install`: on a `-dev` CLI the latter resolves the release
+      # channel to `stable` and fails to find `-dev` tool builds (cli PR #2650).
+      # uipcli's ToolManager then discovers them on disk under
+      # `<npm-prefix>/@uipath/`, so `uip rpa …` / `uip rpa-legacy …` resolve
+      # without triggering auto-install. Job-level UIPATH_CLI_DISABLE_VERSION_SYNC
+      # keeps a `-dev` CLI from trying to re-align tools through the (stable-only)
+      # channel path at runtime.
+      #
+      # `npm install -g` runs from a fresh tempdir so any future workspace-aware
+      # `package.json` at the repo root cannot pull the install into a workspace.
+      - name: Install uip CLI + RPA tools (GitHub Packages @dev)
         shell: bash
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
-          set -e
+          set -euo pipefail
+          if [ -z "${GH_PAT:-}" ]; then
+            echo "::error::GH_PAT is empty — cannot authenticate to the GitHub Packages @dev feed"
+            exit 1
+          fi
           install_dir="$(mktemp -d)"
           cd "$install_dir"
           echo "Installing from $install_dir (workspace-isolated)"
-          npm config get registry
-          npm install -g \
-            --@uipath:registry=https://registry.npmjs.org/ \
-            @uipath/cli@latest \
-            "@uipath/rpa-tool@>=0.9" \
-            @uipath/rpa-legacy-tool@latest
+          npmrc="$install_dir/.npmrc"
+          {
+            echo "@uipath:registry=https://npm.pkg.github.com/"
+            echo "//npm.pkg.github.com/:_authToken=${GH_PAT}"
+          } > "$npmrc"
+          export NPM_CONFIG_USERCONFIG="$npmrc"
+          npm install -g @uipath/cli@dev
           uip --version
+          for tool in @uipath/rpa-tool @uipath/rpa-legacy-tool; do
+            echo "Installing ${tool}@dev"
+            if ! npm install -g "${tool}@dev"; then
+              echo "::error::${tool}@dev failed to install — no build on the dev train?"
+              exit 1
+            fi
+          done
+          rm -f "$npmrc"
+          unset NPM_CONFIG_USERCONFIG
           echo "--- Installed @uipath/* packages ---"
           npm ls -g --depth=0 2>/dev/null | grep '@uipath/' || true
           echo "--- uip tools list ---"


### PR DESCRIPTION
## What

Switch the **RPA-Windows smoke runner** from public-npm `@uipath/cli@latest` to the **GitHub Packages `@dev`** train, so it tests the same CLI the Linux smoke image already uses.

## How this was found (accidentally)

While investigating failing smoke checks on an unrelated docs PR (#2026, a pure `solution project` → `solution projects` rename), I noticed the RPA-Windows job installs the CLI from **public npm `@latest`** — which mirrors the release train **~2 weeks late**. The failing run used `@uipath/cli@1.197.1`, even though the current `@dev` train was already `1.199.0-dev.*`.

The #2026 check failures turned out to be unrelated (agent budget/behavior flakes), but the stale-CLI gap surfaced on its own: RPA-Windows tasks can silently exercise a CLI that predates freshly renamed/added verbs, while the Linux runner tracks `@dev`. This PR closes that gap.

## Why `@dev`

The Linux smoke image builds from `@dev` on **every** branch: `tests/docker/Dockerfile` defaults `ARG CLI_VERSION=dev`, and `smoke-skills.yml` never passes a `--build-arg CLI_VERSION=` override. This change makes RPA-Windows consistent with that established behavior — no branch-aware channel logic is introduced (that would be a separate change touching both runners).

## Changes (`.github/workflows/smoke-rpa-skills.yml`, one step)

- Map the `@uipath` scope to `npm.pkg.github.com` via a temp npmrc (token from `GH_PAT`, `read:packages`), written and deleted inside the step so the token never lingers.
- Pin every package to the explicit `@dev` dist-tag (the feed also carries a frozen `alpha` line and the public `latest` — never rely on `latest`/unspecified).
- Install tools with raw `npm install -g @uipath/<tool>@dev`, **not** `uip tools install` — a `-dev` CLI resolves the release channel to `stable` and can't find `-dev` tool builds (cli PR #2650). Job-level `UIPATH_CLI_DISABLE_VERSION_SYNC` stays on.
- Fail hard with a clear `::error::` if a tool has no build on the dev train.

Secret is passed via `env:` (`$GH_PAT`), not interpolated into the `run:` script.

## Verification

`@uipath/rpa-tool@dev` / `@uipath/rpa-legacy-tool@dev` availability couldn't be checked locally (GH Packages needs auth). The Linux image installs the same tools at `@dev` successfully, so they should exist; if not, the step now fails loudly instead of scoring agents 0. This PR's own CI run is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
