### PR TITLE
feat(uipath-troubleshoot): seal the mock fixture store behind an opaque blob

### DIFF
--- a/tests/tasks/uipath-troubleshoot/_shared/mock_template/m/seal
+++ b/tests/tasks/uipath-troubleshoot/_shared/mock_template/m/seal
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Seal the mock fixture store so the agent cannot read the recorded evidence.
+
+Runs ONCE per task, in `pre_run` (before the agent starts). It packs the
+manifest + every response fixture under `r/` into a single opaque blob
+`<script_dir>/.store`, then deletes the `r/` directory entirely.
+
+Why: the mock backing store (`m/r/*.json`) is staged into the agent's working
+directory so the `m/uip` shim can resolve it. But that also lets the agent
+`cat ./m/r/*.json` and read the pre-recorded `uip` outputs directly — including
+the diagnosis-revealing log lines — diagnosing WITHOUT ever invoking `uip` or
+the `uipath-troubleshoot` skill (empirically the dominant `skill_triggered`
+failure mode). After sealing there is no readable fixture in the sandbox: the
+`r/` directory is gone and `.store` is opaque (zlib+base64). The shim
+(`m/uip`) transparently reads `.store` instead of `r/`.
+
+Idempotent and safe to run anywhere:
+    - No `r/manifest.json` present  → no-op (exit 0). Lets an experiment-level
+      pre_run run this for EVERY task; non-mock tasks simply skip.
+    - `.store` already present       → no-op (exit 0). Safe on sandbox re-use.
+
+Blob format (`.store`): base64( zlib( utf-8 json( {
+    "manifest": <manifest dict>,
+    "files":    { "<name>": "<base64 of the file's raw bytes>", ... }
+} ) ) ). Raw bytes are preserved per file so UTF-16/BOM fixtures survive.
+
+The passthrough cache (`r/_cache`, used only by `docsai ask` proxy rules) is
+moved to `<script_dir>/_cache` so live-proxy caching keeps working after `r/`
+is removed; it holds docs Q&A, not scenario evidence.
+"""
+
+import base64
+import json
+import shutil
+import sys
+import zlib
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+RESPONSES_DIR = SCRIPT_DIR / "r"
+MANIFEST_PATH = RESPONSES_DIR / "manifest.json"
+STORE_PATH = SCRIPT_DIR / ".store"
+CACHE_SRC = RESPONSES_DIR / "_cache"
+CACHE_DST = SCRIPT_DIR / "_cache"
+
+
+def main() -> int:
+    # Already sealed, or nothing to seal (non-mock task) → no-op.
+    if STORE_PATH.exists():
+        return 0
+    if not MANIFEST_PATH.is_file():
+        return 0
+
+    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+
+    files: dict[str, str] = {}
+    for item in RESPONSES_DIR.glob("*.json"):
+        if item.name == "manifest.json":
+            continue
+        files[item.name] = base64.b64encode(item.read_bytes()).decode("ascii")
+
+    blob = {"manifest": manifest, "files": files}
+    packed = base64.b64encode(zlib.compress(json.dumps(blob).encode("utf-8"), 9))
+    STORE_PATH.write_bytes(packed)
+
+    # Preserve the passthrough cache (docsai) outside the doomed r/ dir.
+    if CACHE_SRC.is_dir() and not CACHE_DST.exists():
+        shutil.move(str(CACHE_SRC), str(CACHE_DST))
+
+    # Remove the readable fixture directory entirely.
+    shutil.rmtree(RESPONSES_DIR)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-troubleshoot/_shared/mock_template/m/uip
+++ b/tests/tasks/uipath-troubleshoot/_shared/mock_template/m/uip
@@ -62,6 +62,7 @@ passthrough rule with `match: "docsai ask"` is the typical way to proxy
 open-ended natural-language commands.
 """
 
+import base64
 import hashlib
 import json
 import os
@@ -69,13 +70,49 @@ import shutil
 import subprocess
 import sys
 import time
