### PR TITLE
fix(tests): count escaped-quote pagination calls in paginated_reference_lookup

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -34,7 +34,12 @@ success_criteria:
   - type: command_executed
     description: "Agent invoked `uip is resources run list ... curated_channels` more than once (pagination loop ran)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+"?uipath-salesforce-slack"?\s+"?curated_channels'
+    # Commands are recorded as the raw `bash -lc '...'`/`bash -lc "..."` wrapper. When the
+    # command carries an --output-filter with an embedded single-quoted JMESPath
+    # (items[?name=='simple']), the wrapper switches to double quotes and backslash-escapes the
+    # inner quotes (\"uipath-salesforce-slack\"). Allow an optional escaping backslash before each
+    # quote so both quoting styles match; otherwise paginated calls are silently uncounted.
+    command_pattern: 'uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?curated_channels'
     min_count: 2
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

The `skill-flow-paginated-reference-lookup` eval task fails at **0.880** (gating criterion scores 1/2) even though the agent behaved **correctly** — it paginated `uip is resources run list ... curated_channels` three times (page 1 → nextPage page 2 → nextPage page 3), resolved channel `simple` → `C083AN4E61E`, and wired it into the flow. Every other criterion passes (`nextPage=` used, `flow validate` ran, flow file exists, resolved id present).

This is a **false-negative in the test's regex**, not an agent regression.

## Root cause

`command_executed` matches `command_pattern` against the **raw recorded shell wrapper** (`cmd.parameters["command"]`), and the wrapper's quoting varies with the command's contents:

| call | recorded form | old pattern |
|------|---------------|-------------|
| page 1 | `bash -lc '... "uipath-salesforce-slack" "curated_channels ...'` (bare quotes) | ✅ |
| page 2/3 | `bash -lc "... \"uipath-salesforce-slack\" \"curated_channels ..."` (escaped quotes) | ❌ |

Pages 2 & 3 carry an `--output-filter` with an embedded single-quoted JMESPath (`items[?name=='simple']`). Because the command already contains `'`, the shell wrapper can't single-quote it, so it double-quotes the whole thing and backslash-escapes the inner quotes. The old pattern used `"?` (optional *bare* quote) with no allowance for the `\`, so the backslash broke the match and only the page-1 call was counted → 1/2 → gating fail.

## Fix

Allow an optional escaping backslash before each quote: `\\?"?`.

```
- 'uip\s+is\s+resources\s+run\s+list\s+"?uipath-salesforce-slack"?\s+"?curated_channels'
+ 'uip\s+is\s+resources\s+run\s+list\s+\\?"?uipath-salesforce-slack\\?"?\s+\\?"?curated_channels'
```

## Verification

Replayed the failing run's actual recorded commands through the checker's matching logic (`re.search` on `parameters["command"]`):

- old pattern: **1/3** matched → score 0.50 → **FAIL**
- new pattern: **3/3** matched → score 1.00 → **PASS**
- **0** false positives across the other 16 recorded commands
- PyYAML parses the edited scalar to exactly the intended regex; the match sits within the first ~60 chars, so the checker's 2000-char ReDoS truncation is irrelevant

🤖 Generated with [Claude Code](https://claude.com/claude-code)