### PR TITLE
fix(maestro-case): align return-to-origin and stage SLA contracts

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -350,9 +350,21 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 #### Stage SLA
 
+> Stage SLA supports the same conditional + default `slaRules[]` model as the case root. For `condition-based`, keep the default row below and add one or more Stage Variable SLA Rules before it.
+
+**SLA Type:** {time-based | condition-based}
+
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
 | {count} | {min \| h \| d \| w \| m} | {percentage}% | {Notify: recipient or specific action} | {Notify: recipient or specific action} |
+
+##### Stage Variable SLA Rules
+
+> Include only for a condition-based Stage SLA. Each row is written before that stage's trailing `=js:true` default.
+
+| Expression | SLA | Unit | Display Name |
+|------------|-----|------|--------------|
+| {conditionExpression evaluated against case variables} | {count} | {min \| h \| d \| w \| m} | {non-empty stage-unique title without `:`} |
 
 #### Tasks
 

--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -52,6 +52,7 @@ build the case in the Case Designer without guessing.
    - `Marks Stage Complete: Yes` → WHEN MUST be `required-tasks-completed` (typical) or `wait-for-connector` (stage completes when the bound connector event arrives). **NEVER** `required-stages-completed` or `selected-tasks-completed(...)`.
    - `Marks Stage Complete: No` (routing / divergent exits) → WHEN may be `selected-tasks-completed("TaskA")`, `wait-for-connector`, etc.
    - Same stage may carry one completion exit (`Yes` + `required-tasks-completed` / `wait-for-connector`) plus zero or more routing exits (`No` + `selected-tasks-completed` / `wait-for-connector`).
+   - `return-to-origin` is a completion exit: use `Marks Stage Complete: Yes` with `required-tasks-completed` (or `wait-for-connector`). Never pair it with `No` + `selected-tasks-completed`.
 
    *Case exit (preferred pattern: one row, `Yes` + `required-stages-completed`):*
    - `Marks Case Complete: Yes` → WHEN MUST be `required-stages-completed` or `wait-for-connector`. **NEVER** `selected-stage-completed(...)` / `selected-stage-exited(...)`.
@@ -338,6 +339,7 @@ The runtime engine resolves the binding when the task completes, writing the res
 
 > **WHEN ↔ Marks Stage Complete pairing is a schema constraint (see Key Rule 4):** `Yes` row MUST use `required-tasks-completed` (or `required-stages-completed`); `No` row MAY use `selected-tasks-completed(...)`. Mixing is invalid.
 > Completion (`Yes`) and routing (`No`) rows share this one table. **Regular stage-to-stage routing is expressed by the destination stages' Entry Conditions** (`selected-stage-completed("This Stage")` / `selected-stage-exited("This Stage")`) — one stage can fan out to N stages, each declaring it as their entry trigger. `return-to-origin` returns to the origin stage automatically.
+> **Canonical return shape:** `return-to-origin` requires `required-tasks-completed` (or `wait-for-connector`) + `Marks Stage Complete: Yes`. It is not a `No` + `selected-tasks-completed` routing row.
 > **Exception carve-out:** to route this stage INTO a decision/signal-routed exception lane, add a gated divert row here — `Marks Stage Complete: No`, `selected-tasks-completed("<decider>")`, `IF =js:(<signal> === <exception-value>)`, `exit-only`, with `exitToStageId` → the secondary stage — AND gate this stage's `Yes` completion row with the inverse `IF`. The lane returns via `return-to-origin`. Omitting the divert row → dual-fire or deadlock. See sdd-generation-rules § Logical integrity step 5.
 
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |

--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -324,7 +324,7 @@ For per-scope fields, consult the corresponding condition plugin:
 
 ### 4.8 Set SLA and escalation rules
 
-SLA comes last. Consult [`plugins/sla/planning.md`](plugins/sla/planning.md) for the three sub-operations (default SLA, conditional SLA rules, escalation rules), per-target ordering, and the constraint that conditional SLA rules are root-only.
+SLA comes last. Consult [`plugins/sla/planning.md`](plugins/sla/planning.md) for the three sub-operations (default SLA, conditional SLA rules, escalation rules) and per-target ordering. Root rules target `metadata.slaRules[]`; stage rules target that stage's `data.slaRules[]`.
 
 ### 4.9 Not Covered section
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/impl-json.md
@@ -94,6 +94,8 @@ The case pauses after the rule fires; the user picks the next stage from candida
 
 Routes the case back to the originating stage.
 
+Write this object directly. Do not rely on `uip maestro case stage-exit-conditions add --type return-to-origin` defaults: without the explicit completion rule and `marksStageComplete: true`, the CLI can persist an empty or non-rendering return shape.
+
 ### Divert into an exception lane (gated routing exit)
 
 To route the **origin** stage into a decision/signal-routed exception lane (the lane then returns via `return-to-origin`), the origin carries TWO mutually-exclusive exits: a gated divert (`marksStageComplete: false`) into the lane, and a completion gated by the inverse `IF`.

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -35,6 +35,8 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `wait-for-user` | Exit requires manual user decision or approval. |
 | `return-to-origin` | Rework / exception loop — sends the case back to the previous stage. |
 
