### PR TITLE
test(admin): add outcome-graded user-delete smoke (PLT-107839 follow-up)

### DIFF
--- a/tests/tasks/uipath-admin/cleanup_delete_user.py
+++ b/tests/tasks/uipath-admin/cleanup_delete_user.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Best-effort cleanup: delete the delete-smoke marker user if the agent left it
+behind (e.g. it never ran the delete), so the test does not leak users onto the
+org. Also clears the seed state file. Idempotent; always exits 0."""
+
+import logging
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+from admin_helpers import run_cli
+
+logging.basicConfig(level=logging.INFO, format="cleanup_delete_user: %(message)s")
+logger = logging.getLogger(__name__)
+
+MARKER_EMAIL = "ce-identity-delete@example.com"
+SEARCH = "ce-identity-delete"
+STATE_FILE = os.path.join(tempfile.gettempdir(), "ce_delete_user_seed.txt")
+
+
+def main():
+    data = run_cli(["admin", "users", "list", "--search", SEARCH])
+    if data and data.get("Result") == "Success":
+        for u in data.get("Data", []):
+            if (u.get("Email") or u.get("email") or "").lower() == MARKER_EMAIL:
+                uid = u.get("Id") or u.get("id")
+                if uid:
+                    logger.info("Deleting leftover delete-smoke user id=%s", uid)
+                    run_cli(["admin", "users", "delete", uid])
+    else:
+        logger.warning("Could not list users — skipping cleanup")
+
+    try:
+        os.remove(STATE_FILE)
+    except OSError:
+        pass
+
+
+main()
+sys.exit(0)

--- a/tests/tasks/uipath-admin/identity_delete_user_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_delete_user_smoke.yaml
@@ -6,11 +6,11 @@ description: >
   (list -> identify -> delete), not the command string. Complements the
   user-lifecycle e2e, which grades the update tail but exercises delete only as
   teardown — this smoke grades the delete deterministically.
-tags: [uipath-admin, smoke, mode:operate, lifecycle:setup, identity, user-lifecycle]
+tags: [uipath-admin, smoke, mode:operate, lifecycle:setup, identity, user-lifecycle, delete]
 
 pre_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''setup_delete_user.py''))"'
-    timeout: 60
+    timeout: 90
 
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_delete_user.py''))"'
@@ -28,7 +28,7 @@ success_criteria:
   - type: run_command
     description: "The seeded marker user is gone from the tenant after deletion"
     command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''verify_user_deleted.py''))"'
-    timeout: 40
+    timeout: 90
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/identity_delete_user_smoke.yaml
+++ b/tests/tasks/uipath-admin/identity_delete_user_smoke.yaml
@@ -1,0 +1,34 @@
+task_id: skill-admin-identity-delete-user-smoke
+description: >
+  Smoke test (outcome-graded): agent deletes a user from the organization. A
+  marker user is seeded (invited) in pre_run and its id recorded; graded by
+  confirming that exact user is gone from the tenant after the agent deletes it
+  (list -> identify -> delete), not the command string. Complements the
+  user-lifecycle e2e, which grades the update tail but exercises delete only as
+  teardown — this smoke grades the delete deterministically.
+tags: [uipath-admin, smoke, mode:operate, lifecycle:setup, identity, user-lifecycle]
+
+pre_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''setup_delete_user.py''))"'
+    timeout: 60
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_delete_user.py''))"'
+    timeout: 30
+
+run_limits:
+  expected_turns: 6
+
+initial_prompt: |
+  Remove the user "ce-identity-delete@example.com" from my UiPath organization.
+
+  Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  - type: run_command
+    description: "The seeded marker user is gone from the tenant after deletion"
+    command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''verify_user_deleted.py''))"'
+    timeout: 40
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-admin/setup_delete_user.py
+++ b/tests/tasks/uipath-admin/setup_delete_user.py
@@ -10,7 +10,7 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
-from admin_helpers import run_cli
+from admin_helpers import run_cli, poll
 
 logging.basicConfig(level=logging.INFO, format="setup_delete_user: %(message)s")
 logger = logging.getLogger(__name__)
@@ -50,8 +50,10 @@ def main():
         logger.warning("Seed user invite failed: %s", res)
         return
 
-    # Resolve the invited user's id and record it as authoritative proof of the seed.
-    u = find_user()
+    # Resolve the invited user's id and record it as authoritative proof of the
+    # seed. User provisioning is eventually-consistent — poll so a listing lag
+    # does not leave verify with no state file (which would fail a correct agent).
+    u = poll(find_user)
     seed_id = (u.get("Id") or u.get("id")) if u else None
     if seed_id:
         with open(STATE_FILE, "w") as f:

--- a/tests/tasks/uipath-admin/setup_delete_user.py
+++ b/tests/tasks/uipath-admin/setup_delete_user.py
@@ -2,12 +2,18 @@
 """Pre-run seed for the user-delete smoke: (re)invite the marker user the agent
 will be asked to delete. Records the created user's id to a state file so the
 verify step can prove the seed existed — otherwise a do-nothing agent would
