### PR TITLE
fix(hitl-skill): add non-interactive escape hatch to quickform reference

### DIFF
--- a/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
+++ b/skills/uipath-human-in-the-loop/references/hitl-node-quickform.md
@@ -6,7 +6,7 @@ The agent writes the `uipath.human-in-the-loop.quick-form` node directly into th
 
 ## Step 1 — Extract the Schema Through Conversation
 
-Before designing the schema, ask these focused questions if the business description doesn't answer them. **Ask all missing ones in a single message — never one at a time.**
+Before designing the schema, ask these focused questions if the business description doesn't answer them. **Ask all missing ones in a single message — never one at a time.** **Running non-interactively (CI/headless — no user available to answer):** do not ask — infer the answers from the prompt and any upstream `.flow` data, and proceed to design the schema. Only stop and report the open decision if the request is too ambiguous to pick a sensible default.
 
 | What you need to know | Question to ask |
 |---|---|
@@ -93,7 +93,7 @@ The node schema uses `fields[]` entries inside `inputs.schema`. Use these concep
 - `outcomes`: use domain-specific names (Approve/Reject, not just Submit)
 - Keep it focused — don't add fields the automation won't use
 
-**Show the designed schema to the user and confirm before writing the node.**
+**Show the designed schema to the user and confirm before writing the node.** **Running non-interactively (CI/headless — no user available to answer):** do not block — design the schema from the prompt and any upstream `.flow` data, write the node, and record the chosen schema prominently in the final report. Only stop and report the open decision if the request is too ambiguous to pick a sensible default. (A prompt that already specifies the fields, outcomes, and output shape is never too ambiguous.)
 
 ---
 


### PR DESCRIPTION
## Root cause

The HITL smoke eval (`skill-flow-hitl-smoke-node-placed`, codex / `gpt-5.6-terra`) scored **0.0 — all 3 criteria failed** because the `.flow` file was never created. The agent read the guidance, then stopped and asked the user *"Please confirm this schema and I'll build and validate"* — but the eval is non-interactive, so no answer came and nothing was written.

Why it stopped: the "confirm schema before writing" instruction lives in several places, but the non-interactive escape hatch was **missing from the most task-proximate doc**:

| Location | Had escape hatch? |
|---|---|
| `SKILL.md` Critical Rule #1 | ✅ Yes |
| `SKILL.md` Step 2b | ✅ Yes |
| **`hitl-node-quickform.md` Step 1 + Step 2 (line 96)** | ❌ **No** |

The reference doc is read *last* and followed most closely, so the final, most-specific instruction the model saw was an unqualified *"Show the designed schema to the user and confirm before writing the node."* — and it obeyed.

## Fix

Add the same non-interactive escape hatch already present in `SKILL.md` Critical Rule #1 to both spots in `hitl-node-quickform.md`:

- **Step 1 (schema questions):** non-interactive runs infer answers from the prompt + upstream `.flow` data instead of asking.
- **Step 2 ("confirm before writing"):** non-interactive runs design the schema, write the node, and record the choice in the final report.

Net change: 2 lines, no structural edits. The reference doc now matches `SKILL.md` instead of contradicting it.

## Scope / not covered

This fixes the guidance defect. It does **not** address the deeper layer: the escape hatch still requires the agent to *recognize* it's headless, and the eval system prompt gives no such signal. That class-wide fix (inject a non-interactivity signal into the harness) is intentionally out of scope here.

## Verification

Text-only guidance change with no local runtime to exercise. Real proof is re-running the `skill-flow-hitl-smoke-node-placed` eval (or the full HITL task set) against the patched skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)