### PR TITLE
test(uipath-platform): retag traces tasks by capability mode, not diagnose

### DIFF
--- a/tests/tasks/uipath-platform/traces/traces_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_e2e.yaml
@@ -4,7 +4,7 @@ description: >
   traces-smoke-agent job, wait for completion, fetch LLM trace spans, and
   confirm at least one span is returned. Unlike traces_fetch.yaml (smoke),
   this exercises the full round-trip against a real job and real traces.
-tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces]
+tags: [uipath-platform, e2e, mode:operate, lifecycle:discover, traces]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]

--- a/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_e2e.yaml
@@ -6,7 +6,7 @@ description: >
   creates positive feedback on that trace, then fetches the feedback by ID and
   verifies the round-trip. FolderKey and TraceId are still derived at runtime —
   only the fixture process key is fixed.
-tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces, feedback]
+tags: [uipath-platform, e2e, mode:build, lifecycle:discover, traces, feedback]
 
 agent:
   allowed_tools: ["Skill", "Bash", "Read", "Write"]

--- a/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_smoke.yaml
@@ -4,7 +4,7 @@ description: >
   positive feedback. Verifies the agent knows to call
   `uip traces feedback create --trace-id ... --positive --folder-key ...` with --output json.
   Auth/404 errors are acceptable outcomes — the goal is correct command shape.
-tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces, feedback]
+tags: [uipath-platform, smoke, mode:build, lifecycle:discover, traces, feedback]
 
 run_limits:
   expected_turns: 7

--- a/tests/tasks/uipath-platform/traces/traces_fetch.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_fetch.yaml
@@ -4,7 +4,7 @@ description: >
   given job key against the live tenant. Verifies the agent knows to call
   `uip traces spans get --job-key <guid> --output json`.
   A 404 response (no traces for this job key) is an acceptable outcome.
-tags: [uipath-platform, smoke, mode:diagnose, lifecycle:discover, traces]
+tags: [uipath-platform, smoke, mode:operate, lifecycle:discover, traces]
 
 run_limits:
   expected_turns: 6


### PR DESCRIPTION
## Motivation

All 4 `uipath-platform/traces` coder-eval tasks are tagged `mode:diagnose`, but none of them exercise a Diagnose capability — two test `spans get` (Operate) and two test `feedback create` (Build), per the LLMOps/Traces Coverage Tracker. Because Build/Operate had zero mode-tagged tasks, the Coding Agents Scorecard generator fell back to the row's overall mean with an unmeasured `*` marker for those two columns instead of a real, capability-attributed score. This retags the 4 tasks so Build and Operate Eval Score are backed by real signal.

## Summary

- `traces_fetch.yaml` + `traces_e2e.yaml` (test `uip traces spans get`): `mode:diagnose` → `mode:operate`
- `traces_feedback_smoke.yaml` + `traces_feedback_e2e.yaml` (test `uip traces feedback create`): `mode:diagnose` → `mode:build`
- Tags-only change — no prompt, criteria, or behavior changes.

## How we verified the retag actually improves coverage (not just "tags changed")

1. **Live baseline first, before touching anything.** Ran all 4 tasks against the real alpha/`codereval` tenant via `coder-eval` to get today's real pass rate (the Confluence scorecard's 55%/55%/55% is a stale 07/22 snapshot, predating the 07/24 `TRACES_SMOKE_PROCESS_KEY` fix in #2276). Result: **4/4 succeeded, score 1.000 ± 0.000** — confirms the fixture/process-key issue is already resolved and today's real numbers are nothing like the stale snapshot.
2. **Replayed the scorecard's own aggregation logic**, not a hand-wavy estimate — took the exact per-mode aggregation code from `.claude/commands/generate-confluence-scorecard.md` Phase 1 and ran it against the real `weighted_score`/`status` values from that baseline run, once with the tags as they were actually recorded (`mode:diagnose` ×4) and once with the corrected tags, holding pass/fail fixed so the retag's effect is isolated from any behavior change:

   | | Build | Operate | Troubleshoot |
   |---|---|---|---|
   | Before (as tagged when the run executed) | `100*` (fallback, no build-tagged tasks) | `100*` (fallback, no operate-tagged tasks) | `100` (real, n=4) |
   | After (corrected tags, same real scores) | `100` (real, n=2) | `100` (real, n=2) | `100*` (fallback, no diagnose-tagged tasks left) |

   Net effect: Build and Operate move from a borrowed/unmeasured number to a genuine, correctly-attributed one. Troubleshoot becomes the fallback in their place — intentional and out of scope here; the real Diagnose-mode capabilities for this scorecard row are 7 agent-runtime error-diagnosis playbooks that live in `uipath-troubleshoot`, not in this directory (3 of 7 already have tests but aren't tagged `traces` so don't roll into this row; 4 of 7 have no test at all yet, though their playbook docs already exist). Follow-up, not part of this PR.

## Tests performed

- `coder-eval run` on all 4 tasks (`traces_fetch`, `traces_e2e`, `traces_feedback_smoke`, `traces_feedback_e2e`) against real alpha/`codereval` tenant: **4/4 passed, score 1.000 ± 0.000** (run `2026-07-30_14-39-44`).
- `/lint-task` on all 4 edited files: **0 Critical, 0 High, 0 Medium, 0 Low** — tag-only edit introduced no new issues.
- `scripts/check-cli-verbs.py` on all 4 files: clean against the live catalog (uip 1.200.0-dev.8031, 1384 verbs).
- Scorecard math replay (see table above) using the real run's scores.

## Test plan

- [x] Live coder-eval run against real tenant, all 4 tasks passing
- [x] `/lint-task` clean on all 4 edited files
- [x] CLI-verb reachability clean
- [x] Scorecard per-mode aggregation replayed against real scores, before/after compared
- [ ] Confirm on next ADO nightly scorecard regen that Build/Operate for LLMOPS/Traces show real (non-`*`) values

🤖 Generated with [Claude Code](https://claude.com/claude-code)