+import zlib
 from pathlib import Path
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 RESPONSES_DIR = SCRIPT_DIR / "r"
 MANIFEST_PATH = RESPONSES_DIR / "manifest.json"
 CALL_LOG_PATH = SCRIPT_DIR / ".calls.jsonl"
-CACHE_DIR = RESPONSES_DIR / "_cache"
+# Passthrough (docsai) cache. Canonical location is beside the shim so it
+# survives `m/seal` removing `r/`; fall back to the legacy `r/_cache` for
+# unsealed local runs that shipped committed caches under `r/`.
+CACHE_DIR = SCRIPT_DIR / "_cache"
+LEGACY_CACHE_DIR = RESPONSES_DIR / "_cache"
+
+# Sealed fixture store (written by `m/seal`). When present, the manifest and
+# every response fixture are read from here — decoded in memory — and the
+# readable `r/` directory no longer exists. Opaque on disk (zlib+base64), so
+# `cat`-ing it reveals no evidence. `None` until first access; then either the
+# decoded dict `{"manifest": ..., "files": {name: rawbytes}}` or the sentinel
+# `_NO_STORE` (unsealed run → fall back to `r/`).
+STORE_PATH = SCRIPT_DIR / ".store"
+_NO_STORE = object()
+_STORE: object = None
+
+
+def _get_store():
+    """Load and cache the sealed store, or ``_NO_STORE`` if unsealed.
+
+    Decoded once per process. Returns a dict with ``manifest`` (dict) and
+    ``files`` (name → raw ``bytes``), or ``_NO_STORE`` when there is no
+    ``.store`` (the shim then reads ``r/`` as before).
+    """
+    global _STORE
+    if _STORE is not None:
+        return _STORE
+    if not STORE_PATH.is_file():
+        _STORE = _NO_STORE
+        return _STORE
+    blob = json.loads(zlib.decompress(base64.b64decode(STORE_PATH.read_bytes())).decode("utf-8"))
+    _STORE = {
+        "manifest": blob["manifest"],
+        "files": {name: base64.b64decode(b64) for name, b64 in blob.get("files", {}).items()},
+    }
+    return _STORE
 
 
 def _log_call(args: str, rule: dict | None, exit_code: int, error: str | None = None) -> None:
@@ -173,13 +210,15 @@ def _cache_key(args: str) -> str:
 
 def _load_cache(args: str) -> dict | None:
     """Return cached `{stdout, exit_code, args, cached_at}` or None."""
-    path = CACHE_DIR / f"{_cache_key(args)}.json"
-    if not path.is_file():
-        return None
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
+    key = f"{_cache_key(args)}.json"
+    for path in (CACHE_DIR / key, LEGACY_CACHE_DIR / key):
+        if not path.is_file():
+            continue
+        try:
+            return json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return None
 
 
 def _save_cache(args: str, stdout: str, exit_code: int) -> None:
@@ -256,11 +295,16 @@ def main(argv: list[str]) -> int:
 
     args = " ".join(argv[1:])
 
-    if not MANIFEST_PATH.is_file():
+    # Prefer the sealed store (fixtures decoded in memory, `r/` removed); fall
+    # back to the readable `r/` directory for unsealed local runs.
+    store = _get_store()
+    if store is not _NO_STORE:
+        manifest = store["manifest"]
+    elif MANIFEST_PATH.is_file():
+        manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    else:
         _log_call(args, None, 2, error="manifest_missing")
         return _err({"error": "manifest.json missing", "path": str(MANIFEST_PATH)}, 2)
-
-    manifest = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
 
     # 1. First matching rule wins.
     arg_tokens = set(_tokenize(args))
@@ -269,12 +313,19 @@ def main(argv: list[str]) -> int:
             continue
         if rule.get("passthrough"):
             return _passthrough(args, argv, rule)
