### PR TITLE
test(coded-apps): preinstall TS SDK in offline SDK-authoring tasks

### DIFF
--- a/.claude/rules/test-writing.md
+++ b/.claude/rules/test-writing.md
@@ -47,6 +47,25 @@ Or omit `node:` entirely if no other Node packages are needed.
 
 The template at `tests/templates/test-task-template.yaml` does not include `env_packages` — do not add it unless installing a package other than `@uipath/cli`.
 
+### Preinstall `@uipath/uipath-typescript` in offline coded-apps tasks
+
+Coded-apps references defer SDK signatures/scopes to files inside the npm package. If a task bans `npm` AND grades code that calls SDK services, preinstall the package — otherwise agents fetch `.d.ts` files from unpkg and exhaust the turn budget:
+
+```yaml
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"   # unpinned (same rationale as @uipath/cli above)
+```
+
+Do NOT add when:
+
+- Task grades install/build/deploy (e2e) — preinstall pre-solves graded steps
+- Graded facts are inlined in the skill (UI patterns, wiring, widget must-knows)
+- Refusal test — setup's install creates a root `package.json` declaring the SDK, auto-failing "nothing was built" criteria
+
+Setup runs `npm install` at the sandbox root before the agent starts (creates `package.json`, `package-lock.json`, `node_modules/`). Never pair with criteria asserting a pristine sandbox or `package.json` contents. Keep per-task — experiment defaults hit every suite; the image's global npm space is `uip` tool-discovery territory.
+
 ## Success Criteria — Grade Behavior, Not Self-Reports
 
 Use side effects (`command_executed`, `file_exists`, `file_contains`, `json_check`, `run_command`, `skill_triggered`, `command_not_executed`). Never grade on agent monologue.

--- a/tests/tasks/uipath-coded-apps/app_type_inference_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/app_type_inference_smoke.yaml
@@ -13,7 +13,6 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
 
 initial_prompt: |
   Our claims processors get work items in their UiPath task inbox. When

--- a/tests/tasks/uipath-coded-apps/df_schema_inspect_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/df_schema_inspect_smoke.yaml
@@ -9,7 +9,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/insertOrder.ts` — an async

--- a/tests/tasks/uipath-coded-apps/integration_add_sdk_service_to_existing_app.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_add_sdk_service_to_existing_app.yaml
@@ -9,7 +9,12 @@ description: >
 tags: [uipath-coded-apps, integration, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   You're handed an existing UiPath Coded Web App that currently shows

--- a/tests/tasks/uipath-coded-apps/integration_scope_mismatch_fix.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_scope_mismatch_fix.yaml
@@ -11,7 +11,12 @@ description: >
 tags: [uipath-coded-apps, integration, mode:diagnose, lifecycle:generate]
 run_limits:
   expected_turns: 12
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   You're debugging a UiPath Coded Web App. A teammate reports: "the app

--- a/tests/tasks/uipath-coded-apps/integration_sdk_imports_scopes.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_sdk_imports_scopes.yaml
@@ -12,7 +12,12 @@ description: >
 tags: [uipath-coded-apps, integration, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, build `src/api.ts` and `.env.example`.

--- a/tests/tasks/uipath-coded-apps/integration_sdk_runtime_ops.yaml
+++ b/tests/tasks/uipath-coded-apps/integration_sdk_runtime_ops.yaml
@@ -9,7 +9,12 @@ description: >
 tags: [uipath-coded-apps, integration, mode:operate, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, write `src/ops.ts` at the sandbox root —

--- a/tests/tasks/uipath-coded-apps/sdk_buckets_attachments_processes_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_buckets_attachments_processes_smoke.yaml
@@ -10,7 +10,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/storage.ts` with three exported

--- a/tests/tasks/uipath-coded-apps/sdk_conversational_feedback_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_conversational_feedback_smoke.yaml
@@ -10,7 +10,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/agent-support.ts` exporting

--- a/tests/tasks/uipath-coded-apps/sdk_cursor_loop_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_cursor_loop_smoke.yaml
@@ -9,7 +9,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:operate, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/listAllAssets.ts` — an async

--- a/tests/tasks/uipath-coded-apps/sdk_df_choicesets_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_df_choicesets_smoke.yaml
@@ -10,7 +10,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App that renders Data Fabric records, author

--- a/tests/tasks/uipath-coded-apps/sdk_insights_rtm_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_insights_rtm_smoke.yaml
@@ -12,7 +12,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/insights-rtm.ts` exporting

--- a/tests/tasks/uipath-coded-apps/sdk_maestro_bundle_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/sdk_maestro_bundle_smoke.yaml
@@ -10,7 +10,12 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author `src/maestro.ts` exporting five

--- a/tests/tasks/uipath-coded-apps/ui_bpmn_status_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_bpmn_status_smoke.yaml
@@ -9,7 +9,13 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 8
-  turn_timeout: 600
+
+# Skill refs defer SDK signatures/scopes to the npm package — preinstall so the agent reads them locally.
+sandbox:
+  node:
+    env_packages:
+      - "@uipath/uipath-typescript"
+      - "bpmn-js"
 
 initial_prompt: |
   Inside a UiPath Coded Web App that monitors Maestro processes, author

--- a/tests/tasks/uipath-coded-apps/web_sdk_oauth_init_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/web_sdk_oauth_init_smoke.yaml
@@ -11,7 +11,6 @@ description: >
 tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
 run_limits:
   expected_turns: 10
-  turn_timeout: 600
 
 initial_prompt: |
   Inside a UiPath Coded Web App, author the OAuth bootstrap files needed for


### PR DESCRIPTION
## Problem

Smoke run [30562176276](https://github.com/UiPath/skills/actions/runs/30562176276) failed the 95% pass-rate gate (24/26) on two tasks: `sdk-maestro-bundle` (max turns exhausted) and `sdk-conversational-feedback` (killed by the 600s turn timeout).

This is not random flakiness. The skill's SDK references point to files shipped inside the `@uipath/uipath-typescript` npm package (`dist/*.d.ts`, `docs/oauth-scopes.md`), but these tasks ban `npm` and run in empty sandboxes. Both agents obeyed the ban and downloaded the `.d.ts` files from unpkg with curl instead, burning 25-70 turns before (or instead of) writing the graded files.

## Fix

- Preinstall `@uipath/uipath-typescript` via `sandbox.node.env_packages` in the 12 npm-banning tasks that grade SDK service code (8 smoke, 4 integration). coder_eval installs it at sandbox setup, so the agent reads the shipped files locally. `ui_bpmn_status` also gets `bpmn-js`, which its prompt assumes is declared.
- Remove the per-task `turn_timeout: 600` overrides. These tasks now inherit the experiment's 900s (the conversational agent reached its Write call at ~595s and was killed mid-write).
- Add the decision rule to `.claude/rules/test-writing.md`: when to preinstall and when not to.

Left unchanged on purpose: e2e tasks (install/build is graded work there), refusal tests (a preinstall creates a root `package.json` that would auto-fail the "nothing was built" check), and npm-banning tasks whose graded facts are already inlined in the skill.

## Validation

- The changed YAMLs trigger the coded-apps smoke suite on this PR.
- Full coded-apps suite via run-coder-eval: https://github.com/UiPath/skills/actions/runs/30572206479

🤖 Generated with [Claude Code](https://claude.com/claude-code)