### PR TITLE
test(tasks): drop sandbox.driver tempdir overrides + gate against reintroduction

### DIFF
--- a/.github/workflows/task-driver-gate.yml
+++ b/.github/workflows/task-driver-gate.yml
@@ -1,0 +1,40 @@
+name: Task Driver Gate
+
+# Fails the build if any coder-eval task YAML pins `sandbox.driver: tempdir`.
+#
+# The sandbox driver is chosen by the run environment, never by the task:
+#   - Linux nightly slice  -> `driver: docker` (skills-image bakes the uip CLI
+#     + every tool plugin), set in tests/experiments/nightly.yaml.
+#   - Windows slice        -> selected by the `windows` tag and forced onto
+#     `--driver tempdir` on the CLI (wins over YAML).
+# A task that pins `driver: tempdir` runs on the toolless host and breaks any
+# tool-backed command (e.g. `uip maestro flow validate`). See
+# scripts/check-task-driver.py for the full rationale.
+#
+# No `paths:` filter so this can be wired as a required check — it is a
+# sub-second full scan that always reports a definitive pass/fail.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: task-driver-gate-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    name: No task pins sandbox.driver tempdir
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with: { python-version: '3.13' }
+      - name: Install PyYAML
+        run: pip install --quiet pyyaml
+      - name: Check task drivers
+        run: python3 scripts/check-task-driver.py tests/tasks

--- a/scripts/check-task-driver.py
+++ b/scripts/check-task-driver.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Fail if any coder-eval task YAML pins ``sandbox.driver: tempdir``.
+
+The sandbox driver is decided by the run environment, NOT by the task:
+
+  - The Linux nightly slice runs every non-windows task under ``driver: docker``
+    (the ``skills-image`` bakes the full ``uip`` CLI + all tool plugins). The
+    experiment config (``tests/experiments/nightly.yaml``) sets that default.
+  - The Windows slice selects tasks by the ``windows`` tag and forces
+    ``--driver tempdir`` on the CLI (which wins over any YAML). Windows tasks
+    therefore do NOT need — and must not rely on — a YAML driver override.
+
+A task that pins ``driver: tempdir`` opts out of the docker image and runs on
+the bare host, where the tool plugins are NOT installed. Any task that then
+calls a tool-backed command (e.g. ``uip maestro flow validate`` needs
+``@uipath/maestro-tool``) fails with "No compatible version found", scoring
+zero on an otherwise-correct run. This gate blocks that footgun.
+
+If a task genuinely needs the Windows toolchain, tag it ``windows`` — do not
+pin the driver.
+
+Usage:
+    python3 scripts/check-task-driver.py                 # scans tests/tasks
+    python3 scripts/check-task-driver.py tests/tasks ...  # scan given roots/files
+
+Exit codes:
+    0 — no task pins ``driver: tempdir``
+    1 — one or more tasks pin ``driver: tempdir`` (paths printed)
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover
+    sys.exit("PyYAML is required. Install with: pip install pyyaml")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_ROOT = REPO_ROOT / "tests" / "tasks"
+
+_DRIVER_LINE = re.compile(r"^\s*driver:\s*tempdir\s*$")
+
+
+def _iter_task_yamls(args: list[str]) -> list[Path]:
+    roots = [Path(a) for a in args] if args else [DEFAULT_ROOT]
+    files: list[Path] = []
+    for root in roots:
+        if root.is_file():
+            files.append(root)
+        else:
+            files.extend(sorted(root.rglob("*.yaml")))
+            files.extend(sorted(root.rglob("*.yml")))
+    return files
+
+
+def _rel(path: Path) -> str:
+    """Repo-relative path string, robust to relative/absolute inputs and cwd."""
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _driver_line_number(path: Path) -> int:
+    """1-indexed line of the offending `driver: tempdir` (0 if not found textually)."""
+    for n, line in enumerate(path.read_text(errors="ignore").splitlines(), start=1):
+        if _DRIVER_LINE.match(line):
+            return n
+    return 0
+
+
+def main(argv: list[str]) -> int:
+    offenders: list[tuple[Path, int]] = []
+    docker_pins: list[Path] = []
+
+    for path in _iter_task_yamls(argv):
+        try:
+            doc = yaml.safe_load(path.read_text())
+        except yaml.YAMLError:
+            # Malformed YAML is another gate's problem; don't mask it as a pass
+            # but don't crash this check either.
+            continue
+        if not isinstance(doc, dict):
+            continue
+        sandbox = doc.get("sandbox")
+        if not isinstance(sandbox, dict):
+            continue
+        driver = sandbox.get("driver")
+        if driver == "tempdir":
+            offenders.append((path, _driver_line_number(path)))
+        elif driver == "docker":
+            docker_pins.append(path)
+
+    if docker_pins:
+        print(
+            f"note: {len(docker_pins)} task(s) pin `sandbox.driver: docker` (redundant with "
+            "the Linux default, harmless — not blocked):"
+        )
+        for p in docker_pins:
+            print(f"  {_rel(p)}")
+        print()
+
+    if not offenders:
+        print("OK — no task pins `sandbox.driver: tempdir`.")
+        return 0
+
+    print(f"FAIL — {len(offenders)} task(s) pin `sandbox.driver: tempdir`:\n")
+    for path, line in offenders:
+        rel = _rel(path)
+        loc = f"{rel}:{line}" if line else rel
+        # GitHub Actions annotation (rendered inline on the PR when run in CI).
+        print(f"::error file={rel},line={line}::Task pins sandbox.driver: tempdir")
+        print(f"  {loc}")
+    print()
+    print(
+        "The sandbox driver is decided by the run environment, not the task.\n"
+        "Remove the `driver: tempdir` line (delete the `sandbox:` block if it becomes empty).\n"
+        "If the task needs the Windows toolchain, tag it `windows` instead — see the\n"
+        "docstring in scripts/check-task-driver.py for the full rationale."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/tasks/uipath-agents/lowcode/conversational/guardrails/guardrail_custom_tool/guardrail_custom_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/guardrails/guardrail_custom_tool/guardrail_custom_tool.yaml
@@ -20,7 +20,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/memory_unavailable/memory_unavailable.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/memory_unavailable/memory_unavailable.yaml
@@ -21,7 +21,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/restrictions.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/restrictions.yaml
@@ -19,7 +19,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/scaffold/scaffold.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/with_builtin_tool/with_builtin_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/with_builtin_tool/with_builtin_tool.yaml
@@ -20,7 +20,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-agents/lowcode/conversational/with_context_grounding/with_context_grounding.yaml
+++ b/tests/tasks/uipath-agents/lowcode/conversational/with_context_grounding/with_context_grounding.yaml
@@ -21,7 +21,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
+++ b/tests/tasks/uipath-automation-discovery/e2e_full_discovery.yaml
@@ -14,7 +14,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
+++ b/tests/tasks/uipath-automation-discovery/smoke_intake.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-automation-discovery, smoke, mode:build, lifecycle:discover]
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-coded-apps/dashboard/build/dashboard_full_e2e.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/build/dashboard_full_e2e.yaml
@@ -14,7 +14,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Cleanup: the dashboard build mints a fresh OAuth external app per run

