### PR TITLE
fix(human-in-the-loop): add non-interactive fallback to confirmation gates

### DIFF
--- a/skills/uipath-human-in-the-loop/SKILL.md
+++ b/skills/uipath-human-in-the-loop/SKILL.md
@@ -32,7 +32,7 @@ See [references/hitl-patterns.md](references/hitl-patterns.md) for the full busi
 
 ## Critical Rules
 
-1. **Confirm schema with the user before writing anything for quickform type.** Show the designed schema and wait for explicit confirmation.
+1. **Confirm schema with the user before writing anything for quickform type.** Show the designed schema and wait for explicit confirmation. **Running non-interactively (CI/headless — no user available to answer):** do not block — design the schema from the prompt and any upstream `.flow` data, write the node, and record the chosen schema prominently in the final report. Only stop and report the open decision if the request is too ambiguous to pick a sensible default. (A prompt that already specifies the fields, outcomes, and output shape is never too ambiguous.)
 2. **Always wire the `completed` handle.** A HITL node with no outgoing edge on `completed` blocks the flow forever. Only `completed` is available as an output handle — **not** `output`, `success`, or any other name. This is true even when inserting into an existing flow whose other nodes use `"sourcePort": "output"`.
 3. **Always add the definition entry when inserting into an existing flow.** Before writing the node, check `workflow.definitions[]` for the correct `nodeType` for the selected path (`"uipath.human-in-the-loop.quick-form"` for QuickForm, `"uipath.human-in-the-loop.coded-action-app"` for app-based). If absent, append the full definition entry (with `handleConfiguration` including the `completed` handle). Skipping the definition means the `completed` handle is invisible to the runtime and the wiring check fails.
 4. **Regenerate `variables.nodes` after adding the node.** Replace the entire `workflow.variables.nodes` array — do not append. See the reference docs for the algorithm.
@@ -131,7 +131,7 @@ Read the existing `.flow` file to understand current nodes and edges. Use the Re
 
 > "I noticed that [quote the specific part of their description]. This is a [pattern name] — a point where [brief consequence if no human reviews]. I recommend inserting a Human-in-the-Loop step here so that [human role] can [action] before the automation [continues/writes/sends]. Should I add it?"
 
-Wait for confirmation. Do not proceed to schema design until the user confirms.
+Wait for confirmation. Do not proceed to schema design until the user confirms. **Running non-interactively (CI/headless — no user available to answer):** treat the recommendation as accepted when the signal is clear-cut (an explicit approval / review / sign-off requirement), add the HITL step, and record that you did so in the final report; only skip it and report the open decision when the signal is ambiguous.
 
 **Example:**
 > User: "Build an automation that reads support tickets, uses AI to generate an RCA, and updates the ticket in ServiceNow."


### PR DESCRIPTION
## Problem

The `uipath-human-in-the-loop` skill has two hard "wait for confirmation" gates with **no non-interactive / headless carve-out**:

- **Critical Rule #1** — *"Confirm schema with the user before writing anything for quickform type. Show the designed schema and wait for explicit confirmation."*
- **Step 2b** — *"Wait for confirmation. Do not proceed to schema design until the user confirms."*

When an agent runs non-interactively (CI/eval/headless), it follows these literally: it presents the schema, asks the user to reply "confirm", and halts. There is no user to answer, so the `.flow` file is never written.

### How it surfaced

In the `skill-flow-hitl-quality-result-downstream` eval, the agent read the HITL skill and emitted:

> "Before I create the QuickForm, please confirm this schema: … Reply **"confirm"** to proceed, or specify any adjustment."

…then stopped. `ExpenseApproval.flow` was never created, so `uip maestro flow validate` failed with *File not found* and all 4 criteria scored 0.0 (final score **0.000**). The prompt had already fully specified the fields, outcomes, and output shape — there was nothing genuinely ambiguous to confirm.

## Fix

The sibling `uipath-maestro-flow` skill (rule #5) already defines the correct headless behavior: take the sensible default, proceed, and record the decision in the final report. This PR gives the HITL gates the **same** fallback so the two skills are consistent:

- **Rule #1** — headless → design the schema from the prompt/upstream `.flow` data, write the node, and record the schema in the report; only stop if genuinely too ambiguous. Adds an explicit note that a prompt already specifying fields/outcomes/output shape is never too ambiguous.
- **Step 2b** — headless → treat a clear-cut approval/review/sign-off signal as accepted, add the HITL step, and record it; only skip when the signal is ambiguous.

**Interactive behavior is unchanged** — a real user still gets the confirmation prompt.

## Verification

This is a change to model-facing instruction text, so there's no unit test; whether a model now proceeds vs. asks is probabilistic. Real verification is re-running the `skill-flow-hitl-quality-result-downstream` eval against the updated skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
