### PR TITLE
fix(maestro-flow): discover flow file dynamically in validate criteria

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Locate the Flow project's ``.flow`` file dynamically and run
+``uip maestro flow validate`` on it.
+
+Usage (from a task's run_command, cwd = sandbox root):
+    python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+
+Why this exists — a hardcoded ``<Name>/<Name>/<Name>.flow`` path in a success
+criterion is brittle: ``uip maestro flow init <Name>`` scaffolds a
+``<Name>Solution/`` wrapper directory, so the real path is
+``<Name>Solution/<Name>/<Name>.flow`` — not ``<Name>/<Name>/<Name>.flow``.
+The hardcoded command then fails with "File not found" even though the flow
+itself is valid (observed on skill-flow-loop-multiply: criterion scored 0.0
+purely on the path, while the flow validated fine when addressed correctly).
+
+Discovery mirrors the ``check_*.py`` execution checks: find the lone
+``project.uiproj`` whose manifest declares ``ProjectType="Flow"`` (via
+:func:`flow_check.find_project_dir`), then validate every ``.flow`` file under
+it. Exit 0 iff every file validates; otherwise propagate the failing exit code.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from flow_check import find_project_dir  # noqa: E402
+
+
+def main() -> int:
+    project_dir = find_project_dir()
+    flows = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
+    if not flows:
+        print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
+        return 1
+
+    rc = 0
+    for flow in flows:
+        print(f"Validating {flow}")
+        result = subprocess.run(
+            ["uip", "maestro", "flow", "validate", flow, "--output", "json"],
+            capture_output=True,
+            text=True,
+        )
+        sys.stdout.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        if result.returncode != 0:
+            rc = result.returncode or 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -47,7 +47,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate AcrUserList/AcrUserList/AcrUserList.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
@@ -51,7 +51,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BatchTransformDemo/BatchTransformDemo/BatchTransformDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
@@ -53,7 +53,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate SummarizeDemo/SummarizeDemo/SummarizeDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -76,7 +76,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow validates successfully"
-    command: "uip maestro flow validate ExpenseApproval/ExpenseApproval/ExpenseApproval.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -24,7 +24,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -22,7 +22,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -25,7 +25,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -22,7 +22,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -24,7 +24,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -25,7 +25,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -29,7 +29,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip flow validate passes"
-    command: "uip maestro flow validate VendorPOReview/VendorPOReview/VendorPOReview.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -31,7 +31,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip flow validate passes"
-    command: "uip maestro flow validate ExpenseApproval/ExpenseApproval/ExpenseApproval.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -32,7 +32,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"
-    command: "uip maestro flow validate VendorApproval/VendorApproval/VendorApproval.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -33,7 +33,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes after brownfield insert"
-    command: "uip maestro flow validate ContractReview/ContractReview/ContractReview.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -41,7 +41,7 @@ success_criteria:
 
   - type: run_command
     description: "uip flow validate passes"
-    command: "uip maestro flow validate InvoiceApproval/InvoiceApproval/InvoiceApproval.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -45,7 +45,7 @@ success_criteria:
 
   - type: run_command
     description: "uip maestro flow validate passes"
-    command: "uip maestro flow validate PurchaseApproval/PurchaseApproval/PurchaseApproval.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -33,7 +33,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"
-    command: "uip maestro flow validate LeaveRequest/LeaveRequest/LeaveRequest.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -89,7 +89,7 @@ success_criteria:
 
   - type: run_command
     description: "Generated customer-escalation Flow validates without errors"
-    command: "uip maestro flow validate CustomerEscalationTriage/CustomerEscalationTriage/CustomerEscalationTriage.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -59,7 +59,7 @@ success_criteria:
 
   - type: run_command
     description: "uip maestro flow validate passes on InvoiceRouter.flow"
-    command: "uip maestro flow validate InvoiceRouter/InvoiceRouter/InvoiceRouter.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -55,7 +55,7 @@ success_criteria:
 
   - type: run_command
     description: "uip maestro flow validate passes on Smoke.flow"
-    command: "uip maestro flow validate Smoke/Smoke/Smoke.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -61,7 +61,7 @@ success_criteria:
 
   - type: run_command
     description: "uip maestro flow validate passes on ReceiptIntake.flow"
-    command: "uip maestro flow validate ReceiptIntake/ReceiptIntake/ReceiptIntake.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -23,7 +23,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BellevueWeather/BellevueWeather/BellevueWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_discrepancy_detector/billing_discrepancy_detector.yaml
@@ -50,7 +50,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BillingDiscrepancyDetector/BillingDiscrepancyDetector/BillingDiscrepancyDetector.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_analyst/billing_dispute_analyst.yaml
@@ -42,7 +42,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BillingDisputeAnalyst/BillingDisputeAnalyst/BillingDisputeAnalyst.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -108,7 +108,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BillingDisputeResolution/BillingDisputeResolution/BillingDisputeResolution.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -38,7 +38,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BillingInvoiceLookup/BillingInvoiceLookup/BillingInvoiceLookup.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_resolution_writer/billing_resolution_writer.yaml
@@ -40,7 +40,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate BillingResolutionWriter/BillingResolutionWriter/BillingResolutionWriter.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -20,7 +20,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate Calculator/Calculator/Calculator.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -40,7 +40,7 @@ success_criteria:
   # ── Flow file validity ────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate CustomerEscalation/CustomerEscalation/CustomerEscalation.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -21,7 +21,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate DiceRoller/DiceRoller/DiceRoller.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -25,7 +25,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate FeetInches/FeetInches/FeetInches.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -20,7 +20,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate LoopMultiply/LoopMultiply/LoopMultiply.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -19,7 +19,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"
-    command: "uip maestro flow validate MultiCityWeather/MultiCityWeather/MultiCityWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -47,7 +47,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate ReadingList/ReadingList/ReadingList.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -21,7 +21,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate SlackChannelDescription/SlackChannelDescription/SlackChannelDescription.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -20,7 +20,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "uip maestro flow validate passes"
-    command: "uip maestro flow validate SlackWeatherPipeline/SlackWeatherPipeline/SlackWeatherPipeline.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -37,7 +37,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate WikiPageviews/WikiPageviews/WikiPageviews.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -20,7 +20,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate NameToAge/NameToAge/NameToAge.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/coded_agent/coded_agent.yaml
@@ -32,7 +32,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate ApproverCountAgent/ApproverCountAgent/ApproverCountAgent.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -22,7 +22,7 @@ success_criteria:
   # -- Flow file validity --
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate TemperatureChecker/TemperatureChecker/TemperatureChecker.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -37,7 +37,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate DelayDemo/DelayDemo/DelayDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -38,7 +38,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate AttachmentEcho/AttachmentEcho/AttachmentEcho.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -27,7 +27,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate CountLettersLowCode/CountLettersLowCode/CountLettersLowCode.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
@@ -41,7 +41,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate OpenMeteoWeather/OpenMeteoWeather/OpenMeteoWeather.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -37,7 +37,7 @@ success_criteria:
   # ── Structural: flow builds and validates ──────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate OutlookTriggerInbox/OutlookTriggerInbox/OutlookTriggerInbox.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
@@ -49,7 +49,7 @@ success_criteria:
   # ── Structural: flow builds and validates ──────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate OutlookWaitForEmail/OutlookWaitForEmail/OutlookWaitForEmail.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -21,7 +21,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate ProjectEulerTitle/ProjectEulerTitle/ProjectEulerTitle.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -24,7 +24,7 @@ success_criteria:
   # -- Flow file validity --
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate SubflowDemo/SubflowDemo/SubflowDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -26,7 +26,7 @@ success_criteria:
   # -- Flow file validity --
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate SeasonLookup/SeasonLookup/SeasonLookup.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -27,7 +27,7 @@ success_criteria:
   # -- Flow file validity --
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate TerminateParallel/TerminateParallel/TerminateParallel.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -47,7 +47,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate TransformFilterDemo/TransformFilterDemo/TransformFilterDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -48,7 +48,7 @@ success_criteria:
   # -- Flow file validity --
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate TransformGroupByDemo/TransformGroupByDemo/TransformGroupByDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -46,7 +46,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate TransformMapDemo/TransformMapDemo/TransformMapDemo.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -68,7 +68,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate ParallelSync/ParallelSync/ParallelSync.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -56,7 +56,7 @@ success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────
   - type: run_command
     description: "uip maestro flow validate passes on the flow file"
-    command: "uip maestro flow validate ScheduledReport/ScheduledReport/ScheduledReport.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Problem

The `uip maestro flow validate passes on the flow file` success criterion across the maestro-flow suite hard-codes the flow path as `<Name>/<Name>/<Name>.flow`. That path only matches **one** of the layouts the CLI actually produces, so validate fails with `File not found` even when the flow is valid:

- Canonical skill workflow (`solution init <Name> && flow init <Name>`, matching names) → `<Name>/<Name>/<Name>.flow` ✅ matches
- `flow init <Name>` outside a solution (auto-scaffold) → `<Name>Solution/<Name>/<Name>.flow` ❌
- `--skip-solution-registration` → bare `<Name>/<Name>.flow` ❌

Whether a task hits this is **agent-behavior-dependent**: the criterion is only correct when the agent names the solution exactly like the project. Observed on `skill-flow-loop-multiply`, which scored **0.625** — it failed criterion 1 purely on the path (`.../LoopMultiply/LoopMultiply/LoopMultiply.flow` vs the actual `LoopMultiplySolution/LoopMultiply/LoopMultiply.flow`) while the flow validated cleanly and the execution check (criterion 2, which already discovers dynamically) passed.

## Fix

Add `tests/tasks/uipath-maestro-flow/_shared/validate_flow.py`, which discovers the flow **relative to cwd** (the sandbox root the harness runs criteria from — same as every `check_*.py`): it finds the lone `project.uiproj` with `ProjectType="Flow"` via the existing `flow_check.find_project_dir()`, globs every `.flow` under it, and runs `uip maestro flow validate` on each — propagating the exit code. No args, robust to all three layouts, and it **fails loudly** (never a false pass) when no Flow project is present.

Repoint **all 55** hard-coded validate criteria at it (one-line-per-file swap of the criterion command; nothing else touched):
- `smoke/` (3), `single_node/` (18), `multi_node/` (16), `edit/` (6), `hitl/` (7), `ixp/` (3), `context-grounding/` (2), `connector_features/` (1), `interactive/` (1), `e2e/` (1).

## Verification

`validate_flow.py` exercised end-to-end against every layout it will encounter:
- **Wrapper** (`LoopMultiplySolution/…`, the actual failed run's output) → `Status: Valid`, exit 0 (was exit 1).
- **Standalone** (`flow init` bare) → exit 0.
- **Canonical double-nested** (`edit/` `BellevueWeather` seed fixture) → exit 0.
- **Invalid flow** (corrupted node type) → exit 1 (keeps discriminating power).
- **No Flow project** → exit 1, `FAIL: No project.uiproj found` (fails loud, never false-pass).

Diff is a pure 55-line swap: every removed line is a hard-coded `uip maestro flow validate …flow`; every added line is the `validate_flow.py` invocation.

## Still out of scope (follow-up candidates)

Two **execution-check** scripts (criterion 2, not validate) have the same latent brittleness — a non-recursive `glob.glob("<Name>/<Name>/<Name>.flow")` with no fallback: `e2e/check_devcon_expense_approval.py` and `multi_node/customer_escalation/check_customer_escalation_flow.py`. Most other check scripts already discover dynamically (`**/…*.flow` or `find_project_dir()`). Happy to fold these two in if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)