### PR TITLE
fix(tests): make the update-prompts heredoc criterion quoting-agnostic

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -18,9 +18,9 @@ sandbox:
     - {type: template_dir, path: ../_shared/mock_template}
 
 initial_prompt: |
-  The InvoiceNumber field on IXP project `my_invoices-f1afa9ef-ixp` is
+  The `Invoice Number` field on IXP project `my_invoices-f1afa9ef-ixp` is
   scoring poorly. Validation shows the model is confusing the Purchase
-  Order (PO) number with the Invoice Number. Update the field instruction
+  Order (PO) number with the invoice number. Update the field instruction
   to clarify:
 
     "Extract the unique invoice identifier from the document header.
@@ -56,10 +56,14 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
+  # The name must be the field's exact taxonomy name — `update-prompts` matches
+  # by name and reports an unmatched one WITHOUT failing, so a reworded name is
+  # a silent no-op. `Invoice Number` is the name in _shared/fixtures/taxonomy.json
+  # and in the skill's own examples; keep the prompt and this pattern on it.
   - type: file_matches_regex
-    description: "CLI received the structured InvoiceNumber update with the requested instruction"
+    description: "CLI received the structured `Invoice Number` update with the requested instruction"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+fields\s+update-prompts\s+["']?my_invoices-f1afa9ef-ixp["']?\s+(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*\}\s*\])(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*"name"\s*:\s*"InvoiceNumber")(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*"instructions"\s*:\s*"[^"\r\n]*Extract the unique invoice identifier[^"\r\n]*Do NOT use the Purchase Order[^"\r\n]*")(?=[^\r\n]*--output\s+json(?:\s|$))[^\r\n]*)$
+      (?m)^(?:uip\s+ixp\s+fields\s+update-prompts\s+["']?my_invoices-f1afa9ef-ixp["']?\s+(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*\}\s*\])(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*"name"\s*:\s*"Invoice Number")(?=[^\r\n]*--updates\s+\[\s*\{[^}\r\n]*"instructions"\s*:\s*"[^"\r\n]*Extract the unique invoice identifier[^"\r\n]*Do NOT use the Purchase Order[^"\r\n]*")(?=[^\r\n]*--output\s+json(?:\s|$))[^\r\n]*)$
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -43,10 +43,15 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
+  # Quote runs are `(?:\\?["'])*`, not `["']?`: this criterion reads raw Bash
+  # text, and an agent harness that wraps commands in `/bin/bash -lc "…"`
+  # backslash-escapes the inner quotes, so `--updates "$(cat …)"` is recorded as
+  # `--updates \""'$(cat …)"`. Matching one bare optional quote passed under
+  # claude-code and failed under codex for the same correct command.
   - type: command_executed
     description: "Agent passed the heredoc file to `fields update-prompts --updates`"
     tool_name: "Bash"
-    command_pattern: 'uip\s+ixp\s+fields\s+update-prompts\s+["'']?my_invoices-f1afa9ef-ixp["'']?\s+.*--updates\s+["'']?\$\(cat\s+/tmp/ixp/my_invoices-f1afa9ef-ixp/prompts/[^\s]+\.json\)'
+    command_pattern: 'uip\s+ixp\s+fields\s+update-prompts\s+(?:\\?["''])*my_invoices-f1afa9ef-ixp(?:\\?["''])*\s+.*--updates\s+(?:\\?["''])*\$\(cat\s+/tmp/ixp/my_invoices-f1afa9ef-ixp/prompts/[^\s]+\.json\)'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0


### PR DESCRIPTION
One of two grader fixes for the [2026-07-29 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-07-29_04-37-44) uipath-ixp failures (other: #2316). The agent did the task correctly in both cases; the `uipath-ixp` skill needs no change.

Two independent brittle criteria, each of which passed under one agent harness and failed under the other.

## 1. Quoting — failed under codex, passed under claude-code

The `calls.log` criterion proving the fully expanded, correct payload reached the CLI passed. The criterion regexing raw Bash text did not:

- pattern wanted: `--updates ["']?$(cat …json)`
- codex emitted: `--updates \""'$(cat …json)"`

Codex wraps commands in `/bin/bash -lc "…"`, backslash-escaping the inner quotes. `["']?` allows one bare quote and no backslash, so the **same correct command** passed at score 1.0 under `claude-code` on [2026-07-20](https://coder-evalboard.uipath-dev.com/runs/2026-07-20_04-26-57) and failed under codex on 2026-07-29.

**Fix:** quote runs are now `(?:\\?["'])*`.

## 2. Field name — failed under claude-code, passed under codex

With fix 1 in place, CI surfaced the opposite failure: both `command_executed` criteria passed, but the `calls.log` criterion scored 0.00. It required `"name": "InvoiceNumber"`; the agent sent `"name": "Invoice Number"`.

**The agent was right.** `Invoice Number` is the field's name in `_shared/fixtures/taxonomy.json`, in every sibling ixp task, and in the `improve-prompts-guide` / `label-documents-guide` references — and the CI transcript shows the agent reading those two guides immediately before writing the payload. `InvoiceNumber` appears nowhere in the ixp suite except this task's own prompt and criterion.

Worse, the prompt contradicted itself:

```
The InvoiceNumber field on IXP project `my_invoices-f1afa9ef-ixp` is
scoring poorly. Validation shows the model is confusing the Purchase
Order (PO) number with the Invoice Number. …
```

Codex echoed the first spelling; claude-code resolved to the one the taxonomy actually uses. Whichever the criterion picked, one agent failed.

**Fix:** prompt and pattern both use `Invoice Number`, backticked in the prompt so neither agent reformats it. The pattern stays strict on the exact name — `update-prompts` matches by name and reports an unmatched one *without* failing the command, so a reworded name is a silent no-op worth catching.

## Verification

✅ **Passing-run claim:** `Run skill smoke tests` on this PR — `skill-ixp-update-prompts-heredoc-smoke` **3/3 criteria, weighted score 1.000, SUCCESS** (claude-code / claude-sonnet-5, docker driver), pass rate 100% ([run](https://github.com/UiPath/skills/actions/runs/30439505630/job/90535204730)). Scored 0.67 on the nightly under codex, and 0.67 on this PR's first CI attempt under claude-code before fix 2.

The passing run's `calls.log`, verbatim:

```
uip ixp fields update-prompts my_invoices-f1afa9ef-ixp --updates [   {"name": "Invoice Number", "instructions": "Extract the unique invoice identifier from the document header. Do NOT use the Purchase Order (PO) number, even if it is the most visually prominent number on the page."} ] --output json
```

Also verified locally, since only one harness can run per CI job — all three criteria were replayed against the **real recorded commands** from all three runs (codex nightly, claude-code 2026-07-20, claude-code CI):

- Criterion 3 matches all three JSON shapes agents actually produce: pretty-printed multi-line (newlines normalized to spaces by the mock), compact single-line, and the semi-compact form above.
- Negatives hold: name reworded to `InvoiceNumber`, missing `--output json`, instruction text not carried over, and `groups` instead of `fields` all correctly fail.
- `scripts/check-cli-verbs.py` clean — 0 High, 0 Medium.

## Note for reviewers

This task tripped the anti-pattern `.claude/rules/test-writing.md` ("grade the outcome, not the literal flag") and `mock_template/README.md` ("not regexes over agent-authored Bash text") already warn about. The stricter alternative is to **delete** the raw-Bash criterion — criteria 1 and 3 already prove the file was written and the right payload arrived; only the file→CLI linkage is lost. Happy to drop it if you prefer; I kept it because nothing else asserts that linkage. `grep` confirms this was the only `$(cat` pattern of its kind in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNsX5UrVVqZfHUFhsCn6E
