### PR TITLE
test(coded-apps): check pack/publish/deploy per-verb, not as a 3-command count

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
@@ -41,12 +41,34 @@ initial_prompt: |
 success_criteria:
   # Pack → publish → deploy sequence (commands fail with auth in CI — we check
   # the agent ran the full sequence, not that the live deploy succeeded).
+  # Check each verb ONCE, not "3 matching commands": agents batch the whole
+  # pipeline into one shell script (pack; publish; deploy in a single set +e
+  # block), which the old count check scored 1/3 and false-failed a correct run;
+  # it also false-passed the reverse (pack ×3, no publish/deploy = 3 matches).
+  # Per-verb presence matches whether the agent runs three commands or one
+  # batched script, and a genuinely skipped step still fails (its check hits 0).
   - type: command_executed
-    description: "Agent ran full pack-publish-deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp deploy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.84
     pass_threshold: 1.0
 
   # Fresh deploy (folderKey null): the agent resolves a folder and deploys with


### PR DESCRIPTION
## What

`uipath-coded-apps-dashboard-deploy-state` false-failed a correct run (score 0.722, 1 of 4 criteria).

The pipeline criterion required **3 matching commands** for `uip codedapp (pack|publish|deploy)` (`min_count: 3`). The agent ran all three — but batched them into **one** shell script:

```bash
set +e
...
uip codedapp pack    dist -n "Agent Health Dashboard" --version "1.0.0" ...
uip codedapp publish      -n "Agent Health Dashboard" --version "1.0.0" ...
uip codedapp deploy       -n "Agent Health Dashboard" --folder-key "$FOLDER_KEY" ...
```

`command_executed` counts matching **commands (tool calls)**, so one batched command = **1 match → 1/3 → FAILURE**. Proof the work was done: the two deploy-shape checks (`deploy … -n`, `deploy … --folder-key`) both **passed** against that same batched command.

The count check was also weak the other way: `pack` ×3 with no publish/deploy = 3 matches → would **false-pass**.

## Fix

Replace the single `min_count: 3` count with **three per-verb presence checks** (`pack`, `publish`, `deploy`, each `min_count: 1`, weights summing to the original 2.5). This:
- matches whether the agent runs three separate commands **or** one batched script, and
- still fails a genuinely skipped step (its check hits 0) — closing the false-pass hole too.

## Verification

- Failing run's batched command → all three per-verb checks match → PASS.
- Synthetic publish-skip → publish check hits 0 → still FAILS.
- YAML parses; `check-cli-verbs.py` clean.

Same class as #2298 / #2199: a check bound to *how* commands were grouped into tool calls rather than *which verbs ran*. Cut as its own branch per review preference.

Generated with Claude Code