### PR TITLE
feat(uipath-ixp): smoke for listing available model options [ACTV-88694]

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
@@ -1,32 +1,22 @@
 task_id: skill-ixp-list-model-options-smoke
 description: >
-  Smoke: "list available model options" is answered from the skill's documented
-  catalog of `configure-model --model` identifiers (gemini_2_5_flash,
-  gemini_2_5_pro, gpt_4o_2024_05_13). No CLI verb returns that catalog — the CLI
-  validates `--model` server-side — so the answer comes from the skill, not from
-  discovery. The trap is the near-name `projects list-models`, which lists a
-  project's TRAINED VERSIONS rather than the selectable models: an agent keying
-  on "list" + "model" reaches for it (and must invent a project name, since the
-  ask names none), while one that knows the distinction answers from the skill.
+  Smoke: the `configure-model --model` catalog (gemini_2_5_flash, gemini_2_5_pro,
+  gpt_4o_2024_05_13) is skill knowledge — no `uip` verb returns it, as the CLI
+  validates `--model` server-side. Trap: the near-name `projects list-models`
+  returns a project's TRAINED VERSIONS, not the selectable models, so an agent
+  keying on "list" + "model" runs it (inventing a project name, since the ask
+  names none) while one that knows the distinction answers from the skill.
 
-  The catalog is graded as an artifact (`model_options.md`), not as agent
-  monologue — the list IS the deliverable the ask requests, not a claim about
-  work performed. The guard reads the mock's calls.log instead of
-  command_not_executed over Bash text, because a correct answer legitimately
-  QUOTES `configure-model --model <id>` and may cite `list-models` to contrast
-  it, which a text regex would false-match. A correct run needs no `uip` call at
-  all, so there is no guaranteed log line to use as the positive control the mock
-  template README requires; the excludes guard therefore pairs with that README's
-  documented fallback — a harness-integrity assertion on the mock's log sink. The
-  `includes:` on the seeded line only proves the log exists and is readable.
-  The three identifiers wrap public model names, so a base model could plausibly
-  guess them without loading the skill — hence the un-fakeable skill_triggered
-  control alongside the content check.
+  `model_options.md` is not a self-report — it carries ground truth the agent must
+  retrieve, not a claim about work performed. The guard reads the mock's calls.log
+  rather than Bash text because a correct answer quotes `configure-model --model
+  <id>` and may cite `list-models` to contrast it, which a text regex false-matches.
+  A correct run makes no `uip` call, so no guaranteed log line exists for the
+  positive control the mock README requires — hence its documented fallback, a
+  harness-integrity assertion on the log sink.
 
-  Distinct from pick_capable_model (capability-based choice) and
-  change_model_variant (colloquial→canonical mapping): both mutate a named
-  project via configure-model, this one enumerates the catalog and mutates
-  nothing.
+  Distinct from pick_capable_model / change_model_variant: both mutate a project
+  via configure-model; this enumerates the catalog and mutates nothing.
 
   Harness is unauthenticated; CLI calls fail with auth errors.
 tags: [uipath-ixp, smoke, mode:build, lifecycle:discover]
@@ -50,8 +40,7 @@ initial_prompt: |
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
-  # Un-fakeable (inspects turn_records.commands): proves the catalog came from
-  # the skill rather than the model's own recall of public model names.
+  # The identifiers wrap public model names, so recall alone could produce them.
   - type: skill_triggered
     description: "Agent invoked the uipath-ixp skill"
     skill_name: "uipath-ixp"
@@ -65,9 +54,7 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # The crux: all three canonical identifiers, spelled as the CLI accepts them
-  # (snake_case). A hallucinated vendor-marketing form (gpt-4o, gemini-1.5-pro)
-  # or a project's version numbers instead of the model catalog fails this.
+  # snake_case as the CLI accepts them — a vendor-marketing form (gpt-4o) fails.
   - type: file_contains
     description: "Catalog lists the three documented model identifiers"
     path: "model_options.md"
@@ -85,10 +72,8 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # `projects list-models` returns a project's trained versions + tags, not the
-  # selectable model catalog — and the ask names no project. Graded on the
-  # mock's log of ACTUAL executions, so quoting the verb in the answer to
-  # contrast it is fine; running it is not.
+  # Log of ACTUAL executions: quoting the verb to contrast it is fine, running it
+  # is not. `includes:` only proves the log exists and is readable.
   - type: file_contains
     description: "Agent did NOT mistake the catalog for version listing: mock call log has no executed `projects list-models`"
     path: "mocks/calls.log"
