### PR TITLE
test(uipath-agents): harden deterministic guardrail verifier

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -5,7 +5,6 @@ on:
     paths:
       - 'tests/tasks/uipath-maestro-flow/**'
       - 'tests/tasks/uipath-maestro-case/**'
-      - 'tests/tasks/uipath-agents/**'
       - 'tests/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
       - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
@@ -44,22 +43,6 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/tasks/uipath-maestro-case/ -v
-
-  pytest-agents-check:
-    runs-on: ubuntu-latest
-    name: uipath-agents checker unit tests
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
-      - name: Install pytest
-        run: pip install pytest
-
-      - name: Run pytest
-        run: pytest tests/tasks/uipath-agents/ -v
 
   runtime-payload-casing-guard:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'tests/tasks/uipath-maestro-flow/**'
       - 'tests/tasks/uipath-maestro-case/**'
+      - 'tests/tasks/uipath-agents/**'
       - 'tests/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
       - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
@@ -43,6 +44,22 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/tasks/uipath-maestro-case/ -v
+
+  pytest-agents-check:
+    runs-on: ubuntu-latest
+    name: uipath-agents checker unit tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/tasks/uipath-agents/ -v
 
   runtime-payload-casing-guard:
     runs-on: ubuntu-latest

--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/check_deterministic.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/check_deterministic.py
@@ -3,12 +3,12 @@
 
 Validates (middleware or decorator style both accepted):
 - Either UiPathDeterministicGuardrailMiddleware or CustomValidator is used
-- A lambda/rule that checks for the word "secret" in the input is present
-- BlockAction is used
-- The guardrail targets the lookup_account_info tool
+- The configured callable checks customer_id for the word "secret"
+- BlockAction is configured on that guardrail
+- The guardrail targets or decorates the lookup_account_info tool
 """
 
-import re
+import ast
 import sys
 from pathlib import Path
 
@@ -26,53 +26,159 @@ def check(condition: bool, msg: str) -> None:
         sys.exit(f"FAIL: {msg}")
 
 
+def call_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def keyword(call: ast.Call, name: str) -> ast.expr | None:
+    return next((item.value for item in call.keywords if item.arg == name), None)
+
+
+def is_call(node: ast.expr | None, name: str) -> bool:
+    return isinstance(node, ast.Call) and call_name(node.func) == name
+
+
+def collection_items(node: ast.expr | None) -> list[ast.expr]:
+    if isinstance(node, (ast.List, ast.Tuple, ast.Set)):
+        return list(node.elts)
+    return []
+
+
+def contains_reference(node: ast.AST, name: str) -> bool:
+    return any(
+        (isinstance(item, ast.Name) and item.id == name)
+        or (isinstance(item, ast.Constant) and item.value == name)
+        for item in ast.walk(node)
+    )
+
+
+def contains_string_literal(node: ast.AST, value: str) -> bool:
+    return any(
+        isinstance(item, ast.Constant)
+        and isinstance(item.value, str)
+        and item.value.casefold() == value.casefold()
+        for item in ast.walk(node)
+    )
+
+
+def checks_secret_customer_id(node: ast.Lambda | ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return whether a callable contains `"secret" in <customer_id expression>`."""
+    for item in ast.walk(node):
+        if not isinstance(item, ast.Compare):
+            continue
+
+        operands = [item.left, *item.comparators]
+        for index, operator in enumerate(item.ops):
+            if not isinstance(operator, ast.In):
+                continue
+            if contains_string_literal(operands[index], "secret") and contains_reference(
+                operands[index + 1], "customer_id"
+            ):
+                return True
+    return False
+
+
+def resolve_rule(
+    node: ast.expr,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+) -> ast.Lambda | ast.FunctionDef | ast.AsyncFunctionDef | None:
+    if isinstance(node, ast.Lambda):
+        return node
+    if isinstance(node, ast.Name):
+        return functions.get(node.id)
+    return None
+
+
+def has_valid_rule(
+    node: ast.expr | None,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+) -> bool:
+    for item in collection_items(node):
+        rule = resolve_rule(item, functions)
+        if rule is not None and checks_secret_customer_id(rule):
+            return True
+    return False
+
+
+def valid_middleware(
+    tree: ast.Module,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+) -> bool:
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or call_name(node.func) != "UiPathDeterministicGuardrailMiddleware":
+            continue
+
+        tools = collection_items(keyword(node, "tools"))
+        targets_lookup = any(isinstance(tool, ast.Name) and tool.id == "lookup_account_info" for tool in tools)
+        if (
+            targets_lookup
+            and has_valid_rule(keyword(node, "rules"), functions)
+            and is_call(keyword(node, "action"), "BlockAction")
+        ):
+            return True
+    return False
+
+
+def valid_decorator(
+    tree: ast.Module,
+    functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef],
+) -> bool:
+    lookup_functions = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name == "lookup_account_info"
+    ]
+    for function in lookup_functions:
+        for decorator in function.decorator_list:
+            if not isinstance(decorator, ast.Call) or call_name(decorator.func) != "guardrail":
+                continue
+
+            validator = keyword(decorator, "validator")
+            if not is_call(validator, "CustomValidator"):
+                continue
+            assert isinstance(validator, ast.Call)
+            rule = keyword(validator, "rule")
+            resolved = resolve_rule(rule, functions) if rule is not None else None
+            if (
+                resolved is not None
+                and checks_secret_customer_id(resolved)
+                and is_call(keyword(decorator, "action"), "BlockAction")
+            ):
+                return True
+    return False
+
+
 def main() -> None:
     src = read()
+    try:
+        tree = ast.parse(src, filename=str(GRAPH))
+    except SyntaxError as error:
+        sys.exit(f"FAIL: {GRAPH} is not valid Python: {error}")
 
