### PR TITLE
fix (ipe-eval): jira create issue e2e failure (#ENGCE-60137)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
@@ -33,8 +33,9 @@ initial_prompt: |
   connector activity, and expose the new issue's key as a flow output.
 
   Read `seed.json` in the current directory for the issue details: use the
-  `project_key`, `issuetype_id`, and `summary` exactly as given (pass the
-  summary verbatim).
+  `project_key`, `issuetype_id`, `summary`, and `reporter_id` exactly as
+  given (pass the summary verbatim; use `reporter_id` for the issue's
+  reporter field). Do not stop to ask for missing values.
 
   Use the Atlassian Jira connection available in the `Shared/uipath-maestro-flow`
   folder. If the Atlassian Jira connector isn't available in your registry,

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_is.py
@@ -34,6 +34,14 @@ def connection_id() -> str:
     return next(c["Id"] for c in conns if c["Name"] == CONNECTION_NAME)
 
 
+def myself(conn_id: str) -> str:
+    """Return the connection user's Atlassian accountId."""
+    return _run(
+        "is", "resources", "run", "get", CONNECTOR, "myself",
+        "--connection-id", conn_id,
+    )["Data"]["accountId"]
+
+
 def create_issue(conn_id: str, summary: str) -> str:
     body = {"fields": {"project": {"key": PROJECT_KEY}, "issuetype": {"id": ISSUETYPE_ID}, "summary": summary}}
     return _run(

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/seed_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/seed_jira.py
@@ -16,6 +16,9 @@ seed = {
     "summary": summary,
     "project_key": jira_is.PROJECT_KEY,
     "issuetype_id": jira_is.ISSUETYPE_ID,
+    # Jira's design-time schema marks fields.reporter.id as required for this
+    # project/issue type; pin it so agents never have to guess or ask.
+    "reporter_id": jira_is.myself(jira_is.connection_id()),
 }
 Path("seed.json").write_text(json.dumps(seed, indent=2))
 print(f"OK: wrote seed targets (summary={summary!r}, project={jira_is.PROJECT_KEY})")


### PR DESCRIPTION
## What was failing

Nightly codex run [`2026-07-31_04-38-51`](https://coder-evalboard.uipath-dev.com/runs/2026-07-31_04-38-51/skill-flow-ipe-jira-create-issue) scored 0.00 on `skill-flow-ipe-jira-create-issue`. Jira's design-time schema for project `CE` / issue type `11457` marks `fields.reporter.id` as required, but `seed.json` didn't provide it. The agent refused to guess, stopped at turn 10 asking the user for a reporter account ID — non-interactive run, so it never ran `uip maestro flow validate` and never created the issue. Both criteria failed.

Claude replicates hit the same gap but recovered by resolving the reporter themselves (connector `myself` / `search_user` lookups) — costing 2–5 extra turns and nondeterministically picking either the connection's service account or the user found via email search.

## Fix

Pin the reporter in the seed so there is nothing to guess or resolve:

- `seed_jira.py`: `seed.json` now includes `reporter_id`, resolved live at seed time via the connector's `myself` resource (connection's own account — no hardcoded ID).
- `jira_is.py`: new `myself(conn_id)` helper returning the connection user's Atlassian `accountId`.
- `jira_create_issue.yaml`: prompt lists `reporter_id` among the seed fields to use exactly as given, and adds "Do not stop to ask for missing values".

## Passing run

Local run: 3/3 replicates SUCCESS, score 1.000 (2/2 criteria).
GH Action run: https://github.com/UiPath/skills/actions/runs/30625393200/job/91139393289

🤖 Generated with [Claude Code](https://claude.com/claude-code)