### PR TITLE
fix(tests): make move-field-between-groups winnable — serve the taxonomy read

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/mock_template/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template/README.md
@@ -34,3 +34,8 @@ disobedient agent cannot reach the cloud with the harness-injected token.
 
 Integration/e2e tasks use `live_calls_template`; its wrapper records the same log
 format and delegates unchanged to the real CLI.
+
+A task whose correct path reads before it writes cannot be graded on this mock
+alone — the read fails, so there is nothing to carry into the graded write, and
+an agent that declines to invent the values correctly stops. Overlay
+`mock_template_taxonomy` (listed second) to serve that read.

--- a/tests/tasks/uipath-ixp/_shared/mock_template_taxonomy/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_taxonomy/README.md
@@ -1,0 +1,68 @@
+# uipath-ixp taxonomy-serving mock
+
+Overlay for smoke tasks whose correct path **starts with a read**. Overlays the
+base [`mock_template`](../mock_template/README.md) — list it SECOND so its
+`mocks/uip` wins:
+
+```yaml
+sandbox:
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+    - {type: template_dir, path: ../_shared/mock_template_taxonomy}
+```
+
+## Why it exists
+
+The base mock fails every invocation. That is right for a task whose graded
+commands are independent, and wrong for one that reads before it writes:
+
+- **A value carried from the taxonomy is unobtainable.** If grading requires
+  `fields add --type … --instructions …` with the field's existing type and
+  instructions, a failing `get-taxonomy` leaves the agent nothing to carry. An
+  agent that declines to invent them stops — the correct call, graded as a fail.
+- **A mutation gated on an earlier mutation is wrong to issue.** The skill
+  teaches add-before-delete so a failed `fields add` leaves the field where it
+  was. If the add fails, withholding the `fields delete` is correct behavior.
+
+Serving the reads makes the graded shape reachable, and lets criteria assert the
+carried-over *values* rather than just flag presence.
+
+## Fixture
+
+Project `my_invoices-f1afa9ef-ixp` (`Title` `My_Invoices`):
+
+| Field group      | Fields                                        |
+|------------------|-----------------------------------------------|
+| `Invoice Header` | Invoice Number, Invoice Date, Total Amount    |
+| `Line Items`     | Description                                   |
+
+`Total Amount` is `Monetary Quantity`. Its `moon_form` entry's `field_id` is the
+field's own identity and matches no `entity_def` — the type resolves through
+`field_type_id`, the distinction the move-a-field recipe calls out.
+
+Served: `projects list`, `projects get`, `projects get-taxonomy`, `fields add`,
+`fields delete`. Everything else falls through to the base mock's offline
+failure, so a task can still guard against unwanted verbs.
+
+## get-taxonomy is stateful
+
+An agent that re-reads the taxonomy to verify a move sees its own writes, not
+stale canned state it would then try to re-apply:
+
+| After | `Invoice Header` | `Line Items` |
+|-------|------------------|--------------|
+| — | Total Amount | — |
+| `fields add` | Total Amount | Total Amount (**new** `field_id`) |
+| `fields delete` | — | Total Amount |
+
+The intermediate both-groups state is what the real backend does between add and
+delete, and the new `field_id` is why a move drops the field's confirmed labels.
+State lives in dot-prefixed marker files beside `calls.log`, so it stays out of
+graded globs and CI artifact uploads.
+
+## Constraints
+
+Logging matches the base mock exactly — same `uip ` prefix, same newline
+normalization — so anchored `^uip\s+ixp …` criteria keep matching. Change one
+and change both. `mocks/uip` must stay mode `755`.

