### PR TITLE
fix(ci): harden catalog refresh — branch cleanup, token split, subtree-loss guard

### DIFF
--- a/.github/workflows/automerge-catalog-refresh.yml
+++ b/.github/workflows/automerge-catalog-refresh.yml
@@ -32,7 +32,12 @@ jobs:
         env:
           # PAT so the merge commit triggers downstream workflows (e.g. any
           # post-merge job that depends on the new catalog landing on main).
-          # Same PAT used elsewhere — see activation-gate.yml.
+          # Repo-write credential: needs contents + pull-requests + issues
+          # (the `--label automated` filter below reads labels, which sit
+          # under the Issues permission) + metadata (the rules API call).
+          # Shared with refresh-uip-catalog.yml and nothing else — both
+          # trigger on `schedule`/`check_suite`, so a PR author cannot reach
+          # this token. Feed-read consumers use GH_PACKAGES_TOKEN.
           GH_TOKEN: ${{ secrets.GH_PAT }}
           # `gh pr {list,view,merge}` resolve the repo from a local git
           # remote; this job has no actions/checkout step, so GH_REPO is

--- a/.github/workflows/refresh-uip-catalog.yml
+++ b/.github/workflows/refresh-uip-catalog.yml
@@ -89,6 +89,13 @@ jobs:
           # --min-verbs 1000 is a deliberate hard tripwire — it caught the
           # orchestrator-tool drop (#1203 follow-up). The build must clear it;
           # a stuck refresh is louder than a silently shrunk catalog.
+          # A third guard needs no flag and is always on: the build refuses to
+          # write if a group walked in the committed snapshot comes back
+          # unwalkable. Losing one command group is far too small a fraction of
+          # a ~1380-verb catalog for --max-drop-frac to notice (`rpa debug` +
+          # 2 others = 0.5% on 2026-07-30), and the group node survives, so the
+          # subtree vanishes silently. Failed `--help` walks are also retried
+          # first — see scripts/build-uip-catalog.py.
           python3 scripts/build-uip-catalog.py --install-tools \
             --min-verbs 1000 --max-drop-frac 0.2
 

--- a/.github/workflows/refresh-uip-catalog.yml
+++ b/.github/workflows/refresh-uip-catalog.yml
@@ -63,7 +63,11 @@ jobs:
       - name: Install uip CLI (GitHub Packages @dev)
         if: steps.check.outputs.exists != 'true'
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_PAT }}
+          # Feed read only — deliberately NOT the repo-write PAT. See the
+          # `Open PR` step below for the split rationale. Falls back to
+          # GH_PAT so this keeps working until GH_PACKAGES_TOKEN is created;
+          # drop the fallback once it exists.
+          NODE_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}
         run: |
           npm config set @uipath:registry https://npm.pkg.github.com/
           npm config set //npm.pkg.github.com/:_authToken "$NODE_AUTH_TOKEN"
@@ -105,11 +109,22 @@ jobs:
         # Use a PAT (not GITHUB_TOKEN) so the opened PR triggers
         # `pull_request:` workflows — required-check workflows authored by
         # GITHUB_TOKEN do not fire, which would let `--auto` merge before
-        # the verb gate / smoke tests ran. Same PAT already used by
-        # activation-gate.yml.
+        # the verb gate / smoke tests ran.
+        #
+        # GH_PAT is the repo-WRITE credential: contents + pull-requests +
+        # issues (labels live under the Issues permission — a token without
+        # it fails here with `HTTP 404 .../labels`, which is how this
+        # workflow broke for a month from 2026-06-30). It is referenced only
+        # by this workflow and automerge-catalog-refresh.yml, both of which
+        # trigger on `schedule`/`check_suite` and so cannot be influenced by
+        # a PR author. Feed reads use GH_PACKAGES_TOKEN instead, because
+        # that secret IS exposed to `pull_request`-triggered builds on this
+        # public repo and must not carry write access.
         env:
           GH_TOKEN: ${{ secrets.GH_PAT }}
         run: |
