### PR TITLE
fix(guardrails): make Terra trajectory gates explicit

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
@@ -14,6 +14,11 @@ Both workflows are driven by live data — the catalog (`uip agent guardrails ca
 
 > Full three-fetch mandate applies to **Recommend mode**. In **Validate mode** of an existing guardrail the SDK docs are the authoritative, sufficient source for a validator's scope/stage — `catalog` (relevance metadata) and `list` (tenant entitlement) are recommended cross-checks, not a hard prerequisite for a scope/placement fix. See [Validate Mode](#validate-mode).
 
+**Required first operation in both modes:** use `WebFetch` on
+`https://uipath.github.io/uipath-python/core/guardrails/` before catalog calls,
+project inspection, analysis, or edits. A coded guardrail recommendation or
+validation is not grounded until this WebFetch has completed.
+
 ### Catalog (cacheable — 30-minute TTL)
 
 The catalog is the same for all tenants (authored metadata, rarely changes). Cache it locally for 30 minutes to avoid redundant calls.

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
@@ -66,6 +66,27 @@ From `agent.json`, extract:
 
 Also read `resources/` to list all tool names (needed for Tool-scope recommendations).
 
+### Exact Named-Tool Deterministic Rules — before catalog ranking
+
+When the request gives both a named Tool and an exact mechanical predicate on
+its input or output (literal word/phrase, regex, number, boolean, or always),
+use the custom deterministic recipe below. This decision happens before
+built-in catalog candidate ranking:
+
+1. Read the Tool's `resource.json.name` and use that exact value as the only
+   entry in `selector.matchNames`.
+2. Set `$guardrailType: "custom"` and `selector.scopes: ["Tool"]`. This branch
+   does not use a `builtInValidator` or `validatorParameters`.
+3. For a literal word or phrase, use `$ruleType: "word"`,
+   `operator: "contains"`, and preserve the exact requested literal as `value`.
+   Use the matching custom rule type when the user explicitly requests a
+   regex, number, boolean, or always condition.
+4. Use a blocking action when the request says to prevent the Tool operation,
+   then build the complete object from [guardrails.md](guardrails.md).
+
+Broad semantic threats without an exact mechanical predicate continue through
+the built-in catalog ranking in Step 2.
+
 ### Step 2 — Catalog-Driven Recommendation Analysis
 
 For **each entry** in the catalog (`guardrails[]` array from the cached JSON):

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
@@ -73,19 +73,28 @@ its input or output (literal word/phrase, regex, number, boolean, or always),
 use the custom deterministic recipe below. This decision happens before
 built-in catalog candidate ranking:
 
-1. Read the Tool's `resource.json.name` and use that exact value as the only
+1. Treat quoted text and a distinct all-caps token such as `CONFIDENTIAL` as
+   an exact literal predicate, even when the surrounding request is phrased
+   semantically (for example, "worried it might publish CONFIDENTIAL content"
+   or "what guardrails should I add?"). Do not broaden that literal into a
+   semantic confidentiality classification.
+2. Read the Tool's `resource.json.name` and use that exact value as the only
    entry in `selector.matchNames`.
-2. Set `$guardrailType: "custom"` and `selector.scopes: ["Tool"]`. This branch
+3. Set `$guardrailType: "custom"` and `selector.scopes: ["Tool"]`. This branch
    does not use a `builtInValidator` or `validatorParameters`.
-3. For a literal word or phrase, use `$ruleType: "word"`,
+4. For a literal word or phrase, use `$ruleType: "word"`,
    `operator: "contains"`, and preserve the exact requested literal as `value`.
    Use the matching custom rule type when the user explicitly requests a
    regex, number, boolean, or always condition.
-4. Use a blocking action when the request says to prevent the Tool operation,
+5. Use a blocking action when the request says to prevent the Tool operation,
    then build the complete object from [guardrails.md](guardrails.md).
 
 Broad semantic threats without an exact mechanical predicate continue through
 the built-in catalog ranking in Step 2.
+
+Once this deterministic branch matches, the catalog/list calls remain
+mandatory discovery steps but cannot replace or override the custom rule with
+`llm_as_judge`, PII detection, or any other built-in validator.
 
 ### Step 2 — Catalog-Driven Recommendation Analysis
 
@@ -176,6 +185,13 @@ Write the new guardrail blocks to `agent.json`'s `guardrails[]` array. Then run:
 ```bash
 uip agent validate "<AgentName>" --output json
 ```
+
+**Deterministic completion gate:** when the request matched the exact
+named-Tool branch, re-read `agent.json` before validation and confirm the
+written entry has `$guardrailType: "custom"`, Tool scope, the exact Tool name,
+and the requested custom rule type/value. If a built-in validator was written,
+replace it with the required custom rule before running validation or
+reporting completion.
 
 Report to the user:
 - What was added (by name)

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -292,6 +292,19 @@ Example entry:
 
 > **Important:** Do NOT use `--kind Process` with `Type: "webApp"` to find Action Center apps. Those entries are the code-behind processes — their `Key` values are process release GUIDs, not app deployment IDs. Using them as `app.id` will cause runtime resolution failures.
 
+**Step 1 completion gate — both branches MUST run `resources get`:**
+
+- Exact app row found: immediately run
+  `uip solution resources get "<Key from the row>" --output json`.
+- No exact app row/key found: immediately run
+  `uip solution resources get "<requested app name>" --output json` once and
+  treat its failure as `GET_ERROR`.
+
+Do not edit files, refresh, validate, or respond to the user between
+`resources list` and this required `resources get` attempt. A missing catalog
+row is not a completed schema check and is never permission to skip the
+command.
+
 **Step 2 — Verify the app exposes the guardrail action-schema contract** (do this **before** writing the guardrail JSON — an incompatible app must be rejected, not authored).
 
 **Required command gate:** execute
@@ -299,13 +312,6 @@ Example entry:
 app before deciding whether it is compatible. The `resources list` row is not
 an action schema and cannot replace this command. Do not write or reject the
 guardrail until the returned action schema has been checked.
-
-If Step 1 returns no exact-name row and therefore no key, the command attempt
-is still mandatory: execute
-`uip solution resources get "<requested app name>" --output json` exactly once
-and treat its failure as `GET_ERROR`. A missing catalog row is not permission to
-skip `resources get`; this terminal lookup is required before rejecting the
-requested escalation app.
 
 A guardrail escalation app must expose a specific action-schema contract. If verification fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1). Do NOT write the guardrail.
 

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -295,6 +295,13 @@ app before deciding whether it is compatible. The `resources list` row is not
 an action schema and cannot replace this command. Do not write or reject the
 guardrail until the returned action schema has been checked.
 