--- a/tests/tasks/uipath-ixp/_shared/mock_template_taxonomy/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_taxonomy/mocks/uip
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Taxonomy-serving `uip` mock for uipath-ixp smoke tasks whose correct path
+# STARTS with a read. Overlays the base mock_template (list it SECOND in
+# template_sources so this file wins).
+#
+# The base mock fails every invocation. That makes any task unwinnable whose
+# graded command must carry values read from the taxonomy: the read returns
+# nothing, and an agent that declines to invent a field's type and instructions
+# correctly stops instead. Same for a graded `fields delete` after a `fields
+# add` — the skill teaches add-before-delete precisely so a failed add leaves
+# the field where it was, so a failing add makes the delete wrong to issue.
+#
+# Fixture — project my_invoices-f1afa9ef-ixp:
+#   "Invoice Header": Invoice Number, Invoice Date, Total Amount
+#   "Line Items":     Description
+# "Total Amount" is Monetary Quantity. Its moon_form `field_id` is the field's
+# own identity and matches no entity_def — the type resolves through
+# `field_type_id`, the distinction the move-a-field recipe calls out.
+#
+# get-taxonomy is stateful, so an agent that re-reads to verify a move sees its
+# own writes rather than stale canned state and retries a mutation it already
+# made: after `fields add` the field is in BOTH groups, after `fields delete`
+# only in the target, and the recreated entry carries a NEW field_id (the real
+# backend mints one, which is why confirmed labels do not follow a move).
+#
+# Response shapes follow the skill's cli-reference: {Result, Data} envelope;
+# `projects list` Data is the paged { Projects, Total, Offset, Limit }; and
+# get-taxonomy Data is { status, dataset: { entity_defs, label_groups } } with
+# label_groups[0].label_defs[] as the field groups and moon_form[] as fields.
+#
+# Logging matches the base mock exactly — same `uip ` prefix, same newline
+# normalization — so anchored `^uip\s+ixp …` criteria keep matching.
+{
+    printf 'uip %s' "$*" | tr '\r\n' '  '
+    printf '\n'
+} >> "$(dirname "$0")/calls.log" 2>/dev/null || true
+
+ADDED="$(dirname "$0")/.total-amount-added"
+DELETED="$(dirname "$0")/.total-amount-deleted"
+
+ENTITY_DEFS='{"id":"b3a63e6483adaaba","name":"Exact Text","title":"","inherits_from":[],"trainable":true,"color":2,"instructions":""},{"id":"c128ad65bd8af3f8","name":"Date","title":"","inherits_from":["0000000000000007"],"trainable":true,"color":1,"instructions":""},{"id":"e5d7402ba91c6f38","name":"Monetary Quantity","title":"","inherits_from":["0000000000000005"],"trainable":true,"color":4,"instructions":""}'
+
+F_INVOICE_NUMBER='{"field_id":"9a3f5d2c81b7e604","id":"b3a63e6483adaaba","field_type_id":"b3a63e6483adaaba","kind":"Exact Text","name":"Invoice Number","instructions":"The unique invoice identifier printed in the document header.","rule_set":null}'
+F_INVOICE_DATE='{"field_id":"1d8e42b7c3a95f60","id":"c128ad65bd8af3f8","field_type_id":"c128ad65bd8af3f8","kind":"Date","name":"Invoice Date","instructions":"The issue date of the invoice.","rule_set":null}'
+F_DESCRIPTION='{"field_id":"c47a91e05d2b3f68","id":"b3a63e6483adaaba","field_type_id":"b3a63e6483adaaba","kind":"Exact Text","name":"Description","instructions":"The line item description as printed on the row.","rule_set":null}'
+F_TOTAL_AMOUNT='{"field_id":"6e0b74a1f83c2d95","id":"e5d7402ba91c6f38","field_type_id":"e5d7402ba91c6f38","kind":"Monetary Quantity","name":"Total Amount","instructions":"The grand total payable on the invoice, including tax.","rule_set":null}'
+F_TOTAL_AMOUNT_RECREATED='{"field_id":"04c9be71a2f5d380","id":"e5d7402ba91c6f38","field_type_id":"e5d7402ba91c6f38","kind":"Monetary Quantity","name":"Total Amount","instructions":"The grand total payable on the invoice, including tax.","rule_set":null}'
+
+case "$1 $2 $3" in
+"ixp projects list")
+cat <<'EOF'
+{"Result":"Success","Data":{"Projects":[{"Id":"f1afa9ef-1c4d-4b70-9e02-6d3b8a5c7e11","Name":"my_invoices-f1afa9ef-ixp","Title":"My_Invoices","CreatedAt":"2026-06-11T08:42:19Z"}],"Total":1,"Offset":0,"Limit":50}}
+EOF
+exit 0
+;;
+"ixp projects get")
+cat <<'EOF'
+{"Result":"Success","Data":{"Name":"my_invoices-f1afa9ef-ixp","Title":"My_Invoices","Description":"Supplier invoices","CreatedTime":"2026-06-11T08:42:19Z"}}
+EOF
+exit 0
+;;
+"ixp projects get-taxonomy")
+    header_fields="$F_INVOICE_NUMBER,$F_INVOICE_DATE"
+    line_item_fields="$F_DESCRIPTION"
+    if [ -f "$ADDED" ]; then
+        line_item_fields="$line_item_fields,$F_TOTAL_AMOUNT_RECREATED"
+        [ -f "$DELETED" ] || header_fields="$header_fields,$F_TOTAL_AMOUNT"
+    else
+        header_fields="$header_fields,$F_TOTAL_AMOUNT"
+    fi
+    printf '{"Result":"Success","Data":{"status":"ready","dataset":{"entity_defs":[%s],"label_groups":[{"name":"default","label_defs":[{"name":"Invoice Header","id":"5f21c88ab90d4e17","instructions":"Header-level fields of the supplier invoice.","moon_form":[%s]},{"name":"Line Items","id":"7be409c2d15fa833","instructions":"One entry per line item row on the invoice.","moon_form":[%s]}]}]}}}\n' \
+        "$ENTITY_DEFS" "$header_fields" "$line_item_fields"
+    exit 0
+;;
+"ixp fields add")
+    case "$*" in *"Line Items"*) case "$*" in *"Total Amount"*) : > "$ADDED" ;; esac ;; esac
+    echo '{"Result":"Success"}'
+    exit 0
+;;
+"ixp fields delete")
+    case "$*" in *"Invoice Header"*) case "$*" in *"Total Amount"*) : > "$DELETED" ;; esac ;; esac
+    echo '{"Result":"Success"}'
+    exit 0
+;;
+esac
+
+echo "uip (mock): not connected to a tenant in this sandbox; offline smoke mock." >&2
+exit 1

