### PR TITLE
test(uipath-troubleshoot): stage missing project source in invokevba-method-name-de fixture

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/Main.xaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/Main.xaml
@@ -1,0 +1,37 @@
+<Activity mc:Ignorable="sap sap2010" x:Class="Main" sap2010:ExpressionActivityEditor.ExpressionActivityEditor="C#" sap2010:WorkflowViewState.IdRef="ActivityBuilder_1" xmlns="http://schemas.microsoft.com/netfx/2009/xaml/activities" xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:sap="http://schemas.microsoft.com/netfx/2009/xaml/activities/presentation" xmlns:sap2010="http://schemas.microsoft.com/netfx/2010/xaml/activities/presentation" xmlns:scg="clr-namespace:System.Collections.Generic;assembly=System.Private.CoreLib" xmlns:sco="clr-namespace:System.Collections.ObjectModel;assembly=System.Private.CoreLib" xmlns:ui="http://schemas.uipath.com/workflow/activities" xmlns:uix="http://schemas.uipath.com/workflow/activities/excel" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+  <TextExpression.NamespacesForImplementation>
+    <sco:Collection x:TypeArguments="x:String">
+      <x:String>System.Activities</x:String>
+      <x:String>System.Activities.Statements</x:String>
+      <x:String>System</x:String>
+      <x:String>System.Collections</x:String>
+      <x:String>System.Collections.Generic</x:String>
+      <x:String>UiPath.Core</x:String>
+      <x:String>UiPath.Core.Activities</x:String>
+      <x:String>UiPath.Excel</x:String>
+      <x:String>UiPath.Excel.Activities</x:String>
+      <x:String>UiPath.Excel.Activities.Business</x:String>
+    </sco:Collection>
+  </TextExpression.NamespacesForImplementation>
+  <TextExpression.ReferencesForImplementation>
+    <sco:Collection x:TypeArguments="AssemblyReference">
+      <AssemblyReference>System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.System.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.Excel.Activities</AssemblyReference>
+      <AssemblyReference>UiPath.Excel.Activities.Design</AssemblyReference>
+    </sco:Collection>
+  </TextExpression.ReferencesForImplementation>
+  <Sequence DisplayName="Main Sequence" sap2010:WorkflowViewState.IdRef="Sequence_1">
+    <uix:ExcelProcessScope DisplayName="Excel Process Scope" KillExcelProcessesEachIteration="True" Private="False" ShowExcel="True" sap2010:WorkflowViewState.IdRef="ExcelProcessScope_1">
+      <uix:ExcelApplicationCard DisplayName="Use Excel File" WorkbookPath="data\Invoices.xlsx" Private="False" sap2010:WorkflowViewState.IdRef="ExcelApplicationCard_1">
+        <uix:InvokeVBAX CodeFilePath="macro.txt" DisplayName="Invoke VBA" EntryMethodName="ProcessInvoces" Private="False" sap2010:WorkflowViewState.IdRef="InvokeVBAX_1">
+          <uix:InvokeVBAX.EntryMethodParameters>
+            <InArgument x:TypeArguments="scg:IEnumerable(x:Object)">
+              <CSharpValue x:TypeArguments="scg:IEnumerable(x:Object)" sap2010:WorkflowViewState.IdRef="CSharpValue`1_1">new Object[] { }</CSharpValue>
+            </InArgument>
+          </uix:InvokeVBAX.EntryMethodParameters>
+        </uix:InvokeVBAX>
+      </uix:ExcelApplicationCard>
+    </uix:ExcelProcessScope>
+  </Sequence>
+</Activity>

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/entry-points.json
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/entry-points.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://cloud.uipath.com/draft/2024-12/entry-point",
+  "entryPoints": [
+    {
+      "filePath": "Main.xaml",
+      "uniqueId": "c3d4e5f6-a7b8-9012-3456-789abcdef012",
+      "type": "process"
+    }
+  ]
+}

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/macro.txt
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/macro.txt
@@ -1,0 +1,11 @@
+Sub ProcessInvoices()
+    Dim ws As Worksheet
+    Set ws = ActiveWorkbook.Sheets("Invoices")
+    Dim lastRow As Long
+    lastRow = ws.Cells(ws.Rows.Count, 1).End(xlUp).Row
+    Dim i As Long
+    For i = 2 To lastRow
+        ws.Cells(i, 5).Value = ws.Cells(i, 3).Value * ws.Cells(i, 4).Value
+    Next i
+    ActiveWorkbook.Save
+End Sub

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/project.json
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/project.json
@@ -1,0 +1,51 @@
+{
+  "name": "InvoiceImporter",
+  "projectId": "a3b2c1d4-5e6f-4789-0abc-def123456789",
+  "description": "Runs the invoice-processing VBA macro against the Invoices workbook via Invoke VBA inside an Excel Process Scope.",
+  "main": "Main.xaml",
+  "dependencies": {
+    "UiPath.Excel.Activities": "[3.4.1]",
+    "UiPath.System.Activities": "[25.10.5]"
+  },
+  "webServices": [],
+  "entitiesStores": [],
+  "schemaVersion": "4.0",
+  "studioVersion": "25.10.7.0",
+  "projectVersion": "1.0.0",
+  "runtimeOptions": {
+    "autoDispose": false,
+    "isAttended": false,
+    "executionType": "Workflow",
+    "requiresUserInteraction": true,
+    "supportsPersistence": false,
+    "excludedLoggedData": [
+      "Private:*",
+      "*password*"
+    ]
+  },
+  "designOptions": {
+    "projectProfile": "Developement",
+    "outputType": "Process",
+    "libraryOptions": {
+      "privateWorkflows": []
+    },
+    "processOptions": {
+      "ignoredFiles": []
+    },
+    "fileInfoCollection": [],
+    "saveToCloud": false
+  },
+  "expressionLanguage": "CSharp",
+  "entryPoints": [
+    {
+      "filePath": "Main.xaml",
+      "uniqueId": "c3d4e5f6-a7b8-9012-3456-789abcdef012",
+      "input": [],
+      "output": []
+    }
+  ],
+  "isTemplate": false,
+  "templateProjectData": {},
+  "publishData": {},
+  "targetFramework": "Windows"
+}

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/project.uiproj
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/process/project.uiproj
@@ -1,0 +1,6 @@
+{
+  "Name": "InvoiceImporter",
+  "ProjectType": "Process",
+  "Description": "Runs the invoice-processing VBA macro against the Invoices workbook via Invoke VBA inside an Excel Process Scope.",
+  "MainFile": "Main.xaml"
+}

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
@@ -21,6 +21,8 @@ sandbox:
   - type: template_dir
     path: ../../_shared/mock_template
   - type: template_dir
