### PR TITLE
fix(coded-apps): dashboard deploy grading brittleness + invocation-volume refuse-vs-build

### DIFF
--- a/skills/uipath-coded-apps/references/dashboards/primitives/tier-resolution.md
+++ b/skills/uipath-coded-apps/references/dashboards/primitives/tier-resolution.md
@@ -429,11 +429,11 @@ EmptyState when the window has no governance data — un-instrumented agents mus
 
 ## T0 — Hard Refuse
 
-**Refuse ONLY the specific metric — not the whole dashboard.** Always offer an alternative.
+**Refuse ONLY the specific metric — not the whole dashboard.** Always offer an alternative. **"No direct endpoint" ≠ "impossible": if the alternative is a metric you can derive from a read method (e.g. a Jobs trend), BUILD that widget — do not drop it.** Only rows whose alternative is a genuinely *different* metric (cost, RAM, …) are true refusals.
 
 | User asks for | Why impossible | Suggest instead |
 |--------------|----------------|-----------------|
-| Agent **invocation-count** timeline (runs/calls per period) | SDK 1.5.0 has error/latency/consumption timelines but no invocation-count endpoint | `agent-consumption-timeline` (AGU over time), `agent-error-timeline`, or T3 Jobs trend with `ProcessType eq 'Agent'` |
+| Agent **invocation volume / count over time** (runs/calls per period) | SDK 1.5.0 has error/latency/consumption timelines but no invocation-count endpoint | **Not a refusal — BUILD it** as a T3 Jobs trend: `new Jobs(sdk).getAll({ filter: "ProcessType eq 'Agent'" })` bucketed by period. Agent job runs ARE agent invocations, so this answers the ask; do NOT omit the widget. (Use `agent-consumption-timeline`/`agent-error-timeline` only if the user specifically wants AGU/errors.) |
 | Agent cost in dollars | Platform tracks AGU/PLTU units, not currency | `agent-consumption` for per-agent unit totals |
 | CPU/RAM per agent | Not exposed by any API ("Agent Memory" = memory entries, not RAM) | `agent-health`; or `agent-memory-timeline` if they meant the Memory feature |
 | Who triggered a job | Job records have no end-user identity | `job-completion-trend` grouped by process; `policy-denials` includes `actorIdentityId` for governance events |

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_deploy_state.yaml
@@ -41,12 +41,34 @@ initial_prompt: |
 success_criteria:
   # Pack → publish → deploy sequence (commands fail with auth in CI — we check
   # the agent ran the full sequence, not that the live deploy succeeded).
+  # Check each verb ONCE, not "3 matching commands": agents batch the whole
+  # pipeline into one shell script (pack; publish; deploy in a single set +e
+  # block), which the old count check scored 1/3 and false-failed a correct run;
+  # it also false-passed the reverse (pack ×3, no publish/deploy = 3 matches).
+  # Per-verb presence matches whether the agent runs three commands or one
+  # batched script, and a genuinely skipped step still fails (its check hits 0).
   - type: command_executed
-    description: "Agent ran full pack-publish-deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp deploy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.84
     pass_threshold: 1.0
 
   # Fresh deploy (folderKey null): the agent resolves a folder and deploys with

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
@@ -29,6 +29,15 @@ pre_run:
   - command: |
       mkdir -p .dashboard dist
       echo "<html></html>" > dist/index.html