--- a/tests/tasks/uipath-ixp/smoke/move_field_between_groups.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_field_between_groups.yaml
@@ -10,8 +10,11 @@ description: >
   BOTH groups), and `groups delete`/`groups add` (destroys every other field
   in the group).
 
-  Harness is unauthenticated; CLI calls fail with auth errors.
-  Grades command shape, not wire effect.
+  The overlaid uip mock serves the fixture taxonomy and succeeds on the two
+  `fields` mutations. Both are required for the graded shape to be reachable:
+  a failing `get-taxonomy` leaves nothing to carry into `fields add`, and a
+  failing `fields add` makes withholding the `fields delete` the correct call
+  (add-before-delete). Grades command shape, not wire effect.
 tags: [uipath-ixp, smoke, mode:build, lifecycle:execute]
 
 run_limits:
@@ -21,6 +24,7 @@ sandbox:
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}
+    - {type: template_dir, path: ../_shared/mock_template_taxonomy}
 
 initial_prompt: |
   In the IXP project my_invoices-f1afa9ef-ixp, the field "Total Amount"
@@ -28,9 +32,9 @@ initial_prompt: |
   items instead — move it into the existing "Line Items" group.
 
   Important:
-  - The `uip` CLI is available but is NOT connected to a live IXP tenant in
-    this environment. Commands will fail with auth errors — that is expected.
-    Run each command once and move on. Do NOT retry or attempt to login.
+  - The `uip` CLI in this environment is not connected to a live tenant;
+    some commands fail. Run each command once and move on. Do NOT retry or
+    attempt to login.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
@@ -42,11 +46,15 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # --type asserts the value, not just the flag: "Monetary Quantity" is only
+  # knowable from the taxonomy read, via the moon_form entry's field_type_id.
+  # --instructions stays presence-only — carrying them over is the graded
+  # behavior; rewording them is not a failure.
   - type: file_matches_regex
