### PR TITLE
fix(uipath-functions): teach required pyproject authors + add Critical Rules

### DIFF
--- a/skills/uipath-functions/SKILL.md
+++ b/skills/uipath-functions/SKILL.md
@@ -44,7 +44,7 @@ Use Python when the logic needs job semantics, platform SDK access, or is invoke
 
 ## Critical Rules
 
-1. **Pass `-l py`.** `uip function new` defaults to TypeScript. Omitting the flag scaffolds the wrong project type.
+1. **Pass `-l py`, then verify the scaffold.** `uip function new` defaults to TypeScript. And when `uipath-langchain` is installed it emits a LangGraph *agent* even with `-l py` — check for `langgraph.json` and replace the scaffold if present (Step 1).
 2. **Add `authors` to `pyproject.toml` right after scaffolding.** The scaffold omits it; `uip function pack` then fails with `Project authors cannot be empty`. Do this as part of scaffolding, not before packing — every project needs it, including ones you only run locally.
 3. **Never instantiate `UiPath()` at module level.** Use a lazy getter (Step 3 template).
 4. **Return errors, never raise them.** Populate `error_type`/`error_message` on the output model; an exception escaping the entrypoint faults the job.
@@ -80,6 +80,14 @@ uip function new <name> --language js       # JavaScript Function (JS/TS, no job
 **`--language py` is required for Python.** The default language is TypeScript — omitting `--language` scaffolds a JS/TS project. Always pass `-l py` or `--language py` when building a Python Coded Function.
 
 `--empty` skips the hello-world function (JS/TS only).
