### PR TITLE
fix(tests): stage the project source the agents scenarios tell the agent to read

### DIFF
--- a/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
@@ -20,6 +20,8 @@ sandbox:
     - type: template_dir
       path: ../../../_shared/mock_template
     - type: template_dir
+      path: process
+    - type: template_dir
       path: data
   mock_path_dirs:
     - m

--- a/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
@@ -20,6 +20,8 @@ sandbox:
     - type: template_dir
       path: ../../../_shared/mock_template
     - type: template_dir
+      path: process
+    - type: template_dir
       path: data
   mock_path_dirs:
     - m

--- a/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
@@ -20,6 +20,8 @@ sandbox:
     - type: template_dir
       path: ../../../_shared/mock_template
     - type: template_dir
+      path: process
+    - type: template_dir
       path: data
   mock_path_dirs:
     - m


### PR DESCRIPTION
## Problem

The three `products/agents` scenarios each ship a `process/<X>Solution` tree, state *"The local source is under `process/<X>Solution`"* in `initial_prompt`, and repeat it as a simulation constraint:

> "If the agent asks where the source code is, say it is under `process/<X>Solution`."

None of them staged `process/` into the sandbox. The simulated user was asserting a directory that was never there.

This is not a regression: `process/` and each `task.yaml` were added in the **same commit** (#1976), and `path: process` has never been present in any revision of those files.

## Consequence

The agent hunts the host filesystem for the directory it was promised. In a local run, `context-grounding-index-not-found` spent **356s of its 466s** of command time on:

| Duration | Command |
|---|---|
| 121s | `grep -rlF "support-kb-prod" /d/Repos` |
| 116s | `find /c/Users/<user> -iname "SupportSolution"` |
| 79s | `find /c /d -maxdepth 8 -iname "SupportSolution" -type d` |
| 20s + 20s | `Glob **/SupportSolution/**` on `C:\` and `D:\` |

Total task time was **1024s**, against ~226–318s for the correctly-staged orchestrator scenarios in the same batch. `input-schema-validation-failure` did the same thing at smaller scale (`find / -maxdepth 6 -iname "*IntakeSolution*"`).

Beyond the wasted time, all three were diagnosing **without the source they were told to inspect**, and all three scored below the correctly-staged peers (0.85–0.925 vs 1.00).

## Change

Adds the `process` template_dir to all three, positioned between `_shared/mock_template` and `data` to match `TASK_YAML_TEMPLATE` in `generate_scenario.py`:

```yaml
    - type: template_dir
      path: process

No simulation changes are needed — the existing constraints already claim the source is present, so staging makes them true.

Verification

Re-run with sources staged:

┌─────────────────────────────────┬─────────────┬─────────────┐
│              Task               │   Before    │    After    │
├─────────────────────────────────┼─────────────┼─────────────┤
│ input-schema-validation-failure │ 333s, 0.925 │ 181s, 0.925 │
└─────────────────────────────────┴─────────────┴─────────────┘

Duration roughly halved with the score unchanged, consistent with the filesystem scanning disappearing. The other two are still running; I'll add their numbers as a comment.