### PR TITLE
test(coded-apps): grade gov-deploy provisioning by outcome, not command string

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
@@ -71,15 +71,30 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # Order/variable-tolerant: agents commonly bind the folder name to a shell var
-  # (FOLDER_NAME="codedapp-govtest-…"; node …/setup-admin-folder.mjs "$FOLDER_NAME"),
-  # so the literal appears BEFORE the script name. Two lookaheads (DOTALL) just
-  # require both tokens present in the same command, in any order.
-  - type: command_executed
-    description: "Governance provisioning ran against a DISPOSABLE codedapp-govtest-* folder, not the real AdminDashboards"
-    tool_name: "Bash"
-    command_pattern: '(?=.*setup-admin-folder\.mjs)(?=.*codedapp-govtest-)'
-    min_count: 1
+  # Grade the OUTCOME the provisioning script records, not the command string.
+  # The two tokens (setup-admin-folder.mjs + codedapp-govtest-<epoch>) need not
+  # co-occur in one command: agents bind the name to a shell var OR stash it in a
+  # temp file and read it back (`FOLDER=$(cat /tmp/name)`; node …/setup-admin-folder.mjs
+  # "$FOLDER"), so no command-string regex reliably sees both. Instead check what
+  # setup-admin-folder.mjs itself writes: updateState() records the provisioned
+  # folder into .dashboard/state.json as deployment.folderName + folderKey. pre_run
+  # seeds both as null, so a populated codedapp-govtest-* name with a real key can
+  # only come from the script actually provisioning a disposable folder this run —
+  # variable/idiom-immune, and not a self-report (the script writes it, not the agent).
+  - type: run_command
+    description: "Governance provisioning created a DISPOSABLE codedapp-govtest-* folder (recorded in .dashboard/state.json), not the real AdminDashboards"
+    command: |
+      python3 -c "
+      import json
+      dep = json.load(open('.dashboard/state.json')).get('deployment', {})
+      name = dep.get('folderName') or ''
+      key  = dep.get('folderKey') or ''
+      assert name.startswith('codedapp-govtest-'), f'folderName is not a disposable govtest folder: {name!r}'
+      assert key, 'no folderKey recorded — folder was not actually provisioned'
+      print(f'OK: provisioned disposable folder {name} (key {key})')
+      "
+    timeout: 15
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## What

`uipath-coded-apps-dashboard-gov-live-deploy-e2e` false-failed a correct run (score 0.75, 1 of 6 criteria).

The disposable-folder criterion required two literals — `setup-admin-folder.mjs` **and** `codedapp-govtest-` — to co-occur in **one** Bash command (two lookaheads). The comment anticipated shell-variable binding, but the agent stashed the folder name in a temp file and read it back in the provisioning command:

```bash
FOLDER=$(cat /tmp/folder_name_final.txt)          # "codedapp-govtest-<epoch>", set in an earlier command
node ".../setup-admin-folder.mjs" "$FOLDER" "$(pwd)"
```

So the `codedapp-govtest-` literal never appeared in that command → 0/1 → FAILURE, even though the agent **correctly** provisioned the disposable folder (the other five criteria all passed).

## Fix

Grade the **invariant**, not the command string. `setup-admin-folder.mjs`'s `updateState()` records the provisioned folder into `.dashboard/state.json` as `deployment.folderName` + `folderKey`. `pre_run` seeds both `null`, so a populated `codedapp-govtest-*` name with a real key can only come from the script actually provisioning a disposable folder **this run** — immune to how the agent passed the name (variable, temp file, literal), and not a self-report (the script writes `state.json`, not the agent).

Replaced the `command_executed` regex with a `run_command` asserting `deployment.folderName` starts with `codedapp-govtest-` and `folderKey` is set.

## Verification

- New check **passes** against the actual failing run's `state.json` (`codedapp-govtest-1785223018`, real key).
- **Fails** on a null-seeded state (provisioning skipped) — negative control intact.
- YAML parses.
- The negative guard (`setup-admin-folder.mjs … AdminDashboards`, `max_count: 0`) is unchanged; the new positive check now also proves a govtest folder — not the real shared one — was used.

Same class as #2199: a check bound to *how* the command was written rather than *what it achieved*. Grade run-scoped outcome evidence instead.

Generated with Claude Code