### PR TITLE
fix(uipath-api-workflow): stop grading tasks on batch-hostile command counts

### DIFF
--- a/.claude/commands/lint-task.md
+++ b/.claude/commands/lint-task.md
@@ -48,7 +48,7 @@ For each target task file:
 
 ## Phase 3 — Apply the Rubric
 
-Evaluate the task against seven axes. Each axis can produce zero or more issues, each tagged with a severity. When raising an issue, refer to the axis by its human-readable title (e.g. "Self-report anti-pattern", "Prompt over-specification") — do not use letter labels.
+Evaluate the task against the axes below. Each axis can produce zero or more issues, each tagged with a severity. When raising an issue, refer to the axis by its human-readable title (e.g. "Self-report anti-pattern", "Prompt over-specification") — do not use letter labels.
 
 ### Self-report anti-pattern
 
@@ -58,6 +58,21 @@ Evaluate the task against seven axes. Each axis can produce zero or more issues,
 2. One or more `success_criteria` entries (`file_contains`, `file_check`, `json_check`, `file_matches_regex`) reads that same file as their evidence.
 
 **Why it's broken:** the test should check what the agent *did* (commands run, artifacts produced) using deterministic criteria, not what the agent *claims* it did in a self-written summary. The agent grades its own homework, the result is hallucination-prone, and the deterministic criteria coder-eval was built for are bypassed.
+
+### Batch-hostile command counting
+
+Inspect every `command_executed` criterion with `min_count: 2` or higher.
+
+`min_count` counts matching **tool calls**, not command occurrences — the regex is applied once per tool call and yields at most one match per call. An agent that batches N invocations into a single `bash -lc "cmd1; cmd2; …"` call scores 1, not N. Batching is normal, correct agent behavior (some models do it by default), so these criteria produce false negatives on agents that did the work correctly.
+
+**Raise an issue for each `command_executed` criterion with `min_count >= 2` and `pass_threshold >= 1.0`** (i.e. gating):
+
+- **Critical** — `min_count >= 4`, or the task has **no** behavioral criteria at all (`file_exists` / `file_contains` / `json_check` / `run_command` / `file_check`), so the counter is the only evidence and there is no way for a batching agent to recover the score
+- **High** — `min_count` of 2–3 and the task does have behavioral criteria covering the same operations (the counter is redundant *and* harmful)
+
+**Fix to recommend:** gate on `min_count: 1` (proves the command was used), prove the N operations with one behavioral criterion per expected outcome, and if the "one call per item" shape is still worth recording, re-add the `min_count: N` check as advisory (`weight: 0`, `pass_threshold: 0`). Point to `tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml` as the reference pattern.
+
+Do **not** raise this for criteria already advisory (`weight: 0` / `pass_threshold: 0`) — that is the recommended shape.
 
 ### Prompt over-specification
 

--- a/.claude/rules/test-writing.md
+++ b/.claude/rules/test-writing.md
@@ -55,6 +55,8 @@ Weight: `1.0` supporting · `1.5` core command/artifact · `2.0` artifact conten
 
 When criteria parse CLI output, steer the prompt toward `--output json`, but grade the **outcome** (the parsed value, via `run_command` / `file_check`), NOT the literal flag. Never add a gating `command_executed` check on `(uip|\$UIP)\s+.*--output\s+json`: the flag is outcome-invisible (often the CLI default), so gating on it docks agents that reach the same result without typing it. To record convention adherence, use an advisory check (`pass_threshold: 0`).
 
+Never gate on `command_executed` with `min_count: 2+` to mean "did this N times". `min_count` counts matching **tool calls**, not command occurrences — the regex yields at most one match per call, so an agent that batches N invocations into one `bash -lc "cmd1; cmd2; …"` scores 1/N and fails despite correct behavior. Gate `min_count: 1` (the command was used), prove the N operations with behavioral criteria (one `file_exists`/`json_check`/`run_command` per expected outcome), and make any `min_count: N` shape check advisory (`weight: 0`, `pass_threshold: 0`). See tests/README.md §`command_executed`.
+
 ## Prompts
 
 Minimal. State the goal and the success bar ("not complete until `uip ... validate` passes"). Do not enumerate CLI flags — the skill teaches those.
