### PR TITLE
fix(uipath-agents): drop tool_name Read filter from coded-IS doc-preload criteria

### DIFF
--- a/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
+++ b/tests/tasks/uipath-agents/coded/is_jira_create_issue/is_jira_create_issue.yaml
@@ -59,7 +59,8 @@ success_criteria:
 
   - type: command_executed
     description: "Loaded platform IS discovery reference into context (agent-workflow.md — mandatory preload, not just the coded capability doc)"
-    tool_name: "Read"
+    # No tool_name filter: Claude reads via Read (file_path in params), Codex via
+    # shell cat/sed (path in Bash command) — the path pattern matches both.
     command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
     min_count: 1
     weight: 1.5
@@ -67,7 +68,8 @@ success_criteria:
 
   - type: command_executed
     description: "Loaded platform reference-resolution.md into context — the capability doc mandates reading it before authoring a Jira create (parent/reference fields are the #1 curated-activity rejection)"
-    tool_name: "Read"
+    # No tool_name filter: Claude reads via Read (file_path in params), Codex via
+    # shell cat/sed (path in Bash command) — the path pattern matches both.
     command_pattern: 'uipath-platform/references/integration-service/reference-resolution\.md'
     min_count: 1
     weight: 1.5

--- a/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
+++ b/tests/tasks/uipath-agents/coded/is_outlook_send_mail/is_outlook_send_mail.yaml
@@ -60,7 +60,8 @@ success_criteria:
 
   - type: command_executed
     description: "Loaded platform IS discovery reference into context (agent-workflow.md — mandatory preload, not just the coded capability doc)"
-    tool_name: "Read"
+    # No tool_name filter: Claude reads via Read (file_path in params), Codex via
+    # shell cat/sed (path in Bash command) — the path pattern matches both.
     command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
     min_count: 1
     weight: 1.5

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -48,7 +48,8 @@ success_criteria:
 
   - type: command_executed
     description: "Loaded the platform IS discovery reference into context (the capability doc requires reading agent-workflow.md before authoring an invoke_activity call, not just following the coded doc)"
-    tool_name: "Read"
+    # No tool_name filter: Claude reads via Read (file_path in params), Codex via
+    # shell cat/sed (path in Bash command) — the path pattern matches both.
     command_pattern: 'uipath-platform/references/integration-service/agent-workflow\.md'
     min_count: 1
     weight: 1.5


### PR DESCRIPTION
## Why

The 2026-07-24 nightly failed `skill-agents-coded-is-smoke` at 0.842 on a Codex run (`gpt-5.6-terra`) despite the agent producing a fully correct artifact. Root cause: the "loaded the platform IS reference into context" criterion was a `command_executed` check filtered on `tool_name: "Read"`. Codex has no `Read` tool — the harness normalizes all its file reads to `Bash` (shell `cat`/`sed`) — so the filter was unmatchable by construction. The transcript shows the agent read `agent-workflow.md` twice via `sed`; the grader just couldn't see it.

Same in-repo precedent: `tests/tasks/uipath-mcp-servers/e2e-uipath-allkinds/task.yaml` already dropped a `tool_name: Read` filter for exactly this reason ("flaked when the agent used `cat`").

## What

Removed `tool_name: "Read"` from the 4 doc-preload criteria across the 3 coded Integration Service tasks (scoped to uipath-agents only):

- `is_smoke/is_smoke.yaml` — agent-workflow.md preload
- `is_outlook_send_mail/is_outlook_send_mail.yaml` — agent-workflow.md preload
- `is_jira_create_issue/is_jira_create_issue.yaml` — agent-workflow.md + reference-resolution.md preloads

With no `tool_name` filter, the coder_eval checker matches the path pattern against Bash command text or any other tool's JSON-serialized params, so the criterion grades Claude (`Read` file_path) and Codex (shell read) identically. The full-path regex is specific enough not to false-positive on directory-level searches. What's graded is unchanged: the reference must be loaded into context.

## Passing run

`coder-eval run tasks/uipath-agents/coded/is_smoke/is_smoke.yaml -e experiments/default.yaml -T codex -m gpt-5.6-terra` (2026-07-24, local, tempdir driver): **status=SUCCESS, score 1.000, 4/4 criteria** — the fixed criterion matched 2/1 required commands (the shell `sed` reads the old filter excluded). `/lint-task` verdict: OK on all three files. The two e2e siblings are `skip: true` (tenant-gated) and can't be re-run locally, but their fixed criteria are identical in shape to the validated one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)