-    description: "Agent recreated \"Total Amount\" in the target group via `fields add` (with --type and --instructions carried over)"
+    description: "Agent recreated \"Total Amount\" in the target group via `fields add`, carrying over its type and instructions"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+fields\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--group\s+["']?Line Items)(?=.*--field\s+["']?Total Amount)(?=.*--type)(?=.*--instructions).*)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+fields\s+add\b(?=.*my_invoices-f1afa9ef-ixp)(?=.*--group\s+["']?Line Items)(?=.*--field\s+["']?Total Amount)(?=.*--type\s+["']?Monetary Quantity)(?=.*--instructions).*)[^\r\n]*$
     weight: 3.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
One of two grader fixes for the [2026-07-29 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-07-29_04-37-44) uipath-ixp failures (other: #2317). The `uipath-ixp` skill needs no change.

## The task was unwinnable by any agent (scored 0.54)

The base mock exits 1 on every invocation, which breaks this task two ways:

1. **The carried-over values are unobtainable.** `projects get-taxonomy` returns nothing, yet the criterion requires `fields add … --type … --instructions …` with the field's existing type and instructions.
2. **The graded `fields delete` is wrong to issue.** The skill teaches add-before-delete so a failed add leaves the field in place (`cli-reference.md`: "if the add fails, the field is still in its original group"). With `fields add` guaranteed to fail, withholding the delete is the documented correct behavior.

The agent said as much:

> Couldn't complete the move: the required taxonomy lookup failed because this sandbox is not connected to an IXP tenant. I did not guess the field's existing type or extraction instructions, so no add/delete operation was issued.

Added 2026-07-28 in #2288, so this was its first nightly — it has never passed.

## Fix

New `_shared/mock_template_taxonomy` overlay (same layering pattern as the existing `mock_template_ambiguous`, listed second) serving canned JSON for the reads and success for the two `fields` mutations. `get-taxonomy` is stateful, so an agent that re-reads to verify sees its own writes instead of stale state it would try to re-apply:

| After | `Invoice Header` | `Line Items` |
|-------|------------------|--------------|
| — | Total Amount | — |
| `fields add` | Total Amount | Total Amount (**new** `field_id`) |
| `fields delete` | — | Total Amount |

The intermediate both-groups state is what the real backend does between add and delete, and the new `field_id` is why a move drops the field's confirmed labels. State lives in dot-prefixed markers beside `calls.log`, so it stays out of graded globs and CI artifact uploads.

`--type` now asserts the value `Monetary Quantity` rather than flag presence — only knowable from the read, via the `moon_form` entry's `field_type_id`. That matches `_shared/fixtures/taxonomy.json`, where `Total Amount` is `Monetary Quantity`.

## Verification

✅ **Passing-run claim:** `Run skill smoke tests` on this PR — `skill-ixp-move-field-between-groups-smoke` **6/6 criteria, weighted score 1.000, SUCCESS** (claude-code / claude-sonnet-5, docker driver), pass rate 100% ([run](https://github.com/UiPath/skills/actions/runs/30433056181/job/90514470019)). The same task scored 0.54 on the 2026-07-29 nightly before this change.

Additional local verification:

- Executed the new mock under `sh` and graded the real `calls.log` it produces against all 6 criteria — all pass, including the 4 negative guards (confirmed they still bite by probing `groups add`).
- `get-taxonomy` emits valid JSON at all three states; type resolves through `field_type_id`; `field_id` matches no `entity_def` at every state.
- `mocks/uip` committed mode `755`, LF-clean, `sh -n` clean.
- `scripts/check-task-driver.py` and `scripts/check-cli-verbs.py` clean — 0 High, 0 Medium.
- The two-`template_dir` layering mechanism was already proven under codex in the same nightly: `skill-ixp-rename-ambiguous-entity-smoke` uses it and scored 1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNsX5UrVVqZfHUFhsCn6E