--- a/tests/tasks/uipath-coded-apps/dashboard/build/dashboard_scaffold.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/build/dashboard_scaffold.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Cleanup: the dashboard build mints a fresh OAuth external app per run

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_smoke.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-coded-apps, smoke, dashboard, mode:operate, lifecycle:setup]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 pre_run:

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, mode:operate, lifecycle:setup]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 pre_run:

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
@@ -23,7 +23,6 @@ run_limits:
   task_timeout: 1500
 
 sandbox:
-  driver: tempdir
   node: {}
 
 pre_run:

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
@@ -16,7 +16,6 @@ run_limits:
   task_timeout: 1500
 
 sandbox:
-  driver: tempdir
   node: {}
 
 pre_run:

--- a/tests/tasks/uipath-coded-apps/dashboard/detail/dashboard_rowlink_clickable.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/detail/dashboard_rowlink_clickable.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/diagnose/dashboard_diagnose_broken_metric.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/diagnose/dashboard_diagnose_broken_metric.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   node: {}
 
 pre_run:

--- a/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_change_widget.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_change_widget.yaml
@@ -14,7 +14,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_remove_widget.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/edit/dashboard_edit_remove_widget.yaml
@@ -15,7 +15,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/governance/dashboard_gov_gated_routing.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/governance/dashboard_gov_gated_routing.yaml
@@ -9,7 +9,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, feature:compliance, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/governance/dashboard_gov_generic_no_regression.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/governance/dashboard_gov_generic_no_regression.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, feature:compliance, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/incremental/dashboard_incremental_add.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/incremental/dashboard_incremental_add.yaml
@@ -13,7 +13,6 @@ run_limits:
   turn_timeout: 1200
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/refuse/dashboard_refuse_invocation_timeline.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/refuse/dashboard_refuse_invocation_timeline.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
@@ -10,7 +10,6 @@ description: >
 tags: [uipath-coded-apps, integration, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 # Reclaim the build's node_modules before artifact preservation. The build

--- a/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_disambiguate.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_disambiguate.yaml
@@ -6,7 +6,6 @@ description: >
 tags: [uipath-coded-apps, smoke, dashboard, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_plan_before_question.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_plan_before_question.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-coded-apps, smoke, dashboard, feature:approval-gate, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_plan_gate.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/smoke/dashboard_plan_gate.yaml
@@ -6,7 +6,6 @@ description: >
 tags: [uipath-coded-apps, smoke, dashboard, feature:approval-gate, mode:build, lifecycle:generate]
 
 sandbox:
-  driver: tempdir
   node: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/change_field_type.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/change_model_variant.yaml
+++ b/tests/tasks/uipath-ixp/smoke/change_model_variant.yaml
@@ -15,7 +15,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_choice_type.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/create_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_field_group.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_blank.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
+++ b/tests/tasks/uipath-ixp/smoke/create_project_suggest_taxonomy.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_field_group.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_multiple_fields.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/delete_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_project.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
+++ b/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 4
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
+++ b/tests/tasks/uipath-ixp/smoke/import_taxonomy_from_file.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/list_documents.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_documents.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/list_projects.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_projects.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 4
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
+++ b/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -14,7 +14,6 @@ run_limits:
   max_turns: 45
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -16,7 +16,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
@@ -17,7 +17,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
+++ b/tests/tasks/uipath-ixp/smoke/pick_capable_model.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/preprocessing_by_doc_shape.yaml
+++ b/tests/tasks/uipath-ixp/smoke/preprocessing_by_doc_shape.yaml
@@ -16,7 +16,6 @@ run_limits:
   expected_turns: 8
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/rename_ambiguous_entity.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_ambiguous_entity.yaml
@@ -28,7 +28,6 @@ run_limits:
   expected_turns: 8
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/rename_field.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_field_group.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/rename_project.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_project.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/reuse_default_type.yaml
+++ b/tests/tasks/uipath-ixp/smoke/reuse_default_type.yaml
@@ -12,7 +12,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/show_predictions.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
+++ b/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
@@ -18,7 +18,6 @@ agent:
   type: claude-code
 
 sandbox:
-  driver: tempdir
   python: {}
   mock_path_dirs: [mocks]
   template_sources:

--- a/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-ixp, smoke, lifecycle:execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   mock_path_dirs: [mocks]
   template_sources:

--- a/tests/tasks/uipath-ixp/smoke/unpublish.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unpublish.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/untag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/untag.yaml
@@ -13,7 +13,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_group_instructions.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 5
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -15,7 +15,6 @@ run_limits:
   expected_turns: 8
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
@@ -7,7 +7,6 @@ description: >
 tags: [uipath-maestro-bpmn, smoke, "mode:build"]
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -21,7 +21,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion"]
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-mcp-servers/cross-folder-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/cross-folder-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/gmail-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/gmail-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/is-activity-availability-gate/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/is-activity-availability-gate/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/jira-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/jira-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/jira-update-fix-lookups/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/jira-update-fix-lookups/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/outlook-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/outlook-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/remote-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/remote-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/resource-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/resource-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/slack-create/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/slack-create/task.yaml
@@ -6,7 +6,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-mcp-servers/update-cross-folder-retarget/task.yaml
+++ b/tests/tasks/uipath-mcp-servers/update-cross-folder-retarget/task.yaml
@@ -10,7 +10,6 @@ agent:
   type: claude-code
   allowed_tools: [Skill, Bash, Read, Write]
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
   - {type: template_dir, path: ../_shared/mock_template}

--- a/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
+++ b/tests/tasks/uipath-platform/integration-service/record_crud_e2e.yaml
@@ -11,7 +11,6 @@ run_limits:
   expected_turns: 18
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
+++ b/tests/tasks/uipath-platform/integration-service/resource_execute.yaml
@@ -10,7 +10,6 @@ run_limits:
   expected_turns: 15
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
@@ -11,7 +11,6 @@ run_limits:
   max_turns: 35
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
@@ -15,7 +15,6 @@ description: >
 tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
@@ -13,7 +13,6 @@ run_limits:
   max_turns: 60
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_results_grounded/testmanager_results_grounded.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_results_grounded/testmanager_results_grounded.yaml
@@ -22,7 +22,6 @@ tags: [uipath-platform, integration, integration-service, test-manager, resource
 skip: true
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
@@ -12,7 +12,6 @@ description: >
 tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
 
 sandbox:
-  driver: tempdir
   python: {}
   node: {}
 

--- a/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_error_handling/coded_review_error_handling.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_action_ineffective/coded_review_guardrail_action_ineffective.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_misapplied/coded_review_guardrail_misapplied.yaml
@@ -14,7 +14,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_recommended/coded_review_guardrail_recommended.yaml
@@ -14,7 +14,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_guardrail_wrong_import/coded_review_guardrail_wrong_import.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_guardrail_wrong_import/coded_review_guardrail_wrong_import.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_output_enum_missing/coded_review_output_enum_missing.yaml
@@ -16,7 +16,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_pii_in_traces/coded_review_pii_in_traces.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
+++ b/tests/tasks/uipath-review/agents/coded_review_runs_review_cli/coded_review_runs_review_cli.yaml
@@ -16,7 +16,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_action_ineffective/lowcode_review_guardrail_action_ineffective.yaml
@@ -19,7 +19,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -14,7 +14,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -16,7 +16,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_pii_missing/lowcode_review_guardrail_pii_missing.yaml
@@ -22,7 +22,6 @@ run_limits:
   max_turns: 60
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_unknown_validator/lowcode_review_guardrail_unknown_validator.yaml
@@ -16,7 +16,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_prompt_instruction_conflicts/lowcode_review_prompt_instruction_conflicts.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_tool_overlap/lowcode_review_tool_overlap.yaml
@@ -15,7 +15,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_vague_tool_description/lowcode_review_vague_tool_description.yaml
@@ -16,7 +16,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   python: {}
 
 pre_run:

--- a/tests/tasks/uipath-review/rpa/coded-structural/coded-structural.yaml
+++ b/tests/tasks/uipath-review/rpa/coded-structural/coded-structural.yaml
@@ -18,7 +18,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/credential-security/credential-security.yaml
+++ b/tests/tasks/uipath-review/rpa/credential-security/credential-security.yaml
@@ -20,7 +20,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/e2e-multi-project-solution.yaml
+++ b/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/e2e-multi-project-solution.yaml
@@ -22,7 +22,6 @@ run_limits:
   max_turns: 60
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/e2e-reframework-process/e2e-reframework-process.yaml
+++ b/tests/tasks/uipath-review/rpa/e2e-reframework-process/e2e-reframework-process.yaml
@@ -21,7 +21,6 @@ run_limits:
   max_turns: 60
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/exception-classification/exception-classification.yaml
+++ b/tests/tasks/uipath-review/rpa/exception-classification/exception-classification.yaml
@@ -20,7 +20,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/hardcoded-config/hardcoded-config.yaml
+++ b/tests/tasks/uipath-review/rpa/hardcoded-config/hardcoded-config.yaml
@@ -19,7 +19,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/legacy-precision/legacy-precision.yaml
+++ b/tests/tasks/uipath-review/rpa/legacy-precision/legacy-precision.yaml
@@ -20,7 +20,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/logging-pii/logging-pii.yaml
+++ b/tests/tasks/uipath-review/rpa/logging-pii/logging-pii.yaml
@@ -18,7 +18,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/performance-datatable/performance-datatable.yaml
+++ b/tests/tasks/uipath-review/rpa/performance-datatable/performance-datatable.yaml
@@ -19,7 +19,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/reframework-integrity/reframework-integrity.yaml
+++ b/tests/tasks/uipath-review/rpa/reframework-integrity/reframework-integrity.yaml
@@ -19,7 +19,6 @@ run_limits:
   max_turns: 50
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/selector-brittle/selector-brittle.yaml
+++ b/tests/tasks/uipath-review/rpa/selector-brittle/selector-brittle.yaml
@@ -20,7 +20,6 @@ run_limits:
   max_turns: 40
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-review/rpa/transaction-shape/transaction-shape.yaml
+++ b/tests/tasks/uipath-review/rpa/transaction-shape/transaction-shape.yaml
@@ -20,7 +20,6 @@ run_limits:
   max_turns: 50
 
 sandbox:
-  driver: tempdir
   template_sources:
     - type: template_dir
       path: fixture

--- a/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
+++ b/tests/tasks/uipath-solution/operate/pack_determinism_integration.yaml
@@ -19,7 +19,6 @@ agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]
 
 sandbox:
-  driver: tempdir
   python: {}
 
 initial_prompt: |

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
@@ -24,7 +24,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
@@ -23,7 +23,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
@@ -23,7 +23,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
@@ -21,7 +21,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
@@ -23,7 +23,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
@@ -24,7 +24,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -23,7 +23,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
@@ -19,7 +19,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 5400
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
@@ -28,7 +28,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
@@ -24,7 +24,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
@@ -27,7 +27,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
@@ -27,7 +27,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
@@ -21,7 +21,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
@@ -19,7 +19,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
@@ -24,7 +24,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
@@ -17,7 +17,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -20,7 +20,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
@@ -24,7 +24,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
@@ -18,7 +18,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
@@ -28,7 +28,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
@@ -29,7 +29,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
@@ -33,7 +33,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -27,7 +27,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
@@ -26,7 +26,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
@@ -20,7 +20,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
@@ -20,7 +20,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
@@ -22,7 +22,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
@@ -25,7 +25,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir


### PR DESCRIPTION
## What

Remove the `sandbox.driver: tempdir` override from all 190 task YAMLs that had it, and add a CI gate that fails the build if any task reintroduces it.

## Why

The sandbox driver is decided by the run environment, not by the task. The Linux nightly slice runs every non-windows task under `driver: docker` — the `skills-image` bakes the `uip` CLI and every tool plugin. The Windows slice selects tasks by the `windows` tag and forces `--driver tempdir` on the CLI (which wins over any YAML), so no task needs a YAML driver override.

A task that pinned `driver: tempdir` opted out of the docker image and ran on the bare host, where the tool plugins are not installed. Any tool-backed command then failed — e.g. `skill-flow-interactive-customer-escalation-triage`'s `uip maestro flow validate` needs `@uipath/maestro-tool`, which isn't on the host, so it failed with "No compatible version found for the CLI's 1.199.x line" and scored zero on otherwise-correct runs. The gate prevents that footgun from returning.

Existing `driver: docker` pins are left in place (they match the Linux default and are harmless); the gate reports them as an informational note rather than blocking.

## Validation

Ran the affected tasks on the docker driver (skills-image with the full baked toolchain: `uip` 1.199.0-dev.7959 + 31 tool plugins, coder-eval 0.8.8, Bedrock backend) to confirm they run cleanly in the container they were opting out of. Two cuts, **42 tasks across 9 of the affected categories**.

**Headline: every task executed in-container (`sandbox_path` under `/work/output`) — 0 ran on the host, and there were 0 tool-resolution / host-missing failures.** That is the failure class this PR removes, and it is gone.

### Cut 1 — 12 tasks, 12/12 passed (1.0)

| Task | Category | Score |
|---|---|---|
| `skill-flow-interactive-customer-escalation-triage` | maestro-flow *(the original bug)* | 1.0 ✅ |
| `skill-bpmn-smoke-registry-discovery` | maestro-bpmn *(tool-backed)* | 1.0 ✅ |
| `skill-agent-conversational-guardrail-custom-tool` | agents | 1.0 ✅ |
| `skill-ixp-change-field-type-smoke` / `list-documents` / `negative-guards` | ixp | 1.0 ✅ |
| `skill-mcp-servers-cross-folder-create` / `remote-create` | mcp | 1.0 ✅ |
| `skill-platform-solution-pack-determinism-integration` | solution | 1.0 ✅ |
| `uipath-coded-apps-dashboard-diagnose-broken-metric` / `edit-remove-widget` / `refuse-invocation-timeline` | coded-apps | 1.0 ✅ |

The two tool-backed tasks (`customer-escalation-triage`, `bpmn-smoke-registry-discovery`) are the direct proof: these are exactly the tasks that failed on the toolless host with "No compatible version of `@uipath/maestro-tool`", and both pass on the docker driver because the tool is baked into the image.

### Cut 2 — 30 tasks (troubleshoot + review), the two largest categories by count

- **troubleshoot: 15/15 passed** (10 at 1.0, 5 at 0.85–0.925 partial credit) — clean sweep.
- **review: 8/15 passed at 1.0**; the other 7 hit `MAX_TURNS_EXHAUSTED` (3) or a 1200s agent-turn timeout (4).

Those 7 review misses are **not** driver-related — they are pre-existing agent-loop behavior on long static-analysis tasks:
- All 7 ran in-container with commands succeeding (e.g. `skill-review-rpa-selector-brittle`: 60 assistant turns, 38 successful commands, ran the full 1202s before the wall-clock turn timeout). Nothing failed on a missing tool.
- Review tasks are static analysis (read an agent/RPA project, flag issues); they don't invoke the baked tool plugins that the tempdir removal restores, so the driver is orthogonal to their outcome.
- Turn-timeouts and max-turns are a suite-wide, pre-existing phenomenon — a single normal nightly (2026-06-23) logged 19 `MAX_TURNS_EXHAUSTED` and 20 turn-timeouts across the suite.

Net: the driver switch introduces no environment or tool-resolution regressions; the residual review flakiness is independent of this change and would occur on either driver.
