### PR TITLE
fix(tests): grade 8 more troubleshoot dialogs with include_dialog instead of last-turn-only judging

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-file-locked/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/cv-element-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/cv-element-not-found/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-unauthorized/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-unauthorized/task.yaml
@@ -48,6 +48,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-folder-not-found/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-invalid-odata-query/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-invalid-odata-query/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-dotnet-runtime-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-dotnet-runtime-hang/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-key-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-key-not-found-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.


### PR DESCRIPTION
Follow-up to #2193, same defect, disjoint set of tasks.

The llm_judge in these simulation-mode troubleshoot tasks graded only the final dialog turn (`include_agent_output: true`, no `include_dialog`). When the simulated user keeps talking after the resolution (confirmation questions, cleanup acks, handoffs), the final turn is chit-chat and correct diagnoses get scored 0 - 7 false failures in the 2026-07-23 codex nightly, all with the correct diagnosis present in earlier turns.

#2193 fixed the 4 tasks that failed the 2026-07-22 gemini nightly (plus the 5 from #2159). The codex nightly hit the identical problem on 7 different tasks that were never converted:

- o365-getmail-invalid-odata-query
- ipc-broadcast-message-unauthorized
- o365-getmail-folder-not-found
- csv-append-file-locked
- if-key-not-found-exception
- excel-rr-file-deleted
- py-scope-dotnet-runtime-hang

Fix: add `include_dialog: true` to the llm_judge criterion of each, so the judge sees the whole conversation. Scoped to these tasks; the canonical judge block and prompts are unchanged.

Also adds `include_dialog: true` to `cv-element-not-found` (scored 0.5 in the same nightly). This is a harder, deliberately source-free scenario - the agent under-committed to Branch A across the dialog - so the flag may not by itself clear the 0.7 bar, but it is the same design-consistent change and removes the last-turn-only confound. Note: staging its `process/` source was considered and rejected - the scenario's simulation explicitly denies project source and RESOLUTION.md is written to be solvable from platform evidence alone, so staging would change what the test exercises.

Not covered by this PR (different root cause):
- excel-rr-sheet-dynamic-empty - codex final-turn API error (`TurnStatus.failed`), a harness flake; needs a re-run, not a fixture change.