### PR TITLE
chore(release): bump v1.198 line 1.198.0 -> 1.198.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "uipath",
       "source": "./",
       "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath workflows, UI automation, UI testing and UiPath troubleshoot",
-      "version": "1.198.0",
+      "version": "1.198.1",
       "author": {
         "name": "UiPath"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "description": "UiPath plugin for Claude Code — custom skills, agents, hooks, and MCP servers for UiPath RPA workflows, UI automation, UI testing, Python coded agents and UiPath troubleshoot",
   "author": {
     "name": "UiPath"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "uipath",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "description": "UiPath skills for building, validating, deploying, and operating automations and agents from Codex.",
   "author": {
     "name": "UiPath"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uipath/skills",
-  "version": "1.198.0",
+  "version": "1.198.1",
   "description": "UiPath agent skills for Claude Code, Codex, Cursor, Copilot, Gemini and OpenCode — RPA, UI automation, UI testing, coded agents/apps/workflows, and troubleshooting. Distributed as the UiPath Claude Code plugin.",
   "author": {
     "name": "UiPath"

--- a/version-manifest.json
+++ b/version-manifest.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 2,
-  "skillsVersion": "1.198.0",
+  "skillsVersion": "1.198.1",
   "targetCli": "^1.198.0"
 }


### PR DESCRIPTION
## What

Bumps the `v1.198` release line from `1.198.0` to `1.198.1`.

`package.json` is the single source of truth; the four derived manifests were rewritten by `npm run version:sync` — none were hand-edited.

| File | Field | 1.198.0 → |
|------|-------|-----------|
| `package.json` | `version` | `1.198.1` |
| `version-manifest.json` | `skillsVersion` | `1.198.1` |
| `.claude-plugin/plugin.json` | `version` | `1.198.1` |
| `.claude-plugin/marketplace.json` | `plugins[0].version` | `1.198.1` |
| `.codex-plugin/plugin.json` | `version` | `1.198.1` |

`version-manifest.json.targetCli` stays `^1.198.0` — a patch bump does not move the CLI minor line, so the `@uipath/cli` 1.198.x ↔ skills 1.198.x pairing is unchanged.

## Why

`release/v1.198` has taken cherry-picks since `1.198.0` was published (most recently #2292, Data Fabric `MULTILINE_MAX` guidance). Those fixes cannot ship without a new version: npm never overwrites a published version, and Claude Code / Codex plugin auto-update only moves forward on a version change.

## Verification

- `npm run version:sync` — synced 4 manifests, no drift
- `npm run version:check` — `✓ All manifests in sync (package 1.198.1, plugin 1.198.1, targetCli ^1.198.0)`
- Diff is version strings only, 5 files, 5 insertions / 5 deletions

## Follow-up (not in this PR)

Per [docs/RELEASE.md](../blob/release/v1.198/docs/RELEASE.md#cutting-a-stable-release), publishing is a separate step after merge: create the GitHub Release tagged `v1.198.1` on `release/v1.198`, or dispatch `publish.yml --ref release/v1.198 -f target=npmjs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
