### PR TITLE
fix: close four gaps in the repo's own guard rails

### DIFF
--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -580,8 +580,9 @@ jobs:
         if: always()
         env:
           PASS_RATE_THRESHOLD: "0.95"
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
         run: |
-          if [ "${{ steps.smoke.outcome }}" = "cancelled" ]; then
+          if [ "$SMOKE_OUTCOME" = "cancelled" ]; then
             echo "::error::Smoke step cancelled (timeout) — failing without rate check"
             exit 1
           fi
@@ -593,6 +594,17 @@ jobs:
           passed = sum(1 for d in results if d.get('final_status') == 'SUCCESS')
           n = len(results)
           if n == 0:
+              # Zero results is legitimate only when the run itself succeeded and
+              # had nothing smoke-tagged to do. The run step is
+              # `continue-on-error`, so a crash before any task.json is written
+              # (bad glob, config/schema error, auth bootstrap, feed outage) would
+              # otherwise land here and report this REQUIRED check green with no
+              # smoke coverage at all. smoke-rpa-skills.yml guards the same way.
+              if os.environ.get('SMOKE_OUTCOME') != 'success':
+                  print('::error::Smoke step outcome was '
+                        f"'{os.environ.get('SMOKE_OUTCOME')}' and it produced no results "
+                        '— nothing to gate, so failing instead of passing vacuously')
+                  sys.exit(1)
               print('No smoke-tagged tasks matched — skipping rate check')
               sys.exit(0)
           rate = passed / n

--- a/scripts/check-task-driver.py
+++ b/scripts/check-task-driver.py
@@ -67,7 +67,7 @@ def _rel(path: Path) -> str:
 
 def _driver_line_number(path: Path) -> int:
     """1-indexed line of the offending `driver: tempdir` (0 if not found textually)."""
-    for n, line in enumerate(path.read_text(errors="ignore").splitlines(), start=1):
+    for n, line in enumerate(path.read_text(encoding="utf-8", errors="ignore").splitlines(), start=1):
         if _DRIVER_LINE.match(line):
             return n
     return 0
@@ -79,8 +79,8 @@ def main(argv: list[str]) -> int:
 
     for path in _iter_task_yamls(argv):
         try:
-            doc = yaml.safe_load(path.read_text())
-        except yaml.YAMLError:
+            doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (yaml.YAMLError, UnicodeDecodeError):
             # Malformed YAML is another gate's problem; don't mask it as a pass
             # but don't crash this check either.
             continue

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
@@ -100,7 +100,7 @@ description: >
   runs the uipath-troubleshoot skill against a uip CLI mock whose
   responses are the verbatim sub-agent outputs from the real session.
   Success = the agent reaches the same root cause as RESOLUTION.md.
-tags: [uipath-troubleshoot, {domain_tags}e2e, faithful-replay]
+tags: [uipath-troubleshoot, {domain_tags}e2e, mode:diagnose, faithful-replay]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
+++ b/tests/tasks/uipath-troubleshoot/_shared/scripts/generate_scenario.py
@@ -112,7 +112,6 @@ run_limits:
   turn_timeout: 1800
 
 sandbox:
-  driver: tempdir
   python: {{}}
   template_sources:
     - type: template_dir


### PR DESCRIPTION
## Why

Four independent pre-existing defects in the repo's own guard rails, each found while working nearby. None is caused by the others; they are batched because all four are small and all four make a check quieter than it should be.

## 1. `fix(ci)`: the smoke gate could report success having run nothing

`smoke-skills.yml` runs `coder-eval` with `continue-on-error: true`, so the run step never fails the job on its own; the pass-rate step is the gate. That step treats zero results as "nothing smoke-tagged matched" and exits 0 - which is correct when the run genuinely had nothing to do, but indistinguishable from a run that crashed before writing any `task.json` (bad glob expansion, config/schema error, auth bootstrap failure, feed outage while installing image deps). In that case a **required** check goes green with no smoke coverage at all.

Now zero results is only acceptable when the run step itself succeeded. `smoke-rpa-skills.yml:439` already guards this way (`::error::No task.json files found - nothing to gate`); this brings the Linux gate in line.

Verified by extracting the gate's Python and driving it through every case:

| Run outcome | Results | Before | After |
|---|---|---|---|
| `failure` | none | **green** | **red** - `Smoke step outcome was 'failure' and it produced no results` |
| `success` | none | green | green - `No smoke-tagged tasks matched` |
| `success` | 10/10 pass | green | green - `Pass rate: 100.0%` |
| `success` | 9/10 pass | red | red - `Pass rate 90.0% < threshold 95%` |

`steps.smoke.outcome` also moves out of the `run:` body into `env:`, per the repo's own CI convention of not interpolating contexts directly into shell.

Residual, deliberately not changed: a run that fails *after* writing results is still graded on those results. That is the existing intent of `continue-on-error` plus a rate threshold, and changing it is a separate policy decision.

## 2. `fix(scripts)`: `check-task-driver.py` crashed on Windows

`read_text()` with no encoding, so under a cp1252 console it died with `UnicodeDecodeError: 'charmap' codec can't decode byte 0x90` against the real tree - the check was simply unrunnable locally on Windows (CI is unaffected; Linux defaults to UTF-8). Now reads UTF-8 explicitly and tolerates a decode error the same way it already tolerated malformed YAML.

## 3. `fix(troubleshoot)`: the scenario generator pinned a forbidden sandbox driver

`TASK_YAML_TEMPLATE` emitted `sandbox.driver: tempdir`, which `scripts/check-task-driver.py` blocks for task YAMLs - a pin opts the task out of the docker image and onto a host without the tool plugins. That gate scans `tests/tasks/**.yaml` only, so a pin embedded in a `.py` string was invisible to it, and every newly generated scenario would have carried a violation of an existing required check until someone noticed. Completes #2210, which stripped the pins from the tasks but not from the template that produces new ones.

Rendered template now yields `sandbox: [python, template_sources, mock_path_dirs]`.

## 4. `fix(troubleshoot)`: the scenario generator emitted no `mode:*` tag

`.claude/rules/test-writing.md` requires `skill` + `tier` + `mode:*` on every task, and `mode:*` is what `--tags mode:diagnose` selects on - a task missing it is silently absent from those runs. The generator emitted `tags: [uipath-troubleshoot, {domain_tags}e2e, faithful-replay]` and never added one. All 297 committed scenarios carry `mode:diagnose` only because a human added it by hand each time.

Rendered template now yields `['uipath-troubleshoot', 'rpa', 'e2e', 'mode:diagnose', 'faithful-replay']`.

## Verification

```
$ python3 scripts/check-task-driver.py tests/tasks     # previously crashed on Windows
OK - no task pins `sandbox.driver: tempdir`.
```

Template rendered and parsed to confirm both generator fixes; smoke-gate logic table above; `smoke-skills.yml` re-validated as YAML.
