### PR TITLE
test(bpmn): execute Jint lifecycle against Alpha

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/README.md
+++ b/tests/tasks/uipath-maestro-bpmn/README.md
@@ -1,7 +1,8 @@
 # Maestro BPMN Skill Eval Tasks
 
-These tasks exercise the `uipath-maestro-bpmn` skill — a registry-driven,
-authoring-only skill for producing valid, importable Maestro `.bpmn` XML.
+These tasks exercise the `uipath-maestro-bpmn` skill — a registry-driven skill
+for producing valid, importable Maestro `.bpmn` XML and verifying selected
+runtime contracts through live debug.
 
 - `smoke/` covers the core registry-driven authoring loop.
   `registry_discovery.yaml` checks that the agent discovers extension types via
@@ -14,7 +15,10 @@ authoring-only skill for producing valid, importable Maestro `.bpmn` XML.
 - `author/` covers BPMN skeleton structure, gateways, sequence flows, and
   diagrams.
 - `authoring/` covers implementation rows that are not fixture-only: business
-  rules, API workflow execution, and the script/Jint lifecycle path.
+  rules, API workflow execution, and the script/Jint lifecycle path. The Jint
+  lifecycle task validates locally and then performs a side-effect-free live
+  debug session against the configured Alpha tenant; its post-run hook removes
+  any Studio Web solution created for the test.
 - `nodes/` covers task-wrapper and script-task authoring behavior, including
   public-safe Maestro BPMN XML contract variants.
 - `connector/` covers Integration Service boundary behavior and registry

--- a/tests/tasks/uipath-maestro-bpmn/README.md
+++ b/tests/tasks/uipath-maestro-bpmn/README.md
@@ -38,7 +38,8 @@ runtime contracts through live debug.
 - `operate-diagnose/` covers diagnostic inspection and operate-action guidance
   using mocked CLI responses, matching the operate and diagnose capabilities the
   skill retains.
