### PR TITLE
Fix reflected XSS in OAuth callback error response

### DIFF
--- a/.github/scripts/uipath-oauth-login.mjs
+++ b/.github/scripts/uipath-oauth-login.mjs
@@ -112,7 +112,12 @@ function startCallbackServer() {
         const st = url.searchParams.get("state");
         const error = url.searchParams.get("error");
         if (error) {
-          res.writeHead(200);
+          // Explicit text/plain + nosniff so the reflected provider error
+          // can never be interpreted as HTML (XSS, see #2273).
+          res.writeHead(400, {
+            "Content-Type": "text/plain; charset=utf-8",
+            "X-Content-Type-Options": "nosniff",
+          });
           res.end("Login failed: " + error);
           server.close();
           reject(new Error("OAuth error: " + error));


### PR DESCRIPTION
## Summary

Fixes #2273 (Snyk High — reflected XSS in `uipath-oauth-login.mjs`).

The local OAuth callback server in `.github/scripts/uipath-oauth-login.mjs` echoed the provider-supplied `error` query parameter into a response written with `res.writeHead(200)` — no `Content-Type` at all. Browsers content-sniff such responses, so a crafted callback URL like `http://localhost:8104/oidc/login?error=<script>...</script>` would be rendered as HTML and the script executed on the callback origin.

## Fix (minimal diff)

Serve the error branch with an explicit `Content-Type: text/plain; charset=utf-8` plus `X-Content-Type-Options: nosniff`, and a 400 status. With an explicit plain-text type the reflected value is always rendered as inert text — script injection is an HTML-context problem, and this removes the HTML context. `nosniff` additionally rules out legacy-browser MIME sniffing.

The error message itself is kept in the response (rather than replaced with a generic one) to keep the diff minimal; the provider error also still reaches CI logs through the existing `reject(new Error("OAuth error: " + error))` path.

## Testing

Not covered by automated tests (CI-only login helper). Verified by inspection that:
- the error branch now always declares a plain-text content type, so `<script>` payloads render as text;
- the success path is unchanged (static HTML, no interpolation);
- behavior of the promise flow (`resolve`/`reject`, `server.close()`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)