-    # Accept either middleware or decorator style
-    has_middleware = "UiPathDeterministicGuardrailMiddleware" in src
-    has_decorator = "CustomValidator" in src
-
+    functions = {
+        node.name: node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    middleware_ok = valid_middleware(tree, functions)
+    decorator_ok = valid_decorator(tree, functions)
     check(
-        has_middleware or has_decorator,
-        "Neither UiPathDeterministicGuardrailMiddleware nor CustomValidator found in graph.py "
-        "— deterministic guardrail not added",
+        middleware_ok or decorator_ok,
+        "No deterministic guardrail with a callable rule checking customer_id for 'secret', "
+        "a BlockAction, and lookup_account_info targeting was found",
     )
-    if has_middleware:
+    if middleware_ok:
         print("OK: UiPathDeterministicGuardrailMiddleware used (middleware style)")
     else:
         print("OK: CustomValidator used (decorator style)")
-
-    # Rule must check for "secret" somewhere in the source
-    check(
-        "secret" in src.lower(),
-        "No reference to 'secret' found in graph.py — the blocking rule must check for this word",
-    )
-    print("OK: 'secret' keyword referenced in the rule")
-
-    # A lambda (or function) must be the rule
-    has_lambda = bool(re.search(r"lambda\s+\w+.*secret", src, re.IGNORECASE))
-    has_func_rule = bool(re.search(r"def\s+\w+.*\(.*\).*:\s*\n.*secret", src, re.IGNORECASE))
-    check(
-        has_lambda or has_func_rule,
-        "No lambda or function rule checking for 'secret' found — the rule must be a callable",
-    )
-    print("OK: lambda/function rule checking for 'secret' found")
-
-    check(
-        "BlockAction" in src,
-        "BlockAction not found — deterministic guardrail must use a block action",
-    )
+    print("OK: callable rule checks customer_id for 'secret'")
     print("OK: BlockAction used")
-
-    # lookup_account_info should be referenced near the guardrail
-    check(
-        "lookup_account_info" in src,
-        "lookup_account_info not referenced after modification — Tool-scoped guardrail "
-        "should target this tool",
-    )
     print("OK: lookup_account_info referenced (target tool)")
-
     print("OK: Deterministic guardrail with 'secret' rule correctly added to graph.py")
 
 

--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py
@@ -1,0 +1,169 @@
+"""Unit tests for the deterministic coded-agent guardrail checker."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+CHECKER = Path(__file__).with_name("check_deterministic.py")
+
+
+def run_checker(tmp_path: Path, source: str) -> subprocess.CompletedProcess[str]:
+    (tmp_path / "graph.py").write_text(textwrap.dedent(source))
+    return subprocess.run(
+        [sys.executable, str(CHECKER)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_accepts_inline_lambda_rule(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[
+                    lambda data: "secret"
+                    in data.get("customer_id", "").lower()
+                ],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_named_rule_with_docstring(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def contains_secret_customer_id(data: dict) -> bool:
+            \"\"\"Return whether a tool call includes a forbidden customer ID.\"\"\"
+            return "secret" in data.get("customer_id", "").lower()
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[contains_secret_customer_id],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_decorator_rule_with_docstring(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        def contains_secret_customer_id(data: dict) -> bool:
+            \"\"\"Return whether a tool call includes a forbidden customer ID.\"\"\"
+            return "secret" in data.get("customer_id", "").lower()
+
+        @guardrail(
+            validator=CustomValidator(rule=contains_secret_customer_id),
+            action=BlockAction(detail="blocked"),
+        )
+        @tool
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_secret_function_not_wired_as_rule(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def mentions_secret(data: dict) -> bool:
+            return "secret" in data.get("customer_id", "").lower()
+
+        def allow_everything(data: dict) -> bool:
+            return True
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[allow_everything],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode != 0
+    assert "callable rule checking customer_id for 'secret'" in result.stderr
+
+
+def test_rejects_variable_named_secret_without_secret_literal(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        secret = "public"
+
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def misleading_rule(data: dict) -> bool:
+            return secret in data.get("customer_id", "").lower()
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[misleading_rule],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode != 0
+    assert "callable rule checking customer_id for 'secret'" in result.stderr
+
+
+def test_rejects_middleware_targeting_another_tool(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def another_tool(customer_id: str) -> str:
+            return customer_id
+
+        def contains_secret_customer_id(data: dict) -> bool:
+            return "secret" in data.get("customer_id", "").lower()
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[another_tool],
+                rules=[contains_secret_customer_id],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode != 0
+    assert "lookup_account_info" in result.stderr


### PR DESCRIPTION
## What changed?

- Replaced regex-based verification for the coded deterministic guardrail task with Python AST inspection.
- Accepts both inline lambda rules and named callable rules, including functions with docstrings, for middleware and decorator styles.
- Verifies that the callable is wired to the guardrail, checks `customer_id` for the literal `"secret"`, uses `BlockAction`, and targets or decorates `lookup_account_info`.
- Keeps the separate low-code `agent.json` verifier unchanged.
- Added focused regression tests for valid Claude/Codex output shapes and previous false-positive cases.

### Why test the checker?

The daily run produced a semantically correct named callable, but the old regex rejected it because a docstring appeared before the function body. The checker is grading logic, so its supported output shapes need regression coverage to prevent correct agent results from receiving a zero score.

## How has this been tested?

- `python3 -m pytest -c /dev/null -o cache_dir=... tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py -q` — 6 passed.
- Ran the updated checker against the exact `graph.py` artifact from daily run `2026-07-24_04-33-37` — passed.
- Rebased onto the latest `origin/main` after committing.

## Are there any breaking changes?

None.
