### PR TITLE
fix(test): make permission-denied check-access smoke agent-agnostic

### DIFF
--- a/tests/tasks/uipath-admin/authz_diagnose_permission_denied_smoke.yaml
+++ b/tests/tasks/uipath-admin/authz_diagnose_permission_denied_smoke.yaml
@@ -26,16 +26,27 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent resolved the user via users list --search"
-    tool_name: "Bash"
-    command_pattern: 'uip\s+admin\s+users\s+list\s+.*--search\s+.*jane'
-    min_count: 1
-    weight: 1.5
+  - type: skill_triggered
+    description: "Agent activated the uipath-admin skill"
+    skill_name: "uipath-admin"
+    expected_skill: "uipath-admin"
+    weight: 1.0
     pass_threshold: 1.0
 
+  # Advisory: check-access accepts an email/name directly (check-access.md),
+  # so resolving the GUID via users list first is a legitimate-to-skip
+  # prerequisite. Scored but not gated — agents that pass the email straight
+  # to the PDP still reach the correct diagnosis.
   - type: command_executed
-    description: "Agent ran check-access for the user"
+    description: "Agent resolved the user via users list --search (advisory — check-access accepts email directly)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+users\s+list\b[\s\S]*--search\s+\S'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 0
+
+  - type: command_executed
+    description: "Agent ran check-access as the primary authorization diagnostic"
     tool_name: "Bash"
     command_pattern: 'uip\s+admin\s+authorization\s+check-access\b'
     min_count: 1


### PR DESCRIPTION
## Problem

`skill-admin-permission-denied-check-access-smoke` fails on agents that pass the user's email **directly** to `check-access` and skip `users list --search` first. Evalboard run scored 0.57 (ran `check-access` ✓ but not `users list` ✗).

This is a legitimate agent path: `check-access.md` documents `uip admin authorization check-access alice@example.com` — the PDP accepts an email/name inline, so resolving the GUID via `users list` first is an optional prerequisite, not a required diagnostic step.

## Changes

- **Add `skill_triggered` guard** for `uipath-admin` activation (weight 1.0, mandatory).
- **Keep `check-access` mandatory** (weight 2.0) — the primary authorization diagnostic per CAPABILITY.md rule 5, the core lesson this smoke test covers.
- **Make `users list --search` advisory** (`pass_threshold: 0`): scored but not gated, since `check-access` reaches the same diagnosis from the email.
- **Harden the `users list` regex**: `[\s\S]*` for multi-line/flag reordering, drop the brittle literal `jane` requirement.

## Coverage

Still validates the core skill behavior: agent activates `uipath-admin` and uses `check-access` as the primary PDP diagnostic. Identity resolution is scored (advisory) but no longer gates a valid email-first diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)