+          set -euo pipefail
+
           RAW_VERSION=$(jq -r .cli_version assets/uip-catalog-snapshot.json | tr -d '\r\n')
           # Sanitize before interpolating into title/body/branch — defense
           # in depth against unexpected characters in `uip --version` output.
@@ -125,15 +140,38 @@ jobs:
           git commit -m "chore: refresh uip CLI catalog ($CLI_VERSION, $VERB_COUNT verbs)"
           git push -u origin "$BRANCH"
 
+          # Past this point the branch exists on the remote, so any failure
+          # would strand it: the guard at the top of this job only looks for
+          # open PRs, so it never notices its own debris, and 34 orphans
+          # accumulated while the label call below was failing. Worse, the
+          # branch name is derived from version + UTC date, so a same-day
+          # retry at an unchanged CLI version collides with the orphan and
+          # dies on a non-fast-forward push instead of the real error.
+          # Delete the branch unless a PR ended up owning it.
+          PR_CREATED=false
+          cleanup_branch() {
+            if [ "$PR_CREATED" != "true" ]; then
+              echo "::warning::PR creation did not complete — deleting pushed branch $BRANCH"
+              git push origin --delete "$BRANCH" || true
+            fi
+          }
+          trap cleanup_branch EXIT
+
           # Ensure the `automated` label exists before referencing it on the
           # PR. The label is the join key the auto-merger uses to identify
           # refresh PRs (see automerge-catalog-refresh.yml). Creating it
           # idempotently here keeps the workflow self-contained — no
           # one-time repo setup step required after a fresh fork.
+          # Non-fatal: the label already exists on this repo, so a failure
+          # here is a token/permission hiccup, not a reason to abandon an
+          # otherwise-good catalog refresh. `gh pr create --label` below is
+          # the call that actually matters; if the label is genuinely
+          # missing that one fails loudly.
           gh label create automated \
             --color cccccc \
             --description "Bot-generated automated PR" \
-            --force
+            --force \
+            || echo "::warning::gh label create failed — continuing to PR creation"
 
           gh pr create \
             --title "chore: refresh uip CLI catalog ($CLI_VERSION)" \