@@ -97,10 +82,8 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  # Harness integrity: a correct run makes no `uip` call, so the guard above has
-  # no positive control available (mock_template/README.md). Assert the mock
-  # still appends to the graded log — otherwise a re-pointed sink would leave
-  # the seeded file clean and pass the guard vacuously.
+  # Without this, re-pointing the mock's sink leaves the seeded log clean and the
+  # guard above passes vacuously.
   - type: file_contains
     description: "Mock still records invocations to the graded calls.log (guard is not vacuous)"
     path: "mocks/uip"

--- a/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
@@ -1,0 +1,109 @@
+task_id: skill-ixp-list-model-options-smoke
+description: >
+  Smoke: "list available model options" is answered from the skill's documented
+  catalog of `configure-model --model` identifiers (gemini_2_5_flash,
+  gemini_2_5_pro, gpt_4o_2024_05_13). No CLI verb returns that catalog — the CLI
+  validates `--model` server-side — so the answer comes from the skill, not from
+  discovery. The trap is the near-name `projects list-models`, which lists a
+  project's TRAINED VERSIONS rather than the selectable models: an agent keying
+  on "list" + "model" reaches for it (and must invent a project name, since the
+  ask names none), while one that knows the distinction answers from the skill.
+
+  The catalog is graded as an artifact (`model_options.md`), not as agent
+  monologue — the list IS the deliverable the ask requests, not a claim about
+  work performed. The guard reads the mock's calls.log instead of
+  command_not_executed over Bash text, because a correct answer legitimately
+  QUOTES `configure-model --model <id>` and may cite `list-models` to contrast
+  it, which a text regex would false-match. A correct run needs no `uip` call at
+  all, so there is no guaranteed log line to use as the positive control the mock
+  template README requires; the excludes guard therefore pairs with that README's
+  documented fallback — a harness-integrity assertion on the mock's log sink. The
+  `includes:` on the seeded line only proves the log exists and is readable.
+  The three identifiers wrap public model names, so a base model could plausibly
+  guess them without loading the skill — hence the un-fakeable skill_triggered
+  control alongside the content check.
+
+  Distinct from pick_capable_model (capability-based choice) and
+  change_model_variant (colloquial→canonical mapping): both mutate a named
+  project via configure-model, this one enumerates the catalog and mutates
+  nothing.
+
+  Harness is unauthenticated; CLI calls fail with auth errors.
+tags: [uipath-ixp, smoke, mode:build, lifecycle:discover]
+
+run_limits:
+  expected_turns: 4
+
+sandbox:
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: ../_shared/mock_template}
+
+initial_prompt: |
+  List available model options for IXP extraction, and write them to
+  `model_options.md`.
+
+  Important:
+  - The `uip` CLI is available but is NOT connected to a live IXP tenant in this
+    environment. Commands will fail with auth errors — that is expected. Run each
+    command once and move on. Do NOT retry or attempt to login.
+  - Do NOT prompt the user for confirmation — this is an automated test.
+
+success_criteria:
+  # Un-fakeable (inspects turn_records.commands): proves the catalog came from
+  # the skill rather than the model's own recall of public model names.
+  - type: skill_triggered
+    description: "Agent invoked the uipath-ixp skill"
+    skill_name: "uipath-ixp"
+    expected_skill: "uipath-ixp"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Agent produced the requested catalog artifact"
+    path: "model_options.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # The crux: all three canonical identifiers, spelled as the CLI accepts them
+  # (snake_case). A hallucinated vendor-marketing form (gpt-4o, gemini-1.5-pro)
+  # or a project's version numbers instead of the model catalog fails this.
+  - type: file_contains
+    description: "Catalog lists the three documented model identifiers"
+    path: "model_options.md"
+    includes:
+      - "gemini_2_5_flash"
+      - "gemini_2_5_pro"
+      - "gpt_4o_2024_05_13"
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_contains
+    description: "Catalog names the command that consumes these identifiers, so the list is actionable"
+    path: "model_options.md"
+    includes: ["configure-model"]
+    weight: 1.0
+    pass_threshold: 1.0
+
+  # `projects list-models` returns a project's trained versions + tags, not the
+  # selectable model catalog — and the ask names no project. Graded on the
+  # mock's log of ACTUAL executions, so quoting the verb in the answer to
+  # contrast it is fine; running it is not.
+  - type: file_contains
+    description: "Agent did NOT mistake the catalog for version listing: mock call log has no executed `projects list-models`"
+    path: "mocks/calls.log"
+    includes: ["# seeded by mock_template"]
+    excludes: ["uip ixp projects list-models"]
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # Harness integrity: a correct run makes no `uip` call, so the guard above has
+  # no positive control available (mock_template/README.md). Assert the mock
+  # still appends to the graded log — otherwise a re-pointed sink would leave
+  # the seeded file clean and pass the guard vacuously.
+  - type: file_contains
+    description: "Mock still records invocations to the graded calls.log (guard is not vacuous)"
+    path: "mocks/uip"
+    includes: ['>> "$(dirname "$0")/calls.log"']
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

