### PR TITLE
fix(uipath-maestro-bpmn): separate portable and live resource resolution

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -92,31 +92,53 @@ Two halves make a valid Maestro `.bpmn`:
 Work the four steps quickly, but keep the path matched to the user's ask. Treat
 requests to discover before authoring, save raw registry JSON/evidence, or "do
 not author yet" as discovery-only even if they describe an eventual BPMN. In
-that mode, immediately create `registry-evidence/`, run and save `registry pull
---output json`, `registry list --output json` or `registry search ... --output
-json`, and `registry get <type> --output json` for each requested type; do not
-read deep authoring references or scaffold a project. For authoring asks, author
-early: do not pre-read every reference before writing. Read a reference only
-when you reach the structure it covers, get the needed templates, then write the
-first complete draft before further spelunking. If
+that mode, immediately create `registry-evidence/`, but run only the discovery
+commands the user requested or the selected mode requires. By default, a known
+portable built-in needs only `registry get <type> --output json`; do not add an
+authenticated pull, list/search, or tenant-resource inventory on your own. If
+the user explicitly requests `registry pull`, `list`, or `search`—including as
+raw command evidence—run those requested read-only forms without a profile.
+That evidence request does not authorize tenant-resource inventory. Do not read
+deep authoring references or scaffold a project. For authoring asks, author early:
+do not pre-read every reference before writing. Read a reference only when you
+reach the structure it covers, get the needed templates, then write the first
+complete draft before further spelunking. If
 [references/structural-bpmn.md](references/structural-bpmn.md) or
 [references/expression-authoring.md](references/expression-authoring.md)
 directly covers the requested construct, write a first complete draft before
 further spelunking.
 
+Resolve live resources only when the user asks for a real, current,
+tenant-bound, or runnable node, or supplies a concrete resource to verify.
+`RequiresDiscovery` describes runnable-node completeness; it is not permission
+to inventory a tenant. For portable, synthetic, local-only, or structural
+drafts, keep placeholders unresolved and label the node non-runnable. If the
+mode is unclear and live discovery would materially change the result, ask
+first. In live mode, verify the active CLI context and follow
+[references/live-resource-resolution-guide.md](references/live-resource-resolution-guide.md).
+Use the default CLI context when the user selected it. Named-profile selection
+is per command: `login status --profile <name>` verifies that context but does
+not make later commands inherit it, so repeat the same `--profile <name>` on
+every tenant-dependent registry, queue, and connection command. Portable
+built-in lookups deliberately omit it.
+
 For registry-evidence-only tasks, be command-first and time-boxed:
 
 - Create `registry-evidence/` before anything else.
-- Run the registry command forms the user asked for. For RPA job + internal
-  message discovery, use `uip maestro bpmn registry list --limit -1 --output
-  json`, `uip maestro bpmn registry get Orchestrator.StartJob --output json`,
-  and `uip maestro bpmn registry get Maestro.ReceiveMessageEvent --output json`.
-- If `uip` is unavailable in a temp/smoke sandbox, or if it writes a valid JSON
+- Run every registry command form the user asked for. If the request names or
+  exemplifies `registry pull`, preserve its raw output too. For RPA job +
+  internal message discovery, use `uip maestro bpmn registry list --limit -1
+  --output json`, `uip maestro bpmn registry get Orchestrator.StartJob --output
+  json`, and `uip maestro bpmn registry get Maestro.ReceiveMessageEvent
+  --output json`.
+- If a discovery-only request is limited to login-free built-in templates and
+  `uip` is unavailable in a temp/smoke sandbox, or if it writes a valid JSON
   failure object such as `"Result": "Failure"` instead of registry content, do
   not search the repo for a replacement CLI or inspect test fixtures. Still
-  issue the required `list` and `get` command forms once each with output
-  redirected to their evidence files (allowing failure with `|| true`), so the
-  transcript shows the discovery loop:
+  issue every explicitly requested registry form and the required `list` and
+  `get` forms once each with output redirected to their evidence files
+  (allowing failure with `|| true`), so the transcript shows the requested
+  discovery loop:
   `uip maestro bpmn registry list --limit -1 --output json` and
   `uip maestro bpmn registry get <type> --output json`. Record the failed CLI
   attempts in `registry-evidence/cli-error.txt`, then overwrite any failure JSON
@@ -124,17 +146,31 @@ For registry-evidence-only tasks, be command-first and time-boxed:
   `skills/uipath-maestro-bpmn/validator/bpmn-spec.json` containing the same
   extension types and stop. The final evidence files must literally contain the
   discovered type names, for example `Orchestrator.StartJob` and
-  `Maestro.ReceiveMessageEvent`.
+  `Maestro.ReceiveMessageEvent`. Never use this fallback for a live process,
+  queue, connector, connection, operation, object, schema, or runnable-node
+  claim; stop that path as blocked.
 
-1. **Discover.** `uip maestro bpmn registry pull` **once** (cached for the
-   session — do not re-pull), then `list` / `search` to map intent to extension
-   types; `uip is connections list --all-folders` for live connections (always
-   `--all-folders` — a folder-scoped list silently misses connections). Confirm
-   every selection with the user (use AskUserQuestion). Never fabricate an identifier.
-   See [references/registry-workflow.md](references/registry-workflow.md).
-2. **Get templates.** `uip maestro bpmn registry get <type> --output json` for
-   each chosen registry-owned node only. Enrich `Intsvc.*` connector nodes with
-   `--connection-id`/`--object-name`. Do not call `registry get` for structural
+1. **Discover.** Choose portable-draft or live mode from the request. For a
+   known built-in type in portable mode, get that template without an
+   authenticated pull or tenant-resource listing. If portable intent cannot be
+   mapped without the live catalog, ask before crossing that boundary. In live
+   mode, run `uip maestro bpmn registry pull --output json` once initially
+   (cached for the session) in the selected CLI context. When that context is a
+   named profile, add `--profile <name>` to the pull and repeat it on
+   `registry list`, `registry search`, and every downstream discovery command;
+   omit it only for an explicitly selected default context. Resolve bindings
+   only from the retrieved full contract, using the adapter, exact-identity,
+   ambiguity, and bounded-refresh rules in
+   [references/live-resource-resolution-guide.md](references/live-resource-resolution-guide.md).
+   Never fabricate an identifier or select the first list row implicitly.
+2. **Get templates.** Get each chosen registry-owned node only. In live mode,
+   use `uip maestro bpmn registry get <type> --output json` in the selected
+   context, adding the same `--profile <name>` when that context is named; in
+   portable mode, use it without a profile. When live authoritative binding
+   metadata requires a resource, resolve it with the adapter selected in step 1
+   before claiming the node is runnable. In draft mode, preserve the unresolved
+   fields. Do not call
+   `registry get` for structural
    gaps the registry never owns: sequence flows, gateways, events, boundary
    events, multi-instance/loop markers, `errorMapping`/retry structure, or
    diagrams. If a registry template's BPMN host tag is PascalCase (for example
@@ -294,8 +330,10 @@ and honestly surfaced to the user as gaps when asked.
    as `<bpmn:startEvent>`, `<bpmn:intermediateCatchEvent>`,
    `<bpmn:scriptTask>`, and `<bpmn:endEvent>`. Do not write PascalCase tags
    like `<bpmn:IntermediateCatchEvent>`.
-4. **Confirm before authoring.** Confirm the chosen connector/connection/process
-   and the process structure with the user (AskUserQuestion).
+4. **Resolve ambiguity before authoring.** Confirm the chosen resource and the
+   process structure when the request did not already provide an unambiguous
+   identity or approve a deterministic selection policy. Never select the first
+   list row implicitly.
 5. **The diagram is mandatory.** Import is diagram-driven — every node needs a
    `BPMNShape`, every flow a `BPMNEdge`, or it will not appear on the canvas.
 6. **Node type is a child element, never an attribute.** Every `uipath:activity`

