### PR TITLE
test(uipath-troubleshoot): grade activity-package dialogs with include_dialog

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-column-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-column-mismatch/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-csvhelper-method-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-csvhelper-method-not-found/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-file-not-found/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-invalid-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-invalid-format/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-more-values-than-header/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-more-values-than-header/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-access-denied/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-cannot-set-unknown-member/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-cannot-set-unknown-member/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-invalid-delimiter/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-invalid-delimiter/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-unsupported-encoding/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-unsupported-encoding/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-empty-sql/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-empty-sql/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-in-connection-string/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-in-connection-string/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-403-forbidden/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-403-forbidden/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-host-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-host-not-found/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-httpclient-reused-in-loop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-httpclient-reused-in-loop/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-stuck-tmp/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-stuck-tmp/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/du-digitize-license-not-validated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/du-digitize-license-not-validated/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
@@ -68,6 +68,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-add-sheet-name-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-add-sheet-name-conflict/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-connection-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-connection-invalid/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-getfileinfo-malformed-url/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-getfileinfo-malformed-url/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-sheets-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-sheets-invalid-range/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-timeout/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-activity-restsharp-load/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-activity-restsharp-load/task.yaml
@@ -66,6 +66,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-auth-username-not-email/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-auth-username-not-email/task.yaml
@@ -64,6 +64,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-403-permission/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-403-permission/task.yaml
@@ -64,6 +64,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-issue-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-issue-not-found/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-visibility-restriction/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-visibility-restriction/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-response-not-json-500/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-response-not-json-500/task.yaml
@@ -64,6 +64,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-deserialization/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-deserialization/task.yaml
@@ -65,6 +65,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-invalid-id/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-invalid-id/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-required-field/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-required-field/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-shared-mailbox-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-shared-mailbox-account/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-createfolder-invalid-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-createfolder-invalid-path/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-download-folder-item/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-download-folder-item/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-forwardmail-null-message/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-forwardmail-null-message/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-message-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-message-not-found/task.yaml
@@ -48,6 +48,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
@@ -43,6 +43,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sendmail-missing-attachment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sendmail-missing-attachment/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-trigger-connection-503/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-trigger-connection-503/task.yaml
@@ -48,6 +48,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-extract-page-range-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-extract-page-range-invalid/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-corrupt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-corrupt/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-encrypted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-encrypted/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-file-not-found/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-load-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-load-hang/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-local-import/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-local-import/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-toplevel-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-toplevel-exception/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-version-unsupported/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-version-unsupported/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
@@ -66,6 +66,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-invalid-advanced-param/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-invalid-advanced-param/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-no-host/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-no-host/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/slack-send-message-channel-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/slack-send-message-channel-not-found/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-compress-extract-corrupt-archive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-compress-extract-corrupt-archive/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-copy-file-destination-exists/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-copy-file-destination-exists/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-download-file-dns-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-download-file-dns-failure/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-get-queue-item-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-get-queue-item-not-found/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-activity-silent-failure/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getqueueitem-queue-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getqueueitem-queue-not-found/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/terminal-session-connect-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/terminal-session-connect-failed/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-dependency-version-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-dependency-version-conflict/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-recommendation-only/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-recommendation-only/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-app-request-trigger-connection-lost/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-app-request-trigger-connection-lost/task.yaml
@@ -51,6 +51,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-handle-app-request-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-handle-app-request-null-reference/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-initialize-hub-connection-aggregate-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-initialize-hub-connection-aggregate-failure/task.yaml
@@ -51,6 +51,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.


### PR DESCRIPTION
## What

Adds `include_dialog: true` to the `llm_judge` criterion of every `uipath-troubleshoot` **activity-packages** task that grades a diagnosis dialog, so the judge receives the full dialog instead of only the final simulator turn.

Extends the pattern from #2221 (and originally #2159) to the rest of the activity-packages suite.

## Why

The `llm_judge` criterion defaults to grading only the last turn. In dialog scenarios the agent delivers the correct diagnosis in an earlier turn and then closes with a terse acknowledgment; the judge scores the acknowledgment and returns a false negative. This surfaced across the 2026-07-24 nightly (codex agent) where 9+ troubleshoot activity tasks failed purely on last-turn-only judging while `skill_triggered` passed and the diagnosis was correct.

`include_dialog: true` feeds the whole dialog to the judge so it grades the turn where the diagnosis actually appears.

## Scope

- 86 task YAMLs under `tests/tasks/uipath-troubleshoot/activity-packages/`.
- One line added per file, directly above the existing `include_agent_output: true`. No prompt or other changes.
- Excluded: tasks with `skip: true` (129) and tasks that already had `include_dialog: true` (11, incl. the #2221 set).
- Out of scope: the `excel-invokevba-method-name-de` fixture (missing `process/` source dir) and the `uia-click-noop-simulate-tech` genuine codex-quality partial — neither is a last-turn-judging issue.