### PR TITLE
fix(tests): five uipath-agents coded nightly fixes (eval smoke prompt, handoff + llm-judges checkers, mockito fixture, HITL app retarget)

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_llm_judges/check_eval_llm_judges.py
+++ b/tests/tasks/uipath-agents/coded/eval_llm_judges/check_eval_llm_judges.py
@@ -1,19 +1,23 @@
 #!/usr/bin/env python3
 """Eval-lifecycle check for the LLM-judge path (two evaluators).
 
-Validates the dual-evaluator harness:
-  - `LLMJudgeOutputEvaluator` config with the
-    `uipath-llm-judge-output-semantic-similarity` typeId.
-  - `LLMJudgeTrajectoryEvaluator` config with the
-    `uipath-llm-judge-trajectory-similarity` typeId.
-  - One eval set whose `evaluatorRefs` lists BOTH ids and whose test
-    cases key `evaluationCriterias` on BOTH ids — the output judge
-    gets an `expectedOutput` block, the trajectory judge gets an
-    `expectedAgentBehavior` string.
+Validates the dual-evaluator harness by `evaluatorTypeId`, not by
+evaluator `id` — the skill documents the `id` as a free placeholder
+(`<EvaluatorId>`), so agents may pick any self-consistent name:
+  - Exactly one OUTPUT judge config: `evaluatorTypeId` in
+    `OUTPUT_JUDGE_TYPES` (semantic-similarity or strict-json-similarity
+    — both are documented LLM output judges; strict-json is the
+    documented fit for structured outputs like this fixture's).
+  - Exactly one TRAJECTORY judge config: `evaluatorTypeId` in
+    `TRAJECTORY_JUDGE_TYPES`.
+  - One eval set whose `evaluatorRefs` lists BOTH discovered ids and
+    whose test cases key `evaluationCriterias` on BOTH ids — the
+    output judge gets an `expectedOutput` block, the trajectory judge
+    gets an `expectedAgentBehavior` string.
   - `eval-results.json` exists and is a non-empty test-case list.
     LLM-judge scores are continuous (0.0-1.0) so we don't assert an
     exact score — only that the results file is well-formed and
-    references the expected evaluator ids.
+    references both discovered evaluator ids.
 """
 
 from __future__ import annotations
@@ -28,9 +32,13 @@ from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("intent-classifier")
 
