### PR TITLE
MST-12630: Fix coder eval tests using CodeX

### DIFF
--- a/tests/tasks/uipath-maestro-case/edit/remove_task/check_remove_task.py
+++ b/tests/tasks/uipath-maestro-case/edit/remove_task/check_remove_task.py
@@ -4,11 +4,14 @@
 The starting fixture chains three stages: Intake → Review → Decision. The
 Review stage runs TWO parallel wait-for-timer tasks in distinct data.tasks
 lanes: "Hold For 1 Hour" (required) and "Notify Reviewer" (optional). The
-agent must remove the REQUIRED "Hold For 1 Hour" task, leaving Review with
-exactly one task ("Notify Reviewer") otherwise unchanged, while keeping
-Review's required-tasks-completed exit condition intact. Verifies the removal
-happened, the exit condition still holds, the surviving task and the stage
-chain are intact (a true delete, not a rebuild), and the edited case launches.
+agent must remove the REQUIRED "Hold For 1 Hour" task — Review's ONLY required
+task — leaving Review with exactly one task ("Notify Reviewer"). Because a
+required-tasks-completed exit rule needs at least one required task to stay
+valid, the agent must promote the surviving "Notify Reviewer" to required
+while leaving it otherwise unchanged, keeping Review's required-tasks-completed
+exit condition intact. Verifies the removal happened, the survivor was promoted
+to required and is otherwise intact, the exit condition still holds, the stage
+chain is intact (a true delete, not a rebuild), and the edited case launches.
 """
 
 import os
@@ -103,6 +106,17 @@ def main():
         sys.exit(
             f"FAIL: 'Notify Reviewer' task-entry rule should be "
             f"'current-stage-entered'; got {rule and rule.get('rule')!r}"
+        )
+
+    # The survivor must be promoted to required. "Hold For 1 Hour" was Review's
+    # only required task; a required-tasks-completed exit rule needs at least
+    # one required task, so leaving "Notify Reviewer" optional would make the
+    # stage's exit condition invalid (it could never complete / fails validate).
+    if not survivor.get("isRequired"):
+        sys.exit(
+            "FAIL: 'Notify Reviewer' must be promoted to required "
+            "(isRequired: true) so Review's required-tasks-completed exit rule "
+            "still has a required task; got isRequired=false"
         )
 
     # Review's exit condition must still hold: the required-tasks-completed

--- a/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
+++ b/tests/tasks/uipath-maestro-case/edit/remove_task/remove_task.yaml
@@ -4,10 +4,12 @@ description: >
   stage of an existing LinearThreeStages case. Review starts with two parallel
   tasks in distinct data.tasks lanes ("Hold For 1 Hour" required, "Notify
   Reviewer" optional); after the edit Review must carry only "Notify Reviewer".
-  Exercises editing an existing caseplan.json: deleting a task from a stage's
-  data.tasks lanes while leaving the stage's required-tasks-completed exit
-  condition intact (it still holds — the agent must not rewrite or break it),
-  the surviving task undisturbed, and the linear stage chain unchanged.
+  Exercises editing an existing caseplan.json: deleting a stage's ONLY required
+  task from its data.tasks lanes, then keeping the stage's
+  required-tasks-completed exit condition valid by promoting the surviving
+  "Notify Reviewer" to required (a required-tasks-completed exit needs at least
+  one required task), while leaving the surviving task otherwise undisturbed and
+  the linear stage chain unchanged.
 tags: [uipath-maestro-case, e2e, mode:build, lifecycle:edit, shape:multi-node, feature:stages, feature:conditions, feature:wait-for-timer]
 max_iterations: 1
 
@@ -35,7 +37,10 @@ initial_prompt: |
     - Review's exit condition must still hold: leave the
       required-tasks-completed exit rule (marksStageComplete) in place,
       unchanged. Do NOT rewrite, weaken, or delete it.
-    - "Notify Reviewer" must be left otherwise unchanged (same type and
+    - "Hold For 1 Hour" was Review's ONLY required task, and a
+      required-tasks-completed exit rule needs at least one required task to
+      stay valid. So promote the surviving "Notify Reviewer" to required
+      (isRequired: true). Leave it otherwise unchanged (same type and
       task-entry condition).
     - The three stages and the Intake → Review → Decision chain must be
       unchanged — do NOT touch Intake, Decision, the stage-entry conditions, or
@@ -59,7 +64,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Hold For 1 Hour task removed from Review: 3 stages unchanged, Review carries exactly one task ('Notify Reviewer') left intact, 'Hold For 1 Hour' is gone from the whole case, Review's required-tasks-completed exit condition still holds, the linear chain is unchanged, and the edited case launches in the Studio Web debug runtime"
+    description: "Hold For 1 Hour task removed from Review: 3 stages unchanged, Review carries exactly one task ('Notify Reviewer') promoted to required and otherwise intact, 'Hold For 1 Hour' is gone from the whole case, Review's required-tasks-completed exit condition still holds, the linear chain is unchanged, and the edited case launches in the Studio Web debug runtime"
     command: "python3 $TASK_DIR/check_remove_task.py"
     timeout: 720
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
@@ -168,10 +168,10 @@ success_criteria:
     path: "InvoiceReviewCase/InvoiceReviewCase/caseplan.json"
     assertions:
       - operator: regex
-        expression: "nodes[].data.tasks[][].type"
+        expression: "join(',', nodes[].data.tasks[][].type)"
         expected: "\\baction\\b"
       - operator: regex
-        expression: "nodes[].data.tasks[][].type"
+        expression: "join(',', nodes[].data.tasks[][].type)"
         expected: "\\bprocess\\b"
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
@@ -163,12 +163,16 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: json_check
     description: "Caseplan contains both an action task and a process task"
     path: "InvoiceReviewCase/InvoiceReviewCase/caseplan.json"
-    includes:
-      - '"type": "action"'
-      - '"type": "process"'
+    assertions:
+      - expression: "nodes[].data.tasks[][].type"
+        operator: contains
+        expected: "action"
+      - expression: "nodes[].data.tasks[][].type"
+        operator: contains
+        expected: "process"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
@@ -167,12 +167,12 @@ success_criteria:
     description: "Caseplan contains both an action task and a process task"
     path: "InvoiceReviewCase/InvoiceReviewCase/caseplan.json"
     assertions:
-      - expression: "nodes[].data.tasks[][].type"
-        operator: contains
-        expected: "action"
-      - expression: "nodes[].data.tasks[][].type"
-        operator: contains
-        expected: "process"
+      - operator: regex
+        expression: "nodes[].data.tasks[][].type"
+        expected: "\\baction\\b"
+      - operator: regex
+        expression: "nodes[].data.tasks[][].type"
+        expected: "\\bprocess\\b"
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
+++ b/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
@@ -154,7 +154,7 @@ success_criteria:
     description: "build-issues.md carries the issue-log header naming this case (per logging/impl-json.md dump template)"
     path: "tasks/build-issues.md"
     includes:
-      - "Build Issues"
+      - "Build"
       - "TimerLogCase"
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
test(maestro-case): harden remove_task + guardrail criteria

- remove_task: clarify that "Hold For 1 Hour" is Review's ONLY required
  task, requiring promotion of "Notify Reviewer" to isRequired:true to
  keep the required-tasks-completed exit rule valid; add checker assertion
  for the promotion
- artifact_safety_guard: replace brittle file_contains string match with
  json_check on nodes[].data.tasks[][].type for action/process presence
- logging_issue_log: relax header match from "Build Issues" to "Build"
  to de-flake against header casing variation