### PR TITLE
chore(codeowners): Update owners for uipath-coded-apps skill and test suite

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -105,8 +105,8 @@
 /tests/tasks/uipath-maestro-case/guardrails/ @apetraru-uipath @valentinabojan @ctiliescuuipath
 
 # Coded Apps skill
-/skills/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354
-/tests/tasks/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354
+/skills/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354 @ninja-shreyash
+/tests/tasks/uipath-coded-apps/ @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354 @ninja-shreyash
 
 # Connector Builder skill
 /skills/uipath-connector-builder/ @mukeshkumar-uipath @chandusailella @apoosarla-uipath


### PR DESCRIPTION
Adds `@ninja-shreyash` as a code owner for the Coded Apps skill and its test tasks.

## Change
```
/skills/uipath-coded-apps/       + @ninja-shreyash
/tests/tasks/uipath-coded-apps/  + @ninja-shreyash
```

Scoped to CODEOWNERS only — no skill/content changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)