-EXPECTED_EVALUATORS = {
-    "LLMJudgeOutputEvaluator": "uipath-llm-judge-output-semantic-similarity",
-    "LLMJudgeTrajectoryEvaluator": "uipath-llm-judge-trajectory-similarity",
+OUTPUT_JUDGE_TYPES = {
+    "uipath-llm-judge-output-semantic-similarity",
+    "uipath-llm-judge-output-strict-json-similarity",
+}
+TRAJECTORY_JUDGE_TYPES = {
+    "uipath-llm-judge-trajectory-similarity",
+    "uipath-llm-judge-trajectory-simulation",
 }
 
 
@@ -43,33 +51,56 @@ def _load_json(path: Path) -> dict:
         sys.exit(f"FAIL: {path} is not valid JSON: {e}")
 
 
-def check_evaluator_configs() -> None:
+def check_evaluator_configs() -> dict[str, str]:
+    """Resolve the two judges by typeId; return {'output': id, 'trajectory': id}."""
     evaluators_dir = ROOT / "evaluations" / "evaluators"
     if not evaluators_dir.is_dir():
         sys.exit(f"FAIL: {evaluators_dir} does not exist")
-    found_by_id: dict[str, Path] = {}
+    found: dict[str, list[tuple[str, Path]]] = {"output": [], "trajectory": []}
     for json_file in sorted(evaluators_dir.glob("*.json")):
         doc = _load_json(json_file)
-        eval_id = doc.get("id")
         type_id = doc.get("evaluatorTypeId")
-        if eval_id in EXPECTED_EVALUATORS:
-            expected_type = EXPECTED_EVALUATORS[eval_id]
-            if type_id != expected_type:
-                sys.exit(
-                    f'FAIL: evaluator {eval_id!r} should have evaluatorTypeId='
-                    f'{expected_type!r}, got {type_id!r}'
-                )
-            found_by_id[eval_id] = json_file
-            print(f'OK: evaluator config {json_file.name} has id={eval_id!r} typeId={type_id!r}')
-    missing = set(EXPECTED_EVALUATORS) - set(found_by_id)
-    if missing:
-        sys.exit(
-            f'FAIL: missing evaluator configs for ids {sorted(missing)}. '
-            f'Found ids: {sorted(found_by_id)}'
+        if type_id in OUTPUT_JUDGE_TYPES:
+            kind = "output"
+        elif type_id in TRAJECTORY_JUDGE_TYPES:
+            kind = "trajectory"
+        else:
+            continue
+        eval_id = doc.get("id")
+        if not eval_id or not isinstance(eval_id, str):
+            sys.exit(
+                f'FAIL: {json_file.name} has evaluatorTypeId={type_id!r} but '
+                f'no string `id` field. Got: {eval_id!r}'
+            )
+        found[kind].append((eval_id, json_file))
+        print(
+            f'OK: evaluator config {json_file.name} is the {kind} judge '
+            f'(id={eval_id!r}, typeId={type_id!r})'
         )
+    ids: dict[str, str] = {}
+    for kind, types in (("output", OUTPUT_JUDGE_TYPES), ("trajectory", TRAJECTORY_JUDGE_TYPES)):
+        matches = found[kind]
+        if not matches:
+            sys.exit(
+                f'FAIL: no {kind}-judge evaluator config in {evaluators_dir} — '
+                f'expected exactly one file with `evaluatorTypeId` in '
+                f'{sorted(types)}'
+            )
+        if len(matches) > 1:
+            sys.exit(
+                f'FAIL: expected exactly one {kind}-judge evaluator config, '
+                f'got {len(matches)}: {sorted(p.name for _, p in matches)}'
+            )
+        ids[kind] = matches[0][0]
+    if ids["output"] == ids["trajectory"]:
+        sys.exit(
+            f'FAIL: output and trajectory judges share the same id '
+            f'{ids["output"]!r} — evaluator ids must be unique'
+        )
+    return ids
 
 
-def check_eval_set() -> None:
+def check_eval_set(ids: dict[str, str]) -> None:
     eval_sets_dir = ROOT / "evaluations" / "eval-sets"
     if not eval_sets_dir.is_dir():
         sys.exit(f"FAIL: {eval_sets_dir} does not exist")
@@ -83,7 +114,7 @@ def check_eval_set() -> None:
     if doc.get("version") != "1.0":
         sys.exit(f'FAIL: eval set version should be "1.0", got {doc.get("version")!r}')
     refs = doc.get("evaluatorRefs") or []
-    missing_refs = set(EXPECTED_EVALUATORS) - set(refs)
+    missing_refs = set(ids.values()) - set(refs)
     if missing_refs:
         sys.exit(
             f'FAIL: eval set `evaluatorRefs` is missing {sorted(missing_refs)}. '
@@ -94,7 +125,7 @@ def check_eval_set() -> None:
         sys.exit(f"FAIL: eval set must have at least 2 test cases, got {len(cases)}")
     for i, case in enumerate(cases):
         crit = case.get("evaluationCriterias") or {}
-        for evaluator_id in EXPECTED_EVALUATORS:
+        for evaluator_id in ids.values():
             if evaluator_id not in crit:
                 sys.exit(
                     f'FAIL: test case {i} (`{case.get("id", "?")}`) does not '
@@ -102,18 +133,18 @@ def check_eval_set() -> None:
                     f'{list(crit.keys())}'
                 )
         # Trajectory judge requires `expectedAgentBehavior`.
-        traj = crit.get("LLMJudgeTrajectoryEvaluator") or {}
+        traj = crit.get(ids["trajectory"]) or {}
         if not traj.get("expectedAgentBehavior"):
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeTrajectoryEvaluator entry is '
-                f'missing the required `expectedAgentBehavior` field. Got: {traj}'
+                f'FAIL: test case {i} trajectory-judge entry ({ids["trajectory"]!r}) '
+                f'is missing the required `expectedAgentBehavior` field. Got: {traj}'
             )
         # Output judge requires `expectedOutput`.
-        out = crit.get("LLMJudgeOutputEvaluator") or {}
+        out = crit.get(ids["output"]) or {}
         if "expectedOutput" not in out:
             sys.exit(
-                f'FAIL: test case {i} LLMJudgeOutputEvaluator entry is '
-                f'missing the required `expectedOutput` field. Got: {out}'
+                f'FAIL: test case {i} output-judge entry ({ids["output"]!r}) '
+                f'is missing the required `expectedOutput` field. Got: {out}'
             )
     print(
         f"OK: eval set {path.name} references both judges across {len(cases)} "
@@ -121,7 +152,7 @@ def check_eval_set() -> None:
     )
 
 
-def check_results() -> None:
+def check_results(ids: dict[str, str]) -> None:
     path = ROOT / "eval-results.json"
     doc = _load_json(path)
     if not isinstance(doc, dict):
@@ -141,7 +172,7 @@ def check_results() -> None:
                 eid = r.get("evaluatorId")
                 if eid:
                     seen_ids.add(eid)
-    missing = set(EXPECTED_EVALUATORS) - seen_ids
+    missing = set(ids.values()) - seen_ids
     if missing:
         sys.exit(
             f'FAIL: results file does not surface evaluatorId entries for '
@@ -157,9 +188,9 @@ def check_results() -> None:
 def main() -> None:
     if not ROOT.is_dir():
         sys.exit(f"FAIL: project directory {ROOT} does not exist")
-    check_evaluator_configs()
-    check_eval_set()
-    check_results()
+    ids = check_evaluator_configs()
+    check_eval_set(ids)
+    check_results(ids)
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/langgraph.json
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/langgraph.json
@@ -1,0 +1,5 @@
+{
+    "graphs": {
+      "agent": "./main.py:graph"
+    }
+}

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/main.py
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/main.py
@@ -1,15 +1,19 @@
-from dataclasses import dataclass
 import requests
+from langgraph.graph import START, StateGraph, END
+from pydantic import BaseModel
 from uipath.platform import UiPath
 
 
-@dataclass
-class SecretPeekInput:
+class GraphInput(BaseModel):
     asset_name: str
 
 
-@dataclass
-class SecretPeekOutput:
+class GraphState(BaseModel):
+    asset_name: str
+    secret_value: str = ""
+
+
+class GraphOutput(BaseModel):
     masked_key: str
     label: str
 
@@ -20,8 +24,7 @@ def fetch_label(key_id: str) -> str:
     try:
         response = requests.get(url, timeout=5)
         response.raise_for_status()
-        data = response.json()
-        return data.get("label", "unknown")
+        return response.json().get("label", "unknown")
     except Exception:
         return "unknown"
 
@@ -33,17 +36,26 @@ def mask_secret(secret: str) -> str:
     return secret[:4] + "*" * (len(secret) - 4)
 
 
-def main(input: SecretPeekInput) -> SecretPeekOutput:
+async def retrieve_asset(state: GraphState) -> dict:
     sdk = UiPath()
+    asset = sdk.assets.retrieve(state.asset_name, folder_name="Shared")
+    return {"secret_value": asset.value}
 
-    # Read asset from Shared folder
-    asset = sdk.assets.retrieve(input.asset_name, folder_name="Shared")
-    secret_value = asset.value
 
-    # Mask the secret
-    masked = mask_secret(secret_value)
+async def build_summary(state: GraphState) -> GraphOutput:
+    return GraphOutput(
+        masked_key=mask_secret(state.secret_value),
+        label=fetch_label(state.asset_name),
+    )
 
-    # Fetch label from registry
-    label = fetch_label(input.asset_name)
 
-    return SecretPeekOutput(masked_key=masked, label=label)
+builder = StateGraph(GraphState, input=GraphInput, output=GraphOutput)
+
+builder.add_node("retrieve_asset", retrieve_asset)
+builder.add_node("build_summary", build_summary)
+
+builder.add_edge(START, "retrieve_asset")
+builder.add_edge("retrieve_asset", "build_summary")
+builder.add_edge("build_summary", END)
+
+graph = builder.compile()

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/pyproject.toml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "asset-retriever"
 version = "0.0.1"
-description = "UiPath agent that returns a structured summary of an asset with masked value and remote label"
-authors = [{ name = "john doe", email = "john.doe@example.com" }]
+description = "asset-retriever"
+authors = [{ name = "John Doe", email = "john.doe@myemail.com" }]
 dependencies = [
     "requests>=2.34.2",
-    "uipath>=2.10.0, <2.11.0",
+    "uipath-langchain[bedrock,vertex]>=0.10.0, <0.11.0",
 ]
 requires-python = ">=3.11"
 

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/uipath.json
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever/uipath.json
@@ -1,5 +1,0 @@
-{
-  "functions": {
-    "main": "main.py:main"
-  }
-}

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -1,6 +1,6 @@
 task_id: skill-agent-coded-eval-mocking-mockito
 description: >
-  Coded-agent eval lifecycle with the **two documented mocking
+  Coded-agent (LangGraph) eval lifecycle with the **two documented mocking
   patterns** (declarative `mockingStrategy: mockito` AND in-code
   `@mockable`) plus a structured-output evaluator. The agent reads
   an Orchestrator asset (mocked declaratively per test case) AND
@@ -10,20 +10,21 @@ description: >
   pipeline runs offline. Project files are pre-seeded via `pre_run`
   (fixtures in `_fixtures/`) so the eval grades mocking + evaluator
   wiring, not file transcription.
-tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking, feature:framework-simple]
+tags: [uipath-agents, e2e, coded, mode:build, feature:eval, feature:eval-mocking, feature:framework-langgraph]
 max_iterations: 1
 
 pre_run:
   - command: "cp -r $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/eval_mocking_mockito/_fixtures/asset-retriever ."
     timeout: 10
   - command: "bash -c 'cd asset-retriever && uv sync && source .venv/bin/activate && uip codedagent setup --force'"
-    timeout: 180
+    timeout: 300
 
 initial_prompt: |
-  I have an existing coded agent project at `asset-retriever/`
-  (`main.py`, `pyproject.toml`, `uipath.json`). It reads an
-  Orchestrator asset from the Shared folder, masks its value, and
-  fetches a human-readable label from a remote registry over HTTP.
+  I have an existing LangGraph coded agent project at
+  `asset-retriever/` (`main.py`, `langgraph.json`,
+  `pyproject.toml`). It reads an Orchestrator asset from the Shared
+  folder, masks its value, and fetches a human-readable label from
+  a remote registry over HTTP.
 
   Add a smoke evaluation suite with 2–3 cases covering different
   asset values and run it locally. The evals must pass without

--- a/tests/tasks/uipath-agents/coded/eval_smoke_default_output/eval_smoke_default_output.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_smoke_default_output/eval_smoke_default_output.yaml
@@ -16,10 +16,10 @@ run_limits:
 
 initial_prompt: |
   I've got chunks of text I want boiled down to a short paragraph each. Can you
-  build me a small coded agent for that — call it `summarizer`, takes some text
-  in and hands back a one-paragraph summary. Once it's running, set up a quick
-  eval with a couple of test cases so I can sanity-check it locally. No need to
-  deploy it anywhere.
+  build me a small LangGraph coded agent for that — call it `summarizer`, takes
+  some text in and hands back a one-paragraph summary. Once it's running, set up
+  a quick eval with a couple of test cases so I can sanity-check it locally. No
+  need to deploy it anywhere.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -6,11 +6,12 @@ Asserts:
   2. `main.py` imports `CreateTask` from `uipath.platform.common`.
   3. At least one `interrupt(CreateTask(...))` call site exists.
   4. The `CreateTask` call targets `app_name="RefundReview"`,
-     `app_folder_path="Compliance"`.
+     `app_folder_path="Shared/uipath-agents/RefundReview"` (where the app
+     is deployed on the codereval tenant).
   5. `main.py` does NOT use `CreateEscalation` (that's a different pattern
      covered by hitl_create_task — keep them disjoint).
   6. `bindings.json` declares the `app` resource for `RefundReview` /
-     `Compliance`.
+     `Shared/uipath-agents/RefundReview`.
   7. A top-level `graph =` variable is exported.
   8. `langgraph.json` exists at the resolved project root and points at
      the exported graph.
@@ -37,6 +38,9 @@ from _shared.bindings_assertions import (  # noqa: E402
 )
 
 ROOT = find_project_root("refund-gate")
+
+APP_NAME = "RefundReview"
+APP_FOLDER = "Shared/uipath-agents/RefundReview"
 
 
 def fail(msg: str) -> None:
@@ -127,14 +131,14 @@ def main() -> None:
 
     consts = module_constants(tree)
     kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
-    expected = {"app_name": "RefundReview", "app_folder_path": "Compliance"}
+    expected = {"app_name": APP_NAME, "app_folder_path": APP_FOLDER}
     for kw, want in expected.items():
         if kw not in kwargs:
             fail(f"`CreateTask(...)` is missing `{kw}=`")
         got = resolve_kwarg(kwargs[kw], consts)
         if got != want:
             fail(f"`CreateTask({kw}=...)` resolves to {got!r}, expected {want!r}")
-    print('OK: CreateTask targets app_name="RefundReview" / app_folder_path="Compliance"')
+    print(f'OK: CreateTask targets app_name="{APP_NAME}" / app_folder_path="{APP_FOLDER}"')
 
     if not re.search(r"^\s*graph\s*=\s*", text, re.M):
         fail("main.py does not export a top-level `graph =` variable")
@@ -148,12 +152,12 @@ def main() -> None:
     print("OK: no module-level UiPath* construction")
 
     doc = load_bindings(ROOT / "bindings.json")
-    entry = find_resource(doc, resource="app", key="RefundReview.Compliance")
-    assert_value_field(entry, field="name", expected="RefundReview")
-    assert_value_field(entry, field="folderPath", expected="Compliance")
+    entry = find_resource(doc, resource="app", key=f"{APP_NAME}.{APP_FOLDER}")
+    assert_value_field(entry, field="name", expected=APP_NAME)
+    assert_value_field(entry, field="folderPath", expected=APP_FOLDER)
     assert_metadata_field(entry, field="ActivityName", expected="create_async")
-    assert_metadata_field(entry, field="DisplayLabel", expected="RefundReview")
-    print("OK: bindings.json declares the RefundReview/Compliance `app` resource")
+    assert_metadata_field(entry, field="DisplayLabel", expected=APP_NAME)
+    print(f"OK: bindings.json declares the {APP_NAME}/{APP_FOLDER} `app` resource")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -15,8 +15,9 @@ initial_prompt: |
   Can you build me a uipath coded agent in LangGraph for handling refunds?
   Call it refund-gate, put it in a refund-gate folder. The idea: anything
   over $500 needs a human to sign off first. Someone on the Compliance team
-  reviews it in their RefundReview app (that's in the Compliance folder) -
-  show them the customer, the amount, and why the refund's being asked for.
+  reviews it in their RefundReview app (that's in the
+  Shared/uipath-agents/RefundReview folder) - show them the customer, the
+  amount, and why the refund's being asked for.
   Once they decide, carry on with their call and whatever note they left.
   Anything $500 or under just goes through. And please make sure the
   RefundReview app is actually hooked up, otherwise it can't send them the
@@ -50,7 +51,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "LangGraph config, interrupt(CreateTask) shape (not CreateEscalation), correct app targeting, RefundReview/Compliance app binding"
+    description: "LangGraph config, interrupt(CreateTask) shape (not CreateEscalation), correct app targeting, RefundReview app binding in Shared/uipath-agents/RefundReview"
     command: "python3 $TASK_DIR/check_hitl_create_task_with_app.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
@@ -1,23 +1,30 @@
 #!/usr/bin/env python3
 """OpenAI Agents agent project-shape check.
 
-The factory-function pattern (`def main() -> Agent`) is the load-bearing
-invariant for this framework — without it, `UiPathChatOpenAI(...)` and
+The factory-function pattern (a function that returns an `Agent`, e.g.
+`def main() -> Agent`) is the load-bearing invariant for this framework
+— without it, `UiPathChatOpenAI(...)` and
 `_openai_shared.set_default_openai_client(...)` execute at module
 import time and `uip codedagent init` blows up before it can introspect
-the agent.
+the agent. The skill guide
+(`references/coded/frameworks/openai-agents-integration.md`) documents
+the mapping as `<file>:<symbol>` where the symbol may be any variable
+or "function that returns an Agent" — so the factory's NAME is free;
+what matters is that the symbol is a function, not a module-level
+variable.
 
 Checks performed:
 
-  1. `triage-bot/pyproject.toml` declares `uipath-openai-agents`, has
+  1. `triage-agent/pyproject.toml` declares `uipath-openai-agents`, has
      `[project]` with `authors`, no `[build-system]`.
-  2. `openai_agents.json` exists with an `agents` mapping pointing at
-     `main.py:main` (factory pattern) — pointing at a top-level
-     `agent` variable would mean module-level `Agent[...]`
-     construction, which fails because the agent context type
-     resolution itself can pull in the LLM client.
-  3. `main.py` defines a `def main()` factory, declares a
-     `CustomerInput` Pydantic model with `customer_id`, has the
+  2. `openai_agents.json` exists with an `agents` mapping whose target
+     `<file>:<symbol>` resolves (AST) to a top-level FUNCTION in that
+     file (factory pattern, any name) — pointing at a top-level
+     variable would mean module-level `Agent[...]` construction,
+     which fails because the agent context type resolution itself can
+     pull in the LLM client.
+  3. `main.py` declares a `CustomerInput` Pydantic model with
+     `customer_id`, has the
      `_openai_shared.set_default_openai_client(...)` call INSIDE the
      factory, configures three agents (`triage`, `billing`,
      `technical`) with at least one `handoffs=` list, and has NO
@@ -44,7 +51,7 @@ from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
-ROOT = find_project_root("triage-bot")
+ROOT = find_project_root("triage-agent")
 
 
 def _read_text(path: Path) -> str:
@@ -79,25 +86,58 @@ def check_pyproject() -> None:
     print("OK: pyproject.toml is hygienic and declares uipath-openai-agents")
 
 
-def check_openai_agents_json() -> None:
+def check_openai_agents_json() -> tuple[Path, str]:
+    """Validate the agents mapping and return (factory_file, factory_symbol).
+
+    The skill guide allows `<file>:<symbol>` where the symbol is a variable
+    OR a function that returns an Agent. Only the function form preserves
+    the lazy-LLM-init invariant, so require the symbol to resolve to a
+    top-level function def — under any name (`main`, `agent`, ...).
+    """
     doc = _load_json(ROOT / "openai_agents.json")
     agents = doc.get("agents") or {}
     if not agents:
         sys.exit("FAIL: openai_agents.json has no `agents` mapping")
     target = next(iter(agents.values()))
-    if not isinstance(target, str) or ":main" not in target:
+    if not isinstance(target, str) or ":" not in target:
         sys.exit(
-            f'FAIL: openai_agents.json should point at the factory function '
-            f'(`<file>:main`), got {target!r}. Pointing at a top-level '
-            f'variable would break the lazy-LLM-init invariant.'
+            f"FAIL: openai_agents.json agent target must be `<file>:<symbol>`, "
+            f"got {target!r}"
         )
-    print(f"OK: openai_agents.json registers an agent -> {target!r} (factory pattern)")
+    file_part, symbol = target.split(":", 1)
+    factory_path = ROOT / file_part
+    tree = ast.parse(_read_text(factory_path), filename=str(factory_path))
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == symbol:
+            print(
+                f"OK: openai_agents.json registers an agent -> {target!r} "
+                f"(factory function `{symbol}`)"
+            )
+            return factory_path, symbol
+    assigned = {
+        t.id
+        for node in tree.body
+        if isinstance(node, (ast.Assign, ast.AnnAssign))
+        for t in (node.targets if isinstance(node, ast.Assign) else [node.target])
+        if isinstance(t, ast.Name)
+    }
+    if symbol in assigned:
+        sys.exit(
+            f"FAIL: openai_agents.json points at {target!r}, a top-level "
+            f"variable — module-level `Agent[...]` construction breaks the "
+            f"lazy-LLM-init invariant. Point at a factory function that "
+            f"returns the Agent instead."
+        )
+    sys.exit(
+        f"FAIL: openai_agents.json points at {target!r} but {file_part} "
+        f"defines no top-level function or variable named `{symbol}`."
+    )
 
 
-def check_main_py() -> None:
+def check_main_py(factory_symbol: str) -> None:
     main_path = ROOT / "main.py"
     text = _read_text(main_path)
-    for needle in ("CustomerInput", "customer_id", "def main", "handoffs"):
+    for needle in ("CustomerInput", "customer_id", "handoffs"):
         if needle not in text:
             sys.exit(f"FAIL: main.py is missing `{needle}`")
     if "set_default_openai_client" not in text:
@@ -137,9 +177,9 @@ def check_main_py() -> None:
             if isinstance(func, ast.Attribute) and func.attr == "set_default_openai_client":
                 sys.exit(
                     f"FAIL: main.py:{node.lineno} `set_default_openai_client(...)` "
-                    "is at module level — it must run inside the factory "
-                    "function body to defer authentication until the runtime "
-                    "calls main()."
+                    "is at module level — it must run inside a function body "
+                    "(the factory or a hook) to defer authentication until "
+                    f"the runtime resolves `{factory_symbol}()`."
                 )
     print("OK: set_default_openai_client(...) is inside the factory body")
 
@@ -172,8 +212,8 @@ def main() -> None:
     if not ROOT.is_dir():
         sys.exit(f"FAIL: project directory {ROOT} does not exist")
     check_pyproject()
-    check_openai_agents_json()
-    check_main_py()
+    _, factory_symbol = check_openai_agents_json()
+    check_main_py(factory_symbol)
     check_entry_points()
     check_bindings()
     check_run()

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
@@ -4,8 +4,9 @@ description: >
   handoff. Verifies the agent scaffolds an OpenAI Agents project
   (`uip codedagent new` → `openai_agents.json` + `main.py`
   exporting an `Agent` factory function), uses the factory
-  function pattern (`def main() -> Agent`) so `UiPathChatOpenAI`
-  and `_openai_shared.set_default_openai_client` are deferred
+  function pattern (a function returning `Agent`, any name — e.g.
+  `def main() -> Agent`) so `UiPathChatOpenAI` and
+  `_openai_shared.set_default_openai_client` are deferred
   (Critical Rule C4 — module-level setup breaks
   `uip codedagent init`), and runs the triage agent end-to-end.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, lifecycle:execute, feature:framework-openai-agents]
@@ -15,7 +16,7 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  I want an OpenAI Agents UiPath coded agent called `triage-bot` that
+  I want an OpenAI Agents UiPath coded agent called `triage-agent` that
   sits in front of two specialists. A triage agent reads the customer's
   message and hands off to a billing agent for invoice and payment
   questions, or to a technical agent for product and feature questions.


### PR DESCRIPTION
## Summary

Five fixes for `uipath-agents` coded tasks that failed recent nightlies — one prompt fix, two checker relaxes, one fixture rebuild, one live-tenant retarget.

### 1. `eval_smoke_default_output` — name LangGraph in the prompt (2f0619779)

The 2026-07-27 nightly failed at turn 1: the prompt gave no framework signal, so the agent took the skill's sanctioned "ambiguous → ask" path at the framework fork and stopped to ask which framework to use — a dead end in the single-shot harness, and the evaluator-default behavior under test was never reached. It was the only greenfield LLM-agent task in the suite that left the fork unresolved (all others name a framework or seed a project).

Naming LangGraph keeps the agent on the infer path without touching the tested behavior — a single-node LangGraph agent still has no tool calls or meaningful trajectory, so the output-vs-trajectory evaluator trap stays intact.

### 2. `openai_agents_handoff` — accept any factory function in the checker (c9a96011e)

The 2026-07-27 nightly failure was a false negative: the checker hard-required `main.py:main` + a literal `def main`, but the skill documents the `openai_agents.json` target as `<file>:<symbol>` with any function returning an `Agent`, and models pick the symbol name unpredictably (observed: `agent`, `main`, `create_triage_agent`). Now AST-resolves the target: any top-level function def passes; a module-level variable still fails (the real lazy-LLM-init violation the check exists to catch). Also renames the project `triage-bot` → `triage-agent` so the derived agent name survives the role-name normalizer.

### 3. `hitl_create_task_with_app` — retarget to redeployed RefundReview folder (b2f8f1f4c)

The RefundReview app moved to `Shared/uipath-agents/RefundReview` on the codereval tenant (the old Compliance-folder deployment was a stale virtual placeholder). Prompt and checker literals now match the live deployment agents actually bind against.

### 4. `eval_mocking_mockito` — rebuild fixture as a LangGraph agent (fb839a6bd)

The 2026-07-27 nightly failed criterion 1 (`uip codedagent init`) as a false negative: the fixture's `uipath.json` declared a `functions` map — literally the example in uipath-agents SKILL.md Critical Rule #1 (added in #1144), which redirects agents to the uipath-functions skill, so the model correctly ran `uip functions init` instead.

Rebuilt the fixture from a real `uip codedagent new` LangGraph scaffold (two-node graph, `langgraph.json` ships, `uipath.json` dropped so `init` stays motivated), named LangGraph in the prompt (precedent: fix 1), retagged `feature:framework-simple` → `feature:framework-langgraph`, and bumped the pre_run timeout for the heavier dependency install.

### 5. `eval_llm_judges` — match evaluators by typeId instead of pinned ids (7af0c9aff)

The 2026-07-27 nightly failed the 5.0-weight checker as a false negative: the agent built a fully working dual-judge harness (3 cases × 2 judges, all scores 1.0) under self-chosen ids `LLMJudgeAnswer`/`LLMJudgeTrajectory`, but the checker hard-required the doc-example ids `LLMJudgeOutputEvaluator`/`LLMJudgeTrajectoryEvaluator` plus the semantic-similarity typeId. The skill documents evaluator `id` as a free placeholder (`<EvaluatorId>`) and only mandates id-consistency between config, `evaluatorRefs`, and criteria — which the agent satisfied.

The checker now resolves the two judges by `evaluatorTypeId` family — exactly one output judge (semantic-similarity or strict-json-similarity; both documented LLM output judges, and the fixture's structured `{category, text}` output makes strict-json a legitimate pick) and exactly one trajectory judge (trajectory-similarity or trajectory-simulation) — then threads the discovered ids through the eval-set and results checks unchanged. Validated against the failed nightly's actual artifacts (now passes), a canonical-style variant (still passes), and negative cases (missing judge, missing `expectedAgentBehavior`, duplicate output judges — all fail correctly).

## Passing-run claims

- `eval_smoke_default_output`: coder-eval 0.8.10, codex/gpt-5.6-terra, `experiments/default.yaml` — **SUCCESS, 2/2 criteria, weighted score 1.000** (output-based `LLMJudgeOutputEvaluator` scaffolded, no trajectory/tool-call evaluators, live model-backed run + eval at 0.90).
- `openai_agents_handoff`: green on both harnesses (claude-code+sonnet-5 and codex+gpt-5.6-terra) — 4/4 criteria, weighted score 1.0, live `uip codedagent run` through the gateway.
- `hitl_create_task_with_app`: local nightly codex harness — checker criterion passes 14/14 assertions (score 0.864).
- `eval_mocking_mockito`: green on both harnesses (claude-sonnet-5 and codex/gpt-5.6-terra) — 3/3 criteria, weighted score 1.000; codex takes the `codedagent init` path with no functions detour.
- `eval_llm_judges`: codex/gpt-5.6-terra, `experiments/default.yaml` — **SUCCESS, 3/3 criteria, weighted score 1.000** in 207s; fresh trajectory again chose free-form evaluator ids (this time with the semantic-similarity typeId), confirming id-pinning was the systematic failure axis and type-based matching absorbs both documented output-judge choices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
