### PR TITLE
fix(tests): recover IXP cleanup from calls.log when report.json is missing

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/cleanup_project.py
+++ b/tests/tasks/uipath-ixp/_shared/cleanup_project.py
@@ -2,21 +2,41 @@
 """
 Post-run cleanup for IXP e2e/integration tasks: delete THIS run's project.
 
-Reads report.json (CWD), written by the agent right after creation:
+Primary source is report.json (CWD), written by the agent right after creation:
   {"project_name": "<ProjectName from `uip ixp projects create` output>"}
 
-and deletes that one project via `uip ixp projects delete <name> -y --output json`.
-It only ever removes the project the current run created — it does NOT sweep or
-touch any other (older / leftover) project.
+Fallback when report.json is absent or unusable (run aborted before writing it):
+recover the titles this run passed to `uip ixp projects create` from
+mocks/calls.log. A title is not deletable on its own — every other command takes
+the server-assigned Name (slug + uuid + `-ixp`) — so each title is resolved in
+this order:
+  1. a Name already in calls.log that provably derives from that title
+     (`<title>-<hex>-ixp`), needing no tenant call;
+  2. `uip ixp projects list`, on an EXACT and UNIQUE Title match;
+  3. neither -> print `WARN: possible leaked project <title>` for CI grep.
 
-Best-effort and ALWAYS exits 0 (a delete failure is logged as WARN, never fails
-the test). Locally without a tenant this is a no-op.
+Never deletes on an ambiguous or approximate match: a leaked project costs one
+grep in CI logs, deleting a concurrent run's project costs that run. The wrapper
+logs each call BEFORE exec'ing the CLI, so a create line proves only that the
+call was launched — an unresolved title therefore always WARNs and never reports
+the tenant clean.
+
+Only ever removes what this run created — it does NOT sweep older leftovers.
+Best-effort and ALWAYS exits 0 (failures are logged as WARN, never fail the
+test). Locally without a tenant this is a no-op.
 """
 
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
+
+CALLS_LOG = os.path.join("mocks", "calls.log")
+LIST_LIMIT = 1000
+CREATE_LINE = re.compile(r"^uip\s+ixp\s+projects\s+create\s+(.*)$")
+VALUE_FLAGS = {"-d", "--description", "-o", "--output"}
 
 
 def run(cmd, timeout=60):
@@ -56,10 +76,13 @@ def load_report():
         return None
 
 
-def cleanup_own_project():
+def name_from_report():
     report = load_report()
-    if not report:
-        return
+    if report is None:
+        return None
+    if not isinstance(report, dict):
+        print("SKIP: report.json is not a JSON object")
+        return None
     name = (
         report.get("project_name")
         or report.get("name")
@@ -67,12 +90,125 @@ def cleanup_own_project():
     )
     if not name:
         print("SKIP: no 'project_name' key in report.json")