-"pass" because the user is trivially absent. Always exits 0 (best-effort seed)."""
+"pass" because the user is trivially absent. Always exits 0 (best-effort seed).
+
+Assumes serial execution: the marker email and the state-file name are fixed
+(org-wide singletons), so two concurrent instances of this task on the same org
+would race the shared user record. This matches the repo's sequential-run rule
+and the other single-marker identity tests; salt both if parallelism is enabled."""
 
 import logging
 import os
 import sys
 import tempfile
+import time
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
 from admin_helpers import run_cli, poll
@@ -43,6 +49,13 @@ def main():
         uid = u.get("Id") or u.get("id")
         if uid:
             run_cli(["admin", "users", "delete", uid])
+            # Wait for the delete to propagate before re-inviting the same email
+            # — otherwise the invite can collide ("already exists") and the seed
+            # fails, which would false-FAIL a correct agent at verify time.
+            for _ in range(4):
+                if not find_user():
+                    break
+                time.sleep(3)
 
     res = run_cli(["admin", "users", "invite", "--email", MARKER_EMAIL,
                    "--name", "Test", "--surname", "DeleteUser"])

--- a/tests/tasks/uipath-admin/setup_delete_user.py
+++ b/tests/tasks/uipath-admin/setup_delete_user.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Pre-run seed for the user-delete smoke: (re)invite the marker user the agent
+will be asked to delete. Records the created user's id to a state file so the
+verify step can prove the seed existed — otherwise a do-nothing agent would
+"pass" because the user is trivially absent. Always exits 0 (best-effort seed)."""
+
+import logging
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+from admin_helpers import run_cli
+
+logging.basicConfig(level=logging.INFO, format="setup_delete_user: %(message)s")
+logger = logging.getLogger(__name__)
+
+MARKER_EMAIL = "ce-identity-delete@example.com"
+SEARCH = "ce-identity-delete"
+STATE_FILE = os.path.join(tempfile.gettempdir(), "ce_delete_user_seed.txt")
+
+
+def find_user():
+    data = run_cli(["admin", "users", "list", "--search", SEARCH])
+    if not data or data.get("Result") != "Success":
+        return None
+    for u in data.get("Data", []):
+        if (u.get("Email") or u.get("email") or "").lower() == MARKER_EMAIL:
+            return u
+    return None
+
+
+def main():
+    # Clear any stale state from a prior run in this container.
+    try:
+        os.remove(STATE_FILE)
+    except OSError:
+        pass
+
+    # Remove any leftover marker user first (idempotent seed).
+    u = find_user()
+    if u:
+        uid = u.get("Id") or u.get("id")
+        if uid:
+            run_cli(["admin", "users", "delete", uid])
+
+    res = run_cli(["admin", "users", "invite", "--email", MARKER_EMAIL,
+                   "--name", "Test", "--surname", "DeleteUser"])
+    if not res or res.get("Result") != "Success":
+        logger.warning("Seed user invite failed: %s", res)
+        return
+
+    # Resolve the invited user's id and record it as authoritative proof of the seed.
+    u = find_user()
+    seed_id = (u.get("Id") or u.get("id")) if u else None
+    if seed_id:
+        with open(STATE_FILE, "w") as f:
+            f.write(seed_id)
+        logger.info("Seeded delete-target user '%s' id=%s", MARKER_EMAIL, seed_id)
+    else:
+        logger.warning("Could not resolve seeded user id")
+
+
+main()
+sys.exit(0)

--- a/tests/tasks/uipath-admin/verify_user_deleted.py
+++ b/tests/tasks/uipath-admin/verify_user_deleted.py
@@ -22,25 +22,49 @@ SEARCH = "ce-identity-delete"
 STATE_FILE = os.path.join(tempfile.gettempdir(), "ce_delete_user_seed.txt")
 
 
+def id_present(o, sid):
+    """True if any record anywhere in o carries Id/id == sid (shape-tolerant)."""
+    if isinstance(o, dict):
+        if (o.get("Id") or o.get("id")) == sid:
+            return True
+        return any(id_present(v, sid) for v in o.values())
+    if isinstance(o, list):
+        return any(id_present(v, sid) for v in o)
+    return False
+
+
 def main():
     if not os.path.exists(STATE_FILE):
         fail("seed user was never created (no state file) — cannot validate deletion")
-    seed_id = open(STATE_FILE).read().strip()
+    with open(STATE_FILE) as f:
+        seed_id = f.read().strip()
     if not seed_id:
         fail("seed user id missing — cannot validate deletion")
 
+    # Primary signal: the seed id must vanish from the marker-scoped listing.
+    # --search (not an unfiltered list) keeps this reliable against user-list
+    # pagination on a busy org. Poll to absorb delete propagation lag.
     present = None
     for i in range(4):
         data = run_cli(["admin", "users", "list", "--search", SEARCH])
         if not data or data.get("Result") != "Success":
             fail("could not list users to confirm deletion")
-        present = any((u.get("Id") or u.get("id")) == seed_id for u in data.get("Data", []))
+        present = id_present(data.get("Data", []), seed_id)
         if not present:
             break
         time.sleep(5)
 
     if present:
         fail(f"seed user id={seed_id} still present — agent did not delete it")
+
+    # Guard the one false-pass the search can't see: if the agent renamed the
+    # user (changing the email out of the marker prefix) instead of deleting it,
+    # the id drops from the search but the user still exists. A direct get-by-id
+    # confirms real deletion — a live record here means no delete happened.
+    got = run_cli(["admin", "users", "get", seed_id])
+    if got and got.get("Result") == "Success" and id_present(got, seed_id):
+        fail(f"seed user id={seed_id} still exists (get-by-id) — agent modified it, did not delete")
+
     ok(f"seed user id={seed_id} successfully deleted (absent from tenant)")
 
 

--- a/tests/tasks/uipath-admin/verify_user_deleted.py
+++ b/tests/tasks/uipath-admin/verify_user_deleted.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Verify the seeded marker user was deleted by the agent.
+
+Reads the seed user id recorded by setup_delete_user.py. If the seed was never
+created (no state file) this is an ERROR, not a pass — otherwise a do-nothing
+agent would "pass" because the user is trivially absent. Given a real seed id,
+asserts that exact user is now gone from the tenant.
+"""
+
+import logging
+import os
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), '_shared'))
+from admin_helpers import run_cli, fail, ok
+
+logging.basicConfig(level=logging.INFO, format="verify_user_deleted: %(message)s")
+
+SEARCH = "ce-identity-delete"
+STATE_FILE = os.path.join(tempfile.gettempdir(), "ce_delete_user_seed.txt")
+
+
+def main():
+    if not os.path.exists(STATE_FILE):
+        fail("seed user was never created (no state file) — cannot validate deletion")
+    seed_id = open(STATE_FILE).read().strip()
+    if not seed_id:
+        fail("seed user id missing — cannot validate deletion")
+
+    present = None
+    for i in range(4):
+        data = run_cli(["admin", "users", "list", "--search", SEARCH])
+        if not data or data.get("Result") != "Success":
+            fail("could not list users to confirm deletion")
+        present = any((u.get("Id") or u.get("id")) == seed_id for u in data.get("Data", []))
+        if not present:
+            break
+        time.sleep(5)
+
+    if present:
+        fail(f"seed user id={seed_id} still present — agent did not delete it")
+    ok(f"seed user id={seed_id} successfully deleted (absent from tenant)")
+
+
+main()

