### PR TITLE
fix(tests): de-flake HITL completed-port smoke — raise turn_timeout 600→900

### DIFF
--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -8,7 +8,11 @@ tags: [uipath-maestro-flow, uipath-human-in-the-loop, smoke, mode:build, lifecyc
 run_limits:
   expected_turns: 24
   max_turns: 105
-  turn_timeout: 600
+  # 600s was too tight for this multi-node HITL build on Bedrock: one
+  # over-exploring turn hit 604s (commands ~38s; the rest was model latency)
+  # and ERRORed before criteria ran. 900 matches sibling
+  # smoke_03_multi_outcome_routing and the experiment default.
+  turn_timeout: 900
 
 initial_prompt: |
   Build a UiPath Flow named "PurchaseApproval" with this structure:


### PR DESCRIPTION
## What

Raises `turn_timeout` from **600 → 900** on the `skill-flow-hitl-smoke-completed-port` smoke task (`tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml`). One-line config change plus a justifying comment.

## Why

Pre-existing flake (unrelated to any skill/guidance change). In the latest smoke run the task **ERRORed** with:

```
Agent turn timed out after 600s (iteration 1)
```

One agent turn over-explored (28 tool calls, 48 assistant turns) and hit **604s** — just over the task's 600s cap — so it errored **before any success criteria ran**. The tool calls themselves took only ~38s total; the remaining wall-clock was Bedrock model-generation latency. That single ERROR dropped the smoke pass rate to 85.7%, below the 95% gate.

600 was anomalously low for this task:
- Sibling `smoke_03_multi_outcome_routing` — a comparable multi-node HITL build — already runs at **900**.
- The smoke experiment default (`tests/experiments/smoke.yaml`) is also **900**.

Aligning to 900 gives the build headroom without changing what it grades.

## Scope / notes

- No change to `initial_prompt` or `success_criteria` — the task still tests the same behavior (wiring the HITL `completed` output port + `flow validate`).
- Effective budget stays bounded: this is a single-turn task, so `min(turn_timeout, task_timeout)` still caps at the experiment's 900.
- A second pre-existing smoke failure in that run — `skill-flow-solution-select-ask` — is a **separate infra issue** (the `BEDROCK_MODEL` secret carries an `eu.` region prefix while the account/region is `us-*`, which breaks the user simulator across all skills' simulation tasks). It is **not** a flow-task bug and is being handled separately by correcting the secret; intentionally out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)