+    return name
+
+
+def read_calls_log():
+    path = os.path.join(os.getcwd(), CALLS_LOG)
+    if not os.path.exists(path):
+        print(f"SKIP: no {CALLS_LOG} - nothing to recover from")
+        return None
+    try:
+        with open(path, errors="replace") as f:
+            return f.readlines()
+    except Exception as e:
+        print(f"SKIP: could not read {CALLS_LOG}: {e}")
+        return None
+
+
+def created_titles(lines):
+    """Titles passed to `projects create`, in log order, deduplicated.
+
+    The wrapper logs `uip $*`, so the original quoting is gone: a title with
+    spaces recovers as its first word only, matches nothing below, and degrades
+    to the WARN line instead of to a wrong delete.
+    """
+    titles = []
+    for line in lines:
+        match = CREATE_LINE.match(line.strip())
+        if not match:
+            continue
+        try:
+            args = shlex.split(match.group(1))
+        except ValueError:
+            args = match.group(1).split()
+        skip_next = False
+        for arg in args:
+            if skip_next:
+                skip_next = False
+            elif arg.startswith("-"):
+                skip_next = arg in VALUE_FLAGS
+            else:
+                if arg not in titles:
+                    titles.append(arg)
+                break
+    return titles
+
+
+def names_in_log(title, lines):
+    """Names in the log that provably derive from `title`.
+
+    Anchoring on the whole title plus a hex uuid excludes a foreign project
+    whose title merely extends ours (`<title>x-<uuid>-ixp` does not match).
+    """
+    pattern = re.compile(rf"^{re.escape(title.lower())}-[0-9a-f][0-9a-f-]*-ixp$")
+    found = []
+    for line in lines:
+        for token in line.split():
+            token = token.strip("\"'")
+            if pattern.match(token.lower()) and token not in found:
+                found.append(token)
+    return found
+
+
+def resolve_name_on_tenant(title):
+    """Resolve Title -> Name via `projects list`. Returns (name, reason); reason
+    is set only when unresolved."""
+    proc = run(["uip", "ixp", "projects", "list", "-l", str(LIST_LIMIT), "--output", "json"])
+    if proc is None or proc.returncode != 0:
+        return None, "tenant lookup failed"
+    try:
+        payload = json.loads(proc.stdout or "").get("Data") or {}
+    except Exception:
+        return None, "tenant lookup returned no usable JSON"
+    rows = payload.get("Projects") if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        return None, "tenant lookup returned no usable JSON"
+    names = sorted({
+        row["Name"] for row in rows
+        if isinstance(row, dict) and row.get("Title") == title and row.get("Name")
+    })
+    if len(names) == 1:
+        return names[0], None
+    if len(names) > 1:
+        return None, f"{len(names)} projects share that title"
+    total = payload.get("Total") if isinstance(payload, dict) else None
+    if isinstance(total, int) and total > len(rows):
+        return None, f"title absent from the first {len(rows)} of {total} projects"
+    return None, "no exact-title match on tenant"
+
+
+def cleanup_from_calls_log():
+    lines = read_calls_log()
+    if lines is None:
         return
-    delete_project(name)
+    titles = created_titles(lines)
+    if not titles:
+        print(f"SKIP: no `projects create` in {CALLS_LOG} - this run created no project")
+        return
+    for title in titles:
+        candidates = names_in_log(title, lines)
+        if len(candidates) == 1:
+            delete_project(candidates[0])
+        elif len(candidates) > 1:
+            print(f"WARN: possible leaked project {title} (ambiguous names: {', '.join(candidates)})")
+        else:
+            name, reason = resolve_name_on_tenant(title)
+            if name:
+                delete_project(name)
+            else:
+                print(f"WARN: possible leaked project {title} ({reason})")
 
 
 def main():
-    cleanup_own_project()
+    try:
+        name = name_from_report()
+        if name:
+            delete_project(name)
+        else:
+            cleanup_from_calls_log()
+    except Exception as e:
+        print(f"WARN: cleanup aborted: {e}")
     sys.exit(0)
 
 


### PR DESCRIPTION
Live-tenant IXP projects leak whenever a run aborts before writing `report.json`. `tests/tasks/uipath-ixp/_shared/cleanup_project.py` keyed cleanup solely off that file and printed `SKIP: no report.json`, so nothing was deleted.

## Evidence

Real antigravity (gemini-3.5-flash) run, GH run **30463311391**: 7 of 48 `uipath-ixp` tasks failed (claude 48/48, codex 47/48). At least 4 live tasks died before the `report.json` write, so their projects survived on the tenant. Later runs then read them: antigravity was observed calling `projects get` / `list-models` / `get-metrics` against **foreign concurrent-run projects**, despite explicit isolation instructions in the prompts.

## Change

Fallback when `report.json` is absent or unusable: recover the titles this run passed to `uip ixp projects create` from `mocks/calls.log`, then resolve each to a deletable Name.