+`return-to-origin` uses the completion pairing: `marks-stage-complete: true` with `required-tasks-completed` (or `wait-for-connector`). Never plan it as `false` + `selected-tasks-completed`; that routing shape does not render as a return lane.
+
 > **Routing the origin INTO a decision/signal-routed exception lane.** The origin stage carries the route: a gated divert exit (`marks-stage-complete: false`, `selected-tasks-completed("<decider>")`, `conditionExpression =js:(<signal> === <exception-value>)`, `exit-to-stage-id` → the lane) PLUS its completion exit gated by the inverse `IF`. The two must be mutually exclusive (ungated completion → dual-fire; gated completion with no divert → deadlock). The lane returns via `return-to-origin`. See [stage-exit-conditions/impl-json.md § Divert into an exception lane](impl-json.md#divert-into-an-exception-lane-gated-routing-exit) and [`sdd-generation-rules.md` § Logical integrity step 5](../../../sdd-generation-rules.md#logical-integrity--stage-graph).
 
 ## Rule-Type Catalog (stage-exit scope)

--- a/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/impl-json.md
@@ -17,7 +17,7 @@ Compose the `slaRules[]` array for each target (root or stage) in one write. Gro
 | T-entry kind | Required fields | Notes |
 |---|---|---|
 | Default SLA | `target`, `count`, `unit`, `display-name` | One per target. Emitted as the `=js:true` entry, always last. |
-| Conditional rule | `target: "root"`, `condition` (natural-language), `count`, `unit`, `display-name` | Root-only. Translated to `=js:<expr>` at execution; see Expression Translation below. |
+| Conditional rule | `target: "root"` \| `"<stage-name>"`, `condition` (natural-language), `count`, `unit`, `display-name` | Translated to `=js:<expr>` at execution and prepended to the target's default; see Expression Translation below. |
 | Escalation | `target`, `attach-to: T<m>` \| `default`, `trigger-type`, `at-risk-percentage?`, `recipients[]`, `display-name` | `attach-to` points to the T-number of the parent rule (or the default). |
 
 ## ID generation
@@ -33,6 +33,8 @@ Record every `T<n> → esc_xxxxxx` in `id-map.json` under `{kind: "escalation", 
 - `target: "<stage-name>"` → locate node by `data.label === <stage-name>`; write to `node.data.slaRules`
 - Accepted node types: `case-management:Stage` (a secondary/exception stage is the same node with `data.stageType === "secondary"`).
 - If the stage node isn't found, halt and AskUserQuestion with candidate stage labels + "Something else".
+
+> **Stage conditional rules are direct JSON only.** `uip maestro case sla rules add` exposes a root-only CLI surface; do not use it for a stage target. Compose the stage's complete conditional + default array here and write `node.data.slaRules`.
 
 ## Recipe — one target
 

--- a/skills/uipath-maestro-case/references/plugins/sla/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/sla/planning.md
@@ -16,7 +16,7 @@ Pick this plugin whenever the sdd.md mentions deadlines, service-level agreement
 | Sub-op | Purpose |
 |--------|---------|
 | **Default SLA** | The time-based catch-all SLA. One per target (root or stage). Written into the SLA rules array with `expression: "=js:true"`. See [impl-json.md § Target resolution](impl-json.md) for the destination paths. |
-| **Conditional SLA rules** | Expression-driven SLA overrides. Root-only. Prepended to the root SLA rules array ahead of the default. |
+| **Conditional SLA rules** | Expression-driven SLA overrides. Supported on root and stage targets. Prepended to the target's SLA rules array ahead of the default. |
 | **Escalation rules** | Notifications triggered at-risk or on breach. Attached to a specific rule via `escalationRule[]`. |
 
 ## Applying SLA at Root vs Stage
@@ -26,7 +26,7 @@ Pick this plugin whenever the sdd.md mentions deadlines, service-level agreement
 
 Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage > root.
 
-> **Conditional SLA rules are root-only.** They live in `metadata.slaRules[]`; per-stage conditional SLA is not supported. If the sdd.md describes one, flag to the user.
+> **Conditional SLA rules use the same target scope as defaults.** Root rules live in `metadata.slaRules[]`; stage rules live in the stage node's `data.slaRules[]`. On either target, conditional entries precede the trailing `=js:true` default.
 
 > **Secondary-stage SLA is supported.** Author it the same way as a regular Stage SLA — write `data.slaRules[]` on the `case-management:Stage` node (the secondary stage, i.e. `data.stageType: "secondary"`). See [`impl-json.md`](impl-json.md).
 
@@ -47,6 +47,7 @@ Set root SLA first, then stage SLAs. This mirrors the schema precedence: stage >
 
 | Field | Source | Notes |
 |-------|--------|-------|
+| `target` | sdd.md target (root vs stage) | `"root"` or `"<stage-name>"` |
 | `expression` | sdd.md condition | Natural-language in planning; the execution phase translates. **Do not fabricate syntax during planning.** |
 | `count`, `unit` | sdd.md duration for this condition | Same units as default |
 | `display-name` | sdd.md or generated fallback | Required non-empty unique title, no `:`; use `SLA Rule {N}` only when the author supplied no title. |
@@ -134,7 +135,7 @@ Rationale values: `auto-exact-email`, `auto-exact-name`, `user-picked-from-N`, `
 SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each target, order within the target:
 
 1. Default SLA T-entry
-2. Conditional SLA rule T-entries (root only)
+2. Conditional SLA rule T-entries for that target
 3. Escalation rule T-entries (one per rule)
 
 ## tasks.md Entry Format
@@ -154,7 +155,8 @@ SLA is the **last** category in `tasks.md` (§4.8), after conditions. For each t
 ### Conditional SLA rule
 
 ```markdown
-## T<n>: Add conditional SLA rule for root case — <condition summary>
+## T<n>: Add conditional SLA rule for "<target>" — <condition summary>
+- target: "root" | "<stage-name>"
 - display-name: "Urgent SLA"              # required; target-unique, no ':'
 - condition: "<natural-language condition from sdd.md>"
 - count: 30
@@ -196,7 +198,7 @@ Before emitting SLA T-entries, reject or repair the same cases the Case App reje
 ## Anti-Patterns
 
 - **Do not fabricate expression syntax.** Describe conditional SLA rules in natural language during planning; the execution phase handles the exact syntax.
-- **Do not put conditional SLA rules on stages.** Conditional SLA rules live in `metadata.slaRules[]` only. Flag to the user if the sdd.md describes a per-stage conditional SLA.
+- **Do not lose the conditional rule's target.** Root and stage rules have the same entry shape but different destinations (`metadata.slaRules[]` vs `node.data.slaRules[]`). Preserve `target` through `tasks.md`.
 - **Do not invert rule order.** Conditional rules are evaluated in insertion order — insert them in the priority order the sdd.md specifies.
 - **Do not skip the resolver to save a CLI call.** Email / group-name recipients MUST go through [§ Identity Resolution](#identity-resolution). Writing `<UNRESOLVED: ...>` directly without attempting `uip admin users/groups list` is a planning bug.
 - **Do not fabricate UUIDs.** When the resolver returns 0 / multi / partial matches, AskUserQuestion or keep `<UNRESOLVED>` — never guess a UUID, never auto-pick the first candidate without the exact-email / exact-name gate.

--- a/skills/uipath-maestro-case/references/plugins/stages/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/stages/planning.md
@@ -9,7 +9,7 @@ A stage node inside the case. Stages contain tasks and connect via entry/exit co
 | Regular stage | `case-management:Stage` (default) |
 | Secondary stage | `case-management:Stage` with `data.stageType: "secondary"` |
 
-The only difference is `data.stageType`: omitted for a primary/regular stage (do NOT emit `"primary"`), `"secondary"` for a secondary stage; both use `type: case-management:Stage`. All other fields (label, description, entry/exit conditions, tasks, SLA) behave identically. A secondary stage can carry `slaRules` (expression-driven SLA) the same as a regular Stage; conditional SLA rules themselves are root-only.
+The only difference is `data.stageType`: omitted for a primary/regular stage (do NOT emit `"primary"`), `"secondary"` for a secondary stage; both use `type: case-management:Stage`. All other fields (label, description, entry/exit conditions, tasks, SLA) behave identically. Primary and secondary stages can both carry conditional + default `data.slaRules[]`.
 
 The UI's **Secondary stage** toggle means an interrupting exception lane, not a second kind of primary flow stage. It is used for exception, optional, rework, or special handling that may move the case out of the active primary stage. Secondary stages cannot be connected to other stages as ordinary flow links, must not be required for `required-stages-completed`, and a returning secondary stage must use `return-to-origin` with `Interrupting: Yes`.
 

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -367,7 +367,7 @@ The trailing `` `{stage_id}` `` (e.g., `` `stage-intake` ``) MUST appear so read
 | Description | yes (primary) / optional (secondary) | One prose sentence |
 | Required for case completion | yes | `Yes` (primary, default) / `No` (secondary stages always `No`) |
 | Interrupting | secondary stages only | `Yes` / `No` — does this stage interrupt active stages on activation? |
-| Stage SLA | yes when stage has SLA | Duration + type, plus escalation table |
+| Stage SLA | yes when stage has SLA | Default duration + `time-based` or `condition-based`, plus conditional-rule and escalation tables |
 
 ### Stage Entry Conditions table
 
@@ -399,6 +399,14 @@ Optional. Used for early hand-offs / routing. Same columns and order as the comp
 | `selected-tasks-completed("<Task>")` / `wait-for-connector` | optional | `exit-only` / `wait-for-user` | `No` | optional |
 
 `return-to-origin` is a completion exit, not a divergent exit: render it in the `Yes` table with `required-tasks-completed` (or `wait-for-connector`). Never generate `return-to-origin` + `No` + `selected-tasks-completed`.
+
+### Stage conditional SLA rules table
+
+Render when the Stage SLA type is `condition-based`. Each expression-keyed override targets this stage's `data.slaRules[]` and precedes its default row.
+
+| Expression | SLA | Unit | Display Name |
+|---|---|---|---|
+| condition evaluated against case variables | positive count | `min` / `h` / `d` / `w` / `m` | non-empty, stage-unique title without `:` |
 
 ### Stage SLA escalation table
 

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -32,8 +32,8 @@ The case, each stage, and each task move through a lifecycle gated by **rules** 
 |---|---|---|
 | **Case entry** | how does a case instance begin? | No case-entry condition object — a **trigger** starts the case; the root stage carries `case-entered`. |
 | **Stage entry** | when does this stage activate? | `case-entered` (root only) · `selected-stage-completed` · `selected-stage-exited` · `wait-for-connector` · `user-selected-stage` |
-| **Stage completion** (`Marks Stage Complete: Yes`) | when is the stage done, on the main flow? | `required-tasks-completed` · `wait-for-connector` |
-| **Stage exit** (`Marks Stage Complete: No`) | early hand-off / route without completing | `selected-tasks-completed` · `wait-for-connector`; exit `type`: `exit-only` / `wait-for-user` / `return-to-origin` |
+| **Stage completion** (`Marks Stage Complete: Yes`) | when is the stage done, on the main flow or returning lane? | `required-tasks-completed` · `wait-for-connector`; exit `type`: `exit-only` / `wait-for-user` / `return-to-origin` |
+| **Stage exit** (`Marks Stage Complete: No`) | early hand-off / route without completing | `selected-tasks-completed` · `wait-for-connector`; exit `type`: `exit-only` / `wait-for-user` |
 | **Task entry** | when does this task start inside its stage? | `current-stage-entered` (first task — required) · `selected-tasks-completed` · `wait-for-connector` · `adhoc` · `runs-sequentially` |
 | **Task completion / exit** | — | A task has **no** exit/completion condition. It completes when its own work finishes; downstream stages/tasks key off that via `required-tasks-completed` / `selected-tasks-completed`. |
 | **Case completion** (`Marks Case Complete: Yes`) | when does the case close successfully? | `required-stages-completed` · `wait-for-connector` |
@@ -42,7 +42,7 @@ The case, each stage, and each task move through a lifecycle gated by **rules** 
 How to reason with these:
 
 - **`required-*` vs `selected-*`.** `required-tasks-completed` / `required-stages-completed` = "all items flagged required are done" (the `isRequired` flow). `selected-tasks-completed` / `selected-stage-completed` / `selected-stage-exited` = "these *specific named* items." Pairing rule (Key Rule 4): `Marks Complete: Yes` pairs only with `required-*`; `selected-*` is for `No` (routing / early exit / alternate disposition). A `Yes` + `selected-*` pair is a schema error.
-- **Secondary stage** uses **stage-entry + stage-exit rules only, never edges** (true of every stage — edges retired). Its entry rule is typically *interrupting* (`isInterrupting: true`); its exit uses `return-to-origin` to rejoin the flow it left. **For a decision/signal-routed lane, the routing lives on the *origin* stage:** a gated diverting exit (`Marks Stage Complete: No`, `IF` on the decision/signal, `exitToStageId` → the lane), with the origin's completion exit gated by the inverse `IF` so the two paths are mutually exclusive — see [§ Logical integrity step 5](#logical-integrity--stage-graph).
+- **Secondary stage** uses **stage-entry + stage-exit rules only, never edges** (true of every stage — edges retired). Its entry rule is typically *interrupting* (`isInterrupting: true`); its returning exit uses the canonical completion shape `return-to-origin` + `Marks Stage Complete: Yes` + `required-tasks-completed` to rejoin the flow it left. **For a decision/signal-routed lane, the routing lives on the *origin* stage:** a gated diverting exit (`Marks Stage Complete: No`, `IF` on the decision/signal, `exitToStageId` → the lane), with the origin's completion exit gated by the inverse `IF` so the two paths are mutually exclusive — see [§ Logical integrity step 5](#logical-integrity--stage-graph).
 - **First event-driven task in a stage** must carry `current-stage-entered` (emit it explicitly). A sequential chain is the exception: the first sequential task carries only `runs-sequentially`, which the frontend interprets as current-stage-entered; later sequential tasks carry only `runs-sequentially`, which the frontend interprets as the preceding task completing. `wait-for-connector` makes a gate pause for an inbound connector callback — its `conditionExpression` gates on **case state** only (no `event` payload; in-rule extract-then-gate is unsupported at runtime — gate a downstream condition instead); `adhoc` lets a *task* fire manually from the case app (task-entry only — never a stage-entry rule).
 
 **Frontend task-mode mapping.** The UI's `sequential`, `event-triggered`, and `manually-triggered` choices are not interchangeable: sequential means the task-only `runs-sequentially` rule; event-triggered means an explicit event/condition rule (use `wait-for-connector` for an external connector callback); manually-triggered means an `adhoc`-only task with `isRequired: false`. Do not infer one mode from `data.tasks` lanes, and do not add a second entry rule that changes the selected mode.
@@ -397,6 +397,8 @@ Optional. Used for early hand-offs / routing. Same columns and order as the comp
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
 |---|---|---|---|---|
 | `selected-tasks-completed("<Task>")` / `wait-for-connector` | optional | `exit-only` / `wait-for-user` | `No` | optional |
+
+`return-to-origin` is a completion exit, not a divergent exit: render it in the `Yes` table with `required-tasks-completed` (or `wait-for-connector`). Never generate `return-to-origin` + `No` + `selected-tasks-completed`.
 
 ### Stage SLA escalation table
 

--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -278,6 +278,38 @@ def first_rule_of_condition(cond: dict | None) -> dict | None:
     return first_group[0]
 
 
+RETURN_TO_ORIGIN_COMPLETION_RULES = frozenset(
+    {"required-tasks-completed", "wait-for-connector"}
+)
+
+
+def partition_return_to_origin_conditions(
+    conditions: Iterable[dict],
+    *,
+    allowed_rules: frozenset[str] = RETURN_TO_ORIGIN_COMPLETION_RULES,
+) -> tuple[list[dict], list[dict]]:
+    """Return all return lanes and the subset with an invalid completion pairing."""
+    returns = [
+        condition
+        for condition in conditions
+        if condition.get("type") == "return-to-origin"
+    ]
+    invalid = []
+    for condition in returns:
+        rules = condition.get("rules")
+        has_single_rule = (
+            isinstance(rules, list)
+            and len(rules) == 1
+            and isinstance(rules[0], list)
+            and len(rules[0]) == 1
+            and isinstance(rules[0][0], dict)
+        )
+        rule = rules[0][0].get("rule") if has_single_rule else None
+        if condition.get("marksStageComplete") is not True or rule not in allowed_rules:
+            invalid.append(condition)
+    return returns, invalid
+
+
 def iter_stage_entry_conditions(node: dict):
     for cond in (node.get("data") or {}).get("entryConditions") or []:
         yield cond

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -16,10 +16,11 @@ Checks (domain-agnostic):
      legal **for its gate**, with the correct Marks-Complete pairing.
   5. Conditions present — each stage section has Entry + Exit conditions, and the
      case can close (a ``required-stages-completed`` case-completion row exists).
-  6. Interrupting semantics — every exception (secondary) stage declares an
-     Interrupting flag, and any lane that returns to its origin
-     (``return-to-origin`` exit) is marked ``Interrupting: Yes`` (you can only
-     return to a stage you interrupted).
+  6. Return-lane semantics — every ``return-to-origin`` exit uses
+     ``required-tasks-completed`` or ``wait-for-connector`` with
+     ``Marks Stage Complete: Yes``, and every exception (secondary) stage that
+     returns declares ``Interrupting: Yes`` (you can only return to a stage you
+     interrupted).
   7. PO.Frontend name/SLA parity — stage/task/SLA/escalation names, uniqueness,
      duration bounds, conditional expressions, recipients, and at-risk fields.
 
@@ -49,6 +50,7 @@ CASE_COMPLETION = {"required-stages-completed", "wait-for-connector"}    # Marks
 CASE_EXIT = {"selected-stage-completed", "selected-stage-exited",
              "wait-for-connector"}                                       # Marks: No
 EXIT_TYPES = {"exit-only", "wait-for-user", "return-to-origin"}
+RETURN_TO_ORIGIN_COMPLETION = {"required-tasks-completed", "wait-for-connector"}
 KNOWN_RULES = STAGE_ENTRY | STAGE_COMPLETION | STAGE_EXIT | TASK_ENTRY | CASE_COMPLETION | CASE_EXIT
 
 
@@ -63,6 +65,18 @@ def _rule_token(cell: str) -> str | None:
     """Leading rule keyword from a WHEN cell (``case-entered``, ``adhoc``, …)."""
     m = re.match(r"`?\s*([a-z][a-z]+(?:-[a-z]+)*)", cell.strip())
     return m.group(1) if m else None
+
+
+def _return_to_origin_pairing_issue(
+    rule: str, marks_complete: bool, where: str
+) -> str | None:
+    """Return an error unless a return lane uses a supported completing trigger."""
+    if marks_complete and rule in RETURN_TO_ORIGIN_COMPLETION:
+        return None
+    return (
+        "rule: return-to-origin requires 'required-tasks-completed' or "
+        f"'wait-for-connector' with Marks=Yes ({where})"
+    )
 
 
 def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
@@ -364,6 +378,10 @@ def main() -> None:
                         exit_types.setdefault(cur_stage, set()).add(et)
                     if et and et not in EXIT_TYPES:
                         issues.append(f"rule: invalid exit-type {et!r} at {where}")
+                    if et == "return-to-origin":
+                        pairing_issue = _return_to_origin_pairing_issue(rule, yes, where)
+                        if pairing_issue:
+                            issues.append(pairing_issue)
 
     missing = sorted(
         st for st in has_entry

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -85,6 +85,8 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
     stage_names: list[str] = []
     in_stage_sla = False
     in_variable_sla = False
+    stage_variable_sla = False
+    variable_sla_names: set[str] = set()
 
     def check_duration(count_text: str, unit_text: str, line_no: int) -> None:
         try:
@@ -102,12 +104,21 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
         if stripped == "#### Stage SLA":
             in_stage_sla = True
             in_variable_sla = False
+            stage_variable_sla = False
         elif stripped == "### Variable SLA Rules":
             in_variable_sla = True
             in_stage_sla = False
+            stage_variable_sla = False
+            variable_sla_names = set()
+        elif stripped == "##### Stage Variable SLA Rules":
+            in_variable_sla = True
+            in_stage_sla = False
+            stage_variable_sla = True
+            variable_sla_names = set()
         elif stripped.startswith("#"):
             in_stage_sla = False
             in_variable_sla = False
+            stage_variable_sla = False
 
         case_sla = re.match(r"^\|\s*Case-Level SLA\s*\|\s*([0-9]+(?:\.[0-9]+)?)\s+([A-Za-z]+)", line, re.I)
         if case_sla:
@@ -118,6 +129,29 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
             check_duration(cells[0], cells[1], line_no)
         if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
             check_duration(cells[1], cells[2], line_no)
+            expression = cells[0].strip().strip("\"'")
+            if not expression or expression in {"—", "-"}:
+                issues.append(
+                    f"sla: conditional rule requires an expression at "
+                    f"{source}:{line_no}"
+                )
+            if stage_variable_sla:
+                display = cells[3].strip().strip("\"'") if len(cells) >= 4 else ""
+                if not display or display in {"—", "-"}:
+                    issues.append(
+                        f"naming: SLA title is missing at {source}:{line_no}"
+                    )
+                elif display in variable_sla_names:
+                    issues.append(
+                        f"naming: duplicate SLA title {display!r} at "
+                        f"{source}:{line_no}"
+                    )
+                else:
+                    variable_sla_names.add(display)
+                if ":" in display:
+                    issues.append(
+                        f"naming: SLA title contains ':' at {source}:{line_no}"
+                    )
 
         stage = re.match(r"###\s+(Stage \d+|Exception Stage|Secondary Stage):\s*(.*)", line.strip())
         if stage:

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
@@ -19,6 +19,7 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from case_check import (  # noqa: E402
     _get_ci,
     collect_outputs,
+    partition_return_to_origin_conditions,
     run_debug,
 )
 import case_check  # noqa: E402
@@ -62,6 +63,44 @@ def test_collect_outputs_pascalcase_matches_camelcase():
     camel = {"variables": {"globals": {"a": "x"}, "globalVariables": [{"value": 1}]}}
     pascal = {"Variables": {"Globals": {"a": "x"}, "GlobalVariables": [{"Value": 1}]}}
     assert sorted(map(str, collect_outputs(camel))) == sorted(map(str, collect_outputs(pascal)))
+
+
+def test_return_to_origin_partition_checks_every_return_condition():
+    valid_required = {
+        "type": "return-to-origin",
+        "marksStageComplete": True,
+        "rules": [[{"rule": "required-tasks-completed"}]],
+    }
+    valid_connector = {
+        "type": "return-to-origin",
+        "marksStageComplete": True,
+        "rules": [[{"rule": "wait-for-connector"}]],
+    }
+    malformed = {
+        "type": "return-to-origin",
+        "marksStageComplete": False,
+        "rules": [[{"rule": "selected-tasks-completed"}]],
+    }
+    malformed_extra_rule = {
+        "type": "return-to-origin",
+        "marksStageComplete": True,
+        "rules": [[
+            {"rule": "required-tasks-completed"},
+            {"rule": "selected-tasks-completed"},
+        ]],
+    }
+
+    returns, invalid = partition_return_to_origin_conditions(
+        [valid_required, valid_connector, malformed, malformed_extra_rule]
+    )
+
+    assert returns == [
+        valid_required,
+        valid_connector,
+        malformed,
+        malformed_extra_rule,
+    ]
+    assert invalid == [malformed, malformed_extra_rule]
 
 
 def test_run_debug_gate_accepts_pascalcase_finalstatus(monkeypatch):

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -113,6 +113,27 @@ def test_return_to_origin_accepts_both_completing_triggers():
     )
 
 
+def test_stage_variable_sla_rules_are_checked():
+    text = """
+#### Stage SLA
+| 1 | m | 80% | Notify | Notify |
+##### Stage Variable SLA Rules
+| Expression | SLA | Unit | Display Name |
+|---|---|---|---|
+| - | 0 | d | - |
+| priority is Urgent | 10 | min | Urgent: SLA |
+| priority is Standard | 5 | d | Standard SLA |
+| priority is Escalated | 2 | w | Standard SLA |
+"""
+    issues = _sdd_frontend_issues(text)
+    assert any("conditional rule requires an expression" in issue for issue in issues)
+    assert any("count must be positive" in issue for issue in issues)
+    assert any("minute count" in issue for issue in issues)
+    assert any("SLA title is missing" in issue for issue in issues)
+    assert any("SLA title contains ':'" in issue for issue in issues)
+    assert any("duplicate SLA title 'Standard SLA'" in issue for issue in issues)
+
+
 def test_tasks_sla_validation_matches_frontend_contract():
     tasks = '''
 ## T01: Set default SLA for "root"

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -1,11 +1,19 @@
-"""Deterministic naming guards for Phase-0/Phase-1 case authoring."""
+"""Deterministic guards for Phase-0/Phase-1 case authoring."""
 
 import os
+import subprocess
 import sys
+import tempfile
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from sdd_check import _colon_issues, _sdd_frontend_issues, _tasks_frontend_issues  # noqa: E402
+from sdd_check import (  # noqa: E402
+    _colon_issues,
+    _return_to_origin_pairing_issue,
+    _sdd_frontend_issues,
+    _tasks_frontend_issues,
+)
 
 
 def test_stage_label_colon_is_rejected_but_heading_separator_is_allowed():
@@ -46,6 +54,63 @@ def test_sdd_sla_duration_bounds_are_checked():
     issues = _sdd_frontend_issues(text)
     assert any("count must be positive" in issue for issue in issues)
     assert any("minute count" in issue for issue in issues)
+
+
+def test_return_to_origin_requires_canonical_completion_pairing():
+    text = """
+## Case Variables
+| Name | Category | Type | Source Trigger | Source Field | Default | Description |
+|---|---|---|---|---|---|---|
+| caseId | In | String | Manual | caseId | — | Case identifier |
+
+### Secondary Stage: Escalation
+**Stage Kind:** secondary
+**Interrupting:** Yes
+
+#### Entry Conditions
+| WHEN | IF |
+|---|---|
+| selected-stage-exited("Review") | — |
+
+#### Exit Conditions
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| selected-tasks-completed("Notify") | — | return-to-origin | No | Return |
+
+### Case Exit Conditions
+| WHEN | IF | Marks Case Complete | Display Name |
+|---|---|---|---|
+| required-stages-completed | — | Yes | Complete |
+"""
+    checker = Path(__file__).with_name("sdd_check.py")
+    with tempfile.TemporaryDirectory() as workdir:
+        Path(workdir, "sdd.md").write_text(text, encoding="utf-8")
+        result = subprocess.run(
+            [sys.executable, str(checker)],
+            cwd=workdir,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    assert result.returncode != 0
+    assert (
+        "return-to-origin requires 'required-tasks-completed' or "
+        "'wait-for-connector' with Marks=Yes"
+        in result.stdout + result.stderr
+    )
+
+
+def test_return_to_origin_accepts_both_completing_triggers():
+    assert _return_to_origin_pairing_issue(
+        "required-tasks-completed", True, "Escalation"
+    ) is None
+    assert _return_to_origin_pairing_issue(
+        "wait-for-connector", True, "Escalation"
+    ) is None
+    assert _return_to_origin_pairing_issue(
+        "selected-tasks-completed", False, "Escalation"
+    )
 
 
 def test_tasks_sla_validation_matches_frontend_contract():

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
@@ -8,7 +8,7 @@ description: >
   NameToAgeFixed2, CountLetters, ProjectEuler, purchaseorderapp, CaseTest) is the
   sole source of truth. The skill builds the case-management solution and
   validates the caseplan; a structural check then asserts the primary chain, the
-  two interrupting/return-to-origin exception lanes, the connector-free
+  two interrupting/canonical-return-to-origin exception lanes, the connector-free
   task-type mix, the Payment Tracking child case, and the aged_invoice_cases
   event trigger. No debug — the case is HITL- and interrupt-driven, which cannot
   run headless; this is the structural counterpart to the runnable expense e2e.
@@ -93,7 +93,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "caseplan preserves the 3-stage primary chain, the two interrupting/return-to-origin exception lanes, the connector-free task-type mix, the Payment Tracking child case, and the aged_invoice_cases event trigger"
+    description: "caseplan preserves the 3-stage primary chain, the two interrupting exception lanes with canonical return-to-origin exits (required-tasks-completed + marksStageComplete=true), the connector-free task-type mix, the Payment Tracking child case, and the aged_invoice_cases event trigger"
     command: "python3 $TASK_DIR/check_aged_invoice_structure.py"
     timeout: 120
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/check_aged_invoice_structure.py
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/check_aged_invoice_structure.py
@@ -7,7 +7,8 @@ staged sdd.md encodes the intended design:
   - 8 primary stages (Intake -> Enrichment -> Triage -> AP Review -> Exception
     Resolution -> Payment Risk -> Approval -> Closure) chained as a happy path
   - 2 interrupting secondary lanes (SLA Escalation, Automation Incident), each
-    marked interrupting and exiting via return-to-origin
+    marked interrupting and exiting via the canonical return-to-origin shape
+    (required-tasks-completed + marksStageComplete=true)
   - the case starts from an aged_invoice_cases Intsvc.EventTrigger, not Manual
   - the connector-free task-type mix is present (api-workflow, agent, action,
     rpa, wait-for-timer, case-management) and NO connector task types
@@ -32,6 +33,7 @@ from _shared.case_check import (  # noqa: E402
     get_case_exit_conditions,
     find_triggers,
     iter_tasks,
+    partition_return_to_origin_conditions,
     read_caseplan,
 )
 
@@ -53,10 +55,6 @@ FORBIDDEN_TYPES = {"execute-connector-activity", "wait-for-connector"}
 
 def _fail(msg: str) -> None:
     sys.exit(f"FAIL: {msg}")
-
-
-def _norm(s: str) -> str:
-    return re.sub(r"[^a-z0-9]", "", (s or "").lower())
 
 
 def _label(node: dict) -> str:
@@ -133,8 +131,37 @@ def main() -> None:
             _fail(f"secondary lane {name!r} is not marked stageType=secondary")
         if "interrupt" not in blob:
             _fail(f"secondary lane {name!r} must declare an interrupting entry condition")
-        if "returntoorigin" not in _norm(blob):
-            _fail(f"secondary lane {name!r} must exit via return-to-origin")
+        exits = data.get("exitConditions") or []
+        returns, invalid_returns = partition_return_to_origin_conditions(
+            exits,
+            allowed_rules=frozenset({"required-tasks-completed"}),
+        )
+        if not returns:
+            shapes = [
+                (
+                    condition.get("type"),
+                    condition.get("marksStageComplete"),
+                    (first_rule_of_condition(condition) or {}).get("rule"),
+                )
+                for condition in exits
+            ]
+            _fail(
+                f"secondary lane {name!r} must use canonical return-to-origin "
+                f"(required-tasks-completed + marksStageComplete=true); got {shapes}"
+            )
+        if invalid_returns:
+            shapes = [
+                (
+                    condition.get("marksStageComplete"),
+                    (first_rule_of_condition(condition) or {}).get("rule"),
+                )
+                for condition in invalid_returns
+            ]
+            _fail(
+                f"secondary lane {name!r} has malformed additional "
+                f"return-to-origin exit(s); expected every return to use "
+                f"required-tasks-completed + marksStageComplete=true; got {shapes}"
+            )
 
     # --- task-type mix: required present, connectors absent
     tasks = list(iter_tasks(plan))
@@ -159,7 +186,7 @@ def main() -> None:
 
     print(
         f"OK: AgedInvoiceResolution caseplan sound — 8 primary stages chained, "
-        f"2 interrupting return-to-origin lanes, aged_invoice_cases event trigger, "
+        f"2 interrupting canonical return-to-origin lanes, aged_invoice_cases event trigger, "
         f"{len(tasks)} tasks across connector-free types {sorted(REQUIRED_TYPES & types_seen)}, "
         f"no connector task types, Payment Tracking child case, case can close"
     )

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
@@ -415,7 +415,7 @@
 
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
 |------|-----|-----------|---------------------|--------------|
-| selected-tasks-completed("SLA warning timer") | — | return-to-origin | No | Return After Escalation |
+| required-tasks-completed | — | return-to-origin | Yes | Return After Escalation |
 
 #### Stage SLA
 
@@ -469,7 +469,7 @@
 
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
 |------|-----|-----------|---------------------|--------------|
-| selected-tasks-completed("Create incident record") | — | return-to-origin | No | Return After Incident |
+| required-tasks-completed | — | return-to-origin | Yes | Return After Incident |
 
 #### Stage SLA
 

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_case.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_case.py
@@ -9,7 +9,7 @@ design, not just a structurally valid case:
     lane) and S7->S8
   - exactly 1 Manual trigger (not an event trigger)
   - 2 case-exit rules: required-stages-completed (marksCaseComplete) +
-    Stage 4 lane exit (does not mark complete)
+    Stage 4 lane exit gated on the Rework Approval reject output
   - 15 tasks, per-stage task-type multisets covering all 9 task types
   - the named Stage 2 timer is explicitly marked run-once
   - direct task-output passing and connector activity v2 are enabled
@@ -157,6 +157,28 @@ def main():
     happy = False
     lane_exit = False
     stage4_id = stage_by_key[SECONDARY_STAGE]["id"]
+    rework_tasks = [
+        task
+        for task in _stage_tasks(stage_by_key[SECONDARY_STAGE])
+        if task.get("displayName") == "Rework Approval"
+    ]
+    if len(rework_tasks) != 1:
+        _fail(f"expected exactly one Stage 4 'Rework Approval' task; got {len(rework_tasks)}")
+    action_outputs = [
+        output
+        for output in ((rework_tasks[0].get("data") or {}).get("outputs") or [])
+        if output.get("name") == "Action"
+    ]
+    if len(action_outputs) != 1 or not action_outputs[0].get("id"):
+        _fail(
+            "Stage 4 'Rework Approval' must expose exactly one generated "
+            "'Action' output with an id"
+        )
+    action_output_id = action_outputs[0]["id"]
+    reject_gate = re.compile(
+        rf"^\s*=js:\s*vars\.{re.escape(action_output_id)}\s*"
+        rf"===\s*(['\"])reject\1\s*$"
+    )
     for case_exit in case_exits:
         rule = first_rule_of_condition(case_exit) or {}
         name = rule.get("rule")
@@ -167,13 +189,19 @@ def main():
             and rule.get("selectedStageId") == stage4_id
             and case_exit.get("marksCaseComplete") is not True
         ):
+            expression = rule.get("conditionExpression")
+            if not isinstance(expression, str) or reject_gate.fullmatch(expression) is None:
+                _fail(
+                    "Stage 4 non-completing case exit must be gated on "
+                    f"vars.{action_output_id} === 'reject'; got {expression!r}"
+                )
             lane_exit = True
     if not happy:
         _fail("missing case-exit 'required-stages-completed' with marksCaseComplete=true")
     if not lane_exit:
         _fail(
-            "missing case-exit on the 'Stage 4 - return to origin' lane "
-            "(selected-stage-completed, marksCaseComplete=false)"
+            "missing reject-gated case-exit on the 'Stage 4 - return to origin' "
+            "lane (selected-stage-completed, marksCaseComplete=false)"
         )
 
     # -- tasks: count + per-stage type multisets -------------------------------

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_semantics.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/check_cm_golden_semantics.py
@@ -12,6 +12,8 @@ contract that previously depended on an LLM judge:
   - every stage/task entry and exit condition has the expected rule + target
   - Stage 2 reject and Stage 4 approve/reject gates use the correct output,
     polarity, exit type, and completion behavior
+  - the Stage 4 non-completing case exit is gated on rejection, so approval
+    returns to origin without also exiting the case
 """
 
 from __future__ import annotations
@@ -414,6 +416,25 @@ def _condition_signature(
     )
 
 
+def _case_condition_signature(
+    condition: dict, stage_ids: dict, task_ids: dict, output_ids: dict
+):
+    groups = condition.get("rules") or []
+    if len(groups) != 1 or not isinstance(groups[0], list) or len(groups[0]) != 1:
+        _fail(
+            f"case condition {condition.get('displayName')!r} must contain "
+            f"exactly one rule; got {groups!r}"
+        )
+    rule = groups[0][0]
+    return (
+        rule.get("rule"),
+        _selected_stages(rule, stage_ids),
+        _selected_tasks(rule, task_ids),
+        _canonical_expression(rule.get("conditionExpression"), output_ids),
+        condition.get("marksCaseComplete"),
+    )
+
+
 def _sig(
     rule: str,
     *,
@@ -444,7 +465,14 @@ def _assert_condition_set(where: str, actual_conditions: list, expected, indexes
         _fail(f"{where} conditions differ\n  actual={actual}\n  expected={wanted}")
 
 
-def _assert_conditions(stages: dict, tasks: dict, stage_ids: dict, task_ids: dict, output_ids):
+def _assert_conditions(
+    plan: dict,
+    stages: dict,
+    tasks: dict,
+    stage_ids: dict,
+    task_ids: dict,
+    output_ids,
+):
     manager = ("Stage 2", "Manager Approval")
     rework = ("Stage 4", "Rework Approval")
     indexes = (stage_ids, task_ids, output_ids)
@@ -480,11 +508,10 @@ def _assert_conditions(stages: dict, tasks: dict, stage_ids: dict, task_ids: dic
                 marks=True,
             ),
             _sig(
-                "selected-tasks-completed",
-                tasks=(rework,),
+                "required-tasks-completed",
                 expression=("equals", (*rework, "Action"), "approve"),
                 exit_type="return-to-origin",
-                marks=False,
+                marks=True,
             ),
         ],
         "Stage 5": [_sig("required-tasks-completed", exit_type="wait-for-user", marks=True)],
@@ -561,6 +588,29 @@ def _assert_conditions(stages: dict, tasks: dict, stage_ids: dict, task_ids: dic
             indexes,
         )
 
+    actual_case_exits = Counter(
+        _case_condition_signature(condition, stage_ids, task_ids, output_ids)
+        for condition in ((plan.get("metadata") or {}).get("caseExitRules") or [])
+    )
+    expected_case_exits = Counter(
+        [
+            ("required-stages-completed", (), (), None, True),
+            (
+                "selected-stage-completed",
+                ("Stage 4",),
+                (),
+                ("equals", (*rework, "Action"), "reject"),
+                False,
+            ),
+        ]
+    )
+    if actual_case_exits != expected_case_exits:
+        _fail(
+            "case exit conditions differ\n"
+            f"  actual={actual_case_exits}\n"
+            f"  expected={expected_case_exits}"
+        )
+
 
 def main():
     plan = _read_plan()
@@ -573,7 +623,7 @@ def main():
         output_ids,
     ) = _index_plan(plan)
     _assert_dataflow(plan, tasks, outputs, output_ids)
-    _assert_conditions(stages, tasks, stage_ids, task_ids, output_ids)
+    _assert_conditions(plan, stages, tasks, stage_ids, task_ids, output_ids)
 
     print(
         "OK: CM-Golden caseplan deterministically matches SDD dataflow "

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
@@ -53,7 +53,7 @@
 | WHEN | IF | THEN | Marks Case Complete | Display Name |
 |------|-----|------|---------------------|--------------|
 | `required-stages-completed` | — | Case exited | Yes | Case complete rule |
-| `selected-stage-completed("Stage 4 - return to origin")` | — | Case exited | No | Case exit rule 1 |
+| `selected-stage-completed("Stage 4 - return to origin")` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "reject"` | Case exited | No | Reject after rework |
 
 ### Case Variables
 
@@ -479,7 +479,7 @@
 | WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
 |------|-----|-----------|---------------------|--------------|
 | `required-tasks-completed` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "reject"` | exit-only | Yes | Stage 6 App Reject |
-| `selected-tasks-completed("Rework Approval")` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "approve"` | return-to-origin | No | Exit rule 1 |
+| `required-tasks-completed` | `=js:vars.$xref('Stage 4 - return to origin','Rework Approval','Action') === "approve"` | return-to-origin | Yes | Return to origin |
 
 #### Tasks
 

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/test_cm_golden_expense_checkers.py
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/test_cm_golden_expense_checkers.py
@@ -27,8 +27,11 @@ def task(
     *,
     duration: str | None = None,
     run_once: bool = False,
+    outputs: list[dict] | None = None,
 ) -> dict:
     data = {"duration": duration} if duration else {}
+    if outputs:
+        data["outputs"] = outputs
     return {
         "id": task_id,
         "type": task_type,
@@ -109,7 +112,20 @@ def expected_caseplan() -> dict:
         ),
         stage(
             4,
-            [task("task-4-action", "action", "Rework Approval")],
+            [
+                task(
+                    "task-4-action",
+                    "action",
+                    "Rework Approval",
+                    outputs=[
+                        {
+                            "name": "Action",
+                            "id": "reworkActionOutput",
+                            "var": "reworkActionOutput",
+                        }
+                    ],
+                )
+            ],
             label="Stage 4 - return to origin",
             secondary=True,
             entry_conditions=[
@@ -168,7 +184,11 @@ def expected_caseplan() -> dict:
                 },
                 {
                     **condition(
-                        "selected-stage-completed", selectedStageId="stage-4"
+                        "selected-stage-completed",
+                        selectedStageId="stage-4",
+                        conditionExpression=(
+                            "=js:vars.reworkActionOutput === 'reject'"
+                        ),
                     ),
                     "marksCaseComplete": False,
                 },
@@ -226,6 +246,19 @@ class CMGoldenCheckerTests(unittest.TestCase):
         result = run_topology_checker(copy.deepcopy(expected_caseplan()))
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_topology_checker_rejects_ungated_stage4_case_exit(self) -> None:
+        plan = expected_caseplan()
+        lane_exit = plan["metadata"]["caseExitRules"][1]
+        lane_exit["rules"][0][0].pop("conditionExpression")
+
+        result = run_topology_checker(plan)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "must be gated on vars.reworkActionOutput === 'reject'",
+            result.stdout + result.stderr,
+        )
 
     def test_topology_checker_rejects_missing_stage(self) -> None:
         plan = expected_caseplan()

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/check_exception_stage.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/check_exception_stage.py
@@ -12,6 +12,7 @@ from _shared.case_check import (  # noqa: E402
     get_default_sla,
     iter_stage_entry_conditions,
     iter_stage_exit_conditions,
+    partition_return_to_origin_conditions,
     read_caseplan,
 )
 
@@ -100,10 +101,22 @@ def main():
 
     for label, node in (("Issues", issues), ("Critical", critical)):
         exits = list(iter_stage_exit_conditions(node))
-        if not any(ec.get("type") == "return-to-origin" for ec in exits):
+        returns, invalid_returns = partition_return_to_origin_conditions(
+            exits,
+            allowed_rules=frozenset({"required-tasks-completed"}),
+        )
+        if not returns:
             sys.exit(
-                f"FAIL: {label!r} missing return-to-origin exit; "
-                f"types={[ec.get('type') for ec in exits]}"
+                f"FAIL: {label!r} missing canonical return-to-origin exit "
+                f"(marksStageComplete=true + required-tasks-completed); "
+                f"got {[(ec.get('type'), ec.get('marksStageComplete'), (first_rule_of_condition(ec) or {}).get('rule')) for ec in exits]}"
+            )
+        if invalid_returns:
+            sys.exit(
+                f"FAIL: {label!r} has malformed additional return-to-origin "
+                f"exit(s); expected every return to use marksStageComplete=true "
+                f"+ required-tasks-completed; got "
+                f"{[(ec.get('marksStageComplete'), (first_rule_of_condition(ec) or {}).get('rule')) for ec in invalid_returns]}"
             )
 
     default = get_default_sla(issues)

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/check_sla_with_escalation.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/check_sla_with_escalation.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
-"""SlaWithEscalation: root SLA (w + min) + regular-stage SLA (m) + escalations."""
+"""SlaWithEscalation: root and regular-stage conditional SLAs + escalations."""
 
 import os
+import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
@@ -13,14 +14,24 @@ from _shared.case_check import (  # noqa: E402
 )
 
 
+def _matches_priority_expression(expression: object, expected_value: str) -> bool:
+    if not isinstance(expression, str):
+        return False
+    pattern = (
+        r"""=js:\s*vars\.priority\s*===\s*"""
+        + rf"""(?P<quote>["']){re.escape(expected_value)}(?P=quote)\s*"""
+    )
+    return re.fullmatch(pattern, expression, re.IGNORECASE) is not None
+
+
 def main():
     plan = read_caseplan()
     rules = get_sla_rules(plan)
 
-    if len(rules) < 3:
+    if len(rules) != 3:
         sys.exit(
-            f"FAIL: case-level slaRules should have ≥3 entries (2 conditional + "
-            f"1 default); got {len(rules)}"
+            "FAIL: case-level slaRules should have exactly 3 entries "
+            f"(2 conditional + 1 default); got {len(rules)}"
         )
     if rules[-1].get("expression") != "=js:true":
         sys.exit(
@@ -38,9 +49,9 @@ def main():
         )
 
     conditional_rules = [r for r in rules if r.get("expression") != "=js:true"]
-    if len(conditional_rules) < 2:
+    if len(conditional_rules) != 2:
         sys.exit(
-            f"FAIL: expected ≥2 conditional SLA rules (Urgent before Standard); "
+            f"FAIL: expected exactly 2 conditional SLA rules (Urgent before Standard); "
             f"got {len(conditional_rules)}"
         )
     urgent = conditional_rules[0]
@@ -49,11 +60,21 @@ def main():
             f"FAIL: 1st conditional rule (Urgent) should be count=30, unit=min; "
             f"got count={urgent.get('count')!r}, unit={urgent.get('unit')!r}"
         )
+    if not _matches_priority_expression(urgent.get("expression"), "Urgent"):
+        sys.exit(
+            "FAIL: 1st conditional rule must be exactly the priority-is-Urgent "
+            f"predicate; got expression={urgent.get('expression')!r}"
+        )
     standard = conditional_rules[1]
     if standard.get("count") != 5 or standard.get("unit") != "d":
         sys.exit(
             f"FAIL: 2nd conditional rule (Standard) should be count=5, unit=d; "
             f"got count={standard.get('count')!r}, unit={standard.get('unit')!r}"
+        )
+    if not _matches_priority_expression(standard.get("expression"), "Standard"):
+        sys.exit(
+            "FAIL: 2nd conditional rule must be exactly the priority-is-Standard "
+            f"predicate; got expression={standard.get('expression')!r}"
         )
 
     default_escs = default.get("escalationRule") or []
@@ -112,6 +133,45 @@ def main():
         )
 
     resolve = find_node_by_label(plan, "Resolve")
+    stage_rules = get_sla_rules(resolve)
+    if len(stage_rules) != 2:
+        sys.exit(
+            "FAIL: stage 'Resolve' should have exactly one conditional SLA plus "
+            f"default; got {len(stage_rules)} rule(s)"
+        )
+    if stage_rules[-1].get("expression") != "=js:true":
+        sys.exit(
+            f"FAIL: stage 'Resolve' trailing SLA must be the '=js:true' default; "
+            f"got expression={stage_rules[-1].get('expression')!r}"
+        )
+    stage_conditionals = [
+        rule for rule in stage_rules if rule.get("expression") != "=js:true"
+    ]
+    if len(stage_conditionals) != 1:
+        sys.exit(
+            "FAIL: stage 'Resolve' must have exactly one conditional SLA rule; "
+            f"got {len(stage_conditionals)}"
+        )
+    stage_urgent = stage_conditionals[0]
+    if stage_urgent.get("count") != 2 or stage_urgent.get("unit") != "w":
+        sys.exit(
+            f"FAIL: stage 'Resolve' Urgent conditional SLA should be count=2, "
+            f"unit=w; got count={stage_urgent.get('count')!r}, "
+            f"unit={stage_urgent.get('unit')!r}"
+        )
+    stage_expression = stage_urgent.get("expression")
+    if not _matches_priority_expression(stage_expression, "Urgent"):
+        sys.exit(
+            "FAIL: stage 'Resolve' conditional SLA must be exactly the "
+            f"priority-is-Urgent predicate; got expression={stage_expression!r}"
+        )
+    stage_display_name = stage_urgent.get("displayName")
+    if stage_display_name != "Resolve Urgent SLA":
+        sys.exit(
+            "FAIL: stage 'Resolve' conditional SLA displayName should be "
+            f"'Resolve Urgent SLA'; got {stage_display_name!r}"
+        )
+
     stage_default = get_default_sla(resolve)
     if not stage_default:
         sys.exit(
@@ -137,7 +197,8 @@ def main():
         "escalation) → Standard (5d) → default =js:true (3w, at-risk 80% "
         "MULTI-RECIPIENT escalation to User manager@corp.com + UserGroup "
         "Operations Leadership); 'Resolve' stage carries its own data.slaRules "
-        "with default 1m AND a non-empty data.description; SLA units "
+        "with conditional Urgent 2w before default 1m AND a non-empty "
+        "data.description; SLA units "
         "min/d/w/m all exercised"
     )
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -1,12 +1,14 @@
 task_id: skill-case-multi-sla-with-escalation
 description: >
   Build a Case Management definition that exercises root-level SLA,
-  TWO conditional overrides, and a regular-stage SLA — covering four
+  TWO root conditional overrides, and a regular-stage SLA with its own
+  conditional override — covering four
   of the five SLA units in one test (min/d/w/m). Root: default 3
   weeks (unit=w) + conditional 30 minutes (unit=min) for Urgent
   priority + conditional 5 days (unit=d) for Standard priority,
   inserted in priority order. Resolve (regular stage) carries its own
-  default SLA of 1 month (unit=m) — the regular-stage SLA path that
+  conditional 2 weeks for Urgent priority plus a default SLA of 1
+  month (unit=m) — the regular-stage conditional-SLA path that
   no other multi_stages_tasks test covers (exception_stage uses h on a
   secondary stage). The root default rule carries an at-risk 80%
   MULTI-RECIPIENT escalation (User manager@corp.com + UserGroup
@@ -18,7 +20,7 @@ description: >
   both escalation trigger types (at-risk + sla-breached), both
   recipient scopes (User + UserGroup), MULTI-RECIPIENT escalation
   (≥2 recipients on one notification), regular-Stage data.slaRules,
-  and the d + w + m + min duration units. Recipient UUIDs are
+  stage-level conditional-rule placement, and the d + w + m + min duration units. Recipient UUIDs are
   unresolved and stay as UNRESOLVED skeletons per the skill rules.
 tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation, feature:conditional-sla, feature:stage-sla]
 max_iterations: 1
@@ -39,7 +41,7 @@ initial_prompt: |
 
   **Case Definition Blueprint** · Generic — SLA Rule & Escalation Coverage
 
-  Root-level SLA with TWO conditional overrides plus a regular-stage SLA — covering four of the five SLA units (min/d/w/m) in one test. Exercises multiple slaRules in priority order, conditional-rule expression-driven SLA, escalation attached to a conditional rule (not just the default), both escalation trigger types (at-risk + sla-breached), both recipient scopes (User + UserGroup), MULTI-RECIPIENT escalation (≥2 recipients on one notification), and regular-Stage data.slaRules.
+  Root-level SLA with TWO conditional overrides plus a regular-stage SLA with its own conditional override — covering four of the five SLA units (min/d/w/m) in one test. Exercises multiple slaRules in priority order, root and stage conditional-rule placement, escalation attached to a conditional rule (not just the default), both escalation trigger types (at-risk + sla-breached), both recipient scopes (User + UserGroup), MULTI-RECIPIENT escalation (≥2 recipients on one notification), and regular-Stage data.slaRules.
 
   > **Unresolved recipients.** Recipient UUIDs are not provided. The agent MUST leave them as UNRESOLVED skeletons per the skill rules; do NOT fabricate UUIDs.
 
@@ -51,7 +53,7 @@ initial_prompt: |
   | Property | Value |
   |---|---|
   | Case Name | SlaWithEscalation |
-  | Case Description | Root-level SLA with two conditional overrides (Urgent 30min, Standard 5d) and a default of 3w; Resolve stage carries its own 1m SLA. |
+  | Case Description | Root-level SLA with two conditional overrides (Urgent 30min, Standard 5d) and a default of 3w; Resolve stage carries an Urgent 2w conditional override plus its own 1m default. |
   | Case Identifier | Prefix: SWE, Type: constant |
   | Priority | Choiceset: Urgent, Standard - Default: Standard |
   | Case-Level SLA | 3w (default) |
@@ -111,11 +113,12 @@ initial_prompt: |
   | No stage exit hand-off declared. | - | exit-only | - | No |
   **Stage SLA**
 
-  Stage-level data.slaRules — overrides the root default while Resolve is active. Stage data.description is set to "Active resolution stage; carries its own monthly SLA."
+  Stage-level data.slaRules — overrides the root SLA while Resolve is active. The conditional row must precede the default. Stage data.description is set to "Active resolution stage; carries its own monthly SLA."
 
-  | # | Rule Type | Duration | Unit | Escalation |
-  |---|---|---|---|---|
-  | 1 | Default | 1 | m | - |
+  | # | Rule Type | Expression | Duration | Unit | Display Name | Escalation |
+  |---|---|---|---|---|---|---|
+  | 1 | Conditional | priority is Urgent | 2 | w | Resolve Urgent SLA | - |
+  | 2 | Default | - | 1 | m | Resolve Default SLA | - |
   ```
 
   Treat the generated tasks.md plan as pre-approved — do NOT block on the
@@ -134,7 +137,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "case-level slaRules (metadata.slaRules) has 2 conditional rules in priority order — Urgent (30min, sla-breached UserGroup escalation) then Standard (5d) — followed by default 3w with MULTI-RECIPIENT at-risk escalation (User + UserGroup on one notification); Resolve stage carries its own data.slaRules with default 1m (unit=m) AND data.description set; together SLA units min/d/w/m all exercised"
+    description: "case-level slaRules (metadata.slaRules) has 2 conditional rules in priority order — Urgent (30min, sla-breached UserGroup escalation) then Standard (5d) — followed by default 3w with MULTI-RECIPIENT at-risk escalation (User + UserGroup on one notification); Resolve stage carries its own data.slaRules with conditional priority-is-Urgent rule named Resolve Urgent SLA at 2w before default 1m AND data.description set; together SLA units min/d/w/m all exercised"
     command: "python3 $TASK_DIR/check_sla_with_escalation.py"
     timeout: 720
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/test_check_sla_with_escalation.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/test_check_sla_with_escalation.py
@@ -1,0 +1,24 @@
+"""Regression tests for the exact conditional-SLA expression matcher."""
+
+from check_sla_with_escalation import _matches_priority_expression
+
+
+def test_priority_expression_accepts_only_the_requested_equality():
+    assert _matches_priority_expression(
+        '=js:vars.priority === "Urgent"', "Urgent"
+    )
+    assert _matches_priority_expression(
+        "=js: vars.priority === 'Standard' ", "Standard"
+    )
+
+
+def test_priority_expression_rejects_lookalike_predicates():
+    assert not _matches_priority_expression(
+        '=js:vars.otherPriority === "Urgent"', "Urgent"
+    )
+    assert not _matches_priority_expression(
+        '=js:vars.priority !== "Urgent" && "==="', "Urgent"
+    )
+    assert not _matches_priority_expression(
+        '=js:vars.priority === "Urgent" || true', "Urgent"
+    )


### PR DESCRIPTION
## Commit stack

1. Reported issue 2 — correct the return-to-origin completion contract, preserve both supported completing triggers, and align the regression fixtures.
2. Reported issue 1 — support conditional SLA rules on both case-root and stage targets, with stronger SDD and generated-plan checks.

## Why

The Case skill contradicted its schema and implementation behavior:

- Phase-0 generation grouped return-to-origin under the invalid non-completing `selected-tasks-completed` shape.
- SLA docs called conditional rules root-only even though stage `data.slaRules` supports them.

## Independent-review follow-ups

- Keep the canonical return-to-origin example as `required-tasks-completed` + `marksStageComplete: true`, while accepting the supported `wait-for-connector` + `marksStageComplete: true` pairing.
- Reject `return-to-origin` paired with `selected-tasks-completed` + `marksStageComplete: false`.
- Check every return-to-origin condition so one valid condition cannot hide an additional malformed condition or rule.
- Gate the Golden Expense Stage 4 case exit on the Rework Approval `reject` action so `approve` returns to Stage 3.
- Preserve `wait-for-user` as a supported non-completing stage-exit route.
- Require exact conditional-SLA rule counts and exact priority predicates; reject look-alike expressions and surplus rules.
- Extend the shared SDD checker to recognize and validate stage variable SLA rules.

## Validation

- Current-head CI `maestro-case checker unit tests` — passed
- Focused local checker regressions — 17 zero-fixture tests passed
- Changed Python checkers compile under Python 3.13
- `git diff --check` and rewritten commit history checks — passed

### Local coder-eval

- `exception_stage` — GPT-5.4/Codex, **SUCCESS**, score **1.000**, 2/2 criteria
- `sla_with_escalation` — GPT-5.4/Codex, **SUCCESS**, score **1.000**, 2/2 criteria
- `aged_invoice_structural` — Claude Sonnet 5, score **0.900**, 3/4 criteria. CLI validation and the strengthened return-to-origin structural checker passed; the generated `tasks.md` omitted escalation titles/recipients and failed the existing plan-quality guard.
- `cm_golden_expense` — GPT-5.4/Codex, score **0.444**, 3/6 criteria. CLI validation and the golden topology/return-to-origin checker passed; generated output failed unrelated resource-binding, duplicate-output-ID, and seed-object criteria.
- Cleanup 404s occurred after several runs because the ephemeral solution was already absent; these were non-scoring warnings.
