### PR TITLE
test(uipath-troubleshoot): drop sandbox.driver tempdir pin from two UIA replay tasks

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
@@ -16,7 +16,6 @@ run_limits:
   turn_timeout: 3600
 
 sandbox:
-  driver: tempdir
   python: {}
   template_sources:
     - type: template_dir


### PR DESCRIPTION
## What

Removes the `sandbox.driver: tempdir` line from two `uipath-troubleshoot` replay tasks:

- `activity-packages/uia-browser-communication-failed/task.yaml`
- `activity-packages/uia-napplicationcard-view-generation/task.yaml`

## Why

The **Task Driver Gate** (`task-driver-gate.yml`) fails the build if any task pins `sandbox.driver: tempdir`. The gate has no `paths:` filter, so it currently fails on **every** open PR against main until these two offenders are removed.

Both tasks are faithful-replay diagnoses that run against a `uip` CLI mock; they do not need the Windows toolchain, so per the gate's guidance the fix is to drop the driver pin (not tag `windows`) and let the run environment choose the driver.

## Verification

`python3 scripts/check-task-driver.py tests/tasks` → `OK — no task pins sandbox.driver: tempdir` (exit 0).