### PR TITLE
fix(troubleshoot): add missing cross-redirects between sibling playbooks

### DIFF
--- a/skills/uipath-troubleshoot/references/activity-packages/classic-activities/playbooks/click-silent-no-op.md
+++ b/skills/uipath-troubleshoot/references/activity-packages/classic-activities/playbooks/click-silent-no-op.md
@@ -14,7 +14,7 @@ Distinct from the classic exception paths:
 - **`"Only one of the {0} and {1} options can be set"`** (both `SimulateClick` and `SendWindowMessages` set) → [ui-activity-configuration-error.md](./ui-activity-configuration-error.md).
 - **Nothing threw** → **this playbook**. Route here via `summary.md` (top level) § No-signature routing ("Job/run Successful but the action had no effect").
 
-Classic Click, unlike the modern `NClick`, has **no Verify Execution feature** — there is nothing on the activity to assert the outcome, so a missed classic click is silent *by design*. (For the modern `NClick` silent no-op see the **ui-automation** package.)
+Classic Click, unlike the modern `NClick`, has **no Verify Execution feature** — there is nothing on the activity to assert the outcome, so a missed classic click is silent *by design*. (For the modern `NClick` silent no-op see [ui-automation/click-silent-no-op.md](../../ui-automation/playbooks/click-silent-no-op.md).)
 
 Applies to the classic input activities whose driver posts an event without asserting the outcome: `Click`, `Type Into`, `Send Hotkey`.
 

--- a/skills/uipath-troubleshoot/references/activity-packages/system-activities/playbooks/queue-transaction-activity-failed.md
+++ b/skills/uipath-troubleshoot/references/activity-packages/system-activities/playbooks/queue-transaction-activity-failed.md
@@ -8,7 +8,7 @@ confidence: medium
 
 A modern Orchestrator queue activity (`Get Queue Item` / `Get Transaction Item`, `Set Transaction Status`, or `Add Queue Item`) from `UiPath.System.Activities` faulted — either on client-side input validation or on the Orchestrator API call. Storage-bucket activities (`Get / Upload / Delete Storage File`) share the same "not connected" and API-error modes below.
 
-> For the classic `Add Queue Item` activity (`UiPath.Core.Activities` — "Queue name may not be null or empty", reserved-character keys, duplicate keys), use [classic-activities/add-queue-item-failed.md](../../classic-activities/playbooks/add-queue-item-failed.md). For `Get Asset` / `Get Credential`, use the get-asset playbooks in this package.
+> For the classic `Add Queue Item` activity (`UiPath.Core.Activities` — "Queue name may not be null or empty", reserved-character keys, duplicate keys), use [classic-activities/queue-operation-failed.md](../../classic-activities/playbooks/queue-operation-failed.md). For `Get Asset` / `Get Credential`, use the get-asset playbooks in this package.
 
 What this looks like:
 - `Queue Name is required.` (`ArgumentValueNotSetException`) — the `QueueName` input was empty/unresolved.

