### PR TITLE
fix(tests): grade simulated troubleshoot scenarios on the full dialog + CI gate

### DIFF
--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -273,6 +273,7 @@ Every `llm_judge` criterion across all troubleshoot tasks uses the **same** prom
   weight: 3.0
   pass_threshold: 0.7
   include_reference: true
+  include_dialog: true
   include_agent_output: true
   prompt: |
     Grade the agent's final answer against the attached RESOLUTION.md.
@@ -289,12 +290,15 @@ Every `llm_judge` criterion across all troubleshoot tasks uses the **same** prom
     Return JSON: {"score": <float>, "rationale": "<one sentence>"}
 ```
 
-**What the judge sees** (both flags MUST be `true`):
+**What the judge sees** (all three flags MUST be `true`):
 
 - `include_reference: true` — passes `RESOLUTION.md` (the file named under `reference:` at the task root)
+- `include_dialog: true` — passes the full user<->agent dialog, every turn
 - `include_agent_output: true` — passes the agent's final user-facing response
 
 That is **all** the context the judge gets. The contract: agent's diagnosis (wherever it appears in the dialog) vs. RESOLUTION.md → score. Tool calls are deliberately excluded — the judge grades the presented diagnosis, not how it was reached.
+
+`include_dialog` is what makes "wherever it appears in the dialog" true. Without it the judge receives only the final turn, and the simulator keeps talking past the diagnosis — so the graded turn is an acknowledgement ("Will do.", "You're welcome.") and a correct investigation scores `0.00`. Six scenarios failed this way in the 2026-07-28 nightly. `scripts/check-judge-dialog.py` (CI: `judge-dialog-gate.yml`) blocks a PR that reintroduces it.
 
 **Forbidden on `llm_judge`:**
 

--- a/tests/tasks/uipath-troubleshoot/CLAUDE.md
+++ b/tests/tasks/uipath-troubleshoot/CLAUDE.md
@@ -325,6 +325,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-browserscope-efail/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-browserscope-efail/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-runlocaltriggers-generated-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-runlocaltriggers-generated-missing/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-enable-constraints/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-enable-constraints/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
@@ -65,6 +65,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
@@ -51,6 +51,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
@@ -66,6 +66,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
@@ -66,6 +66,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
@@ -65,6 +65,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-work-offline/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-work-offline/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-auth-basic-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-auth-basic-disabled/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-port-tls-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-port-tls-mismatch/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-relay-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-relay-denied/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
@@ -66,6 +66,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-not-found/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-method-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-method-not-found/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-scrambled-text/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-scrambled-text/task.yaml
@@ -48,6 +48,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-401-auth/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-401-auth/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-415-content-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-415-content-type/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-proxy-blocked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-proxy-blocked/task.yaml
@@ -49,6 +49,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
@@ -50,6 +50,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-webapi-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-webapi-version-mismatch/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
@@ -64,6 +64,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
@@ -64,6 +64,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
@@ -61,6 +61,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
@@ -69,6 +69,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
@@ -63,6 +63,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
@@ -62,6 +62,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/cross-system/rpa-preflight-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/cross-system/rpa-preflight-failure/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-aggregate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-aggregate/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-disabled/task.yaml
@@ -43,6 +43,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-no-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-no-access/task.yaml
@@ -43,6 +43,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-null-reference/task.yaml
@@ -43,6 +43,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-runtime-notfound/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-runtime-notfound/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/is-activities-prerelease-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/is-activities-prerelease-not-found/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
@@ -41,6 +41,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     include_tool_calls: true
     prompt: |

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
@@ -42,6 +42,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-folder-permission-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-folder-permission-cns/task.yaml
@@ -42,6 +42,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-personal-workspace-connection-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-personal-workspace-connection-cns/task.yaml
@@ -42,6 +42,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
@@ -41,6 +41,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     include_tool_calls: true
     prompt: |

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-response-too-large/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-response-too-large/task.yaml
@@ -42,6 +42,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
@@ -43,6 +43,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -60,6 +60,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/platform-incident-multi-process-fault/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/platform-incident-multi-process-fault/task.yaml
@@ -58,6 +58,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-console-conflict-hd/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-console-conflict-hd/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-credprovider-path-known-issue/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-credprovider-path-known-issue/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
@@ -51,6 +51,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
@@ -53,6 +53,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-output-too-large/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-output-too-large/task.yaml
@@ -55,6 +55,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-stopped-exit-code-e0434352/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-stopped-exit-code-e0434352/task.yaml
@@ -59,6 +59,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-screenshot-handle-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-screenshot-handle-invalid/task.yaml
@@ -57,6 +57,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
@@ -56,6 +56,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-workstation-in-use/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-workstation-in-use/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-out-of-range-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-out-of-range-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-linq-no-data-rows/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-linq-no-data-rows/task.yaml
@@ -46,6 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-type-mismatch-object-string/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-type-mismatch-object-string/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/directory-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/directory-not-found-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-condition-compiler-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-condition-compiler-error/task.yaml
@@ -47,6 +47,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-null-reference-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-wrong-branch-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-wrong-branch-case/task.yaml
@@ -48,6 +48,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/index-out-of-range-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/index-out-of-range-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/invalid-operation-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/invalid-operation-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/key-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/key-not-found-exception/task.yaml
@@ -44,6 +44,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
@@ -45,6 +45,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-csharp-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-csharp-mismatch/task.yaml
@@ -54,6 +54,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-smart-quotes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-smart-quotes/task.yaml
@@ -52,6 +52,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
     include_reference: true
+    include_dialog: true
     include_agent_output: true
     prompt: |
       Grade the agent's final answer against the attached RESOLUTION.md.


### PR DESCRIPTION
## Problem

Six `uipath-troubleshoot` scenarios failed the 2026-07-28 nightly (`2026-07-28_04-39-07`) with `skill_triggered` = 1.00 and `llm_judge` = **0.00**. In every case the agent had already produced the correct root cause and fix.

Their `llm_judge` sets `include_agent_output: true` **without** `include_dialog: true`, so the judge receives only the agent's *final* turn. Under `simulation.enabled: true` the simulated user keeps talking after the diagnosis lands, so the final turn is an acknowledgement. What the judge actually graded:

| Task | Graded turn | Diagnosis it never saw |
|---|---|---|
| `rpa-executor-service-disconnect` | `"Will do."` | Robot service shut down / lost Orchestrator connection mid-run -> rerun |
| `web-http-401-auth` | `"You're welcome. The corrective change is limited to that existing header expression..."` | Bare token in `Authorization`, no `Bearer ` prefix, with the exact expression fix |
| `rpa-is-folder-permission-cns` | `"Sounds good. Once the grant is in place..."` | `CNS1045` / 403, robot lacks `Connections.View` in Finance, 3-step grant |
| `rpa-preflight-failure` | `"Kept the investigation evidence in .local/investigations."` | Missing `PO_PricingTable` asset + inaccessible Outlook connection; `Throw` ruled out as propagation |
| `rpa-is-personal-workspace-connection-cns` | `"That should resolve the unattended failure..."` | Process bound to a personal-workspace OneDrive connection; create in shared folder, rebind, republish |
| `assign-linq-no-data-rows` | a blocked `uip rpa pack` report (turn 4 was a *publish* request) | Unguarded `CopyToDataTable()` on an empty LINQ result + `If(rows.Any(), ..., dtInvoices.Clone())` |

Judge findings confirm it, e.g. for `rpa-executor-service-disconnect`: *"Agent output is 'Will do.' - no root cause identified ... Zero diagnostic content provided."*

## Changes

1. **`include_dialog: true` on the six failing tasks.**
2. **Canonical judge block in `tests/tasks/uipath-troubleshoot/CLAUDE.md`** - the block authors are told to "copy verbatim into every new scenario" omitted `include_dialog`, while the prose below it promised the judge grades the diagnosis "wherever it appears in the dialog". That is the origin of the defect; without this change the new gate would block every scenario authored per the repo's own instructions.
3. **Full sweep: 188 more criteria across the whole troubleshoot tree**, including all 143 `skip: true` tasks so they are correct the moment anyone unskips them. 297 of 298 task YAMLs now carry the flag; the one holdout has no `simulation` block, where the final turn *is* the whole answer. Insertions are structural (walk `success_criteria`, only touch an `llm_judge` in a simulation-enabled task that sets `include_agent_output: true` and lacks `include_dialog`), not a text replace: diff is `+188/-0`, and every file parses and reads back the flag. **No `skip:` flag was changed.**
4. **`scripts/check-judge-dialog.py` + `.github/workflows/judge-dialog-gate.yml`** - deterministic gate modeled on `task-driver-gate.yml`, emitting `::error` annotations at the offending criterion's line.

## Gate scoping

Restricted to task YAMLs a PR **adds or modifies** (`--diff-filter=AM`). No `paths:` filter, so it can be wired as a required check - it exits 0 when a PR touches no troubleshoot task YAMLs. `workflow_dispatch` scans the whole skill.

Now that the tree is clean it could be switched to a full-tree scan (strictly stronger: catches an unflagged task arriving via a merge, not just one the author edited). Left PR-scoped for now; it is a three-line change.

## Validation

**Gate:** green on this PR (10s). Log confirms it is non-vacuous - the diff step resolved exactly the six task YAMLs, then `OK - every simulated task's llm_judge grades the full dialog.` Also verified locally: 6 correct annotations on the pre-fix state, clean on the fixed files, clean on empty input, and clean across all 298 files after the sweep.