--- a/skills/uipath-maestro-bpmn/references/cli-conventions.md
+++ b/skills/uipath-maestro-bpmn/references/cli-conventions.md
@@ -1,9 +1,10 @@
 # CLI Conventions (authoring)
 
-This reference covers the **authoring-side** CLI surface only: the read-only
-registry discovery commands used to produce a valid, importable Maestro `.bpmn`
-file. The registry commands below never mutate cloud state. Operate and diagnose
-use different CLI commands — see
+This reference covers the **authoring-side** CLI surface only: active-context
+checks and read-only discovery commands used to produce a valid, importable
+Maestro `.bpmn` file. These commands may update local metadata caches but do not
+mutate the discovered cloud resources. Operate and diagnose use different CLI
+commands — see
 [operate/CAPABILITY.md](operate/CAPABILITY.md) and
 [diagnose/CAPABILITY.md](diagnose/CAPABILITY.md).
 
@@ -13,16 +14,27 @@ All commands below are discovery/read-only. None mutate cloud state.
 
 | Command | Purpose |
 | --- | --- |
-| `uip maestro bpmn registry pull [-f\|--force]` | Sync and cache the registry. Without login, only OOTB extension types are synced; login adds discovered connectors and processes. |
-| `uip maestro bpmn registry list [--limit <n\|-1>]` | List cached extension types (and discovered connectors/processes). Default 30; use `--limit -1` for all. |
-| `uip maestro bpmn registry search <keyword>` | Find entries by keyword across extension type, label, connector name, process name. |
-| `uip maestro bpmn registry get <extensionType> [--connection-id <id>] [--object-name <name>]` | Get the full spec for one extension type: `xmlTemplate`, `contextFields`, `bindingInfo`, input/output patterns. `--connection-id`/`--object-name` add live Integration Service field metadata for `Intsvc.*` connector types. |
-| `uip is connections list --all-folders` | List live Integration Service connections (id + state) across all folders. Always pass `--all-folders`; a folder-scoped list silently misses connections. |
+| `uip login status [--profile <name>] --output json` | Report the active base URL, organization, and tenant for the selected login context. The response does not report the profile name. |
+| `uip maestro bpmn registry pull [--profile <name>] [-f\|--force] --output json` | Sync and cache the registry. Without login, only OOTB extension types are synced; login adds discovered connectors and processes. |
+| `uip maestro bpmn registry list [--profile <name>] [--limit <n\|-1>] --output json` | List cached extension types (and discovered connectors/processes). Default 30; use `--limit -1` for all. |
+| `uip maestro bpmn registry search <keyword> [--profile <name>] --output json` | Find entries by keyword across extension type, label, connector name, process name. |
+| `uip maestro bpmn registry get <extensionType> [--profile <name>] [--connection-id <id>] [--object-name <name>] --output json` | Get the full spec for one extension type: `XmlTemplate`, `ContextFields`, `BindingPattern`, `BindingInfo`, and input/output patterns. `--connection-id`/`--object-name` add live Integration Service field metadata for connector types. |
+| `uip or queues list [--profile <name>] [--folder-key <key>\|--folder-path <path>\|--all-folders] --output json` | Resolve queue bindings in an exact supplied folder, or exhaustively when scope is unknown. |
+| `uip is connections list <connector-key> [--profile <name>] --all-folders [--refresh] --output json` | Resolve enabled connections for one exact, registry-discovered connector key across every accessible folder. `--refresh` bypasses the connection cache. |
+
+Square brackets mark syntax that is optional only when no named profile was
+selected. Once the user selects a profile for live discovery, include
+`--profile <name>` on every command in this table.
 
 These are the registry/discovery commands the skill verifies against the CLI
 source (`packages/maestro-tool/src/commands/registry.ts`). Do not invent flags.
 Validation uses `uip maestro bpmn validate <file>` — see
 [Validation](structural-bpmn.md#validation).
+
+`registry list` is a coarse discovery view; `registry get` owns the full binding
+contract. Route that contract, resolve exact identity/folder/state, and handle
+ambiguity or stale evidence with the bounded workflow in
+[live-resource-resolution-guide.md](live-resource-resolution-guide.md#2-select-the-adapter-from-the-full-contract).
 
 ## Validation order
 
@@ -61,12 +73,36 @@ Local source authoring and `uip maestro bpmn validate` work without login (the
 validator runs fully offline). Registry
 discovery of **connectors and processes** (and Integration Service field
 enrichment) requires `uip login`. Without login, `registry pull` still returns
-the built-in (OOTB) extension types.
+the built-in (OOTB) extension types. Before live discovery, read
+`uip login status [--profile <name>] --output json`; if authentication is
+needed, use interactive login only where browser authentication can complete,
+then verify status again. Never infer an environment URL, organization, tenant,
+or profile from a task name or a prior session. If the user named a target
+context and status reports another one, stop instead of silently switching. For
+a named profile, pass the user-provided `--profile <name>` to status and every
+dependent registry, queue, and connection command; the status payload identifies
+the base URL/organization/tenant but not the profile name. Profile selection is
+not sticky: `login status --profile <name>` does not switch the default context
+or make later commands inherit that profile.
+
+The bundled validator spec can replace failed CLI evidence only for login-free
+built-in templates. It cannot prove the existence or current state of a live
+resource; follow the blocked/refresh boundary in
+[live-resource-resolution-guide.md](live-resource-resolution-guide.md#4-refresh-once-then-stop).
 
 ## Never fabricate an identifier
 
 Connection IDs, `releaseKey`/process keys, queue keys, connector keys, app IDs,
-folder IDs/paths — every concrete identifier comes from discovery
-(`registry get`, `registry search`, `uip is connections list`) or from the user.
-Never invent one. When a required identifier is unknown, leave the placeholder
-in place, flag it as a draft binding, and ask the user.
+folder IDs/paths — every concrete identifier comes from the active context's
+discovery results or from the user. Never invent one. In live mode, ask when a
+required identity remains ambiguous; in portable draft mode, leave the
+placeholder unresolved and label the node non-runnable.
+
+## Side-effect boundary
+
+Status, registry pull/list/search/get, queue list, and connection list are
+authoring-safe discovery. They may update local session or metadata cache state,
+but they do not mutate the discovered resource. Connection create/edit/delete
+changes tenant configuration, and direct connector operation execution can
+change an external system. Those actions require explicit user consent and are
+never substitutes for resource or schema discovery.

--- a/skills/uipath-maestro-bpmn/references/live-resource-resolution-guide.md
+++ b/skills/uipath-maestro-bpmn/references/live-resource-resolution-guide.md
@@ -1,0 +1,140 @@
+# Live resource resolution
+
+Use this guide only when the user asks for a live, tenant-bound, or runnable
+node, or supplies a concrete live resource that must be verified. A portable,
+synthetic, local-only, or structural draft does not authorize tenant inventory.
+`RequiresDiscovery` describes what a node needs to become runnable; it is not
+permission to discover resources.
+
+If the requested mode is unclear and live discovery would materially change the
+result, ask before inventorying the tenant. In draft mode, preserve unresolved
+placeholders, label the node non-runnable, and name the missing resource
+contract. An unknown live adapter blocks a runnable claim, not the structural
+draft.
+
+## 1. Verify the active context
+
+Run status before any tenant-dependent discovery:
+
+```bash
+uip login status --profile <name> --output json
+```
+
+The live examples below show a named profile deliberately. Omit `--profile`
+only when the user selected the default CLI context instead.
+
+Follow the [login boundary](cli-conventions.md#login-boundary). If the user
+provided `--profile`, pass that same profile to status and every dependent
+command. Profile selection is per command, not a session switch: a successful
+`login status --profile <name>` does not make later commands inherit that
+profile. Stop on a base URL, organization, or tenant mismatch; never silently
+switch environments.
+
+## 2. Select the adapter from the full contract
+
+Retrieve the chosen node's full contract:
+
+```bash
+uip maestro bpmn registry get <extensionType> --profile <name> --output json
+```
+
+A flattened `registry list` row is only a screening view. Route from
+`Data.ExtensionType.BindingInfo` and `BindingPattern` in the full response:
+
+| Full-contract signal | Live discovery adapter |
+| --- | --- |
+| `RequiresDiscovery: false` / no live binding | No live lookup; the current template is sufficient. |
+| `BindingInfo.Resource: process` | Authenticated registry `Data.Processes`. |
+| `BindingInfo.Resource: queue` | Exact folder-scoped queue list when supplied; otherwise `uip or queues list --profile <name> --all-folders --output json`. |
+| `BindingPattern: connection` (even when `BindingInfo` is null) | `uip is connections list <connector-key> --profile <name> --all-folders --output json`. |
+| unrecognized live resource | Block the runnable claim; do not guess an adapter. |
+
+Prefer `BindingInfo.Resource` when present. A specialized binding pattern can
+still bind to a process. Connection-backed contracts can have
+`BindingInfo: null`, so `BindingPattern: connection` is the authoritative
+fallback for that adapter. Never route from a display label or a list-only
+guess.
+
+## 3. Resolve exact resource identity
+
+Only candidates in a usable lifecycle state are viable. Preserve exact keys,
+types, and folder identity; do not substitute a similarly named row.
+
+### Process
+
+Use authenticated registry `Data.Processes`. Match the requested process name,
+the exact `Type` expected by the selected node, and any supplied folder. Names
+can repeat across folders or versions, so do not collapse rows or exchange one
+key field for another.
+
+### Queue
+
+Use an exact supplied folder directly:
+
+```bash
+uip or queues list --profile <name> --folder-path "<folder-path>" \
+    --name <queue-name> --all-fields --output json
+```
+
+Use `--folder-key` when the exact key is supplied. If scope is unknown, search
+exhaustively:
+
+```bash
+uip or queues list --profile <name> --all-folders --name <queue-name> \
+    --output json
+```
+
+The server-side name filter is a contains match, so compare returned names
+exactly. All-folder results can aggregate folder associations into
+`FoldersCount`; a count greater than one is ambiguous until a folder is chosen.
+
+### Connection
+
+Take the connector key from registry discovery, never from a provider or product
+label:
+
+```bash
+uip is connections list <connector-key> --profile <name> --all-folders \
+    --output json
+```
+
+Accept only an exact `ConnectorKey` match in the `Enabled` state. Preserve the
+connection id and folder identity. Disabled rows and enabled rows for another
+connector are not fallbacks.
+
+If several viable candidates remain and the user did not approve a deterministic
+selection policy, ask which one to use. Never select the first row implicitly.
+
+## 4. Refresh once, then stop
+
+A missing selected id, an id absent from current discovery, or incomplete
+required scope is stale or blocked evidence. Refresh only the affected source
+once:
+
+- process: `uip maestro bpmn registry pull --profile <name> --force --output
+  json`, then `uip maestro bpmn registry list --profile <name> --limit -1
+  --output json`;
+- queue: repeat the affected `uip or queues list --profile <name> ... --output
+  json` call (the queue command has no refresh flag); or
+- connection: repeat `uip is connections list <connector-key> --profile <name>
+  --all-folders --refresh --output json`.
+
+A second failure remains blocked. Do not loop, use stale ids, or replace live
+evidence with bundled data.
+
+## 5. Preserve the binding boundary
+
+For `BindingInfo.Resource: process` or `queue`, fill the context field named by
+`BindingInfo.ContextField` with the selected resource's exact value at the
+property named by `BindingInfo.PropertyAttribute`. Do not put the property-name
+token itself into the context, guess a GUID, or reuse a resource from another
+folder.
+
+A connection id proves identity only. It does not prove an operation, object,
+payload schema, output schema, or XML connection-binding shape. Those require
+the retrieved enrichment contract; keep the node draft when that contract is
+unavailable.
+
+This workflow is read-only. Follow the
+[side-effect boundary](cli-conventions.md#side-effect-boundary) before any
+connection mutation or direct connector operation.

--- a/skills/uipath-maestro-bpmn/references/registry-workflow.md
+++ b/skills/uipath-maestro-bpmn/references/registry-workflow.md
@@ -1,63 +1,81 @@
 # Registry workflow
 
-Every `uipath:*` payload in a Maestro `.bpmn` comes from the registry — never
-from prose, never hand-written. This file is the loop for turning user intent
-into registry-backed XML.
+Registry-listed node execution payloads come from the registry — never from
+prose or hand-written approximations. Structural BPMN and serializer-owned
+scaffold metadata follow the structural/canvas contract. This file is the loop
+for turning user intent into registry-backed node XML.
 
-## 1. Sync and discover
+## 1. Choose draft or live mode, then discover the node type
 
-```bash
-uip maestro bpmn registry pull            # sync + cache (login for connectors/processes)
-uip maestro bpmn registry list --limit -1 --output json   # all extension types
-uip maestro bpmn registry search <keyword> --output json  # find a type by intent
-uip is connections list --all-folders --output json   # live IS connections (all folders)
-```
+Choose the mode from the request before tenant-dependent discovery:
 
-Map the user's intent to an extension type from the list. Confirm the choice
-with the user (and the specific connection / process / queue) before authoring.
-**Never fabricate an identifier** — see [cli-conventions.md](cli-conventions.md).
+- **Portable draft:** for synthetic, local-only, structural, or explicitly
+  draft work, default to a known login-free built-in template without adding an
+  authenticated pull or tenant-resource listing, and preserve unresolved
+  placeholders. An explicit request for raw `registry pull`, `list`, or
+  `search` evidence still authorizes those read-only registry forms without a
+  profile; it does not authorize tenant-resource inventory. If the type cannot
+  be identified without the live catalog, ask before crossing that boundary:
 
-**Connection discovery must be exhaustive.** Always pass `--all-folders` to
-`uip is connections list` — connections live in many folders and a folder-scoped
-listing silently misses them. An empty or unmatched result from a missing
-`--all-folders`, or from a connector key guessed from a brand name rather than
-found via `registry search`, is a **false negative** — never conclude "no
-connection exists" or ask the user to create one until you have searched the
-registry for the real connector key and listed across all folders.
+  ```bash
+  uip maestro bpmn registry get <known-built-in-type> --output json
+  ```
 
-`registry list` returns three buckets in `Data`: `ExtensionTypes` (the OOTB
-extension types, always available), `Connectors` and `Processes` (only after
-`uip login`). Each extension-type row carries `ExtensionType`, `Label`,
-`BpmnElement` (the host BPMN element), `ExtensionTag`, and
-`RequiresDiscovery` (`Yes` means you must resolve a concrete resource — process,
-queue, connection — before the node is runnable).
+- **Live/runnable:** when the user asks for a real, current, tenant-bound, or
+  runnable resource, verify the active context and follow
+  [live-resource-resolution-guide.md](live-resource-resolution-guide.md):
 
-In temp/smoke sandboxes, a CLI/tooling mismatch can produce valid JSON that is
-only a failure envelope (for example `"Result": "Failure"`) instead of registry
-content. For discovery-only tasks, keep that failed output in the transcript or
-`registry-evidence/cli-error.txt`, then replace the final raw evidence JSON with
-the matching entries from `validator/bpmn-spec.json`. The final saved evidence
-must literally contain the requested extension type strings, such as
-`Orchestrator.StartJob` and `Maestro.ReceiveMessageEvent`, not just the failure
-envelope.
+  ```bash
+  uip login status --profile <name> --output json
+  uip maestro bpmn registry pull --profile <name> --output json
+  uip maestro bpmn registry list --profile <name> --limit -1 --output json
+  uip maestro bpmn registry search <keyword> --profile <name> --output json
+  uip maestro bpmn registry get <extensionType> --profile <name> --output json
+  ```
+
+- **Unclear:** ask before tenant inventory when live versus portable would
+  materially change the result.
+
+`RequiresDiscovery` means a concrete resource is needed to make the node
+runnable; it does not authorize live discovery. An unknown resource adapter
+blocks a runnable claim, not a structural draft.
+
+Map intent to an extension type and inspect the full contract from `registry
+get`. `registry list` is a coarse discovery view. When authenticated, it can
+also include live `Connectors` and `Processes`; use those only in live mode.
+
+In temp/smoke sandboxes, a CLI/tooling mismatch can produce a valid JSON failure
+envelope instead of registry content. The bundled `validator/bpmn-spec.json`
+fallback is allowed only for login-free built-in-template evidence. It must
+never stand in for a live process, queue, connector, connection, operation,
+object, schema, or runnable-node claim. For a live-resource failure, stop and
+report the node as blocked.
 
 ## 2. Get the template for each chosen type
 
+For a portable built-in, use:
+
 ```bash
 uip maestro bpmn registry get <extensionType> --output json
+```
+
+For a live lookup under a named profile, repeat the profile on this command too:
+
+```bash
+uip maestro bpmn registry get <extensionType> --profile <name> --output json
 ```
 
 `Data.ExtensionType` contains everything needed to author the node:
 
 | Field | Use |
 | --- | --- |
-| `xmlTemplate` | The literal node XML with `{placeholder}` slots. **Author from this; fill placeholders only.** |
-| `bpmnElement` | The host BPMN element the template uses (for source files, normalize to lower-camel such as `bpmn:serviceTask`). |
-| `extensionTag` | `uipath:activity`, `uipath:event`, or `uipath:mapping`. |
-| `contextFields[]` | The `uipath:context` inputs; each may carry its own `bindingInfo`. |
-| `bindingInfo` | How the node binds to a resource (see §4). |
-| `inputPattern` / `inputName` / `inputTarget` | How the request body input is shaped. |
-| `requiresDiscovery` / `isDynamic` | Whether a concrete resource must be resolved first. |
+| `XmlTemplate` | The literal node XML with `{placeholder}` slots. **Author from this; fill placeholders only.** |
+| `BpmnElement` | The host BPMN element the template uses (for source files, normalize to lower-camel such as `bpmn:serviceTask`). |
+| `ExtensionTag` | `uipath:activity`, `uipath:event`, or `uipath:mapping`. |
+| `ContextFields[]` | The `uipath:context` inputs; each may carry its own `BindingInfo`. |
+| `BindingPattern` / `BindingInfo` | Whether and how the node binds to a resource; for live mode, use [live-resource-resolution-guide.md](live-resource-resolution-guide.md). |
+| `InputPattern` / `InputName` / `InputTarget` | How the request body input is shaped. |
+| `RequiresDiscovery` / `IsDynamic` | Whether a concrete resource must be resolved first. |
 
 The placeholders you fill are the obvious ones: `{id}`, `{name}`,
 `{incomingEdge}`, `{outgoingEdge}`, `{varId}` (the output variable id), plus the
@@ -80,43 +98,13 @@ only user-supplied values in the body or configurable context fields. Label the
 node non-runnable. Do not inspect sibling skills, test fixtures, or generated
 packages to invent the missing live schema.
 
-## 3. Connector (`Intsvc.*`) enrichment
+## 3. Resolve live resources only when requested
 
-For connector types (`requiresDiscovery: Yes`, e.g.
-`Intsvc.ActivityExecution`, `Intsvc.WaitForEvent`, `Intsvc.EventTrigger`),
-resolve a live connection and object, then enrich:
-
-```bash
-uip is connections list --all-folders --output json   # pick a connection id + its connector (search all folders)
-uip maestro bpmn registry get Intsvc.ActivityExecution \
-    --connection-id <id> --object-name <object> --output json
-```
-
-The response adds an `ISEnrichment` block with the live field metadata. Write
-the activity's `body` input (`target="body"`) and `context` (`connectorKey`,
-`objectName`) from that enrichment — do not hand-author connector schemas. The
-connection is referenced through a connection binding, `=bindings.<bindingId>`
-(see §4).
-
-## 4. Bindings — from `bindingInfo`, never invented
-
-A node that targets a cloud resource carries a binding. The `bindingInfo` on the
-extension type tells you the binding shape; the concrete value comes from
-discovery or the user.
-
-- **Resource bindings** (`bindingInfo.resource` = `process` / `queue` /
-  `businessRule`): the context field named by `bindingInfo.contextField`
-  (e.g. `releaseKey`, `queueName`) holds the resource key
-  (`bindingInfo.propertyAttribute`, usually `Key`). Resolve the real key with
-  `registry search` / discovered `Processes` / `Queues`; never guess a GUID.
-- **Connection bindings** (`Intsvc.*`): the context references a connection via
-  `=bindings.<bindingId>`, and a `<uipath:binding>` of `resource="Connection"`
-  with `propertyAttribute="ConnectionId"` in the process-level
-  `<uipath:bindings>` holds the live connection id from `uip is connections list`.
-
-Declare all bindings in a single process-level `<uipath:bindings version="v1">`
-block. Each `<uipath:binding>` carries `id`, `resource`, `propertyAttribute`,
-and a `default` value (the resolved key/id).
+For live mode, use the full-contract adapters, exact identity/folder/lifecycle
+rules, ambiguity handling, bounded refresh, and binding boundary in
+[live-resource-resolution-guide.md](live-resource-resolution-guide.md). For portable draft
+mode, keep placeholders unresolved and label the node non-runnable; do not
+substitute bundled or stale data for live proof.
 
 ## Agent wrapper selection — pick by `processType`, not the label
 
@@ -161,8 +149,9 @@ the exact `registry get Intsvc.TimerTrigger` template. It does not require a
 live connection or schema enrichment.
 
 `Intsvc.EventTrigger` and connector waits such as `Intsvc.WaitForEvent` do need
-their **trigger properties** enriched/bound through the CLI — the same
-enrichment path as `Intsvc.*` activities (§3). A hand-authored connector
+their **trigger properties** enriched/bound through the CLI — follow the same
+live contract boundary as `Intsvc.*` activities in
+[live-resource-resolution-guide.md](live-resource-resolution-guide.md). A hand-authored
 trigger shell stays **draft** until the CLI supplies the concrete trigger
 properties, connection binding, and schemas.
 
@@ -175,7 +164,8 @@ properties, connection binding, and schemas.
   resolved before upload or run, and that boundary notes should name explicitly
   — are **connection binding**, **dynamic schemas**, generated **package
   metadata** (`bindings_v2.json`, `entry-points.json`, `operate.json`,
-  `package-descriptor.json`). Do not hand-author any of these (§3).
+  `package-descriptor.json`). Do not hand-author any of these; follow the
+  [live binding boundary](live-resource-resolution-guide.md#5-preserve-the-binding-boundary).
 - **Connectionless / manual HTTP** (`Intsvc.HttpExecution`, or
   `Intsvc.UnifiedHttpRequest` when current tooling exposes the unified shape):
   use when the workflow itself owns the URL, method, payload, and response
@@ -231,8 +221,8 @@ exact template for any of them with `registry get <type>`.
 | `Maestro.SendMessageEvent` | `bpmn:intermediateThrowEvent` | event |
 | `Maestro.CaseRulesEvaluator` / `Maestro.CaseManagerGuardrails` | `bpmn:serviceTask` | activity |
 
-This table is a discovery aid, not a substitute for `registry get` — always pull
-the live template before authoring.
+This table is a discovery aid, not a substitute for `registry get` — always
+retrieve the exact template before authoring.
 
 If a registry `xmlTemplate` returns a PascalCase BPMN host tag such as
 `bpmn:SendTask` or `bpmn:ReceiveTask`, normalize only the BPMN host element

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/check_resource_resolution.py
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/check_resource_resolution.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Check exact, bounded, provider-neutral BPMN resource resolution."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def fail(message: str) -> None:
+    sys.exit(f"FAIL: {message}")
+
+
+def strings(value: Any) -> set[str]:
+    found: set[str] = set()
+    if isinstance(value, str):
+        found.add(value)
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            found.add(str(key))
+            found.update(strings(item))
+    elif isinstance(value, list):
+        for item in value:
+            found.update(strings(item))
+    elif value is not None:
+        found.add(str(value))
+    return found
+
+
+def request_by_id(payload: dict[str, Any], request_id: str) -> dict[str, Any]:
+    requests = payload.get("requests")
+    if not isinstance(requests, list):
+        fail("bindings.resolved.json must preserve the requests list")
+    for request in requests:
+        if isinstance(request, dict) and request.get("requestId") == request_id:
+            return request
+    fail(f"missing request {request_id}")
+
+
+def require_tokens(value: Any, expected: set[str], label: str) -> None:
+    actual = strings(value)
+    missing = expected - actual
+    if missing:
+        fail(f"{label} is missing exact discovered values: {sorted(missing)}")
+
+
+def read_calls() -> list[str]:
+    path = Path("mocks/.calls.jsonl")
+    if not path.is_file():
+        fail("mock CLI call log is missing")
+    calls: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        record = json.loads(line)
+        calls.append(str(record.get("args", "")))
+    return calls
+
+
+def is_local_help_call(call: str) -> bool:
+    """Help output is CLI introspection; it does not select or access a tenant."""
+    return bool({"--help", "-h"} & set(call.split()))
+
+
+def main() -> None:
+    output = Path("bindings.resolved.json")
+    if not output.is_file():
+        fail("bindings.resolved.json is missing")
+    try:
+        payload = json.loads(output.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        fail(f"bindings.resolved.json is not valid JSON: {exc}")
+    if not isinstance(payload, dict):
+        fail("bindings.resolved.json must contain an object")
+
+    context = payload.get("context")
+    if not isinstance(context, dict):
+        fail("bindings.resolved.json must preserve the context object")
+    require_tokens(context.get("profile"), {"resource-review"}, "requested profile")
+    require_tokens(
+        context.get("actual"),
+        {
+            "https://cloud.example.invalid",
+            "automation-lab",
+            "operations",
+        },
+        "verified active context",
+    )
+
+    process = request_by_id(payload, "process-risk-classifier")
+    if str(process.get("status", "")).lower() != "resolved":
+        fail("the exact Function process should be resolved")
+    require_tokens(
+        process.get("selected"),
+        {"release-function-001", "folder-automation-001", "Function"},
+        "process selection",
+    )
+    process_text = json.dumps(process)
+    if "release-process-001" in process_text or "release-function-other-folder" in process_text:
+        fail("process selection retained a wrong-type or wrong-folder candidate")
+
+    queue = request_by_id(payload, "queue-review-items")
+    if str(queue.get("status", "")).lower() != "resolved":
+        fail("the exact folder-scoped queue should be resolved")
+    require_tokens(
+        queue.get("selected"),
+        {"queue-review-001"},
+        "queue selection",
+    )
+    if "queue-review-other-folder" in json.dumps(queue):
+        fail("queue selection retained the same-named queue from another folder")
+
+    connection = request_by_id(payload, "connection-neutral-records")
+    status = str(connection.get("status", "")).lower()
+    if "blocked" not in status and "ambiguous" not in status:
+        fail("multiple enabled exact connections must remain blocked/ambiguous")
+    if connection.get("selected") not in (None, {}, ""):
+        fail("ambiguous connection must not have a selected resource")
+    require_tokens(
+        connection.get("viableCandidates"),
+        {"conn-enabled-a", "conn-enabled-b"},
+        "connection candidates",
+    )
+    connection_text = json.dumps(connection)
+    if "conn-disabled" in connection_text or "conn-other-connector" in connection_text:
+        fail("disabled or wrong-connector rows were treated as viable")
+    if "connection-stale-000" in json.dumps(connection.get("selected")):
+        fail("the stale connection id was retained")
+
+    draft = request_by_id(payload, "draft-hitl-shell")
+    if str(draft.get("mode", "")).lower() != "portable-draft":
+        fail("intent-only HITL request must preserve portable-draft mode")
+    draft_status = (
+        str(draft.get("status", "")).lower().replace("_", "-").replace(" ", "-")
+    )
+    explicit_draft = draft_status == "draft" or (
+        "draft" in draft_status
+        and any(
+            marker in draft_status
+            for marker in ("portable", "unresolved", "non-runnable")
+        )
+    )
+    if not explicit_draft:
+        fail("intent-only HITL request must remain an explicit portable draft")
+    if draft.get("selected") not in (None, {}, ""):
+        fail("portable HITL draft must not select a live resource")
+    if draft.get("viableCandidates") not in ([], None):
+        fail("portable HITL draft must not retain live candidates")
+
+    calls = read_calls()
+    queue_calls = [call for call in calls if "or queues list" in call]
+    if not any(
+        "--folder-path Shared/Operations" in call
+        or "--folder-path \"Shared/Operations\"" in call
+        or "--folder-key folder-operations-001" in call
+        for call in queue_calls
+    ):
+        fail("aggregate queue discovery was not confirmed in the requested folder")
+
+    connection_calls = [
+        call
+        for call in calls
+        if "is connections list uipath-neutral-records" in call
+    ]
+    if len(connection_calls) != 2:
+        fail(
+            "stale connection discovery must be attempted once and refreshed "
+            f"once; observed {len(connection_calls)} calls"
+        )
+    if sum("--refresh" in call for call in connection_calls) != 1:
+        fail("exactly one connection discovery call must use --refresh")
+    if sum("maestro bpmn registry pull" in call for call in calls) != 1:
+        fail("registry pull must run exactly once")
+
+    required_gets = {
+        "maestro bpmn registry get Orchestrator.StartJob",
+        "maestro bpmn registry get Orchestrator.CreateQueueItem",
+        "maestro bpmn registry get Intsvc.ActivityExecution",
+        "maestro bpmn registry get Actions.HITL",
+    }
+    for required in required_gets:
+        if not any(required in call for call in calls):
+            fail(f"missing authoritative binding lookup: {required}")
+
+    hitl_indices = [
+        index
+        for index, call in enumerate(calls)
+        if "maestro bpmn registry get Actions.HITL" in call
+    ]
+    if len(hitl_indices) != 1:
+        fail("portable HITL phase must retrieve its built-in contract exactly once")
+    if "--profile" in calls[hitl_indices[0]]:
+        fail("portable built-in lookup must not depend on a live login profile")
+
+    live_calls = [
+        (index, call)
+        for index, call in enumerate(calls)
+        if not is_local_help_call(call)
+        if any(
+            marker in call
+            for marker in (
+                "login status",
+                "maestro bpmn registry pull",
+                "maestro bpmn registry list",
+                "maestro bpmn registry search",
+                "maestro bpmn registry get Orchestrator.",
+                "maestro bpmn registry get Intsvc.",
+                "or queues list",
+                "is connections list",
+            )
+        )
+    ]
+    if not live_calls:
+        fail("live resource phase did not execute")
+    if hitl_indices[0] > min(index for index, _ in live_calls):
+        fail("tenant-dependent discovery began before the portable draft phase")
+
+    for _, call in live_calls:
+        if (
+            "--profile resource-review" not in call
+            and "--profile=resource-review" not in call
+        ):
+            fail(f"live command did not propagate the requested profile: {call}")
+
+    print(
+        "OK: named-profile live resolution, bounded ambiguity, and portable draft boundary"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/binding-requests.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/binding-requests.json
@@ -1,0 +1,55 @@
+{
+  "context": {
+    "profile": "resource-review",
+    "expectedBaseUrl": "https://cloud.example.invalid",
+    "expectedOrganization": "automation-lab",
+    "expectedTenant": "operations",
+    "actual": null
+  },
+  "requests": [
+    {
+      "requestId": "process-risk-classifier",
+      "mode": "live",
+      "kind": "process",
+      "extensionType": "Orchestrator.StartJob",
+      "name": "RiskClassifier",
+      "processType": "Function",
+      "folderPath": "Shared/Automation",
+      "status": "pending",
+      "selected": null,
+      "viableCandidates": []
+    },
+    {
+      "requestId": "queue-review-items",
+      "mode": "live",
+      "kind": "queue",
+      "extensionType": "Orchestrator.CreateQueueItem",
+      "name": "ReviewItems",
+      "folderPath": "Shared/Operations",
+      "status": "pending",
+      "selected": null,
+      "viableCandidates": []
+    },
+    {
+      "requestId": "connection-neutral-records",
+      "mode": "live",
+      "kind": "connection",
+      "extensionType": "Intsvc.ActivityExecution",
+      "connectorLabel": "Neutral Records",
+      "currentId": "connection-stale-000",
+      "status": "pending",
+      "selected": null,
+      "viableCandidates": []
+    },
+    {
+      "requestId": "draft-hitl-shell",
+      "mode": "portable-draft",
+      "kind": "app",
+      "extensionType": "Actions.HITL",
+      "name": "PortableApproval",
+      "status": "pending",
+      "selected": null,
+      "viableCandidates": []
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/connections-current.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/connections-current.json
@@ -1,0 +1,37 @@
+{
+  "Result": "Success",
+  "Data": [
+    {
+      "Id": "conn-enabled-a",
+      "Name": "Records Primary",
+      "ConnectorKey": "uipath-neutral-records",
+      "State": "Enabled",
+      "FolderPath": "Shared/IntegrationsA",
+      "FolderKey": "folder-integrations-a"
+    },
+    {
+      "Id": "conn-enabled-b",
+      "Name": "Records Secondary",
+      "ConnectorKey": "uipath-neutral-records",
+      "State": "Enabled",
+      "FolderPath": "Shared/IntegrationsB",
+      "FolderKey": "folder-integrations-b"
+    },
+    {
+      "Id": "conn-disabled",
+      "Name": "Records Disabled",
+      "ConnectorKey": "uipath-neutral-records",
+      "State": "Disabled",
+      "FolderPath": "Shared/IntegrationsA",
+      "FolderKey": "folder-integrations-a"
+    },
+    {
+      "Id": "conn-other-connector",
+      "Name": "Archive Primary",
+      "ConnectorKey": "uipath-archive-records",
+      "State": "Enabled",
+      "FolderPath": "Shared/IntegrationsA",
+      "FolderKey": "folder-integrations-a"
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/connections-stale.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/connections-stale.json
@@ -1,0 +1,5 @@
+{
+  "Result": "Failure",
+  "ErrorCode": "CATALOG_STALE",
+  "Message": "Cached connection metadata is stale; refresh the connection list."
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/login-status.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/login-status.json
@@ -1,0 +1,9 @@
+{
+  "Result": "Success",
+  "Data": {
+    "IsLoggedIn": true,
+    "BaseUrl": "https://cloud.example.invalid",
+    "Organization": "automation-lab",
+    "Tenant": "operations"
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/manifest.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/manifest.json
@@ -1,0 +1,59 @@
+{
+  "version": 2,
+  "_doc": "Provider-neutral resource discovery fixtures. The initial connection list is stale; only one explicit refresh returns current candidates.",
+  "rules": [
+    {
+      "match": "login status",
+      "file": "login-status.json"
+    },
+    {
+      "match": "maestro bpmn registry get Orchestrator.StartJob",
+      "file": "registry-get-start-job.json"
+    },
+    {
+      "match": "maestro bpmn registry get Orchestrator.CreateQueueItem",
+      "file": "registry-get-queue.json"
+    },
+    {
+      "match": "maestro bpmn registry get Intsvc.ActivityExecution",
+      "file": "registry-get-connection.json"
+    },
+    {
+      "match": "maestro bpmn registry get Actions.HITL",
+      "file": "registry-get-hitl.json"
+    },
+    {
+      "match": "maestro bpmn registry list",
+      "file": "registry-list.json"
+    },
+    {
+      "match": "maestro bpmn registry search",
+      "file": "registry-list.json"
+    },
+    {
+      "match": "maestro bpmn registry pull",
+      "file": "registry-pull.json"
+    },
+    {
+      "match": "--folder-path Shared/Operations",
+      "file": "queues-folder-list.json"
+    },
+    {
+      "match": "or queues list",
+      "file": "queues-all-folders-list.json"
+    },
+    {
+      "match": "--refresh",
+      "file": "connections-current.json"
+    },
+    {
+      "match": "is connections list uipath-neutral-records",
+      "file": "connections-stale.json",
+      "exit_code": 1
+    }
+  ],
+  "unmocked_default": {
+    "response": "{\"Result\":\"Failure\",\"Message\":\"Unsupported read in this discovery fixture\"}\n",
+    "exit_code": 1
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/queues-all-folders-list.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/queues-all-folders-list.json
@@ -1,0 +1,15 @@
+{
+  "Result": "Success",
+  "Data": [
+    {
+      "Name": "ReviewItems",
+      "Key": "queue-review-001",
+      "FoldersCount": 2
+    },
+    {
+      "Name": "ArchiveItems",
+      "Key": "queue-archive-001",
+      "FoldersCount": 1
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/queues-folder-list.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/queues-folder-list.json
@@ -1,0 +1,15 @@
+{
+  "Result": "Success",
+  "Data": [
+    {
+      "Name": "ReviewItems",
+      "Key": "queue-review-001",
+      "Id": 1206001
+    },
+    {
+      "Name": "ArchiveItems",
+      "Key": "queue-archive-001",
+      "Id": 1206002
+    }
+  ]
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-connection.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-connection.json
@@ -1,0 +1,18 @@
+{
+  "Result": "Success",
+  "Data": {
+    "ExtensionType": {
+      "ExtensionType": "Intsvc.ActivityExecution",
+      "RequiresDiscovery": true,
+      "BindingPattern": "connection",
+      "BindingInfo": null,
+      "DiscoveryNotes": "Resolve the exact connector and list its connections.",
+      "ContextFields": [
+        {
+          "Name": "connection",
+          "BindingInfo": null
+        }
+      ]
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-hitl.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-hitl.json
@@ -1,0 +1,28 @@
+{
+  "Result": "Success",
+  "Code": "RegistryGetSuccess",
+  "Data": {
+    "ExtensionType": {
+      "ExtensionType": "Actions.HITL",
+      "Label": "Create action app task",
+      "BpmnElement": "bpmn:UserTask",
+      "ExtensionTag": "uipath:activity",
+      "ContextFields": [
+        {
+          "Name": "appId",
+          "Type": "string",
+          "Required": false,
+          "Hidden": true,
+          "IsPrimaryKey": true,
+          "Binding": false,
+          "DefaultValue": null
+        }
+      ],
+      "BindingPattern": "none",
+      "BindingInfo": null,
+      "RequiresDiscovery": true,
+      "IsDynamic": true,
+      "XmlTemplate": "<bpmn:UserTask id=\"{id}\" name=\"{name}\"><bpmn:extensionElements><uipath:activity version=\"v1\"><uipath:type value=\"Actions.HITL\" version=\"v1\" /><uipath:context><uipath:input name=\"appId\" value=\"{appId}\" /></uipath:context></uipath:activity></bpmn:extensionElements><bpmn:incoming>{incomingEdge}</bpmn:incoming><bpmn:outgoing>{outgoingEdge}</bpmn:outgoing></bpmn:UserTask>"
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-queue.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-queue.json
@@ -1,0 +1,24 @@
+{
+  "Result": "Success",
+  "Data": {
+    "ExtensionType": {
+      "ExtensionType": "Orchestrator.CreateQueueItem",
+      "RequiresDiscovery": true,
+      "BindingPattern": "queue",
+      "BindingInfo": {
+        "Resource": "queue",
+        "ContextField": "queueName",
+        "PropertyAttribute": "Key"
+      },
+      "ContextFields": [
+        {
+          "Name": "queueName",
+          "BindingInfo": {
+            "Resource": "queue",
+            "PropertyAttribute": "Key"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-start-job.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-get-start-job.json
@@ -1,0 +1,24 @@
+{
+  "Result": "Success",
+  "Data": {
+    "ExtensionType": {
+      "ExtensionType": "Orchestrator.StartJob",
+      "RequiresDiscovery": true,
+      "BindingPattern": "process",
+      "BindingInfo": {
+        "Resource": "process",
+        "ContextField": "releaseKey",
+        "PropertyAttribute": "Key"
+      },
+      "ContextFields": [
+        {
+          "Name": "releaseKey",
+          "BindingInfo": {
+            "Resource": "process",
+            "PropertyAttribute": "Key"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-list.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-list.json
@@ -1,0 +1,70 @@
+{
+  "Result": "Success",
+  "Data": {
+    "ExtensionTypes": [
+      {
+        "ExtensionType": "Orchestrator.StartJob",
+        "Label": "Run process",
+        "RequiresDiscovery": "Yes",
+        "BindingPattern": "process"
+      },
+      {
+        "ExtensionType": "Orchestrator.CreateQueueItem",
+        "Label": "Create queue item",
+        "RequiresDiscovery": "Yes",
+        "BindingPattern": "queue"
+      },
+      {
+        "ExtensionType": "Intsvc.ActivityExecution",
+        "Label": "Run connector activity",
+        "RequiresDiscovery": "Yes",
+        "BindingPattern": "connection"
+      }
+    ],
+    "Connectors": [
+      {
+        "Name": "Neutral Records",
+        "ElementKey": "uipath-neutral-records"
+      },
+      {
+        "Name": "Archive Records",
+        "ElementKey": "uipath-archive-records"
+      }
+    ],
+    "Processes": [
+      {
+        "Name": "RiskClassifier",
+        "ProcessKey": "risk-classifier-function",
+        "ProcessVersion": "3",
+        "PackageProcessKey": "risk-classifier-function-package",
+        "ReleaseKey": "release-function-001",
+        "Type": "Function",
+        "Folder": "Shared/Automation",
+        "FolderKey": "folder-automation-001",
+        "FeedId": "feed-001"
+      },
+      {
+        "Name": "RiskClassifier",
+        "ProcessKey": "risk-classifier-process",
+        "ProcessVersion": "3",
+        "PackageProcessKey": "risk-classifier-process-package",
+        "ReleaseKey": "release-process-001",
+        "Type": "Process",
+        "Folder": "Shared/Automation",
+        "FolderKey": "folder-automation-001",
+        "FeedId": "feed-001"
+      },
+      {
+        "Name": "RiskClassifier",
+        "ProcessKey": "risk-classifier-other",
+        "ProcessVersion": "2",
+        "PackageProcessKey": "risk-classifier-other-package",
+        "ReleaseKey": "release-function-other-folder",
+        "Type": "Function",
+        "Folder": "Shared/Other",
+        "FolderKey": "folder-other-001",
+        "FeedId": "feed-002"
+      }
+    ]
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-pull.json
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/fixtures/mocks/responses/registry-pull.json
@@ -1,0 +1,6 @@
+{
+  "Result": "Success",
+  "Data": {
+    "Refreshed": true
+  }
+}

--- a/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/resource_resolution.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/discovery/resource_resolution/resource_resolution.yaml
@@ -1,0 +1,99 @@
+task_id: skill-bpmn-resource-resolution
+description: >
+  Provider-neutral mocked discovery eval: the agent resolves process, queue,
+  and connection binding requests from registry metadata and the active CLI
+  context using a named profile. It must preserve exact folder-scoped
+  identities, refresh stale connection discovery only once, leave an ambiguous
+  connection unresolved, and keep an intent-only HITL request as a portable
+  draft instead of treating RequiresDiscovery as permission to inventory.
+tags: [uipath-maestro-bpmn, integration, "mode:build", "lifecycle:discover", resource, connector, "feature:registry", "feature:connections"]
+
+run_limits:
+  expected_turns: 30
+  max_turns: 35
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../../../../../skills/uipath-maestro-bpmn
+    - type: template_dir
+      path: ../../_shared/mock_template
+    - type: template_dir
+      path: fixtures
+  mock_path_dirs:
+    - mocks
+
+initial_prompt: |
+  Resolve the pending BPMN resource requests in `binding-requests.json` using
+  the installed `uip` CLI and the `uipath-maestro-bpmn` skill. The CLI is backed
+  by a local test harness.
+
+  Preserve the input schema in `bindings.resolved.json`. For each request, set
+  its status, selected resource (or null), and viable candidates. Populate the
+  active context from the CLI, and use the requested named profile for every
+  live-context command. Do not choose an ambiguous resource implicitly; leave
+  it blocked instead of asking me.
+
+  Process requests marked `portable-draft` first. Retrieve only their known
+  login-free built-in contract, record them as non-runnable drafts, and do not
+  inspect login status or tenant resources for that phase. Only after that
+  phase, resolve the requests marked `live` in the requested context.
+
+  This is read-only discovery. Do not author BPMN, create or edit connections,
+  invoke connector operations, or inspect `mocks/`, `fixtures/`, or response
+  files directly.
+
+success_criteria:
+  - type: run_command
+    description: "Resolved bindings contain exact live identities and preserve the ambiguous connection boundary"
+    command: "python3 $TASK_DIR/check_resource_resolution.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent established the requested named-profile CLI context"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+login\s+status[\s\S]*--profile(?:=|\s+)resource-review'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent retrieved authoritative registry binding contracts"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+bpmn\s+registry\s+get'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent used the exact supplied folder for queue discovery"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+or\s+queues\s+list[\s\S]*--folder-path\s+["'']?Shared/Operations'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent scoped exhaustive connection discovery to the registry connector key"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+is\s+connections\s+list\s+uipath-neutral-records[\s\S]*--all-folders'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not mutate connections or invoke a connector operation"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+(?:is\s+connections\s+(?:create|edit|delete)|is\s+resources\s+run)'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not read mocked response files directly"
+    tool_name: "Bash"
+    command_pattern: '(cat|less|head|tail|grep|rg|find)\s+[\s\S]*(?:mocks/|fixtures/)'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-bpmn/smoke/check_registry_discovery.py
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/check_registry_discovery.py
@@ -31,10 +31,11 @@ def main() -> None:
         sys.exit("FAIL: registry-evidence directory has no raw JSON files")
 
     body_parts: list[str] = []
+    payloads: list[object] = []
     for path in files:
         try:
             text = path.read_text(encoding="utf-8", errors="ignore")
-            json.loads(text)
+            payloads.append(json.loads(text))
             body_parts.append(text)
         except json.JSONDecodeError as exc:
             sys.exit(f"FAIL: registry evidence file is not valid JSON: {path}: {exc}")
@@ -50,8 +51,34 @@ def main() -> None:
     if missing:
         sys.exit(f"FAIL: registry evidence missing required extension types: {missing}")
 
+    def contains_template(value: object, extension_type: str) -> bool:
+        if isinstance(value, dict):
+            normalized = {str(key).lower(): item for key, item in value.items()}
+            if (
+                normalized.get("extensiontype") == extension_type
+                and isinstance(normalized.get("xmltemplate"), str)
+                and normalized["xmltemplate"].strip()
+            ):
+                return True
+            return any(contains_template(item, extension_type) for item in value.values())
+        if isinstance(value, list):
+            return any(contains_template(item, extension_type) for item in value)
+        return False
+
+    missing_templates = [
+        f"{label} ({token})"
+        for label, token in REQUIRED_TYPES.items()
+        if not any(contains_template(payload, token) for payload in payloads)
+    ]
+    if missing_templates:
+        sys.exit(
+            "FAIL: registry evidence missing populated templates for required "
+            f"extension types: {missing_templates}"
+        )
+
     print(
-        f"OK: registry-evidence covers {', '.join(REQUIRED_TYPES.values())} "
+        f"OK: registry-evidence covers populated templates for "
+        f"{', '.join(REQUIRED_TYPES.values())} "
         f"across {len(files)} raw output files"
     )
 

--- a/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/smoke/registry_discovery.yaml
@@ -1,10 +1,10 @@
 task_id: skill-bpmn-smoke-registry-discovery
 description: >
-  Skill-guided evaluation: agent uses the uipath-maestro-bpmn skill to discover
-  Maestro BPMN extension types via the registry CLI (pull, list/search, get)
-  before authoring anything. Tests that the skill teaches the registry-driven
-  discovery loop instead of hand-authoring uipath:* XML from prose.
-tags: [uipath-maestro-bpmn, smoke, "mode:build"]
+  Skill-guided evaluation: agent honors an explicit raw-evidence request for a
+  registry sync, catalog enumeration, and exact built-in templates before
+  authoring anything. Tests that this explicit request overrides the portable
+  built-in shortcut without authorizing live tenant-resource inventory.
+tags: [uipath-maestro-bpmn, smoke, "mode:build", "lifecycle:discover", "feature:registry"]
 
 sandbox:
   python: {}
@@ -15,11 +15,12 @@ initial_prompt: |
   uipath-maestro-bpmn skill and use the registry to discover the right
   extension types and their templates.
 
-  Save the raw JSON output of every registry command you run into a
-  `registry-evidence/` directory (one file per command), for example:
-    - `uip maestro bpmn registry pull --output json > registry-evidence/pull.json`
-    - `uip maestro bpmn registry list --output json > registry-evidence/list.json`
-    - `uip maestro bpmn registry get <type> --output json > registry-evidence/get-<type>.json`
+  For this evidence-only request, I explicitly need raw JSON from all three
+  parts of the discovery loop: a registry sync, a complete registry catalog
+  enumeration, and the exact template lookup for each requested built-in type.
+  Save each command's unmodified output in a separate JSON file under
+  `registry-evidence/`. This explicit sync-and-enumeration request applies even
+  though the target types are portable built-ins.
 
   Do not summarize or paraphrase the output — preserve the raw CLI JSON so the
   RPA-job and receive-message extension types and their templates are present in
@@ -41,19 +42,27 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed or searched registry extension types"
+    description: "Agent enumerated the complete registry catalog"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+(list|search)'
+    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+list(?=[^\r\n;&|]*--limit(?:\s+|=)-1(?:\s|$|[;&|]))'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent fetched a template with registry get"
+    description: "Agent fetched the RPA-job template with registry get"
     tool_name: "Bash"
-    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+get'
+    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+get\s+Orchestrator\.StartJob(?:\s|$)'
     min_count: 1
-    weight: 1.5
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent fetched the receive-message template with registry get"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+maestro\s+bpmn\s+registry\s+get\s+Maestro\.ReceiveMessageEvent(?:\s|$)'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command


### PR DESCRIPTION
## Summary

- Separate **portable draft** intent from **live/runnable** intent. A known built-in draft uses only `registry get`; `RequiresDiscovery` describes runnable completeness and no longer grants permission to inventory a tenant.
- Verify the requested CLI context before live discovery. Named profiles are non-sticky and every copyable live registry, queue, connection, and refresh example repeats `--profile <name>`.
- Route live lookup from the retrieved full registry contract: `BindingInfo.Resource` for process/queue resources and `BindingPattern: connection` for connection identity.
- Resolve exact names, types, folders, lifecycle state, and keys; preserve ambiguity; refresh only the affected source once; never take the first row or fabricate an identifier.
- Keep connection identity separate from operation/object/schema authoring. A connection ID alone cannot make a connector node runnable.

## Why

The prior guidance could interpret registry metadata as permission for tenant discovery and could treat a named profile as if one status call switched subsequent commands. The first correction explained that profiles are per-command, but several copyable live examples still omitted the profile placeholder; the eval proved that agents copied those examples selectively. The final guidance makes the prose and every live command form consistent while leaving portable built-in examples explicitly profile-free.

This is product-wide and environment-neutral. It contains no environment, organization, tenant, Alpha, or connector-provider assumptions. The current adapters cover the resource contracts the CLI exposes today—process, queue, and connection—and unknown contracts block only the runnable claim instead of forcing a provider-specific guess.

## Stack and independence

- Native GitHub stack **#2663**: [#2662](https://github.com/UiPath/skills/pull/2662) BPMN DI before validation → [#2655](https://github.com/UiPath/skills/pull/2655) portable registry templates → [#2363](https://github.com/UiPath/skills/pull/2363) → [#2369](https://github.com/UiPath/skills/pull/2369) → [#2366](https://github.com/UiPath/skills/pull/2366) → this PR.
- This PR is one atomic resource-resolution layer with two focused commits: the provider-neutral discovery contract/eval and a smoke-task update that requires explicit registry evidence. It is independently useful after the lower stack layers merge and does not include connector-operation authoring, runtime work, or the complex live eval.

## Verification

Ran `skill-bpmn-resource-resolution` locally with Claude Sonnet 5. The post-fix run against the frozen task and checker recorded **7/7, score `1.000`**.

Replacement current-head skill smoke suite: pending.

| Run | Duration | Assistant turns | Commands | Cost | Recorded result | What it exposed |
| --- | ---: | ---: | ---: | ---: | --- | --- |
| `2026-07-30_06-33-25` | 130.460s | 33 | 20 | $0.655 | 5/7, `0.548` | Harness defect: a correct named-profile queue command missed an option-order-sensitive fixture rule; the agent also inspected the wrapper once. |
| `2026-07-30_06-36-48` | 120.768s | 33 | 19 | $0.619 | 6/7, `0.613` | Queue fixture and no-inspection behavior were fixed. Semantic replay then exposed a real profile-propagation gap. |
| `2026-07-30_06-40-07` | 133.924s | 34 | 19 | $0.772 | 6/7 recorded; final-checker replay passes | Profile propagation and all resource behavior passed; the recorded miss was only the equivalent status spelling `draft-non-runnable`. |
| `2026-07-30_06-43-18` | 162.650s | 36 | 22 | $0.737 | 6/7 recorded; final-checker replay passes | Reconfirmed every substantive behavior; the recorded miss was only the equivalent spelling `non_runnable_draft`. |
| `2026-07-30_06-49-53` | 261.683s | 36 | 21 | $0.747 | 6/7, `0.613` | Frozen checker caught the remaining substantive inconsistency: three live `registry get` calls omitted the requested profile because copied examples still omitted it. |
| `2026-07-30_06-57-30` | 122.760s | 27 | 16 | $0.552 | **7/7, `1.000`** | After making every live example consistent, all profile, ordering, identity, ambiguity, refresh, and safety assertions passed. |

Earlier implementation baselines, before adding the portable-vs-live and named-profile coverage, also recorded 7/7 in 139.5s and 197.2s.

The frozen final checker requires:

- portable HITL contract retrieval before any login or tenant-dependent call, with no profile;
- verified base URL, organization, and tenant under the requested named profile;
- that same profile on every live pull/list/search/get, queue, and connection call;
- exact process type/folder/key and exact folder-scoped queue resolution;
- exactly one connection refresh, two enabled exact candidates, and no implicit selection;
- no connector mutation, operation invocation, or direct response-fixture inspection.

Static verification:

- Python compilation;
- YAML and JSON fixture parsing;
- `coder-eval plan`;
- task CLI-verb gate;
- `git diff --check`;
- provider/environment/profile-hardcoding scan.