--- a/tests/tasks/uipath-admin/verify_user_deleted.py
+++ b/tests/tasks/uipath-admin/verify_user_deleted.py
@@ -43,16 +43,18 @@ def main():
 
     # Primary signal: the seed id must vanish from the marker-scoped listing.
     # --search (not an unfiltered list) keeps this reliable against user-list
-    # pagination on a busy org. Poll to absorb delete propagation lag.
+    # pagination on a busy org. Poll generously to absorb delete-propagation lag
+    # (deletes are eventually-consistent, at least as slow as invites).
     present = None
-    for i in range(4):
-        data = run_cli(["admin", "users", "list", "--search", SEARCH])
+    for i in range(6):
+        data = run_cli(["admin", "users", "list", "--search", SEARCH], timeout=15)
         if not data or data.get("Result") != "Success":
             fail("could not list users to confirm deletion")
         present = id_present(data.get("Data", []), seed_id)
         if not present:
             break
-        time.sleep(5)
+        if i < 5:
+            time.sleep(5)
 
     if present:
         fail(f"seed user id={seed_id} still present — agent did not delete it")
@@ -60,10 +62,18 @@ def main():
     # Guard the one false-pass the search can't see: if the agent renamed the
     # user (changing the email out of the marker prefix) instead of deleting it,
     # the id drops from the search but the user still exists. A direct get-by-id