-        response_file = RESPONSES_DIR / rule["file"]
-        if not response_file.is_file():
-            _log_call(args, rule, 2, error="fixture_missing")
-            return _err({"error": "response file missing", "path": str(response_file)}, 2)
+        # Fetch the fixture bytes from the sealed store or the `r/` directory.
+        if store is not _NO_STORE:
+            raw = store["files"].get(rule["file"])
+            if raw is None:
+                _log_call(args, rule, 2, error="fixture_missing")
+                return _err({"error": "response file missing", "path": rule["file"]}, 2)
+        else:
+            response_file = RESPONSES_DIR / rule["file"]
+            if not response_file.is_file():
+                _log_call(args, rule, 2, error="fixture_missing")
+                return _err({"error": "response file missing", "path": str(response_file)}, 2)
+            raw = response_file.read_bytes()
         # Tolerate fixtures written by PowerShell (UTF-16 LE BOM) or UTF-8.
-        raw = response_file.read_bytes()
         if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
             text = raw.decode("utf-16")
         else:


### PR DESCRIPTION
## Problem

The mock backing store (`m/r/*.json`) is staged into the agent's working directory so the `m/uip` shim can resolve it. That also lets the agent `cat ./m/r/*.json` and read the pre-recorded `uip` outputs directly — including the diagnosis-revealing log lines — reaching a root cause without ever invoking `uip` or the `uipath-troubleshoot` skill.

## Change

| File | Purpose |
|------|---------|
| `_shared/mock_template/m/seal` | Packs the manifest + every response fixture into a single opaque blob (`m/.store`, zlib+base64) and removes the readable `r/` directory. |
| `_shared/mock_template/m/uip` | Reads `.store` when present, decoding once per process. Falls back to `r/` when absent. |

Raw bytes are preserved per fixture so UTF-16/BOM fixtures survive. The passthrough cache (`r/_cache`, docsai proxy only) moves beside the shim so live-proxy caching keeps working after `r/` is gone.

`m/seal` is idempotent and safe to run anywhere: no `r/manifest.json` (a non-mock task) and an existing `.stor

## This PR is a no-op until a task opts in

`m/uip` sets a `_NO_STORE` sentinel when there is no `.store` and reads `r/` exactly as before. No task YAML changes are included here — the per-task `pre_run` wiring lands separately.

## Verification

**Unsealed fallback (this PR's safety claim)** — `argument-out-of-range-exception`, untouched, no `pre_run`:

| Check | Result |
|---|---|
| Result | SUCCESS, weighted score 1.0, 160.5s |
| `pre_run_results` | empty — ran unsealed |
| `m/r/` in sandbox | present, 4 fixtures readable |
| `m/.store` | absent |
| Calls served from `r/` | 3 — fallback exercised |

**Sealed behaviour** — 5 tasks wired to `python m/seal` via `pre_run` locally (wiring not in this PR):

| Task | Domains | Rules / store | Weighted | Duration |
|---|---|---|---|---|
| `maestro-stuck-rpa-job` | maestro + bpmn + rpa | 16 / 15.7 KB | 1.00 | 594.0s |
| `rpa-preflight-failure` | orchestrator + IS + rpa | 9 / 13.2 KB | 1.00 | 388.9s |
| `faulted_excel_o365` | IS + rpa (excel + o365) | 15 / 14.3 KB | 0.85 | 333.4s |
| `rpa-is-folder-permission-cns` | IS + rpa | 9 / 3.8 KB | 1.00 | 282.5s |
| `argument-exception` | rpa | 3 / 4.7 KB | 1.00 | 201.6s |

In all five: `pre_run` exit 0, `m/r/` removed, `.store` written, and a leak grep of 4–10 distinctive 45+ character snippets taken from each task's real fixtures found **zero** verbatim fixture content anywhere in the sandbox tree. Investigations stayed real — 11–45 `uip` calls per task, 3–9 served from the packed store.

`maestro-stuck-rpa-job` and `faulted_excel_o365` are quarantined as *"mature: 100% pass rate"*, so they serve as controls; both still pass sealed (run with `--include-skipped`, no `skip:` flags edited).

**Unit-level:** seal round-trip replays fixtures byte-identically, is idempotent (second run leaves `.store` unchanged), no-ops with no manifest, migrates `_cache` out of the doomed `r/`, and prefers `.store` when both exist.