@@ -62,6 +64,8 @@ Minimal. State the goal and the success bar ("not complete until `uip ... valida
 ## Anti-patterns
 
 - Pinning `@uipath/cli` in `sandbox.node.env_packages` (see Sandbox Configuration above)
+- Gating a `command_executed` criterion on `min_count: 2+` (counts tool calls, not occurrences — batching agents fail; see Success Criteria above)
+- Grading a multi-step task *only* on `command_executed` counters with no behavioral criterion proving the outcome
 - Copying the full `agent:` block instead of inheriting
 - Tagging `connector:slack` / `resource:rpa` — `connector` and `resource` are flat boolean markers; the specific value is in the path/`task_id`/body
 - Inventing `feature:` leaf names that duplicate the file path

--- a/tests/README.md
+++ b/tests/README.md
@@ -384,10 +384,32 @@ Verify the agent ran a specific CLI command (matched by regex). From `init_valid
   description: "Agent created a solution with uip solution new"
   tool_name: "Bash"
   command_pattern: 'uip\s+solution\s+new'
-  min_count: 1          # minimum times the command must appear
+  min_count: 1          # minimum number of matching TOOL CALLS (see warning)
   weight: 1.5           # scoring weight
   pass_threshold: 1.0   # fraction of min_count required to pass
 ```
+
+> **`min_count` counts matching tool calls, not command occurrences.** The regex
+> is applied once per tool call and yields at most one match per call. An agent
+> that batches N invocations into a single `bash -lc "cmd1; cmd2; …"` call scores
+> **1**, not N — even though the shell ran the command N times.
+
+Consequence: `min_count: N` gating a criterion requires the agent to make N
+*separate* tool calls. Batching is normal, correct agent behavior (some models do
+it by default), so a high `min_count` reliably produces false negatives.
+
+Do NOT gate on `min_count: 2+` to mean "did this N times". Instead:
+
+1. Gate on `min_count: 1` — proves the command was used at all.
+2. Prove the N operations with **behavioral** criteria (`file_exists`,
+   `file_contains`, `json_check`, `run_command`) — one per expected outcome.
+   These cannot be satisfied without the work actually happening, and they are
+   indifferent to how the agent packaged its shell calls.
+3. If the "once per item" shape is still worth recording, add the `min_count: N`
+   check as advisory (`weight: 0`, `pass_threshold: 0`) so it never docks score.
+
+See `tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml` for
+this pattern applied.
 
 ### `file_exists`
 

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_attachments/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_attachments/testmanager_attachments.yaml
@@ -52,13 +52,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 4 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 4 stub
+  # commands into one Bash call scores 1/4 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 4 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each attachment activity (4) with a real connection id"
+    description: "Stubbed attachment activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 4 attachment activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 4 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (4) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 4
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_crud_grounded/testmanager_crud_grounded.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_crud_grounded/testmanager_crud_grounded.yaml
@@ -51,13 +51,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 2 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 2 stub
+  # commands into one Bash call scores 1/2 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 2 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed connector activities with a connection id (create + get)"
+    description: "Stubbed create + get activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 2 create + get activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 2 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (2) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 2
-    weight: 1.5
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_execution_results/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_execution_results/testmanager_execution_results.yaml
@@ -58,13 +58,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 9 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 9 stub
+  # commands into one Bash call scores 1/9 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 9 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each execution/results activity (9) with a real connection id"
+    description: "Stubbed execution/results activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 9 execution/results activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 9 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (9) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 9
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_generic_records/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_generic_records/testmanager_generic_records.yaml
@@ -53,13 +53,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 5 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 5 stub
+  # commands into one Bash call scores 1/5 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 5 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each generic record activity (5) with a real connection id"
+    description: "Stubbed generic record activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 5 generic record activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 5 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (5) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 5
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
@@ -57,13 +57,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 6 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 6 stub
+  # commands into one Bash call scores 1/6 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 6 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each Requirement activity (6) with a real connection id (`registry stub ... --connection-id`)"
+    description: "Stubbed Requirement activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 6 Requirement activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 6 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (6) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 6
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow (`uip api-workflow validate`)"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
@@ -55,13 +55,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 5 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 5 stub
+  # commands into one Bash call scores 1/5 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 5 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each TestCase activity (5) with a real connection id"
+    description: "Stubbed TestCase activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 5 TestCase activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 5 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (5) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 5
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/connector/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-api-workflow/connector/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
@@ -56,13 +56,36 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # Gate on "the stub flow ran with a real connection", NOT on 7 separate calls:
+  # min_count counts matching TOOL CALLS, so an agent that batches its 7 stub
+  # commands into one Bash call scores 1/7 and fails despite correct work. The
+  # per-activity count is graded behaviorally below, which is strictly stronger --
+  # invoking stub 7 times proves nothing if the output was never wired in.
   - type: command_executed
-    description: "Stubbed each TestSet activity (7) with a real connection id"
+    description: "Stubbed TestSet activities via the registry with a real connection id"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Behavioral: workflow wires all 7 TestSet activities as IntSvc connector calls"
+    command: 'WF=$(find . -name Workflow.json -not -path "./Workflow.json" -not -path "*/node_modules/*" | head -1); test -n "$WF" && [ "$(grep -o ''"call"[[:space:]]*:[[:space:]]*"UiPath.IntSvc"'' "$WF" | wc -l)" -ge 7 ]'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the one-stub-call-per-activity convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one stub invocation per activity (7) (advisory, batching not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+registry\s+stub[\s\S]+?--connection-id'
     min_count: 7
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: command_executed
     description: "Validated the workflow"

--- a/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
+++ b/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
@@ -31,13 +31,28 @@ initial_prompt: |
   Do NOT ask for approval or confirmation.
 
 success_criteria:
+  # Gate on "the runner was used at all". Do NOT gate on min_count: 2 — the
+  # checker counts matching TOOL CALLS, not command occurrences, so an agent
+  # that batches both runs into one Bash call scores 1/2 and fails despite
+  # correct behavior. Per-input evidence is carried by the file_exists +
+  # run_command criteria below, which cannot be satisfied without both runs.
   - type: command_executed
-    description: "Agent executed the workflow with the local runner, once per input (the operate action)"
+    description: "Agent executed the workflow with the local runner (the operate action)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # Advisory: records the "one invocation per input" convention without docking
+  # agents that batch. Weight 0 so it never moves the score.
+  - type: command_executed
+    description: "Convention: one runner invocation per input (advisory, batching is not penalized)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+api-workflow\s+run'
     min_count: 2
-    weight: 2.0
-    pass_threshold: 1.0
+    weight: 0
+    pass_threshold: 0
 
   - type: file_exists
     description: "Agent captured the score-85 run output (proves it ran, did not just report)"
@@ -51,17 +66,22 @@ success_criteria:
     weight: 0.5
     pass_threshold: 1.0
 
+  # Assert the runner's own envelope (Code: WorkflowRun) alongside the grade, not
+  # just the grade substring. "PASS"/"FAIL" are stated in the initial_prompt, so a
+  # bare grade grep is satisfiable by transcription; the envelope is not — it only
+  # appears in real `api-workflow run` output. Key is matched case-insensitively
+  # because the runner title-cases the workflow's `grade` output to `Grade`.
   - type: run_command
-    description: "Behavioral: the captured score-85 run output grades PASS"
-    command: 'grep -q ''"PASS"'' run_85.json'
+    description: "Behavioral: the captured score-85 run output is real runner output grading PASS"
+    command: 'grep -q ''"WorkflowRun"'' run_85.json && grep -qi ''"grade"[[:space:]]*:[[:space:]]*"PASS"'' run_85.json'
     timeout: 10
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Behavioral: the captured score-40 run output grades FAIL"
-    command: 'grep -q ''"FAIL"'' run_40.json'
+    description: "Behavioral: the captured score-40 run output is real runner output grading FAIL"
+    command: 'grep -q ''"WorkflowRun"'' run_40.json && grep -qi ''"grade"[[:space:]]*:[[:space:]]*"FAIL"'' run_40.json'
     timeout: 10
     expected_exit_code: 0
     weight: 1.5
@@ -78,5 +98,9 @@ success_criteria:
     pass_threshold: 0
 
 run_limits:
-  expected_turns: 6
+  # 6 was understated: a clean passing run (claude-code / claude-sonnet-5, score
+  # 1.000) used 8 visible turns and tripped the advisory overage warning. 10
+  # leaves headroom over that observed baseline while staying well under the
+  # max_turns hard cap. Advisory only — expected_turns never affects the score.
+  expected_turns: 10
   max_turns: 20


### PR DESCRIPTION
## Problem

`command_executed` counts matching **tool calls**, not command occurrences. From `coder_eval/criteria/command_executed.py` (0.8.10, the pinned version):

```python
for cmd in all_commands:                                     # iterates TOOL CALLS
    if pattern is not None and not pattern.search(cmd_text):  # boolean gate, not findall
        continue
    matching.append(label)                                    # appends ONCE per call
...
match_count = len(matching_commands)
score = 1.0 if min_count == 0 else min(1.0, match_count / criterion.min_count)
```

So an agent that batches N invocations into one `bash -lc "cmd1; cmd2; …"` scores **1/N**. Batching is normal, correct agent behavior — some models do it by default.

This produced a false negative on `skill-api-workflow-operate-run-execute`. Codex ran both inputs correctly in a single batched Bash call, **every behavioral criterion passed**, and the task still failed:

> `Matched 1/2 required commands` → `score=0.5` → weighted **0.833**, FAILURE

`1/2 = 0.5` is exactly what the formula above predicts, and exactly what the run's `review.json` recorded.

## Fix

Across the 8 api-workflow tasks, each gating counter becomes three criteria:

| | criterion | weight |
|---|---|---|
| gate | the command was used at all (`min_count: 1`) | 1.5 |
| **behavioral** | one check per expected outcome | 2.0 |
| advisory | the `min_count: N` shape check | **0** |

The harness recognises the advisory shape natively — it reports `Informational (weight=0, not gated)`.

For the 7 testmanager tasks the behavioral check counts IntSvc activities actually wired into `Workflow.json`. This is **strictly stronger than what it replaces**: invoking `registry stub` N times proves nothing if the output was never pasted in. The old counter could be satisfied by N discarded stub calls; the new one cannot.

### Also: closed a transcription hole

`run_execute`'s grade checks were bare `grep '"PASS"'` / `'"FAIL"'` — but those literals appear in the `initial_prompt`, so they were satisfiable by `echo`. Verified:

```
OLD: run_85 ACCEPTED  <-- fooled by echo '{"grade":"PASS"}'
NEW: run_85 REJECTED
```

They now assert the runner's `"WorkflowRun"` envelope alongside the grade. The envelope only appears in real `api-workflow run` output and is never revealed to the agent.

## Verification

Ran locally with coder-eval **0.8.10** (matching `tests/.coder-eval-version`), `experiments/default.yaml`, claude-code / claude-sonnet-5:

```
Task finished: status=SUCCESS  score=1.000  7/7 criteria passed
```

Two consecutive clean runs (1.000 both). Replaying the original failure's batched single-call shape against the new criteria also scores **1.000** (was 0.833).

Negative tests on the behavioral criteria, run verbatim from the YAML against real CLI output:

| scenario | verdict |
|---|---|
| honest real CLI output | PASS |
| fabricated (`echo`) | **REJECTED** 0/2 |
| swapped outputs | **REJECTED** 0/2 |
| ran once, copied to both | **REJECTED** 1/2 |
| empty files | **REJECTED** 0/2 |

Counting logic tested on both pretty-printed and compact JSON — `grep -c` returns 1 on single-line JSON, so this uses `grep -o | wc -l`.

Gates run locally: `check-task-driver.py` PASS, `check-cli-verbs.py` PASS ("no CLI-verb issues").

`expected_turns` on `run_execute` bumped 6 → 10: a clean passing run used 8 visible turns and tripped the advisory overage warning. It's report-only and never affects score.

### Caveats

- **The local run does not reproduce the bug.** claude-sonnet-5 made two separate Bash calls, so it would have passed under the old criteria too. It proves no regression; the fix itself is evidenced by the CI artifact plus the source above. Reproducing the batching needs codex (`gpt-5.6-terra` via internal `CODEX_BASE_URL`), which isn't available locally.
- **The 7 testmanager tasks are `skip: true`** (tenant-gated; Test Manager isn't in the local registry). Their `≥ N` thresholds are fixture-validated against the documented stub shape, not a live run. The assumption is one IntSvc activity per operation — worth confirming on the first unskipped run.
- **No CI job executes these tasks.** `smoke-skills.yml` runs `--tags smoke`; `run_execute` is `integration` and the rest are `e2e` + skipped. Green CI is not evidence here.

## Not in scope

**49 gating `min_count: 2+` criteria remain in 31 files** across other skills — uipath-platform worst (32, including a `min_count: 10` and two `min_count: 9`), plus coded-apps, insights, solution, agents, maestro-flow, tasks, review, test, admin, maestro-case. **14 of those files have no behavioral criteria at all**, so a batching agent has no way to recover the score. Each needs per-task authoring rather than a mechanical edit; happy to follow up per skill.

## Note for reviewers

`tests/README.md`, `.claude/rules/test-writing.md` and `.claude/commands/lint-task.md` fall to the repo-wide default owner, so this pulls in reviewers beyond uipath-api-workflow. The doc wording (`min_count` documented as "times the command must **appear**") is the root cause of all 56 instances, which is why the correction ships with the fix rather than separately — both docs cite `run_execute.yaml` as the reference pattern. Happy to split if you'd rather review them apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
