### PR TITLE
test(uipath-rpa): grade test-case tasks on artifacts, not report.json self-reports [PILOT-6606]

### DIFF
--- a/tests/tasks/uipath-rpa/coded_test_case.yaml
+++ b/tests/tasks/uipath-rpa/coded_test_case.yaml
@@ -50,20 +50,6 @@ initial_prompt: |
   - Update project.json so the test case shows up in fileInfoCollection
     with the correct testCaseType entry.
 
-  Write a `report.json` IMMEDIATELY after scaffolding the project (with
-  placeholder values) and update it as you complete each piece. Do not
-  leave it as the last step — previous runs got distracted by build
-  errors and never wrote it. Final shape:
-    {
-      "hooks_file": "CodedWorkflowHooks.cs",
-      "hooks_pattern": "partial_class",
-      "hooks_class_declaration": "<the class declaration line>",
-      "test_case_file": "TestLoginSuccess.cs",
-      "test_case_class": "TestLoginSuccess",
-      "base_class": "CodedWorkflow",
-      "assertions_used": ["<list of testing.Verify* methods used>"]
-    }
-
   Important:
   - The `uip` CLI is already available in the environment.
   - Use `--output json` on any uip commands you run.
@@ -92,13 +78,19 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
-    description: "Test case has [TestCase] attribute and uses CodedWorkflow"
+  # Regex rather than substring includes: a bare "CodedWorkflow" match also
+  # accepts `: CodedWorkflowHooks`, a using, or a comment — it does not prove
+  # inheritance. The pattern anchors on the class declaration itself.
+  - type: file_check
+    description: "Test case declares [TestCase] Execute and inherits CodedWorkflow"
     path: "LoginTests/TestLoginSuccess.cs"
-    includes:
-      - "[TestCase]"
-      - "CodedWorkflow"
-      - "void Execute"
+    patterns:
+      - pattern: '\[TestCase\]'
+        must_match: true
+      - pattern: 'class\s+TestLoginSuccess\s*:\s*CodedWorkflow\b'
+        must_match: true
+      - pattern: 'void\s+Execute'
+        must_match: true
     weight: 2.0
     pass_threshold: 1.0
 
@@ -117,26 +109,4 @@ success_criteria:
       - "TestLoginSuccess"
       - "testCaseType"
     weight: 1.5
-    pass_threshold: 1.0
-
-  - type: file_exists
-    description: "report.json was created"
-    path: "report.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: json_check
-    description: "report.json confirms partial-class hooks + CodedWorkflow base class"
-    path: "report.json"
-    assertions:
-      - expression: "hooks_pattern"
-        operator: equals
-        expected: "partial_class"
-      - expression: "hooks_class_declaration"
-        operator: contains
-        expected: "partial class CodedWorkflow"
-      - expression: "base_class"
-        operator: contains
-        expected: "CodedWorkflow"
-    weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-rpa/xaml_test_case.yaml
+++ b/tests/tasks/uipath-rpa/xaml_test_case.yaml
@@ -31,16 +31,8 @@ initial_prompt: |
   - Register the test case in `project.json` so it shows up in the test
     runner.
   - The generated test must validate cleanly:
-    `uip rpa validate --file-path LoginTests/TestLoginSuccess.xaml --project-dir LoginTests --output json`.
-
-  Write a `report.json` IMMEDIATELY after scaffolding the project (with
-  placeholder values) and update it as you complete each piece. Do not
-  leave it as the last step. Final shape:
-    {
-      "test_case_file": "TestLoginSuccess.xaml",
-      "verify_activity": "<class name of the Verify activity used, e.g. VerifyExpression>",
-      "validate_passed": true
-    }
+    `uip rpa validate --file-path TestLoginSuccess.xaml --project-dir LoginTests --output json`
+    (`--file-path` is relative to `--project-dir`).
 
   Important:
   - The `uip` CLI is already available in the environment.
@@ -106,18 +98,19 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "report.json was created"
-    path: "report.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: json_check
-    description: "report.json claims validate passed"
-    path: "report.json"
-    assertions:
-      - expression: "validate_passed"
-        operator: equals
-        expected: true
-    weight: 1.0
+  # Grades the validate OUTCOME, not the agent's claim about it: the
+  # command_executed check above only proves the command was typed (a run that
+  # failed on a bad --file-path and then succeeded on a retry still matches).
+  # `--file-path` resolves relative to `--project-dir`, hence the bare filename.
+  # coder_eval's `run_command` runs through subprocess(shell=True) → cmd.exe on
+  # Windows, /bin/sh on Linux; the Python wrapper resolves the project path via
+  # os.path.abspath and the `uip` shim via shutil.which (Windows `uip.cmd`
+  # PATHEXT resolution).
+  - type: run_command
+    description: "uip rpa validate exits 0 against the agent's test case"
+    command: |-
+      python3 -c "import subprocess, os, sys, shutil; uip = shutil.which('uip') or 'uip'; sys.exit(subprocess.call([uip, 'rpa', 'validate', '--file-path', 'TestLoginSuccess.xaml', '--project-dir', os.path.abspath('LoginTests'), '--output', 'json']))"
+    expected_exit_code: 0
+    timeout: 180
+    weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Issue

