### PR TITLE
fix(maestro-flow): count node configure at least once in reconfigure test

### DIFF
--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -50,11 +50,20 @@ initial_prompt: |
       cp BindingsReconfigure/flow_files/BindingsReconfigure.flow after_b.flow
 
 success_criteria:
+  # min_count: 1 (not 2). Per uipath-maestro-flow SKILL.md rule #10, agents
+  # chain sequential `uip` calls — e.g. `node configure <A> && ... && node
+  # configure <B> && validate && format` — into ONE Bash event. command_executed
+  # counts matching Bash events, not command occurrences within an event, so a
+  # correct batched run registers only 1 match and this criterion false-fails.
+  # Multiplicity is instead proven by the A/B snapshot checks below: after_a
+  # references connection A while after_b references ONLY B (no leak, equal
+  # count) — a result a single configure cannot produce. Mirrors the min_count:1
+  # convention in multi_connector_independence.yaml / no_duplicate_connection_bindings.yaml.
   - type: command_executed
-    description: "Agent called `node configure` at least twice"
+    description: "Agent used `uip flow node configure` at least once"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 2
+    min_count: 1
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Problem

The `skill-flow-bindings-reconfigure-different-connection` task fails
(`final_status=FAILURE`, weighted **0.9667**) even though **all six binding
assertions pass**. The single failing criterion:

> "Agent called `node configure` at least twice" — matched **1/2**, score 0.5

**Root cause.** Per `uipath-maestro-flow` SKILL.md **rule #10**, agents chain
sequential `uip` calls into one Bash event — e.g.:

```
… && uip … flow node configure <nodeId> --detail '{…connectionId A…}' \
   && cp … after_a.flow \
   && uip … flow node configure <nodeId> --detail '{…connectionId B…}' \
   && cp … after_b.flow && validate && format
```

The `command_executed` checker counts matching **Bash events**, not command
occurrences within an event (`match_count = len(matching_commands)`, one append
per record). So two chained `configure` calls register as **1** match →
`min_count: 2` false-fails. The skill is behaving correctly; the criterion's
assumption of two separate Bash events contradicts the skill's own guidance.

## Fix

Lower the `command_executed` `min_count` from **2 → 1** and reword it to
"at least once".

**No coverage is lost.** Multiplicity is already proven — more robustly — by
the A/B snapshot assertions:

- `after_a` references connection **A**
- `after_b` references **only B** (zero refs to A)
- `count_equal(after_a, after_b)`

A single configure cannot produce two snapshots that reference *different*
connections, so these checks already entail two distinct configures — verifying
the **effect**, not just that a command string appeared. This mirrors the
`min_count: 1` convention already used by `multi_connector_independence.yaml`
and `no_duplicate_connection_bindings.yaml`.

## Scope

- **Localized to the test** — one YAML file. The skill is unchanged (batching
  is the documented best practice) and the `coder_eval` checker is untouched.
- Not addressed here: `idempotent_reconfigure.yaml` shares the same
  `min_count: 2` pattern and the same latent fragility, but its snapshots use
  the *same* connection, so its artifact checks can't prove multiplicity on
  their own. Left as-is intentionally (deferred).

## Validation

- YAML parses; `scripts/check-cli-verbs.py` exits 0.
- Score recomputation: crit0 `0.5 → 1.0` ⇒ 15/15 ⇒ **SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)