### PR TITLE
fix(codeowners): drop owners without write access, refresh MCP owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for the entire repo
-* @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2 @smflorentino
+* @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2 @smflorentino @abhiram-vad
 
 # CI workflows and review config
 /.github/ @uipreliga @bai-uipath @akshaylive
@@ -120,8 +120,8 @@
 /tests/tasks/uipath-maestro-flow/connector_features/ @baishalighosh @chandusailella @mukundbayyaram
 
 # IXP
-/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
-/tests/tasks/uipath-maestro-flow/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
+/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @jcalero @constantinmuraru @scallaway-uipath @joe-prosser @vlad-crisan @richsilv @AWilcke
+/tests/tasks/uipath-maestro-flow/ixp/ @jcalero @constantinmuraru @scallaway-uipath @joe-prosser @vlad-crisan @richsilv @AWilcke
 
 # Review skill
 /skills/uipath-review/ @AlvinStanescu @gabrielavaduva @roalexandru
@@ -160,8 +160,8 @@
 /skills/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath @alexandrujircan
 /tests/tasks/uipath-ixp/ @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath @alexandrujircan
 # MCP skill (UiPath AgentHub MCP server registration + tool authoring)
-/skills/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents
-/tests/tasks/uipath-mcp-servers/ @cosminpaunel @UiPath/team-coded-agents
+/skills/uipath-mcp-servers/ @cristipufu @UiPath/team-coded-agents
+/tests/tasks/uipath-mcp-servers/ @cristipufu @UiPath/team-coded-agents
 
 # Insights skill (job monitoring and analytics)
 /skills/uipath-insights/ @suranabhavya @rliuup


### PR DESCRIPTION
## Problem

GitHub flagged three CODEOWNERS entries as invalid — the listed owners cannot be assigned as reviewers, so those paths effectively had no enforceable ownership.

## Changes

| Line(s) | Owner | Action | Reason |
|---------|-------|--------|--------|
| 123–124 (IXP) | `@tommilligan` | Removed | Account exists but holds only **read** access on this repo (ex-`@reinfer`). CODEOWNERS requires write. No alternate org account found. |
| 163–164 (MCP servers) | `@cosminpaunel` | Replaced with `@cristipufu` | `@cosminpaunel` is not a GitHub account. The person behind it (Cosmin Paunel / `@cosmyo`) has left the company, so ownership moves to `@cristipufu` rather than being remapped to a departed account. |
| 2 (default owners) | `@abhiram-vad` | Added | Requested; write access verified. |

## Verification

Every individual owner was resolved against the repo permissions API (`repos/UiPath/skills/collaborators/<user>/permission`):

- `@cristipufu` → `write` ✅
- `@abhiram-vad` → `write` ✅
- Remaining IXP owners (`@jcalero`, `@constantinmuraru`, `@scallaway-uipath`, `@joe-prosser`, `@vlad-crisan`, `@richsilv`, `@AWilcke`) → all `write` ✅
- Full-file sweep of all **112** individual owners → every entry resolves to `write`, `maintain`, or `admin`; no remaining unknown or read-only owners.

Team handles (`@UiPath/*`) were left untouched — GitHub raised no errors against them.

## Note on scope

There is no `skills/uipath-skills/` folder, so the request to "add `abhiram-vad` as owner to uipath-skills" was applied to this repo's **repo-wide default `*` owners** (line 2). If a narrower path was intended, say which and I'll rescope.

Diff touches `CODEOWNERS` only — 5 insertions, 5 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)