### PR TITLE
fix(skills): scrub internal references from shipped playbooks and guides

### DIFF
--- a/skills/uipath-maestro-bpmn/references/diagnose/CAPABILITY.md
+++ b/skills/uipath-maestro-bpmn/references/diagnose/CAPABILITY.md
@@ -35,9 +35,7 @@ deployed BPMN asset correlation, element executions, cursors, generated package 
    reveal the likely root cause.
 2. **Always include folder context on instance and incident reads** - `instance` commands require `--folder-key` or `-f`,
    and `incident get` requires `--folder-key`.
-3. **Use the CLI as the diagnostic interface** - run `uip maestro bpmn ... --output json` reads. When mock or fixture
-   files are present in a test harness, treat them as CLI backing data and do not read those files directly unless you
-   are explicitly debugging the mock harness.
+3. **Use the CLI as the diagnostic interface** - run `uip maestro bpmn ... --output json` reads.
 4. **Fetch deployed BPMN when local source may differ** - do not assume the working tree matches what ran.
 5. **Map failures to BPMN element IDs** - use IDs to identify the source node, gateway, event, sequence flow,
    or extension that needs Author work.

--- a/skills/uipath-troubleshoot/references/activity-packages/excel-activities/playbooks/execute-macro-failures.md
+++ b/skills/uipath-troubleshoot/references/activity-packages/excel-activities/playbooks/execute-macro-failures.md
@@ -69,7 +69,7 @@ What to look for:
 
 7. **Confirm branch 6 (concurrent COM access).** Look for:
    - The workflow uses `Parallel` activities containing Excel calls.
-   - Multiple Robot jobs against the same workflow on the same host (`uip or jobs list --process-name '<process>' --host '<MOCK-HOST>'`) overlap with the macro window.
+   - Multiple Robot jobs against the same workflow on the same host (`uip or jobs list --process-name '<PROCESS_NAME>' --host '<HOSTNAME>'`) overlap with the macro window.
    - A different automation on the same host using Excel (PowerShell, another RPA tool, scheduled VBA add-in).
    - Failures are intermittent — the symptom of an STA race.
 

--- a/skills/uipath-troubleshoot/references/products/maestro/playbooks/expression-evaluation-errors.md
+++ b/skills/uipath-troubleshoot/references/products/maestro/playbooks/expression-evaluation-errors.md
@@ -19,7 +19,7 @@ What can cause it:
 - Property casing — objects wrapped in `ExpressionDictionary` expose lowercase property accessors (e.g., `vars.error.detail` works, `vars.error.Detail` does not)
 - Iterator references inside parallel multi-instance subprocesses were not supported historically — known workaround was to use embedded subprocess
 - C# ternary type-erasure bug in Dynamic Expresso — known workaround is to switch to JS expressions (`=js:` prefix)
-- Script Task iterator references unresolved by the engine (fix shipped in alpha and rolled forward)
+- Script Task iterator references unresolved by the engine
 - Upstream activity failed silently and left the consumed variable unset
 
 Not this playbook - route on these observable data instead:


### PR DESCRIPTION
## Problem

Shipped skill content (`skills/**` installs on client machines via the plugin) carried a few fragments of UiPath-internal context that have no value to a client and should not leave the building:

- `uipath-maestro-bpmn`'s diagnose capability rule 3 instructed agents about "mock or fixture files in a test harness" — internal validation machinery, not product guidance (same class as the invariant removed from `uipath-troubleshoot` in #2358).
- One Maestro playbook carried "(fix shipped in alpha and rolled forward)" as release provenance.
- One Excel playbook example used a `<MOCK-HOST>` placeholder (plus a lowercase `<process>` breaking the `<UPPER_SNAKE_CASE>` convention).

## Solution

Three one-line edits, one commit each:

1. `skills/uipath-maestro-bpmn/references/diagnose/CAPABILITY.md` — rule 3 reduced to its product-scoped sentence ("Use the CLI as the diagnostic interface").
2. `skills/uipath-troubleshoot/references/products/maestro/playbooks/expression-evaluation-errors.md` — the release-train parenthetical is dropped (the cause list entry stands on its own).
3. `.../excel-activities/playbooks/execute-macro-failures.md` — `<PROCESS_NAME>` / `<HOSTNAME>` placeholders.

No behavioral guidance changes: every edit preserves the diagnostic meaning of its line.

## Validation

Prose-only edits to existing playbook lines; the PR smoke gate runs the affected skills' smoke sets in CI.