@@ -141,3 +179,6 @@ jobs:
 
           Merges automatically once all checks pass (handled by \`automerge-catalog-refresh.yml\`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to \`.claude/rules/cli-renames.md\`. \`/lint-task\` and the CLI Verb Gate will surface the affected references." \
             --label "automated"
+
+          # PR owns the branch now — leave it for the auto-merger.
+          PR_CREATED=true

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -193,10 +193,10 @@ jobs:
       # Pull the agent image from GHCR (never built from source); the skills
       # image extends it below. Tag defaults to the wheel version but can be
       # overridden (coder_eval_image_tag) for ad-hoc / unreleased images.
-      # GH_PAT needs read:packages.
+      # Needs read:packages only — GH_PACKAGES_TOKEN, never the repo-write PAT.
       - name: Pull coder-eval-agent image
         run: |
-          echo "${{ secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker pull ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_image_tag }}
 
       # Build the skills extension image (`@uipath/cli` + `@uipath/admin-tool`
@@ -205,7 +205,7 @@ jobs:
         run: |
           docker build \
             --build-arg CODER_EVAL_IMAGE=ghcr.io/uipath/coder-eval-agent:${{ needs.partition.outputs.coder_eval_image_tag }} \
-            --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
+            --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}" \
             --build-arg CLI_VERSION="${{ inputs.cli_version }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
@@ -402,7 +402,7 @@ jobs:
         shell: bash
         env:
           CLI_VERSION:    ${{ inputs.cli_version }}
-          NPM_AUTH_TOKEN: ${{ secrets.GH_PAT }}
+          NPM_AUTH_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}
         run: |
           set -e
           install_dir="$(mktemp -d)"

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -194,6 +194,9 @@ jobs:
       # image extends it below. Tag defaults to the wheel version but can be
       # overridden (coder_eval_image_tag) for ad-hoc / unreleased images.
       # Needs read:packages only — GH_PACKAGES_TOKEN, never the repo-write PAT.
+      # This workflow is `workflow_dispatch`-triggered, so it is not exposed to
+      # the fork/branch-push reader that motivates the split in smoke-skills.yml
+      # and smoke-rpa-skills.yml; the narrower token is least-privilege here.
       - name: Pull coder-eval-agent image
         run: |
           echo "${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -142,7 +142,8 @@ jobs:
       # smoke-skills.yml and tests/docker/Dockerfile).
       #
       # The `@uipath` scope is mapped to npm.pkg.github.com via a temp npmrc
-      # (token from GH_PAT, read:packages). EVERY package is pinned to the
+      # (token from GH_PACKAGES_TOKEN, read:packages only — never the
+      # repo-write PAT; this workflow is `pull_request`-triggered). EVERY package is pinned to the
       # explicit `@dev` dist-tag: the same feed also carries a FROZEN `alpha`
       # tag (1.197.0-alpha.*) and the public `latest` line — never rely on
       # `latest`/unspecified here, which could resolve to a stale line. The
@@ -163,11 +164,11 @@ jobs:
       - name: Install uip CLI + RPA tools (GitHub Packages @dev)
         shell: bash
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}
         run: |
           set -euo pipefail
-          if [ -z "${GH_PAT:-}" ]; then
-            echo "::error::GH_PAT is empty — cannot authenticate to the GitHub Packages @dev feed"
+          if [ -z "${GH_PACKAGES_TOKEN:-}" ]; then
+            echo "::error::GH_PACKAGES_TOKEN is empty — cannot authenticate to the GitHub Packages @dev feed"
             exit 1
           fi
           install_dir="$(mktemp -d)"
@@ -176,7 +177,7 @@ jobs:
           npmrc="$install_dir/.npmrc"
           {
             echo "@uipath:registry=https://npm.pkg.github.com/"
-            echo "//npm.pkg.github.com/:_authToken=${GH_PAT}"
+            echo "//npm.pkg.github.com/:_authToken=${GH_PACKAGES_TOKEN}"
           } > "$npmrc"
           export NPM_CONFIG_USERCONFIG="$npmrc"
           npm install -g @uipath/cli@dev

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -141,14 +141,16 @@ jobs:
       # Linux smoke image, which builds from the same `@dev` tag (see
       # smoke-skills.yml and tests/docker/Dockerfile).
       #
-      # The `@uipath` scope is mapped to npm.pkg.github.com via a temp npmrc
-      # (token from GH_PACKAGES_TOKEN, read:packages only — never the
-      # repo-write PAT; this workflow is `pull_request`-triggered). EVERY package is pinned to the
-      # explicit `@dev` dist-tag: the same feed also carries a FROZEN `alpha`
-      # tag (1.197.0-alpha.*) and the public `latest` line — never rely on
-      # `latest`/unspecified here, which could resolve to a stale line. The
-      # npmrc is written and deleted inside this step so the token never
-      # lingers on the runner.
+      # The `@uipath` scope is mapped to npm.pkg.github.com via a temp npmrc.
+      # Token is GH_PACKAGES_TOKEN (read:packages only), never the repo-write
+      # PAT: this workflow is `pull_request`-triggered, so anyone who can push
+      # a branch to this public repo can read the secret it is handed.
+      #
+      # EVERY package is pinned to the explicit `@dev` dist-tag: the same feed
+      # also carries a FROZEN `alpha` tag (1.197.0-alpha.*) and the public
+      # `latest` line — never rely on `latest`/unspecified here, which could
+      # resolve to a stale line. The npmrc is written and deleted inside this
+      # step so the token never lingers on the runner.
       #
       # Tools are installed with raw `npm install -g @uipath/<tool>@dev`, NOT
       # `uip tools install`: on a `-dev` CLI the latter resolves the release

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -338,10 +338,13 @@ jobs:
         run: uv pip install --system "coder-eval==${{ steps.ceref.outputs.version }}"
 
       # Pull the pinned agent image from GHCR (never built from source); the
-      # skills smoke image extends it below. GH_PAT needs read:packages.
+      # skills smoke image extends it below. Needs read:packages only —
+      # GH_PACKAGES_TOKEN, never the repo-write PAT: this workflow is
+      # `pull_request`-triggered, so anyone who can push a branch to this
+      # public repo can read the secret it is handed.
       - name: Pull pinned coder-eval-agent image
         run: |
-          echo "${{ secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+          echo "${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
           docker pull ghcr.io/uipath/coder-eval-agent:${{ steps.ceref.outputs.version }}
 
       # Build custom smoke image extending coder-eval-agent with @uipath/cli and
@@ -354,7 +357,7 @@ jobs:
         run: |
           docker build \
             --build-arg CODER_EVAL_IMAGE=ghcr.io/uipath/coder-eval-agent:${{ steps.ceref.outputs.version }} \
-            --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PAT }}" \
+            --build-arg NPM_AUTH_TOKEN="${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}" \
             -t skills-image:latest \
             -f tests/docker/Dockerfile \
             .

--- a/scripts/build-uip-catalog.py
+++ b/scripts/build-uip-catalog.py
@@ -17,6 +17,7 @@ import json
 import re
 import subprocess
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -47,6 +48,53 @@ def verb_count_error(new_count, prev_count, min_verbs, max_drop_frac):
     return None
 
 
+def unwalkable_regression_error(new_unwalkable, prev_unwalkable, prev_verbs):
+    """Return an error string if a previously-walked group is now unwalkable, else None.
+
+    A group whose `--help` walk fails contributes ZERO children to the
+    catalog while the group node itself survives, so the loss is invisible to
+    verb_count_error: on 2026-07-30 a build lost the entire `rpa debug`
+    subtree (16 verbs) plus `rpa analyzer-rules list` and `rpa files diff`,
+    a 0.5% drop that sailed past --max-drop-frac 0.2 and produced a PR that
+    would have auto-merged.
+
+    A group is a regression when all three hold:
+      1. it is unwalkable in THIS build,
+      2. it was NOT unwalkable in the committed snapshot, and
+      3. the committed snapshot enumerated at least one child under it.
+
+    Condition 3 is what keeps this quiet. Leaf commands legitimately land in
+    UNWALKABLE — `uip rpa pack --help` emits no `Subcommands` — and they have
+    no children in the previous snapshot, so they never trip the guard. A
+    group genuinely deleted from the CLI is also silent: it never enters the
+    walk frontier, so collect_group is never called and it cannot appear in
+    `new_unwalkable`. That leaves exactly the flaky/broken case.
+
+    Pure function — no I/O — so it is unit-testable without the CLI.
+    """
+    prev_unwalkable = set(prev_unwalkable or ())
+    regressed = []
+    for group in sorted(set(new_unwalkable or ())):
+        if group in prev_unwalkable:
+            continue
+        prefix = f"{group} "
+        lost = sorted(v for v in (prev_verbs or ()) if v.startswith(prefix))
+        if lost:
+            regressed.append((group, lost))
+    if not regressed:
+        return None
+    total = sum(len(lost) for _, lost in regressed)
+    detail = "; ".join(
+        f"{group!r} (-{len(lost)}: {', '.join(lost[:3])}"
+        f"{', …' if len(lost) > 3 else ''})"
+        for group, lost in regressed
+    )
+    return (
+        f"{len(regressed)} group(s) walked in the committed snapshot are "
+        f"unwalkable in this build, dropping {total} verb(s): {detail}"
+    )
+
+
 _DECODER = json.JSONDecoder()
 
 # Top-level groups whose JSON help could not be enumerated. Populated by
@@ -63,6 +111,13 @@ UNWALKABLE = set()
 # top-level subcommand in the current catalog build — that way a catalog
 # built on Windows still resolves `uip rpa …` verbs concretely.
 PLATFORM_SPECIFIC_PREFIXES = {"rpa"}
+
+# How many times to attempt a group's `--help` walk before marking it
+# unwalkable, and the base backoff between attempts (multiplied by the
+# attempt number). A failed walk drops the group's entire subtree from the
+# catalog, so a transient failure is expensive — see collect_group.
+GROUP_HELP_ATTEMPTS = 3
+GROUP_HELP_BACKOFF_SECONDS = 1.0
 
 
 def _ci(d, key):
@@ -250,13 +305,30 @@ def collect_top_level():
 
 
 def collect_group(group_path):
-    data = run_uip([*group_path.split(), "--help"])
+    # Retry before giving up: a single failed `--help` silently deletes the
+    # group's whole subtree from the catalog, and the failures are not always
+    # deterministic (the unwalkable set churns between builds minutes apart —
+    # `rpa debug` walked at 05:35 UTC on 2026-07-30 and did not at 21:39).
+    # Cost is bounded: only failing groups retry, and a healthy build has few.
+    data = None
+    for attempt in range(1, GROUP_HELP_ATTEMPTS + 1):
+        data = run_uip([*group_path.split(), "--help"])
+        if data is not None and data.get("Result") != "Failure":
+            break
+        if attempt < GROUP_HELP_ATTEMPTS:
+            print(f"group {group_path!r}: help walk failed "
+                  f"(attempt {attempt}/{GROUP_HELP_ATTEMPTS}) — retrying",
+                  file=sys.stderr)
+            time.sleep(GROUP_HELP_BACKOFF_SECONDS * attempt)
     if data is None or data.get("Result") == "Failure":
         # Tool errored, doesn't support `--output json`, or failed to load
         # (common for Click/Python plugins and tools with broken npm deps).
-        # Mark so the scanner can downgrade findings under this prefix from
-        # "stale" to "uncertain".
+        # Also the normal outcome for a leaf command, which emits no
+        # Subcommands. Mark so the scanner can downgrade findings under this
+        # prefix from "stale" to "uncertain".
         UNWALKABLE.add(group_path)
+        print(f"group {group_path!r}: unwalkable after "
+              f"{GROUP_HELP_ATTEMPTS} attempt(s)", file=sys.stderr)
         return set()
     subs = data.get("Data", {}).get("Subcommands", []) or []
     found = set()
@@ -325,6 +397,14 @@ def main():
         help="Refuse to write if the verb count drops more than this fraction "
              "(0-1) vs the existing --output snapshot. E.g. 0.2 = abort on a >20%% drop.",
     )
+    parser.add_argument(
+        "--allow-unwalkable-regression",
+        action="store_true",
+        help="Write the catalog even if a group that was walked in the existing "
+             "--output snapshot is unwalkable in this build. Escape hatch for a "
+             "genuine, permanent loss of JSON help; without it such a build is "
+             "refused because the cause is usually transient.",
+    )
     args = parser.parse_args()
 
     # Validate before any work: a fraction outside [0, 1] silently breaks the
@@ -339,15 +419,34 @@ def main():
     verbs = expand(verbs, groups)
 
     # Integrity guards — never overwrite a good snapshot with a collapsed one.
-    prev_count = None
+    prev = None
     if not args.stdout and args.output.exists():
         try:
-            prev_count = len(json.loads(args.output.read_text()).get("verbs", []))
+            prev = json.loads(args.output.read_text())
         except (json.JSONDecodeError, OSError):
-            prev_count = None
+            prev = None
+    prev_verbs = (prev or {}).get("verbs") or []
+    prev_unwalkable = (prev or {}).get("unwalkable_groups") or []
+    prev_count = len(prev_verbs) if prev else None
+
     err = verb_count_error(len(verbs), prev_count, args.min_verbs, args.max_drop_frac)
     if err:
         sys.exit(f"Refusing to write catalog: {err}. Aborting suspected bad build.")
+
+    # Subtree-loss guard. verb_count_error cannot see this: losing a whole
+    # command group is a small fraction of a ~1380-verb catalog.
+    regression = unwalkable_regression_error(UNWALKABLE, prev_unwalkable, prev_verbs)
+    if regression and not args.allow_unwalkable_regression:
+        sys.exit(
+            f"Refusing to write catalog: {regression}. Re-run the build first — "
+            "these walks are often transient. Use --allow-unwalkable-regression "
+            "only if the loss is real: either the CLI genuinely stopped exposing "
+            "JSON help for these groups, or the committed snapshot is itself a "
+            "flaky build whose extra groups this good build cannot match."
+        )
+    if regression:
+        print(f"warning: accepting unwalkable regression ({regression})",
+              file=sys.stderr)
 
     snapshot = {
         "generated_at": dt.datetime.now(dt.timezone.utc)

--- a/tests/scripts/test_catalog_build_guards.py
+++ b/tests/scripts/test_catalog_build_guards.py
@@ -241,3 +241,111 @@ def test_install_all_tools_skips_already_installed_pascalcase(monkeypatch):
     build.install_all_tools()
     specs = [c[3] for c in installs if c[:3] == ["npm", "install", "-g"]]
     assert specs == ["@uipath/df-tool@dev"]            # solution-tool skipped
+
+
+# --- subtree-loss guard (unwalkable regression) ------------------------------
+#
+# Added after 2026-07-30, where a build lost the whole `rpa debug` subtree
+# (16 verbs) plus `rpa analyzer-rules list` and `rpa files diff`. The group
+# nodes survived, so the loss was only 0.5% of a 1384-verb catalog and sailed
+# past --max-drop-frac 0.2 into a PR that would have auto-merged.
+
+def test_lost_subtree_is_rejected():
+    """A group that was walked before and is unwalkable now trips the guard."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable={"rpa debug"},
+        prev_unwalkable=[],
+        prev_verbs=["rpa debug", "rpa debug start", "rpa debug step-over", "rpa run"],
+    )
+    assert err is not None
+    assert "rpa debug" in err
+    assert "-2" in err                      # start + step-over, not the group node
+
+
+def test_leaf_command_does_not_trip_the_guard():
+    """Leaves legitimately fail to walk — no children before, so not a regression."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable={"rpa pack", "rpa validate"},
+        prev_unwalkable=[],
+        prev_verbs=["rpa pack", "rpa validate", "rpa run"],
+    )
+    assert err is None
+
+
+def test_already_unwalkable_group_does_not_trip_the_guard():
+    """A group unwalkable in both builds is the status quo, not a regression."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable={"coder", "context-grounding"},
+        prev_unwalkable=["coder", "context-grounding"],
+        prev_verbs=["coder", "coder foo", "context-grounding", "context-grounding bar"],
+    )
+    assert err is None
+
+
+def test_genuinely_deleted_group_does_not_trip_the_guard():
+    """A group removed from the CLI never enters the walk, so never lands here."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable=set(),
+        prev_unwalkable=[],
+        prev_verbs=["agenthub mcp-tools create-is-activity", "agenthub mcp-tools list"],
+    )
+    assert err is None
+
+
+def test_new_group_appearing_unwalkable_does_not_trip_the_guard():
+    """A group absent from the previous snapshot has no children to lose."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable={"brand-new-tool"},
+        prev_unwalkable=[],
+        prev_verbs=["rpa run"],
+    )
+    assert err is None
+
+
+def test_multiple_regressions_are_all_reported():
+    """Every regressed group is named, with a total verb count."""
+    err = build.unwalkable_regression_error(
+        new_unwalkable={"rpa debug", "rpa files"},
+        prev_unwalkable=[],
+        prev_verbs=["rpa debug start", "rpa debug resume", "rpa files diff"],
+    )
+    assert err is not None
+    assert "2 group(s)" in err and "3 verb(s)" in err
+    assert "rpa debug" in err and "rpa files" in err
+
+
+def test_no_previous_snapshot_is_not_a_regression():
+    """First build (no committed snapshot) cannot regress."""
+    assert build.unwalkable_regression_error({"rpa debug"}, [], []) is None
+    assert build.unwalkable_regression_error({"rpa debug"}, None, None) is None
+
+
+def test_group_help_retries_before_marking_unwalkable(monkeypatch):
+    """A transient help failure is retried and does not lose the subtree."""
+    build.UNWALKABLE.clear()
+    monkeypatch.setattr(build.time, "sleep", lambda _s: None)
+    calls = []
+
+    def flaky_run_uip(argv):
+        calls.append(argv)
+        if len(calls) == 1:
+            return None                     # transient failure
+        return {"Data": {"Subcommands": [{"Name": "start"}]}}
+
+    monkeypatch.setattr(build, "run_uip", flaky_run_uip)
+    found = build.collect_group("rpa debug")
+    assert found == {"rpa debug start"}
+    assert "rpa debug" not in build.UNWALKABLE
+    assert len(calls) == 2                  # failed once, succeeded on retry
+
+
+def test_group_help_gives_up_after_max_attempts(monkeypatch):
+    """A persistent failure is marked unwalkable after the retry budget."""
+    build.UNWALKABLE.clear()
+    monkeypatch.setattr(build.time, "sleep", lambda _s: None)
+    calls = []
+    monkeypatch.setattr(build, "run_uip", lambda argv: calls.append(argv) or None)
+    found = build.collect_group("rpa debug")
+    assert found == set()
+    assert "rpa debug" in build.UNWALKABLE
+    assert len(calls) == build.GROUP_HELP_ATTEMPTS


### PR DESCRIPTION
Two independent failures of the nightly catalog refresh, both found while fixing the first: a **month-long outage** (2026-06-30 → 07-30) and a **silent catalog corruption** that nearly auto-merged on 07-30.

## Part 1 — the outage

Reported in Slack as a suspected expired PAT; it was not. `GH_PAT` was rotated on 2026-06-25 (secret `updated_at`) to a token that can read the GitHub Packages `@dev` feed but cannot write labels. `gh label create` returned:

```
HTTP 404: Not Found (https://api.github.com/repos/UiPath/skills/labels)
```

GitHub returns **404, not 403**, when a token lacks a permission — which is why this read as "token revoked" rather than "token under-scoped". The token was valid the whole time: the same secret authenticated the npm feed in the step immediately before.

The rotation was 06-25 but the first failure was 06-30, because runs on 06-26…06-29 skipped every step behind the "existing open refresh PR" guard and reported green **vacuously**. Last catalog to actually merge: 06-24.

### Fixes

**Failures no longer strand branches.** The step pushed the branch and then died, and the guard at the top only looks at open PRs — so it never noticed its own debris. 34 `auto/refresh-uip-catalog-*` branches accumulated with zero open PRs (since deleted). A trap now removes the pushed branch unless a PR ended up owning it.

This also closes a latent deadlock: the branch name is `<cli-version>-$(date -u +%Y%m%d)`, so a same-day retry at an unchanged CLI version collided with its own orphan and died on a non-fast-forward `git push` — failing *before* the real error, with a misleading message.

**`gh label create` is no longer fatal.** The `automated` label already exists on this repo, so the call is belt-and-braces for fresh forks — but it ran under `bash -e`, so a permission hiccup there aborted an otherwise-good refresh. Now non-fatal with a `::warning::`. `gh pr create --label automated` is the call that actually has to succeed, and it still fails loudly.

**One secret no longer serves two very different jobs.** `smoke-skills.yml` and `smoke-rpa-skills.yml` are `pull_request`-triggered **required checks** on a **public** repo. Fork PRs don't receive secrets, but anyone who can push a branch here could read the secret handed to those builds — and that secret also carried repo write. Feed-read consumers now take `GH_PACKAGES_TOKEN`; `GH_PAT` is referenced only by `refresh-uip-catalog.yml` and `automerge-catalog-refresh.yml`, which trigger on `schedule` / `check_suite` and cannot be influenced by a PR author.

**Two stale comments corrected.** Both workflows claimed this PAT is "already used by activation-gate.yml". It isn't — `activation-gate.yml` never references `GH_PAT`. That claim is what pointed the original triage at a blanket token expiry.

## Part 2 — the silent catalog corruption

The first successful run after the token fix produced #2397, which dropped the entire `rpa debug` subtree (16 verbs) plus `rpa analyzer-rules list` and `rpa files diff`. It was **not** a CLI change: `uip <group> --help` failed for those three groups, and `collect_group` marks a group unwalkable and returns no children when that happens. The group node itself survives, so the subtree vanishes silently — 18 verbs is 1.3% of a 1384-verb catalog, comfortably inside `--max-drop-frac 0.2`.

The failures are transient, not structural: the same three groups walked fine 16 hours earlier, and five *different* `rpa` groups failed in that earlier build instead. #2397 had green required checks and the `automated` label, and the CLI Verb Gate is deliberately advisory — so it would have auto-merged unattended.

### Fixes

- **Retry** — `collect_group` attempts a failed `--help` 3 times with linear backoff before marking a group unwalkable. Only failing groups pay the cost.
- **Subtree-loss guard** (always on, no flag) — refuse to write when a group that was walked in the committed snapshot is unwalkable in this build. `--allow-unwalkable-regression` is the escape hatch for a genuine permanent loss, or for recovering when the committed snapshot is itself the flaky build.

The discriminator is "did the previous snapshot enumerate children under this group", which keeps the guard quiet on everything that isn't a regression: leaf commands (`uip rpa pack --help` emits no `Subcommands`), groups already unwalkable, groups genuinely deleted from the CLI (a deleted group never enters the walk, so it cannot appear in the unwalkable set), and brand-new groups.

## Sequencing — read before merging

Every feed site reads `${{ secrets.GH_PACKAGES_TOKEN || secrets.GH_PAT }}`. The fallback is deliberate: pointing required checks at a secret that doesn't exist yet would fail them, block every merge in the repo, and block this PR. Behavior is **identical to today** until the secret is created.

Follow-up once `GH_PACKAGES_TOKEN` exists (classic PAT, `read:packages` only, no repo scopes — GitHub Packages' npm registry rejects the fine-grained path):

- [ ] Create `GH_PACKAGES_TOKEN`
- [ ] Scope `GH_PAT` down to contents + pull-requests + issues + metadata, pinned to this repo
- [ ] Drop the `|| secrets.GH_PAT` fallbacks
- [ ] Consider a GitHub App for the write credential so expiry stops causing silent multi-week outages

## Verification

- Outage fix confirmed on [run 30581973513](https://github.com/UiPath/skills/actions/runs/30581973513): green with **every step executed, none skipped** — including `Open PR with updated catalog`, the step that had 404'd daily. It produced #2397 carrying the `automated` label, so the label write is proven rather than vacuously green.
- Trap tested on both paths: `gh pr create` failure deletes the branch **and still exits 1** (cleanup does not mask the error); success keeps the branch for the auto-merger.
- Subtree-loss guard tested against the two **real** snapshots, not just fixtures. On the bad build it reports exactly `'rpa analyzer-rules' (-1); 'rpa debug' (-16); 'rpa files' (-1)` = 18 verbs; `verb_count_error` on the same inputs returns `None`, confirming the gap it closes.
- 10 new unit tests in `tests/scripts/test_catalog_build_guards.py` covering the non-regression cases and both retry paths. **103 tests pass** across `tests/scripts/`.
- All 5 workflows: YAML parses, `bash -n` clean on every `run:` block.

Note the flakiness is symmetric: if a flaky snapshot ever lands on main, the guard will block the next *good* build too. The error message says so and points at the flag.

No changes to any skill, reference, or task YAML.
