### PR TITLE
test(coded-apps): grade pack/publish by verb, not --output json flag position

### DIFF
--- a/tests/tasks/uipath-coded-apps/integration_pack_publish_lifecycle.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_pack_publish_lifecycle.yaml
@@ -58,8 +58,11 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # pack/publish below grade the verb only — `--output json` may precede the
+  # subcommand as a global flag (`uip --output json codedapp pack`), so the
+  # pattern must not require it after the verb. Outcomes are graded separately.
   - type: command_executed
-    description: "Agent ran `uip codedapp pack` (grade the verb, not flag position — `--output json` is a global flag that may precede the subcommand, e.g. `uip --output json codedapp pack`)"
+    description: "Agent ran `uip codedapp pack`"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedapp\s+pack\b'
     min_count: 1
@@ -67,7 +70,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip codedapp publish` (grade the verb, not flag position — `--output json` is a global flag that may precede the subcommand, e.g. `uip --output json codedapp publish`)"
+    description: "Agent ran `uip codedapp publish`"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedapp\s+publish\b'
     min_count: 1

--- a/tests/tasks/uipath-coded-apps/integration_pack_publish_lifecycle.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_pack_publish_lifecycle.yaml
@@ -59,17 +59,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip codedapp pack` with --output json"
+    description: "Agent ran `uip codedapp pack` (grade the verb, not flag position — `--output json` is a global flag that may precede the subcommand, e.g. `uip --output json codedapp pack`)"
     tool_name: "Bash"
-    command_pattern: '(?s)uip\s+codedapp\s+pack\b.*--output\s+json'
+    command_pattern: 'uip\s+codedapp\s+pack\b'
     min_count: 1
     weight: 2.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent ran `uip codedapp publish` with --output json"
+    description: "Agent ran `uip codedapp publish` (grade the verb, not flag position — `--output json` is a global flag that may precede the subcommand, e.g. `uip --output json codedapp publish`)"
     tool_name: "Bash"
-    command_pattern: '(?s)uip\s+codedapp\s+publish\b.*--output\s+json'
+    command_pattern: 'uip\s+codedapp\s+publish\b'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

The integration test `skill-coded-apps-integration-pack-publish-lifecycle` failed even though the agent completed the build → pack → publish cycle successfully. The cause is a **brittle test regex**, not a skill or agent problem.

## What was going wrong

The `pack` and `publish` criteria required `--output json` to appear **after** the subcommand:
```
(?s)uip\s+codedapp\s+publish\b.*--output\s+json
```
On the failing run (gpt-5.6-terra) the agent published successfully with:
```
uip --output json codedapp publish -n integrationlifecycleapp --version 0.1.0-...   ✅ "Package uploaded to Orchestrator"
```
It put `--output json` **before** the subcommand — a valid global flag, and the publish worked. But the regex only looks *after* `publish`, so it matched 0/1 and failed the whole task (score 0.864, but marked FAILURE on this one check). `uip codedapp publish --output json` and `uip --output json codedapp publish` are equivalent; the pattern only accepted the first.

## Fix

Grade that the **verb ran**, order-agnostic — drop `--output json` from the two `command_executed` patterns:
- `(?s)uip\s+codedapp\s+pack\b.*--output\s+json` → `uip\s+codedapp\s+pack\b`
- `(?s)uip\s+codedapp\s+publish\b.*--output\s+json` → `uip\s+codedapp\s+publish\b`

This is also what the repo's own rules call for (`.claude/rules/test-writing.md`): don't grade the outcome-invisible `--output json` flag; grade the outcome. The pack/publish **outcomes** are already graded by the `.nupkg`, `app.config.json`, and `systemName` file checks, so no coverage is lost. The prompt still steers the agent toward `--output json`.

Fixed both `pack` and `publish` (identical latent bug — `pack` just happened not to trigger this run).

## Verification

Re-ran on codex/gpt-5.6 (the agent that hit the failure) — **now passes**:
**11/11 criteria, weighted score 1.000** (was FAILURE at 0.864 on the flag-position bug).
Run: **https://github.com/UiPath/skills/actions/runs/30560839289**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

