### PR TITLE
test(coded-apps): re-scope gov-admin-deploy to branch decision + pipeline attempt

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
@@ -29,6 +29,15 @@ pre_run:
   - command: |
       mkdir -p .dashboard dist
       echo "<html></html>" > dist/index.html
+      # The skill's deploy flow runs `npm run build` before pack (deploy/impl.md).
+      # This is a deploy-only sandbox with a pre-seeded dist/ and no real project,
+      # so without a package.json that build step fails with ENOENT and a careful
+      # agent halts the whole pipeline before pack/publish/deploy. Seed a minimal
+      # project whose build is a no-op (leaves the pre-seeded dist/ intact) so the
+      # build step succeeds and the agent proceeds. A real dashboard has one anyway.
+      cat > package.json << 'EOF'
+      { "name": "runtime-compliance-dashboard", "private": true, "scripts": { "build": "true" } }
+      EOF
       cat > .dashboard/state.json << 'EOF'
       {
         "app": { "name": "Runtime Compliance Dashboard", "routingName": "runtime-compliance-k4p9", "semver": "1.0.0" },
@@ -82,14 +91,40 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  # Full pipeline still runs after provisioning.
+  # Pipeline ATTEMPT, checked per-verb — not "3 matching commands".
+  # This is a credential-free integration test: it verifies the governance-branch
+  # decision + that the agent issues the right pipeline commands, NOT a live deploy
+  # (the sister dashboard_gov_live_deploy_e2e owns that, with a disposable folder +
+  # cleanup). Two reasons per-verb, not a count:
+  #  - agents batch pack;publish;deploy into one shell script → a count check scored
+  #    1/3 and false-failed a correct run.
+  #  - `deploy` reads .uipath/app.config.json, which only a SUCCESSFUL publish writes;
+  #    offline (or on the shared tenant, where the fixed name+1.0.0 publish collides)
+  #    publish fails, so a careful agent correctly SKIPS deploy. Gate pack + publish
+  #    (both issued regardless of outcome); record deploy as advisory.
   - type: command_executed
-    description: "Agent ran the pack → publish → deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent reached uip codedapp deploy (advisory — a failed/colliding publish legitimately blocks the app.config.json-dependent deploy offline; live deploy is covered by the sister e2e)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.5
+    pass_threshold: 0
 
   # Dashboards are Web apps — never -t Action.
   - type: command_executed


### PR DESCRIPTION
## What

`uipath-coded-apps-dashboard-gov-admin-deploy` false-failed (gpt-5.6-terra, 0.619). It's a **credential-free integration** test whose real job is verifying the **governance-branch decision** — not a live deploy — but it was grading a live pipeline it can't safely run.

Two stacked problems:

1. **Build stop.** The skill's deploy flow runs `npm run build` before pack (`deploy/impl.md:202`). The deploy-only sandbox seeds `dist/` but **no `package.json`**, so the build fails ENOENT and a careful agent halts before pack/publish/deploy → **0/3**.
2. **Count-based pipeline check.** `min_count: 3` on `(pack|publish|deploy)` breaks when an agent batches the pipeline into one script (counts 1/3). And requiring `deploy` is unrealistic offline — `deploy` needs `.uipath/app.config.json` from a **successful** publish, but publish fails (no live tenant, or the fixed name+`1.0.0` collides on the shared tenant), so a careful agent correctly skips deploy.

## Fix — scope to what it can honestly verify offline

- **`pre_run` seeds a minimal `package.json` with a no-op build** (`"build": "true"`), leaving the pre-seeded `dist/` intact, so the build step succeeds and the agent proceeds. (A real dashboard has one anyway.)
- **Per-verb checks** replace the count: `pack` (gate), `publish` (gate), `deploy` (**advisory**). Batching-robust, and honest that deploy is blocked offline.
- **Unchanged:** provisioning via `setup-admin-folder.mjs` → AdminDashboards, no hand-create, no `-t Action`, semver `1.0.0`.

The **real** end-to-end deploy stays covered by the sister test `dashboard_gov_live_deploy_e2e` (disposable folder + cleanup).

### Bonus
Publish still harmlessly collides and deploy never lands → **nothing is deployed into the shared `AdminDashboards`**. The test stays non-mutating.

## Verification
- No-op build → exits 0, `dist/index.html` intact.
- Per-verb patterns match **both** a batched one-command pipeline **and** separate commands (deploy advisory when a careful agent skips it after a failed publish).
- YAML parses; `check-cli-verbs.py` clean.

Honest caveat: the failing run stopped *at* the build step, so its transcript can't prove post-build behavior — the criteria and no-op build are verified in isolation; end-to-end green needs the CI re-run.

Generated with Claude Code