### PR TITLE
test(case): add tolerance for flaky tests

### DIFF
--- a/tests/tasks/uipath-maestro-case/connector_features/connector_activity/connector_activity.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_activity/connector_activity.yaml
@@ -129,7 +129,7 @@ success_criteria:
   - type: command_executed
     description: "Agent pulled the case registry before resolving the connector"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+case\s+registry\s+pull'
+    command_pattern: '(uip|\$UIP)"?\s+maestro\s+case\s+registry\s+pull'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -137,7 +137,7 @@ success_criteria:
   - type: command_executed
     description: "Agent fetched the connector spec to resolve typeId/connectionId"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+case\s+spec'
+    command_pattern: '(uip|\$UIP)"?\s+maestro\s+case\s+spec'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-case/io_binding/check_io_binding_case.py
+++ b/tests/tasks/uipath-maestro-case/io_binding/check_io_binding_case.py
@@ -347,13 +347,15 @@ def assert_tasks_md() -> None:
         r"copiedResult\s*=\s*=vars\.renamedResult",
         r"computedResult\s*=\s*=js:vars\.\$xref\('Binding Matrix','Echo literal','APIOutput1'\)\s*\+\s*'-computed'",
         r"metadataResult\s*=\s*=metadata\.ExternalId",
-        r"APIInput1\s*<-\s*\"Binding Matrix\"\.\"Lookup colliding same name\"\.estimatedAge",
+        r"APIInput1:?\s*<-\s*\"Binding Matrix\"\.\"Lookup colliding same name\"\.estimatedAge",
         r"collisionCopy\s*=\s*=js:vars\.\$xref\('Binding Matrix','Lookup colliding same name','estimatedAge'\)\s*\+\s*0",
-        r"APIInput1\s*<-\s*\"Binding Matrix\"\.\"Consume colliding output\"\.collisionCopy",
+        r"APIInput1:?\s*<-\s*\"Binding Matrix\"\.\"Consume colliding output\"\.collisionCopy",
         r"customReferenceCopy\s*=\s*=js:vars\.\$xref\('Binding Matrix','Consume colliding output','collisionCopy'\)\s*\+\s*0",
     )
     for pattern in expected_rows:
-        if not re.search(rf"^\s*-\s*(?:outputs:\s*)?{pattern}\s*$", text, re.MULTILINE):
+        if not re.search(
+            rf"^\s*-\s*(?:(?:inputs|outputs):\s*)?{pattern}\s*$", text, re.MULTILINE
+        ):
             fail(f"tasks.md did not preserve row matching {pattern!r}")
 
     bare = re.compile(r"^\s*-\s*(?:outputs:\s*)?APIOutput1\s*$", re.MULTILINE)


### PR DESCRIPTION
test(case): tolerate cosmetic pattern variance in maestro-case checks

Loosen regexes in connector_activity.yaml and check_io_binding_case.py
so quoted CLI verbs and inputs:/outputs: label prefixes don't cause
false-negative test failures.
