### PR TITLE
fix(uipath-rpa): keep Studio Web-editable projects XAML-only

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -54,6 +54,16 @@ Before creating or modifying anything, determine which project to work with. See
 
 **Quick check:** Find `project.json` to establish `{projectRoot}`. That's it — no Studio Desktop check needed for the standard loop. `uip rpa` auto-launches a headless Studio (UiPath.Studio.Helm NuGet) on first call. Studio Desktop is required only for `files diff`, `focus-activity`, and regenerating coded UI automation's `ObjectRepository.cs` (the `Descriptors.*` class — see Rule 7 and [environment-setup.md](references/environment-setup.md)).
 
+## Authoring Surface Gate
+
+Resolve whether the RPA project must remain **editable in Studio Web** before choosing coded vs. XAML. Merely carrying or deploying an RPA project inside a Studio Web Solution is not the same requirement; apply this gate when the user expects the project's workflow and test files to open and remain editable in the browser.
+
+- **Studio Web editability required** → for a new project, use **Portable + XAML only**. Author workflows, helper logic, and test cases as `.xaml` with supported activities and expressions. Do not add coded workflows, coded test cases, or Coded Source Files (`.cs`).
+- **Studio Web editability + explicit coded request** → surface the incompatible constraints and ask the user to choose: keep Studio Web editability and use XAML, or use coded artifacts and author them in Studio Desktop. Do not silently choose one.
+- **Existing Windows project or existing coded artifacts** → do not claim the project will remain browser-editable, and do not change `targetFramework` in place. Surface the conflict and offer a separate/new Portable XAML project if browser editing is required.
+
+This gate overrides the mode-selection heuristics below, including the usual coded recommendation for unit-testable business logic. See [coded-vs-xaml-guide.md](references/coded-vs-xaml-guide.md) for the full decision flow.
+
 ## Project Type Detection
 
 After establishing `PROJECT_DIR`, **first check `project.json` for `targetFramework`**:
@@ -83,8 +93,8 @@ For modern projects, determine whether this is a **coded** or **XAML** project:
 | Complex data transforms, HTTP, parsing | **Coded** | C# is more natural than nested XAML activities |
 | Tempted to call a PowerShell script | **Coded** | Prefer a coded workflow. If PS is genuinely needed (admin cmdlets, existing `.ps1`), use the `InvokePowerShell<T>` activity — never `Invoke Process` + `powershell.exe`. See [powershell-interop-guide.md](references/powershell-interop-guide.md) |
 | Custom data models / DTOs | **Coded Source File** | XAML cannot define types — plain `.cs`, no `CodedWorkflow` base |
-| Unit tests with assertions | **Coded Test Case** | `[TestCase]` with Arrange/Act/Assert |
-| User explicitly requests coded/XAML | **User's choice** | Never second-guess explicit preference |
+| Unit tests with assertions | **Coded Test Case** for Studio Desktop; **XAML Test Case** when Studio Web editability is required | `[TestCase]` with Arrange/Act/Assert in coded mode; Testing activities in XAML |
+| User explicitly requests coded/XAML | **User's choice when compatible with the authoring surface** | Surface a conflict instead of creating artifacts the requested editor cannot edit |
 
 ### UI Automation Boundaries
 
@@ -187,7 +197,9 @@ uip rpa activities find --query log --output json > /dev/null 2>&1 &
 
 ### Destination Preflight (Both Modes)
 
-**Studio Web destination → Solution-wrapped deliverable, not a bare project.** Studio Web ingests Solutions only; a bare project folder is invisible in both SW workspace tabs. Treat these phrases as SW signals in the request: "Studio Web", "SW", "upload to web", "browser editor", "cloud workspace edit". On match, build the RPA project normally per the rest of this skill, then hand off to `uipath-solution` to wrap and ship it: `uip solution init <NAME>` → `uip solution projects import "<PROJECT_DIR>" --solutionFile <SOLUTION>.uipx` → `uip solution upload "<SOLUTION_DIR>"`. The final deliverable is the Solution, not the bare project folder. Local execution (`uip rpa run`) and the Orchestrator package flow (`uip rpa pack` → `uip or packages upload` — there is no `uip rpa publish`) are fine with a bare project — only an SW destination changes the deliverable shape.
+**Studio Web destination → Solution-wrapped deliverable, not a bare project.** Studio Web ingests Solutions only; a bare project folder is invisible in both SW workspace tabs. Treat these phrases as SW destination signals in the request: "Studio Web", "SW", "upload to web", "browser editor", "cloud workspace edit". On match, build the RPA project normally per the rest of this skill, then hand off to `uipath-solution` to wrap and ship it: `uip solution init <NAME>` → `uip solution projects import "<PROJECT_DIR>" --solutionFile <SOLUTION>.uipx` → `uip solution upload "<SOLUTION_DIR>"`. The final deliverable is the Solution, not the bare project folder.
+
+Solution delivery and browser editability are separate constraints. If the user requires browser editing, the project must already satisfy the Authoring Surface Gate before it is wrapped. If the project only needs to be carried or deployed inside a Studio Web Solution, do not rewrite its authoring mode solely because of the Solution destination. Local execution (`uip rpa run`) and the Orchestrator package flow (`uip rpa pack` → `uip or packages upload` — there is no `uip rpa publish`) are fine with a bare project — only an SW destination changes the deliverable shape.
 
 ### Execution Discipline (Both Modes)
 

