### PR TITLE
fix(uipath-rpa): fix Windows backgrounding footgun in Session Pre-warm

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -171,6 +171,8 @@ First heavy `uip rpa` call pays a ~22s Studio host cold-start (shared across `va
 uip rpa activities find --query log --output json > /dev/null 2>&1 &
 ```
 
+On Windows PowerShell, `&` doesn't background — use `Start-Process powershell.exe -ArgumentList ...` (not `pwsh`). Never `Start-Process -FilePath "uip"` (or any `.ps1`): Windows opens it in Notepad, not PowerShell.
+
 **Skip** when 0 or 1 heavy `uip rpa` calls are expected (read-only Q&A, single-file inspection) — the warm-up doesn't reclaim its cost.
 
 ## Critical Rules


### PR DESCRIPTION
## What
Add a one-line Windows note to the `uipath-rpa` skill's Session Pre-warm section.

## Why
The warm-up example uses bash `&`. On Windows PowerShell `&` isn't background syntax, and an agent that reached for `Start-Process -FilePath "uip"` opened the `uip.ps1` wrapper in Notepad on-screen mid-session (`.ps1` default handler is a text editor, not PowerShell). The note points Windows at `Start-Process powershell.exe` and flags the `Start-Process "uip"`/`.ps1` → Notepad trap.

## Scope
Docs only — one file, one added line. No frontmatter/description, CODEOWNERS, or status change; no test (optional-optimization guidance prose).

---
_Generated by [Claude Code](https://claude.ai/code/session_01QCGq6EEmf4rJx9p6VYUF2A)_