-    # confirms real deletion — a live record here means no delete happened.
-    got = run_cli(["admin", "users", "get", seed_id])
-    if got and got.get("Result") == "Success" and id_present(got, seed_id):
-        fail(f"seed user id={seed_id} still exists (get-by-id) — agent modified it, did not delete")
+    # confirms real deletion. Retry so a single transient CLI failure (which,
+    # like a genuine not-found, surfaces as None) cannot silently skip the guard:
+    # a live renamed user surfaces on a retry, while a real not-found stays None
+    # across all attempts (and the search above already proved the CLI is up).
+    for attempt in range(3):
+        got = run_cli(["admin", "users", "get", seed_id], timeout=15)
+        if got and got.get("Result") == "Success" and id_present(got, seed_id):
+            fail(f"seed user id={seed_id} still exists (get-by-id) — agent modified it, did not delete")
+        if got is not None:
+            break  # definitive response with no live record for the id → deleted
+        if attempt < 2:
+            time.sleep(3)
 
     ok(f"seed user id={seed_id} successfully deleted (absent from tenant)")
 


### PR DESCRIPTION
## What

Adds `identity_delete_user_smoke` — the deferred **user-delete** coverage from the identity migration (#2280, PLT-107839).

The `identity_user_lifecycle_e2e` test grades the *update* tail but exercises delete only as teardown (a single read-back can't grade both the updated state and a subsequent delete — the delete erases the evidence). This dedicated smoke grades the **delete** deterministically.

## How it's graded (agent-agnostic, outcome-based)

Mirrors the blessed `identity_pat_revoke_smoke` pattern:

1. **`pre_run`** (`setup_delete_user.py`) — invites a distinct marker user (`ce-identity-delete@example.com`) and records its id to a temp state file.
2. **agent** — deletes the user (`list → identify → delete`).
3. **verify** (`verify_user_deleted.py`) — asserts that exact seeded id is **gone** from the live tenant. The state file proves the seed existed, so a do-nothing agent **fails** rather than trivially passing on absence.
4. **`post_run`** (`cleanup_delete_user.py`) — deletes any leftover user + clears state (idempotent; distinct marker keeps it `-jN`-safe alongside the lifecycle test's `ce-identity-lifecycle` marker).

No `command_executed` / `skill_triggered` — consistent with the migration.

## Validation

- `/lint-task`: **OK** (0 findings).
- Live coder-eval run: _pending — will post the passing verdict below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)