### PR TITLE
test(uipath-troubleshoot): simulated user declines fix application in scenario sims

### DIFF
--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
@@ -176,6 +176,7 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6
 """
 

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-browserscope-efail/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-browserscope-efail/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report (the project path and its files are a real fact about your setup and may be shared)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-arg-mismatch/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-cache-error-7/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-child-throws/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-ignored-file/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-persistence/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-invoke-session-isolated/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found-de/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-movefile-source-not-found/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-openapp-wrong-scope-type/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-runlocaltriggers-generated-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-runlocaltriggers-generated-missing/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-column-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-column-mismatch/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-append-file-locked/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-csvhelper-method-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-csvhelper-method-not-found/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-file-not-found/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-invalid-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-invalid-format/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-more-values-than-header/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-read-more-values-than-header/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-access-denied/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-cannot-set-unknown-member/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-cannot-set-unknown-member/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-invalid-delimiter/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-invalid-delimiter/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-unsupported-encoding/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/csv-write-unsupported-encoding/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/cv-element-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/cv-element-not-found/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-ace-not-registered/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-file-locked/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-malformed-connstring/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-connect-database-provider-init/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report, except that the process worked before the Windows migration."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-driver-load/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-empty-sql/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-empty-sql/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-out-param-size/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-non-query-unsafe-sql/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-clr-crash/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-enable-constraints/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-enable-constraints/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-in-connection-string/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-in-connection-string/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-null-connection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-null-connection/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-provider-mismatch/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-sql-syntax-error/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-timeout-expired/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-execute-query-wrong-activity/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-body-skip/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-connection-not-propagated/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-provider-migration/task.yaml
@@ -99,4 +99,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/db-start-transaction-silent-rollback/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-403-forbidden/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-403-forbidden/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-host-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-host-not-found/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-httpclient-reused-in-loop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-httpclient-reused-in-loop/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/download-file-stuck-tmp/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/download-file-stuck-tmp/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/du-digitize-license-not-validated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/du-digitize-license-not-validated/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-column-schema-mismatch/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-hidden-rows-target/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-append-range-variant-mismatch/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-excel-not-installed/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-rpc-race-across-scopes/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-card-sensitivity-label-rejection/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-filter-misalignment/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-shift-conflict/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-code-file/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-com-interop/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name-de/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-method-name/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-params/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-invokevba-trust-access/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-active-filters/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-file-locked/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-formula-cells/task.yaml
@@ -101,4 +101,5 @@ simulation:
     - "Never invent factual data beyond what is stated in the persona and these constraints."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-invalid-range/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-not-installed/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-lookuprange-null-reference/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-not-found/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-trust-center/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-macro-vba-error/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-concurrent-jobs/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-file-deleted/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-host-evidence/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-label/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-namedrange/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-nre-opaque/task.yaml
@@ -105,4 +105,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-orphan-process/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-relative-path/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-bytes/task.yaml
@@ -104,4 +104,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-dynamic-empty/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-typo/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-unmapped-drive/task.yaml
@@ -101,4 +101,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-addin-clash/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-com-registration-broken/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-formula-semicolons/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-loop-thrash/task.yaml
@@ -100,4 +100,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-wc-scope-conflict/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-empty-source/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-add-sheet-name-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-add-sheet-name-conflict/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-connection-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-connection-invalid/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-file-not-found/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-drive-multiple-items-name-conflict/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-getfileinfo-malformed-url/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-getfileinfo-malformed-url/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-invalid-or-null-input/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-sheets-invalid-range/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/gsuite-sheets-invalid-range/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-timeout/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-unauthorized/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/ipc-broadcast-message-unauthorized/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-activity-restsharp-load/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-activity-restsharp-load/task.yaml
@@ -101,4 +101,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-auth-username-not-email/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-auth-username-not-email/task.yaml
@@ -99,4 +99,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-403-permission/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-403-permission/task.yaml
@@ -99,4 +99,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-issue-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-issue-not-found/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-visibility-restriction/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-comment-visibility-restriction/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-response-not-json-500/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-response-not-json-500/task.yaml
@@ -100,4 +100,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-deserialization/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-deserialization/task.yaml
@@ -100,4 +100,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-invalid-id/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-invalid-id/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-required-field/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/jira-transition-required-field/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-collection-modified/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-permission-denied/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-delete-outlook-mail-stale-reference/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-cached-mode-desync/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report (you can confirm the missing emails are visible in your Outlook client)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-filter-syntax/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-folder-not-found/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-outlook-not-running/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-shared-mailbox-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-shared-mailbox-account/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you only know the folder-does-not-exist error and that the Invoices folder lives in the accounts-payable@test.com shared mailbox. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-get-outlook-mail-timeout-large-folder/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-com-session-loss/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-folder-path/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-move-outlook-mail-type-mismatch/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-com-not-registered/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-null-input/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-timeout-security-prompt/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data - you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-work-offline/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-outlook-mail-work-offline/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you only know that the job times out every run, that no pop-up appeared in your attended test, and that the email was left in the Outbox. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-auth-basic-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-auth-basic-disabled/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you only know the 535 5.7.139 error and that the password is correct and unchanged. EXCEPTION: the project source path is a real fact and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-port-tls-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-port-tls-mismatch/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you only know the SmtpException (connection forcibly closed) on every run and that the server/account are correct. EXCEPTION: the project source path is a real fact and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-relay-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/mail-send-smtp-relay-denied/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you only know the 550 5.7.60 error on every send and that the SMTP login works. EXCEPTION: the project source path is a real fact and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-app-scope-asset-not-found/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-copyitem-null-driveitem/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-createfolder-invalid-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-createfolder-invalid-path/task.yaml
@@ -85,4 +85,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-download-folder-item/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-download-folder-item/task.yaml
@@ -85,4 +85,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-forwardmail-null-message/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-forwardmail-null-message/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-folder-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-folder-not-found/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-invalid-odata-query/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-invalid-odata-query/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-message-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-getmail-message-not-found/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-interactive-token-timeout/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sendmail-missing-attachment/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sendmail-missing-attachment/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-sharing-link-access-denied/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-trigger-connection-503/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-trigger-connection-503/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/o365-upload-maxfilesize/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-extract-page-range-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-extract-page-range-invalid/task.yaml
@@ -78,4 +78,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-corrupt/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-corrupt/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-encrypted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-encrypted/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-file-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/pdf-read-file-not-found/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-invoke-method-name-unresolved/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-engine-init/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-load-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-load-hang/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-local-import/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-local-import/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-toplevel-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-toplevel-exception/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-version-unsupported/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-loadscript-version-unsupported/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-pipe-broken-missing-module/task.yaml
@@ -99,4 +99,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-arch-mismatch/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-dotnet-runtime-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-dotnet-runtime-hang/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/py-scope-path-is-file/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-invalid-advanced-param/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-invalid-advanced-param/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-no-host/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sap-connection-no-host/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/slack-send-message-channel-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/slack-send-message-channel-not-found/task.yaml
@@ -78,4 +78,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-compress-extract-corrupt-archive/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-compress-extract-corrupt-archive/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-copy-file-destination-exists/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-copy-file-destination-exists/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-download-file-dns-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-download-file-dns-failure/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-get-queue-item-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-get-queue-item-not-found/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-activity-silent-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-activity-silent-failure/task.yaml
@@ -88,6 +88,7 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6
 
 llm_reviewer:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-external-vault-failure/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-folder-scope-mismatch/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-name-mismatch/task.yaml
@@ -97,4 +97,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-network-connectivity/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-per-robot-no-value/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-permission-denied/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-robot-not-authenticated/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getasset-wrong-activity-type/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/sys-getqueueitem-queue-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/sys-getqueueitem-queue-not-found/task.yaml
@@ -103,4 +103,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/terminal-session-connect-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/terminal-session-connect-failed/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-alter-if-disabled/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-ambiguous-node-test/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-application-open-failed/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report (the project path and its files are a real fact about your setup and may be shared)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-dependency-version-conflict/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-dependency-version-conflict/task.yaml
@@ -98,4 +98,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-disabled-no-consumption/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-invalid-license/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
     - "If the agent asks whether the tenant is on Flex or Unified, say you don't know — that information is in Automation Cloud Admin and you don't have access."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-no-license/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-no-license/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never instruct the agent to stop, abort, or skip phases."
     - "If the agent asks whether the tenant is on Flex or Unified, say you don't know — that information is in Automation Cloud Admin and you don't have access."
     - "If the agent asks which job in folder Shared you mean, say it's the most recent one — you don't have the key."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-recommendation-only/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-healing-agent-recommendation-only/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-napplicationcard-view-generation/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report — you don't know any other details. EXCEPTION: the project source path is a real fact about your setup and may be shared (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-no-healing-agent/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-node-not-found/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-out-of-screen-bounds/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide other new factual data."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-rpa-selector-healing-disabled/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-silent-noop-verify-missing/task.yaml
@@ -85,4 +85,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any runtime details beyond your initial report (the project path and its files are a real fact about your setup and may be shared)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-method-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-method-not-found/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-scrambled-text/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-type-into-scrambled-text/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-verify-execution-failure/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the project path above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-jsonarray-malformed/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-malformed-input/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-null-input/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-deserialize-xml-malformed/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-401-auth/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-401-auth/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-415-content-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-415-content-type/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-connection-failure/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-proxy-blocked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-proxy-blocked/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "Never invent or provide new factual data beyond that — you don't know proxy addresses or credentials. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-http-timeout/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/web-webapi-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/web-webapi-version-mismatch/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-bookmark-missing/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-com-interop/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-image-variable/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-missing-scope/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-addpicture-word-crash/task.yaml
@@ -101,4 +101,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-missing-container/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-not-installed/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-append-text-zero-byte-file/task.yaml
@@ -85,4 +85,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-com-hang/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-missing-output-dir/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-output-path-format/task.yaml
@@ -87,4 +87,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-external-close/task.yaml
@@ -95,4 +95,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report and these answers."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-parallel/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report and these answers."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-export-pdf-wrongthread-session0/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report and these answers."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-doc-format/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-missing-container/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-read-text-protected-view/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-com-busy/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-file-locked/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-headers-skipped/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-length-limit/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-loop-overwrite/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-multiline-formatting/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-silent-no-substitution/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-replace-text-version-mismatch/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-corrupted/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-file-path/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-hangs/task.yaml
@@ -92,4 +92,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-not-installed/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/word-scope-unknown-type/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-app-request-trigger-connection-lost/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-app-request-trigger-connection-lost/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-handle-app-request-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-handle-app-request-null-reference/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-initialize-hub-connection-aggregate-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/workflowevents-initialize-hub-connection-aggregate-failure/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/cross-system/faulted_excel_o365/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/cross-system/rpa-preflight-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/cross-system/rpa-preflight-failure/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
@@ -72,4 +72,5 @@ simulation:
     - "If the agent asks whether it can run mutating repair commands, say no and ask for the commands instead."
     - "If the agent asks whether to expand investigation scope, answer yes."
     - "Keep replies short and do not invent new facts."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
@@ -72,4 +72,5 @@ simulation:
     - "If the agent asks whether it can run uip agent debug, say no and ask it to provide the command instead."
     - "If the agent asks whether to expand investigation scope, answer yes."
     - "Keep replies short and do not invent new facts."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
@@ -72,4 +72,5 @@ simulation:
     - "If the agent asks whether it can run uip agent debug, say no and ask it to provide the command instead."
     - "If the agent asks whether to expand investigation scope, answer yes."
     - "Keep replies short and do not invent new facts."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-aggregate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-aggregate/task.yaml
@@ -76,4 +76,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-disabled/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-disabled/task.yaml
@@ -75,4 +75,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-no-access/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-general-no-access/task.yaml
@@ -75,4 +75,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-null-reference/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-null-reference/task.yaml
@@ -75,4 +75,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-remote-token/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/connector-runtime-notfound/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/connector-runtime-notfound/task.yaml
@@ -76,4 +76,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/is-activities-prerelease-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/is-activities-prerelease-not-found/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-disabled-dap/task.yaml
@@ -104,4 +104,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-missing-dap/task.yaml
@@ -106,4 +106,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-folder-permission-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-folder-permission-cns/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-personal-workspace-connection-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-personal-workspace-connection-cns/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-request-failed-dap/task.yaml
@@ -96,4 +96,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-response-too-large/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-response-too-large/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/maestro/maestro-stuck-rpa-job/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -99,4 +99,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-host-pending/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "If the agent asks how to proceed when some data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never volunteer new factual data beyond your initial report and the answers above. Keep replies short (one sentence)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 10

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/no-login-pending/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "If the agent asks how to proceed when some data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never volunteer new factual data beyond your initial report and the answers above. Keep replies short (one sentence)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 10

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/platform-incident-multi-process-fault/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/platform-incident-multi-process-fault/task.yaml
@@ -93,4 +93,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
@@ -83,4 +83,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report and the folder fact above."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-console-conflict-hd/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-console-conflict-hd/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never invent or provide new factual data beyond your initial report and the answers above. Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 8

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-credprovider-path-known-issue/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-credprovider-path-known-issue/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
@@ -78,4 +78,5 @@ simulation:
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never invent or provide new factual data beyond your initial report and the answers above. Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 8

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-already-running/task.yaml
@@ -84,4 +84,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-foreground-misconfigured/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-autocancel-trigger/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know about any trigger."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-operator-ui/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know who killed the job."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-killed-by-watchdog-account/task.yaml
@@ -86,4 +86,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know about any watchdog."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-output-too-large/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-output-too-large/task.yaml
@@ -89,4 +89,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-stopped-exit-code-e0434352/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-job-stopped-exit-code-e0434352/task.yaml
@@ -94,4 +94,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-screenshot-handle-invalid/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-screenshot-handle-invalid/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
@@ -76,4 +76,5 @@ simulation:
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never invent or provide new factual data beyond your initial report and the answers above. Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 8

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-session-creation-timeout/task.yaml
@@ -91,4 +91,5 @@ simulation:
     - "If the agent asks how to proceed when some data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never invent or provide new factual data beyond your initial report and the answers above. Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 8

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-workstation-in-use/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-workstation-in-use/task.yaml
@@ -78,4 +78,5 @@ simulation:
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings from the evidence it already gathered."
     - "Never invent or provide new factual data beyond your initial report and the answers above. Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 8

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-null-exception/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-out-of-range-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/argument-out-of-range-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-linq-no-data-rows/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-linq-no-data-rows/task.yaml
@@ -79,4 +79,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-type-mismatch-object-string/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/assign-type-mismatch-object-string/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/directory-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/directory-not-found-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-condition-compiler-error/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-condition-compiler-error/task.yaml
@@ -80,4 +80,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-key-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-key-not-found-exception/task.yaml
@@ -78,4 +78,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-null-reference-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-wrong-branch-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/if-wrong-branch-case/task.yaml
@@ -81,4 +81,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (`.`)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/index-out-of-range-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/index-out-of-range-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/invalid-operation-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/invalid-operation-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/key-not-found-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/key-not-found-exception/task.yaml
@@ -77,4 +77,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/null-reference-exception/task.yaml
@@ -82,4 +82,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-csharp-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-csharp-mismatch/task.yaml
@@ -90,4 +90,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6

--- a/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-smart-quotes/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/runtime-exceptions/visualbasicvalue-smart-quotes/task.yaml
@@ -88,4 +88,5 @@ simulation:
     - "Never invent or provide new factual data — you don't know any details beyond your initial report. EXCEPTION: the project source code path IS a real fact about your test setup; you may share it when asked (see rules above)."
     - "Keep replies short (one sentence or pick a numbered option)."
     - "Never instruct the agent to stop, abort, or skip phases."
+    - "If the agent offers or asks to apply/implement the fix itself (editing project files, or running validate/build/pack/publish), DECLINE: say you will apply the change yourself in Studio later, and ask only for the root cause and the exact fix steps. Never approve a source-file edit."
   max_turns: 6


### PR DESCRIPTION
## Why

Nightly duration analysis (2026-07-28 runs) showed the claude arm spends 2x the wall-clock of the codex arm on the uipath-troubleshoot suite (817m vs 403m over 155 tasks). A third of the gap comes from 39 scenarios where the agent, after delivering the diagnosis, offers to apply the fix and the simulated user approves - pulling the run into a full edit + validate/build/pack workflow (8-31m per task) that the judge never grades: the scenario contract is skill_triggered + llm_judge on the diagnosis vs RESOLUTION.md only.

## What

- Append one constraint to `simulation.constraints` in all 296 scenario task.yamls: the simulated user DECLINES fix application (source edits, validate/build/pack/publish) and asks only for the root cause and exact fix steps. Wording follows the existing precedent in `activity-packages/uia-application-not-found/task.yaml` (already had it; untouched).
- Same line added to the generator template in `_shared/scripts/generate_scenario.py` so new scenarios inherit it.

## Validation

Local re-runs of the four worst nightly offenders (sequential, sonnet-4-6 via bedrock), all SUCCESS, zero source edits and zero build commands in transcripts:

| Task | Nightly claude (old sim) | Re-run (new sim) |
|---|---|---|
| replace-text-silent | 31.1m, fix workflow entered | 11.9m, score 0.85, clean |
| excel-rr-sheet-dynamic-empty | 21.4m, fix workflow | 6.6m, score 1.00, clean |
| excel-rr-sheet-bytes | 14.2m, fix workflow | 3.5m, score 1.00, clean |
| uia-type-into-method-not-found | 16.9m, fix workflow | 6.0m, score 0.85, clean |

Runs of the remaining 35 affected scenarios are in progress; results will be posted on this PR.