+    path: process
+  - type: template_dir
     path: data
   mock_path_dirs:
   - m


### PR DESCRIPTION
## What

Restores the `process/` project source (and its `template_dir` source in `task.yaml`) to the `excel-invokevba-method-name-de` troubleshoot fixture.

## Why

The `-de` (German-locale) variant was cloned from its sibling `excel-invokevba-method-name` but the `process/` snapshot and its `- path: process` template_source were dropped, so:

- `initial_prompt` promises "The project source for the failing process is in the current working directory" — but no source was staged.
- The confirmed root cause is a near-miss typo: `EntryMethodName="ProcessInvoces"` in `Main.xaml` vs the correctly-spelled `Sub ProcessInvoices()` in `macro.txt`. The mock CLI logs only surface the typo'd name and a "macro not available" error; the correct spelling that proves it's a typo lives **only** in `macro.txt`.
- Without the source, the agent could not confirm the typo with the required specificity. The 2026-07-24 nightly scored the `llm_judge` at 0.5 ("adjacent cause, missing a key specific").

The project source is locale-neutral (VBA + XAML); the only German element is the runtime error text, already present in the `-de` mock job logs. Copying the sibling's `process/` verbatim is therefore the correct fix.

## Verification

Local `coder-eval` (bedrock, sonnet-4-6), 3 sequential runs — all 1.0:

| Run | skill_triggered | llm_judge | weighted |
|-----|-----------------|-----------|----------|
| 1 | 1.0 | 1.0 | 1.0 |
| 2 | 1.0 | 1.0 | 1.0 |
| 3 | 1.0 | 1.0 | 1.0 |

`llm_judge` went from 0.5 (nightly, source absent) to 1.0 with the source staged.