+
+**Verify what you got before writing logic.** `uip function new -l py` passes through to `uipath new`. When `uipath-langchain` is installed in the same environment, its `langgraph_new_middleware` intercepts that command and scaffolds a **LangGraph agent instead of a Function** ([uipath-python#1543](https://github.com/UiPath/uipath-python/issues/1543)). Symptoms: a `langgraph.json` file, a `main.py` importing `langgraph` / `UiPathChat`, and no `functions` map in `uipath.json`.
+
+```bash
+ls langgraph.json 2>/dev/null && echo "WRONG SCAFFOLD — agent, not function"
+```
+
+If you see it: delete `langgraph.json`, replace `main.py` with the Step 3 template, and write `uipath.json` per Step 4. Do not try to adapt the agent template — it carries an LLM call, which Critical Rule 5 forbids. Two edits fix it; iterating on the wrong scaffold burns the whole turn budget.
 
 ### Step 2: Define Function Schema
 

--- a/skills/uipath-functions/SKILL.md
+++ b/skills/uipath-functions/SKILL.md
@@ -42,6 +42,15 @@ Use Python when the logic needs job semantics, platform SDK access, or is invoke
 
 ---
 
+## Critical Rules
+
+1. **Pass `-l py`.** `uip function new` defaults to TypeScript. Omitting the flag scaffolds the wrong project type.
+2. **Add `authors` to `pyproject.toml` right after scaffolding.** The scaffold omits it; `uip function pack` then fails with `Project authors cannot be empty`. Do this as part of scaffolding, not before packing — every project needs it, including ones you only run locally.
+3. **Never instantiate `UiPath()` at module level.** Use a lazy getter (Step 3 template).
+4. **Return errors, never raise them.** Populate `error_type`/`error_message` on the output model; an exception escaping the entrypoint faults the job.
+5. **No LLM calls.** LLM reasoning belongs in a coded agent → `uipath-agents`.
+6. **Run `uip function init` before `pack` or `push`.** It regenerates `entry-points.json` from the current Input/Output models.
+
 ## CLI Reference
 
 All Python Coded Function lifecycle commands use `uip function`:
@@ -161,6 +170,7 @@ The key is the entrypoint name — it can be any string and marks this as the ca
 name = "my-function"
 version = "0.1.0"
 description = "..."
+authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.11"
 dependencies = [
     "uipath",
@@ -168,6 +178,8 @@ dependencies = [
     "pydantic-settings>=2", # if using Settings for env/asset config
 ]
 ```
+
+`authors` is **required and the scaffold omits it** — add it immediately after `uip function new`, not later. Empty or missing: `uip function pack` fails with `Project authors cannot be empty`. Keep `name`, `version`, `description`, `authors` all present.
 
 No `[build-system]` section. The project is identified as a Coded Function by the `functions` map in `uipath.json` (Step 4).
 


### PR DESCRIPTION
## Why

3/12 `uipath-functions` tasks failed the **2026-07-31_04-38-51** nightly on `gpt-5.6-terra`:

| Task | Score |
|---|---|
| `skill-functions-file-attachment-input` | 0.41 |
| `skill-functions-simple-echo` | 0.52 |
| `skill-functions-python-e2e-lifecycle` | 0.64 |

All three failed on the **same single assertion**:

```
FAIL: pyproject.toml has no `authors` entry — `uip function pack` will reject
the package with `Project authors cannot be empty`.
```

Every `command_executed` and `skill_triggered` criterion passed. Turn counts were well under budget (10/35, 13/25, 13/31) — the agent finished cleanly and lost only the `run_command` criterion.

Root cause: five check scripts under `tests/tasks/uipath-functions/` require `authors`, but `SKILL.md` **never mentioned it**. `uip function new` omits the field. Sonnet infers it; `gpt-5.6-terra` does not.

## What changed

1. **`authors` in the Step 5 `pyproject.toml` template**, plus an explicit note that the scaffold omits it.
2. **New `Critical Rules` section.** The skill had none — required by `.claude/rules/skill-structure.md` (§ SKILL.md Body Structure) and flagged as a red flag by `.claude/rules/skill-review.md`.

Deliberate wording choice: `authors` is tied to **scaffolding**, not packing. The three failing tasks never pack, so guidance phrased as "set it before packing" lets an agent correctly conclude it is unnecessary. Rule 2 says to add it as part of scaffolding, "including ones you only run locally."

## Relationship to #1979

#1979 contains the same one-line `authors` template addition. It branched from main ~382 commits back, so it predates main's `uip functions` -> `uip function` doc rename — but it never edited those verb lines, and on uip 1.200.0-dev.8046 the CLI reports usage as `uip function|functions`, i.e. both forms remain live aliases. So there is no functional regression either way; it is a docs-convention difference only. #1979's other two fixes (deploy_tenant turn budget, in_flow_register entrypoint resolution) remain valuable and are not covered here. Recommend rebasing #1979 and dropping only its duplicated `authors` hunk.

Note for whoever reviews #1979: the comment claiming "Ran 5 times all suite and all tests passed" holds for 4 of the 5 linked runs. Run 29086622276 concluded failure at 11/12 — `smoke-trigger/business-days` scored 0.000 on activation recall while the suite itself reported `pass_rate=80% (4/5) gate=PASS`. That red is the verdict-step bug in item 1 below, not a defect in #1979's fixes.

## Verification

Validators pass locally:
- `hooks/validate-skill-descriptions.sh` — 389 chars
- `scripts/check-skill-status.py` — OK, 24 skills
- `scripts/check-cli-verbs.py` — 0 High, 0 Medium (catalog uip 1.200.0-dev.8042)
- Heading hierarchy verified — no skipped levels

Coder-eval on the `uipath-functions` tree pending; the hypothesis is that Critical Rule 2 makes the field impossible to miss, but that needs a run on `gpt-5.6-terra` to confirm.

## Not addressed here

Two separate findings from the same investigation, worth their own issues:

1. **`run-coder-eval.yml` verdict ignores suite gates.** The step exits non-zero unless *every* `task.json` is `SUCCESS`, so a rate-gated recall suite can never be green if one row misses — even when the suite reports `gate=PASS`. Hit this on `smoke-trigger/business-days` (suite `pass_rate=80% (4/5) gate=PASS`, run still red).
2. **No IS-discovery or bindings guidance in `uipath-functions`.** The skill shows `invoke_activity` with `object_path` pre-filled and no route from an activity name to a path; `bindings.json` is mentioned only as a generated filename. The content exists under `uipath-platform` and `uipath-agents`, but the self-contained-skill rule forbids linking to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