**coder-eval, all six scenarios: 6/6 SUCCESS, every criterion 1.00**, no simulator failures, all clean `stop_token` (local, claude-sonnet-4-6 via Bedrock, experiment `default.yaml`):

| Task | turns | `llm_judge` nightly -> now | score |
|---|---|---|---|
| `rpa-preflight-failure` | 3 | 0.00 -> **1.00** | 1.000 |
| `web-http-401-auth` | 3 | 0.00 -> **1.00** | 1.000 |
| `assign-linq-no-data-rows` | 2 | 0.00 -> **1.00** | 1.000 |
| `rpa-executor-service-disconnect` | 1 | 0.00 -> **1.00** | 1.000 |
| `rpa-is-folder-permission-cns` | 1 | 0.00 -> **1.00** | 1.000 |
| `rpa-is-personal-workspace-connection-cns` | 1 | 0.00 -> **1.00** | 1.000 |

Three ran as genuine multi-turn dialogs (3, 3, 2 turns) - the exact condition the fix targets. `rpa-preflight-failure` is the sharpest case: its final turn's `agent_output` was the **empty string**, so the old config would have handed the judge nothing; with `include_dialog` it scored 1.00. Judge prompts now contain `REFERENCE SOLUTION` + `DIALOG` + `AGENT OUTPUT` where the nightly's had `AGENT OUTPUT` alone.

