### PR TITLE
fix(uipath-maestro-flow): resolve the three ixp coder-eval validate failures [RE-12972]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
@@ -106,7 +106,7 @@ Confirm:
 
 ## Adding / Editing
 
-For step-by-step add, delete, and wiring procedures, see [editing-operations.md](../../editing-operations.md). Use the JSON structure below for the node-specific `inputs` and `outputs` fields. Author CAPABILITY rule #15 (no top-level `model` block on the instance) and rule #14 (`outputs` populated for nodes that produce data) both apply.
+For step-by-step add, delete, and wiring procedures, see [editing-operations.md](../../editing-operations.md). Use the JSON structure below for the node-specific `inputs` and `outputs` fields. Author CAPABILITY rule #15 (no top-level `model` block on the instance) and rule #14 (`variables.nodes[]` entry for every data-producing node) both apply. One IxP-specific difference: general action-node guidance treats the instance `outputs` block as optional, but on `uipath.ixp.*` it is required — see [Authoring rule #4](#authoring-rules).
 
 ## JSON Structure
 
@@ -114,7 +114,7 @@ The IxP node instance carries `inputs` and `outputs` — and **no top-level `mod
 
 ### Build procedure — copy from `registry get`, do not construct from memory
 
-The IxP node instance is **derived from the registry response**, not authored from scratch. Any IxP node built from training-data recall will hit at least one of: missing `inputs.model` (canvas crash), missing `outputs.error` (broken `$vars` resolution), legacy forbidden fields (silent schema drift).
+The IxP node instance is **derived from the registry response**, not authored from scratch. Any IxP node built from training-data recall will hit at least one of: missing `inputs.model` (canvas crash), missing `outputs.error` (`flow validate` exits 1), legacy forbidden fields (silent schema drift).
 
 Run this once and source every field below from the response:
 
@@ -204,11 +204,12 @@ sufficient. There is no version of this node where omitting `outputs` is correct
    - **`inputs.model.modelName` MUST be a non-empty string.** For many published/OOB deployments `inputDefaults.model.modelName` comes back `null`, with the name carried in `inputDefaults.model.modelDisplayName` instead. When `modelName` is `null`/empty, set `inputs.model.modelName` to `modelDisplayName`. This is NOT synthesis — `modelDisplayName` is the model's own name from the same blob (and matches the flat `inputDefaults.modelName`). The `ixp-node` validator rejects a `null`/empty `inputs.model.modelName` (`flow validate` fails), and Studio Web crashes on it.
 2. **Flat mirrors stay alongside `inputs.model`.** `modelName`, `projectName`, `folderKey`, `folderName` are surfaced as disabled text fields in the `ixp-model` form section and are read directly from `inputs.*`, not from `inputs.model.*`.
 3. **`fileRef` is the only schema-required input** (`inputDefinition.required: ["fileRef"]`). Use `=js:$vars.<upstream>.output.<field>` per Critical Rule #13.
-4. **`outputs.output` AND `outputs.error` MUST both be present** — copy the fixed four-field literals from [Final shape](#final-shape); they are identical for every IxP node and need no `registry get` lookup. Omitting either breaks downstream `$vars.<nodeId>.output` / `.error` resolution and hides the field in Studio Web's variable picker. **`flow validate` hard-fails on the omission** — `ixp-node` emits `[nodes[<nodeId>].outputs.output] outputs.output must be present on the instance`, and the matching error for `outputs.error`.
+4. **`outputs.output` AND `outputs.error` MUST both be present** — copy the fixed four-field literals from [Final shape](#final-shape); they are identical for every IxP node and need no `registry get` lookup. **`flow validate` hard-fails on the omission** — `ixp-node` emits `[nodes[<nodeId>].outputs.output] outputs.output must be present on the instance`, and the matching error for `outputs.error`.
 5. **No top-level `model` on the instance.** Studio Web–authored .flow files never carry one; the BPMN-format `model` envelope (with `context`, `version`, `inputs`, `outputs`) is emitted at serialize time only.
 6. **`inputs` MUST NOT contain `digitizationMode`, `documentTaxonomy`, `attachmentId`, `fileName`, or `mimeType`.** These five fields were on a prior schema and have been removed from the standalone IxP node. Including them is the most common training-data-recall mistake. The serializer defaults `digitizationMode` to `fileUpload` internally — there is no scenario where you should set it on the instance.
+7. **Every edge carries all five keys** — `id`, `sourceNodeId`, `sourcePort`, `targetNodeId`, `targetPort`. The node-reference keys are `sourceNodeId` / `targetNodeId`, not `source` / `target`. Port names are under [Registry Validation](#registry-validation).
 
-The `definitions[]` entry is copied verbatim from `registry get` (`Data.Node`). Critical Rule #7 applies unchanged.
+The `definitions[]` entry is copied verbatim from `registry get` (`Data.Node`) — every key, including `sortOrder`, which the schema requires on each definition. Critical Rule #7 applies unchanged.
 
 > **`uip maestro flow validate` enforces the Authoring rules above** via the `ixp-node` validator. Failures surface as `severity: "error"` issues with `path` like `nodes[<nodeId>].inputs.model` and a self-contained `message` describing the violation — fix the `.flow` file, not the validator. A common failure is `inputs.model must be an object with non-empty string modelName and folderKey` — this fires when `inputDefaults.model.modelName` was `null` and copied through verbatim; fix it by setting `inputs.model.modelName` from `inputDefaults.model.modelDisplayName` (Authoring rule #1), not by relaxing the validator. The registry's `inputDefinition.properties` is the schema of the property catalog, not a license to override the rules: `digitizationMode`, `documentTaxonomy`, `attachmentId`, `fileName`, and `mimeType` are NOT returned by `registry get` and must not be set on the instance.
 

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -51,8 +51,8 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
   - Work inside the stated working directory — do NOT `cd` to a parent.
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors.
+  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
+    the `.flow` and re-run it. Do not exceed 3 validation runs.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -42,8 +42,8 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
   - Work inside the stated working directory — do NOT `cd` to a parent.
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors.
+  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
+    the `.flow` and re-run it. Do not exceed 3 validation runs.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -30,8 +30,8 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
   - Work inside the stated working directory — do NOT `cd` to a parent.
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors.
+  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
+    the `.flow` and re-run it. Do not exceed 3 validation runs.
 
 success_criteria:
   - type: skill_triggered
@@ -88,5 +88,5 @@ success_criteria:
 run_limits:
   expected_turns: 27
   max_turns: 40
-  turn_timeout: 600
-  task_timeout: 600
+  turn_timeout: 900
+  task_timeout: 900

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -31,8 +31,8 @@ initial_prompt: |
   - Use `--output json` on all uip commands.
   - Work inside the stated working directory — do NOT `cd` to a parent.
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors.
+  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
+    the `.flow` and re-run it. Do not exceed 3 validation runs.
 
 success_criteria:
   - type: skill_triggered
@@ -95,5 +95,5 @@ success_criteria:
 run_limits:
   expected_turns: 24
   max_turns: 40
-  turn_timeout: 600
-  task_timeout: 600
+  turn_timeout: 900
+  task_timeout: 900


### PR DESCRIPTION
Three IxP rows were failing `uip maestro flow validate`: `scaffold_minimal` on a missing instance `outputs` block, and both `e2e_02_project_selection` rows on edge keys — `source`/`target` invented in place of `sourceNodeId`/`targetNodeId`, a missing `edges[].id`, and a hand-trimmed `definitions[].sortOrder`.

`impl.md` already stated the `outputs` rule, but three shared authoring guides describe that block as optional on action nodes, and `impl.md` routes the agent straight into them. Rewording the rule alone (#2331) didn't land it. The rule is real — `ixp-node-validator.ts` in UiPath/cli applies to `uipath.ixp.*` only and rejects a missing port — but it's a canonical-shape gate, not a runtime dependency (the serializer hardcodes `model.outputs`). So the doc now states the scope difference rather than a consequence that doesn't hold.

- **`impl.md`** — flag the scope difference at the point the agent is sent to the shared guides; fix the CAPABILITY #14 citation (it covers `variables.nodes[]`); drop the inaccurate `$vars` claim from Authoring rule #4; add rule #7 for the five edge keys and name `sortOrder` on the `definitions[]` line.
- **Four task yamls** that assert "validate passes" — allow up to 3 validate runs with fixes in between, so they measure convergence to a valid flow rather than first-shot perfection. `routing.yaml` / `routing_negative.yaml` keep the once-only rule; they assert node selection, not validity.

**Verified on both agents** at `a368185f2`, scoped coder-eval runs, 4/5 each — [claude](https://github.com/UiPath/skills/actions/runs/30527919406) · [codex](https://github.com/UiPath/skills/actions/runs/30532596516). All three previously-failing rows pass at 1.0, confirmed structurally against all eight generated `.flow` files. On codex, `scaffold_minimal` ran **one** validate and it passed — first-shot clean, so the doc change did the work rather than the iteration bound.

`scaffold_multinode` fails in both runs for pre-existing unrelated reasons (3/9 on codex historically, never green on claude or antigravity; codex builds nothing, claude grinds past the timeout) — tracked separately.

Not yet run: a full-suite regression pass. `impl.md` is read by all 29 IxP rows and only 5 were exercised here.

RE-12972
