### PR TITLE
feat(discovery): add skills.sh.json, a zero-install trial path, and a drift guard

### DIFF
--- a/.github/workflows/validate-skills-sh.yml
+++ b/.github/workflows/validate-skills-sh.yml
@@ -1,0 +1,30 @@
+name: Validate skills.sh Grouping
+
+on:
+  pull_request:
+    paths:
+      - 'skills/*/SKILL.md'
+      - 'skills.sh.json'
+      - 'scripts/check-skills-sh.py'
+      - '.github/workflows/validate-skills-sh.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  validate-skills-sh:
+    runs-on: ubuntu-latest
+    name: Validate skills.sh.json against skills/
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      # skills.sh.json only affects the repo's page on skills.sh, so nothing
+      # else fails when it drifts. Adding or renaming a skill without updating
+      # it leaves the public page showing a stale grouping — this is the only
+      # thing that notices.
+      - name: Validate skills.sh grouping
+        run: python3 scripts/check-skills-sh.py

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -200,7 +200,26 @@ python3 scripts/check-skill-status.py
 
 CI (`validate-skill-status.yml`) fails if a skill is missing from the manifest, has an invalid status, leaves a stale `[PREVIEW]` / `> **Preview**` marker in SKILL.md, or if the README table is out of date.
 
-### 5. Add Reference Documents (Optional)
+### 5. Register the skills.sh Grouping
+
+Add the skill to a section in [`skills.sh.json`](skills.sh.json). This controls how the skill is grouped on the repository's [skills.sh page](https://skills.sh/UiPath/skills) — it does **not** affect what `uip skills install` or the `skills` CLI installs.
+
+```json
+{
+  "title": "Authoring",
+  "skills": ["uipath-<your-skill>"]
+}
+```
+
+Pick the section that matches the skill's purpose — the same four the README catalog uses (Authoring, Solution & Planning, Platform & Operations, Diagnostics & Feedback). Then validate:
+
+```bash
+python3 scripts/check-skills-sh.py
+```
+
+CI (`validate-skills-sh.yml`) fails if a skill is in no grouping, is listed in two, or is grouped but no longer exists on disk. `--fix` removes entries for deleted skills but will not place new ones — that is an editorial call.
+
+### 6. Add Reference Documents (Optional)
 
 Reference files go in `references/` and follow these conventions:
 
@@ -209,7 +228,7 @@ Reference files go in `references/` and follow these conventions:
 - **Organize by subdomain** when a skill covers multiple areas (e.g., `references/integration-service/`, `references/lifecycle/`)
 - **Link from SKILL.md** so the agent can discover them
 
-### 6. Add Templates/Assets (Optional)
+### 7. Add Templates/Assets (Optional)
 
 Static files like code templates go in `assets/`:
 
@@ -329,6 +348,7 @@ Before submitting your PR, verify:
 - [ ] No references to other skills (skills must be self-contained)
 - [ ] All links to reference files use relative paths and point to existing files
 - [ ] Lifecycle status registered in `assets/skill-status.json` and README table regenerated (run `python3 scripts/check-skill-status.py`)
+- [ ] Grouped in `skills.sh.json` (run `python3 scripts/check-skills-sh.py`)
 
 ### References
 - [ ] File names use kebab-case

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ CI (`validate-skill-status.yml`) fails if a skill is missing from the manifest, 
 
 ### 5. Register the skills.sh Grouping
 
-Add the skill to a section in [`skills.sh.json`](skills.sh.json). This controls how the skill is grouped on the repository's [skills.sh page](https://skills.sh/UiPath/skills) — it does **not** affect what `uip skills install` or the `skills` CLI installs.
+Add the skill to a section in [`skills.sh.json`](skills.sh.json). This controls how the skill is grouped on the repository's [skills.sh page](https://www.skills.sh/uipath/skills) — it does **not** affect what `uip skills install` or the `skills` CLI installs.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # UiPath Agent Skills
 
