### PR TITLE
fix(tests): publish-lifecycle — publish before retraining so two versions exist

### DIFF
--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -6,11 +6,14 @@ description: >
   the published flag / tag pointer actually moved (wire-effect), not just command
   shape.
 
-  Version numbers come from `list-models`, never from training order: what a
-  retrain numbers a version is not guaranteed, and publishing a guessed number
-  returns "model version not found". An agent that guesses and then stops is
-  behaving correctly, so the prompt makes the read explicit rather than leaving
-  the numbering to be inferred.
+  Ordering matters and the prompt pins it: the first version is published BEFORE
+  the retrain that produces the second. Publishing pins a version; an unpublished
+  one is discarded when the next trains, leaving a single version and no distinct
+  V_OLD to tag or move. Measured over 10 live runs — every run that published
+  before its final retrain passed, every run that retrained first found one
+  version left and could not complete the sequence.
+
+  Version numbers also come from `list-models`, never from training order.
 tags: [uipath-ixp, integration, mode:operate]
 
 run_limits:
@@ -35,8 +38,13 @@ initial_prompt: |
   signed into (check I'm logged in; don't re-authenticate): start a project from
   the files in `./fixtures/` (give it a unique title
   `codereval-integ-publish-<random-suffix>` so concurrent runs don't collide) — import the taxonomy, upload one of the invoices —
-  and let it train. I want two trained versions to tag, so once the first has
-  trained, tweak the "Total Amount" field's instruction to retrain a second.
+  and let it train.
+
+  Once that first version has trained, put it on staging right away — before you
+  retrain. An unpublished version is discarded when the next one trains, so
+  publishing it is what keeps two versions around to tag. Then tweak the
+  "Total Amount" field's instruction to retrain a second version.
+
   Work only on the project you create; other runs share this tenant, so never
   list, read, or modify any other project.
 
@@ -46,14 +54,14 @@ initial_prompt: |
   only once training has completed; if it's still training after 5 checks, stop
   and report rather than waiting longer.
 
-  Take the two version numbers you tag from `list-models` — read them off its
-  output rather than assuming what a retrain numbered them. If a publish reports
-  the version was not found, re-read `list-models` and use the numbers it
-  reports; don't stop on the first rejection.
+  Take every version number you use from `list-models` — read it off that output
+  rather than assuming what a retrain numbered it. If the two versions you need
+  are not both there, stop and report; do not tag one version twice to finish the
+  sequence.
 
   Then, saving the model list after each step so I can see the state move
-  (call the older of the two versions V_OLD and the newer V_NEW):
-  - Put V_OLD on staging and V_NEW on live → save to `models_tagged.json`.
+  (V_OLD = the version you put on staging, V_NEW = the one trained after it):
+  - Put V_NEW on live → save to `models_tagged.json`.
   - Move the live tag over to V_OLD → save to `models_after_move.json`.
   - Take the tags off V_OLD → save to `models_after_untag.json`.
   - Unpublish V_NEW → save to `models_after_unpublish.json`.

--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -5,6 +5,12 @@ description: >
   staging/live, moving a tag to another version, unpublish, and untag — asserting
   the published flag / tag pointer actually moved (wire-effect), not just command
   shape.
+
+  Version numbers come from `list-models`, never from training order: what a
+  retrain numbers a version is not guaranteed, and publishing a guessed number
+  returns "model version not found". An agent that guesses and then stops is
+  behaving correctly, so the prompt makes the read explicit rather than leaving
+  the numbering to be inferred.
 tags: [uipath-ixp, integration, mode:operate]
 
 run_limits:
@@ -40,22 +46,31 @@ initial_prompt: |
   only once training has completed; if it's still training after 5 checks, stop
   and report rather than waiting longer.
 
-  Then, saving the model list after each step so I can see the state move:
-  - Put the first trained version on staging and the second on live → save to
-    `models_tagged.json`.
-  - Move the live tag over to the first version → save to `models_after_move.json`.
-  - Take the tags off the first version → save to `models_after_untag.json`.
-  - Unpublish the second version → save to `models_after_unpublish.json`.
+  Take the two version numbers you tag from `list-models` — read them off its
+  output rather than assuming what a retrain numbered them. If a publish reports
+  the version was not found, re-read `list-models` and use the numbers it
+  reports; don't stop on the first rejection.
+
+  Then, saving the model list after each step so I can see the state move
+  (call the older of the two versions V_OLD and the newer V_NEW):
+  - Put V_OLD on staging and V_NEW on live → save to `models_tagged.json`.
+  - Move the live tag over to V_OLD → save to `models_after_move.json`.
+  - Take the tags off V_OLD → save to `models_after_untag.json`.
+  - Unpublish V_NEW → save to `models_after_unpublish.json`.
 
   Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
 
 success_criteria:
+  # Shape only — the log records the invocation whether or not the server
+  # accepted it, so a rejected `publish` still matches here. The wire effect is
+  # owned by check_tags.py below; keep this at supporting weight so a run that
+  # only *attempted* the tagging cannot bank most of the score.
   - type: file_matches_regex
-    description: "Published with a tag (staging/live)"
+    description: "Issued two tagged publishes (staging/live) — command shape"
     path: "mocks/calls.log"
     pattern: >-
       (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+projects\s+publish\b.*--tag\s+(live|staging))[^\r\n]*$){2}
