### PR TITLE
feat(uipath-maestro-bpmn): add declarative BPMN builder

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -7,12 +7,26 @@ on:
       - 'tests/tasks/uipath-maestro-case/**'
       - 'tests/tasks/uipath-agents/**'
       - 'tests/scripts/**'
+      - 'skills/uipath-maestro-bpmn/scripts/**'
       - 'scripts/**'  # guarded scripts (e.g. build-uip-catalog.py) must trigger their tests
       - 'hooks/**'    # telemetry hook has a contract guard in tests/scripts/
       - '.github/workflows/test-helpers.yml'
   workflow_dispatch:
 
 jobs:
+  maestro-bpmn-builder-tests:
+    runs-on: ubuntu-latest
+    name: maestro-bpmn declarative builder tests
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Run builder tests
+        run: python3 skills/uipath-maestro-bpmn/scripts/test_build_bpmn.py
+
   pytest-flow-check:
     runs-on: ubuntu-latest
     name: maestro-flow checker unit tests

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -115,8 +115,11 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-examples)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already
    shows variables, the entry point, a branch, and the diagram. **Do not
-   reverse-engineer authoring patterns from task fixtures or generated package
-   files** — fixture spelunking is the top reason authoring runs out of time.
+   reverse-engineer authoring patterns from task fixtures, generated package
+   files, or the declarative renderer's implementation/tests.** The
+   declarative-builder guide and `--example` output are its public contract;
+   fixture and implementation spelunking is the top reason authoring runs out
+   of time.
    Add only the structural pieces your process needs (extra
    gateways, events, boundary events, containers, multi-instance markers,
    expression/error mappings, retry attributes), then generate one
@@ -155,6 +158,21 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    metadata shape in
    [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
    Do not copy CLI scaffold metadata shapes into a synthetic local project.
+
+   For a large new graph, use the generic structural renderer described in
+   [references/declarative-builder.md](references/declarative-builder.md).
+   Author its JSON spec instead of precomposing repetitive XML. The spec must
+   state every variable, node, condition, scope, loop, error, and flow; the
+   renderer derives references, DI, and local metadata, but does not generate
+   business policy. Start from:
+
+   ```bash
+   python3 scripts/build-bpmn.py --example
+   ```
+
+   Direct XML editing remains appropriate for a small graph. Do not use the
+   renderer to regenerate an existing/imported BPMN whose unknown content must
+   be preserved.
 4. **Validate.** Run the CLI validator — it runs the full PO.Frontend canvas
    rule set (structural rules plus variable, method-call, input-type, and
    event-object checks) offline, plus deploy-readiness checks:
@@ -252,6 +270,7 @@ and honestly surfaced to the user as gaps when asked.
 | Discover → template → bind → assemble loop | [references/registry-workflow.md](references/registry-workflow.md) |
 | Structural BPMN, event matrix, boundary events, containers, multi-instance, diagram, validation | [references/structural-bpmn.md](references/structural-bpmn.md) |
 | Runtime expressions, `vars.`/`bindings.`/`iterator.`, `=js:` (Jint) syntax | [references/expression-authoring.md](references/expression-authoring.md) |
+| Declarative renderer for large new BPMN graphs | [references/declarative-builder.md](references/declarative-builder.md) |
 | CLI conventions and the side-effect boundary | [references/cli-conventions.md](references/cli-conventions.md) |
 | Keeping content public-safe | [references/public-safety.md](references/public-safety.md) |
 | Package, upload, publish, run, or manage instances | [references/operate/CAPABILITY.md](references/operate/CAPABILITY.md) |

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -202,9 +202,14 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
    Do not copy CLI scaffold metadata shapes into a synthetic local project.
 
-   For a large new graph, use the generic structural renderer described in
+   For a large new graph whose executable work uses only the renderer's
+   documented Variables and ScriptTask mapping forms, use the generic
+   structural renderer described in
    [references/declarative-builder.md](references/declarative-builder.md).
-   Author its JSON spec instead of precomposing repetitive XML. The spec must
+   Do not use this path for connectors, HITL, RPA, agents, send/receive tasks,
+   or another registry template the renderer contract does not explicitly
+   cover; assemble those payloads from their registry XML templates. Author the
+   renderer's JSON spec instead of precomposing repetitive XML. The spec must
    state every variable, node, condition, scope, loop, error, and flow; the
    renderer derives references, DI, and local metadata, but does not generate
    business policy. Start from:

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -112,20 +112,48 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    serializer's lower-camel BPMN element (`<bpmn:sendTask>`,
    `<bpmn:receiveTask>`) while preserving the `uipath:*` payload exactly.
 
-   **Small local fast path.** For a new intent-only graph with at most twelve
-   visible nodes and no connector, subprocess, loop, or boundary event, stop
-   discovery after the single pull and one `registry get` per registry-owned
-   node. Write the project and direct XML immediately from the minimal
-   structural file plus those templates, then validate once. Do not use the
-   declarative renderer, inspect generated scaffold/package files, search
-   fixtures, or read docs for other artifact formats. Manual start/end events,
-   exclusive or parallel gateways, sequence flows, conditions, defaults, and DI
-   are structural: do not search the registry or validator spec for them. A
-   graph using only those elements plus `BPMN.Variables` tasks needs only
+   **Small local fast path (overrides the generic Discover and Assemble
+   guidance).** Use this path only for a new intent-only graph with at most
+   twelve visible nodes and no connector, subprocess, loop, or boundary event.
+   Pull the registry once. If the request names the exact registry-owned types,
+   do not run `registry list` or `registry search`; otherwise stop listing or
+   searching as soon as those types are resolved. Run `registry get` exactly
+   once per **distinct** registry-owned type and reuse its template for every
+   node of that type.
+
+   Read only the
+   [complete minimal file](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-examples)
+   and the directly relevant subsection for each requested node. Then write
+   exactly `<Project>/<Project>.bpmn` and `<Project>/project.uiproj`; the latter
+   is exactly:
+
+   ```json
+   {"projectVersion":"1.0.0","ProjectType":"ProcessOrchestration","Name":"<Project>","main":"<Project>.bpmn"}
+   ```
+
+   Author the XML directly from that minimal structure plus the retrieved
+   templates and validate exactly once. Do not run `uip maestro bpmn init`, the
+   declarative renderer, `pack`, or any solution scaffold/package command. Do
+   not create a solution, `.uipx`, metadata, renderer spec, evidence directory,
+   fixture, implementation source, or test. Manual start/end events, exclusive
+   or parallel gateways, sequence flows, conditions, defaults, and DI are
+   structural: do not search the registry or validator spec for them. A graph
+   using only those elements plus `BPMN.Variables` tasks needs only one
    `registry get BPMN.Variables`. Copy the minimal file's namespace declarations
    verbatim; every `di:waypoint` requires the `xmlns:di` declaration. The first
-   post-template action for this path should create or edit the requested
-   project, not perform more discovery.
+   post-template action must write the requested project.
+
+   **Intent-only `Actions.HITL`.** Use its retrieved registry template; `.flow`
+   QuickForm JSON does not apply. Without a confirmed live app, use visibly
+   synthetic literals for `appId`, `key`, and `taskTitle`; keep `appVersion`
+   numeric; serialize the requested outcome labels in the template's string
+   `actions` field (for example `Approve,Reject`); and put the fields the
+   reviewer must see in the `HitlTaskArguments` JSON body. Declare the
+   template's output variable with type `Actions.HITL`. If the process only
+   records completion, wire the user task directly to a registry-derived
+   `BPMN.Variables` task and then to the end event—do not introduce a gateway or
+   ScriptTask. Report the result as a portable, non-runnable draft until a real
+   app identity replaces the synthetic values.
 3. **Assemble.** Author directly from the complete minimal file in
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-examples)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already
@@ -246,8 +274,11 @@ and honestly surfaced to the user as gaps when asked.
 
 1. **Registry owns every `uipath:*` payload.** Author from
    `registry get` templates; never hand-write `uipath:` XML from prose.
-2. **Never fabricate an identifier.** Connection IDs, process/queue/connector
-   keys, app IDs, folder ids/paths come from discovery or the user.
+2. **Never fabricate a live identifier.** Connection IDs,
+   process/queue/connector keys, app IDs, and folder ids/paths selected for live
+   use come from discovery or the user. Use visibly synthetic intent-only
+   placeholders only where this skill explicitly allows them, and report the
+   resulting draft as non-runnable.
 3. **Structural BPMN is authored, not invented.** Follow the spec/canvas
    contract in [references/structural-bpmn.md](references/structural-bpmn.md);
    flag honestly what the registry does not expose.

--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -111,6 +111,21 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    `<bpmn:SendTask>` or `<bpmn:ReceiveTask>`), normalize the host tag to the
    serializer's lower-camel BPMN element (`<bpmn:sendTask>`,
    `<bpmn:receiveTask>`) while preserving the `uipath:*` payload exactly.
