### PR TITLE
fix(tests): point the agents scenarios at the real staged source path

### DIFF
--- a/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/context-grounding-index-not-found/task.yaml
@@ -78,7 +78,7 @@ simulation:
     Let the agent complete its troubleshooting flow and approve read-only
     investigation steps.
   constraints:
-    - "If the agent asks where the source code is, say it is under process/SupportSolution."
+    - "If the agent asks where the source code is, say it is under ./SupportSolution."
     - "If the agent asks whether it can run mutating repair commands, say no and ask for the commands instead."
     - "If the agent asks whether to expand investigation scope, answer yes."
     - "Keep replies short and do not invent new facts."

--- a/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/input-schema-validation-failure/task.yaml
@@ -77,7 +77,7 @@ simulation:
     Let the agent diagnose the problem and provide a corrected local
     reproduction command.
   constraints:
-    - "If the agent asks where the source code is, say it is under process/IntakeSolution."
+    - "If the agent asks where the source code is, say it is under ./IntakeSolution."
     - "If the agent asks whether it can edit files, say no."
     - "If the agent asks whether it can run uip agent debug, say no and ask it to provide the command instead."
     - "If the agent asks whether to expand investigation scope, answer yes."

--- a/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/agents/llm-insufficient-information/task.yaml
@@ -76,7 +76,7 @@ simulation:
   goal: |
     Let the agent complete the diagnosis and provide a remediation plan.
   constraints:
-    - "If the agent asks where the source code is, say it is under process/MailerSolution."
+    - "If the agent asks where the source code is, say it is under ./MailerSolution."
     - "If the agent asks whether it can edit files, say no."
     - "If the agent asks whether it can run uip agent debug, say no and ask it to provide the command instead."
     - "If the agent asks whether to expand investigation scope, answer yes."


### PR DESCRIPTION
The simulated user tells the agent the source is "under process/<X>Solution", but `template_dir` copies a directory's CONTENTS into the sandbox root, so `process/MailerSolution/` is staged as `./MailerSolution/`. There is no `process/` directory at runtime.

Captured live mid-run, the agent's cwd is:

    <sandbox>/
    |- .venv/
    |- m/
    +- MailerSolution/MailerAgent/agent.json

That the wrong path misleads is already demonstrated: while the same string was still in `initial_prompt` (before #2247 removed it), all three agents acted on it and got nothing back --

    ls -la process/SupportSolution 2>/dev/null
    ls -la process/IntakeSolution 2>/dev/null
    ls -la process/MailerSolution ; find process/MailerSolution

Two recovered by having bundled an `ls -la` of the cwd into the same command; llm-insufficient-information spent two calls on the dead path.

The constraint is the last remaining copy of that string, so the defect is now latent rather than live: with the prompt pointer gone the agent lists its cwd, finds `./MailerSolution`, and never needs to ask. A baseline run on current main scores 1.00 in 295s and never touches `process/`. This removes the trap for the case where it does ask.

Points each constraint at `./<X>Solution`, per review feedback on #2319.