### PR TITLE
fix(bpmn): cover Codex suite follow-ups

### DIFF
--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -174,12 +174,21 @@ jobs:
       - uses: astral-sh/setup-uv@v4
 
       # Host coder-eval CLI = pinned wheel (coder_eval feed + ml-packages for
-      # deps). No source checkout.
-      # codex is NOT installed on the host here: under the docker driver the
-      # agent runs inside skills-image, so the codex SDK belongs in that image
-      # (separate TODO), not on the host CLI.
+      # deps). The Linux docker driver still imports the selected agent class on
+      # the host before dispatching work, so agent-specific extras must be
+      # installed here as well as in the container image.
       - name: Install coder-eval
-        run: uv pip install --system "coder-eval==${{ needs.partition.outputs.coder_eval_version }}"
+        env:
+          CE_VERSION: ${{ needs.partition.outputs.coder_eval_version }}
+          AGENT: ${{ inputs.agent }}
+        run: |
+          if [ "$AGENT" = "codex" ]; then
+            uv pip install --system "coder-eval[codex]==${CE_VERSION}"
+          elif [ "$AGENT" = "antigravity" ]; then
+            uv pip install --system "coder-eval[antigravity]==${CE_VERSION}"
+          else
+            uv pip install --system "coder-eval==${CE_VERSION}"
+          fi
 
       # Pull the agent image from GHCR (never built from source); the skills
       # image extends it below. Tag defaults to the wheel version but can be

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -154,6 +154,10 @@ and honestly surfaced to the user as gaps when asked.
 3. **Structural BPMN is authored, not invented.** Follow the spec/canvas
    contract in [references/structural-bpmn.md](references/structural-bpmn.md);
    flag honestly what the registry does not expose.
+   BPMN XML element names are case-sensitive: use exact lower-camel tags such
+   as `<bpmn:startEvent>`, `<bpmn:intermediateCatchEvent>`,
+   `<bpmn:scriptTask>`, and `<bpmn:endEvent>`. Do not write PascalCase tags
+   like `<bpmn:IntermediateCatchEvent>`.
 4. **Confirm before authoring.** Confirm the chosen connector/connection/process
    and the process structure with the user (AskUserQuestion).
 5. **The diagram is mandatory.** Import is diagram-driven — every node needs a

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -17,6 +17,12 @@ Where the registry stops, the canvas serializer is authoritative. Each
 gap below is labelled **REGISTRY GAP** — the registry exposes no template for
 it, so author it from this reference.
 
+BPMN XML element names are case-sensitive. Use the exact lower-camel BPMN tag
+names the serializer emits, such as `<bpmn:startEvent>`,
+`<bpmn:intermediateCatchEvent>`, `<bpmn:scriptTask>`, and `<bpmn:endEvent>`.
+Do not use PascalCase variants like `<bpmn:IntermediateCatchEvent>`; XML accepts
+them syntactically, but BPMN tools do not treat them as the same elements.
+
 ## The document scaffold (REGISTRY GAP)
 
 The registry emits no `<bpmn:definitions>` / `<bpmn:process>` root and no
@@ -156,6 +162,10 @@ template, but the runtime contract is fixed:
 - Map the return back through `source="=result.response"` (scalar) or
   `source="=result.response.<field>"` (object field); `var` points at a declared
   variable id (do not put the target id in `name`).
+- When the output mapping uses `source="=result.response"`, return an object
+  with a `response` property, such as `return { response: 6 * 7 };`. Do not
+  return the bare primitive `42` for that mapping shape; there is no
+  `response` property to bind, so the runtime variable stays empty.
 - Do not mutate `Globals.*`, `vars.*`, or process variables inside the script
   body. The supported path is: return a value from the script, then use a
   `uipath:output` mapping to write it to the declared variable. Direct mutation
@@ -245,6 +255,12 @@ Payload shapes the canvas serializes:
   Maestro internal-message events (`Maestro.ReceiveMessageEvent` /
   `Maestro.SendMessageEvent`) carry the `uipath:event` payload **and** a bare
   `<bpmn:messageEventDefinition />` (see their registry templates).
+  A mid-flow wait for an inbound message is a
+  `<bpmn:intermediateCatchEvent>` with incoming and outgoing sequence flows,
+  the registry-provided `Maestro.ReceiveMessageEvent` payload under
+  `bpmn:extensionElements`, and a sibling `<bpmn:messageEventDefinition />`.
+  Do not model a mid-flow receive as `bpmn:receiveTask`, `bpmn:serviceTask`, a
+  start event, or the PascalCase `bpmn:IntermediateCatchEvent`.
 - **Error**: `<bpmn:errorEventDefinition errorRef="Error_1" />` with a
   `<bpmn:error id="Error_1" name="…" errorCode="…"/>` at definitions level. An
   error end event with no `errorRef` fails to parse at runtime


### PR DESCRIPTION
## Summary
- Document BPMN XML tag casing so Codex emits lower-camel elements such as bpmn:intermediateCatchEvent.
- Clarify the Jint script-task return shape required by source="=result.response" mappings.
- Install agent-specific coder-eval extras on the Linux Actions host when running Codex or Antigravity.

## Context
The full BPMN Codex suite run completed 65/70. PR #2202 covers the local synthetic metadata drift. This follow-up covers the other observed failure modes: message-catch tag casing, live-debug product output mapping, and the smoke-registry-discovery host import error for openai_codex.

## Validation
- git diff --check
- python3 YAML parse check for .github/workflows/run-coder-eval.yml