### PR TITLE
fix(tests): point ixp prompts at the working directory, not ./fixtures/

### DIFF
--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -31,12 +31,12 @@ sandbox:
 
 initial_prompt: |
   Run a complete UiPath IXP project lifecycle ending with a published
-  model, using the three vendor invoices in `./fixtures/` 
+  model, using the three vendor invoices in the working directory
   (`hp_tax_invoice.png`, `york_solutions_invoice.png`, `csi_tower_invoice.png`).
 
   Scenario setup:
   - Create the project WITHOUT a taxonomy, then import the bundled
-    `./fixtures/taxonomy.json` (a taxonomy already exists for this
+    `taxonomy.json` (a taxonomy already exists for this
     scenario).
   - Use a unique title `codereval-e2e-<random-suffix>` so concurrent
     runs do not collide.

--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -29,7 +29,7 @@ initial_prompt: |
   Set up a trained invoice project. Use the tenant I'm already signed into
   (check I'm logged in; don't re-authenticate): create a blank project (give it a unique title
   `codereval-integ-labelling-<random-suffix>` so concurrent runs don't collide) and upload
-  `./fixtures/csi_tower_invoice.png`. Work only on the project you create; other
+  `csi_tower_invoice.png`. Work only on the project you create; other
   runs share this tenant, so never list, read, or modify any other project.
   Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
   Then set up the taxonomy yourself — add a

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -26,7 +26,7 @@ sandbox:
 
 initial_prompt: |
   Use the tenant I'm already signed into (check I'm logged in; don't
-  re-authenticate). Set up an invoice project from the files in `./fixtures/` —
+  re-authenticate). Set up an invoice project from the files in the working directory —
   import the taxonomy and upload the three invoices — and give it a unique title
   `codereval-integ-resolve-<random-suffix>` so concurrent runs don't collide.
 

--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -36,7 +36,7 @@ sandbox:
 initial_prompt: |
   I need to manage releases on an invoice project. Use the tenant I'm already
   signed into (check I'm logged in; don't re-authenticate): start a project from
-  the files in `./fixtures/` (give it a unique title
+  the files in the working directory (give it a unique title
   `codereval-integ-publish-<random-suffix>` so concurrent runs don't collide) — import the taxonomy, upload one of the invoices —
   and let it train.
 

--- a/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/taxonomy_lifecycle.yaml
@@ -29,7 +29,7 @@ sandbox:
 initial_prompt: |
   I want to set up an invoice project, reshape its taxonomy, then undo the reshaping.
   Use the tenant I'm already signed into (check I'm logged in; don't re-authenticate).
-  Create the project from the invoices in `./fixtures/` and let IXP auto-suggest the
+  Create the project from the invoices in the working directory and let IXP auto-suggest the
   taxonomy — I only care about the taxonomy structure here, so don't label or train.
   Use a unique project title `codereval-integ-taxonomy-<random-suffix>` so concurrent runs
   don't collide. Save the suggested taxonomy to `taxonomy_initial.json`.

--- a/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
+++ b/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
@@ -29,7 +29,7 @@ sandbox:
 initial_prompt: |
   I want to improve an invoice extraction model and end up with two trained
   versions to compare. Use the tenant I'm already signed into (check I'm logged
-  in; don't re-authenticate): start a project from the files in `./fixtures/` —
+  in; don't re-authenticate): start a project from the files in the working directory —
   give it a unique title `codereval-integ-versions-<random-suffix>` so concurrent runs don't
   collide — import the taxonomy, upload one of the invoices — and let it train.
   Work only on the project you create; other runs share this tenant, so never


### PR DESCRIPTION
Six `uipath-ixp` prompts told the agent to read `./fixtures/`. That directory does not exist in the sandbox.

## Root cause

These tasks declare:

```yaml
template_sources:
  - type: template_dir
    path: ../_shared/live_calls_template
  - type: template_dir
    path: ../_shared/fixtures
```

`template_dir` copies the directory's *contents* into the sandbox root. The 3 invoice PNGs and `taxonomy.json` land flattened at the root — there is no `fixtures/` subdirectory to read.

Verified against a real run artifact rather than by inspection alone. Sandbox root of `skill-ixp-e2e-full-lifecycle`:

```
csi_tower_invoice.png
hp_tax_invoice.png
taxonomy.json
york_solutions_invoice.png
mocks/          <- from live_calls_template
```

## Evidence

From GH run 30463311391 (antigravity/gemini-3.5-flash: 7 of 48 `uipath-ixp` tasks failed; claude 48/48, codex 47/48):

| Agent | Behavior |
|-------|----------|
| antigravity | 20-45s per task hunting for the directory; ~half of the short `name_resolution` run spent on it |
| claude | `ls: cannot access 'fixtures/': No such file or directory` in the e2e transcript, then fell back to `.` |
| codex | Worked around it with an absolute root path |

Cost 0 tasks directly — every agent recovered. It is a latent trap and pure waste, and it hit the passing agents too.

## Change

Prompt wording only. `./fixtures/` → "the working directory"; `./fixtures/taxonomy.json` → `taxonomy.json`; `./fixtures/csi_tower_invoice.png` → `csi_tower_invoice.png`. 7 occurrences across 6 files, 7 insertions / 7 deletions.

Deliberately **not** restructuring `template_sources` to create a real `fixtures/` subdir: that changes the sandbox root layout for every task sharing `_shared/fixtures` and is far riskier than making the prompts match reality.

The `_shared/fixtures/taxonomy.json` mention in `smoke/update_prompts_heredoc.yaml` is a repo-relative path in a YAML comment, not a sandbox path — left alone.

## Validation

| Check | Result |
|-------|--------|
| All 48 `uipath-ixp` task YAMLs parse (`yaml.safe_load`) | pass |
| `check-cli-verbs.py` on all 6 changed files | `OK — no CLI-verb issues (catalog: uip 1.197.0-alpha.20260623.7621, 1228 verbs)` |
| `check-task-driver.py` | `OK — no task pins sandbox.driver: tempdir` (exit 0; the pre-existing `driver: docker` note is unchanged) |

## Passing-run claim: PENDING

I cannot produce one and have not fabricated one. All 6 tasks are live-tenant integration/e2e tasks requiring an authenticated UiPath tenant and 30-100 min of training waits each.

What is verified: no `success_criteria`, weight, threshold, tag, or sandbox field is touched — the diff is 7 lines of `initial_prompt` prose. What is not verified: that the 6 tasks pass end to end after the reword.

**A live coder-eval run of all 6 tasks is required before merge.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNsX5UrVVqZfHUFhsCn6E