+[![skills.sh](https://skills.sh/b/UiPath/skills)](https://skills.sh/UiPath/skills)
+
 > [!NOTE]
 > **Work in Progress** — This repository is under active development. Skills are being added and refined. Contributions, feedback, and ideas are welcome! See [Contributing](#contributing) below.
 
@@ -39,6 +41,18 @@ See [Installing Node.js via package manager](https://nodejs.org/en/download/pack
 After installing, verify with `node -v` and then run the quick start command above.
 
 </details>
+
+### Try a skill without installing anything
+
+To evaluate a single skill before adopting the whole set, use the [`skills` CLI](https://skills.sh) — no UiPath CLI and no project changes required:
+
+```bash
+npx skills add UiPath/skills --list              # browse the catalog
+npx skills use UiPath/skills@uipath-rpa | claude # run one skill; nothing is written to your project
+npx skills add UiPath/skills --skill uipath-rpa  # install just that one skill
+```
+
+> **For ongoing use, prefer `uip skills install` above.** It detects every coding agent on your machine and keeps skills updated as they change; `npx skills add` installs a point-in-time copy that you must update yourself with `npx skills update`.
 
 ## Skill Catalog
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UiPath Agent Skills
 
-[![skills.sh](https://skills.sh/b/UiPath/skills)](https://skills.sh/UiPath/skills)
+[![skills.sh](https://www.skills.sh/b/uipath/skills)](https://www.skills.sh/uipath/skills)
 
 > [!NOTE]
 > **Work in Progress** — This repository is under active development. Skills are being added and refined. Contributions, feedback, and ideas are welcome! See [Contributing](#contributing) below.
@@ -44,7 +44,7 @@ After installing, verify with `node -v` and then run the quick start command abo
 
 ### Try a skill without installing anything
 
-To evaluate a single skill before adopting the whole set, use the [`skills` CLI](https://skills.sh) — no UiPath CLI and no project changes required:
+To evaluate a single skill before adopting the whole set, use the [`skills` CLI](https://www.skills.sh) — no UiPath CLI and no project changes required:
 
 ```bash
 npx skills add UiPath/skills --list              # browse the catalog

--- a/scripts/check-skills-sh.py
+++ b/scripts/check-skills-sh.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""
+Validate skills.sh.json — the display grouping for the repo's page on skills.sh —
+against the skills that actually exist under skills/.
+
+skills.sh.json is presentation-only: it never changes what the `skills` CLI
+installs. That is exactly why it rots silently — a skill added, renamed, or
+removed under skills/ produces no error anywhere, and the public page keeps
+showing the old grouping. (As of this script's introduction the live page still
+listed 13 skills that had been renamed or retired.) This check makes that drift
+a build failure instead of a discovery months later.
+
+Checks:
+  1. Parses      — the file is valid JSON with the expected top-level shape.
+  2. Schema      — the constraints published at
+                   https://skills.sh/schemas/skills.sh.schema.json, enforced
+                   locally so CI needs no network: groupings is a non-empty
+                   list of at most 50 objects; each has a required `title`
+                   (1-120 chars) and a required non-empty `skills` list (at
+                   most 500 entries, each 1-120 chars); `description` is
+                   optional and at most 500 chars; `notGrouped` is "top" or
+                   "bottom".
+  3. No duplicates — a skill appears in at most one grouping.
+  4. Bijection   — every skills/<name>/ is grouped, and every grouped name
+                   exists on disk.
+
+--fix repairs only what is unambiguous: it removes grouped names that no longer
+exist on disk (and any grouping left empty as a result). It deliberately does
+NOT place newly added skills — which section a skill belongs to is an editorial
+judgement, not something a script should guess.
+
+Outputs:
+  - Default: one finding per line, human-readable; exit 1 if any.
+  - --json : newline-delimited JSON for downstream tooling.
+
+Usage:
+    python3 scripts/check-skills-sh.py
+    python3 scripts/check-skills-sh.py --json
+    python3 scripts/check-skills-sh.py --fix
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "skills.sh.json"
+SKILLS_DIR = REPO_ROOT / "skills"
+
+SCHEMA_URL = "https://skills.sh/schemas/skills.sh.schema.json"
+NOT_GROUPED_VALUES = {"top", "bottom"}
+TOP_LEVEL_KEYS = {"$schema", "schema", "notGrouped", "groupings"}
+
+MAX_GROUPINGS = 50
+MAX_TITLE = 120
+MAX_DESCRIPTION = 500
+MAX_SKILLS_PER_GROUP = 500
+MAX_SKILL_NAME = 120
+
+
+def load_manifest():
+    if not MANIFEST_PATH.exists():
+        sys.exit(f"Manifest not found at {MANIFEST_PATH}.")
+    try:
+        return json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        sys.exit(f"{MANIFEST_PATH.name} is not valid JSON: {exc}")
+
+
+def skills_on_disk():
+    """Skill directory names — a skill is any skills/<name>/SKILL.md."""
+    if not SKILLS_DIR.is_dir():
+        sys.exit(f"Skills directory not found at {SKILLS_DIR}.")
+    return {p.parent.name for p in SKILLS_DIR.glob("*/SKILL.md")}
+
+
+def check_schema(manifest):
+    """Structural findings. Returns (findings, groupings, usable) — `groupings`
+    is the subset safe to reason about downstream, and `usable` is False when
+    the groupings key itself is unusable, so the caller can skip the coverage
+    check rather than report every skill on disk as ungrouped."""
+    findings = []
+
+    if not isinstance(manifest, dict):
+        return ([{"key": MANIFEST_PATH.name, "error": "top level must be a JSON object"}], [], False)
+
+    for key in sorted(set(manifest) - TOP_LEVEL_KEYS):
+        findings.append({"key": key,
+                         "error": f"unknown top-level key — expected one of {sorted(TOP_LEVEL_KEYS)}"})
+
+    schema = manifest.get("$schema")
+    if schema is not None and schema != SCHEMA_URL:
+        findings.append({"key": "$schema", "error": f"expected {SCHEMA_URL!r}, got {schema!r}"})
+
+    not_grouped = manifest.get("notGrouped")
+    if not_grouped is not None and not_grouped not in NOT_GROUPED_VALUES:
+        findings.append({"key": "notGrouped",
+                         "error": f"must be one of {sorted(NOT_GROUPED_VALUES)}, got {not_grouped!r}"})
+
+    groupings = manifest.get("groupings")
+    if not isinstance(groupings, list) or not groupings:
+        findings.append({"key": "groupings", "error": "required, and must be a non-empty list"})
+        return (findings, [], False)
+    if len(groupings) > MAX_GROUPINGS:
+        findings.append({"key": "groupings",
+                         "error": f"at most {MAX_GROUPINGS} groupings, got {len(groupings)}"})
+
+    valid = []
+    for index, group in enumerate(groupings):
+        where = f"groupings[{index}]"
+        if not isinstance(group, dict):
+            findings.append({"key": where, "error": "must be an object"})
+            continue
+
+        title = group.get("title")
+        if not isinstance(title, str) or not 1 <= len(title) <= MAX_TITLE:
+            findings.append({"key": where,
+                             "error": f"`title` is required and must be 1-{MAX_TITLE} characters"})
+        else:
+            where = f"groupings[{index}] {title!r}"
+
+        description = group.get("description")
+        if description is not None and (not isinstance(description, str)
+                                        or len(description) > MAX_DESCRIPTION):
+            findings.append({"key": where,
+                             "error": f"`description` must be a string of at most "
+                                      f"{MAX_DESCRIPTION} characters"})
+
+        skills = group.get("skills")
+        if not isinstance(skills, list) or not skills:
+            findings.append({"key": where, "error": "`skills` is required and must be non-empty"})
+            continue
+        if len(skills) > MAX_SKILLS_PER_GROUP:
+            findings.append({"key": where,
+                             "error": f"at most {MAX_SKILLS_PER_GROUP} skills, got {len(skills)}"})
+        for name in skills:
+            if not isinstance(name, str) or not 1 <= len(name) <= MAX_SKILL_NAME:
+                findings.append({"key": where,
+                                 "error": f"skill entry {name!r} must be a string of "
+                                          f"1-{MAX_SKILL_NAME} characters"})
+        valid.append(group)
+
+    return (findings, valid, True)
+
+
+def check_coverage(groupings, on_disk):
+    """Duplicate and bijection findings."""
+    findings = []
+    seen = {}
+
+    for group in groupings:
+        title = group.get("title", "?")
+        for name in group.get("skills", []):
+            if not isinstance(name, str):
+                continue
+            if name in seen:
+                findings.append({"key": name,
+                                 "error": f"listed in more than one grouping "
+                                          f"({seen[name]!r} and {title!r})"})
+            else:
+                seen[name] = title
+
+    for name in sorted(set(seen) - on_disk):
+        findings.append({"key": name,
+                         "error": "grouped but no skills/<name>/SKILL.md exists — the skill was "
+                                  "renamed or removed. Run --fix to drop it."})
+
+    for name in sorted(on_disk - set(seen)):
+        findings.append({"key": name,
+                         "error": "exists on disk but is in no grouping — it would render "
+                                  "ungrouped on skills.sh. Add it to the right section by hand "
+                                  "(placement is an editorial call, so --fix will not guess)."})
+
+    return findings
+
+
+def validate(manifest, on_disk):
+    schema_findings, groupings, usable = check_schema(manifest)
+    if not usable:
+        # `groupings` is absent or malformed — reporting all 24 skills as
+        # ungrouped would bury the one finding that matters.
+        return schema_findings
+    return schema_findings + check_coverage(groupings, on_disk)
+
+
+def fix(manifest, on_disk):
+    """Drop grouped names that no longer exist, and any grouping left empty."""
+    groupings = manifest.get("groupings")
+    if not isinstance(groupings, list):
+        sys.exit(f"Cannot --fix: `groupings` in {MANIFEST_PATH.name} is not a list.")
+
+    removed, dropped_groups, kept = [], [], []
+    for group in groupings:
+        if not isinstance(group, dict) or not isinstance(group.get("skills"), list):
+            kept.append(group)
+            continue
+        title = group.get("title", "?")
+        surviving = [n for n in group["skills"] if not isinstance(n, str) or n in on_disk]
+        removed += [f"{n} (was in {title!r})" for n in group["skills"]
+                    if isinstance(n, str) and n not in on_disk]
+        if surviving:
+            group["skills"] = surviving
+            kept.append(group)
+        else:
+            dropped_groups.append(title)
+
+    if not removed:
+        print(f"{MANIFEST_PATH.name} has no stale entries to remove.")
+    else:
+        manifest["groupings"] = kept
+        MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+                                 encoding="utf-8")
+        print(f"Removed {len(removed)} stale entr{'y' if len(removed) == 1 else 'ies'} "
+              f"from {MANIFEST_PATH.name}:")
+        for entry in removed:
+            print(f"  - {entry}")
+        for title in dropped_groups:
+            print(f"  ! grouping {title!r} dropped — it had no surviving skills")
+
+    # Ungrouped skills are never auto-placed; surface them so --fix isn't
+    # mistaken for "the manifest is now correct".
+    grouped = {n for g in manifest.get("groupings", []) if isinstance(g, dict)
+               for n in g.get("skills", []) if isinstance(n, str)}
+    ungrouped = sorted(on_disk - grouped)
+    if ungrouped:
+        print(f"\n{len(ungrouped)} skill(s) still need a grouping — add by hand:")
+        for name in ungrouped:
+            print(f"  - {name}")
+        return 1
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--json", action="store_true",
+                        help="Emit newline-delimited JSON instead of text")
+    parser.add_argument("--fix", action="store_true",
+                        help="Remove grouped names that no longer exist on disk")
+    args = parser.parse_args()
+
+    manifest = load_manifest()
+    on_disk = skills_on_disk()
+
+    if args.fix:
+        return fix(manifest, on_disk)
+
+    findings = validate(manifest, on_disk)
+
+    if args.json:
+        for finding in findings:
+            print(json.dumps(finding))
+        return 1 if findings else 0
+
+    if not findings:
+        sections = len(manifest.get("groupings", []))
+        print(f"OK — {len(on_disk)} skills grouped across {sections} section(s).")
+        return 0
+
+    print(f"{len(findings)} finding(s):\n")
+    for finding in findings:
+        print(f"  {finding['key']}: {finding['error']}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills.sh.json
+++ b/skills.sh.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://skills.sh/schemas/skills.sh.schema.json",
+  "notGrouped": "bottom",
+  "groupings": [
+    {
+      "title": "Authoring",
+      "description": "Build automations: RPA workflows, Maestro flows and BPMN, agents, coded apps, API workflows, connectors, functions, and document understanding.",
+      "skills": [
+        "uipath-rpa",
+        "uipath-maestro-flow",
+        "uipath-agents",
+        "uipath-maestro-bpmn",
+        "uipath-maestro-case",
+        "uipath-coded-apps",
+        "uipath-api-workflow",
+        "uipath-human-in-the-loop",
+        "uipath-ixp",
+        "uipath-connector-builder",
+        "uipath-functions"
+      ]
+    },
+    {
+      "title": "Solution & Planning",
+      "description": "Turn a process design into an implementation-ready solution, then package, review, and discover automation opportunities.",
+      "skills": [
+        "uipath-planner",
+        "uipath-solution",
+        "uipath-review",
+        "uipath-automation-discovery"
+      ]
+    },
+    {
+      "title": "Platform & Operations",
+      "description": "Operate the platform via the uip CLI: Orchestrator, Integration Service, Data Fabric, Admin, governance, testing, tasks, analytics, and MCP servers.",
+      "skills": [
+        "uipath-platform",
+        "uipath-admin",
+        "uipath-test",
+        "uipath-governance",
+        "uipath-insights",
+        "uipath-tasks",
+        "uipath-mcp-servers"
+      ]
+    },
+    {
+      "title": "Diagnostics & Feedback",
+      "description": "Investigate failures across any UiPath product and send bug reports or improvement suggestions to the team.",
+      "skills": [
+        "uipath-troubleshoot",
+        "uipath-feedback"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Why

We are already listed on [skills.sh](https://www.skills.sh/uipath/skills) and `npx skills add UiPath/skills` already works — neither fact is mentioned anywhere in the repo. Two problems follow from that:

1. **Our page shows 37 skills; we have 24.** Thirteen indexed entries are renamed or retired: `uipath-rpa-workflows`, `uipath-coded-workflows`, `uipath-flow`, `uipath-coded-agents`, `uipath-data-fabric`, `uipath-servo`, `uipath-interact`, `uipath-rpa-legacy`, `uipath-solution-design`, `uipath-diagnostics`, `uipath-gov-aops-policy`, `uipath-gov-access-policy`, `uipath-case-management`. A visitor sees duplicates like `uipath-flow` beside `uipath-maestro-flow`.
2. **There is no zero-install way to evaluate a skill.** Trying one currently means `npm -g install @uipath/cli` first.

Also worth knowing: the page reports **529 deduplicated installs** — `uipath-rpa` 53, `uipath-platform` 30, `uipath-coded-apps` 30, `uipath-test` 21, `uipath-planner` 21, down to `uipath-functions` 11. About 80 of those installs are against the retired names above. This is per-skill demand data we have not been reading.

## What's in the diff

**`skills.sh.json`** — groups all 24 skills under the four sections the README catalog already uses. Display-only; the [docs](https://skills.sh/docs/customize) are explicit that it *"does not change how the `skills` CLI installs skills."* `notGrouped: "bottom"` pushes the 13 retired entries below the live sections, which is the only lever available without a support request.

**`README.md`** — skills.sh badge, plus a "Try a skill without installing anything" block using `npx skills use` (writes to a temp dir, touches nothing in your project). `uip skills install` stays the recommended path, with the reason stated: it auto-detects every agent and auto-updates; `npx skills add` installs a point-in-time copy.

**`scripts/check-skills-sh.py`** — the drift guard. `skills.sh.json` is presentation-only, so nothing else fails when it goes stale; a skill added, renamed, or removed under `skills/` would otherwise leave the public page showing the old grouping (the exact failure visible on our page today). It checks four things: the file parses; the published skills.sh schema constraints hold (enforced locally so CI needs no network); no skill appears in two groupings; and every `skills/<name>/` is grouped while every grouped name exists on disk.

`--fix` is deliberately asymmetric — it removes names that no longer exist on disk and drops any grouping left empty, but **refuses to place newly added skills**, because which section a skill belongs to is an editorial call. It exits 1 while anything remains ungrouped, so it can never be mistaken for "the manifest is now correct".

**`.github/workflows/validate-skills-sh.yml`** — runs the check on PRs touching `skills/*/SKILL.md`, `skills.sh.json`, the script, or itself. Mirrors `validate-skill-status.yml`; no `${{ }}` interpolation, `pull_request` rather than `pull_request_target`, `contents: read` only.

**`CONTRIBUTING.md`** — a *Register the skills.sh Grouping* step in the *Adding a New Skill* flow, mirroring the existing step 4 for the status manifest, plus a Quality Checklist line. Without it the first contributor to add a skill gets a red check and no documentation saying why. It also states what is easy to assume wrong: the grouping affects only the skills.sh page, never what `uip skills install` installs.

Validated: 24 skills grouped exactly once, no orphans in either direction, every description within the schema's 500-char cap. `scripts/check-skills-sh.py`, `scripts/check-skill-status.py` and `hooks/validate-skill-descriptions.sh` all pass. The new check was exercised against every failure path — stale entry, ungrouped skill, cross-group duplicate, invalid JSON, missing/empty `groupings`, empty `skills`, over-long `description`, bad `notGrouped`, unknown top-level key, wrong `$schema`, missing `title` — each producing the intended finding and exit 1.

## Reviewer decision needed — seven groupings

These skills appear only in the README's *generated status table*, never in its *descriptive catalog tables*, so I inferred placement from the skill name alone. Please confirm or correct:

- [ ] `uipath-automation-discovery` → Solution & Planning
- [ ] `uipath-connector-builder` → Authoring
- [ ] `uipath-functions` → Authoring
- [ ] `uipath-governance` → Platform & Operations
- [ ] `uipath-insights` → Platform & Operations
- [ ] `uipath-mcp-servers` → Platform & Operations
- [ ] `uipath-tasks` → Platform & Operations

Whatever taxonomy we settle on should also close the README catalog gap — see *After merge* below.

## After merge

- [ ] **Trigger a page refresh, then verify it.** Run `npx skills add UiPath/skills --list` once, then open [the page](https://www.skills.sh/uipath/skills). Merging alone changes nothing: skills.sh picks up `skills.sh.json` *"after the repository is seen by the telemetry service"* and caches pages, so the refresh is install-driven. **This is the only confirmation the manifest was accepted** — a schema error would silently fall back to the current flat list. Expect four sections with the 13 retired entries below them.
- [ ] **Send the skills.sh support request** (skills.sh/contact). Two asks: prune the 13 retired entries, since `groupings` can reorder but not delete; and whether install history can carry across the renames `uipath-flow` → `uipath-maestro-flow` and `uipath-case-management` → `uipath-maestro-case` (~40 installs of real signal). This is the one thing this PR cannot do itself.
- [ ] **Close the README catalog gap** with whatever taxonomy the seven placements above settle into. The README documents 17 of 24 skills in its descriptive catalog tables; `skills.sh.json` now groups all 24. Those should be one taxonomy, not two — deliberately not in this diff, because it depends on the decision above.
- [ ] **Give install-count reporting an owner.** The public page is readable without auth; the API (`/api/v1/skills`) needs a Vercel OIDC token. A monthly read of the page is enough to start — but 529 installs of per-skill demand data have gone unread so far precisely because nobody owned it.

Considered and deliberately skipped: wiring the check into `.githooks/pre-commit`, which today runs only `validate-skill-descriptions.sh`. `check-skill-status.py` is CI-only too, and adding Python to a bash pre-commit changes local dev ergonomics for everyone. CI catches it either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)