--- a/skills/uipath-rpa/references/coded-vs-xaml-guide.md
+++ b/skills/uipath-rpa/references/coded-vs-xaml-guide.md
@@ -6,11 +6,19 @@ When to use coded workflows (C#), XAML workflows (low-code), Coded Source Files,
 
 `uip rpa init` produces a mode-agnostic project — both `project.uiproj` and `project.json` are scaffolded, and the project can host coded workflows (`.cs`), XAML workflows (`.xaml`), or both. The coded vs XAML decision happens when you add a workflow to the project (or when an existing project's dominant mode dictates the default — see step 1 below).
 
+## Authoring Surface Gate
+
+Resolve the required authoring surface before applying the decision flowchart.
+
+- **Must remain editable in Studio Web** → use **Portable + XAML only** for workflows, helper logic, and test cases. Do not introduce coded workflows, coded test cases, or Coded Source Files (`.cs`).
+- **Only carried or deployed inside a Studio Web Solution** → this does not by itself force XAML. Preserve the project's compatible authoring mode unless browser editability is also required.
+- **Studio Web editability conflicts with an explicit coded request or existing coded/Windows project** → surface the conflict. The user must choose XAML browser editing, Studio Desktop coded authoring, or a separate/new Portable XAML project. Never imply that Solution wrapping makes coded files browser-editable.
+
 ## Decision Flowchart
 
-Follow top-down. Stop at the first match.
+Apply the Authoring Surface Gate first. If it does not decide the mode, follow this flow top-down and stop at the first match.
 
-0. **Did the user specify a mode?** ("coded workflow", "XAML workflow", "create a .cs file", "low-code") → **Use what they asked for. Do not second-guess.**
+0. **Did the user specify a compatible mode?** ("coded workflow", "XAML workflow", "create a .cs file", "low-code") → **Use what they asked for.** If it conflicts with the Authoring Surface Gate, surface the conflict instead.
 1. **Check the project's existing mode.** Match it unless there is a clear reason not to:
    - **XAML-only project** → default to XAML. Only go coded if steps 3-6 below apply.
    - **Coded-only project** → default to coded. Activities (Excel, Mail, UI automation) are available via services on `CodedWorkflow`.
@@ -19,7 +27,7 @@ Follow top-down. Stop at the first match.
 2. **Can existing activities handle the task directly?** (read Excel, send email, move file, UI click/type, queue processing, connector calls) → **XAML.** This covers the bulk of RPA work. No coded mode needed.
 3. **Does it define data models, DTOs, enums, or custom classes?** → **Coded Source File** (plain `.cs`, no `CodedWorkflow` base). XAML cannot define types — this is the one case where going hybrid is always justified.
 4. **Does it involve complex algorithmic logic?** (5+ nested branches, LINQ aggregation, regex extraction, REST API pagination/retry, sorting/dedup/fuzzy matching) → **Coded Workflow** for that step. Standard if/else, simple loops, and connector calls are fine in XAML — only escalate when a single XAML workflow grows past ~50 activities.
-5. **Does it need unit tests or assertions on business logic?** → **Coded Workflow** + **Coded Test Case** for the logic under test. UI/integration tests can stay XAML.
+5. **Does it need unit tests or assertions on business logic?** → **Coded Workflow** + **Coded Test Case** for Studio Desktop authoring. When Studio Web editability is required, keep the workflow and test case in XAML and use Testing activities.
 6. **Is it reusable utility code?** (helpers, formatters, validators, extension methods) → **Coded Source File**.
 7. **Default** → XAML.
 
@@ -41,7 +49,7 @@ Follow top-down. Stop at the first match.
 
 5. **Reusable utility libraries** — Date formatting, validation helpers, encryption, file path manipulation. Define as a Coded Source File, callable from any workflow.
 
-6. **Unit-testable business logic** — Pure functions (input → output, no UI) that need automated assertions. Coded Test Cases can call coded workflows directly.
+6. **Unit-testable business logic** — Pure functions (input → output, no UI) that need automated assertions. Coded Test Cases can call coded workflows directly when Studio Desktop is the authoring surface.
 
 7. **Algorithm-heavy work** — Sorting, deduplication, fuzzy matching, tree traversal — anything that would require dozens of Assign + If activities in XAML.
 
@@ -59,7 +67,9 @@ Follow top-down. Stop at the first match.
 
 4. **Process orchestration** — REFramework, queue-based transaction processing, retry patterns. The XAML templates for these are battle-tested.
 
-5. **Mixed workloads** — When some steps are activity-heavy and others involve light logic. Use XAML for orchestration; extract only the genuinely complex logic into a coded workflow invoked via `Invoke Workflow File`.
+5. **Mixed workloads** — When some steps are activity-heavy and others involve light logic. Use XAML for orchestration; extract only the genuinely complex logic into a coded workflow invoked via `Invoke Workflow File`, unless Studio Web editability requires the project to remain XAML-only.
+
+6. **Studio Web-editable RPA projects** — Keep workflows, helper logic, and test cases in XAML so every authored artifact remains editable in the browser.
 
 ---
 
@@ -72,7 +82,7 @@ InvokeCode embeds C#/VB code inline in a XAML activity. It works for small snipp
 1. **Code exceeds ~15 lines** → extract to a Coded Source File (utility) or Coded Workflow (if it needs `CodedWorkflow` services).
 2. **Code defines classes or types** → extract to a Coded Source File. InvokeCode cannot define reusable types.
 3. **Same code is copy-pasted across multiple XAML files** → extract to a Coded Workflow and invoke it via `Invoke Workflow File`.
-4. **Code needs unit tests** → extract to a Coded Workflow + Coded Test Case.
+4. **Code needs unit tests** → extract to a Coded Workflow + Coded Test Case for Studio Desktop authoring. For a Studio Web-editable project, keep the implementation and test case in XAML and assert with Testing activities.
 5. **Code uses complex .NET APIs** (HttpClient, LINQ, JSON serialization) → extract to a Coded Workflow for better readability and error handling.
 
 ### Comparison Table
@@ -93,6 +103,8 @@ InvokeCode embeds C#/VB code inline in a XAML activity. It works for small snipp
 ## Hybrid Project Patterns
 
 Hybrid projects mix coded and XAML files. The `workflows` property provides strongly-typed access to **all** workflows — both `.cs` and `.xaml` — so there is no friction in cross-invocation.
+
+Do not use these hybrid patterns when the project must remain editable in Studio Web; that authoring surface requires an XAML-only project.
 
 ### Interop Mechanisms
 
@@ -173,8 +185,9 @@ Both XAML workflows (via typed arguments) and coded workflows (via direct refere
 3. **Duplicating logic in both XAML and coded form.** Pick one, invoke it from the other.
 4. **Using `DataTable` or `Dictionary<string, object>` when a typed class would prevent errors.** Create a Coded Source File with a proper class.
 5. **Defaulting to coded for ambiguous requests.** "Create a workflow", "automate X", "build a process" mean XAML. Switch to coded only on explicit coded phrasing or a coded-specific trigger (custom types, complex algorithms, unit tests on business logic).
-6. **Overriding the user's explicit choice.** If the user says "coded workflow", create a coded workflow — do not suggest XAML instead. Same the other way: if the user says "XAML", do not suggest coded.
+6. **Overriding a compatible explicit choice.** If the user says "coded workflow", create a coded workflow unless it conflicts with the required authoring surface. Same the other way: if the user says "XAML", do not suggest coded.
 7. **Picking coded for UI automation by default.** UI automation defaults to XAML. Coded UI automation via the `uiAutomation` service is the exception, not the rule.
+8. **Treating Solution wrapping as browser-editability.** A Studio Web Solution can carry an RPA project without making coded files editable in the browser. Apply the Authoring Surface Gate separately.
 
 ---
 

--- a/tests/tasks/uipath-rpa/studio-web/studio-web-xaml-authoring.yaml
+++ b/tests/tasks/uipath-rpa/studio-web/studio-web-xaml-authoring.yaml
@@ -1,0 +1,86 @@
+task_id: skill-rpa-studio-web-xaml-authoring
+description: >
+  Regression coverage for destination-aware mode selection: an RPA project
+  containing unit-testable resolver logic and assertions must stay Portable
+  and XAML-only when the user requires every artifact to remain editable in
+  Studio Web.
+tags: [uipath-rpa, windows, smoke, mode:build, lifecycle:generate, feature:test-case]
+
+run_limits:
+  expected_turns: 24
+  max_turns: 50
+  turn_timeout: 1200
+  task_timeout: 1200
+
+initial_prompt: |
+  Prepare a new UiPath RPA project named "BrowserEditableResolver" in the
+  current directory. It will later be imported into an existing Studio Web
+  Solution, and every workflow and automated test must remain editable in
+  Studio Web.
+
+  Implement a simple resolver that maps an input status such as "new" or
+  "closed" to a standardized output, and add an automated test case with an
+  assertion for the resolver behavior. Keep the work local; the existing
+  Solution and cloud upload are out of scope.
+
+  Do not ask for approval or confirmation. The `uip` CLI is already
+  available in the environment.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent initialized an RPA project with Portable target framework"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+rpa\s+init(?=[^\n]*--target-framework\s+Portable)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Project metadata targets Portable for Studio Web editing"
+    path: "BrowserEditableResolver/project.json"
+    includes:
+      - '"targetFramework": "Portable"'
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Project contains a resolver workflow and a separate XAML test case"
+    command: >-
+      test "$(find BrowserEditableResolver -type f -name '*.xaml' | wc -l)" -ge 2
+    expected_exit_code: 0
+    timeout: 10
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "No authored coded workflows, coded tests, or Coded Source Files were added"
+    command: >-
+      test -z "$(find BrowserEditableResolver -type f -name '*.cs'
+      -not -path '*/.local/*' -not -path '*/.codedworkflows/*' -print -quit)"
+    expected_exit_code: 0
+    timeout: 10
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "project.json registers an XAML test case in fileInfoCollection"
+    command: >-
+      python3 -c "import json,sys;
+      d=json.load(open('BrowserEditableResolver/project.json', encoding='utf-8'));
+      files=d.get('designOptions',{}).get('fileInfoCollection',[]);
+      sys.exit(0 if any(str(x.get('fileName','')).lower().endswith('.xaml')
+      and x.get('testCaseType') == 'TestCase' for x in files) else 1)"
+    expected_exit_code: 0
+    timeout: 10
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "At least one XAML test uses a Testing assertion activity"
+    command: >-
+      find BrowserEditableResolver -type f -name '*.xaml' -exec grep -Eil
+      'Verify(Expression|ExpressionWithOperator|ControlAttribute)' {} +
+    expected_exit_code: 0
+    timeout: 10
+    weight: 1.5
+    pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- add an authoring-surface gate before coded-vs-XAML mode selection
- require new browser-editable Studio Web RPA projects to use Portable + XAML workflows and test cases
- distinguish browser editability from merely carrying or deploying an RPA project inside a Studio Web Solution
- add a regression task covering unit-testable resolver logic and an automated assertion without coded artifacts

## Problem

The current mode-selection guidance recommends coded workflows and coded test cases for unit-testable business logic before accounting for the requested authoring surface. When an RPA project is intended for a Studio Web Solution, that ordering can cause an agent to choose coded tests and only reconsider after the user points out that the artifacts must remain editable in Studio Web.

## Expected behavior

- If browser editability is required, create a new Portable project and keep workflows, helper logic, and tests in XAML.
- If the project is only being carried or deployed in a Studio Web Solution, do not change its authoring mode solely because of the Solution destination.
- If Studio Web editability conflicts with an explicit coded request or an existing Windows/coded project, surface the conflict instead of silently choosing or changing the target framework.

## Validation

- `python3 scripts/check-cli-verbs.py --json tests/tasks/uipath-rpa/studio-web/studio-web-xaml-authoring.yaml`
- YAML parse of the new regression task
- `python3 scripts/check-skill-status.py`
- `bash hooks/validate-skill-descriptions.sh`
- `npm run version:check`
- `git diff --check`

The full `coder-eval` task run is pending; this PR is intentionally opened as a draft.