### PR TITLE
test(uipath-maestro-case): drop claude-only sdk_options so case tasks run on codex/antigravity

### DIFF
--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
@@ -28,8 +28,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "TodoWrite"]
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 5400

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -27,8 +27,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "TodoWrite"]
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 4800

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/finalize_from_draft.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/finalize_from_draft.yaml
@@ -26,10 +26,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  # Cap per-turn extended thinking so finalization writes/edits rather than
-  # deliberating the whole document as thinking tokens.
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 3000

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/finalize_from_draft_loan.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/finalize_from_draft_loan.yaml
@@ -22,10 +22,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  # Cap per-turn extended thinking so finalization writes/edits rather than
-  # deliberating the whole document as thinking tokens.
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 3000

--- a/tests/tasks/uipath-maestro-case/phase_0_to_case/candidate_interview/candidate_interview.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_to_case/candidate_interview/candidate_interview.yaml
@@ -24,10 +24,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  # Cap per-turn extended thinking so the agent writes the draft instead of
-  # deliberating it as thinking tokens. Interview turns use far less than this.
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 3300

--- a/tests/tasks/uipath-maestro-case/phase_0_to_case/loan_origination/loan_origination.yaml
+++ b/tests/tasks/uipath-maestro-case/phase_0_to_case/loan_origination/loan_origination.yaml
@@ -24,10 +24,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  # Cap per-turn extended thinking so the agent writes the draft instead of
-  # deliberating it as thinking tokens. Interview turns use far less than this.
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 3000

--- a/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/registry_handoff_action_case_sdd_only.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/registry_handoff_action_case_sdd_only.yaml
@@ -27,8 +27,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 2400

--- a/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/registry_handoff_sdd_only.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/registry_handoff_sdd_only.yaml
@@ -29,8 +29,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 2400

--- a/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/registry_handoff_stale_runnable.yaml
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/registry_handoff_stale_runnable.yaml
@@ -31,8 +31,6 @@ agent:
   type: claude-code
   permission_mode: acceptEdits
   allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "AskUserQuestion", "TodoWrite"]
-  sdk_options:
-    max_thinking_tokens: 10000
 
 run_limits:
   task_timeout: 2400


### PR DESCRIPTION
The nightly eval runner pre-drops any task whose `agent:` block carries a Claude-only field (`sdk_options`, `claude_settings`, `setting_sources`) whenever the harness is non-Claude (codex / antigravity), because coder-eval re-parses each task’s agent config against the codex/antigravity config — whose `extra="forbid"` would otherwise abort the entire suite invocation with no `run.json`.

Nine `uipath-maestro-case` tasks each declared `agent.sdk_options.max_thinking_tokens: 10000`. As a result they silently never ran on the codex or antigravity harnesses and were absent from evalboard for those runs entirely (no result row, not even a skipped-task entry). They only ever executed on the claude-code nightly.

This drops the `sdk_options` block (and its now-orphaned explanatory comment where present) from all nine so they run on every harness. This is the same cleanup pattern as #2210 (which dropped `sandbox.driver` tempdir overrides), applied to the agent-config axis.

### Why this doesn't regress the claude-code run

`max_thinking_tokens` is deprecated in the Claude Agent SDK. On adaptive-thinking models (Opus 4.6+ / Sonnet 4.6+) it is treated as an on/off switch — `0` disables thinking, any non-zero value enables adaptive thinking — **not** as a fixed token budget. The nightly claude-code harness runs `eu.anthropic.claude-sonnet-5` (fallback `eu.anthropic.claude-sonnet-4-6`), both adaptive-thinking models, so `10000` was only ever read as "thinking on." The SDK default when the field is unset is also adaptive thinking (`effort: high`). Before and after this change therefore resolve to the same thinking behavior on these models, so removing the field is effectively a no-op for the claude-code trajectories. The task comments that framed `10000` as a per-turn cap describe older-model behavior, where the value was a real budget; that interpretation no longer applies on the models these evals run.

Affected tasks:
- `skill-case-e2e-expense-runnable`
- `skill-case-aged-invoice-structural`
- `skill-case-phase-0-finalize-draft`
- `skill-case-phase-0-finalize-draft-loan`
- `skill-case-phase-0-candidate-interview`
- `skill-case-phase-0-loan-origination`
- `skill-case-registry-handoff-sdd-only`
- `skill-case-registry-handoff-action-case-sdd-only`
- `skill-case-registry-handoff-stale-runnable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
