### PR TITLE
fix(tests): grade If wrapper by pattern, not hardcoded If_1 key

### DIFF
--- a/tests/tasks/uipath-api-workflow/smoke/if_else_grade.yaml
+++ b/tests/tasks/uipath-api-workflow/smoke/if_else_grade.yaml
@@ -50,7 +50,7 @@ success_criteria:
 
   - type: run_command
     description: "Uses If wrapper pattern with #Then and #Else branches (rule 7)"
-    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); grep -q "If_1#Wrapper" "$WF" && grep -q "If_1#Then" "$WF" && grep -q "If_1#Else" "$WF"'
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); grep -qE "If_[A-Za-z0-9_]+#Wrapper" "$WF" && grep -qE "If_[A-Za-z0-9_]+#Then" "$WF" && grep -qE "If_[A-Za-z0-9_]+#Else" "$WF"'
     timeout: 10
     expected_exit_code: 0
     weight: 2.0


### PR DESCRIPTION
## Problem

The last `coder_eval` run of `skill-api-workflow-if-else-grade` reported **FAILURE** despite the agent authoring a structurally correct, fully-runnable If/Else workflow (both PASS and FAIL runtime paths passed).

Root cause: the **rule 7** grader hardcoded the literal activity key `If_1`:

```
grep -q "If_1#Wrapper" && grep -q "If_1#Then" && grep -q "If_1#Else"
```

The agent named its activity descriptively — `If_Grade` — which is valid (activity keys only need to be **globally unique**; the name is the agent's to choose). The check failed on the incidental name, and because rule 7 is weighted/required, it flipped the whole task to FAILURE (weighted score was 0.846, 8/9 criteria green).

This violates the repo's own [`test-writing.md`](.claude/rules/test-writing.md) guidance — *grade behavior, not incidentals*.

## Fix

Match the wrapper **pattern** instead of a specific key:

```
grep -qE "If_[A-Za-z0-9_]+#Wrapper" && grep -qE "If_[A-Za-z0-9_]+#Then" && grep -qE "If_[A-Za-z0-9_]+#Else"
```

Verified: passes `If_Grade`, `If_1`, `If_scoreCheck`, `If_2`; still fails a workflow with no If wrapper. The previously-failed artifact would now score 1.0 → task **PASS** (9/9).

## Scope — swept the whole suite for the same symptom

Checked every task YAML under `tests/tasks/**` (two methods: parsed-YAML walk of grader fields + raw-text grep). **This was the only test grepping a hardcoded activity key on an agent-authored artifact.**

| Reference | Verdict |
|---|---|
| `if_else_grade.yaml` rule 7 | **Fixed** — build task, agent chooses the name |
| `validate_fix.yaml` / `runtime_fix.yaml` → `Response_1` | **Left as-is** — seed-backed survival checks; the `seed_*.py` writes `Response_1`, agent only edits. Loosening would weaken a valid check. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)