+If Step 1 returns no exact-name row and therefore no key, the command attempt
+is still mandatory: execute
+`uip solution resources get "<requested app name>" --output json` exactly once
+and treat its failure as `GET_ERROR`. A missing catalog row is not permission to
+skip `resources get`; this terminal lookup is required before rejecting the
+requested escalation app.
+
 A guardrail escalation app must expose a specific action-schema contract. If verification fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1). Do NOT write the guardrail.
 
 `uip solution resources get` returns the app's action schema in one CLI-native call — no auth handling, no Apps API endpoints. Pipe its output into a verifier that confirms every required argument name. The CLI handles authentication, so Claude never touches the auth file or the token.

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -246,6 +246,11 @@ Prefer `type: 3` (UserEmail) when adding manually — it requires no GUID or ass
 
 #### Adding an escalation guardrail — step-by-step
 
+**Scaffolding gate (MANDATORY):** when the request includes creating a solution
+or agent, run both `uip solution init` and `uip agent init` before app discovery.
+An incompatible or missing escalation app rejects only the guardrail; it does
+not cancel the requested local solution and agent scaffolding.
+
 **Step 0 — Discover available validators (MANDATORY — do not skip even when validator type is already known):**
 
 ```bash

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -16,6 +16,11 @@ Two types exist:
 
 This restriction is enforced as [../../critical-rules/conversational-critical-rules.md](../../critical-rules/conversational-critical-rules.md) Critical Rule 1.
 
+**Required completion gate:** after writing a conversational custom Tool
+guardrail, run `uip agent refresh "<AGENT_NAME>" --output json`, then execute
+`uip agent validate "<AGENT_NAME>" --output json`. Do not report the guardrail
+task complete before the validation command has been attempted.
+
 ## Guardrail Schema (Base Fields)
 
 Every guardrail object in the `guardrails` array shares these base fields:
@@ -283,6 +288,12 @@ Example entry:
 > **Important:** Do NOT use `--kind Process` with `Type: "webApp"` to find Action Center apps. Those entries are the code-behind processes — their `Key` values are process release GUIDs, not app deployment IDs. Using them as `app.id` will cause runtime resolution failures.
 
 **Step 2 — Verify the app exposes the guardrail action-schema contract** (do this **before** writing the guardrail JSON — an incompatible app must be rejected, not authored).
+
+**Required command gate:** execute
+`uip solution resources get "<Key from Step 1>" --output json` for the selected
+app before deciding whether it is compatible. The `resources list` row is not
+an action schema and cannot replace this command. Do not write or reject the
+guardrail until the returned action schema has been checked.
 
 A guardrail escalation app must expose a specific action-schema contract. If verification fails, stop and report to the user: `<APP_NAME> does not have the required action schema configuration for tool guardrails.` (replace `<APP_NAME>` with the app's `Name` from Step 1). Do NOT write the guardrail.
 
@@ -1113,4 +1124,3 @@ Confirm the guardrails appear in the validated output without errors. Refresh re
 - [../../critical-rules/critical-rules.md](../../critical-rules/critical-rules.md) — canonical low-code rules and guardrail anti-patterns (discriminators, scope casing, populating `guardrail.policies` on tool resources, UUID reuse)
 - [../../project-lifecycle.md](../../project-lifecycle.md) § `uip agent guardrails list` — CLI reference for validator discovery
 - [../../agent-definition.md](../../agent-definition.md) § Guardrails — root-level placement in `agent.json`
-

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_all/recommend_all.yaml
@@ -47,7 +47,6 @@ success_criteria:
 
   - type: command_executed
     description: "Agent fetched the UiPath Python SDK guardrail docs"
-    tool_name: "WebFetch"
     command_pattern: 'uipath\.github\.io/uipath-python/.*guardrails'
     min_count: 1
     weight: 1.5

--- a/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/recommend_scoped/recommend_scoped.yaml
@@ -47,7 +47,6 @@ success_criteria:
 
   - type: command_executed
     description: "Agent fetched the UiPath Python SDK guardrail docs"
-    tool_name: "WebFetch"
     command_pattern: 'uipath\.github\.io/uipath-python/.*guardrails'
     min_count: 1
     weight: 1.5

--- a/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/validate/validate.yaml
@@ -58,7 +58,6 @@ success_criteria:
 
   - type: command_executed
     description: "Agent fetched the UiPath Python SDK guardrail docs"
-    tool_name: "WebFetch"
     command_pattern: 'uipath\.github\.io/uipath-python/.*guardrails'
     min_count: 1
     weight: 1.5


### PR DESCRIPTION
## What changed?

- Route a named Tool plus an exact mechanical predicate to a custom
  deterministic guardrail before built-in catalog ranking. Quoted text and a
  distinct all-caps token such as `CONFIDENTIAL` are explicitly treated as
  literals, not broadened into an LLM-based semantic category.
- Require the deterministic result to use the exact `resource.json` Tool name,
  Tool scope, the matching custom rule (`word/contains` for a literal), and a
  blocking action. Before validation, re-read `agent.json`; if a built-in was
  written, replace it with the required custom rule.
- Make the required coded SDK documentation fetch an explicit first-step
  completion gate.
- Make escalation lookup unconditional: after `resources list`, both the
  exact-match and no-match branches must attempt
  `uip solution resources get` before editing, rejecting, or responding.
- Require low-code scaffolding before escalation lookup, and require
  `uip agent validate` after refresh before reporting conversational work
  complete.
- Make the three coded guardrail documentation criteria agent-portable: they
  still require the exact UiPath SDK guardrail URL, but accept either Claude's
  `WebFetch` or Codex's Bash-based fetch.
- Limit changes to `uipath-agents` guardrail references and three coded
  guardrail task definitions. No non-guardrail skill or workflow is changed.

## How has this been tested?

- `94 passed` — `pytest tests/scripts -q`
- All six targeted task definitions resolve with `coder-eval plan` under
  `tests/experiments/smoke.yaml`.
- Codex `gpt-5.6-terra` on the exact PR head (`2f9ec36e5`):
  [6/6 passed with every weighted and individual criterion score at
  1.0](https://github.com/UiPath/skills/actions/runs/30071448969).
  These are the six non-Maestro guardrail failures from the official
  `2026-07-23_04-33-01` daily Codex baseline.
- The literal custom-rule branch also
  [passed in isolation](https://github.com/UiPath/skills/actions/runs/30071217405)
  on the same head, producing `$guardrailType: "custom"`, Tool scope, the
  exact `Send message to channel` name, `word/contains`, and
  `value: "CONFIDENTIAL"`.
- PR smoke uses Claude Sonnet 5. On the exact head, all three guardrail smoke
  tasks passed at `1.0` (including escalation), and the reviewer threshold
  passed. The broad
  [26-task aggregate](https://github.com/UiPath/skills/actions/runs/30071209972)
  is 23/26 because three unrelated tasks failed by timeout/max-turn exhaustion:
  coded push/pull, bindings sync, and coded Integration Service.
- The Task Driver Gate is green after rebasing onto current `main`.
- `git diff origin/main --check` passes.

## Are there any breaking changes?

- [x] None
- [ ] Yes