-    weight: 2.0
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_matches_regex
@@ -82,12 +97,33 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_matches_regex
-    description: "Re-read list-models after each step (one snapshot per transition)"
-    path: "mocks/calls.log"
-    pattern: >-
-      (?m)(?:[\s\S]*?^(?:uip\s+ixp\s+projects\s+list-models)[^\r\n]*$){4}
-    weight: 2.0
+  # One snapshot per transition, graded as the four artifacts rather than as a
+  # count of `list-models` calls: the agent legitimately polls `list-models`
+  # while waiting for training, so a call count reaches 4 without any transition
+  # having been snapshotted. These are also check_tags.py's inputs — asserting
+  # them here turns a missing file into a named failure instead of a traceback.
+  - type: file_exists
+    description: "Snapshot after tagging (models_tagged.json)"
+    path: "models_tagged.json"
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Snapshot after moving the live tag (models_after_move.json)"
+    path: "models_after_move.json"
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Snapshot after untagging (models_after_untag.json)"
+    path: "models_after_untag.json"
+    weight: 0.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Snapshot after unpublishing (models_after_unpublish.json)"
+    path: "models_after_unpublish.json"
+    weight: 0.5
     pass_threshold: 1.0
 
   - type: file_exists


### PR DESCRIPTION
`skill-ixp-integration-publish-lifecycle` fails for codex roughly 60% of the time and always passed for claude. It is not agent quality and it is not flakiness in the service — it is an ordering dependency the prompt never stated. Pre-existing; unrelated to #2316 / #2317 (confirmed by reproducing it on plain `main` at the same score).

## Root cause: publishing pins a version against cleanup

Publishing a model version pins it. An **unpublished** version is discarded when the next one trains. The task asks for two trained versions to tag, but told the agent to retrain first and tag afterwards — by which point only one version was left.

The failing transcripts say it directly:

> `list-models` reports only trained version 2. Version 0 was rejected as not found, so there is no distinct V_OLD available to tag or move.

Grouped across 10 live runs, the split is clean and has no exceptions:

| Order | Versions left | Outcome |
|-------|---------------|---------|
| `publish` → **then** retrain | 2 | **passed** — 2 codex + claude |
| retrain → **then** `publish` | 1 | **failed** — every run |

Claude never passed by handling the lifecycle better. It passed because it happened to publish v0/v1 before its second retrain. The two codex runs that passed did the same thing.

## Fix

**1. Publish before retraining** (the actual fix). The prompt now puts the first trained version on staging *before* tweaking the instruction to retrain the second, so two versions exist by construction — no recovery path needed:

> Once that first version has trained, put it on staging right away — before you retrain. An unpublished version is discarded when the next one trains, so publishing it is what keeps two versions around to tag.

**2. Stop, don't fake it.** Version numbers come from `list-models` rather than training order, and if the two versions aren't both present the agent stops and reports. An earlier attempt at this told the agent to retry other numbers instead — that pushed one run into completing the sequence with a *single* version, tagging v2 as both staging and live. `check_tags.py` caught it, but the instruction was inviting a passing-looking false end state. Removed.

**3. Two grading fixes** surfaced along the way:

- **"Published with a tag" rewarded rejected calls.** `calls.log` records the invocation whether or not the server accepted it, so a run that only *attempted* the tagging banked 2.0 of 11.0 while landing none of it — most of codex's 0.273. Dropped to supporting weight (1.0); the wire effect is `check_tags.py`'s job at 3.0.
- **"Re-read list-models after each step" was satisfiable by polling.** It counted four `list-models` calls, and the agent legitimately polls `list-models` through two training cycles — so it passed without a single transition being snapshotted. Replaced by the four snapshot files (0.5 each, same 2.0 total). Those are `check_tags.py`'s inputs, so a missing one is now a named failure instead of a `FileNotFoundError` traceback — which is how this whole thing first surfaced confusingly.

`check_tags.py` is unchanged: it already resolved versions through the `staging`/`live` tag pointers and asserted only relative transitions.

Net: 10 criteria, total weight 10.0. `check-cli-verbs.py` and `check-task-driver.py` clean.

## Verification

Baseline on `main`, codex, 5 runs: **2/5 pass** (failures at 0.455 / 0.273 / 0.091).

On this branch, codex, 5 runs — **1 complete so far, 4 still running.** I will post the full tally as a comment before this is ready to merge; please don't merge on the strength of the story alone.

First run: **1.000 SUCCESS**, and the call order is the intended mechanism with no rejection or retry anywhere:

```
publish v1 --tag staging      <- before the retrain
update-prompts                <- retrain
publish v2 --tag live
publish v1 --tag live         <- move
untag --tag live
untag --tag staging
unpublish v2
```

An intermediate commit on this branch (version discovery + retry, without the reordering) measured **3/5** — better than baseline but inside the noise at n=5, which is what prompted digging further and finding the ordering cause. The history is kept rather than squashed because the failed attempt is what produced the evidence.

## Follow-up worth considering separately

"Publishing pins a model version; an unpublished older version is discarded when the next one trains" is real IXP behavior that the `uipath-ixp` skill documents nowhere — not in the publish/rollback guidance, not in `cli-reference.md`. An agent doing this for a user would hit exactly what these runs hit. That is arguably more valuable than this test change, but it is a skill edit rather than a test edit, so it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNsX5UrVVqZfHUFhsCn6E
