### PR TITLE
fix(uipath-insights): pass literal epoch ms for absolute time ranges

### DIFF
--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -47,7 +47,7 @@ uip login tenant set MyTenant
 
 ## Critical Rules
 
-1. **A time range is always required.** Every `uip insights jobs` command needs either `--time-range <minutes>` (relative) or both `--started-after <epoch-ms>` and `--started-before <epoch-ms>` (absolute). Without one, the command fails. Common values:
+1. **A time range is always required.** Every `uip insights jobs` command needs either `--time-range <minutes>` (relative) or both `--started-after <epoch-ms>` and `--started-before <epoch-ms>` (absolute). Without one, the command fails. For absolute ranges, pass literal epoch-millisecond numbers, resolved beforehand (see Workflow: Absolute Time Range). Common values:
    - `--time-range 60` — last 1 hour
    - `--time-range 1440` — last 24 hours
    - `--time-range 10080` — last 7 days
@@ -220,29 +220,26 @@ To discover available folder keys, use `uip or folders list --output json` (from
 
 ## Workflow: Absolute Time Range
 
-When the user specifies an exact date range instead of "last N hours":
+When the user specifies an exact date range instead of "last N hours", use `--started-after`/`--started-before` (not `--time-range`).
+
+**Two steps, two separate command invocations.** Resolve the dates to epoch milliseconds first, read the numbers from the output, then write the literal numbers into the `uip` command. Never embed `$(date ...)` substitutions or shell variables in `uip insights` flag values — if `date` fails silently (macOS and Linux flags differ), the flag becomes garbage and the query runs against the wrong window, and the logged command no longer shows what range was actually queried.
 
 ```bash
-# Convert dates to epoch milliseconds
-# Example: 2026-07-01 00:00:00 UTC to 2026-07-06 00:00:00 UTC
-uip insights jobs summary \
-  --started-after 1782691200000 \
-  --started-before 1783123200000 \
-  --output json
+# Step 1 — resolve each boundary to epoch ms at UTC midnight (run this alone, read the output):
+date -u -d "2026-07-01 00:00:00" +%s000   # Linux  → 1782864000000
+date -u -d "2026-07-06 00:00:00" +%s000   # Linux  → 1783296000000
+date -u -j -f "%Y-%m-%d" "2026-07-01" +%s000   # macOS
 ```
 
-Compute epoch milliseconds in bash:
 ```bash
-# macOS
-START=$(date -j -f "%Y-%m-%d" "2026-07-01" +%s)000
-END=$(date -j -f "%Y-%m-%d" "2026-07-06" +%s)000
-
-# Linux
-START=$(date -d "2026-07-01" +%s)000
-END=$(date -d "2026-07-06" +%s)000
-
-uip insights jobs summary --started-after "$START" --started-before "$END" --output json
+# Step 2 — run each subcommand with the literal resolved values:
+uip insights jobs summary --started-after 1782864000000 --started-before 1783296000000 --output json
 ```
+```bash
+uip insights jobs completed-timeline --started-after 1782864000000 --started-before 1783296000000 --output json
+```
+
+The end boundary is exclusive: "July 1st to July 5th" inclusive means `--started-after` = July 1 00:00:00 UTC and `--started-before` = July 6 00:00:00 UTC.
 
 ---
 
@@ -262,6 +259,8 @@ uip insights jobs summary --started-after "$START" --started-before "$END" --out
 ## What NOT to Do
 
 - **Don't call `uip insights jobs` without a time range.** The server returns a 500 with a misleading success-shaped response. Always pass `--time-range` or `--started-after`/`--started-before`.
+- **Don't embed `$(date ...)` or shell variables in `uip insights` flag values.** Resolve times in a separate command first, then pass literal epoch-millisecond numbers. Literal values make the executed command auditable and immune to platform `date` differences.
+- **Don't chain multiple `uip insights` subcommands with `&&` or `;` in one invocation.** Run each subcommand as its own command so each one's exit status and output are attributable.
 - **Don't start, stop, or manage individual jobs.** This skill is for monitoring and analytics only. Use `uip or jobs start/stop` via uipath-platform to manage jobs.
 - **Don't construct raw API calls to the Insights endpoint.** The CLI handles auth headers (`X-UiPath-Internal-AccountName`, `X-UiPath-Internal-TenantName`), URL construction, and error handling. Hand-rolling `curl` or `fetch` calls will miss these.
 - **Don't retry on auth errors.** If `uip insights jobs` returns 401 or "Not logged in", the fix is `uip login`, not retrying the same command.

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -228,7 +228,7 @@ When the user specifies an exact date range instead of "last N hours", use `--st
 # Step 1 — resolve each boundary to epoch ms at UTC midnight (run this alone, read the output):
 date -u -d "2026-07-01 00:00:00" +%s000   # Linux  → 1782864000000
 date -u -d "2026-07-06 00:00:00" +%s000   # Linux  → 1783296000000
-date -u -j -f "%Y-%m-%d" "2026-07-01" +%s000   # macOS
+date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-01 00:00:00" +%s000   # macOS → 1782864000000
 ```
 
 ```bash

--- a/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
+++ b/tests/tasks/uipath-insights/smoke_job_health_investigation.yaml
@@ -55,9 +55,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent used --output json on all commands"
+    description: "Advisory: agent used --output json on all commands (non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+insights\s+jobs\s+\S+\s+.*--output\s+json'
     min_count: 3
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0


### PR DESCRIPTION
Fixes [IN-13526](https://uipath.atlassian.net/browse/IN-13526).

## Summary

Two insights smoke tasks were failing for reasons that are not agent capability problems:

1. `skill-insights-smoke-absolute-time-range` (weighted 0.28 on delegate-sdk/virtuoso-1-5): the **skill steered agents into shell substitution**, so the graded command string never contained the literal epoch values the criteria require. Fixed in SKILL.md.
2. `skill-insights-smoke-job-health-investigation`: a **gating check on `--output json` in the command string** fails agents that reach the correct outcome without typing the flag where the regex expects it (batched calls, flag before the subcommand, or omitted where json is the default). Demoted to advisory per `.claude/rules/test-writing.md`.

## What was going wrong

The task grades the literal Bash command string:

```
uip\s+insights\s+jobs\s+\S+\s+.*--started-after\s+\d{13}
```

But SKILL.md's "Absolute Time Range" workflow taught exactly this:

```bash
START=$(date -d "2026-07-01" +%s)000
uip insights jobs summary --started-after "$START" --started-before "$END" --output json
```

The failing agent followed the skill faithfully — it ran `--started-after "$(date -d '2026-07-01' +%s)000"`. The CLI received real epoch values at runtime, but the graded command string contains no 13-digit literal, so both epoch criteria scored 0. The agent also chained both subcommands with `&&` in one Bash call, so the two-subcommand count matched 1/2.

The skill's example epoch values were also wrong (`1782691200000` is not 2026-07-01 UTC; `1782864000000` is), and the inline `$(date ...)` pattern is fragile on its own merits: macOS and Linux `date` flags differ, a silent failure turns the flag into garbage, and the executed command no longer shows what window was queried.

## Fix (SKILL.md)

- Absolute-time-range workflow now says: resolve dates to epoch ms in a **separate `date` step (UTC)**, then pass **literal millisecond values**, one subcommand per invocation; end boundary documented as exclusive.
- Corrected the example epoch values.
- Two new "What NOT to Do" bullets: no `$(date ...)`/shell variables in `uip insights` flag values; no `&&`/`;` chaining of subcommands.
- Pointer added to Critical Rule 1.

No change to `smoke_absolute_time_range.yaml`: the grader compiles `command_pattern` with `re.DOTALL` (`coder_eval/criteria/command_executed.py`), so the existing patterns already tolerate multi-line commands. The test was grading the right thing; the skill was teaching the wrong shape.

## Fix (job-health task)

`smoke_job_health_investigation.yaml` gated the whole task on `--output json` appearing in the command strings. That grades typing, not achieving: the flag is outcome-invisible (`.claude/rules/test-writing.md` calls this out explicitly — it is often the CLI default, so an agent can produce identical results without it), and command-string placement varies across valid trajectories (three separate calls vs one batched call, flag before or after the subcommand). The criterion is kept but demoted to advisory: description marked "(advisory)", `pass_threshold` 1.0 → 0, so runs still record convention adherence without failing on it. Same direction as #2388 (coded-apps pack/publish) and #2345 (admin audit).

**Alternative considered, not implemented:** keep it gating but split into one criterion per subcommand:

```yaml
command_pattern: 'uip\s+insights\s+jobs\s+summary\s+.*--time-range.*--output\s+json'
min_count: 1    # (same for top-failures and failures-by-reason)
```

Each needs only 1 matching tool call, and since patterns compile with `re.DOTALL`, a batched call satisfies all three individually (verified against both trajectory forms). An agent that drops the flag on any of the three commands then fails, batched or not. Rejected because it still gates on an outcome-invisible flag against the repo rule, and if the CLI ever makes json the default output, agents that reasonably omit the flag start failing for no user-visible reason.

## Verification

| Run | Agent / model | Result |
|---|---|---|
| coder-eval local, `experiments/default.yaml` | claude-code / claude-sonnet-4-6 | 4/4, score 1.000 |
| coder-eval local, `--type delegate-sdk --model virtuoso-1-5` (the originally failing config) | delegate-sdk / virtuoso-1-5 | 4/4, score 1.000 |
| coder-eval local, job-health task with the advisory demotion | claude-code / claude-sonnet-4-6 | 4/4 gating + advisory recorded, score 1.000 |

Fixed-skill transcripts show the exact intended shape:

```bash
date -u -j -f "%Y-%m-%d %H:%M:%S" "2026-07-01 00:00:00" +%s000
uip insights jobs summary --started-after 1782864000000 --started-before 1783296000000 --output json
uip insights jobs completed-timeline --started-after 1782864000000 --started-before 1783296000000 --output json
```

Not covered: the CI smoke runner has not exercised this branch.


[IN-13526]: https://uipath.atlassian.net/browse/IN-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