### PR TITLE
fix(maestro-flow-tests): run escalation-triage under inherited (docker) driver

### DIFF
--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -20,9 +20,15 @@ agent:
   # questions from coding agents that do not expose AskUserQuestion.
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 
-sandbox:
-  driver: tempdir
-  python: {}
+# No sandbox block: inherit the experiment driver like every sibling e2e Flow
+# task (jira_*, testmanager). This task must run under the docker driver, whose
+# image bakes @uipath/maestro-tool@<train> — the tool `uip maestro flow
+# validate`/`debug` load at grade time. Hard-pinning `driver: tempdir` here
+# forced the toolless host path, where a `-dev` CLI's on-demand `uip tools
+# install` resolves the `stable` channel and fails with "No compatible version
+# of '@uipath/maestro-tool' for the 1.199.x line", zeroing both the validate
+# and business-outcome criteria regardless of the flow's correctness. python3
+# (used by seed/check scripts) is present in the docker image.
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/seed.py"


### PR DESCRIPTION
## Problem

The `skill-flow-interactive-customer-escalation-triage` e2e task fails (observed weighted score **0.24**) even when the agent produces a **fully correct** flow. Both zero-scored criteria die on the same error:

```
uip maestro flow validate ... --output json  → exit 1
{ "Result": "Failure",
  "Message": "No compatible version of '@uipath/maestro-tool' found for the CLI's 1.199.x line on npm or GitHub Packages." }
```

## Root cause

`customer_escalation_triage.yaml` was the **only** maestro-flow task pinning `sandbox.driver: tempdir`. Every sibling (jira_* e2e, testmanager, the other simulated interactive tasks) omits the driver and inherits it from the experiment.

- The **docker** image (`tests/docker/Dockerfile:57-95`) bakes every `uip tools search` tool — including `@uipath/maestro-tool` — at the CLI train's dist-tag. Maestro-flow tasks under the docker driver load the plugin at grade time and pass.
- Under **tempdir**, the plugin is not on disk. On a `-dev` CLI (`1.199.x-dev`), on-demand `uip tools install @uipath/maestro-tool` resolves the `stable` channel — which has no prerelease build for that line — and errors out. This is the identical failure mode the repo already documents for `rpa-tool` (`tests/docker/Dockerfile:44-52`, `tests/tasks/uipath-troubleshoot/smoke-manifest-commands/task.yaml:46-54`).

The hard-pinned `tempdir` forced this task onto the toolless path regardless of which experiment ran it, zeroing `flow validate` and the seeded Sev1/Sev3 business-outcome check even though the agent's flow was correct (verified: Sev1→Draft/eng=true, Sev3→Draft/eng=false, caseKey passthrough — matches the seeded expectations exactly).

## Fix

Remove the `sandbox:` block so the task inherits the experiment driver like every sibling e2e Flow task. No sibling e2e/pre_run task declares `python:` — python3 is present in the docker image (used by the seed/check scripts).

## Verification

- YAML parses; `sandbox` key gone; `run_limits` remains top-level; no `env_packages`/pinned CLI.
- Lint (`/lint-task`): OK — no regressions.
- Will dispatch `run-coder-eval.yml` from this branch to confirm the task now scores green under the docker driver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)