### PR TITLE
fix(maestro-case): enforce plan before case creation

### DIFF
--- a/hooks/guard-case-plan.js
+++ b/hooks/guard-case-plan.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+
+const deny = (reason) => process.stdout.write(JSON.stringify({
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: reason,
+  },
+}));
+const within = (root, item) => {
+  const relative = path.relative(root, item);
+  return relative === "" ||
+    (!relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative));
+};
+
+let input;
+try { input = JSON.parse(fs.readFileSync(0, "utf8")); } catch { process.exit(0); }
+const raw = input?.tool_input?.file_path || input?.tool_input?.path;
+if (!raw || path.basename(raw).toLowerCase() !== "caseplan.json") process.exit(0);
+
+const cwd = path.resolve(input.cwd || process.cwd());
+const target = path.resolve(cwd, raw);
+if (!within(cwd, target)) process.exit(0);
+
+let dir = path.dirname(target);
+let sdd;
+while (within(cwd, dir)) {
+  const candidate = path.join(dir, "sdd.md");
+  if (fs.existsSync(candidate)) { sdd = candidate; break; }
+  if (dir === cwd || path.dirname(dir) === dir) break;
+  dir = path.dirname(dir);
+}
+if (!sdd) process.exit(0);
+
+const planPath = path.join(path.dirname(sdd), "tasks", "tasks.md");
+let plan = "";
+try { plan = fs.readFileSync(planPath, "utf8"); } catch {}
+const entries = plan.match(/^## T\d+:\s/gm) || [];
+if (!/^## Inventory(?:\s|$)/m.test(plan) ||
+    !entries.some((entry) => entry.startsWith("## T01:")) ||
+    entries.length < 3) {
+  deny(`Greenfield case build blocked: create ${planPath} with a ` +
+    "'## Inventory' section and at least three numbered entries beginning " +
+    "'## T01:' before writing caseplan.json.");
+}

--- a/hooks/guard-case-plan.ps1
+++ b/hooks/guard-case-plan.ps1
@@ -1,0 +1,3 @@
+# Behavioral twin: guard-case-plan.sh
+& node (Join-Path $PSScriptRoot 'guard-case-plan.js')
+exit $LASTEXITCODE

--- a/hooks/guard-case-plan.sh
+++ b/hooks/guard-case-plan.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Behavioral twin: guard-case-plan.ps1
+exec node "$(dirname "$0")/guard-case-plan.js"

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -22,6 +22,18 @@
         ]
       }
     ],
+    "PreToolUse": [
+      {
+        "matcher": "Write|WriteFile",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo `# <#` >/dev/null\nbash \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-case-plan.sh\"\nexit $?\n: <<'POLYEOF' #> > $null\n& \"${CLAUDE_PLUGIN_ROOT}/hooks/guard-case-plan.ps1\"\nif ($null -eq $LASTEXITCODE) { exit 1 } else { exit $LASTEXITCODE }\nPOLYEOF\n",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "PostToolUse": [
       {
         "matcher": "*",

--- a/tests/scripts/test_guard_case_plan_hook.py
+++ b/tests/scripts/test_guard_case_plan_hook.py
@@ -1,0 +1,52 @@
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+TWINS = [
+    ["bash", str(ROOT / "hooks/guard-case-plan.sh")],
+    ["pwsh", "-NoProfile", "-File", str(ROOT / "hooks/guard-case-plan.ps1")],
+]
+
+
+def run_hook(hook, cwd: Path, target: Path) -> str:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "cwd": str(cwd),
+        "tool_name": "Write",
+        "tool_input": {"file_path": str(target)},
+    }
+    result = subprocess.run(
+        hook, input=json.dumps(payload), text=True, capture_output=True, check=True
+    )
+    return result.stdout
+
+
+@pytest.mark.parametrize("hook", TWINS, ids=["bash", "pwsh"])
+def test_requires_structured_plan_before_caseplan_write(hook, tmp_path):
+    if shutil.which(hook[0]) is None:
+        pytest.skip(f"{hook[0]} not available")
+    (tmp_path / "sdd.md").write_text("# SDD\n", encoding="utf-8")
+    target = tmp_path / "Solution/Project/caseplan.json"
+
+    output = json.loads(run_hook(hook, tmp_path, target))
+    decision = output["hookSpecificOutput"]
+    assert decision["permissionDecision"] == "deny"
+    assert "tasks/tasks.md" in decision["permissionDecisionReason"]
+
+    plan = tmp_path / "tasks/tasks.md"
+    plan.parent.mkdir()
+    plan.write_text("# Implementation plan\nEverything is covered.\n", encoding="utf-8")
+    assert json.loads(run_hook(hook, tmp_path, target))[
+        "hookSpecificOutput"
+    ]["permissionDecision"] == "deny"
+
+    plan.write_text(
+        "## Inventory\n\n## T01: Case\n## T02: Trigger\n## T03: Stage\n",
+        encoding="utf-8",
+    )
+    assert run_hook(hook, tmp_path, target) == ""


### PR DESCRIPTION
## Summary

Add a deterministic `PreToolUse` guard on `caseplan.json` creation. When a greenfield case has an `sdd.md`, the guard denies the write unless the canonical `tasks/tasks.md` contains:

- a `## Inventory` section
- at least three numbered T-entries beginning with `## T01:`

The hook sits outside the authoring model, so the model cannot bypass it by claiming the plan is complete. The bash and PowerShell hook twins delegate to the same small implementation. Brownfield edits use `Edit`, so they are not matched by the guard.

## Why

The failed golden run skipped the phased workflow, wrote a five-line summary to root `tasks.md`, and then created `caseplan.json` directly. More skill instructions or feature-specific SLA/connector checks would not address that bypass. This guard blocks the exact invalid phase transition before artifact generation.

This is deliberately a structural gate, not a claim that it proves all case semantics. Existing semantic graders and `uip maestro case validate` continue to own artifact correctness.

## Validation

- `bash -n hooks/guard-case-plan.sh`
- `node --check hooks/guard-case-plan.js`
- `python3 -m json.tool hooks/hooks.json`
- `uv run --with pytest python -m pytest tests/scripts/test_guard_case_plan_hook.py -q` — bash passed; PowerShell skipped locally because `pwsh` is unavailable
- `git diff --check`