+      # The skill's deploy flow runs `npm run build` before pack (deploy/impl.md).
+      # This is a deploy-only sandbox with a pre-seeded dist/ and no real project,
+      # so without a package.json that build step fails with ENOENT and a careful
+      # agent halts the whole pipeline before pack/publish/deploy. Seed a minimal
+      # project whose build is a no-op (leaves the pre-seeded dist/ intact) so the
+      # build step succeeds and the agent proceeds. A real dashboard has one anyway.
+      cat > package.json << 'EOF'
+      { "name": "runtime-compliance-dashboard", "private": true, "scripts": { "build": "true" } }
+      EOF
       cat > .dashboard/state.json << 'EOF'
       {
         "app": { "name": "Runtime Compliance Dashboard", "routingName": "runtime-compliance-k4p9", "semver": "1.0.0" },
@@ -82,14 +91,40 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-  # Full pipeline still runs after provisioning.
+  # Pipeline ATTEMPT, checked per-verb — not "3 matching commands".
+  # This is a credential-free integration test: it verifies the governance-branch
+  # decision + that the agent issues the right pipeline commands, NOT a live deploy
+  # (the sister dashboard_gov_live_deploy_e2e owns that, with a disposable folder +
+  # cleanup). Two reasons per-verb, not a count:
+  #  - agents batch pack;publish;deploy into one shell script → a count check scored
+  #    1/3 and false-failed a correct run.
+  #  - `deploy` reads .uipath/app.config.json, which only a SUCCESSFUL publish writes;
+  #    offline (or on the shared tenant, where the fixed name+1.0.0 publish collides)
+  #    publish fails, so a careful agent correctly SKIPS deploy. Gate pack + publish
+  #    (both issued regardless of outcome); record deploy as advisory.
   - type: command_executed
-    description: "Agent ran the pack → publish → deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent reached uip codedapp deploy (advisory — a failed/colliding publish legitimately blocks the app.config.json-dependent deploy offline; live deploy is covered by the sister e2e)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.5
+    pass_threshold: 0
 
   # Dashboards are Web apps — never -t Action.
   - type: command_executed

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_admin_deploy.yaml
@@ -28,7 +28,11 @@ sandbox:
 pre_run:
   - command: |
       mkdir -p .dashboard dist
-      echo "<html></html>" > dist/index.html
+      # Carry the uipath:org-name meta tag: the deploy step's CONFIG_OK gate
+      # (deploy/impl.md) greps dist/index.html for it and refuses to publish a
+      # bundle without it — the bare <html></html> stub fails that gate and the
+      # agent halts before pack. A real build injects it; bake it into the stub.
+      printf '%s\n' '<html><head><meta name="uipath:org-name" content="testorg"></head><body></body></html>' > dist/index.html
       # The skill's deploy flow runs `npm run build` before pack (deploy/impl.md).
       # This is a deploy-only sandbox with a pre-seeded dist/ and no real project,
       # so without a package.json that build step fails with ENOENT and a careful

--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
@@ -26,7 +26,17 @@ pre_run:
   - command: |
       EPOCH=$(date +%s)
       mkdir -p .dashboard dist
-      echo "<html></html>" > dist/index.html
+      # Seed a "built" dashboard the skill's deploy gates accept:
+      #  - the deploy flow runs `npm run build`; with no package.json it fails
+      #    ENOENT and a strict agent (set -euo pipefail) aborts before pack. A
+      #    no-op build succeeds and leaves the seeded dist/ intact.
+      #  - the deploy step greps dist/index.html for the uipath:org-name meta tag
+      #    (CONFIG_OK, deploy/impl.md) and refuses to deploy a bundle without it —
+      #    so bake it into the seeded html.
+      cat > package.json << 'PKGEOF'
+      { "name": "runtime-compliance-dashboard", "private": true, "scripts": { "build": "true" } }
+      PKGEOF
+      printf '%s\n' '<html><head><meta name="uipath:org-name" content="testorg"></head><body></body></html>' > dist/index.html
       cat > .dashboard/state.json <<EOF
       {
         "app": { "name": "Runtime Compliance Dashboard $EPOCH", "routingName": "runtime-compliance-$EPOCH", "semver": "1.0.0" },
@@ -107,12 +117,32 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # Per-verb, not a 3-command count: agents batch pack;publish;deploy into one
+  # shell script, so the count scored 1/3 and false-failed a correct run. Each
+  # verb checked once matches whether batched or separate; a skipped step still
+  # fails (its check hits 0). This is a live deploy, so all three are gating.
   - type: command_executed
-    description: "Agent ran the pack -> publish -> deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp deploy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.84
     pass_threshold: 1.0
 
   # Order/variable-tolerant: agents bind tags to a var (TAGS="governance,dashboard";


### PR DESCRIPTION
**Passed Run: https://github.com/UiPath/skills/actions/runs/30562243042**


Four coded-apps dashboard fixes surfaced by nightly evals. Common thread: grade/guidance that punished correct agent behavior.

## Test grading fixes (3 deploy tasks)

**1. `dashboard_deploy_state.yaml`** — `min_count: 3` on `(pack|publish|deploy)` scored 1/3 when the agent batched all three into one script → three per-verb presence checks.

**2. `dashboard_gov_admin_deploy.yaml`** — re-scope to branch decision + attempt. Skill runs `npm run build` before pack; deploy-only sandbox had no `package.json` → build ENOENT → strict agent halts (0/3). Seed a no-op `package.json`; per-verb checks (pack/publish gate, deploy advisory). Real live deploy stays with task 3.

**3. `dashboard_gov_live_deploy_e2e.yaml`** — unblock the live pipeline (provisioning fix already merged in #2298). Same missing-`package.json` build stop; plus the deploy CONFIG_OK gate greps `dist/index.html` for `uipath:org-name`. Seed a no-op `package.json` **and** the org-name meta tag; per-verb checks (all gating).

## Skill guidance fix (1 file)

**4. `tier-resolution.md`** — the `refuse-invocation-timeline` eval failed because the agent, asked for "invocation volume over time", concluded there's no invocation endpoint and **omitted** the widget (built 1 of 2). But agent job runs ARE invocations, so it's buildable from a read method (`Jobs.getAll` + `ProcessType eq 'Agent'`, bucketed) — which is what the eval requires. The T0 table's "impossible / suggest instead" framing read as "skip it". Made that row prescriptive ("Not a refusal — BUILD it as a Jobs trend") and noted that a metric derivable from a read method is a real widget, not a refusal. The test itself was correct.

## Verification
- Per-verb patterns match batched and separate command forms; synthetic skips still fail.
- gov-live `pre_run` runs clean: valid `package.json`, no-op build leaves org-name-tagged `dist/` intact, EPOCH app name expands.
- All YAMLs parse; `check-cli-verbs.py` clean; T0 table intact (genuinely-impossible rows unchanged).

Supersedes #2373, #2374, #2380. Same principle throughout: grade/instruct on *what the agent should achieve*, not the exact way it types or the fixtures we half-stubbed.

Generated with Claude Code