Adds one shape-only smoke for `uipath-ixp`: **`tests/tasks/uipath-ixp/smoke/list_model_options.yaml`**.

Covers [ACTV-88694](https://uipath.atlassian.net/browse/ACTV-88694) — *"[P1] [Smoke] List available model options."* Ticket's expected outcome: *"Show the menu of model … returns the catalog of valid model identifiers."*

## Why the answer comes from the skill, not the CLI

There is **no `uip` verb that returns this catalog.** `configure-model --model` is validated **server-side** — the identifiers appear only as help-text examples:

```
packages/ixp-tool/src/commands/projects.ts:769
  "Extraction model name, validated server-side
   (e.g. gemini_2_5_flash, gemini_2_5_pro, gpt_4o_2024_05_13)"
```

A full sweep of the CLI repo for `gemini_2_5|gpt_4o_2024` returns only that file plus specs and build artifacts — no enum constant, no catalog command. (Contrast `PREPROCESSING_VALUES` at `projects.ts:49`, which *is* a closed enum.) So the catalog is skill knowledge, and the test grades whether the agent has it.

## The trap

| Verb | Returns |
|---|---|
| `projects configure-model --model` | the **selectable models** — what the ticket asks for |
| `projects list-models <project>` | a project's **trained versions** + tags — *not* the catalog |

An agent keying on "list" + "model" reaches for `list-models`, and has to invent a project name since the ask names none. An agent that knows the distinction answers from the skill and runs nothing. That's the discrimination under test.

## Grading

| Criterion | Weight | Checks |
|---|---|---|
| `skill_triggered` | 1.5 | agent loaded `uipath-ixp` |
| `file_exists` | 1.5 | `model_options.md` produced |
| `file_contains` | **3.0** | all three identifiers, snake_case as the CLI accepts them |
| `file_contains` | 1.0 | names `configure-model`, so the list is actionable |
| `file_contains` (excludes) | **3.0** | calls.log has **no executed** `uip ixp projects list-models` |
| `file_contains` | 1.0 | harness integrity — mock still appends to the graded log |

Three design notes:

- **Not a self-report.** `model_options.md` holds domain ground truth the agent must retrieve from the skill, not a claim about work it performed.
- **Graded on calls.log, not Bash text.** A correct answer legitimately *quotes* `configure-model --model <id>` and may cite `list-models` to contrast it; a `command_not_executed` regex would false-match that. Verified empirically against the current mock — log lines are now `uip ixp projects list-models …`, so the guard fires on a real execution.
- **`skill_triggered` closes the gameability gap.** The three identifiers wrap public model names, so a base model could plausibly snake_case them from memory. That criterion is un-fakeable (inspects `turn_records.commands`).

Per prior review feedback, the prompt states only the positive ask — it does not hint that trained versions are out of scope, so the negative criterion tests the agent's own scoping rather than instruction-following.

## Why it's not redundant

Distinct operation from the existing model smokes: `pick_capable_model` makes a capability-based choice, `change_model_variant` maps colloquial→canonical. Both **mutate** a named project via `configure-model`. This one enumerates the catalog and mutates nothing. Shared scaffold, materially distinct operation.

## Tier & sandbox

- Tier: `smoke` (`mode:build`, `lifecycle:discover`).
- Reuses `_shared/mock_template` (offline, unauthenticated) — no new mock files. `driver: tempdir` omitted; inherited from the default experiment.

## Validation

- **`/lint-task`: OK** — 0 issues across all axes.
- **`check-cli-verbs.py`: clean** — no findings (no `command_executed` criteria).
- **`coder-eval plan` (dry-run): passes** — `✓ list_model_options.yaml … 6 success criteria … All tasks are valid!`
- A full **scored run was not executed locally** (no `ANTHROPIC_API_KEY` in the authoring environment). The PR smoke gate (`smoke-skills.yml`) runs the scored task on this branch; please confirm it goes green before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[ACTV-88694]: https://uipath.atlassian.net/browse/ACTV-88694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