### PR TITLE
test(case): fix aged_invoice_structural test

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -206,11 +206,16 @@ def _tasks_frontend_issues(text: str, source: str) -> list[str]:
     escalation_names: dict[str, set[str]] = {}
     for block in blocks:
         header = re.match(r"##\s+T\d+[^\n]*", block)
-        if not header or not re.search(r"\bSLA\b|\bescalation\b", header.group(0), re.I):
+        if not header:
+            continue
+        is_escalation = bool(re.search(r"Add escalation rule for", header.group(0), re.I))
+        is_sla_entry = is_escalation or re.search(
+            r"Set default SLA for|Add conditional SLA rule for", header.group(0), re.I
+        )
+        if not is_sla_entry:
             continue
         target_match = re.search(r"^\s*-\s*target:\s*[\"']?([^\"'\n]+)", block, re.M | re.I)
         target = (target_match.group(1).strip() if target_match else "root")
-        is_escalation = bool(re.search(r"\bescalation\b", header.group(0), re.I))
         display_match = re.search(r"^\s*-\s*display-name:\s*(.*?)\s*$", block, re.M | re.I)
         display = _parse_value(display_match.group(1)) if display_match else ""
         names = escalation_names if is_escalation else rule_names

--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
@@ -44,8 +44,8 @@
 
 | SLA Status | Threshold | Action |
 |------------|-----------|--------|
-| At-Risk | 70% of SLA duration | Notify: AP Team Leads |
-| Breached | 100% of SLA duration | Notify: Finance Leadership |
+| At-Risk | 70% of SLA duration | Notify: UserGroup: AP Team Leads |
+| Breached | 100% of SLA duration | Notify: UserGroup: Finance Leadership |
 
 ### Case Triggers
 
@@ -100,7 +100,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: AP Intake | Notify: AP Intake |
+| 15 | m | 70% | Notify: UserGroup: AP Intake | Notify: UserGroup: AP Intake |
 
 #### Tasks
 
@@ -203,7 +203,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: AP Clerk | Notify: AP Team Lead |
+| 15 | m | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
 
 #### Tasks
 
@@ -281,7 +281,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: AP Clerk | Notify: AP Team Lead |
+| 15 | m | 70% | Notify: UserGroup: AP Clerk | Notify: UserGroup: AP Team Lead |
 
 #### Tasks
 
@@ -421,7 +421,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: AP Team Lead | Notify: Finance Operations |
+| 15 | m | 70% | Notify: UserGroup: AP Team Lead | Notify: UserGroup: Finance Operations |
 
 #### Tasks
 
@@ -475,7 +475,7 @@
 
 | SLA | Unit | At-Risk | At-Risk Action | Breach Action |
 |-----|------|---------|----------------|---------------|
-| 5 | m | 70% | Notify: Automation Support | Notify: Automation CoE |
+| 15 | m | 70% | Notify: UserGroup: Automation Support | Notify: UserGroup: Automation CoE |
 
 #### Tasks
 


### PR DESCRIPTION
Both fixes verified independently:

1. sdd.md fixture — bumped all five 5 m stage SLAs to 15 m (meets the documented 15–1000 minute floor) and added the UserGroup: scope prefix to every escalation "Notify:" action, matching the working convention used in phase_0_finalize_draft/phase_0_finalize_draft_loan. Confirmed the fixture alone now passes sdd_check.py clean.

2. sdd_check.py — replaced the loose \bescalation\b-anywhere-in-header match with exact header-pattern matching (Add escalation rule for / Set default SLA for / Add conditional SLA rule for), mirroring the documented tasks.md entry formats in planning.md. Re-running against the old stale tasks.md confirms the 2 false-positive "title is missing" hits (from T13/T21, whose headers merely mention the "SLA Escalation" stage name) are gone, and the 5 false-positive recipient hits (T13/T21/T29/T30/T55) are gone too — leaving only the 12 genuinely-malformed escalation entries from that specific agent run, which a fixture edit can't retroactively fix.
