### PR TITLE
ci(uipath-agents): run checker unit tests

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - 'tests/tasks/uipath-maestro-flow/**'
       - 'tests/tasks/uipath-maestro-case/**'
+      - 'tests/tasks/uipath-agents/**'
       - 'tests/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
       - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
@@ -43,6 +44,22 @@ jobs:
 
       - name: Run pytest
         run: pytest tests/tasks/uipath-maestro-case/ -v
+
+  pytest-agents-check:
+    runs-on: ubuntu-latest
+    name: uipath-agents checker unit tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run pytest
+        run: pytest tests/tasks/uipath-agents/ -v
 
   runtime-payload-casing-guard:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- add a dedicated `uipath-agents checker unit tests` job to the existing helper workflow
- run `pytest tests/tasks/uipath-agents/ -v`
- trigger the helper workflow when files under `tests/tasks/uipath-agents/**` change

## Why

The guardrail checker in #2262 accepts multiple valid generated-agent layouts. These focused unit tests protect that grading behavior, but they need an explicit CI job so regressions cannot pass unnoticed.

This PR intentionally contains only CI workflow wiring; all guardrail logic and checker tests remain in #2262.

## Dependency

Depends on #2262. At present, `main` does not contain the `uipath-agents` checker unit tests, so this job collects zero tests until #2262 merges. After #2262 lands, rebase this PR onto the latest `main`; the strict pytest command will then execute the six checker tests.

## Validation

- workflow YAML parses successfully
- diff against `main` contains only `.github/workflows/test-helpers.yml`
- with #2262's tests present, `pytest tests/tasks/uipath-agents/ -v` passes all 6 tests
- the `uipath-agents checker unit tests` GitHub Actions job previously passed in 14 seconds on the stacked branch
- against current `main`, the command correctly reports zero collected tests, confirming the documented dependency
