### PR TITLE
fix(test): grade trigger filter as the --detail object with a top-level filter

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_trigger/check_trigger_filter.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/check_trigger_filter.py
@@ -44,19 +44,29 @@ def main():
     if detail.get("filterExpression") is not None:
         sys.exit("FAIL: trigger_detail.json must not carry top-level `filterExpression`")
 
-    filter_tree = detail.get("filter")
-    if not isinstance(filter_tree, dict):
-        sys.exit("FAIL: trigger_detail.json has no `filter` object")
+    # Studio Web's persisted group shape: numeric groupOperator (0 = And,
+    # 1 = Or) + a non-empty `filters` array.
+    def _is_filter_group(n):
+        return (
+            isinstance(n, dict)
+            and isinstance(n.get("groupOperator"), (int, float))
+            and not isinstance(n.get("groupOperator"), bool)
+            and isinstance(n.get("filters"), list)
+            and bool(n.get("filters"))
+        )
 
-    # Studio Web's persisted shape: numeric groupOperator (0 = And, 1 = Or) and a
-    # non-empty `filters` array.
-    if not isinstance(filter_tree.get("groupOperator"), (int, float)) or isinstance(
-        filter_tree.get("groupOperator"), bool
-    ):
-        sys.exit("FAIL: filter.groupOperator must be a number (0 = And, 1 = Or)")
-    filters = filter_tree.get("filters")
-    if not isinstance(filters, list) or not filters:
-        sys.exit("FAIL: filter.filters must be a non-empty array")
+    # trigger_detail.json IS the `--detail` object (the exact JSON passed to
+    # `node configure --detail`), so `filter` must be a TOP-LEVEL key — that is
+    # where the CLI reads it. A filter wrapped under `detail` / `inputs` is not
+    # the --detail object and the CLI would silently ignore it, so it fails.
+    filter_tree = detail.get("filter")
+    if not _is_filter_group(filter_tree):
+        top = sorted(detail.keys()) if isinstance(detail, dict) else type(detail).__name__
+        sys.exit(
+            "FAIL: expected a `filter` tree as a TOP-LEVEL key of the --detail "
+            "object (numeric groupOperator + non-empty `filters`); do not wrap it "
+            f"under `detail`/`inputs`. Top-level keys found: {top}"
+        )
 
     nodes = list(_walk(filter_tree))
 

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
@@ -8,22 +8,24 @@ run_limits:
   expected_turns: 7
 
 initial_prompt: |
-  You are authoring a UiPath Flow that is triggered by an Outlook email with subject containing "good day" and sent from
+  You are authoring a UiPath Flow triggered by an Outlook email whose subject contains "good day" and sent from
   abc@xyz.com.
-  Do NOT run any command that requires a live connection — this sandbox has no UiPath
-  tenant. so you can't configure the trigger against a live connection. Instead, capture to trigger_detail.json the configuration 
-  you'd apply for an Outlook trigger that fires on emails whose subject contains 'good day' from abc@xyz.com — include the 
-  connection/folder/event-mode placeholders and the subject filter, in whatever shape the connector trigger actually expects.
+  Do NOT run any command that requires a live connection — this sandbox has no UiPath tenant, so you cannot configure
+  the trigger against a live connection.
+  Instead, write to `trigger_detail.json` the exact JSON object you would pass to
+  `uip maestro flow node configure <flow> <triggerId> --detail '<JSON>'` to configure that trigger.
+  Use placeholders for any connection/folder/event ids you cannot resolve offline.
 
 
 success_criteria:
-  # `check_trigger_filter.py` resolves trigger_detail.json recursively (root or
-  # nested in the flow project dir) and asserts: valid JSON, no top-level
-  # filterExpression (MST-8802 guard), a structured filter tree with numeric
-  # groupOperator + non-empty filters array, and at least one leaf referencing
-  # `subject` with the PascalCase `Contains` operator.
+  # `check_trigger_filter.py` locates trigger_detail.json (root or nested in the
+  # flow project dir) and asserts it is the --detail object: valid JSON, no
+  # top-level filterExpression (MST-8802 guard), and a `filter` tree as a
+  # TOP-LEVEL key (numeric groupOperator + non-empty filters) with at least one
+  # leaf referencing `subject` via the PascalCase `Contains` operator. A filter
+  # wrapped under detail/inputs fails — that is not the --detail object.
   - type: run_command
-    description: "trigger_detail.json (found anywhere under the solution) carries a structured filter tree on `subject` Contains, with no top-level filterExpression"
+    description: "trigger_detail.json is the --detail object with a top-level `filter` tree on `subject` Contains, no top-level filterExpression"
     command: "python3 $TASK_DIR/check_trigger_filter.py"
     timeout: 10
     expected_exit_code: 0


### PR DESCRIPTION
## Problem

`skill-flow-trigger-with-filter` flaked red on maestro-flow PRs — a **checker + prompt mismatch**, not a skill or agent defect.

The prompt said *"capture the config… in whatever shape the connector trigger actually expects"* → agents emitted the filter at varying depths (`detail.filter`, `inputs.detail.filter`), because `trigger_detail.json` is a **fictional offline artifact** with no fixed wrapper. The checker read only a **top-level** `filter` → a correct-but-nested tree failed. With a small smoke suite (95% of ~14 ≈ all-pass), that one intermittent flake turned the PR red.

Note: the sandbox has no live tenant, so `node configure` (which resolves a connector trigger against Integration Service) can't run — hence the offline `trigger_detail.json` stand-in.

## Fix — pin the container, grade strictly, don't leak the answer

- **Prompt:** *"write the exact JSON you would pass to `node configure --detail`."* This pins the **container** (the `--detail` object → `filter` at its top level), but **not** the filter tree — the agent must still derive the tree (groupOperator/filters/operators) from the skill. So it stays a skill-coverage test, not instruction-following (repo rule: prompts minimal).
- **Checker:** require the `filter` tree as a **top-level key** of that object — numeric `groupOperator` + non-empty `filters`, a `subject` leaf, PascalCase `Contains`. Reject wrapping under `detail`/`inputs`. Keep the MST-8802 top-level `filterExpression` guard.

Now the artifact maps 1:1 to a real `--detail` call, with one unambiguous correct shape.

## Verification
**5/5 local runs**: the agent emits root-level `filter` and passes (score 1.0) using only skill knowledge for the tree. No wrapper variance.

## Scope
`trigger_with_filter` only (checker + prompt). Does **not** touch `solution_select.yaml` — that interactive/`simulation` task's flake is handled separately (#2235). #2272 removes one of the two maestro-flow smoke blockers.