### PR TITLE
test(maestro-flow): grade jdbc-databricks skill load with skill_triggered, not a Skill-tool match

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
@@ -56,11 +56,10 @@ initial_prompt: |
   Do NOT pause between planning and implementation.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent loaded the uipath-maestro-flow skill"
-    tool_name: "Skill"
-    command_pattern: "uipath-maestro-flow"
-    min_count: 1
+  - type: skill_triggered
+    skill_name: "uipath-maestro-flow"
+    expected_skill: "uipath-maestro-flow"
+    description: "Agent invoked the uipath-maestro-flow Skill"
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Problem

The `skill-flow-jdbc-databricks-query` task fails (`final_status: FAILURE`) even when the agent produces a fully correct artifact.

Root cause is a single **gating** success-criterion — *"Agent loaded the uipath-maestro-flow skill"* — that scored `0.0`:

```yaml
- type: command_executed
  description: "Agent loaded the uipath-maestro-flow skill"
  tool_name: "Skill"          # ← only matches Claude Code's first-class Skill tool
  command_pattern: "uipath-maestro-flow"
  min_count: 1
```

The graded run was a **codex** agent (`agent_type: codex`, `model_used: gpt-5.6-terra`). Codex has no `Skill` tool — it loads a skill by **reading `SKILL.md` via Bash** (the very first command in the trace was `sed -n '1,240p' .../uipath-maestro-flow/SKILL.md`). So the matcher found 0 `Skill`-tool calls → `0/1` → score `0.0`. Because the criterion is `gating: true`, the whole task is marked `FAILURE`.

Everything else passed:

| Criterion | Score |
|---|---|
| `flow validate` was called | ✅ 1.0 |
| `flow debug` was called | ✅ 1.0 |
| `check_databricks_query.py` (JDBC gateway node + bound connection, not native/HTTP) | ✅ 1.0 |
| **Skill loaded** (`tool_name: "Skill"`) | ❌ **0.0** |

The weighted score confirms this is the *only* miss: passing weight `2.0 + 1.5 + 3.0 = 6.5` over total `7.5` = **`0.867`**, exactly the reported `weighted_score`.

> Note: `review.json`'s human summary ("agent could not execute required flow commands") is inaccurate — the trace shows validate + debug both ran and succeeded. The real cause is the skill-load probe keying on `tool_name: "Skill"`.

## Why it's a repo-wide outlier

This was the **only** task in the repo using `tool_name: "Skill"` (1 occurrence). The established, agent-agnostic convention is the dedicated **`skill_triggered`** criterion — **454 usages across 433 tasks**, and the documented *"un-fakeable"* primitive in `.claude/commands/generate-task.md`. `coder_eval` owns `skill_triggered` detection per agent type (Skill tool for Claude Code, `SKILL.md` read for codex/antigravity), which is exactly why it's used in the activation benchmark that runs codex.

## Fix

Replace the brittle `command_executed`/`tool_name: "Skill"` block with the canonical `skill_triggered` criterion used by every other maestro-flow task, preserving the original weight (`1.0`):

```yaml
- type: skill_triggered
  skill_name: "uipath-maestro-flow"
  expected_skill: "uipath-maestro-flow"
  description: "Agent invoked the uipath-maestro-flow Skill"
  weight: 1.0
  pass_threshold: 1.0
```

This fixes the false-negative for codex (and any non-Claude-Code agent) without loosening what's asserted — the flow's structural correctness is still fully graded by the three unchanged criteria.

## Testing

- YAML parses; `success_criteria` types are now `[skill_triggered, command_executed, command_executed, run_command]`; no residual `tool_name: "Skill"`.
- Change is a 1-block, convention-conforming edit identical in shape to the 400+ existing `skill_triggered` criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)