--- a/skills/uipath-troubleshoot/references/activity-packages/ui-automation/playbooks/click-silent-no-op.md
+++ b/skills/uipath-troubleshoot/references/activity-packages/ui-automation/playbooks/click-silent-no-op.md
@@ -15,7 +15,7 @@ This is the **no-signature** counterpart to [verify-execution-failure.md](./veri
 
 Applies to the input activities whose driver posts an event without asserting the outcome: `NClick`, `NTypeInto`, `NSetText`, `NCheck`, `NSelectItem`, `NHover`, `NKeyboardShortcuts`.
 
-**Classic `Click` (UiPath.Core.Activities) is a different playbook** — it has no Verify Execution feature at all, so a missed classic click is silent by design: [classic-activities click-silent-no-op](../../classic-activities/playbooks/click-silent-no-op.md). This playbook covers UIAutomationNext (`N*`) activities only.
+**Classic input activities (`UiPath.Core.Activities` — `Click`, `Type Into`, `Send Hotkey`) are a different playbook** — they have no Verify Execution feature at all, so a missed classic click is silent by design: [classic-activities/click-silent-no-op.md](../../classic-activities/playbooks/click-silent-no-op.md). This playbook covers UIAutomationNext (`N*`) activities only.
 
 What this looks like:
 

--- a/skills/uipath-troubleshoot/references/activity-packages/ui-automation/playbooks/click-silent-no-op.md
+++ b/skills/uipath-troubleshoot/references/activity-packages/ui-automation/playbooks/click-silent-no-op.md
@@ -15,6 +15,8 @@ This is the **no-signature** counterpart to [verify-execution-failure.md](./veri
 
 Applies to the input activities whose driver posts an event without asserting the outcome: `NClick`, `NTypeInto`, `NSetText`, `NCheck`, `NSelectItem`, `NHover`, `NKeyboardShortcuts`.
 
+**Classic `Click` (UiPath.Core.Activities) is a different playbook** — it has no Verify Execution feature at all, so a missed classic click is silent by design: [classic-activities click-silent-no-op](../../classic-activities/playbooks/click-silent-no-op.md). This playbook covers UIAutomationNext (`N*`) activities only.
+
 What this looks like:
 
 - Job/instance `State = Successful`; **zero** Error-level logs for the run.

--- a/skills/uipath-troubleshoot/references/products/api-workflows/playbooks/connection-auth-failure.md
+++ b/skills/uipath-troubleshoot/references/products/api-workflows/playbooks/connection-auth-failure.md
@@ -10,6 +10,7 @@ What this looks like:
 - The workflow runs clean locally with `uip api-workflow run` but a Connector/HTTP activity fails once published (or against the real IS proxy)
 - The Integration Service proxy returns an auth-shaped **4xx**, surfaced in the failing activity's result. (The executor normalizes any 4xx from the proxy to a 400 client-error status on its own error envelope, so triage on the **status code in the result payload**, not the envelope status.)
 - A connection binding that is missing entirely fails earlier, locally, as a 400 validation error (`CONNECTION_REQUIRED`) before any proxy call — not a cloud auth failure
+- A 401 from a **browser Coded App** SDK call (`https://api.uipath.com/...` in the network tab, External Application PKCE token) is a different surface → [coded-apps/api-401-after-login.md](../../coded-apps/playbooks/api-401-after-login.md)
 
 The status code in the result payload discriminates the cause family:
 

--- a/skills/uipath-troubleshoot/references/products/coded-apps/playbooks/api-401-after-login.md
+++ b/skills/uipath-troubleshoot/references/products/coded-apps/playbooks/api-401-after-login.md
@@ -9,6 +9,7 @@ confidence: high
 What this looks like:
 - The app authenticates and renders, then an SDK call to `https://api.uipath.com/...` returns `HTTP 401 Unauthorized` (visible in the network tab or a caught SDK error)
 - The failure is on a specific API call, **after** a successful login — not an OAuth `error=` on the callback URL (that is [invalid-scope.md](./invalid-scope.md))
+- A 401 on an **API Workflow connector/HTTP activity** (`Invalid Organization or User secret, or invalid Element token provided` in the activity result payload) is a different surface → [api-workflows/connection-auth-failure.md](../../api-workflows/playbooks/connection-auth-failure.md)
 
 What can cause it:
 - The access token lacks the scope required by the API being called

--- a/skills/uipath-troubleshoot/references/runtime-exceptions/playbooks/null-reference-exception.md
+++ b/skills/uipath-troubleshoot/references/runtime-exceptions/playbooks/null-reference-exception.md
@@ -18,6 +18,7 @@ What this looks like:
 What can cause it:
 - Variable declared but never assigned (or assigned only in a conditional branch that wasn't taken)
 - Activity output was null and used directly without a null check (e.g., data table lookup with no match, JSON path that doesn't exist, regex with no match)
+- A `Get Asset` / `Get Orchestrator Asset` upstream completed successfully but returned null/empty (activity bug — copy-paste state, `Ctrl+K` variable in `UiPath.System.Activities` 22.10.x). If the backward trace lands on a Get Asset output → [get-asset-activity-bug-silent-failure](../../activity-packages/system-activities/playbooks/get-asset-activity-bug-silent-failure.md)
 - Queue item field missing or null (`TransactionItem.SpecificContent("fieldName")` with wrong field name)
 - External system returned null or empty response (HTTP Request, database query, SOAP call)
 - Collection used before initialization (array, List, DataTable)

--- a/skills/uipath-troubleshoot/references/runtime-exceptions/playbooks/null-reference-exception.md
+++ b/skills/uipath-troubleshoot/references/runtime-exceptions/playbooks/null-reference-exception.md
@@ -18,7 +18,7 @@ What this looks like:
 What can cause it:
 - Variable declared but never assigned (or assigned only in a conditional branch that wasn't taken)
 - Activity output was null and used directly without a null check (e.g., data table lookup with no match, JSON path that doesn't exist, regex with no match)
-- A `Get Asset` / `Get Orchestrator Asset` upstream completed successfully but returned null/empty (activity bug — copy-paste state, `Ctrl+K` variable in `UiPath.System.Activities` 22.10.x). If the backward trace lands on a Get Asset output → [get-asset-activity-bug-silent-failure](../../activity-packages/system-activities/playbooks/get-asset-activity-bug-silent-failure.md)
+- A `Get Asset` / `Get Orchestrator Asset` upstream completed without fault but returned null/empty. If the activity was copy-pasted from another sequence, or the output variable was created with `Ctrl+K` on `UiPath.System.Activities` 22.10.x (known activity bug) → [get-asset-activity-bug-silent-failure.md](../../activity-packages/system-activities/playbooks/get-asset-activity-bug-silent-failure.md). Otherwise the asset value is genuinely empty (unset per-robot value, empty asset in Orchestrator) — a data/config issue, not that bug
 - Queue item field missing or null (`TransactionItem.SpecificContent("fieldName")` with wrong field name)
 - External system returned null or empty response (HTTP Request, database query, SOAP call)
 - Collection used before initialization (array, List, DataTable)


### PR DESCRIPTION
Playbook routing fixes for asymmetric or broken cross-references in the troubleshoot skill, found via knowledge-graph analysis of the docs plus a full relative-link audit (1134 links checked).

## Changes

1. **ui-automation/playbooks/click-silent-no-op.md** - the classic playbook already redirects modern `NClick` cases to ui-automation, but the reverse redirect was missing. Both playbooks match the same grep tokens (click, silent, reported success), so an agent landing on the ui-automation playbook with a classic `Click` fault would be told to configure Verify Execution - a feature classic Click does not have. Added a one-line discriminator: classic `Click` (UiPath.Core.Activities) -> classic-activities playbook.

2. **runtime-exceptions/playbooks/null-reference-exception.md** - the Get Asset silent-failure playbook routes plain-null cases here, but the reverse route was missing. An NRE investigation tracing the null backward to a `Get Asset` output would stop at "add a null check" (symptom) instead of reaching the known activity-bug root cause (copy-paste state / Ctrl+K variable in UiPath.System.Activities 22.10.x). Added a cause bullet with the redirect.

3. **system-activities/playbooks/queue-transaction-activity-failed.md** - the classic `Add Queue Item` redirect pointed to `classic-activities/playbooks/add-queue-item-failed.md`, which does not exist. The correct target is `queue-operation-failed.md`, which covers all three signatures the redirect names (null/empty queue name, reserved-character keys, duplicate keys). This was the only broken link in the corpus.

4. **api-workflows/playbooks/connection-auth-failure.md + coded-apps/playbooks/api-401-after-login.md** - both are "401 in cloud after auth" with heavy shared grep tokens (401, Unauthorized, scope, OAuth, token, after login) and no mutual discriminator. An API Workflow author landing on the coded-apps playbook would be told to clear browser storage and edit External Application scopes - nonsense for a connector activity. Added one discriminator bullet in each file's "What this looks like", keyed on caller surface + verbatim signature.

All changes are single-line discriminator/redirect additions; no workflow or resolution content changed.