-- `_shared/` contains small Python helpers for durable XML shape assertions.
+- `_shared/` contains Python helpers for durable XML shape assertions and
+  post-run cleanup hooks.
 
 These tasks validate with `uip maestro bpmn validate <file>`, which runs the
 full PO.Frontend canvas rule set offline (added in UiPath/cli#3135). If the CLI

--- a/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Best-effort cleanup for Studio Web solutions created by BPMN live debug.
+
+``uip maestro bpmn debug`` may upload a local solution before execution.  This
+post-run hook removes only SolutionIds embedded in ``.uipx`` files created in
+the task sandbox.  It never fails an evaluation; CI must not accumulate test
+solutions, while developers can preserve them with ``BPMN_E2E_CLEANUP=never``.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import subprocess
+
+
+def main() -> int:
+    policy = os.environ.get("BPMN_E2E_CLEANUP", "always").lower()
+    if policy not in {"always", "never"}:
+        print(f"cleanup_solutions: invalid BPMN_E2E_CLEANUP={policy!r}; using always")
+        policy = "always"
+
+    for path in glob.glob("**/*.uipx", recursive=True):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                solution_id = json.load(handle).get("SolutionId")
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"cleanup_solutions: skip {path}: {error}")
+            continue
+        if not solution_id:
+            continue
+        if policy == "never":
+            print(f"cleanup_solutions: preserving {solution_id}")
+            continue
+        try:
+            result = subprocess.run(
+                ["uip", "solution", "delete", solution_id, "--yes", "--output", "json"],
+                capture_output=True,
+                text=True,
+                timeout=60,
+            )
+            if result.returncode == 0:
+                print(f"cleanup_solutions: deleted {solution_id}")
+            else:
+                print(f"cleanup_solutions: could not delete {solution_id}: {result.stdout[:300]}")
+        except (OSError, subprocess.TimeoutExpired) as error:
+            print(f"cleanup_solutions: could not delete {solution_id}: {error}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Best-effort cleanup for Studio Web solutions created by BPMN live debug.
 
-``uip maestro bpmn debug`` may upload a local solution before execution.  This
-post-run hook removes only SolutionIds embedded in ``.uipx`` files created in
-the task sandbox.  It never fails an evaluation; CI must not accumulate test
+``uip maestro bpmn debug`` may upload a local solution before execution. This
+post-run hook removes SolutionIds embedded in local ``.uipx`` files or returned
+in saved debug JSON. It never fails an evaluation; CI must not accumulate test
 solutions, while developers can preserve them with ``BPMN_E2E_CLEANUP=never``.
 """
 
@@ -15,21 +15,39 @@ import os
 import subprocess
 
 
+def solution_ids(value):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if isinstance(key, str) and key.lower() == "solutionid" and isinstance(child, str) and child:
+                yield child
+            yield from solution_ids(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from solution_ids(child)
+
+
 def main() -> int:
     policy = os.environ.get("BPMN_E2E_CLEANUP", "always").lower()
     if policy not in {"always", "never"}:
         print(f"cleanup_solutions: invalid BPMN_E2E_CLEANUP={policy!r}; using always")
         policy = "always"
 
+    ids = set()
     for path in glob.glob("**/*.uipx", recursive=True):
         try:
             with open(path, encoding="utf-8") as handle:
-                solution_id = json.load(handle).get("SolutionId")
+                ids.update(solution_ids(json.load(handle)))
         except (OSError, json.JSONDecodeError) as error:
             print(f"cleanup_solutions: skip {path}: {error}")
             continue
-        if not solution_id:
-            continue
+    for path in glob.glob("debug-evidence/**/*.json", recursive=True):
+        try:
+            with open(path, encoding="utf-8") as handle:
+                ids.update(solution_ids(json.load(handle)))
+        except (OSError, json.JSONDecodeError) as error:
+            print(f"cleanup_solutions: skip {path}: {error}")
+
+    for solution_id in sorted(ids):
         if policy == "never":
             print(f"cleanup_solutions: preserving {solution_id}")
             continue

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
@@ -1,9 +1,15 @@
 #!/usr/bin/env python3
-"""Verify that the ScriptNormalizer live BPMN debug session completed."""
+"""Verify that the ScriptNormalizer live BPMN debug session completed.
+
+The agent's saved response is the primary evidence.  If it omitted that file,
+recover by running one bounded debug session against Alpha instead of grading
+file-saving discipline.  This mirrors the existing BPMN live-debug evaluator.
+"""
 
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -37,19 +43,60 @@ def values_for_key(value, wanted: str):
             yield from values_for_key(child, wanted)
 
 
-def main() -> None:
-    evidence = Path("debug-evidence/debug.json")
-    if not evidence.is_file():
-        fail("missing debug-evidence/debug.json; save the raw BPMN debug response")
-    payload = parse_json(evidence)
-    if payload is None:
-        fail("debug-evidence/debug.json is not parseable JSON")
-    if not any(
+def completed(payload) -> bool:
+    return any(
         isinstance(status, str) and status.strip().lower() == "completed"
         for status in values_for_key(payload, "finalstatus")
-    ):
-        fail("debug evidence does not contain finalStatus == Completed")
-    print("OK: live BPMN debug reached finalStatus Completed")
+    )
+
+
+def recover_live_debug() -> bool:
+    """Run at most one fresh debug session for the authored project."""
+    candidates = sorted(
+        {path.parent for path in Path(".").glob("**/ScriptNormalizer.bpmn")},
+        key=lambda path: (len(path.parts), str(path)),
+    )
+    for project in candidates[:2]:
+        try:
+            result = subprocess.run(
+                ["uip", "maestro", "bpmn", "debug", str(project), "--output", "json"],
+                capture_output=True,
+                text=True,
+                timeout=300,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            print(f"note: live recovery could not debug {project}: {error}", file=sys.stderr)
+            continue
+        payload = parse_json_text(result.stdout)
+        if result.returncode == 0 and payload is not None and completed(payload):
+            print("OK: live recovery debug reached finalStatus Completed")
+            return True
+    return False
+
+
+def parse_json_text(text: str):
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        for index, line in enumerate(text.splitlines()):
+            if line.lstrip().startswith(("{", "[")):
+                try:
+                    return json.loads("\n".join(text.splitlines()[index:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def main() -> None:
+    evidence = Path("debug-evidence/debug.json")
+    if evidence.is_file():
+        payload = parse_json(evidence)
+        if payload is not None and completed(payload):
+            print("OK: live BPMN debug reached finalStatus Completed")
+            return
+        print("note: saved debug evidence is absent or incomplete; recovering live", file=sys.stderr)
+    if not recover_live_debug():
+        fail("no completed BPMN debug response from saved evidence or live recovery")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import json
 import subprocess
-import sys
 from pathlib import Path
 
 

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_live_debug_completed.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Verify that the ScriptNormalizer live BPMN debug session completed."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def parse_json(path: Path):
+    text = path.read_text(encoding="utf-8", errors="replace")
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        for index, line in enumerate(text.splitlines()):
+            if line.lstrip().startswith(("{", "[")):
+                try:
+                    return json.loads("\n".join(text.splitlines()[index:]))
+                except json.JSONDecodeError:
+                    continue
+    return None
+
+
+def values_for_key(value, wanted: str):
+    if isinstance(value, dict):
+        for key, child in value.items():
+            if isinstance(key, str) and key.lower() == wanted:
+                yield child
+            yield from values_for_key(child, wanted)
+    elif isinstance(value, list):
+        for child in value:
+            yield from values_for_key(child, wanted)
+
+
+def main() -> None:
+    evidence = Path("debug-evidence/debug.json")
+    if not evidence.is_file():
+        fail("missing debug-evidence/debug.json; save the raw BPMN debug response")
+    payload = parse_json(evidence)
+    if payload is None:
+        fail("debug-evidence/debug.json is not parseable JSON")
+    if not any(
+        isinstance(status, str) and status.strip().lower() == "completed"
+        for status in values_for_key(payload, "finalstatus")
+    ):
+        fail("debug evidence does not contain finalStatus == Completed")
+    print("OK: live BPMN debug reached finalStatus Completed")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_validate_script_jint.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_validate_script_jint.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Require the generated ScriptNormalizer BPMN to pass offline validation."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+path = Path("ScriptNormalizer/ScriptNormalizer/ScriptNormalizer.bpmn")
+if not path.is_file():
+    sys.exit(f"FAIL: missing BPMN file: {path}")
+result = subprocess.run(
+    ["uip", "maestro", "bpmn", "validate", str(path), "--output", "json"],
+    capture_output=True,
+    text=True,
+    timeout=45,
+)
+if result.returncode:
+    sys.exit(f"FAIL: BPMN validation failed (exit {result.returncode}): {result.stdout[:2000]}{result.stderr[:1000]}")
+print("OK: offline BPMN validation passed")

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -3,7 +3,7 @@ description: >
   Author a complete Maestro BPMN script-task project, covering the full
   live Alpha lifecycle for the Jint-backed script path: validate locally, then
   debug against Studio Web and prove the run completed.
-tags: [uipath-maestro-bpmn, e2e, "mode:operate", lifecycle:setup, "node:script", "feature:jint"]
+tags: [uipath-maestro-bpmn, e2e, "mode:operate", lifecycle:setup, "node:script"]
 
 run_limits:
   expected_turns: 22
@@ -19,14 +19,16 @@ initial_prompt: |
     ScriptNormalizer/ScriptNormalizer/ScriptNormalizer.bpmn
 
   Model a public-safe request normalizer:
-  - Manual start with a rawRequest JSON/string input.
+  - Manual start with an optional rawRequest JSON/string input.
   - A `bpmn:scriptTask` named "Normalize Request".
   - Set `scriptFormat="JavaScript"` and include `uipath:scriptVersion`
     value `v3`.
   - Use deterministic Jint-compatible JavaScript only: no Node.js packages,
     filesystem, network, browser globals, or long-running async behavior.
   - Map input into the script and map the returned normalized response to a
-    declared output variable.
+    declared output variable. For the live run, normalize a deterministic
+    in-script sample when rawRequest is absent; `bpmn debug --inputs` does not
+    currently reach manual-start inputs on Alpha.
   - End with a success end event and include BPMN DI for visible elements.
 
   Also create the standard local package files next to the BPMN:
@@ -75,9 +77,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
+    description: "Offline BPMN validation succeeds before live execution"
+    command: "python3 $TASK_DIR/check_validate_script_jint.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
     description: "Live Alpha debug evidence reports finalStatus Completed"
     command: "python3 $TASK_DIR/check_live_debug_completed.py"
-    timeout: 30
+    timeout: 900
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -3,7 +3,7 @@ description: >
   Author a complete Maestro BPMN script-task project, covering the full
   live Alpha lifecycle for the Jint-backed script path: validate locally, then
   debug against Studio Web and prove the run completed.
-tags: [uipath-maestro-bpmn, e2e, "mode:operate", lifecycle:setup, "node:script", "feature:jint", path-to-ga]
+tags: [uipath-maestro-bpmn, e2e, "mode:operate", lifecycle:setup, "node:script", "feature:jint"]
 
 run_limits:
   expected_turns: 22

--- a/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/script_jint_lifecycle.yaml
@@ -1,11 +1,14 @@
 task_id: skill-bpmn-script-jint-lifecycle
 description: >
   Author a complete Maestro BPMN script-task project, covering the full
-  local lifecycle for the Jint-backed script path with package metadata.
-tags: [uipath-maestro-bpmn, e2e, "mode:build", lifecycle:generate, "node:script", "feature:jint"]
+  live Alpha lifecycle for the Jint-backed script path: validate locally, then
+  debug against Studio Web and prove the run completed.
+tags: [uipath-maestro-bpmn, e2e, "mode:operate", lifecycle:setup, "node:script", "feature:jint", path-to-ga]
 
 run_limits:
   expected_turns: 22
+  task_timeout: 2400
+  max_turns: 80
   turn_timeout: 1200
 
 initial_prompt: |
@@ -30,8 +33,15 @@ initial_prompt: |
     project.uiproj, operate.json, entry-points.json, bindings_v2.json,
     package-descriptor.json
 
-  Do not upload, publish, deploy, debug, run, or call cloud-side UiPath
-  commands. Do not ask for approval or pause for feedback.
+  Validate the BPMN locally, then debug the project against the connected
+  Studio Web tenant. Use the documented solution context if the debug workflow
+  requires it. The process must have no external side effects: it may only run
+  deterministic Jint code. Save the raw debug JSON to
+  `debug-evidence/debug.json`; the task is not complete until it reports
+  `finalStatus` `Completed`.
+
+  You have explicit consent to execute this test project in the connected Alpha
+  tenant. Do not ask for approval or pause for feedback.
 
 success_criteria:
   - type: file_exists
@@ -47,3 +57,31 @@ success_criteria:
     expected_exit_code: 0
     weight: 4.0
     pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the BPMN before execution"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+validate'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran a live BPMN debug session"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+debug\s'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Live Alpha debug evidence reports finalStatus Completed"
+    command: "python3 $TASK_DIR/check_live_debug_completed.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py"
+    timeout: 120

--- a/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/debug/live_debug_e2e/live_debug_e2e.yaml
@@ -123,3 +123,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 6.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-bpmn/_shared/cleanup_solutions.py"
+    timeout: 120


### PR DESCRIPTION
## Summary
- convert the deterministic BPMN Jint lifecycle E2E from local-only authoring to a live Alpha debug execution
- require successful offline validation, a completed debug session, and raw debug evidence or bounded live recovery
- clean up Studio Web solutions returned by debug output, matching the Flow live-e2e pattern

## Why
Structural validation cannot prove that the Alpha BPMN runtime accepts and executes the Jint script path. This adds a bounded, side-effect-free runtime contract alongside the existing product-variable live debug scenario.

## Validation
- Ran `skill-bpmn-script-jint-lifecycle` in CI Alpha and it passed: https://github.com/UiPath/skills/actions/runs/30408805680
- Passed Python compilation, YAML parsing, and cleanup-hook checks locally.