### PR TITLE
fix(maestro-flow): document that Decision/Switch gateways have no .output

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/decision/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/decision/impl.md
@@ -60,3 +60,4 @@ Output ports: `true` and `false`. Both branches must be wired. See [editing-oper
 | Expression does not evaluate to boolean | Expression returns non-boolean value | Ensure expression uses comparison operators (`===`, `>`, etc.) |
 | `$vars.nodeId` is undefined | Upstream node not connected or wrong ID | Check edges and node IDs |
 | Only one branch wired | Missing true or false edge | Add the missing edge — both branches are required |
+| `Cannot read property '…' of undefined` in a downstream script (debug Faults) | A downstream node read `$vars.<decision>.output.<field>` — a Decision is routing-only and has no `.output` | Recompute the condition in the downstream node from the same upstream `$vars` the Decision tested; do not read the gateway's result. See [node-output-wiring.md § Routing Nodes](../../../shared/node-output-wiring.md#routing-nodes-decision--switch-have-no-output) |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/decision/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/decision/planning.md
@@ -36,3 +36,7 @@ Use a Decision node for binary branching (if/else) based on a boolean condition.
 - Decision nodes produce exactly **two** outgoing edges: one from `true`, one from `false`
 - Both branches must lead to a downstream node (no dangling branches)
 - Each branch typically ends at its own End node or merges back into a shared path
+
+## Outputs
+
+A Decision node is **routing-only** — it has no `.output` object for downstream nodes to read. `$vars.checkTemperature.output.<field>` resolves to `undefined` and crashes the node that dereferences it. When branches merge back into a shared node, that node must **recompute the condition** from the same upstream `$vars` the Decision tested (or a per-branch node must set a variable before the merge); it cannot ask the gateway which branch ran. See [node-output-wiring.md § Routing Nodes](../../../shared/node-output-wiring.md#routing-nodes-decision--switch-have-no-output).

--- a/skills/uipath-maestro-flow/references/author/references/plugins/switch/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/switch/impl.md
@@ -58,3 +58,4 @@ Each case creates a dynamic output port `case-{id}`. An optional `default` port 
 | Case expression error | Invalid JavaScript in case expression | Check `=js:` expression syntax |
 | Wrong port name in edge | Port ID doesn't match case ID | Ensure edge `sourcePort` is `case-{id}` matching the case's `id` field |
 | `$vars.nodeId` is undefined | Upstream node not connected or wrong ID | Check edges and node IDs |
+| `Cannot read property '…' of undefined` in a downstream script (debug Faults) | A downstream node read `$vars.<switch>.output.<field>` — a Switch is routing-only and has no `.output` | Recompute the condition in the downstream node from the same upstream `$vars` the Switch tested; do not read the gateway's result. See [node-output-wiring.md § Routing Nodes](../../../shared/node-output-wiring.md#routing-nodes-decision--switch-have-no-output) |

--- a/skills/uipath-maestro-flow/references/author/references/plugins/switch/planning.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/switch/planning.md
@@ -36,3 +36,7 @@ Each case creates a dynamic output port: `case-{item.id}`. An optional `default`
 - Switch nodes produce one outgoing edge per case + optionally one from `default`
 - Each case edge uses `sourcePort: "case-{id}"` where `{id}` matches the case's `id` field
 - Every case branch must lead to a downstream node
+
+## Outputs
+
+A Switch node is **routing-only** — it has no `.output` object for downstream nodes to read. `$vars.routeByPriority.output.<field>` resolves to `undefined` and crashes the node that dereferences it. When cases merge back into a shared node, that node must **recompute the condition** from the same upstream `$vars` the Switch tested (or a per-case node must set a variable before the merge); it cannot ask the gateway which case matched. See [node-output-wiring.md § Routing Nodes](../../../shared/node-output-wiring.md#routing-nodes-decision--switch-have-no-output).

--- a/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
+++ b/skills/uipath-maestro-flow/references/shared/node-output-wiring.md
@@ -52,6 +52,21 @@ Three failure modes observed in agent-generated `.flow` files:
 
 ---
 
+## Routing Nodes (Decision / Switch) Have No `.output`
+
+Unlike data-producing nodes (HTTP, Script, Connector, …), **Decision (`core.logic.decision`) and Switch (`core.logic.switch`) are routing-only** — they steer flow through ports and expose no `.output` object. `$vars.<gateway>.output` is `undefined`, so dereferencing it (e.g. `.matchedCaseId`) throws `Cannot read property '…' of undefined` in the downstream node and **Faults the debug run** — even though `flow validate` passed.
+
+Their registry outputs `matchedCase`/`matchedCaseId` are **top-level vars** (`$vars.<gateway>.matchedCaseId`, never `.output.*`), exist mainly for the Studio debug panel, and come back `null` in backend `uip maestro flow debug` — don't read them. To vary behavior where branches merge, **recompute the condition** in the merged node from the same upstream `$vars` the gateway tested (or set a variable per-branch before the merge).
+
+```javascript
+// WRONG — gateways have no .output; throws "Cannot read property 'matchedCaseId' of undefined"
+const message = $vars.checkTemperature.output.matchedCaseId === 'true' ? 'nice day' : 'bring a jacket';
+// RIGHT — recompute from the same upstream value the gateway tested
+const message = $vars.getWeather.output.body.current.temperature_2m > 60 ? 'nice day' : 'bring a jacket';
+```
+
+---
+
 ## Where the Rule Applies
 
 `=js:` is **required** in every field below when the value references `$vars`, `$metadata`, or `$self`:
@@ -117,6 +132,7 @@ Plugin-specific path fields are not value fields. **Always** follow the plugin r
 3. **Never wrap conditions** (Decision, Switch, HTTP branch) in `=js:`. Those are parsed as JS automatically.
 4. **Never use `{ }` template interpolation in connector or HTTP activity inputs.** The flow-layer template runner skips these fields. The `$` is stripped and `{vars.X}` ships literally to the IS runtime. Use `=js:` and JS template literals (`` `…${$vars.X}…` ``) instead.
 5. **Never quote `=js:` itself in an expression.** `"=js:$vars.X"` is correct. `"\"=js:$vars.X\""` is a string containing the prefix.
+6. **Never read `$vars.<gateway>.output.*`** for Decision/Switch nodes — they are routing-only and have no `.output` object, so this throws `Cannot read property '…' of undefined` at runtime. See [Routing Nodes (Decision / Switch) Have No `.output`](#routing-nodes-decision--switch-have-no-output).
 
 ---
 

--- a/skills/uipath-review/references/flows/flow-review-checklist.md
+++ b/skills/uipath-review/references/flows/flow-review-checklist.md
@@ -84,6 +84,7 @@ uip maestro flow validate "<PROJECT_NAME>.flow" --output json
 | Default branch defined (to avoid runtime faults) | Warning | Check for default path |
 | Condition expression is valid and testable | Warning | Read condition |
 | Fail-fast patterns used (check errors before processing) | Info | Review decision placement |
+| No downstream node reads `$vars.<decision-or-switch>.output.*` — gateways are routing-only and have no `.output`, so this faults at runtime (`Cannot read property … of undefined`). Merged branches must recompute the condition instead | Critical | Grep merged/downstream node inputs and script bodies for `$vars.<gatewayId>.output` |
 
 ### Loop Nodes (`core.logic.loop`)
 


### PR DESCRIPTION
## Problem

The `skill-flow-move-node` eval failed at runtime. The task was to move the decision node before `formatSummary`, merge both branches into it, then a single end node — which was done correctly (`flow validate` passed). But `uip maestro flow debug` **Faulted** at `formatSummary`:

```
[300501] Error invoking script task (element formatSummary)
detail: "Cannot read property 'matchedCaseId' of undefined"
```

The merged script read the branch result off the gateway:

```js
const message = $vars.checkTemperature.output.matchedCaseId === 'true'
  ? 'nice day' : 'bring a jacket';
```

## Root cause

Decision/Switch are **routing-only** gateways with **no `.output` object**, so `$vars.checkTemperature.output` is `undefined` and `.matchedCaseId` throws. This is a skill-guidance gap, not a task bug (the task is solvable by recomputing the condition in the merged script):

- `node-output-wiring.md` (the "single source of truth") universalized the `$vars.<node>.output.<field>` pattern with **no carve-out** for routing nodes.
- `decision`/`switch` docs anticipate "merge back into a shared path" but never say how a merged node learns which branch ran.

Note: the registry *does* define `matchedCase`/`matchedCaseId`, but as **top-level node vars** (`$vars.<gateway>.matchedCaseId`, not `.output.*`) — and they exist mainly for the Studio debug schema panel; backend debug runs return them `null` for a completed gateway. So the guidance steers toward **recomputing the condition** in the merged node rather than reading the gateway result.

## Changes

**`uipath-maestro-flow`**
- `references/shared/node-output-wiring.md` — new "Routing Nodes (Decision / Switch) Have No `.output`" section with WRONG/RIGHT example, plus anti-pattern #6.
- `decision/planning.md`, `switch/planning.md` — new **Outputs** section.
- `decision/impl.md`, `switch/impl.md` — Debug-table row mapping the exact symptom to the fix.

**`uipath-review`**
- `flows/flow-review-checklist.md` — Critical reviewer check for `$vars.<gateway>.output` reads in downstream nodes.

Docs-only; no task/grading changes. The `uipath-maestro-bpmn` skill uses a different (`.bpmn`/native gateway) expression model and does not reference this pattern, so it was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)