[PILOT-6606](https://uipath.atlassian.net/browse/PILOT-6606)

## Summary

- Delete the `report.json` artifact and its two criteria from `skill-rpa-xaml-test-case` and `skill-rpa-coded-test-case` — the only criteria failing in otherwise-clean nightly runs, and the only ones grading agent self-reports.
- Strengthen the surviving artifact checks so no assertion is lost: `file_check` anchored on `class TestLoginSuccess : CodedWorkflow` (coded), `run_command` re-running `uip rpa validate` gated on exit 0 (xaml).
- Fix the xaml prompt's validate example — `--file-path` is project-relative, so `--file-path LoginTests/TestLoginSuccess.xaml --project-dir LoginTests` duplicated the segment and the agent had to find the correct form by retrying.
- **Not** caused by Studio#29001 / [PILOT-6491](https://uipath.atlassian.net/browse/PILOT-6491); that fix is working in these runs. Evidence below.

## Why the tasks were failing

Both tasks scored 0.84 / 0.769 on 2026-07-29 with **every** artifact criterion green. The two `report.json` criteria were the entire deficit: the agent wrote `LoginTests/report.json`, while criteria paths resolve against the sandbox root.

The prompt said *"Write a `report.json` IMMEDIATELY after scaffolding the project"* — no location, and the only noun-phrase in the sentence is "the project". The 07-29 xaml transcript has the agent state the reading outright before the write: *"I'll place `report.json` directly in the new project."* It's a model-dependent coin flip on an ambiguity:

| Agent | Runs | `report.json` at sandbox root |
|---|---|---|
| claude-code (sonnet-4-6 / 5) | 4 | 4/4 |
| codex (gpt-5.6-terra) | 3 | 1/3 |

## Why removal rather than anchoring the path

Anchoring the path was the cheap fix, but `report.json` shouldn't be graded here at all:

- It is a **task-harness convention, not a UiPath artifact** — no `uip` command emits it. It exists to give `json_check` something to read and to act as an anti-distraction beacon.
- Grading it contradicts `.claude/rules/test-writing.md` — *"Grade behavior, not self-reports"*. A claim laundered through a file the agent wrote is still a claim.
- Neither task used it for anything else: no `pre_run`, `post_run`, or cleanup block references it. (Other tasks — the ixp suite — read their own `report.json` in teardown; those are untouched.)

## Why no assertion was lost

Each removed assertion was mapped to an artifact-based check before deletion.

### coded — `json_check` was redundant

| Removed assertion (agent's claim) | Already proven by |
|---|---|
| `hooks_pattern == "partial_class"` | `file_contains` on `CodedWorkflowHooks.cs` requiring `partial class CodedWorkflow` |
| `hooks_class_declaration` contains `partial class CodedWorkflow` | same check — byte-for-byte identical string |
| `base_class` contains `CodedWorkflow` | `file_contains` on `TestLoginSuccess.cs` |

The third was the weak link: a bare `"CodedWorkflow"` substring also matches `: CodedWorkflowHooks`, a `using`, or a comment — it never proved inheritance. Since the criterion nominally covering the base class was going away, that check is now a regex:

```yaml
- pattern: 'class\s+TestLoginSuccess\s*:\s*CodedWorkflow\b'
```

Net effect: strictly stronger than before, at the same weight.

### xaml — `validate_passed` had no twin, so it was replaced

`command_executed` only proves `uip rpa validate` was **typed**. In the 07-29 run the first invocation failed on the duplicated path and only the retry passed — the criterion still scored 2/1. So deleting the self-report without replacement would have left nothing tied to validation *succeeding*:

```yaml
- type: run_command
  description: "uip rpa validate exits 0 against the agent's test case"
  command: |-
    python3 -c "import subprocess, os, sys, shutil; uip = shutil.which('uip') or 'uip'; sys.exit(subprocess.call([uip, 'rpa', 'validate', '--file-path', 'TestLoginSuccess.xaml', '--project-dir', os.path.abspath('LoginTests'), '--output', 'json']))"
  expected_exit_code: 0
```

Modeled on the existing precedent at `uia_google_search.yaml:120` — `run_command` goes through `subprocess(shell=True)` (cmd.exe on Windows), so the wrapper resolves the `uip` shim via `shutil.which` for `uip.cmd` PATHEXT and the project dir via `os.path.abspath`. `command_executed` stays as the convention check; `run_command` grades the outcome.

## Ruling out Studio#29001

The hypothesis was that the `rpa-tool` `create-project` location fix caused these failures. It didn't:

- `skill-rpa-coded-test-case` failed **identically** (0.769, `report.json` in `LoginTests/`) on **2026-07-23** — four days before #29001 merged on 07-27.
- The fix is visibly working in the 07-29 runs: the project scaffolds into the sandbox and all project-file criteria pass. Compare the 07-22 xaml run at **0.08** with `LoginTests/` missing entirely — that is the symptom #29001 describes, and it's gone.
- Net for the xaml task: 0.08 → 0.84 thanks to #29001. What remained was this independent flake.

## Weights

| Task | Before | After |
|---|---|---|
| coded | 13.0 | 10.0 |
| xaml | 12.5 | 12.5 (2.0 `run_command` replaces two 1.0 self-reports) |

## Testing

- Both YAMLs parse (`npx js-yaml`).
- **Not yet run through `coder-eval`** — the new `run_command` is untested; its wrapper is copied from a working precedent in the same suite, but the `validate` flag combination hasn't been exercised under `subprocess`. Needs a passing run before merge, per `.claude/rules/test-writing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PILOT-6606]: https://uipath.atlassian.net/browse/PILOT-6606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PILOT-6491]: https://uipath.atlassian.net/browse/PILOT-6491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