### PR TITLE
fix(uipath-maestro-flow): repair ixp coder-eval fixtures and stale validator docs [RE-12960]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
@@ -135,8 +135,8 @@ Then assemble the instance by copying these paths verbatim:
 | `inputs.versionTag` | `""` (empty string unless pinning a version) | YES |
 | `inputs.pageRange` | `""` (empty string for full document) | YES |
 | `inputs.fileRef` | `"=js:$vars.<upstream>.output.<field>"` (author this) | YES |
-| `outputs.output` (full object) | `Data.Node.outputDefinition.output` | **YES** — missing → `$vars.<id>.output` fails |
-| `outputs.error` (full object) | `Data.Node.outputDefinition.error` | **YES** — missing → `$vars.<id>.error` fails |
+| `outputs.output` | the four-field literal below (no `registry get` lookup needed) | **YES** — missing → `flow validate` fails |
+| `outputs.error` | the four-field literal below (no `registry get` lookup needed) | **YES** — missing → `flow validate` fails |
 
 **Forbidden in `inputs`** (legacy schema, removed from current standalone node — including any of these is a defect even if `flow validate` passes):
 
@@ -176,19 +176,35 @@ If you find yourself typing any of those five field names while authoring an IxP
     "pageRange": ""
   },
   "outputs": {
-    "output": { /* copy verbatim from definition.outputDefinition.output */ },
-    "error":  { /* copy verbatim from definition.outputDefinition.error */ }
+    "output": {
+      "name": "output",
+      "type": "object",
+      "source": "=this",
+      "var": "output"
+    },
+    "error": {
+      "type": "object",
+      "description": "Error information if the node fails",
+      "source": "=Error",
+      "var": "error"
+    }
   }
 }
 ```
 
+**`outputs` is a fixed literal — copy the block above as-is.** It is the same for
+every IxP node regardless of model; nothing in it is derived from `registry get`.
+Copying `outputDefinition.output` verbatim instead also validates, but that drags
+in an ~18KB `schema` blob the runtime does not need — the four fields above are
+sufficient. There is no version of this node where omitting `outputs` is correct.
+
 ### Authoring rules
 
-1. **`inputs.model` MUST be present and MUST be copied from `Data.Node.inputDefaults.model`.** Copy the blob verbatim — do not abbreviate, do not omit fields, do not invent fields that aren't there. The current deployment-node blob is `{ id, modelName, modelDisplayName, folderKey, folderName, folderPath, description }`; source every field from the actual `registry get` response, not from memory (older docs showed `fullyQualifiedName` / `kind` / `type` / `detailsUrl` / `async*` fields — these are NOT present on deployment nodes; do not add them). The `schema-definition` form section binds `inputs.model` to the `ixp-model-taxonomy` custom component, which destructures `modelName` and `folderKey` out of it. If `inputs.model` is undefined, clicking the node in Studio Web crashes the property panel with `Cannot destructure property 'modelName' of 't' as it is undefined` — and `flow validate` does not catch it.
+1. **`inputs.model` MUST be present and MUST be copied from `Data.Node.inputDefaults.model`.** Copy the blob verbatim — do not abbreviate, do not omit fields, do not invent fields that aren't there. The current deployment-node blob is `{ id, modelName, modelDisplayName, folderKey, folderName, folderPath, description }`; source every field from the actual `registry get` response, not from memory (older docs showed `fullyQualifiedName` / `kind` / `type` / `detailsUrl` / `async*` fields — these are NOT present on deployment nodes; do not add them). The `schema-definition` form section binds `inputs.model` to the `ixp-model-taxonomy` custom component, which destructures `modelName` and `folderKey` out of it. If `inputs.model` is undefined, clicking the node in Studio Web crashes the property panel with `Cannot destructure property 'modelName' of 't' as it is undefined` — and `flow validate` fails on it too (`ixp-node`: `inputs.model must be an object with non-empty string modelName and folderKey`).
    - **`inputs.model.modelName` MUST be a non-empty string.** For many published/OOB deployments `inputDefaults.model.modelName` comes back `null`, with the name carried in `inputDefaults.model.modelDisplayName` instead. When `modelName` is `null`/empty, set `inputs.model.modelName` to `modelDisplayName`. This is NOT synthesis — `modelDisplayName` is the model's own name from the same blob (and matches the flat `inputDefaults.modelName`). The `ixp-node` validator rejects a `null`/empty `inputs.model.modelName` (`flow validate` fails), and Studio Web crashes on it.
 2. **Flat mirrors stay alongside `inputs.model`.** `modelName`, `projectName`, `folderKey`, `folderName` are surfaced as disabled text fields in the `ixp-model` form section and are read directly from `inputs.*`, not from `inputs.model.*`.
 3. **`fileRef` is the only schema-required input** (`inputDefinition.required: ["fileRef"]`). Use `=js:$vars.<upstream>.output.<field>` per Critical Rule #13.
-4. **`outputs.output` AND `outputs.error` MUST both be present**, copied verbatim from `Data.Node.outputDefinition.output` and `Data.Node.outputDefinition.error`. Omitting either breaks downstream `$vars.<nodeId>.output` / `.error` resolution and hides the field in Studio Web's variable picker. `flow validate` does not catch the omission.
+4. **`outputs.output` AND `outputs.error` MUST both be present** — copy the fixed four-field literals from [Final shape](#final-shape); they are identical for every IxP node and need no `registry get` lookup. Omitting either breaks downstream `$vars.<nodeId>.output` / `.error` resolution and hides the field in Studio Web's variable picker. **`flow validate` hard-fails on the omission** — `ixp-node` emits `[nodes[<nodeId>].outputs.output] outputs.output must be present on the instance`, and the matching error for `outputs.error`.
 5. **No top-level `model` on the instance.** Studio Web–authored .flow files never carry one; the BPMN-format `model` envelope (with `context`, `version`, `inputs`, `outputs`) is emitted at serialize time only.
 6. **`inputs` MUST NOT contain `digitizationMode`, `documentTaxonomy`, `attachmentId`, `fileName`, or `mimeType`.** These five fields were on a prior schema and have been removed from the standalone IxP node. Including them is the most common training-data-recall mistake. The serializer defaults `digitizationMode` to `fileUpload` internally — there is no scenario where you should set it on the instance.
 

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -18,11 +18,12 @@ initial_prompt: |
   date, total amount, line items), and posts the result to SAP through an
   HTTP request.
 
-  - SharePoint connector: configured (use a connector trigger node)
-  - SharePoint folder: "New Vendor"
-  - IxP model: "Invoice Model"
-  - SAP: HTTP POST request to the configured endpoint, sending the extracted
-    invoice fields as the request body
+  - SharePoint connector: configured (use a connector trigger node against
+    any document library the connection exposes)
+  - IxP model: pick the published model that matches vendor invoices from
+    `registry search "uipath.ixp"`
+  - SAP: HTTP POST to https://sap.example.com/api/invoices, sending the
+    extracted invoice fields as the request body
 
 success_criteria:
   - type: skill_triggered
@@ -43,7 +44,10 @@ success_criteria:
   - type: command_executed
     description: "Agent searched the registry for a SharePoint connector"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*sharepoint'
+    # Case-insensitive: "SharePoint" is the product's own capitalisation and is
+    # what agents type. A case-sensitive pattern failed an agent that searched
+    # `registry search "SharePoint"` and had built the connector node correctly.
+    command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*sharepoint'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -9,6 +9,10 @@ description: >
   Validate-only: no `uip maestro flow debug`. Validation in CI is offline
   (`uip maestro flow validate`).
 
+  The prompt names the document domain, not a model — see scaffold_minimal.yaml.
+  A storage bucket is deliberately not named: the IxP flow node has no
+  bucket input, so the reference is unbindable and only blocks the build.
+
 tags: [uipath-maestro-flow, integration, lifecycle:generate, shape:multi-node, node:ixp, node:decision]
 
 initial_prompt: |
@@ -17,8 +21,8 @@ initial_prompt: |
 
   1. Manual trigger.
   2. IxP extraction node — extracts at least vendor name and total amount
-     from a PDF invoice using the model "Invoice Model" with the storage
-     bucket named "InvoiceBucket".
+     from a PDF vendor invoice, using the published model matching that
+     document domain.
   3. Decision node — branches on the extracted total amount: if greater
      than 1000, route to a "HighValueReview" script; otherwise route to an
      "AutoApprove" script.
@@ -72,40 +76,54 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  # The four checks below locate the .flow rather than hardcoding
+  # `<Name>/<Name>/<Name>.flow`. `uip maestro flow init <Name>` run outside a
+  # solution auto-scaffolds a `<Name>Solution/` wrapper (see greenfield.md),
+  # so the literal path only resolves when the agent happens to run
+  # `uip solution init` first — an authoring idiom these checks don't test.
+  # Each grep line is one `includes:` needle; all must match.
+  - type: run_command
     description: "Flow contains a Decision node (core.logic.decision)"
-    path: "InvoiceRouter/InvoiceRouter/InvoiceRouter.flow"
-    includes:
-      - "core.logic.decision"
+    command: |
+      set -e
+      flow=$(find . -name '*.flow' -print -quit)
+      grep -qF 'core.logic.decision' "$flow"
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Decision condition references the canonical IxP output path ($vars.<ixp>.output.ExtractionResult.ResultsDocument.Fields)"
-    path: "InvoiceRouter/InvoiceRouter/InvoiceRouter.flow"
-    includes:
-      - "$vars."
-      - "ExtractionResult"
-      - "ResultsDocument"
-      - "Fields"
+    command: |
+      set -e
+      flow=$(find . -name '*.flow' -print -quit)
+      grep -qF '$vars.'           "$flow"
+      grep -qF 'ExtractionResult' "$flow"
+      grep -qF 'ResultsDocument'  "$flow"
+      grep -qF 'Fields'           "$flow"
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Both branch script nodes are present by name"
-    path: "InvoiceRouter/InvoiceRouter/InvoiceRouter.flow"
-    includes:
-      - "HighValueReview"
-      - "AutoApprove"
+    command: |
+      set -e
+      flow=$(find . -name '*.flow' -print -quit)
+      grep -qF 'HighValueReview' "$flow"
+      grep -qF 'AutoApprove'     "$flow"
+    expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Both Decision branches wired (true and false handles)"
-    path: "InvoiceRouter/InvoiceRouter/InvoiceRouter.flow"
-    includes:
-      - '"true"'
-      - '"false"'
+    command: |
+      set -e
+      flow=$(find . -name '*.flow' -print -quit)
+      grep -qF '"true"'  "$flow"
+      grep -qF '"false"' "$flow"
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -12,12 +12,16 @@ description: >
   Failure here is signal about SKILL.md or the IxP Plugin Index entry —
   do NOT relax assertions; feed findings back in.
 
+  Rows are phrased as greenfield builds because the sandbox seeds no `.flow`.
+  A prompt claiming "I have a UiPath Flow" makes the agent rightly decline to
+  attach a node to a project that does not exist.
+
 tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, node:ixp]
 dataset:
   rows:
     - id: explicit
       prompt: >-
-        I have a UiPath Flow. Add an IXP node that reads PDF invoices from a
+        Build a UiPath Flow with an IXP node that reads PDF invoices from a
         SharePoint folder and extracts the structured fields so the next step
         can post them to SAP.
 
@@ -40,7 +44,7 @@ dataset:
 
     - id: forms-classify
       prompt: >-
-        I have a Maestro flow. Add an IxP node that classifies incoming PDF
+        Build a Maestro flow with an IxP node that classifies incoming PDF
         forms and extracts their fields before the next step.
 
 initial_prompt: |

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -9,14 +9,19 @@ description: >
   deployment which CI does not have; this verifies offline structural
   correctness only.
 
+  The prompt names the document domain, not a model: resolving the domain to a
+  published model via `registry search` is the behaviour under test (same as
+  e2e_02_project_selection.yaml). Naming an unpublished model instead makes the
+  agent stop and ask which to bind — correct behaviour, but it builds nothing.
+
 tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:single-node, node:ixp]
 initial_prompt: |
   Create a new Maestro Flow project called "Smoke" with a manual trigger, an
   extract node, and a script node that just logs "ok". Wire the extracted
   handle to the script and validate the flow.
 
-  Document is in the storage bucket named: InvoiceBucket
-  Model used: Invoice Model
+  Document: a PDF vendor invoice, supplied to the extract node as the flow's
+  document input.
   Script node: contains a JavaScript that logs OK when it receives the
   extraction result.
 
@@ -68,11 +73,15 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  # Locate the .flow rather than hardcoding `Smoke/Smoke/Smoke.flow` — see
+  # integration_handle_routing.yaml for the `<Name>Solution/` wrapper rationale.
+  - type: run_command
     description: "Script node consumes the extraction output via $vars expression"
-    path: "Smoke/Smoke/Smoke.flow"
-    includes:
-      - "$vars."
+    command: |
+      set -e
+      flow=$(find . -name '*.flow' -print -quit)
+      grep -qF '$vars.' "$flow"
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 


### PR DESCRIPTION
Most of the failing IxP rows in `uipath-maestro-flow` were failing for reasons that had nothing to do with skill behaviour — assertions addressing artifacts by a path the CLI no longer produces, prompts naming tenant resources that aren't published, and a case-sensitive regex. This repairs those fixtures and corrects two stale claims in the IxP plugin docs.

**Fixtures**
- Five criteria hardcoded `<Name>/<Name>/<Name>.flow`. Since the CLI change on 2026-07-20, `uip maestro flow init` auto-scaffolds a `<Name>Solution/` wrapper when run outside a solution, so that path resolves only when the agent happens to run `uip solution init` first. They now locate the file. Needles are unchanged — verified against both layouts, a negative control, and the nothing-built case.
- Prompts named `"Invoice Model"`, `"InvoiceBucket"`, library `"New Vendor"` and a SAP endpoint, none of which exist on the runner tenant. Each correctly made the agent stop and ask, so nothing got built. Prompts now name the document domain, as `e2e_02_project_selection.yaml` already does deliberately. The bucket is dropped rather than renamed — the IxP flow node has no bucket input.
- Two rows opened *"I have a UiPath Flow"* while the sandbox seeds none.
- The SharePoint registry-search check was case-sensitive and failed an agent that searched `"SharePoint"`; `routing.yaml`'s equivalent already used `(?i)`.

**Skill docs**
- Authoring rules #1 and #4 claimed `flow validate` doesn't catch a missing `inputs.model` / `outputs` block. It hard-fails on both — and the same file said so six lines later.
- Rule #4 pointed at `Data.Node.outputDefinition` for `outputs`; measured across recent eval artifacts that blob is ~18KB of JSON schema, while 6 of 8 flows carry a four-field literal and validate identically. `Final shape` now inlines that literal instead of `/* copy verbatim … */` stubs — which also makes the block valid JSON for the first time, so it can be copied mechanically.

**Passing runs** (4 files / 8 rows on this branch)
- codex ×3: [7/8](https://github.com/UiPath/skills/actions/runs/30446276548), [8/8](https://github.com/UiPath/skills/actions/runs/30446278298), [7/8](https://github.com/UiPath/skills/actions/runs/30446279803) — 7 rows pass 3/3, from 2/8 before
- claude: [6/8](https://github.com/UiPath/skills/actions/runs/30447927412) — from 2/6 on the in-scope rows of `2026-07-28_04-16-10`

**Known remaining** — not addressed here, follow-ups off RE-12960
- `integration-handle-routing` still hits the sonnet-5 turn timeout (900s, 110 turns) — the same over-reasoning pattern reported for `maestro-case` and `coded-apps`. Pre-existing.
- `e2e_01` times out on sonnet-5 (n=1) though it passes codex 3/3.
- `routing/invoice-extraction` passes 1/3 on codex: the agent adds the SharePoint connector then stops before the extraction node when the downstream target is unresolvable.

[RE-12960](https://uipath.atlassian.net/browse/RE-12960)


[RE-12960]: https://uipath.atlassian.net/browse/RE-12960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