### PR TITLE
feat(case): remove unused "priority" in case metadata from sdd

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
+++ b/skills/uipath-maestro-case/assets/templates/sdd-viewer.html
@@ -500,7 +500,6 @@
         "prefix": string,                     // 2-4 UPPER (constant only)
         "identifierType": "constant" | "external",
         "identifierExpression": string | null, // external only: =vars.<id> or =js:`...`
-        "priority": { "values": string[], "default": string } | null,
         "sla": { "count": number, "unit": "h"|"d"|"w"|"m", "type": "Static"|"Variable" } | null,
         "slaEscalation": [{ "status": "At-Risk"|"Breached", "threshold": string, "action": string }],
         "variableSla": [{ "expression": string, "sla": number, "unit": string }],
@@ -684,7 +683,6 @@
         ["Identifier", c.identifierType === "external"
           ? `${c.identifierExpression || "—"} (external)`
           : (c.prefix ? `${c.prefix} (${c.identifierType || "constant"})` : null)],
-        ["Priority", c.priority ? `${(c.priority.values || []).join(", ")} — default ${c.priority.default || "—"}` : null],
         ["Case-Level SLA", c.sla ? `${c.sla.count} ${c.sla.unit} — ${c.sla.type || "Static"}` : null]
       ];
       const tbl = el("table");

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -197,7 +197,6 @@ Defines what `sdd.md` Section 1 (Case Definition) must contain.
 | Case Name | yes | PascalCase identifier (e.g., `MortgageLoanOrigination`) | Block Approve. Ask. |
 | Description | optional | One prose sentence | `—` |
 | Identifier prefix | yes | UPPER, 2-4 chars (e.g., `MLO`) | Default mechanically from PascalCase first letters; record in source ledger. |
-| Priority | optional | `Low` / `Medium` / `High` / `Critical` | Default `Medium`; record in source ledger. |
 | Case SLA | conditional | Duration (e.g., `5 business days`) | `—` when case has no SLA; otherwise block Approve. |
 | SLA Type | conditional | `time-based` (single unconditional duration) / `condition-based` (one or more conditionExpression-keyed overrides + a default time-based row) | Default `time-based` when Case SLA set with no per-condition overrides. The FE persists `condition-based` whenever ≥ 1 `slaRules[]` entry carries a non-empty `conditionExpression` (see PO.Frontend `CaseManagementSlaProperties.tsx:27-30`). `condition-based` requires populating the §Variable SLA Rules table; `time-based` omits it. |
 | Case App | optional | `Enabled` / `Disabled` — whether the in-product Case App UI is on (`metadata.caseAppEnabled`). | Default `Disabled`; record in source ledger. |


### PR DESCRIPTION
priority shouldn't be in the case metadata in SDD. As it's not mapped, Sonnet 5 may spend a lot of time/tokens to find out the right place to add it, then cause a large lag of latency etc.