### Known-unrelated blocker in `run-coder-eval.yml`

A `Run Coder Eval` dispatch on this branch (codex arm) returned 4/6, but **all six tasks ended `turns=1 / stop=error / simulator_failures=1`**:

```
API Error (eu.anthropic.claude-sonnet-5): 400 The provided model identifier is invalid.
```

The user simulator sets `model=None` by design and inherits the Bedrock **route** model (`BEDROCK_MODEL` + `AWS_REGION` secrets), which currently resolve to an EU inference profile that does not carry sonnet-5. No workflow input can override it (`agent_model` only reaches the agent, which is why the codex agent ran while the simulator died; with `agent=claude` the agent would fail identically). That run therefore never produced a multi-turn dialog and is not evidence either way for this PR.

This blocks `run-coder-eval.yml` for **any** simulated task, well beyond this PR - it needs a secrets change (point `BEDROCK_MODEL` at a model valid in the configured `AWS_REGION`, e.g. the `us.anthropic.claude-sonnet-4-6` the nightly VM uses). The post-merge nightly runs in the VM environment where the simulator works, so it is the clean CI before/after.

## Not in scope

Two genuine nightly failures remain open: `connector-aggregate` (the `connection-not-resolved.md` playbook has no transient-5xx branch, so a 502 Bad Gateway is diagnosed as a broken connection - the real client-facing defect) and `o365-interactive-token-timeout` (agent fused two GUIDs into a nonexistent folder key; the permissive `unmocked_default: []` masked it as "no jobs").