### PR TITLE
test(coded-apps): unblock gov-live-deploy pipeline (build + CONFIG gates) + per-verb check

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/deploy/dashboard_gov_live_deploy_e2e.yaml
@@ -26,7 +26,17 @@ pre_run:
   - command: |
       EPOCH=$(date +%s)
       mkdir -p .dashboard dist
-      echo "<html></html>" > dist/index.html
+      # Seed a "built" dashboard the skill's deploy gates accept:
+      #  - the deploy flow runs `npm run build`; with no package.json it fails
+      #    ENOENT and a strict agent (set -euo pipefail) aborts before pack. A
+      #    no-op build succeeds and leaves the seeded dist/ intact.
+      #  - the deploy step greps dist/index.html for the uipath:org-name meta tag
+      #    (CONFIG_OK, deploy/impl.md) and refuses to deploy a bundle without it —
+      #    so bake it into the seeded html.
+      cat > package.json << 'PKGEOF'
+      { "name": "runtime-compliance-dashboard", "private": true, "scripts": { "build": "true" } }
+      PKGEOF
+      printf '%s\n' '<html><head><meta name="uipath:org-name" content="testorg"></head><body></body></html>' > dist/index.html
       cat > .dashboard/state.json <<EOF
       {
         "app": { "name": "Runtime Compliance Dashboard $EPOCH", "routingName": "runtime-compliance-$EPOCH", "semver": "1.0.0" },
@@ -107,12 +117,32 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # Per-verb, not a 3-command count: agents batch pack;publish;deploy into one
+  # shell script, so the count scored 1/3 and false-failed a correct run. Each
+  # verb checked once matches whether batched or separate; a skipped step still
+  # fails (its check hits 0). This is a live deploy, so all three are gating.
   - type: command_executed
-    description: "Agent ran the pack -> publish -> deploy sequence"
+    description: "Agent ran uip codedapp pack"
     tool_name: "Bash"
-    command_pattern: 'uip\s+codedapp\s+(pack|publish|deploy)'
-    min_count: 3
-    weight: 2.5
+    command_pattern: 'uip\s+codedapp\s+pack\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp publish"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+publish\b'
+    min_count: 1
+    weight: 0.83
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uip codedapp deploy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+codedapp\s+deploy\b'
+    min_count: 1
+    weight: 0.84
     pass_threshold: 1.0
 
   # Order/variable-tolerant: agents bind tags to a var (TAGS="governance,dashboard";


### PR DESCRIPTION
Follow-up to #2298 (merged), same task `dashboard_gov_live_deploy_e2e`. The provisioning check now passes, but a fresh run (gpt-5.6-terra, 0.569) showed the **live pipeline still never runs**.

## Problem

The agent batched pack/publish/deploy in a `set -euo pipefail` script whose first real step is `npm run build`. The deploy-only sandbox seeds `dist/` but **no `package.json`**, so build fails ENOENT → `set -e` aborts before pack → pack→publish→deploy and both deploy criteria scored 0. (Same missing-`package.json` root cause as `gov_admin_deploy`.)

Two stubbed-fixture gates the skill enforces were unmet:
1. `npm run build` needs a `package.json`.
2. The deploy step (`deploy/impl.md` CONFIG_OK) greps `dist/index.html` for a `uipath:org-name` meta tag and refuses to deploy a bundle without it — the stub `<html></html>` would fail this next.

Plus the pipeline check used `min_count: 3`, which scores 1/3 when the agent batches into one script.

## Fix (all in `pre_run` + one criterion)

- Seed `package.json` with a **no-op build** (`"build": "true"`) → `npm run build` succeeds, leaves the seeded `dist/` intact.
- Seed `dist/index.html` **with the `uipath:org-name` meta tag** → the CONFIG_OK deploy gate passes.
- Replace `min_count: 3` with **three per-verb checks** (pack, publish, deploy — all gating; this is a real live deploy).

Provisioning / no-AdminDashboards / deploy-`--tags governance` / deploy-`--folder-key` checks unchanged. Disposable folder + `post_run` cleanup already handle the live-deploy teardown.

## Verification

Ran the actual `pre_run` script: exits 0; `package.json` valid; `npm run build` exits 0 leaving the org-name-tagged `dist/index.html` intact; EPOCH-suffixed app name still expands. Per-verb patterns match batched and separate forms.

Honest caveat: the failing run aborted at the build step, so its transcript can't prove post-build behavior end-to-end — the gates and no-op build are verified in isolation; full green needs the CI re-run.

Generated with Claude Code