### PR TITLE
fix(tests): raise guardrail smoke/escalation turn_timeout 300 -> 1200

### DIFF
--- a/tests/tasks/uipath-agents/coded/guardrails/escalation/escalation.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/escalation/escalation.yaml
@@ -84,4 +84,4 @@ run_limits:
   # drives the cap in coder-eval; max_turns kept for parity with recommend/validate.
   expected_turns: 32
   max_turns: 40
-  turn_timeout: 300
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml
@@ -49,4 +49,4 @@ success_criteria:
 
 run_limits:
   expected_turns: 10
-  turn_timeout: 300
+  turn_timeout: 1200


### PR DESCRIPTION
## Why

The uipath-agents smoke suite is flaking on turn-timeout kills. In the last two runs on PR #1694:

- **July 7:** `skill-agent-guardrail-coded-escalation-smoke` — `Turn timeout (300s) fired after 300.0s — hard-killing subprocess`
- **Today (after branch refresh):** `skill-agent-guardrail-coded-smoke` — same 300s hard-kill

These were the only turn-timeout deaths in the suite, and they map exactly to the only two smoke-suite tasks pinning `turn_timeout: 300`. A single agent turn that wraps a long `pip install` / `uip` invocation legitimately exceeds 5 minutes on CI.

## What

Raises `turn_timeout` from 300 to 1200 in:

- `tests/tasks/uipath-agents/coded/guardrails/smoke/smoke.yaml`
- `tests/tasks/uipath-agents/coded/guardrails/escalation/escalation.yaml`

1200 is the suite standard — 99 of 106 `turn_timeout` pins under `tests/tasks/uipath-agents/` already use it, including every sibling guardrail task. Neither task sets `task_timeout`, so nothing else caps the run sooner.

Three other tasks pin `turn_timeout: 300` (`deploy_folder_and_rebump`, `push_pull_roundtrip`, maestro-flow `routing_listing`) but each pairs it with a deliberate short `task_timeout` (300–600s) and none has failed on turn timeout — left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)