### PR TITLE
fix(test): discover flow path in HITL smoke criteria instead of hardcoding

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Locate the Flow project's ``.flow`` file dynamically and assert its content.
+
+Usage (from a task's run_command, cwd = sandbox root):
+    python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
+    python3 .../flow_contains.py '"uipath.human-in-the-loop.quick-form"' '"end"'
+
+With no arguments this asserts only that a ``.flow`` file exists. Each argument
+is a substring that must appear in at least one discovered ``.flow`` file.
+
+Why this exists — the ``file_exists`` / ``file_contains`` criterion types take a
+literal ``path`` with no glob support, so tasks hardcode
+``<Name>/<Name>/<Name>.flow``. That path is brittle: ``uip maestro flow init``
+scaffolds a wrapper solution directory whose name the prompt does not pin, so a
+correct flow lands at e.g. ``<Name>Solution/<Name>/<Name>.flow`` and the
+criterion scores 0.0 purely on the path while the flow itself validates. This is
+the same failure ``validate_flow.py`` was added to fix (#2213); it reuses that
+module's discovery so both criteria address the same file.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from flow_check import find_project_dir  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    project_dir = find_project_dir()
+    flows = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
+    if not flows:
+        print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
+        return 1
+
+    print(f"Found {len(flows)} .flow file(s): {', '.join(flows)}")
+    if not argv:
+        return 0
+
+    bodies = {path: open(path, encoding="utf-8").read() for path in flows}
+    missing = [s for s in argv if not any(s in body for body in bodies.values())]
+    for s in argv:
+        print(f"{'MISSING' if s in missing else 'OK     '} {s}")
+    if missing:
+        print(
+            f"FAIL: {len(missing)} substring(s) absent from every discovered .flow file",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -24,17 +24,19 @@ initial_prompt: |
   Validate the flow after building it.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "Flow file was created"
-    path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Flow contains the inline HITL node type"
-    path: "InvoiceApproval/InvoiceApproval/InvoiceApproval.flow"
-    includes:
-      - '"uipath.human-in-the-loop.quick-form"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"uipath.human-in-the-loop.quick-form\"'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -28,17 +28,19 @@ initial_prompt: |
   Validate the flow after building.
 
 success_criteria:
-  - type: file_exists
+  - type: run_command
     description: "Flow file was created"
-    path: "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Flow wires the HITL completed output port"
-    path: "PurchaseApproval/PurchaseApproval/PurchaseApproval.flow"
-    includes:
-      - 'completed'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'completed'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -39,37 +39,35 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Flow contains inline HITL node"
-    path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
-    includes:
-      - '"uipath.human-in-the-loop.quick-form"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"uipath.human-in-the-loop.quick-form\"'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Flow contains a Decision node"
-    path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
-    includes:
-      - '"core.logic.decision"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"core.logic.decision\"'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Decision node references HITL output variable"
-    path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
-    includes:
-      - "$vars."
-      - ".output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.' '.output'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Both Decision branches are wired (true and false handles present)"
-    path: "LeaveRequest/LeaveRequest/LeaveRequest.flow"
-    includes:
-      - '"true"'
-      - '"false"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"true\"' '\"false\"'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

The three `uipath-maestro-flow` HITL smoke tasks assert flow content at a hardcoded `<Name>/<Name>/<Name>.flow`. That path is wrong whenever the agent names the wrapper solution directory anything other than `<Name>` — `uip maestro flow init` scaffolds one, and no prompt pins its name.

Observed on run [30494491742](https://github.com/UiPath/skills/actions/runs/30494491742): `skill-flow-hitl-smoke-node-placed` built a **valid** flow at `InvoiceApprovalSolution/InvoiceApproval/InvoiceApproval.flow`, `uip maestro flow validate` passed on it, and the task still scored **0.375** — both path-based criteria scored 0.0 purely on the path. That dropped the maestro-flow smoke set to 85.7% and failed the ≥95% gate.

This is the failure `_shared/validate_flow.py` was added to fix in #2213 — its docstring already documents the `<Name>Solution/` wrapper problem. #2213 fixed the *validate* criterion and left the content assertions hardcoded.

## Change

`file_exists` / `file_contains` take a literal `path` with no glob support, so content assertions move to `run_command` against a new `_shared/flow_contains.py`, which reuses `flow_check.find_project_dir` — the same discovery `validate_flow.py` uses, so every criterion in a task addresses the same file.

```
python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '"core.logic.decision"'
```

No arguments → assert a `.flow` exists. Each argument → a substring that must appear in at least one discovered `.flow`.

Weights, descriptions, and assertion substrings are unchanged. The `smoke_02` comment explaining the bare-`completed` substring (port handle serializes by node version) is preserved.

## Verification

Replayed the new criteria against the **recorded artifacts** of the failing run — no re-run needed, so this is graded on the exact bytes the agents produced:

| Task | Old | New |
|---|---|---|
| `skill-flow-hitl-smoke-node-placed` | 0.375 (both path criteria 0.0) | **1.0** — all criteria pass on `InvoiceApprovalSolution/…` |
| `skill-flow-hitl-smoke-completed-port` | 1.0 | **1.0** — no regression |
| `skill-flow-hitl-smoke-multi-outcome-routing` | 1.0 | **1.0** — no regression (4 criteria) |

Also unit-checked `flow_contains.py` against a synthetic wrapper-dir fixture: exit 0 for a present substring, exit 1 with a `MISSING <substring>` line for an absent one.

## Follow-up, not in this PR

16 other `uipath-maestro-flow` task files carry the same hardcoded `<Name>/<Name>/<Name>.flow` pattern (~30 criteria) and are latent flakes of this class — `ixp/`, `hitl/quality_*`, `smoke/inline_agent_robust`, `evaluate/*`. Scoped out to keep this PR to the tasks in the failing smoke gate.
