### PR TITLE
docs(bpmn): clarify local metadata shape

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -123,6 +123,16 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    by the HITL template's `<uipath:output ... var="...">` (for example
    `=vars.Var_HitlResult == "approve"`), not only a copied or derived script
    variable.
+   If a local-only prompt asks for `operate.json`, `entry-points.json`,
+   `bindings_v2.json`, or `package-descriptor.json`, follow the minimal local
+   metadata shape in
+   [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape):
+   `operate.json.main` is the bare BPMN filename, while
+   `entry-points.json.filePath` is `/content/<file>.bpmn#<start-event-id>`, and
+   `package-descriptor.json` uses a top-level `content` array. Do not copy a
+   CLI scaffold shape with `operate.json.main` set to
+   `/content/<file>.bpmn#<start-event-id>` or a descriptor `files` object into a
+   synthetic local project.
 4. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
    bundled validator — it reconstructs the canvas model and runs every
    PO.Frontend rule:

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -126,13 +126,8 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    If a local-only prompt asks for `operate.json`, `entry-points.json`,
    `bindings_v2.json`, or `package-descriptor.json`, follow the minimal local
    metadata shape in
-   [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape):
-   `operate.json.main` is the bare BPMN filename, while
-   `entry-points.json.filePath` is `/content/<file>.bpmn#<start-event-id>`, and
-   `package-descriptor.json` uses a top-level `content` array. Do not copy a
-   CLI scaffold shape with `operate.json.main` set to
-   `/content/<file>.bpmn#<start-event-id>` or a descriptor `files` object into a
-   synthetic local project.
+   [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
+   Do not copy CLI scaffold metadata shapes into a synthetic local project.
 4. **Validate.** There is **no** `uip maestro bpmn validate` CLI command. Run the
    bundled validator — it reconstructs the canvas model and runs every
    PO.Frontend rule:

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -15,12 +15,22 @@ BPMN project, make the project executable and package-shaped before packing:
 
 - The root process must be `<bpmn:process ... isExecutable="true">`.
 - `project.uiproj` must use lowercase `"main"` pointing at the BPMN file.
-- `operate.json` must use `"main"` and `"contentType": "ProcessOrchestration"`.
+- `operate.json` must use `"main"` with the bare BPMN filename, not a
+  `/content/<file>.bpmn#<start-event-id>` entry-point path, plus
+  `"contentType": "ProcessOrchestration"`.
 - `package-descriptor.json` must use a top-level `"content"` array with
-  `content/<file>` entries. Do not use `contentFiles`.
+  `content/<file>` entries. Do not use `contentFiles` or a CLI scaffold
+  `"files"` mapping for synthetic local metadata.
 
 The minimal placeholder-safe JSON shape is shown below; keep it exact apart
 from project, file, and start event names.
+
+This distinction matters in evals and local synthetic authoring. Claude passed
+the API workflow task because it emitted the minimal local metadata contract;
+Codex failed when it copied richer CLI-style metadata where `operate.json.main`
+pointed at `/content/ApiWorkflowDispatch.bpmn#Event_start` and the descriptor
+used a `files` object. Those CLI-style fields can be reasonable generated
+metadata, but they are not the synthetic local package shape expected here.
 
 ## Regeneration Inputs
 

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -25,13 +25,6 @@ BPMN project, make the project executable and package-shaped before packing:
 The minimal placeholder-safe JSON shape is shown below; keep it exact apart
 from project, file, and start event names.
 
-This distinction matters in evals and local synthetic authoring. Claude passed
-the API workflow task because it emitted the minimal local metadata contract;
-Codex failed when it copied richer CLI-style metadata where `operate.json.main`
-pointed at `/content/ApiWorkflowDispatch.bpmn#Event_start` and the descriptor
-used a `files` object. Those CLI-style fields can be reasonable generated
-metadata, but they are not the synthetic local package shape expected here.
-
 ## Regeneration Inputs
 
 Local regeneration reads:

--- a/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
@@ -1,7 +1,11 @@
 task_id: skill-bpmn-api-workflow-task
 description: >
   Author a Maestro BPMN API workflow invocation, covering the
-  Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval.
+  Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval. This task
+  catches the Claude-vs-Codex metadata drift: Claude passed by using the
+  minimal local synthetic package shape, while Codex failed after copying
+  CLI-style metadata where operate.json main used /content/<bpmn>#<start> and
+  package-descriptor.json used a files object.
 tags: [uipath-maestro-bpmn, e2e, "mode:build", lifecycle:generate, "node:service-task", "feature:api-workflow"]
 
 run_limits:


### PR DESCRIPTION
## Summary
- Clarify the BPMN skill workflow for local-only package metadata.
- Make operate.json.main use the bare BPMN filename for synthetic local projects.
- Document that entry-points.json.filePath keeps the /content/<file>.bpmn#<start> entry-point path and package-descriptor.json uses a top-level content array.
- Update the API workflow eval description to call out the Claude-vs-Codex drift.

## Root Cause
The API workflow task passed in Claude because Claude emitted the minimal local synthetic metadata contract. Codex failed after copying richer CLI-style metadata where operate.json.main pointed at /content/ApiWorkflowDispatch.bpmn#Event_start and package-descriptor.json used a files object. Those shapes can be reasonable generated metadata, but they do not match this eval's local synthetic package contract.

## Validation
- python3 YAML parse check for tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
- Ran skill-bpmn-api-workflow-task in the coder-eval pipeline with Codex and it passed: https://github.com/UiPath/skills/actions/runs/29950610630