### PR TITLE
fix(tests): drop tempdir driver pins from classic-invoke troubleshoot tasks

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir


### PR DESCRIPTION
## Why

Every open PR currently fails the **Task Driver Gate** (`No task pins sandbox.driver tempdir`). #2104 added the six `classic-invoke-*` troubleshoot tasks with `sandbox.driver: tempdir` while #2210 — which removed all such pins and introduced the gate — was in flight. The two crossed without conflicting, and since the gate only runs on `pull_request`, main itself never surfaced the breakage.

## What

Deletes the `driver: tempdir` line from the six task YAMLs, exactly as #2210 did for every other task. All six are Linux tasks (no `windows` tag, mock `template_dir` + python sandbox), so per `scripts/check-task-driver.py` the driver must come from the run environment, not the YAML.

Verified locally:

```
$ python3 scripts/check-task-driver.py tests/tasks
OK — no task pins `sandbox.driver: tempdir`.
```

First observed on PR #1694 after updating its branch with main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)