### PR TITLE
test(uipath-test): Playwright integration and e2e tasks (hold until C…

### DIFF
--- a/tests/tasks/uipath-test/playwright_first_mile_e2e.yaml
+++ b/tests/tasks/uipath-test/playwright_first_mile_e2e.yaml
@@ -42,11 +42,18 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Scoped the run to chromium only"
+    description: "Ran the test set scoped to the chromium project"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testsets?\s+run\s+.*--playwright-projects\s+chromium(?!\s+[A-Za-z])'
+    command_pattern: 'uip\s+tm\s+testsets?\s+run\s+.*--playwright-projects\s+chromium'
     min_count: 1
     weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Did not widen the run to a second Playwright project"
+    tool_name: "Bash"
+    command_pattern: '--playwright-projects\s+\S+\s+\S'
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-test/playwright_first_mile_e2e.yaml
+++ b/tests/tasks/uipath-test/playwright_first_mile_e2e.yaml
@@ -1,0 +1,87 @@
+# Prerequisites (see PR description):
+#   - a CLI carrying the external-package commands (npm `latest` on 1.200+)
+#   - the eval tenant's Test Manager has Playwright support enabled
+#   - a folder the runner is a member of, with a Cloud Robots - Serverless
+#     machine, and working serverless Playwright execution
+task_id: skill-test-playwright-first-mile-e2e
+description: >
+  Full Playwright first mile: package a suite, upload it, let ingestion
+  auto-create the test cases, fill a test set by label, run only one Playwright
+  project, and collect the results. Graded on the saved report rather than
+  tenant state, and the agent cleans the project up afterwards.
+tags: [uipath-test, e2e, mode:operate, lifecycle:setup, feature:test-case]
+
+run_limits:
+  turn_timeout: 1200
+
+initial_prompt: |
+  I have a Playwright suite I want to run through Test Manager. Create a
+  minimal one in ./pw-suite with two passing tests and a config defining the
+  projects "chromium" and "firefox", then get it running from the Test Manager
+  project PWE2E (create it if needed) on chromium only — not firefox.
+  Save the final test report to ./report.json, then delete the project so my
+  tenant stays clean.
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+
+success_criteria:
+  - type: command_executed
+    description: "Packaged and uploaded the suite"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(or|orchestrator)\s+packages\s+upload'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Filled the test set by label rather than hand-collected keys"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+add\s+.*--labels'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Scoped the run to chromium only"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testsets?\s+run\s+.*--playwright-projects\s+chromium(?!\s+[A-Za-z])'
+    min_count: 1
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Saved the final report"
+    path: "report.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Both tests passed — the run reached real results"
+    command: "grep -qE '\"Passed\":[[:space:]]*2' report.json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Nothing failed or was left without a result"
+    command: "grep -qE '\"Failed\":[[:space:]]*0' report.json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Cleaned up the project it created"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+project\s+delete\s+.*PWE2E'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Did not use the Studio/RPA link-automation pipeline"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+link-automation'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
+++ b/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
@@ -37,11 +37,18 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Waited for ingestion with an unfiltered test case list"
+    description: "Waited for ingestion by listing the project's test cases"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tm\s+testcases?\s+list(?![^\n]*--filter)[^\n]*--project-key\s+PWINT'
+    command_pattern: 'uip\s+tm\s+testcases?\s+list\s+.*--project-key\s+PWINT'
     min_count: 1
     weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Did not filter that list by package name — the filter never matches ingested test cases"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+list\s+.*--filter'
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed

--- a/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
+++ b/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
@@ -1,6 +1,8 @@
 # Prerequisites (see PR description):
 #   - a CLI carrying the external-package commands (npm `latest` on 1.200+)
 #   - the eval tenant's Test Manager has Playwright support enabled
+#   - the released CLI registers `testsets playwright-context` on stable
+#     (UiPath/cli#3336) — this task's assertion reads that command's output
 # Does NOT need serverless execution — it stops before running the test set.
 task_id: skill-test-playwright-ingest-and-select
 description: >
@@ -67,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "Test set resolves to a single Playwright package, with its projects listed"
-    command: "grep -qi 'true' context.json && grep -qi 'chromium' context.json"
+    command: "grep -qiE '\"IsPlaywright\"[^,}]*true' context.json && grep -qi 'chromium' context.json"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
+++ b/tests/tasks/uipath-test/playwright_ingest_and_select_integration.yaml
@@ -1,0 +1,82 @@
+# Prerequisites (see PR description):
+#   - a CLI carrying the external-package commands (npm `latest` on 1.200+)
+#   - the eval tenant's Test Manager has Playwright support enabled
+# Does NOT need serverless execution — it stops before running the test set.
+task_id: skill-test-playwright-ingest-and-select
+description: >
+  Integration test for the Playwright first mile up to (not including)
+  execution: package a suite, upload it, let ingestion auto-create the test
+  cases, fill a test set by the ingestion-applied labels, and confirm the set
+  resolves to a single Playwright package. Grades the recorded context rather
+  than tenant state, and the agent cleans the project up afterwards.
+tags: [uipath-test, integration, mode:operate, lifecycle:setup, feature:test-case]
+
+initial_prompt: |
+  I have a Playwright suite I want to run from Test Manager. Create a minimal
+  one in ./pw-suite with two passing tests and a config defining the projects
+  "chromium" and "firefox", get it into the Test Manager project PWINT
+  (create it if needed), and collect its smoke tests into a test set.
+  Save what Test Manager reports about that test set's Playwright packaging to
+  ./context.json, then delete the project so my tenant stays clean.
+
+success_criteria:
+  - type: command_executed
+    description: "Packaged the suite as an external test package"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+pack\s+.*--type\s+playwright'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Uploaded the package to Orchestrator"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(or|orchestrator)\s+packages\s+upload'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Waited for ingestion with an unfiltered test case list"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+list(?![^\n]*--filter)[^\n]*--project-key\s+PWINT'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Filled the test set by label rather than hand-collected keys"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+add\s+.*--labels'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Recorded what Test Manager reported about the test set"
+    path: "context.json"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Test set resolves to a single Playwright package, with its projects listed"
+    command: "grep -qi 'true' context.json && grep -qi 'chromium' context.json"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Cleaned up the project it created"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+project\s+delete\s+.*PWINT'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Did not use the Studio/RPA link-automation pipeline"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+testcases?\s+link-automation'
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
## What

The Playwright **integration** and **e2e** eval tasks for the `uipath-test` skill, split out of UiPath/skills#2322 so that PR can merge now while these wait for the capability they exercise.

| Task | Tier | Covers | Needs serverless execution? |
|---|---|---|---|
| `playwright_ingest_and_select_integration.yaml` | integration | pack → upload → ingestion → label-filled test set → single-Playwright-package check | **No** — stops before running |
| `playwright_first_mile_e2e.yaml` | e2e | the same flow through a chromium-only run to real results | Yes |

Both grade **saved artifacts** (`context.json`, `report.json`) rather than live tenant state, so the agent can delete the project it created without breaking the assertions — and a stale execution from an earlier run cannot satisfy an outcome check. Both carry a teardown criterion, so scheduled runs leave nothing behind.

## Why separate

The eval runner installs `@uipath/cli@latest` before any task runs, and tasks are forbidden from pinning a version (`tests/README.md`). Until the external-package commands reach npm `latest`, these can only fail — and a scheduled task that always fails is noise that also desensitises people to real failures. So the skill and its passing smoke task ship in #2322; these wait here.

## Do not merge until

1. **The commands are on npm `latest`** — check `npm view @uipath/cli version` reports 1.200.x. The 1.200 cut is not sufficient: stable promotion is a separate manual dispatch.
2. **UiPath/cli#3336 is in that released line** — the integration task reads `playwright-context` output, which a stable CLI only registers once that fix ships.
3. **The eval tenant has Test Manager Playwright support enabled** (both tasks), and **working serverless Playwright execution** (e2e task only).

Then run each once by hand and merge on green:

```bash
SKILLS_REPO_PATH=$(cd .. && pwd) .venv/bin/coder-eval run \
  tasks/uipath-test/playwright_ingest_and_select_integration.yaml -e experiments/default.yaml
```

## Validation

The flows these tasks assert are proven manually: on a local serverless stack and on alpha `testmanagerdev/DevTest`, a context-free agent using only the skill reached **2/2 passed** on a chromium-only run, including a fix-and-republish loop. What is unproven is these YAMLs executing under `coder-eval` on a capable tenant — hence the manual run in the merge checklist above.

The e2e task is a candidate for the `path-to-ga` tag (must-pass, currently blocked); it is left off so this PR stays mergeable on demand, since that tag needs an allowlisted approval on the head commit.

## Related

- **UiPath/skills#2322** — the skill content and the smoke task that passes today.
- **UiPath/cli#3336** — precondition 2 above.