+
+   **Small local fast path.** For a new intent-only graph with at most twelve
+   visible nodes and no connector, subprocess, loop, or boundary event, stop
+   discovery after the single pull and one `registry get` per registry-owned
+   node. Write the project and direct XML immediately from the minimal
+   structural file plus those templates, then validate once. Do not use the
+   declarative renderer, inspect generated scaffold/package files, search
+   fixtures, or read docs for other artifact formats. Manual start/end events,
+   exclusive or parallel gateways, sequence flows, conditions, defaults, and DI
+   are structural: do not search the registry or validator spec for them. A
+   graph using only those elements plus `BPMN.Variables` tasks needs only
+   `registry get BPMN.Variables`. Copy the minimal file's namespace declarations
+   verbatim; every `di:waypoint` requires the `xmlns:di` declaration. The first
+   post-template action for this path should create or edit the requested
+   project, not perform more discovery.
 3. **Assemble.** Author directly from the complete minimal file in
    [references/structural-bpmn.md](references/structural-bpmn.md#a-complete-minimal-file-author-from-this-not-from-examples)
    plus each node's `xmlTemplate` (fill placeholders only). That skeleton already

--- a/skills/uipath-maestro-bpmn/references/declarative-builder.md
+++ b/skills/uipath-maestro-bpmn/references/declarative-builder.md
@@ -1,12 +1,16 @@
 # Declarative structural renderer
 
-Use `scripts/build-bpmn.py` for a **large new** BPMN project. Do not use it to
-rewrite an existing or imported BPMN; brownfield edits must remain surgical.
+Use `scripts/build-bpmn.py` for a **large new** BPMN project whose executable
+work uses only the Variables and ScriptTask mapping forms documented below.
+Do not use it for connectors, HITL, RPA, agents, send/receive tasks, another
+registry payload absent from this contract, or an existing/imported BPMN.
+Assemble unsupported registry nodes from their exact XML templates, and keep
+brownfield edits surgical.
 
 The renderer removes XML bookkeeping only. The JSON spec must still state every
 process variable, node, gateway condition, Variables assignment, scope, error
-boundary, loop, and sequence flow. Mapping fields must come from live registry
-templates.
+boundary, loop, and sequence flow. Its documented mapping fields must come from
+live registry templates.
 
 This guide and `build-bpmn.py --example` are the renderer's authoring contract.
 Do not inspect the renderer implementation or its tests to infer extra fields or
@@ -79,7 +83,10 @@ rendered XML and then overwrite it from a stale spec.
       "matchingBoundaryById": {
         "End_AssessError": "Boundary_AssessError"
       },
-      "forbidUntypedBoundaries": true
+      "forbidUntypedBoundaries": true,
+      "requiredGuardReferencesById": {
+        "End_AssessError": ["backendAvailable", "severity"]
+      }
     },
     "decisionPhases": {
       "SubProcess_Assess": {
@@ -113,7 +120,8 @@ as a stable `vars.<id>` read in the script body; passing the full `vars` object
 does not require redundant per-variable args. Rendering fails if internal
 variables leak into the public contract, a script's inputs/outputs drift from
 its approved responsibility, an error end lacks one visibly conditional
-incoming flow, or a declared decision phase is underdeveloped. Error-end ids
+incoming flow, an error guard omits an approved qualification variable, or a
+declared decision phase is underdeveloped. Error-end ids
 and their matching, typed, interrupting boundaries must be exact; ordinary
 business outcomes must not be smuggled into extra error ends. Root start/end
 counts and required convergence points are also checked. Use an empty
@@ -437,6 +445,15 @@ eligible routes before the complete error guard. Declare the exact error-end id
 under `constraints.errorEnds.allowedIds`, map it to this boundary under
 `matchingBoundaryById`, and give both elements the same `errorRef`. Never use an
 untyped catch-all boundary to stand in for a requested matching error.
+
+Before authoring, list every variable that the approved design says qualifies
+each error route under `requiredGuardReferencesById`. Use the semantic variable
+name or its stable id; the rendered guard must visibly reference the stable
+`vars.<id>` form for every listed variable. Do not leave this map empty when an
+error route is qualified by availability, severity, eligibility, or another
+approved condition. This constraint proves reference presence, not boolean
+polarity or the complete business expression, so review those semantics
+separately.
 
 ## Sequential multi-instance
 

--- a/skills/uipath-maestro-bpmn/references/declarative-builder.md
+++ b/skills/uipath-maestro-bpmn/references/declarative-builder.md
@@ -1,0 +1,478 @@
+# Declarative structural renderer
+
+Use `scripts/build-bpmn.py` for a **large new** BPMN project. Do not use it to
+rewrite an existing or imported BPMN; brownfield edits must remain surgical.
+
+The renderer removes XML bookkeeping only. The JSON spec must still state every
+process variable, node, gateway condition, Variables assignment, scope, error
+boundary, loop, and sequence flow. Mapping fields must come from live registry
+templates.
+
+This guide and `build-bpmn.py --example` are the renderer's authoring contract.
+Do not inspect the renderer implementation or its tests to infer extra fields or
+copy task-specific graphs. If a required construct is absent here, author that
+small structural fragment from `structural-bpmn.md` or report the renderer gap.
+
+## Start and render
+
+```bash
+python3 scripts/build-bpmn.py --example > <project>.spec.json
+python3 scripts/build-bpmn.py <project>.spec.json <project-directory>
+```
+
+Rendering writes:
+
+- the requested `.bpmn`;
+- `project.uiproj`;
+- `operate.json`;
+- `entry-points.json`;
+- `bindings_v2.json`;
+- `package-descriptor.json`.
+
+Keep registry evidence separately when the user requests it. Re-rendering is
+safe for a new project whose spec is the authored source; do not hand-edit the
+rendered XML and then overwrite it from a stale spec.
+
+## Top-level shape
+
+```json
+{
+  "project": {
+    "name": "OrderTriage",
+    "bpmnFile": "OrderTriage.bpmn",
+    "startId": "Start_Main",
+    "entryPointId": "Entry_Main"
+  },
+  "definitionsId": "Definitions_OrderTriage",
+  "targetNamespace": "http://uipath.com/order-triage",
+  "errors": [
+    {
+      "id": "Error_BackendUnavailable",
+      "name": "BackendUnavailable",
+      "errorCode": "BackendUnavailable"
+    }
+  ],
+  "process": {
+    "id": "Process_OrderTriage",
+    "name": "OrderTriage",
+    "variables": [],
+    "nodes": [],
+    "flows": []
+  },
+  "constraints": {
+    "publicInputs": ["orderId"],
+    "publicOutputs": ["route"],
+    "internalVariables": ["normalizedOrderId"],
+    "scriptTasks": {
+      "exact": 1,
+      "allowedIds": ["Task_Normalize"],
+      "allowedOutputsById": {
+        "Task_Normalize": ["normalizedOrderId"]
+      },
+      "requiredInputReferencesById": {
+        "Task_Normalize": ["orderId"]
+      }
+    },
+    "errorEnds": {
+      "singleGuardedIncoming": true,
+      "allowedIds": ["End_AssessError"],
+      "matchingBoundaryById": {
+        "End_AssessError": "Boundary_AssessError"
+      },
+      "forbidUntypedBoundaries": true
+    },
+    "decisionPhases": {
+      "SubProcess_Assess": {
+        "minDivergingExclusiveGateways": 2
+      }
+    },
+    "rootTopology": {
+      "exactStartEvents": 1,
+      "exactEndEvents": 1
+    },
+    "requiredReachability": [
+      {
+        "sources": ["SubProcess_Assess", "Boundary_AssessError"],
+        "target": "Gateway_FanOut"
+      }
+    ]
+  },
+  "diagram": {
+    "shapes": {},
+    "edges": {}
+  }
+}
+```
+
+`constraints` is mandatory. Copy the exact public contract, internal working
+variables, approved ScriptTask count/ids, each script's exact mapped outputs,
+its required input-variable references, and the approved minimum number of
+diverging exclusive gateways in each bounded decision subprocess into it before
+authoring nodes. A required ScriptTask input may appear in its args mapping or
+as a stable `vars.<id>` read in the script body; passing the full `vars` object
+does not require redundant per-variable args. Rendering fails if internal
+variables leak into the public contract, a script's inputs/outputs drift from
+its approved responsibility, an error end lacks one visibly conditional
+incoming flow, or a declared decision phase is underdeveloped. Error-end ids
+and their matching, typed, interrupting boundaries must be exact; ordinary
+business outcomes must not be smuggled into extra error ends. Root start/end
+counts and required convergence points are also checked. Use an empty
+`decisionPhases` object only when the approved design has no bounded decision
+subprocess, and an empty `requiredReachability` list only when no cross-path
+convergence was approved. These checks complement—not replace—the post-render
+semantic review.
+
+`diagram` is optional. When coordinates are omitted, the renderer emits
+complete DI, expands subprocesses around their child nodes, places boundary
+events on their attached activity, and keeps child shapes inside their
+subprocess. Supply shape/edge overrides only when intentional layout matters.
+
+## Variables
+
+```json
+{
+  "direction": "input",
+  "id": "Var_OrderId",
+  "name": "orderId",
+  "type": "string"
+}
+```
+
+Directions are `input`, `output`, `inputOutput`, or `internal`. The renderer
+serializes `internal` as a mutable process variable but excludes it from the
+generated entry-point input/output schemas. Use `internal` for unbound working
+values such as normalized strings; do not expose implementation variables by
+marking them `inputOutput`. The renderer binds public input variables to the
+configured root start event and public outputs to the configured root end event.
+For a public variable with id `Var_OrderId`, it creates the external
+`input_Var_OrderId` or `output_Var_OrderId` declaration, keeps `Var_OrderId` as
+the mutable process variable, and adds the Start/End bridge mapping
+automatically. Declare the plain stable id once: do not pre-prefix it with
+`input_`/`output_`, and do not manually repeat that public field in the root
+Start/End mapping. The renderer rejects duplicate bridge names because a
+double-prefixed bridge such as `input_input_Var_OrderId` can validate locally
+while discarding the caller's value at runtime. Preserve contract types exactly:
+`integer`, `number`, `array`, `object`, and `json` are distinct.
+
+Use `schema` when generated entry-point metadata needs more detail:
+
+```json
+{
+  "direction": "input",
+  "id": "Var_Attachments",
+  "name": "attachments",
+  "type": "array",
+  "schema": {
+    "type": "array",
+    "items": {
+      "type": "object",
+      "properties": {
+        "name": { "type": "string" }
+      },
+      "required": ["name"]
+    }
+  }
+}
+```
+
+## Nodes and flows
+
+Supported `kind` values:
+
+- `startEvent`, `endEvent`, `boundaryEvent`;
+- `task`, `scriptTask`, `serviceTask`, `userTask`, `callActivity`;
+- `exclusiveGateway`, `parallelGateway`;
+- `subProcess`;
+- `intermediateThrowEvent`, `intermediateCatchEvent`.
+
+Basic node and flow:
+
+```json
+{
+  "nodes": [
+    { "kind": "startEvent", "id": "Start_Main", "name": "Start" },
+    {
+      "kind": "exclusiveGateway",
+      "id": "Gateway_Route",
+      "name": "Route",
+      "default": "Flow_Route_Default"
+    },
+    { "kind": "endEvent", "id": "End_Main", "name": "End" }
+  ],
+  "flows": [
+    {
+      "id": "Flow_Start_Route",
+      "source": "Start_Main",
+      "target": "Gateway_Route"
+    },
+    {
+      "id": "Flow_Route_Default",
+      "source": "Gateway_Route",
+      "target": "End_Main"
+    }
+  ]
+}
+```
+
+A conditional flow adds:
+
+```json
+{
+  "condition": "=js:vars.Var_Route === \"NewEscalation\""
+}
+```
+
+Every non-default guard leaving one exclusive gateway must be mutually
+exclusive with its siblings. An exclusive gateway is not an ordered `if /
+else-if` list: do not rely on which true flow the engine happens to inspect
+first. Encode precedence in the predicates (for example, the lower-priority
+guard also excludes the higher-priority case), or split the decision into
+cascaded exclusive gateways. Every diverging exclusive gateway must name
+exactly one outgoing `default` flow. Leave that default flow unconditional and
+give every other outgoing flow an explicit condition; the renderer rejects an
+incomplete split before it can become a runtime stall.
+
+For a parallel fork/join region, each forked workstream must contribute one
+token to the matching parallel join. When a workstream has exclusive internal
+alternatives, add an exclusive merge inside that workstream and connect the
+merge to the parallel join. Do not wire all mutually exclusive alternative
+tasks directly into the parallel join; the join waits for every incoming path
+and will deadlock. For example, a three-way fork whose branches each contain
+their own decisions still needs exactly three incoming flows at the parallel
+join, not one incoming flow per alternative task.
+
+A workstream owns behavior, not merely an output name. If an approved branch
+owns an intent or result, assign its real outcome values inside that branch.
+Do not precompute the value upstream and add a no-op mapping such as
+`action <- vars.action` to satisfy a shape review; that hides policy in the
+wrong phase and makes the branch semantically empty.
+
+The renderer derives every node's `<bpmn:incoming>` and `<bpmn:outgoing>` from
+the owning scope's `flows`.
+
+## Registry-derived mappings
+
+Copy the service type, version, and field names/types/targets from
+`registry get`. The renderer converts a mapping into the registry-owned
+`uipath:mapping` shape.
+
+Variables assignment:
+
+```json
+{
+  "kind": "task",
+  "id": "Task_SetRoute",
+  "name": "Set route",
+  "mapping": {
+    "serviceType": "BPMN.Variables",
+    "version": "v1",
+    "outputs": [
+      {
+        "name": "route",
+        "type": "string",
+        "var": "route",
+        "source": "NewEscalation"
+      }
+    ]
+  }
+}
+```
+
+The renderer resolves an output `var` given as a declared variable name to that
+variable's stable id.
+
+Mapping `source` is always a string because it becomes an XML attribute. A bare
+value is therefore a string literal. For non-string constants, use a typed
+expression: `"source": "=true"` / `"source": "=false"` for booleans and
+`"source": "=42"` for a number. Do not use JSON `true`, `false`, or a numeric
+value as `source`; the renderer rejects those before their type can collapse
+into XML text. Array and object constants likewise need an expression such as
+`=js:[]` or `=js:{}`.
+
+ScriptTask:
+
+```json
+{
+  "kind": "scriptTask",
+  "id": "Task_Normalize",
+  "name": "Normalize",
+  "scriptFormat": "JavaScript",
+  "scriptVersion": "v3",
+  "mapping": {
+    "serviceType": "BPMN.Variables",
+    "version": "v1",
+    "context": [
+      {
+        "name": "inputSchema",
+        "type": "jsonSchema",
+        "body": {
+          "$schema": "http://json-schema.org/draft-07/schema#",
+          "type": "object",
+          "properties": {
+            "vars": { "type": "object" },
+            "metadata": { "type": "object" }
+          },
+          "required": []
+        }
+      }
+    ],
+    "inputs": [
+      {
+        "name": "args",
+        "type": "json",
+        "target": "bodyField",
+        "body": {
+          "vars": "=vars",
+          "metadata": "=metadata"
+        }
+      }
+    ],
+    "outputs": [
+      {
+        "name": "scriptResponse",
+        "type": "string",
+        "var": "normalizedValue",
+        "source": "=result.response"
+      },
+      {
+        "name": "Error",
+        "type": "jsonSchema",
+        "var": "normalizeError",
+        "source": "=Error"
+      }
+    ]
+  },
+  "script": "return (vars.Var_Value || \"\").trim();"
+}
+```
+
+For new v3 ScriptTasks, use the Studio serializer's `BPMN.Variables`
+mapping shape, pass the `vars` and `metadata` objects through `args`, and read
+stable ids as `vars.<id>` in the script. The renderer serializes an input
+`body` as the engine-readable `value` attribute; ordinary XML text is ignored
+by the runtime mapping parser. A multi-instance script also passes
+`"iterator": "=iterator"` and declares it in the input schema.
+
+Declare both the response variable and the typed Error variable in the process
+variable block. Return the response value directly; the runtime exposes it as
+`result.response` to output mappings. Do not add another `{ response: ... }`
+wrapper in the script.
+
+The Error target is activity-scoped, not a generic working variable. Declare it
+with `name: "Error"`, `type: "jsonSchema"`, and
+`elementId: "<script-task-id>"`. A process with several ScriptTasks therefore
+has several same-named Error declarations with distinct ids. In each script
+mapping, set the Error output's `var` to that declaration's explicit stable id;
+using the ambiguous name `Error` would resolve to only one of them.
+
+Do not put business routing/classification policy in a normalization script.
+
+## Embedded subprocess and error boundary
+
+`subProcess` owns nested `nodes` and `flows`:
+
+```json
+{
+  "kind": "subProcess",
+  "id": "SubProcess_Assess",
+  "name": "Assess",
+  "nodes": [
+    { "kind": "startEvent", "id": "Start_Assess", "name": "Start" },
+    {
+      "kind": "endEvent",
+      "id": "End_AssessError",
+      "name": "Backend unavailable",
+      "errorRef": "Error_BackendUnavailable"
+    }
+  ],
+  "flows": [
+    {
+      "id": "Flow_Assess_Error",
+      "source": "Start_Assess",
+      "target": "End_AssessError",
+      "condition": "=js:vars.Var_Severity === \"Sev1\" && !vars.Var_BackendAvailable"
+    }
+  ]
+}
+```
+
+Every execution scope must be connected. Give each root or subprocess
+`startEvent` exactly one outgoing flow, keep every flow's source and target in
+that same scope, and make every node reachable from a start, boundary, or event
+subprocess entry. The renderer rejects disconnected scopes because Alpha can
+otherwise enter a subprocess, find no schedulable work, complete it without an
+incident, and return unset outputs.
+
+Values assigned inside an embedded subprocess are scoped to that subprocess.
+When later root workstreams or public outputs need them, add a
+`BPMN.Variables` mapping on the subprocess itself and map each value explicitly
+from `=vars.<stable-id>` back to the root variable. A structurally valid file
+without this scope bridge can complete while its root outputs remain unset.
+
+That subprocess mapping is a **normal-completion bridge**, not an error payload.
+When an error end terminates the subprocess, Alpha does not apply its normal
+output mapping, and the matching parent boundary cannot read the terminated
+child scope. If the boundary path must retain a child-computed business result,
+model that explicitly in parent scope. Prefer a visible exclusive gateway plus
+`BPMN.Variables` assignment tasks that re-establish each allowed result from
+parent-visible inputs/state. Alternatively, compute and retain the required
+state in the parent before entering the subprocess. Do not rely on a
+child-scope "checkpoint" mapping or on an undocumented error payload.
+
+The interrupting boundary is a root sibling:
+
+```json
+{
+  "kind": "boundaryEvent",
+  "id": "Boundary_AssessError",
+  "name": "Backend unavailable",
+  "attachedTo": "SubProcess_Assess",
+  "cancelActivity": true,
+  "errorRef": "Error_BackendUnavailable"
+}
+```
+
+An error end should have one visibly guarded incoming flow. Merge multiple
+eligible routes before the complete error guard. Declare the exact error-end id
+under `constraints.errorEnds.allowedIds`, map it to this boundary under
+`matchingBoundaryById`, and give both elements the same `errorRef`. Never use an
+untyped catch-all boundary to stand in for a requested matching error.
+
+## Sequential multi-instance
+
+Add `loop` to a task or subprocess:
+
+```json
+{
+  "loop": {
+    "sequential": true,
+    "collection": "=vars.Var_Attachments"
+  }
+}
+```
+
+For a multi-instance task, read the current item with the documented
+`iterator.item` expression and omit `item`; emitting an `inputElement` alias on
+a task-level marker leaves the runtime `iterator` null. For a multi-instance
+subprocess, bind
+`item: "iterator[0]"` and read `iterator[0].item` inside its body.
+Per-iteration task outputs are marker records, not an implicit process-level
+array. A separate reducer after a sequential task marker should read the
+original input collection when it needs the final processed item.
+
+## Required review
+
+After rendering:
+
+1. Parse the XML.
+2. Audit the rendered source against the approved design: exact ScriptTask
+   count/responsibilities, visible policy predicates and tokens, decision-gateway
+   counts, error guards, mappings, and loops. Confirm that sibling exclusive
+   guards cannot both be true. Do not use a default branch to conceal a named
+   business value or predicate that the user expects to audit.
+3. Trace every path to each root end and confirm that every declared public
+   output is explicitly assigned on every completing path. Do not rely on an
+   implicit type default. Use visible Variables tasks for neutral initial values
+   or assign the neutral value on each applicable branch.
+4. Run `uip maestro bpmn validate <file.bpmn> --output json`.
+5. Pack when requested.

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -13,7 +13,8 @@ Use this guide when BPMN source changed and local package metadata must be refre
 When no CLI generator is available and you must author a local-only synthetic
 BPMN project, make the project executable and package-shaped before packing:
 
-- The root process must be `<bpmn:process ... isExecutable="true">`.
+- The root process must match the current Studio Web serializer:
+  `<bpmn:process ... isExecutable="false">`.
 - `project.uiproj` must use lowercase `"main"` pointing at the BPMN file.
 - `operate.json` must use `"main"` with the bare BPMN filename, not a
   `/content/<file>.bpmn#<start-event-id>` entry-point path, plus

--- a/skills/uipath-maestro-bpmn/references/shared/project-layout.md
+++ b/skills/uipath-maestro-bpmn/references/shared/project-layout.md
@@ -61,7 +61,8 @@ For the regeneration and drift-check contract, see [local-metadata-regeneration-
 
 A synthetic local project authored without a CLI generator must still match the
 executable and metadata contract before packing: the BPMN root process includes
-`isExecutable="true"`, `project.uiproj` has lowercase `"main"`,
+`isExecutable="false"` (the current Studio Web serializer default),
+`project.uiproj` has lowercase `"main"`,
 `operate.json` has `"main"` plus `"contentType": "ProcessOrchestration"`, and
 `package-descriptor.json` has top-level `"content"` entries under `content/`.
 For the exact minimal JSON, see

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -42,7 +42,7 @@ namespace, at least one `<bpmn:process>`, and (to render) a
     xmlns:uipath="http://uipath.org/schema/bpmn"
     id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
     exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
-  <bpmn:process id="Process_1" isExecutable="true">
+  <bpmn:process id="Process_1" isExecutable="false">
     <!-- variables, flow nodes, sequence flows -->
   </bpmn:process>
   <bpmndi:BPMNDiagram id="Diagram_1">
@@ -85,9 +85,9 @@ need.
     xmlns:uipath="http://uipath.org/schema/bpmn"
     id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn"
     exporter="UiPath (https://bpmn.uipath.com)" exporterVersion="1.0">
-  <bpmn:process id="Process_1" isExecutable="true">
+  <bpmn:process id="Process_1" isExecutable="false">
     <bpmn:extensionElements>
-      <uipath:migrationVersion version="11.5" />
+      <uipath:migrationVersion version="15" />
       <uipath:variables version="v1">
         <uipath:inputOutput id="Var_Amount" name="Amount" type="number" />
         <uipath:inputOutput id="Var_Tier" name="Tier" type="string" />

--- a/skills/uipath-maestro-bpmn/scripts/build-bpmn.py
+++ b/skills/uipath-maestro-bpmn/scripts/build-bpmn.py
@@ -612,6 +612,247 @@ def script_references_stable_variable(
     return reference in serialized_inputs or reference in script_body
 
 
+def resolve_constraint_variable_id(
+    reference: object,
+    variables: list[dict[str, object]],
+    constraint_path: str,
+) -> str:
+    """Resolve a constraint reference without guessing between variables."""
+    if not isinstance(reference, str) or not reference:
+        raise ValueError(
+            f"{constraint_path} must contain non-empty variable names or ids"
+        )
+    id_matches = [
+        stringify(variable["id"])
+        for variable in variables
+        if stringify(variable["id"]) == reference
+    ]
+    if len(id_matches) == 1:
+        return id_matches[0]
+    name_matches = [
+        stringify(variable["id"])
+        for variable in variables
+        if stringify(variable["name"]) == reference
+    ]
+    if not name_matches:
+        raise ValueError(
+            f"{constraint_path} references unknown variable {reference!r}"
+        )
+    if len(name_matches) != 1:
+        raise ValueError(
+            f"{constraint_path} references ambiguous variable name "
+            f"{reference!r}; use a stable variable id"
+        )
+    return name_matches[0]
+
+
+def mask_javascript_non_code(expression: object) -> str:
+    """Blank literals and comments before inspecting executable JS tokens."""
+    source = stringify(expression)
+    masked = list(source)
+    index = 0
+    can_start_regex = True
+    regex_prefix_words = {
+        "await",
+        "case",
+        "delete",
+        "in",
+        "instanceof",
+        "new",
+        "of",
+        "return",
+        "throw",
+        "typeof",
+        "void",
+        "yield",
+    }
+
+    def blank(position: int) -> None:
+        if masked[position] not in "\r\n":
+            masked[position] = " "
+
+    while index < len(source):
+        char = source[index]
+        if char.isspace():
+            index += 1
+            continue
+        if char in {"'", '"', "`"}:
+            delimiter = char
+            blank(index)
+            index += 1
+            while index < len(source):
+                char = source[index]
+                blank(index)
+                if char == "\\" and index + 1 < len(source):
+                    index += 1
+                    blank(index)
+                elif char == delimiter:
+                    index += 1
+                    break
+                index += 1
+            can_start_regex = False
+            continue
+        if char == "/" and index + 1 < len(source):
+            next_char = source[index + 1]
+            if next_char == "/":
+                blank(index)
+                blank(index + 1)
+                index += 2
+                while index < len(source) and source[index] not in "\r\n":
+                    blank(index)
+                    index += 1
+                continue
+            if next_char == "*":
+                blank(index)
+                blank(index + 1)
+                index += 2
+                while index < len(source):
+                    char = source[index]
+                    blank(index)
+                    if (
+                        char == "*"
+                        and index + 1 < len(source)
+                        and source[index + 1] == "/"
+                    ):
+                        index += 1
+                        blank(index)
+                        index += 1
+                        break
+                    index += 1
+                continue
+            if can_start_regex:
+                blank(index)
+                index += 1
+                in_character_class = False
+                while index < len(source):
+                    char = source[index]
+                    blank(index)
+                    if char == "\\" and index + 1 < len(source):
+                        index += 1
+                        blank(index)
+                    elif char == "[":
+                        in_character_class = True
+                    elif char == "]":
+                        in_character_class = False
+                    elif char == "/" and not in_character_class:
+                        index += 1
+                        while (
+                            index < len(source)
+                            and source[index].isalpha()
+                        ):
+                            blank(index)
+                            index += 1
+                        break
+                    index += 1
+                can_start_regex = False
+                continue
+            can_start_regex = True
+            index += 1
+            continue
+        if char.isalpha() or char in {"_", "$"}:
+            end = index + 1
+            while end < len(source) and (
+                source[end].isalnum() or source[end] in {"_", "$"}
+            ):
+                end += 1
+            can_start_regex = source[index:end] in regex_prefix_words
+            index = end
+            continue
+        if char.isdigit():
+            index += 1
+            while index < len(source) and (
+                source[index].isalnum() or source[index] in {"_", "."}
+            ):
+                index += 1
+            can_start_regex = False
+            continue
+        can_start_regex = char in "([{=,:;!?&|+-*%^~<>"
+        index += 1
+    return "".join(masked)
+
+
+def expression_references_stable_variable(
+    expression: object,
+    variable_id: str,
+) -> bool:
+    """Match standalone vars.<id>, not a longer identifier or property path."""
+    pattern = (
+        rf"(?<![A-Za-z0-9_.])vars\.{re.escape(variable_id)}"
+        rf"(?![A-Za-z0-9_])"
+    )
+    return re.search(pattern, mask_javascript_non_code(expression)) is not None
+
+
+def validate_error_guard_reference_constraints(
+    references_by_id: object,
+    conditions_by_id: dict[str, object],
+    variables: list[dict[str, object]],
+) -> None:
+    """Require approved qualification variables in selected error guards."""
+    path = "constraints.errorEnds.requiredGuardReferencesById"
+    if not isinstance(references_by_id, dict):
+        raise ValueError(f"{path} must be an object")
+    unknown_error_end_ids = set(references_by_id) - set(conditions_by_id)
+    if unknown_error_end_ids:
+        raise ValueError(
+            f"{path} names unknown error ends: "
+            f"{sorted(unknown_error_end_ids)}"
+        )
+    for error_end_id, references in references_by_id.items():
+        item_path = f"{path}[{error_end_id!r}]"
+        if not isinstance(references, list):
+            raise ValueError(f"{item_path} must be an array")
+        for reference in references:
+            variable_id = resolve_constraint_variable_id(
+                reference,
+                variables,
+                item_path,
+            )
+            if not expression_references_stable_variable(
+                conditions_by_id[error_end_id],
+                variable_id,
+            ):
+                raise ValueError(
+                    f"error end {error_end_id} guard does not reference "
+                    f"required variable {reference!r} by stable id "
+                    f"'vars.{variable_id}'"
+                )
+
+
+def validate_matching_error_boundary(
+    error_end: dict[str, object],
+    boundary_id: object,
+    nodes_by_id: dict[str, dict[str, object]],
+    owners_by_id: dict[str, str | None],
+) -> None:
+    """Require the typed, interrupting boundary promised by the contract."""
+    error_end_id = stringify(error_end["id"])
+    if boundary_id is None:
+        raise ValueError(
+            f"matching boundary for error end {error_end_id} is required"
+        )
+    boundary = nodes_by_id.get(stringify(boundary_id))
+    if boundary is None or boundary.get("kind") != "boundaryEvent":
+        raise ValueError(
+            f"matching boundary {boundary_id} for error end {error_end_id} "
+            "does not identify a boundary event"
+        )
+    if boundary.get("errorRef") != error_end.get("errorRef"):
+        raise ValueError(
+            f"error end {error_end_id} and boundary {boundary_id} must use "
+            "the same errorRef"
+        )
+    if boundary.get("attachedTo") != owners_by_id[error_end_id]:
+        raise ValueError(
+            f"boundary {boundary_id} must attach to the subprocess "
+            f"containing error end {error_end_id}"
+        )
+    if boundary.get("cancelActivity", True) is not True:
+        raise ValueError(
+            f"matching error boundary {boundary_id} must be interrupting"
+        )
+
+
 def validate_diverging_exclusive_gateways(
     nodes: list[dict[str, object]],
     flows: list[dict[str, object]],
@@ -896,6 +1137,7 @@ def validate_constraints(spec: dict[str, object]) -> None:
             "constraints.errorEnds.matchingBoundaryById must declare every "
             "error end exactly once"
         )
+    error_conditions_by_id: dict[str, object] = {}
     for node in error_ends:
         node_id = stringify(node["id"])
         error_incoming = incoming.get(stringify(node["id"]), [])
@@ -904,29 +1146,19 @@ def validate_constraints(spec: dict[str, object]) -> None:
                 f"error end {node['id']} must have exactly one conditional "
                 "incoming flow"
             )
+        error_conditions_by_id[node_id] = error_incoming[0]["condition"]
         boundary_id = matching_boundaries[node_id]
-        if boundary_id is None:
-            continue
-        boundary = nodes_by_id.get(stringify(boundary_id))
-        if boundary is None or boundary.get("kind") != "boundaryEvent":
-            raise ValueError(
-                f"matching boundary {boundary_id} for error end {node_id} "
-                "does not identify a boundary event"
-            )
-        if boundary.get("errorRef") != node.get("errorRef"):
-            raise ValueError(
-                f"error end {node_id} and boundary {boundary_id} must use "
-                "the same errorRef"
-            )
-        if boundary.get("attachedTo") != owners_by_id[node_id]:
-            raise ValueError(
-                f"boundary {boundary_id} must attach to the subprocess "
-                f"containing error end {node_id}"
-            )
-        if boundary.get("cancelActivity", True) is not True:
-            raise ValueError(
-                f"matching error boundary {boundary_id} must be interrupting"
-            )
+        validate_matching_error_boundary(
+            node,
+            boundary_id,
+            nodes_by_id,
+            owners_by_id,
+        )
+    validate_error_guard_reference_constraints(
+        error_constraint.get("requiredGuardReferencesById", {}),
+        error_conditions_by_id,
+        variables,
+    )
 
     decision_phases = constraints.get("decisionPhases")
     if not isinstance(decision_phases, dict):
@@ -1582,6 +1814,7 @@ def example() -> dict[str, object]:
                 "allowedIds": [],
                 "matchingBoundaryById": {},
                 "forbidUntypedBoundaries": True,
+                "requiredGuardReferencesById": {},
             },
             "decisionPhases": {},
             "rootTopology": {

--- a/skills/uipath-maestro-bpmn/scripts/build-bpmn.py
+++ b/skills/uipath-maestro-bpmn/scripts/build-bpmn.py
@@ -1,0 +1,1619 @@
+#!/usr/bin/env python3
+"""Render a complete UiPath Maestro BPMN project from a declarative JSON graph.
+
+The renderer owns structural boilerplate only: BPMN elements, incoming/outgoing
+references, sequence flows, loop markers, diagram interchange, and local
+project metadata. Callers remain responsible for the process design and for
+supplying mapping fields derived from live registry templates.
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+from pathlib import Path
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+
+BPMN = "http://www.omg.org/spec/BPMN/20100524/MODEL"
+BPMNDI = "http://www.omg.org/spec/BPMN/20100524/DI"
+DC = "http://www.omg.org/spec/DD/20100524/DC"
+DI = "http://www.omg.org/spec/DD/20100524/DI"
+UIPATH = "http://uipath.org/schema/bpmn"
+XSI = "http://www.w3.org/2001/XMLSchema-instance"
+
+NS = {
+    "bpmn": BPMN,
+    "bpmndi": BPMNDI,
+    "dc": DC,
+    "di": DI,
+    "uipath": UIPATH,
+    "xsi": XSI,
+}
+
+for prefix, uri in NS.items():
+    ET.register_namespace(prefix, uri)
+
+
+def q(prefix: str, local: str) -> str:
+    return f"{{{NS[prefix]}}}{local}"
+
+
+def expand_attr(name: str) -> str:
+    if ":" not in name:
+        return name
+    prefix, local = name.split(":", 1)
+    if prefix not in NS:
+        raise ValueError(f"unknown attribute namespace prefix: {prefix}")
+    return q(prefix, local)
+
+
+def stringify(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def attrs(values: dict[str, object] | None) -> dict[str, str]:
+    return {
+        expand_attr(key): stringify(value)
+        for key, value in (values or {}).items()
+        if value is not None
+    }
+
+
+def add_text(parent: ET.Element, tag: str, text: str) -> ET.Element:
+    child = ET.SubElement(parent, tag)
+    child.text = text
+    return child
+
+
+def extension_elements(node: ET.Element) -> ET.Element:
+    """Return the node's single BPMN extensionElements container."""
+    extension = node.find(q("bpmn", "extensionElements"))
+    if extension is None:
+        extension = ET.Element(q("bpmn", "extensionElements"))
+        node.insert(0, extension)
+    return extension
+
+
+def body_text(body: object) -> str:
+    if isinstance(body, (dict, list)):
+        return json.dumps(body, separators=(",", ":"))
+    return stringify(body)
+
+
+def add_mapping(
+    node: ET.Element,
+    mapping: dict[str, object] | None,
+    *,
+    script_version: str | None = None,
+) -> None:
+    if not mapping and not script_version:
+        return
+    extension = extension_elements(node)
+    if mapping:
+        mapping_el = ET.SubElement(
+            extension,
+            q("uipath", "mapping"),
+            {"version": stringify(mapping.get("mappingVersion", "v1"))},
+        )
+        ET.SubElement(
+            mapping_el,
+            q("uipath", "type"),
+            {
+                "value": stringify(mapping["serviceType"]),
+                "version": stringify(mapping.get("version", "v1")),
+            },
+        )
+        context_fields = mapping.get("context", [])
+        if context_fields:
+            context_el = ET.SubElement(mapping_el, q("uipath", "context"))
+            for field in context_fields:
+                field = dict(field)
+                name = stringify(field.pop("name"))
+                body = field.pop("body", None)
+                child = ET.SubElement(
+                    context_el,
+                    q("uipath", name),
+                    attrs(field),
+                )
+                if body is not None:
+                    child.text = body_text(body)
+        for group, local in (
+            ("inputs", "input"),
+            ("outputs", "output"),
+        ):
+            for field in mapping.get(group, []):
+                field = dict(field)
+                body = field.pop("body", None)
+                if group == "outputs" and "source" in field:
+                    source = field["source"]
+                    output_type = stringify(field.get("type", ""))
+                    if not isinstance(source, str):
+                        raise ValueError(
+                            "mapping output source must be a string; use a "
+                            "typed expression such as '=true' or '=42' for "
+                            "non-string constants"
+                        )
+                    if (
+                        output_type
+                        in {"boolean", "integer", "number", "array", "object"}
+                        and not source.startswith("=")
+                    ):
+                        raise ValueError(
+                            f"mapping output {field.get('name')!r} has type "
+                            f"{output_type!r}, so its source must be a typed "
+                            "'=' expression rather than a string literal"
+                        )
+                child = ET.SubElement(
+                    mapping_el,
+                    q("uipath", local),
+                    attrs(field),
+                )
+                if body is not None:
+                    # The engine parser accepts CDATA or a value attribute.
+                    # ElementTree cannot preserve CDATA, so use the equivalent
+                    # parser-supported attribute. Ordinary XML text is ignored.
+                    child.set("value", body_text(body))
+    if script_version:
+        ET.SubElement(
+            extension,
+            q("uipath", "scriptVersion"),
+            {"value": script_version},
+        )
+
+
+def add_variables(
+    process: ET.Element,
+    variables: list[dict[str, object]],
+    *,
+    migration_version: str | None = None,
+) -> None:
+    if not variables:
+        return
+    extension = extension_elements(process)
+    if migration_version is not None:
+        ET.SubElement(
+            extension,
+            q("uipath", "migrationVersion"),
+            {"version": migration_version},
+        )
+    variables_el = ET.SubElement(
+        extension, q("uipath", "variables"), {"version": "v1"}
+    )
+    direction_tags = {
+        "input": "input",
+        "output": "output",
+        "inputOutput": "inputOutput",
+        "input/output": "inputOutput",
+        "internal": "inputOutput",
+    }
+    for variable in variables:
+        data = dict(variable)
+        direction = stringify(data.pop("direction"))
+        if direction not in direction_tags:
+            raise ValueError(f"unsupported variable direction: {direction}")
+        schema = data.pop("schema", None)
+        variable_el = ET.SubElement(
+            variables_el,
+            q("uipath", direction_tags[direction]),
+            attrs(data),
+        )
+        if schema is not None:
+            variable_el.text = json.dumps(schema, separators=(",", ":"))
+
+
+def index_scope(
+    scope: dict[str, object],
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    incoming: dict[str, list[str]] = {}
+    outgoing: dict[str, list[str]] = {}
+    for flow in scope.get("flows", []):
+        flow_id = stringify(flow["id"])
+        source = stringify(flow["source"])
+        target = stringify(flow["target"])
+        outgoing.setdefault(source, []).append(flow_id)
+        incoming.setdefault(target, []).append(flow_id)
+    return incoming, outgoing
+
+
+def node_tag(kind: str) -> str:
+    supported = {
+        "startEvent",
+        "endEvent",
+        "task",
+        "scriptTask",
+        "subProcess",
+        "exclusiveGateway",
+        "parallelGateway",
+        "boundaryEvent",
+        "intermediateThrowEvent",
+        "intermediateCatchEvent",
+        "callActivity",
+        "serviceTask",
+        "userTask",
+    }
+    if kind not in supported:
+        raise ValueError(f"unsupported BPMN node kind: {kind}")
+    return q("bpmn", kind)
+
+
+def add_loop(node: ET.Element, loop: dict[str, object] | None) -> None:
+    if not loop:
+        return
+    item = loop.get("item")
+    if node.tag == q("bpmn", "subProcess"):
+        if item != "iterator[0]":
+            raise ValueError(
+                "multi-instance subprocess loops require "
+                "item='iterator[0]'"
+            )
+    elif item is not None:
+        raise ValueError(
+            "task-level multi-instance loops must omit item; "
+            "use iterator.item inside the activity"
+        )
+    loop_el = ET.SubElement(
+        node,
+        q("bpmn", "multiInstanceLoopCharacteristics"),
+        {"isSequential": stringify(loop.get("sequential", False))},
+    )
+    if loop.get("completionCondition") is not None:
+        condition = ET.SubElement(
+            loop_el,
+            q("bpmn", "completionCondition"),
+            {q("xsi", "type"): "bpmn:tFormalExpression"},
+        )
+        condition.text = stringify(loop["completionCondition"])
+    extension = ET.SubElement(loop_el, q("bpmn", "extensionElements"))
+    loop_attrs = {
+        "inputCollection": stringify(loop["collection"]),
+        "version": stringify(loop.get("version", "v1")),
+    }
+    if item is not None:
+        loop_attrs["inputElement"] = stringify(item)
+    ET.SubElement(
+        extension,
+        q("uipath", "loopCharacteristics"),
+        loop_attrs,
+    )
+
+
+def add_event_definition(node: ET.Element, spec: dict[str, object]) -> None:
+    error_ref = spec.get("errorRef")
+    if error_ref is not None:
+        ET.SubElement(
+            node,
+            q("bpmn", "errorEventDefinition"),
+            {"errorRef": stringify(error_ref)},
+        )
+    terminate = spec.get("terminate")
+    if terminate:
+        ET.SubElement(node, q("bpmn", "terminateEventDefinition"))
+
+
+def add_node(
+    parent: ET.Element,
+    spec: dict[str, object],
+    incoming: dict[str, list[str]],
+    outgoing: dict[str, list[str]],
+    variable_ids: dict[str, str],
+) -> None:
+    kind = stringify(spec["kind"])
+    node_id = stringify(spec["id"])
+    node_attrs = {"id": node_id}
+    if spec.get("name") is not None:
+        node_attrs["name"] = stringify(spec["name"])
+    node_attrs.update(attrs(spec.get("attrs")))
+    if kind == "boundaryEvent":
+        node_attrs["attachedToRef"] = stringify(spec["attachedTo"])
+        node_attrs["cancelActivity"] = stringify(spec.get("cancelActivity", True))
+    if spec.get("default") is not None:
+        node_attrs["default"] = stringify(spec["default"])
+    if kind == "scriptTask":
+        node_attrs["scriptFormat"] = stringify(spec.get("scriptFormat", "JavaScript"))
+
+    node = ET.SubElement(parent, node_tag(kind), node_attrs)
+
+    mapping = spec.get("mapping")
+    if mapping:
+        mapping = json.loads(json.dumps(mapping))
+        for field in mapping.get("outputs", []):
+            target = field.get("var")
+            if target in variable_ids:
+                field["var"] = variable_ids[target]
+    add_mapping(
+        node,
+        mapping,
+        script_version=(
+            stringify(spec.get("scriptVersion", "v3"))
+            if kind == "scriptTask"
+            else None
+        ),
+    )
+    if spec.get("entryPointId") is not None:
+        extension = extension_elements(node)
+        ET.SubElement(
+            extension,
+            q("uipath", "entryPointId"),
+            {"value": stringify(spec["entryPointId"])},
+        )
+
+    for flow_id in incoming.get(node_id, []):
+        add_text(node, q("bpmn", "incoming"), flow_id)
+    for flow_id in outgoing.get(node_id, []):
+        add_text(node, q("bpmn", "outgoing"), flow_id)
+
+    add_loop(node, spec.get("loop"))
+
+    if kind == "scriptTask":
+        add_text(node, q("bpmn", "script"), stringify(spec.get("script", "")))
+
+    add_event_definition(node, spec)
+
+    if kind == "subProcess":
+        internal = {
+            "nodes": spec.get("nodes", []),
+            "flows": spec.get("flows", []),
+        }
+        add_scope(node, internal, variable_ids)
+
+
+def add_flow(parent: ET.Element, spec: dict[str, object]) -> None:
+    flow = ET.SubElement(
+        parent,
+        q("bpmn", "sequenceFlow"),
+        {
+            "id": stringify(spec["id"]),
+            "sourceRef": stringify(spec["source"]),
+            "targetRef": stringify(spec["target"]),
+        },
+    )
+    if spec.get("name") is not None:
+        flow.set("name", stringify(spec["name"]))
+    if spec.get("condition") is not None:
+        condition = ET.SubElement(
+            flow,
+            q("bpmn", "conditionExpression"),
+            {q("xsi", "type"): "bpmn:tFormalExpression"},
+        )
+        condition.text = stringify(spec["condition"])
+
+
+def add_scope(
+    parent: ET.Element,
+    scope: dict[str, object],
+    variable_ids: dict[str, str],
+) -> None:
+    incoming, outgoing = index_scope(scope)
+    for spec in scope.get("nodes", []):
+        add_node(parent, spec, incoming, outgoing, variable_ids)
+    for spec in scope.get("flows", []):
+        add_flow(parent, spec)
+
+
+def collect_nodes(scope: dict[str, object]) -> list[dict[str, object]]:
+    result: list[dict[str, object]] = []
+    for node in scope.get("nodes", []):
+        result.append(node)
+        if node.get("kind") == "subProcess":
+            result.extend(
+                collect_nodes(
+                    {
+                        "nodes": node.get("nodes", []),
+                        "flows": node.get("flows", []),
+                    }
+                )
+            )
+    return result
+
+
+def collect_flows(scope: dict[str, object]) -> list[dict[str, object]]:
+    result = list(scope.get("flows", []))
+    for node in scope.get("nodes", []):
+        if node.get("kind") == "subProcess":
+            result.extend(
+                collect_flows(
+                    {
+                        "nodes": node.get("nodes", []),
+                        "flows": node.get("flows", []),
+                    }
+                )
+            )
+    return result
+
+
+def collect_node_owners(
+    scope: dict[str, object],
+    owner: str | None = None,
+) -> dict[str, str | None]:
+    result: dict[str, str | None] = {}
+    for node in scope.get("nodes", []):
+        node_id = stringify(node["id"])
+        result[node_id] = owner
+        if node.get("kind") == "subProcess":
+            result.update(
+                collect_node_owners(
+                    {
+                        "nodes": node.get("nodes", []),
+                        "flows": node.get("flows", []),
+                    },
+                    node_id,
+                )
+            )
+    return result
+
+
+def reachable(
+    source: str,
+    target: str,
+    outgoing: dict[str, list[str]],
+    flows_by_id: dict[str, dict[str, object]],
+) -> bool:
+    pending = [source]
+    seen: set[str] = set()
+    while pending:
+        node_id = pending.pop()
+        if node_id == target:
+            return True
+        if node_id in seen:
+            continue
+        seen.add(node_id)
+        for flow_id in outgoing.get(node_id, []):
+            pending.append(stringify(flows_by_id[flow_id]["target"]))
+    return False
+
+
+def validate_stable_variable_references(
+    process: dict[str, object],
+) -> None:
+    """Reject runtime expressions that use variable names instead of ids."""
+    serialized = json.dumps(process)
+    for variable in process.get("variables", []):
+        name = stringify(variable["name"])
+        variable_id = stringify(variable["id"])
+        if name == variable_id:
+            continue
+        pattern = rf"vars\.{re.escape(name)}(?![A-Za-z0-9_])"
+        if re.search(pattern, serialized):
+            raise ValueError(
+                f"runtime expression references declared variable name "
+                f"'vars.{name}'; use its stable id 'vars.{variable_id}'"
+            )
+
+
+def validate_script_error_bindings(
+    scripts_by_id: dict[str, dict[str, object]],
+    variables: list[dict[str, object]],
+) -> None:
+    """Require the current activity-scoped Error contract on every script."""
+    variables_by_id = {
+        stringify(variable["id"]): variable for variable in variables
+    }
+    variables_by_name: dict[str, list[dict[str, object]]] = {}
+    for variable in variables:
+        variables_by_name.setdefault(
+            stringify(variable["name"]), []
+        ).append(variable)
+
+    for script_id, script in scripts_by_id.items():
+        outputs = script.get("mapping", {}).get("outputs", [])
+        error_outputs = [
+            output for output in outputs if output.get("name") == "Error"
+        ]
+        if len(error_outputs) != 1:
+            raise ValueError(
+                f"ScriptTask {script_id} needs exactly one Error output"
+            )
+        error_output = error_outputs[0]
+        if (
+            error_output.get("type") != "jsonSchema"
+            or error_output.get("source") != "=Error"
+        ):
+            raise ValueError(
+                f"ScriptTask {script_id} Error output needs "
+                "type='jsonSchema' and source='=Error'"
+            )
+        variable_ref = stringify(error_output.get("var", ""))
+        variable = variables_by_id.get(variable_ref)
+        if variable is None:
+            candidates = variables_by_name.get(variable_ref, [])
+            if len(candidates) != 1:
+                raise ValueError(
+                    f"ScriptTask {script_id} Error output must map an "
+                    "unambiguous declared variable id"
+                )
+            variable = candidates[0]
+        if (
+            variable.get("name") != "Error"
+            or variable.get("type") != "jsonSchema"
+            or variable.get("elementId") != script_id
+        ):
+            raise ValueError(
+                f"ScriptTask {script_id} Error output needs a variable with "
+                "name='Error', type='jsonSchema', and matching elementId"
+            )
+
+
+def validate_script_runtime_contracts(
+    scripts_by_id: dict[str, dict[str, object]],
+    variables: list[dict[str, object]],
+) -> None:
+    """Require the canonical v3 response/Error outputs on every script."""
+    validate_script_error_bindings(scripts_by_id, variables)
+    variable_ids = {
+        stringify(variable["id"]) for variable in variables
+    }
+    variable_names: dict[str, list[str]] = {}
+    for variable in variables:
+        variable_names.setdefault(
+            stringify(variable["name"]), []
+        ).append(stringify(variable["id"]))
+
+    for script_id, script in scripts_by_id.items():
+        if stringify(script.get("scriptVersion", "v3")) != "v3":
+            raise ValueError(
+                f"ScriptTask {script_id} must use scriptVersion='v3'"
+            )
+        mapping = script.get("mapping", {})
+        if mapping.get("serviceType") != "BPMN.Variables":
+            raise ValueError(
+                f"ScriptTask {script_id} must use a BPMN.Variables mapping"
+            )
+        response_outputs = [
+            output
+            for output in mapping.get("outputs", [])
+            if output.get("name") == "scriptResponse"
+        ]
+        if len(response_outputs) != 1:
+            raise ValueError(
+                f"ScriptTask {script_id} needs exactly one "
+                "scriptResponse output"
+            )
+        response = response_outputs[0]
+        if (
+            response.get("source") != "=result.response"
+            or not stringify(response.get("type", ""))
+        ):
+            raise ValueError(
+                f"ScriptTask {script_id} scriptResponse output needs a "
+                "non-empty type and source='=result.response'"
+            )
+        variable_ref = stringify(response.get("var", ""))
+        resolved = (
+            variable_ref
+            if variable_ref in variable_ids
+            else (
+                variable_names.get(variable_ref, [""])[0]
+                if len(variable_names.get(variable_ref, [])) == 1
+                else ""
+            )
+        )
+        if not resolved:
+            raise ValueError(
+                f"ScriptTask {script_id} scriptResponse output must map an "
+                "unambiguous declared variable id"
+            )
+
+
+def script_references_stable_variable(
+    script: dict[str, object],
+    variable_id: str,
+) -> bool:
+    reference = f"vars.{variable_id}"
+    serialized_inputs = json.dumps(
+        script.get("mapping", {}).get("inputs", [])
+    )
+    script_body = stringify(script.get("script", ""))
+    return reference in serialized_inputs or reference in script_body
+
+
+def validate_diverging_exclusive_gateways(
+    nodes: list[dict[str, object]],
+    flows: list[dict[str, object]],
+) -> None:
+    """Require a complete, explicit default/guard contract for every XOR split."""
+    outgoing: dict[str, list[dict[str, object]]] = {}
+    for flow in flows:
+        outgoing.setdefault(stringify(flow["source"]), []).append(flow)
+
+    for gateway in [
+        node for node in nodes if node.get("kind") == "exclusiveGateway"
+    ]:
+        gateway_id = stringify(gateway["id"])
+        gateway_flows = outgoing.get(gateway_id, [])
+        if len(gateway_flows) < 2:
+            continue
+        default_id = stringify(gateway.get("default", ""))
+        flow_ids = {
+            stringify(flow["id"])
+            for flow in gateway_flows
+        }
+        if not default_id:
+            raise ValueError(
+                f"diverging exclusive gateway {gateway_id} needs an "
+                "explicit default flow"
+            )
+        if default_id not in flow_ids:
+            raise ValueError(
+                f"exclusive gateway {gateway_id} default {default_id} "
+                "must identify one of its outgoing flows"
+            )
+        for flow in gateway_flows:
+            flow_id = stringify(flow["id"])
+            condition = stringify(flow.get("condition", "")).strip()
+            if flow_id == default_id and condition:
+                raise ValueError(
+                    f"exclusive gateway {gateway_id} default flow "
+                    f"{flow_id} must not have a condition"
+                )
+            if flow_id != default_id and not condition:
+                raise ValueError(
+                    f"exclusive gateway {gateway_id} non-default flow "
+                    f"{flow_id} needs a condition"
+                )
+
+
+def validate_scope_execution_paths(
+    scope: dict[str, object],
+    scope_id: str = "process",
+) -> None:
+    """Reject disconnected execution graphs before rendering deployable BPMN."""
+    nodes = scope.get("nodes", [])
+    flows = scope.get("flows", [])
+    nodes_by_id = {
+        stringify(node["id"]): node
+        for node in nodes
+    }
+    outgoing: dict[str, list[str]] = {}
+    for flow in flows:
+        flow_id = stringify(flow["id"])
+        source = stringify(flow["source"])
+        target = stringify(flow["target"])
+        if source not in nodes_by_id or target not in nodes_by_id:
+            raise ValueError(
+                f"scope {scope_id} flow {flow_id} must connect nodes in "
+                "that same scope"
+            )
+        outgoing.setdefault(source, []).append(target)
+
+    start_ids = {
+        node_id
+        for node_id, node in nodes_by_id.items()
+        if node.get("kind") == "startEvent"
+    }
+    for start_id in sorted(start_ids):
+        outgoing_count = len(outgoing.get(start_id, []))
+        if outgoing_count != 1:
+            raise ValueError(
+                f"start event {start_id} in scope {scope_id} needs exactly "
+                f"one outgoing flow; found {outgoing_count}"
+            )
+
+    entry_ids = start_ids | {
+        node_id
+        for node_id, node in nodes_by_id.items()
+        if node.get("kind") == "boundaryEvent"
+        or (
+            node.get("kind") == "subProcess"
+            and bool(node.get("triggeredByEvent", False))
+        )
+    }
+    pending = list(entry_ids)
+    reachable_ids: set[str] = set()
+    while pending:
+        node_id = pending.pop()
+        if node_id in reachable_ids:
+            continue
+        reachable_ids.add(node_id)
+        pending.extend(outgoing.get(node_id, []))
+
+    unreachable_ids = sorted(set(nodes_by_id) - reachable_ids)
+    if unreachable_ids:
+        raise ValueError(
+            f"scope {scope_id} has nodes unreachable from a start, boundary, "
+            f"or event-subprocess entry: {unreachable_ids}"
+        )
+
+    for node_id, node in nodes_by_id.items():
+        if node.get("kind") != "subProcess":
+            continue
+        validate_scope_execution_paths(
+            {
+                "nodes": node.get("nodes", []),
+                "flows": node.get("flows", []),
+            },
+            node_id,
+        )
+
+
+def validate_constraints(spec: dict[str, object]) -> None:
+    constraints = spec.get("constraints")
+    if not isinstance(constraints, dict):
+        raise ValueError(
+            "spec must declare constraints for publicInputs, publicOutputs, "
+            "scriptTasks, errorEnds, and decisionPhases"
+        )
+    process = spec["process"]
+    variables = process.get("variables", [])
+    validate_stable_variable_references(process)
+    public_inputs = {
+        stringify(variable["name"])
+        for variable in variables
+        if variable["direction"] in {"input", "inputOutput", "input/output"}
+    }
+    public_outputs = {
+        stringify(variable["name"])
+        for variable in variables
+        if variable["direction"] in {"output", "inputOutput", "input/output"}
+    }
+    expected_inputs = set(constraints.get("publicInputs", []))
+    expected_outputs = set(constraints.get("publicOutputs", []))
+    if public_inputs != expected_inputs:
+        raise ValueError(
+            f"public input contract mismatch: expected {sorted(expected_inputs)}, "
+            f"found {sorted(public_inputs)}"
+        )
+    if public_outputs != expected_outputs:
+        raise ValueError(
+            f"public output contract mismatch: expected {sorted(expected_outputs)}, "
+            f"found {sorted(public_outputs)}"
+        )
+    internal_variables = {
+        stringify(variable["name"])
+        for variable in variables
+        if variable["direction"] == "internal"
+    }
+    expected_internal = set(constraints.get("internalVariables", []))
+    if internal_variables != expected_internal:
+        raise ValueError(
+            f"internal variable contract mismatch: expected "
+            f"{sorted(expected_internal)}, found {sorted(internal_variables)}"
+        )
+
+    scope = {
+        "nodes": process.get("nodes", []),
+        "flows": process.get("flows", []),
+    }
+    validate_scope_execution_paths(scope)
+    nodes = collect_nodes(scope)
+    flows = collect_flows(scope)
+    validate_diverging_exclusive_gateways(nodes, flows)
+    nodes_by_id = {stringify(node["id"]): node for node in nodes}
+    owners_by_id = collect_node_owners(scope)
+    script_ids = {
+        stringify(node["id"])
+        for node in nodes
+        if node.get("kind") == "scriptTask"
+    }
+    script_constraint = constraints.get("scriptTasks", {})
+    exact = script_constraint.get("exact")
+    if exact is None:
+        raise ValueError("constraints.scriptTasks.exact is required")
+    if len(script_ids) != int(exact):
+        raise ValueError(
+            f"ScriptTask count mismatch: expected {exact}, found "
+            f"{len(script_ids)} ({sorted(script_ids)})"
+        )
+    allowed_ids = script_constraint.get("allowedIds")
+    if allowed_ids is not None and script_ids != set(allowed_ids):
+        raise ValueError(
+            f"ScriptTask ids mismatch: expected {sorted(allowed_ids)}, "
+            f"found {sorted(script_ids)}"
+        )
+    scripts_by_id = {
+        stringify(node["id"]): node
+        for node in nodes
+        if node.get("kind") == "scriptTask"
+    }
+    validate_script_runtime_contracts(scripts_by_id, variables)
+    outputs_by_id = script_constraint.get("allowedOutputsById", {})
+    refs_by_id = script_constraint.get("requiredInputReferencesById", {})
+    if set(outputs_by_id) != script_ids:
+        raise ValueError(
+            "constraints.scriptTasks.allowedOutputsById must declare every "
+            "ScriptTask id exactly once"
+        )
+    if set(refs_by_id) != script_ids:
+        raise ValueError(
+            "constraints.scriptTasks.requiredInputReferencesById must declare "
+            "every ScriptTask id exactly once"
+        )
+    variable_ids = {
+        stringify(variable["name"]): stringify(variable["id"])
+        for variable in variables
+    }
+    for script_id, script in scripts_by_id.items():
+        mapping = script.get("mapping", {})
+        output_names = {
+            stringify(field["name"])
+            for field in mapping.get("outputs", [])
+        }
+        expected_names = set(outputs_by_id[script_id])
+        if output_names != expected_names:
+            raise ValueError(
+                f"ScriptTask {script_id} outputs mismatch: expected "
+                f"{sorted(expected_names)}, found {sorted(output_names)}"
+            )
+        for reference in refs_by_id[script_id]:
+            variable_id = variable_ids.get(reference, reference)
+            if not script_references_stable_variable(script, variable_id):
+                raise ValueError(
+                    f"ScriptTask {script_id} does not reference "
+                    f"required variable {reference!r} by stable id "
+                    f"'vars.{variable_id}'"
+                )
+
+    error_constraint = constraints.get("errorEnds", {})
+    if error_constraint.get("singleGuardedIncoming") is not True:
+        raise ValueError(
+            "constraints.errorEnds.singleGuardedIncoming must be true"
+        )
+    incoming: dict[str, list[dict[str, object]]] = {}
+    for flow in flows:
+        incoming.setdefault(stringify(flow["target"]), []).append(flow)
+    error_ends = [
+        node
+        for node in nodes
+        if node.get("kind") == "endEvent" and node.get("errorRef")
+    ]
+    actual_error_end_ids = {
+        stringify(node["id"])
+        for node in error_ends
+    }
+    allowed_error_end_ids = error_constraint.get("allowedIds")
+    if allowed_error_end_ids is None:
+        raise ValueError("constraints.errorEnds.allowedIds is required")
+    if actual_error_end_ids != set(allowed_error_end_ids):
+        raise ValueError(
+            "error-end ids mismatch: expected "
+            f"{sorted(allowed_error_end_ids)}, found "
+            f"{sorted(actual_error_end_ids)}"
+        )
+    if error_constraint.get("forbidUntypedBoundaries") is not True:
+        raise ValueError(
+            "constraints.errorEnds.forbidUntypedBoundaries must be true"
+        )
+    for boundary in [
+        node for node in nodes if node.get("kind") == "boundaryEvent"
+    ]:
+        if not boundary.get("errorRef"):
+            raise ValueError(
+                f"boundary event {boundary['id']} must declare an errorRef"
+            )
+
+    matching_boundaries = error_constraint.get("matchingBoundaryById")
+    if not isinstance(matching_boundaries, dict):
+        raise ValueError(
+            "constraints.errorEnds.matchingBoundaryById is required"
+        )
+    if set(matching_boundaries) != actual_error_end_ids:
+        raise ValueError(
+            "constraints.errorEnds.matchingBoundaryById must declare every "
+            "error end exactly once"
+        )
+    for node in error_ends:
+        node_id = stringify(node["id"])
+        error_incoming = incoming.get(stringify(node["id"]), [])
+        if len(error_incoming) != 1 or not error_incoming[0].get("condition"):
+            raise ValueError(
+                f"error end {node['id']} must have exactly one conditional "
+                "incoming flow"
+            )
+        boundary_id = matching_boundaries[node_id]
+        if boundary_id is None:
+            continue
+        boundary = nodes_by_id.get(stringify(boundary_id))
+        if boundary is None or boundary.get("kind") != "boundaryEvent":
+            raise ValueError(
+                f"matching boundary {boundary_id} for error end {node_id} "
+                "does not identify a boundary event"
+            )
+        if boundary.get("errorRef") != node.get("errorRef"):
+            raise ValueError(
+                f"error end {node_id} and boundary {boundary_id} must use "
+                "the same errorRef"
+            )
+        if boundary.get("attachedTo") != owners_by_id[node_id]:
+            raise ValueError(
+                f"boundary {boundary_id} must attach to the subprocess "
+                f"containing error end {node_id}"
+            )
+        if boundary.get("cancelActivity", True) is not True:
+            raise ValueError(
+                f"matching error boundary {boundary_id} must be interrupting"
+            )
+
+    decision_phases = constraints.get("decisionPhases")
+    if not isinstance(decision_phases, dict):
+        raise ValueError("constraints.decisionPhases is required")
+    for phase_id, phase_constraint in decision_phases.items():
+        phase = nodes_by_id.get(phase_id)
+        if phase is None or phase.get("kind") != "subProcess":
+            raise ValueError(
+                f"decision phase {phase_id} must identify an embedded subprocess"
+            )
+        minimum = phase_constraint.get("minDivergingExclusiveGateways")
+        if minimum is None:
+            raise ValueError(
+                f"decision phase {phase_id} must declare "
+                "minDivergingExclusiveGateways"
+            )
+        phase_outgoing = index_scope(phase)[1]
+        diverging = [
+            node
+            for node in phase.get("nodes", [])
+            if node.get("kind") == "exclusiveGateway"
+            and len(phase_outgoing.get(stringify(node["id"]), [])) >= 2
+        ]
+        if len(diverging) < int(minimum):
+            raise ValueError(
+                f"decision phase {phase_id} requires at least {minimum} "
+                f"diverging exclusive gateways, found {len(diverging)}"
+            )
+
+    root_topology = constraints.get("rootTopology")
+    if not isinstance(root_topology, dict):
+        raise ValueError("constraints.rootTopology is required")
+    root_nodes = process.get("nodes", [])
+    for kind, key in (
+        ("startEvent", "exactStartEvents"),
+        ("endEvent", "exactEndEvents"),
+    ):
+        expected = root_topology.get(key)
+        if expected is None:
+            raise ValueError(f"constraints.rootTopology.{key} is required")
+        actual = len([node for node in root_nodes if node.get("kind") == kind])
+        if actual != int(expected):
+            raise ValueError(
+                f"root topology requires exactly {expected} {kind} nodes, "
+                f"found {actual}"
+            )
+
+    reachability_rules = constraints.get("requiredReachability")
+    if not isinstance(reachability_rules, list):
+        raise ValueError("constraints.requiredReachability is required")
+    root_ids = {stringify(node["id"]) for node in root_nodes}
+    _root_incoming, root_outgoing = index_scope(process)
+    root_flows_by_id = {
+        stringify(flow["id"]): flow
+        for flow in process.get("flows", [])
+    }
+    for rule in reachability_rules:
+        target = stringify(rule["target"])
+        sources = [stringify(source) for source in rule["sources"]]
+        unknown = sorted(({target, *sources}) - root_ids)
+        if unknown:
+            raise ValueError(
+                f"required reachability references unknown root nodes: {unknown}"
+            )
+        unreachable = [
+            source
+            for source in sources
+            if not reachable(source, target, root_outgoing, root_flows_by_id)
+        ]
+        if unreachable:
+            raise ValueError(
+                f"root nodes {unreachable} do not reach required convergence "
+                f"target {target}"
+            )
+
+
+def default_size(kind: str) -> tuple[int, int]:
+    if kind in {"startEvent", "endEvent", "boundaryEvent", "intermediateThrowEvent", "intermediateCatchEvent"}:
+        return 36, 36
+    if kind in {"exclusiveGateway", "parallelGateway"}:
+        return 50, 50
+    if kind == "subProcess":
+        return 600, 420
+    return 120, 80
+
+
+def layout_scope(
+    scope: dict[str, object],
+    overrides: dict[str, object],
+    positions: dict[str, tuple[float, float, float, float]],
+    *,
+    origin_x: float,
+    origin_y: float,
+    max_columns: int,
+) -> tuple[float, float]:
+    """Lay out one BPMN scope while keeping embedded scopes spatially nested."""
+    nodes = list(scope.get("nodes", []))
+    regular_nodes = [
+        node for node in nodes if node.get("kind") != "boundaryEvent"
+    ]
+    boundary_nodes = [
+        node for node in nodes if node.get("kind") == "boundaryEvent"
+    ]
+    cursor_x = origin_x
+    cursor_y = origin_y
+    row_height = 0.0
+    column = 0
+    scope_right = origin_x
+    scope_bottom = origin_y
+
+    for node in regular_nodes:
+        if column >= max_columns:
+            cursor_x = origin_x
+            cursor_y += row_height + 80
+            row_height = 0.0
+            column = 0
+
+        node_id = stringify(node["id"])
+        kind = stringify(node["kind"])
+        override = overrides.get(node_id, {})
+        if not isinstance(override, dict):
+            raise ValueError(f"diagram shape override for {node_id} must be an object")
+        default_width, default_height = default_size(kind)
+        x = float(override.get("x", cursor_x))
+        y = float(override.get("y", cursor_y))
+        width = float(override.get("width", default_width))
+        height = float(override.get("height", default_height))
+
+        if kind == "subProcess":
+            child_scope = {
+                "nodes": node.get("nodes", []),
+                "flows": node.get("flows", []),
+            }
+            child_nodes = collect_nodes(child_scope)
+            if child_nodes:
+                child_right, child_bottom = layout_scope(
+                    child_scope,
+                    overrides,
+                    positions,
+                    origin_x=x + 40,
+                    origin_y=y + 70,
+                    max_columns=5,
+                )
+                width = max(width, child_right - x + 40)
+                height = max(height, child_bottom - y + 50)
+
+        positions[node_id] = (x, y, width, height)
+        cursor_x = max(cursor_x, x + width + 80)
+        row_height = max(row_height, y + height - cursor_y)
+        scope_right = max(scope_right, x + width)
+        scope_bottom = max(scope_bottom, y + height)
+        column += 1
+
+    boundary_counts: dict[str, int] = {}
+    for node in boundary_nodes:
+        node_id = stringify(node["id"])
+        attached_to = stringify(node.get("attachedTo", ""))
+        if attached_to not in positions:
+            raise ValueError(
+                f"boundary event {node_id} references unknown DI host "
+                f"{attached_to!r}"
+            )
+        host_x, host_y, host_width, host_height = positions[attached_to]
+        default_width, default_height = default_size("boundaryEvent")
+        ordinal = boundary_counts.get(attached_to, 0)
+        boundary_counts[attached_to] = ordinal + 1
+        override = overrides.get(node_id, {})
+        if not isinstance(override, dict):
+            raise ValueError(
+                f"diagram shape override for {node_id} must be an object"
+            )
+        width = float(override.get("width", default_width))
+        height = float(override.get("height", default_height))
+        default_x = host_x + host_width - 55 - ordinal * (width + 12)
+        default_y = host_y + host_height - height / 2
+        x = float(override.get("x", default_x))
+        y = float(override.get("y", default_y))
+        positions[node_id] = (x, y, width, height)
+        scope_right = max(scope_right, x + width)
+        scope_bottom = max(scope_bottom, y + height)
+
+    return scope_right, scope_bottom
+
+
+def add_di(
+    definitions: ET.Element,
+    process_id: str,
+    scope: dict[str, object],
+    diagram_spec: dict[str, object],
+) -> None:
+    diagram = ET.SubElement(
+        definitions,
+        q("bpmndi", "BPMNDiagram"),
+        {"id": stringify(diagram_spec.get("id", f"Diagram_{process_id}"))},
+    )
+    plane = ET.SubElement(
+        diagram,
+        q("bpmndi", "BPMNPlane"),
+        {
+            "id": stringify(diagram_spec.get("planeId", f"Plane_{process_id}")),
+            "bpmnElement": process_id,
+        },
+    )
+
+    positions: dict[str, tuple[float, float, float, float]] = {}
+    overrides = diagram_spec.get("shapes", {})
+    if not isinstance(overrides, dict):
+        raise ValueError("diagram.shapes must be an object")
+    layout_scope(
+        scope,
+        overrides,
+        positions,
+        origin_x=100,
+        origin_y=100,
+        max_columns=8,
+    )
+
+    for node in collect_nodes(scope):
+        node_id = stringify(node["id"])
+        kind = stringify(node["kind"])
+        override = overrides.get(node_id, {})
+        x, y, width, height = positions[node_id]
+        shape_attrs = {
+            "id": stringify(override.get("id", f"Shape_{node_id}")),
+            "bpmnElement": node_id,
+        }
+        if kind == "subProcess":
+            shape_attrs["isExpanded"] = stringify(
+                override.get("isExpanded", True)
+            )
+        shape = ET.SubElement(plane, q("bpmndi", "BPMNShape"), shape_attrs)
+        ET.SubElement(
+            shape,
+            q("dc", "Bounds"),
+            {
+                "x": stringify(x),
+                "y": stringify(y),
+                "width": stringify(width),
+                "height": stringify(height),
+            },
+        )
+
+    edge_overrides = diagram_spec.get("edges", {})
+    for flow in collect_flows(scope):
+        flow_id = stringify(flow["id"])
+        source = positions[stringify(flow["source"])]
+        target = positions[stringify(flow["target"])]
+        points = edge_overrides.get(flow_id)
+        if not points:
+            points = [
+                {"x": source[0] + source[2], "y": source[1] + source[3] / 2},
+                {"x": target[0], "y": target[1] + target[3] / 2},
+            ]
+        edge = ET.SubElement(
+            plane,
+            q("bpmndi", "BPMNEdge"),
+            {
+                "id": f"Edge_{flow_id}",
+                "bpmnElement": flow_id,
+            },
+        )
+        for point in points:
+            ET.SubElement(
+                edge,
+                q("di", "waypoint"),
+                {
+                    "x": stringify(point["x"]),
+                    "y": stringify(point["y"]),
+                },
+            )
+
+
+def schema_for_variable(variable: dict[str, object]) -> dict[str, object]:
+    if variable.get("schema") is not None:
+        return variable["schema"]
+    variable_type = stringify(variable["type"])
+    if variable_type == "json":
+        return {}
+    return {"type": variable_type}
+
+
+def prefixed_variable_id(prefix: str, variable_id: str) -> str:
+    return f"{prefix}_{variable_id}"
+
+
+def runtime_variable_contract(
+    variables: list[dict[str, object]],
+    start_id: str,
+    end_id: str | None,
+) -> tuple[
+    list[dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+]:
+    """Expand public variables into external declarations plus mutable internals.
+
+    Alpha runtime binds entry-point payloads to public input declarations and
+    reads results from public output declarations. Gateway and task expressions
+    operate on internal variables. Explicit Start/End mappings bridge those two
+    contracts while preserving callers' stable ids for expressions.
+    """
+    rendered: list[dict[str, object]] = []
+    start_outputs: list[dict[str, object]] = []
+    end_outputs: list[dict[str, object]] = []
+    reserved_ids = {stringify(variable["id"]) for variable in variables}
+
+    def public_id(prefix: str, variable_id: str) -> str:
+        candidate = prefixed_variable_id(prefix, variable_id)
+        if candidate in reserved_ids:
+            raise ValueError(
+                f"generated public variable id {candidate!r} collides with a "
+                "declared variable id"
+            )
+        reserved_ids.add(candidate)
+        return candidate
+
+    for variable in variables:
+        original = copy.deepcopy(variable)
+        direction = stringify(original["direction"])
+        variable_id = stringify(original["id"])
+        variable_name = stringify(original["name"])
+        is_input = direction in {"input", "inputOutput", "input/output"}
+        is_output = direction in {"output", "inputOutput", "input/output"}
+
+        if is_input:
+            external_input = copy.deepcopy(original)
+            external_input["direction"] = "input"
+            external_input["id"] = public_id("input", variable_id)
+            external_input["elementId"] = start_id
+            rendered.append(external_input)
+            start_outputs.append(
+                {
+                    "name": variable_name,
+                    "type": original["type"],
+                    "var": variable_id,
+                    "source": f"=vars.{external_input['id']}",
+                }
+            )
+
+        if is_output:
+            if end_id is None:
+                raise ValueError(
+                    "project.endId is required when a process with public "
+                    "outputs has multiple root end events"
+                )
+            external_output = copy.deepcopy(original)
+            external_output["direction"] = "output"
+            external_output["id"] = public_id("output", variable_id)
+            external_output["elementId"] = end_id
+            rendered.append(external_output)
+            end_outputs.append(
+                {
+                    "name": variable_name,
+                    "type": original["type"],
+                    "var": external_output["id"],
+                    "source": f"=vars.{variable_id}",
+                }
+            )
+
+        internal = copy.deepcopy(original)
+        internal["direction"] = "internal"
+        if is_input:
+            internal.setdefault("elementId", start_id)
+        rendered.append(internal)
+
+    return rendered, start_outputs, end_outputs
+
+
+def merge_bridge_mapping(
+    node: dict[str, object],
+    outputs: list[dict[str, object]],
+) -> None:
+    if not outputs:
+        return
+    mapping = node.setdefault(
+        "mapping",
+        {
+            "serviceType": "BPMN.Variables",
+            "version": "v1",
+            "outputs": [],
+        },
+    )
+    if mapping.get("serviceType") != "BPMN.Variables":
+        raise ValueError(
+            f"public variable bridge on {node['id']} requires "
+            "serviceType BPMN.Variables"
+        )
+    existing = {
+        stringify(field["var"])
+        for field in mapping.setdefault("outputs", [])
+    }
+    existing_names = {
+        stringify(field["name"])
+        for field in mapping["outputs"]
+    }
+    duplicates = existing & {
+        stringify(field["var"])
+        for field in outputs
+    }
+    duplicate_names = existing_names & {
+        stringify(field["name"])
+        for field in outputs
+    }
+    if duplicates or duplicate_names:
+        details = []
+        if duplicates:
+            details.append(f"targets {sorted(duplicates)}")
+        if duplicate_names:
+            details.append(f"names {sorted(duplicate_names)}")
+        raise ValueError(
+            f"public variable bridge on {node['id']} duplicates output "
+            + " and ".join(details)
+        )
+    mapping["outputs"].extend(outputs)
+
+
+def write_metadata(
+    project_dir: Path,
+    project_name: str,
+    bpmn_name: str,
+    start_id: str,
+    entry_point_id: str,
+    variables: list[dict[str, object]],
+) -> None:
+    inputs = {
+        stringify(variable["name"]): schema_for_variable(variable)
+        for variable in variables
+        if variable["direction"] in {"input", "inputOutput", "input/output"}
+    }
+    outputs = {
+        stringify(variable["name"]): schema_for_variable(variable)
+        for variable in variables
+        if variable["direction"] in {"output", "inputOutput", "input/output"}
+    }
+    files = {
+        "project.uiproj": {
+            "projectVersion": "1.0.0",
+            "ProjectType": "ProcessOrchestration",
+            "Name": project_name,
+            "main": bpmn_name,
+        },
+        "operate.json": {
+            "main": bpmn_name,
+            "contentType": "ProcessOrchestration",
+        },
+        "entry-points.json": {
+            "entryPoints": [
+                {
+                    "id": entry_point_id,
+                    "filePath": f"/content/{bpmn_name}#{start_id}",
+                    "inputSchema": {"type": "object", "properties": inputs},
+                    "outputSchema": {"type": "object", "properties": outputs},
+                }
+            ]
+        },
+        "bindings_v2.json": {"version": "2.0", "resources": []},
+        "package-descriptor.json": {
+            "content": [
+                f"content/{bpmn_name}",
+                "content/bindings_v2.json",
+                "content/entry-points.json",
+                "content/operate.json",
+            ]
+        },
+    }
+    for filename, payload in files.items():
+        (project_dir / filename).write_text(
+            json.dumps(payload, indent=2) + "\n", encoding="utf-8"
+        )
+
+
+def build(spec: dict[str, object], project_dir: Path) -> Path:
+    validate_constraints(spec)
+    project = spec["project"]
+    project_name = stringify(project["name"])
+    bpmn_name = stringify(project.get("bpmnFile", f"{project_name}.bpmn"))
+    process_spec = copy.deepcopy(spec["process"])
+    process_id = stringify(process_spec["id"])
+    start_id = stringify(project["startId"])
+    entry_point_id = stringify(project["entryPointId"])
+
+    definitions = ET.Element(
+        q("bpmn", "definitions"),
+        {
+            "id": stringify(spec.get("definitionsId", f"Definitions_{process_id}")),
+            "targetNamespace": stringify(
+                spec.get("targetNamespace", f"http://uipath.com/{project_name}")
+            ),
+            "exporter": "UiPath BPMN structural renderer",
+            "exporterVersion": "1.0",
+        },
+    )
+    for error in spec.get("errors", []):
+        ET.SubElement(
+            definitions,
+            q("bpmn", "error"),
+            attrs(error),
+        )
+
+    process = ET.SubElement(
+        definitions,
+        q("bpmn", "process"),
+        {
+            "id": process_id,
+            "name": stringify(process_spec.get("name", project_name)),
+            "isExecutable": stringify(process_spec.get("isExecutable", False)),
+        },
+    )
+    variables = process_spec.get("variables", [])
+    scope = {
+        "nodes": copy.deepcopy(process_spec.get("nodes", [])),
+        "flows": copy.deepcopy(process_spec.get("flows", [])),
+    }
+    start_nodes = [
+        node
+        for node in scope["nodes"]
+        if node.get("kind") == "startEvent" and node.get("id") == start_id
+    ]
+    if len(start_nodes) != 1:
+        raise ValueError(f"startId must identify one root startEvent: {start_id}")
+    start_nodes[0]["entryPointId"] = entry_point_id
+    root_end_nodes = [
+        node
+        for node in scope["nodes"]
+        if node.get("kind") == "endEvent"
+    ]
+    end_id = project.get("endId")
+    if end_id is None and len(root_end_nodes) == 1:
+        end_id = root_end_nodes[0]["id"]
+    if end_id is not None:
+        matching_end_nodes = [
+            node for node in root_end_nodes if node.get("id") == end_id
+        ]
+        if len(matching_end_nodes) != 1:
+            raise ValueError(
+                f"endId must identify one root endEvent: {end_id}"
+            )
+        end_node = matching_end_nodes[0]
+    else:
+        end_node = None
+
+    rendered_variables, start_bridge, end_bridge = runtime_variable_contract(
+        variables,
+        start_id,
+        stringify(end_id) if end_id is not None else None,
+    )
+    merge_bridge_mapping(start_nodes[0], start_bridge)
+    if end_bridge:
+        if end_node is None:
+            raise ValueError(
+                "public outputs require project.endId or exactly one root "
+                "end event"
+            )
+        merge_bridge_mapping(end_node, end_bridge)
+
+    add_variables(
+        process,
+        rendered_variables,
+        migration_version=stringify(process_spec.get("migrationVersion", 15)),
+    )
+    variable_ids = {
+        stringify(variable["name"]): stringify(variable["id"])
+        for variable in variables
+    }
+    add_scope(process, scope, variable_ids)
+    add_di(definitions, process_id, scope, spec.get("diagram", {}))
+    ET.indent(definitions, space="  ")
+
+    project_dir.mkdir(parents=True, exist_ok=True)
+    bpmn_path = project_dir / bpmn_name
+    tree = ET.ElementTree(definitions)
+    tree.write(bpmn_path, encoding="utf-8", xml_declaration=True)
+    write_metadata(
+        project_dir,
+        project_name,
+        bpmn_name,
+        start_id,
+        entry_point_id,
+        variables,
+    )
+    return bpmn_path
+
+
+def example() -> dict[str, object]:
+    return {
+        "project": {
+            "name": "Example",
+            "bpmnFile": "Example.bpmn",
+            "startId": "Start_Main",
+            "entryPointId": "Entry_Main",
+        },
+        "process": {
+            "id": "Process_Example",
+            "variables": [
+                {
+                    "direction": "input",
+                    "id": "Var_Request",
+                    "name": "request",
+                    "type": "string",
+                },
+                {
+                    "direction": "output",
+                    "id": "Var_Result",
+                    "name": "result",
+                    "type": "string",
+                },
+            ],
+            "nodes": [
+                {"kind": "startEvent", "id": "Start_Main", "name": "Start"},
+                {
+                    "kind": "task",
+                    "id": "Task_Set",
+                    "name": "Set result",
+                    "mapping": {
+                        "serviceType": "BPMN.Variables",
+                        "outputs": [
+                            {
+                                "name": "result",
+                                "type": "string",
+                                "var": "result",
+                                "source": "Done",
+                            }
+                        ],
+                    },
+                },
+                {"kind": "endEvent", "id": "End_Main", "name": "End"},
+            ],
+            "flows": [
+                {
+                    "id": "Flow_Start_Set",
+                    "source": "Start_Main",
+                    "target": "Task_Set",
+                },
+                {
+                    "id": "Flow_Set_End",
+                    "source": "Task_Set",
+                    "target": "End_Main",
+                },
+            ],
+        },
+        "constraints": {
+            "publicInputs": ["request"],
+            "publicOutputs": ["result"],
+            "internalVariables": [],
+            "scriptTasks": {
+                "exact": 0,
+                "allowedIds": [],
+                "allowedOutputsById": {},
+                "requiredInputReferencesById": {},
+            },
+            "errorEnds": {
+                "singleGuardedIncoming": True,
+                "allowedIds": [],
+                "matchingBoundaryById": {},
+                "forbidUntypedBoundaries": True,
+            },
+            "decisionPhases": {},
+            "rootTopology": {
+                "exactStartEvents": 1,
+                "exactEndEvents": 1,
+            },
+            "requiredReachability": [],
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("spec", nargs="?", type=Path)
+    parser.add_argument("project_dir", nargs="?", type=Path)
+    parser.add_argument(
+        "--example",
+        action="store_true",
+        help="print a minimal declarative spec",
+    )
+    args = parser.parse_args()
+    if args.example:
+        json.dump(example(), sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        return 0
+    if not args.spec or not args.project_dir:
+        parser.error("spec and project_dir are required unless --example is used")
+    spec = json.loads(args.spec.read_text(encoding="utf-8"))
+    path = build(spec, args.project_dir)
+    print(path)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/uipath-maestro-bpmn/scripts/test_build_bpmn.py
+++ b/skills/uipath-maestro-bpmn/scripts/test_build_bpmn.py
@@ -1,0 +1,1125 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+
+SCRIPT = Path(__file__).with_name("build-bpmn.py")
+SPEC = importlib.util.spec_from_file_location("build_bpmn", SCRIPT)
+assert SPEC and SPEC.loader
+build_bpmn = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(build_bpmn)
+
+
+class BuildBpmnTests(unittest.TestCase):
+    def test_accepts_connected_nested_execution_scopes(self) -> None:
+        build_bpmn.validate_scope_execution_paths(
+            {
+                "nodes": [
+                    {"kind": "startEvent", "id": "Start_Main"},
+                    {
+                        "kind": "subProcess",
+                        "id": "Sub_Assess",
+                        "nodes": [
+                            {"kind": "startEvent", "id": "Start_Assess"},
+                            {"kind": "task", "id": "Task_Assess"},
+                            {"kind": "endEvent", "id": "End_Assess"},
+                        ],
+                        "flows": [
+                            {
+                                "id": "Flow_Assess_Task",
+                                "source": "Start_Assess",
+                                "target": "Task_Assess",
+                            },
+                            {
+                                "id": "Flow_Task_EndAssess",
+                                "source": "Task_Assess",
+                                "target": "End_Assess",
+                            },
+                        ],
+                    },
+                    {"kind": "endEvent", "id": "End_Main"},
+                ],
+                "flows": [
+                    {
+                        "id": "Flow_Start_Sub",
+                        "source": "Start_Main",
+                        "target": "Sub_Assess",
+                    },
+                    {
+                        "id": "Flow_Sub_End",
+                        "source": "Sub_Assess",
+                        "target": "End_Main",
+                    },
+                ],
+            }
+        )
+
+    def test_rejects_subprocess_start_without_outgoing_flow(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "start event Start_Assess in scope Sub_Assess needs exactly "
+            "one outgoing flow; found 0",
+        ):
+            build_bpmn.validate_scope_execution_paths(
+                {
+                    "nodes": [
+                        {"kind": "startEvent", "id": "Start_Main"},
+                        {
+                            "kind": "subProcess",
+                            "id": "Sub_Assess",
+                            "nodes": [
+                                {
+                                    "kind": "startEvent",
+                                    "id": "Start_Assess",
+                                },
+                                {"kind": "task", "id": "Task_Assess"},
+                                {"kind": "endEvent", "id": "End_Assess"},
+                            ],
+                            "flows": [
+                                {
+                                    "id": "Flow_Task_EndAssess",
+                                    "source": "Task_Assess",
+                                    "target": "End_Assess",
+                                }
+                            ],
+                        },
+                        {"kind": "endEvent", "id": "End_Main"},
+                    ],
+                    "flows": [
+                        {
+                            "id": "Flow_Start_Sub",
+                            "source": "Start_Main",
+                            "target": "Sub_Assess",
+                        },
+                        {
+                            "id": "Flow_Sub_End",
+                            "source": "Sub_Assess",
+                            "target": "End_Main",
+                        },
+                    ],
+                }
+            )
+
+    def test_rejects_unreachable_node_in_scope(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            r"scope process has nodes unreachable .*\['Task_Orphan'\]",
+        ):
+            build_bpmn.validate_scope_execution_paths(
+                {
+                    "nodes": [
+                        {"kind": "startEvent", "id": "Start_Main"},
+                        {"kind": "endEvent", "id": "End_Main"},
+                        {"kind": "task", "id": "Task_Orphan"},
+                    ],
+                    "flows": [
+                        {
+                            "id": "Flow_Start_End",
+                            "source": "Start_Main",
+                            "target": "End_Main",
+                        }
+                    ],
+                }
+            )
+
+    def test_rejects_flow_crossing_execution_scope(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "scope Sub_Assess flow Flow_Escape must connect nodes in that "
+            "same scope",
+        ):
+            build_bpmn.validate_scope_execution_paths(
+                {
+                    "nodes": [
+                        {"kind": "startEvent", "id": "Start_Main"},
+                        {
+                            "kind": "subProcess",
+                            "id": "Sub_Assess",
+                            "nodes": [
+                                {
+                                    "kind": "startEvent",
+                                    "id": "Start_Assess",
+                                }
+                            ],
+                            "flows": [
+                                {
+                                    "id": "Flow_Escape",
+                                    "source": "Start_Assess",
+                                    "target": "End_Main",
+                                }
+                            ],
+                        },
+                        {"kind": "endEvent", "id": "End_Main"},
+                    ],
+                    "flows": [
+                        {
+                            "id": "Flow_Start_Sub",
+                            "source": "Start_Main",
+                            "target": "Sub_Assess",
+                        },
+                        {
+                            "id": "Flow_Sub_End",
+                            "source": "Sub_Assess",
+                            "target": "End_Main",
+                        },
+                    ],
+                }
+            )
+
+    def test_accepts_complete_diverging_exclusive_gateway(self) -> None:
+        build_bpmn.validate_diverging_exclusive_gateways(
+            [
+                {
+                    "kind": "exclusiveGateway",
+                    "id": "Gateway_Route",
+                    "default": "Flow_Default",
+                }
+            ],
+            [
+                {
+                    "id": "Flow_Guarded",
+                    "source": "Gateway_Route",
+                    "target": "Task_Guarded",
+                    "condition": "=vars.Var_Enabled == true",
+                },
+                {
+                    "id": "Flow_Default",
+                    "source": "Gateway_Route",
+                    "target": "Task_Default",
+                },
+            ],
+        )
+
+    def test_rejects_diverging_exclusive_gateway_without_default(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "needs an explicit default flow"
+        ):
+            build_bpmn.validate_diverging_exclusive_gateways(
+                [
+                    {
+                        "kind": "exclusiveGateway",
+                        "id": "Gateway_Route",
+                    }
+                ],
+                [
+                    {
+                        "id": "Flow_One",
+                        "source": "Gateway_Route",
+                        "target": "Task_One",
+                        "condition": "=vars.Var_Route == 1",
+                    },
+                    {
+                        "id": "Flow_Two",
+                        "source": "Gateway_Route",
+                        "target": "Task_Two",
+                        "condition": "=vars.Var_Route == 2",
+                    },
+                ],
+            )
+
+    def test_accepts_script_scoped_error_variable(self) -> None:
+        scripts = {
+            "Task_Normalize": {
+                "mapping": {
+                    "outputs": [
+                        {
+                            "name": "Error",
+                            "type": "jsonSchema",
+                            "var": "Var_NormalizeError",
+                            "source": "=Error",
+                        }
+                    ]
+                }
+            }
+        }
+        variables = [
+            {
+                "direction": "internal",
+                "id": "Var_NormalizeError",
+                "name": "Error",
+                "type": "jsonSchema",
+                "elementId": "Task_Normalize",
+            }
+        ]
+
+        build_bpmn.validate_script_error_bindings(scripts, variables)
+
+    def test_rejects_unscoped_script_error_variable(self) -> None:
+        scripts = {
+            "Task_Normalize": {
+                "mapping": {
+                    "outputs": [
+                        {
+                            "name": "Error",
+                            "type": "jsonSchema",
+                            "var": "Var_NormalizeError",
+                            "source": "=Error",
+                        }
+                    ]
+                }
+            }
+        }
+        variables = [
+            {
+                "direction": "internal",
+                "id": "Var_NormalizeError",
+                "name": "normalizeError",
+                "type": "object",
+            }
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, "matching elementId"
+        ):
+            build_bpmn.validate_script_error_bindings(scripts, variables)
+
+    def test_accepts_complete_v3_script_runtime_contract(self) -> None:
+        scripts = {
+            "Task_Normalize": {
+                "scriptVersion": "v3",
+                "mapping": {
+                    "serviceType": "BPMN.Variables",
+                    "outputs": [
+                        {
+                            "name": "scriptResponse",
+                            "type": "object",
+                            "var": "Var_NormalizeResponse",
+                            "source": "=result.response",
+                        },
+                        {
+                            "name": "Error",
+                            "type": "jsonSchema",
+                            "var": "Var_NormalizeError",
+                            "source": "=Error",
+                        },
+                    ],
+                },
+            }
+        }
+        variables = [
+            {
+                "direction": "internal",
+                "id": "Var_NormalizeResponse",
+                "name": "normalizeResponse",
+                "type": "object",
+            },
+            {
+                "direction": "internal",
+                "id": "Var_NormalizeError",
+                "name": "Error",
+                "type": "jsonSchema",
+                "elementId": "Task_Normalize",
+            },
+        ]
+
+        build_bpmn.validate_script_runtime_contracts(scripts, variables)
+
+    def test_rejects_script_without_standard_response_output(self) -> None:
+        scripts = {
+            "Task_Normalize": {
+                "mapping": {
+                    "serviceType": "BPMN.Variables",
+                    "outputs": [
+                        {
+                            "name": "normalizedTier",
+                            "type": "string",
+                            "var": "Var_NormalizedTier",
+                            "source": "=result.response.normalizedTier",
+                        },
+                        {
+                            "name": "Error",
+                            "type": "jsonSchema",
+                            "var": "Var_NormalizeError",
+                            "source": "=Error",
+                        },
+                    ],
+                }
+            }
+        }
+        variables = [
+            {
+                "direction": "internal",
+                "id": "Var_NormalizedTier",
+                "name": "normalizedTier",
+                "type": "string",
+            },
+            {
+                "direction": "internal",
+                "id": "Var_NormalizeError",
+                "name": "Error",
+                "type": "jsonSchema",
+                "elementId": "Task_Normalize",
+            },
+        ]
+
+        with self.assertRaisesRegex(
+            ValueError, "exactly one scriptResponse output"
+        ):
+            build_bpmn.validate_script_runtime_contracts(
+                scripts, variables
+            )
+
+    def test_rejects_runtime_reference_by_variable_name(self) -> None:
+        process = {
+            "variables": [
+                {
+                    "direction": "input",
+                    "id": "Var_Request",
+                    "name": "request",
+                    "type": "string",
+                }
+            ],
+            "nodes": [
+                {
+                    "kind": "scriptTask",
+                    "id": "Task_Normalize",
+                    "mapping": {
+                        "inputs": [
+                            {
+                                "name": "args",
+                                "body": '{"request":"=vars.request"}',
+                            }
+                        ]
+                    },
+                }
+            ],
+            "flows": [],
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"use its stable id 'vars\.Var_Request'",
+        ):
+            build_bpmn.validate_stable_variable_references(process)
+
+    def test_accepts_runtime_reference_by_stable_variable_id(self) -> None:
+        process = {
+            "variables": [
+                {
+                    "direction": "input",
+                    "id": "Var_Request",
+                    "name": "request",
+                    "type": "string",
+                }
+            ],
+            "nodes": [
+                {
+                    "kind": "scriptTask",
+                    "id": "Task_Normalize",
+                    "mapping": {
+                        "inputs": [
+                            {
+                                "name": "args",
+                                "body": '{"request":"=vars.Var_Request"}',
+                            }
+                        ]
+                    },
+                }
+            ],
+            "flows": [],
+        }
+
+        build_bpmn.validate_stable_variable_references(process)
+
+    def test_script_constraint_accepts_stable_reference_in_script_body(
+        self,
+    ) -> None:
+        script = {
+            "mapping": {
+                "inputs": [
+                    {
+                        "name": "args",
+                        "body": {
+                            "vars": "=vars",
+                            "metadata": "=metadata",
+                        },
+                    }
+                ]
+            },
+            "script": "return vars.Var_Request;",
+        }
+
+        self.assertTrue(
+            build_bpmn.script_references_stable_variable(
+                script,
+                "Var_Request",
+            )
+        )
+
+    def test_script_constraint_rejects_name_only_reference(self) -> None:
+        script = {
+            "mapping": {
+                "inputs": [
+                    {
+                        "name": "args",
+                        "body": {
+                            "vars": "=vars",
+                            "metadata": "=metadata",
+                        },
+                    }
+                ]
+            },
+            "script": "return vars.request;",
+        }
+
+        self.assertFalse(
+            build_bpmn.script_references_stable_variable(
+                script,
+                "Var_Request",
+            )
+        )
+
+    def test_public_bridge_rejects_duplicate_semantic_name(self) -> None:
+        node = {
+            "id": "Start_Main",
+            "mapping": {
+                "serviceType": "BPMN.Variables",
+                "version": "v1",
+                "outputs": [
+                    {
+                        "name": "request",
+                        "type": "string",
+                        "var": "Var_Request",
+                        "source": "=vars.input_Var_Request",
+                    }
+                ],
+            },
+        }
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"duplicates output names \['request'\]",
+        ):
+            build_bpmn.merge_bridge_mapping(
+                node,
+                [
+                    {
+                        "name": "request",
+                        "type": "string",
+                        "var": "input_Var_Request",
+                        "source": "=vars.input_input_Var_Request",
+                    }
+                ],
+            )
+
+    def test_public_bridge_allows_distinct_initialization(self) -> None:
+        node = {
+            "id": "Start_Main",
+            "mapping": {
+                "serviceType": "BPMN.Variables",
+                "version": "v1",
+                "outputs": [
+                    {
+                        "name": "initialized",
+                        "type": "boolean",
+                        "var": "Var_Initialized",
+                        "source": "=true",
+                    }
+                ],
+            },
+        }
+
+        build_bpmn.merge_bridge_mapping(
+            node,
+            [
+                {
+                    "name": "request",
+                    "type": "string",
+                    "var": "Var_Request",
+                    "source": "=vars.input_Var_Request",
+                }
+            ],
+        )
+
+        self.assertEqual(
+            [
+                item["name"]
+                for item in node["mapping"]["outputs"]
+            ],
+            ["initialized", "request"],
+        )
+
+    def test_rejects_json_boolean_mapping_source_before_type_is_lost(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "task"))
+        mapping = {
+            "serviceType": "BPMN.Variables",
+            "outputs": [
+                {
+                    "name": "approved",
+                    "type": "boolean",
+                    "var": "Var_Approved",
+                    "source": True,
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, "source must be a string"
+        ):
+            build_bpmn.add_mapping(node, mapping)
+
+    def test_rejects_bare_literal_for_non_string_mapping_output(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "task"))
+        mapping = {
+            "serviceType": "BPMN.Variables",
+            "outputs": [
+                {
+                    "name": "approved",
+                    "type": "boolean",
+                    "var": "Var_Approved",
+                    "source": "true",
+                }
+            ],
+        }
+
+        with self.assertRaisesRegex(
+            ValueError, "must be a typed '=' expression"
+        ):
+            build_bpmn.add_mapping(node, mapping)
+
+    def test_accepts_typed_boolean_mapping_expression(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "task"))
+        build_bpmn.add_mapping(
+            node,
+            {
+                "serviceType": "BPMN.Variables",
+                "outputs": [
+                    {
+                        "name": "approved",
+                        "type": "boolean",
+                        "var": "Var_Approved",
+                        "source": "=true",
+                    }
+                ],
+            },
+        )
+
+        output = node.find(".//uipath:output", build_bpmn.NS)
+        self.assertIsNotNone(output)
+        self.assertEqual(output.attrib["source"], "=true")
+
+    def test_serializes_runtime_mapping_body_as_value_attribute(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "scriptTask"))
+        build_bpmn.add_mapping(
+            node,
+            {
+                "serviceType": "BPMN.Variables",
+                "context": [
+                    {
+                        "name": "inputSchema",
+                        "type": "jsonSchema",
+                        "body": {"type": "object"},
+                    }
+                ],
+                "inputs": [
+                    {
+                        "name": "args",
+                        "type": "json",
+                        "target": "bodyField",
+                        "body": {"vars": "=vars", "metadata": "=metadata"},
+                    }
+                ],
+            },
+            script_version="v3",
+        )
+
+        input_el = node.find(".//uipath:input", build_bpmn.NS)
+        self.assertIsNotNone(input_el)
+        self.assertEqual(
+            input_el.attrib["value"],
+            '{"vars":"=vars","metadata":"=metadata"}',
+        )
+        self.assertIsNone(input_el.text)
+        schema = node.find(
+            ".//uipath:context/uipath:inputSchema",
+            build_bpmn.NS,
+        )
+        self.assertIsNotNone(schema)
+        self.assertEqual(schema.attrib["type"], "jsonSchema")
+        self.assertEqual(schema.text, '{"type":"object"}')
+        self.assertIsNotNone(
+            node.find(".//uipath:scriptVersion", build_bpmn.NS)
+        )
+
+    def test_loop_item_is_optional_for_root_marker(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "scriptTask"))
+        build_bpmn.add_loop(
+            node,
+            {
+                "sequential": True,
+                "collection": "=vars.Var_Items",
+            },
+        )
+
+        loop = node.find(
+            ".//uipath:loopCharacteristics",
+            build_bpmn.NS,
+        )
+        self.assertIsNotNone(loop)
+        self.assertEqual(loop.attrib["version"], "v1")
+        self.assertEqual(loop.attrib["inputCollection"], "=vars.Var_Items")
+        self.assertNotIn("inputElement", loop.attrib)
+
+    def test_task_loop_rejects_input_element_alias(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "scriptTask"))
+        with self.assertRaisesRegex(
+            ValueError,
+            "task-level multi-instance loops must omit item",
+        ):
+            build_bpmn.add_loop(
+                node,
+                {
+                    "sequential": True,
+                    "collection": "=vars.Var_Items",
+                    "item": "item",
+                },
+            )
+
+    def test_subprocess_loop_requires_iterator_depth_binding(self) -> None:
+        node = ET.Element(build_bpmn.q("bpmn", "subProcess"))
+        with self.assertRaisesRegex(
+            ValueError,
+            "multi-instance subprocess loops require",
+        ):
+            build_bpmn.add_loop(
+                node,
+                {
+                    "sequential": True,
+                    "collection": "=vars.Var_Items",
+                },
+            )
+        build_bpmn.add_loop(
+            node,
+            {
+                "sequential": True,
+                "collection": "=vars.Var_Items",
+                "item": "iterator[0]",
+            },
+        )
+        loop = node.find(
+            ".//uipath:loopCharacteristics",
+            build_bpmn.NS,
+        )
+        self.assertIsNotNone(loop)
+        self.assertEqual(loop.attrib["inputElement"], "iterator[0]")
+
+    def test_nested_error_loop_mapping_and_metadata(self) -> None:
+        spec = {
+            "project": {
+                "name": "Complex",
+                "bpmnFile": "Complex.bpmn",
+                "startId": "Start_Main",
+                "entryPointId": "Entry_Main",
+            },
+            "errors": [
+                {
+                    "id": "Error_Backend",
+                    "name": "Backend",
+                    "errorCode": "Backend",
+                }
+            ],
+            "process": {
+                "id": "Process_Complex",
+                "variables": [
+                    {
+                        "direction": "input",
+                        "id": "Var_Items",
+                        "name": "items",
+                        "type": "array",
+                    },
+                    {
+                        "direction": "output",
+                        "id": "Var_Result",
+                        "name": "result",
+                        "type": "string",
+                    },
+                    {
+                        "direction": "internal",
+                        "id": "Var_Working",
+                        "name": "working",
+                        "type": "string",
+                    },
+                ],
+                "nodes": [
+                    {"kind": "startEvent", "id": "Start_Main"},
+                    {
+                        "kind": "subProcess",
+                        "id": "Sub_Assess",
+                        "nodes": [
+                            {"kind": "startEvent", "id": "Start_Assess"},
+                            {
+                                "kind": "exclusiveGateway",
+                                "id": "Gateway_Check",
+                                "default": "Flow_Check_End",
+                            },
+                            {
+                                "kind": "endEvent",
+                                "id": "End_Error",
+                                "errorRef": "Error_Backend",
+                            },
+                            {"kind": "endEvent", "id": "End_Assess"},
+                        ],
+                        "flows": [
+                            {
+                                "id": "Flow_Assess_Check",
+                                "source": "Start_Assess",
+                                "target": "Gateway_Check",
+                            },
+                            {
+                                "id": "Flow_Check_Error",
+                                "source": "Gateway_Check",
+                                "target": "End_Error",
+                                "condition": "=js:!vars.available",
+                            },
+                            {
+                                "id": "Flow_Check_End",
+                                "source": "Gateway_Check",
+                                "target": "End_Assess",
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "boundaryEvent",
+                        "id": "Boundary_Backend",
+                        "attachedTo": "Sub_Assess",
+                        "errorRef": "Error_Backend",
+                    },
+                    {
+                        "kind": "task",
+                        "id": "Task_Items",
+                        "loop": {
+                            "sequential": True,
+                            "collection": "=vars.Var_Items",
+                        },
+                        "mapping": {
+                            "serviceType": "BPMN.Variables",
+                            "outputs": [
+                                {
+                                    "name": "result",
+                                    "type": "string",
+                                    "var": "result",
+                                    "source": "=iterator.item.name",
+                                }
+                            ],
+                        },
+                    },
+                    {"kind": "endEvent", "id": "End_Main"},
+                ],
+                "flows": [
+                    {
+                        "id": "Flow_Start_Assess",
+                        "source": "Start_Main",
+                        "target": "Sub_Assess",
+                    },
+                    {
+                        "id": "Flow_Assess_Items",
+                        "source": "Sub_Assess",
+                        "target": "Task_Items",
+                    },
+                    {
+                        "id": "Flow_Boundary_Items",
+                        "source": "Boundary_Backend",
+                        "target": "Task_Items",
+                    },
+                    {
+                        "id": "Flow_Items_End",
+                        "source": "Task_Items",
+                        "target": "End_Main",
+                    },
+                ],
+            },
+            "constraints": {
+                "publicInputs": ["items"],
+                "publicOutputs": ["result"],
+                "internalVariables": ["working"],
+                "scriptTasks": {
+                    "exact": 0,
+                    "allowedIds": [],
+                    "allowedOutputsById": {},
+                    "requiredInputReferencesById": {},
+                },
+                "errorEnds": {
+                    "singleGuardedIncoming": True,
+                    "allowedIds": ["End_Error"],
+                    "matchingBoundaryById": {
+                        "End_Error": "Boundary_Backend",
+                    },
+                    "forbidUntypedBoundaries": True,
+                },
+                "decisionPhases": {
+                    "Sub_Assess": {
+                        "minDivergingExclusiveGateways": 1,
+                    }
+                },
+                "rootTopology": {
+                    "exactStartEvents": 1,
+                    "exactEndEvents": 1,
+                },
+                "requiredReachability": [
+                    {
+                        "sources": ["Sub_Assess", "Boundary_Backend"],
+                        "target": "Task_Items",
+                    }
+                ],
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory) / "Complex"
+            bpmn_path = build_bpmn.build(spec, project)
+            root = ET.parse(bpmn_path).getroot()
+
+            ns = build_bpmn.NS
+            entry_point = root.find(
+                ".//bpmn:startEvent/bpmn:extensionElements/uipath:entryPointId",
+                ns,
+            )
+            self.assertIsNotNone(entry_point)
+            self.assertEqual(entry_point.attrib["value"], "Entry_Main")
+            scripts = root.findall(".//bpmn:scriptTask", ns)
+            self.assertEqual(scripts, [])
+            self.assertEqual(
+                len(root.findall(".//bpmn:errorEventDefinition", ns)), 2
+            )
+            loops = root.findall(
+                ".//bpmn:multiInstanceLoopCharacteristics", ns
+            )
+            self.assertEqual(len(loops), 1)
+            self.assertEqual(loops[0].attrib["isSequential"], "true")
+            output = root.find(
+                ".//bpmn:task[@id='Task_Items']"
+                "/bpmn:extensionElements/uipath:mapping/uipath:output",
+                ns,
+            )
+            self.assertIsNotNone(output)
+            self.assertEqual(output.attrib["var"], "Var_Result")
+
+            process = root.find(".//bpmn:process", ns)
+            self.assertIsNotNone(process)
+            self.assertEqual(process.attrib["isExecutable"], "false")
+            migration = process.find(
+                "./bpmn:extensionElements/uipath:migrationVersion",
+                ns,
+            )
+            self.assertIsNotNone(migration)
+            self.assertEqual(migration.attrib["version"], "15")
+
+            declarations = process.findall(
+                "./bpmn:extensionElements/uipath:variables/*",
+                ns,
+            )
+            declaration_ids = {item.attrib["id"] for item in declarations}
+            self.assertEqual(
+                declaration_ids,
+                {
+                    "input_Var_Items",
+                    "Var_Items",
+                    "output_Var_Result",
+                    "Var_Result",
+                    "Var_Working",
+                },
+            )
+            start_bridge = root.find(
+                ".//bpmn:startEvent[@id='Start_Main']"
+                "/bpmn:extensionElements/uipath:mapping/uipath:output",
+                ns,
+            )
+            self.assertIsNotNone(start_bridge)
+            self.assertEqual(start_bridge.attrib["var"], "Var_Items")
+            self.assertEqual(
+                start_bridge.attrib["source"],
+                "=vars.input_Var_Items",
+            )
+            end_bridge = root.find(
+                ".//bpmn:endEvent[@id='End_Main']"
+                "/bpmn:extensionElements/uipath:mapping/uipath:output",
+                ns,
+            )
+            self.assertIsNotNone(end_bridge)
+            self.assertEqual(end_bridge.attrib["var"], "output_Var_Result")
+            self.assertEqual(end_bridge.attrib["source"], "=vars.Var_Result")
+
+            nodes = build_bpmn.collect_nodes(
+                {
+                    "nodes": spec["process"]["nodes"],
+                    "flows": spec["process"]["flows"],
+                }
+            )
+            shapes = root.findall(".//bpmndi:BPMNShape", ns)
+            self.assertEqual(len(shapes), len(nodes))
+            bounds_by_node = {
+                shape.attrib["bpmnElement"]: {
+                    key: float(value)
+                    for key, value in shape.find(
+                        "dc:Bounds",
+                        ns,
+                    ).attrib.items()
+                }
+                for shape in shapes
+            }
+            subprocess_bounds = bounds_by_node["Sub_Assess"]
+            for child_id in (
+                "Start_Assess",
+                "Gateway_Check",
+                "End_Error",
+                "End_Assess",
+            ):
+                child_bounds = bounds_by_node[child_id]
+                self.assertGreaterEqual(
+                    child_bounds["x"],
+                    subprocess_bounds["x"],
+                )
+                self.assertGreaterEqual(
+                    child_bounds["y"],
+                    subprocess_bounds["y"],
+                )
+                self.assertLessEqual(
+                    child_bounds["x"] + child_bounds["width"],
+                    subprocess_bounds["x"] + subprocess_bounds["width"],
+                )
+                self.assertLessEqual(
+                    child_bounds["y"] + child_bounds["height"],
+                    subprocess_bounds["y"] + subprocess_bounds["height"],
+                )
+
+            boundary_bounds = bounds_by_node["Boundary_Backend"]
+            self.assertGreaterEqual(
+                boundary_bounds["x"],
+                subprocess_bounds["x"],
+            )
+            self.assertLessEqual(
+                boundary_bounds["x"] + boundary_bounds["width"],
+                subprocess_bounds["x"] + subprocess_bounds["width"],
+            )
+            self.assertLess(
+                boundary_bounds["y"],
+                subprocess_bounds["y"] + subprocess_bounds["height"],
+            )
+            self.assertGreater(
+                boundary_bounds["y"] + boundary_bounds["height"],
+                subprocess_bounds["y"] + subprocess_bounds["height"],
+            )
+            flows = build_bpmn.collect_flows(
+                {
+                    "nodes": spec["process"]["nodes"],
+                    "flows": spec["process"]["flows"],
+                }
+            )
+            edges = root.findall(".//bpmndi:BPMNEdge", ns)
+            self.assertEqual(len(edges), len(flows))
+
+            entry_points = json.loads(
+                (project / "entry-points.json").read_text(encoding="utf-8")
+            )
+            entry = entry_points["entryPoints"][0]
+            self.assertEqual(entry["id"], "Entry_Main")
+            self.assertIn("items", entry["inputSchema"]["properties"])
+            self.assertIn("result", entry["outputSchema"]["properties"])
+            self.assertNotIn("working", entry["inputSchema"]["properties"])
+            self.assertNotIn("working", entry["outputSchema"]["properties"])
+
+    def test_rejects_underdeveloped_visible_decision_phase(self) -> None:
+        spec = {
+            "project": {
+                "name": "Decisions",
+                "startId": "Start_Main",
+                "entryPointId": "Entry_Main",
+            },
+            "process": {
+                "id": "Process_Decisions",
+                "variables": [],
+                "nodes": [
+                    {"kind": "startEvent", "id": "Start_Main"},
+                    {
+                        "kind": "subProcess",
+                        "id": "Sub_Assess",
+                        "nodes": [
+                            {"kind": "startEvent", "id": "Start_Assess"},
+                            {
+                                "kind": "exclusiveGateway",
+                                "id": "Gateway_One",
+                                "default": "Flow_Gateway_No",
+                            },
+                            {"kind": "endEvent", "id": "End_Yes"},
+                            {"kind": "endEvent", "id": "End_No"},
+                        ],
+                        "flows": [
+                            {
+                                "id": "Flow_Start_Gateway",
+                                "source": "Start_Assess",
+                                "target": "Gateway_One",
+                            },
+                            {
+                                "id": "Flow_Gateway_Yes",
+                                "source": "Gateway_One",
+                                "target": "End_Yes",
+                                "condition": "=js:vars.flag",
+                            },
+                            {
+                                "id": "Flow_Gateway_No",
+                                "source": "Gateway_One",
+                                "target": "End_No",
+                            },
+                        ],
+                    },
+                    {"kind": "endEvent", "id": "End_Main"},
+                ],
+                "flows": [
+                    {
+                        "id": "Flow_Start_Assess",
+                        "source": "Start_Main",
+                        "target": "Sub_Assess",
+                    },
+                    {
+                        "id": "Flow_Assess_End",
+                        "source": "Sub_Assess",
+                        "target": "End_Main",
+                    },
+                ],
+            },
+            "constraints": {
+                "publicInputs": [],
+                "publicOutputs": [],
+                "internalVariables": [],
+                "scriptTasks": {
+                    "exact": 0,
+                    "allowedIds": [],
+                    "allowedOutputsById": {},
+                    "requiredInputReferencesById": {},
+                },
+                "errorEnds": {
+                    "singleGuardedIncoming": True,
+                    "allowedIds": [],
+                    "matchingBoundaryById": {},
+                    "forbidUntypedBoundaries": True,
+                },
+                "decisionPhases": {
+                    "Sub_Assess": {
+                        "minDivergingExclusiveGateways": 2,
+                    }
+                },
+                "rootTopology": {
+                    "exactStartEvents": 1,
+                    "exactEndEvents": 1,
+                },
+                "requiredReachability": [],
+            },
+        }
+
+        with tempfile.TemporaryDirectory() as directory:
+            with self.assertRaisesRegex(
+                ValueError,
+                "requires at least 2 diverging exclusive gateways, found 1",
+            ):
+                build_bpmn.build(spec, Path(directory) / "Decisions")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/uipath-maestro-bpmn/scripts/test_build_bpmn.py
+++ b/skills/uipath-maestro-bpmn/scripts/test_build_bpmn.py
@@ -17,7 +17,202 @@ build_bpmn = importlib.util.module_from_spec(SPEC)
 SPEC.loader.exec_module(build_bpmn)
 
 
+def guard_variables() -> list[dict[str, object]]:
+    return [
+        {"id": "Var_JiraAvailable", "name": "jiraAvailable"},
+        {"id": "Var_Severity", "name": "severity"},
+    ]
+
+
 class BuildBpmnTests(unittest.TestCase):
+    def test_error_guard_reference_constraint_is_backward_compatible(
+        self,
+    ) -> None:
+        build_bpmn.validate_error_guard_reference_constraints(
+            {},
+            {"End_JiraUnavailable": "=js:true"},
+            guard_variables(),
+        )
+
+    def test_error_guard_accepts_required_semantic_variable_names(
+        self,
+    ) -> None:
+        build_bpmn.validate_error_guard_reference_constraints(
+            {
+                "End_JiraUnavailable": [
+                    "jiraAvailable",
+                    "severity",
+                ]
+            },
+            {
+                "End_JiraUnavailable": (
+                    "=js:vars.Var_JiraAvailable === false && "
+                    "(vars.Var_Severity === 'Sev1' || "
+                    "vars.Var_Severity === 'Sev2')"
+                )
+            },
+            guard_variables(),
+        )
+
+    def test_error_guard_rejects_missing_availability_reference(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'jiraAvailable'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {
+                    "End_JiraUnavailable": [
+                        "jiraAvailable",
+                        "severity",
+                    ]
+                },
+                {
+                    "End_JiraUnavailable": (
+                        "=js:vars.Var_Severity === 'Sev1' || "
+                        "vars.Var_Severity === 'Sev2'"
+                    )
+                },
+                guard_variables(),
+            )
+
+    def test_error_guard_rejects_route_proxy_for_severity(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {
+                    "End_JiraUnavailable": [
+                        "jiraAvailable",
+                        "severity",
+                    ]
+                },
+                {
+                    "End_JiraUnavailable": (
+                        "=js:vars.Var_JiraAvailable === false && "
+                        "(vars.Var_Route === 'ExistingIssue' || "
+                        "vars.Var_Route === 'NewEscalation')"
+                    )
+                },
+                guard_variables()
+                + [{"id": "Var_Route", "name": "route"}],
+            )
+
+    def test_error_guard_rejects_unknown_error_end(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            r"names unknown error ends: \['End_Other'\]",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_Other": ["severity"]},
+                {"End_JiraUnavailable": "=js:true"},
+                guard_variables(),
+            )
+
+    def test_error_guard_rejects_unknown_variable(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "references unknown variable 'missing'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["missing"]},
+                {"End_JiraUnavailable": "=js:true"},
+                guard_variables(),
+            )
+
+    def test_error_guard_rejects_ambiguous_variable_name(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "references ambiguous variable name 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["severity"]},
+                {"End_JiraUnavailable": "=js:vars.Var_Severity"},
+                guard_variables()
+                + [{"id": "Var_SeverityScoped", "name": "severity"}],
+            )
+
+    def test_error_guard_rejects_longer_identifier_prefix(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["severity"]},
+                {
+                    "End_JiraUnavailable": (
+                        "=js:vars.Var_SeverityBackup === 'Sev1'"
+                    )
+                },
+                guard_variables()
+                + [
+                    {
+                        "id": "Var_SeverityBackup",
+                        "name": "severityBackup",
+                    }
+                ],
+            )
+
+    def test_error_guard_rejects_reference_inside_string(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["severity"]},
+                {
+                    "End_JiraUnavailable": (
+                        '=js:"vars.Var_Severity" && '
+                        "!vars.Var_JiraAvailable"
+                    )
+                },
+                guard_variables(),
+            )
+
+    def test_error_guard_rejects_reference_inside_comment(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["severity"]},
+                {
+                    "End_JiraUnavailable": (
+                        "=js:!vars.Var_JiraAvailable "
+                        "/* vars.Var_Severity */"
+                    )
+                },
+                guard_variables(),
+            )
+
+    def test_error_guard_rejects_reference_inside_regex(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'severity'",
+        ):
+            build_bpmn.validate_error_guard_reference_constraints(
+                {"End_JiraUnavailable": ["severity"]},
+                {
+                    "End_JiraUnavailable": (
+                        r"=js:/vars\.Var_Severity/.test('x') && "
+                        "!vars.Var_JiraAvailable"
+                    )
+                },
+                guard_variables(),
+            )
+
+    def test_error_end_rejects_null_matching_boundary(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "matching boundary for error end End_Error is required",
+        ):
+            build_bpmn.validate_matching_error_boundary(
+                {"id": "End_Error", "errorRef": "Error_Backend"},
+                None,
+                {},
+                {"End_Error": "Sub_Assess"},
+            )
+
     def test_accepts_connected_nested_execution_scopes(self) -> None:
         build_bpmn.validate_scope_execution_paths(
             {
@@ -776,7 +971,7 @@ class BuildBpmnTests(unittest.TestCase):
                                 "id": "Flow_Check_Error",
                                 "source": "Gateway_Check",
                                 "target": "End_Error",
-                                "condition": "=js:!vars.available",
+                                "condition": "=js:!vars.Var_Working",
                             },
                             {
                                 "id": "Flow_Check_End",
@@ -852,6 +1047,9 @@ class BuildBpmnTests(unittest.TestCase):
                         "End_Error": "Boundary_Backend",
                     },
                     "forbidUntypedBoundaries": True,
+                    "requiredGuardReferencesById": {
+                        "End_Error": ["working"],
+                    },
                 },
                 "decisionPhases": {
                     "Sub_Assess": {
@@ -1024,6 +1222,13 @@ class BuildBpmnTests(unittest.TestCase):
             self.assertIn("result", entry["outputSchema"]["properties"])
             self.assertNotIn("working", entry["inputSchema"]["properties"])
             self.assertNotIn("working", entry["outputSchema"]["properties"])
+
+        spec["process"]["nodes"][1]["flows"][1]["condition"] = "=js:true"
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not reference required variable 'working'",
+        ):
+            build_bpmn.validate_constraints(spec)
 
     def test_rejects_underdeveloped_visible_decision_phase(self) -> None:
         spec = {

--- a/tests/tasks/uipath-maestro-bpmn/e2e/check_invoice_exception_triage.py
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/check_invoice_exception_triage.py
@@ -57,8 +57,8 @@ def main() -> int:
     process = root.find(f"{{{BPMN_NS}}}process")
     if process is None:
         fail("BPMN process is missing")
-    if process.attrib.get("isExecutable") != "true":
-        fail("BPMN process must be executable")
+    if process.attrib.get("isExecutable") != "false":
+        fail("BPMN process must use the Studio Web serializer contract isExecutable=\"false\"")
 
     elements = list(process)
     element_types = {local(elem.tag) for elem in elements}

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/check_customer_escalation.py
@@ -60,8 +60,8 @@ def main() -> None:
     path, root = parse_bpmn("CustomerEscalation")
 
     process = one_or_more(root, "process")[0]
-    if process.attrib.get("isExecutable") != "true":
-        fail("BPMN process must be executable")
+    if process.attrib.get("isExecutable") != "false":
+        fail("BPMN process must use the Studio Web serializer contract isExecutable=\"false\"")
 
     scripts = elements(root, "scriptTask")
     if len(scripts) < 3:

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/check_wiki_pageviews.py
@@ -64,8 +64,8 @@ def main() -> None:
             fail(f"{name} is missing beside {BPMN_NAME}")
 
     process = one_or_more(root, "process")[0]
-    if process.attrib.get("isExecutable") != "true":
-        fail("BPMN process must be executable")
+    if process.attrib.get("isExecutable") != "false":
+        fail("BPMN process must use the Studio Web serializer contract isExecutable=\"false\"")
 
     scripts = elements(root, "scriptTask")
     if len(scripts) < 3:


### PR DESCRIPTION
## Summary

Add a generic declarative renderer for large, greenfield Maestro BPMN processes.

- render an explicit JSON graph contract into BPMN XML, complete BPMN DI, and local project metadata;
- validate variables, public input/output bridges, ScriptTask responsibilities, typed error boundaries, root topology, convergence, and guarded error-end policy before writing;
- reject unknown, ambiguous, string/comment/regex-spoofed error-guard references and null matching boundaries;
- keep a bounded direct-XML path for small intent-only graphs and surgical editing for imported BPMN;
- run the renderer test suite whenever its code or BPMN skill contract changes.

This layer is deliberately connector-agnostic and independently mergeable. The Alpha connector/runtime contract is the next PR in the native stack; the scenario-specific live eval remains isolated at the top.

## Why

Complex BPMN authoring previously required the agent to maintain repetitive XML references, diagram geometry, and project metadata while reasoning about the business process. The renderer removes that bookkeeping without inventing policy: the JSON spec must still declare every variable, node, condition, scope, loop, error, and flow.

## Validation

- 37/37 declarative-renderer tests pass locally
- `build-bpmn.py --example` renders successfully and passes the installed CLI validator
- skill-status manifest and generated README checks pass
- `git diff --check` passes
- no runtime-connector or interactive-eval files are included

## Native stack / dogfooding boundary

1. **this PR** — declarative builder foundation;
2. UiPath/skills#2324 — Alpha/runtime and live-connector skill fixes;
3. UiPath/skills#2203 — comprehensive live eval, intentionally not required for dogfooding.

Independent cross-repository prerequisite: UiPath/cli#3288.
