### PR TITLE
fix(codeowners): rescope abhiram-vad to planner, restore IXP owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners for the entire repo
-* @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2 @smflorentino @abhiram-vad
+* @gabrielavaduva @AlvinStanescu @marius-bughiu @RaduAna-Maria @uipreliga @dmetzgar @rockymadden @gozhang2 @smflorentino
 
 # CI workflows and review config
 /.github/ @uipreliga @bai-uipath @akshaylive
@@ -71,8 +71,8 @@
 /tests/tasks/activation/uipath-functions.jsonl @AlexBizon @UiPath/team-coded-agents
 
 # Planner skill (PDD → SDD design + multi-skill task planning)
-/skills/uipath-planner/ @RaduAna-Maria
-/tests/tasks/uipath-planner/ @RaduAna-Maria
+/skills/uipath-planner/ @RaduAna-Maria @abhiram-vad
+/tests/tasks/uipath-planner/ @RaduAna-Maria @abhiram-vad
 
 # Solution skill (uip solution lifecycle)
 /skills/uipath-solution/ @UiPath/team-merlot @UiPath/team-orange
@@ -120,8 +120,8 @@
 /tests/tasks/uipath-maestro-flow/connector_features/ @baishalighosh @chandusailella @mukundbayyaram
 
 # IXP
-/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @jcalero @constantinmuraru @scallaway-uipath @joe-prosser @vlad-crisan @richsilv @AWilcke
-/tests/tasks/uipath-maestro-flow/ixp/ @jcalero @constantinmuraru @scallaway-uipath @joe-prosser @vlad-crisan @richsilv @AWilcke
+/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
+/tests/tasks/uipath-maestro-flow/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
 
 # Review skill
 /skills/uipath-review/ @AlvinStanescu @gabrielavaduva @roalexandru


### PR DESCRIPTION
Follow-up to #2341, correcting two things from that PR.

## Changes

| Line(s) | Change | Reason |
|---|---|---|
| 2 (default owners) | Removed `@abhiram-vad` | #2341 put them on the repo-wide `*` line; intended scope was uipath-planner. This line is now **byte-identical** to its pre-#2341 state. |
| 74–75 (planner) | Added `@abhiram-vad` | The intended target. Write access verified. |
| 123–124 (IXP) | Restored `@tommilligan` | #2341 removed the entry because the account held only **read** access. It has since been granted **write** on this repo — re-verified via the permissions API. Both IXP lines are now **byte-identical** to their pre-#2341 state. |

## Verification

- `@tommilligan` → `write` ✅ (was `read` at the time of #2341)
- `@abhiram-vad` → `write` ✅

Net diff against the pre-#2341 baseline (`b141bdffb`) is now exactly the two intended ownership changes and nothing else:

- `uipath-planner` gains `@abhiram-vad`
- `uipath-mcp-servers`: `@cosminpaunel` (nonexistent) → `@cristipufu`

The `*` default-owners line and both IXP lines have been returned to their original bytes, so #2341's collateral edits are fully unwound.

## One thing left for you to decide

`@abhiram-vad` also appears on the **uipath-maestro-case** paths (lines 103–104), added independently in #1944 — not by #2341. I left that untouched, since removing another team's existing reviewer is not something to do implicitly. If "abhi should be only on uipath-planner" was meant to cover that entry too, say so and I'll drop it in a follow-up.

Diff touches `CODEOWNERS` only — 5 insertions, 5 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)