| Step | Source | Deletes when |
|------|--------|--------------|
| 1 | a Name already in `calls.log` matching `^<title>-<hex>-ixp$` | exactly one such Name |
| 2 | `uip ixp projects list -l 1000 --output json` | exactly one row whose `Title` equals the recovered title |
| 3 | — | never; prints `WARN: possible leaked project <title> (<reason>)` |

## The title-vs-name caveat, and why it is resolved this way

`mocks/uip` appends to `calls.log` **before** exec'ing the real CLI, so a logged `create` line proves the call was *launched* — not that it succeeded, and not what Name the server assigned. `projects create` takes a **Title**; every other command takes the **Name** (`<slug>-<uuid>-ixp`). A title from the log is therefore not directly deletable.

- **Step 1 first** because it needs no tenant call and is self-proving: the candidate must be `<our-title>-<hex>-ixp`, and our titles carry a per-run random suffix. A foreign project only matches if its title *is* ours; one whose title merely extends ours (`<title>xy-<uuid>-ixp`) is excluded by anchoring the hex segment. This also covers `name_resolution`, where the project is renamed after create — the Name in the log stays valid while the create-time Title no longer matches anything.
- **Step 2** is the CLI's own Title→Name lookup (`projects list` returns both, and `name_resolution` teaches agents to use exactly this). Gated on **exact** Title equality and a **unique** hit; two concurrent runs sharing a title resolve to nothing and WARN. It never sweeps, never pattern-deletes, and never deletes a row it did not match by our own title.
- **Step 3** exists because "not resolvable" is a real outcome and must not be papered over. An unresolved title always WARNs — it never claims the tenant is clean. A leaked project costs one grep in CI logs; deleting a concurrent run's project costs that run.

Known, accepted limits (all fail toward WARN, never toward a wrong delete):

1. A title containing spaces cannot be reconstructed (the wrapper's `uip $*` loses quoting), so only its first word is recovered and both resolution steps miss. Current IXP prompts use hyphenated single-token titles.
2. `projects list` has no server-side title filter; `-l 1000` is a single page, and a truncated listing is reported as such in the WARN reason rather than as "not found".
3. A `create` that failed after being logged produces a WARN with no project behind it. Honest noise, and only on runs that already failed.

Also: a `report.json` that parses to a non-object (e.g. a JSON array) used to raise `AttributeError` out of `main` and exit **1**, contradicting the script's "ALWAYS exits 0" contract. Verified on `origin/main` and fixed.

## Validation

`PYTHONUTF8=1 python -m py_compile` clean. Behavior exercised in 19 temp-workspace scenarios with a fake `uip` on `PATH` (run under Linux/WSL to match the docker driver), asserting exit code, exact set of deleted names, and stdout — all pass:

- fallback deletes via step 1 (Name in log) and step 2 (tenant Title lookup);
- foreign names in the log (`projects get`/`list-models`/`get-metrics` against other runs) are **not** deleted;
- same-title concurrent runs, and ambiguous log candidates, delete nothing and WARN;
- no `calls.log`, no `create` line, unparseable / array / key-less `report.json`, `uip` absent from `PATH`: exit 0 in every case;
- existing `report.json` path unchanged (`project_name` and legacy `ProjectName`), and it does not consult `calls.log`;
- repeated runs stay idempotent: second delete 404s, logs WARN, exits 0.

Not validated: no live-tenant run. Untested against a real tenant are the exact `projects list` envelope in an error state, and real slug transformation for titles that are not already lowercase-hyphenated (both degrade to the WARN line by construction).

Note on `calls.log`: post_run executes after grading (orchestrator `finally`), so cleanup's own `uip` lines cannot affect a live score. They would be visible to an evaluate-only re-grade of the same sandbox — pre-existing for the `delete` call, and this adds at most one `projects list` line, only on runs that already failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HfNsX5UrVVqZfHUFhsCn6E
