### PR TITLE
test(maestro-flow): dice-roller sim must see a working run before sign-off

### DIFF
--- a/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
@@ -50,7 +50,7 @@ simulation:
     WITHHELD — reveal each of these ONLY if the agent asks about it:
       - The project name should be "DiceRoller".
       - You want "uip maestro flow validate" to pass before you sign off.
-      - You do not require the project to execute before signing off.
+      - You want to see it actually produce a number when it runs before you sign off.
 
   constraints:
     - "Never paste or read code. If shown code, say 'I trust you, just make it work.'"
@@ -58,7 +58,7 @@ simulation:
     - "Do not reveal the project name 'DiceRoller' unless asked what to name it."
     - "The one thing worth pushing back on: if the agent reports it built something that is not a Maestro Flow at all (e.g. an API workflow), tell it you specifically want a Maestro Flow — i.e. a `.flow` file in the workspace — and are not satisfied until there is one."
     - "If the agent asks you anything before it starts building, answer every outstanding question in ONE message — include any withheld fact it asked about, stated plainly — and then let it build."
-    - "The moment the agent reports it has built the flow, the conversation is over: reply with exactly <<<END>>> on its own line. Do not ask for a rebuild, polish, re-checks, or alternative designs, and do not raise a requirement you have not mentioned yet — the grader verifies the result from here."
+    - "When the agent reports it built the flow, do not end yet if it hasn't shown you the result: before you sign off you want to see it actually run and produce a number 1 through 6. If it only says the flow is built and validated, ask it once to run it and show you the roll. Once the agent has both built the flow AND shown you a run that produced a number 1 through 6, the conversation is over: reply with exactly <<<END>>> on its own line. Do not ask for a rebuild, polish, or alternative designs, and do not raise any requirement beyond seeing it actually work — the grader verifies the result from here."
   max_turns: 8
   stop_token: "<<<END>>>"
   stop_on_criteria_pass: false


### PR DESCRIPTION
## What

Fixes the `cli_dice_roller_simulated` maestro-flow eval task so a legitimate-but-unrunnable design fails for the right reason (and a correct one passes), instead of the grader tripping over a hang the simulated user never witnessed.

## Root cause

- The persona's withheld fact said **execution was optional** and the dialog ended the instant the agent reported the flow was "built".
- A reasonable agent satisfied "show me the number" with a **blocking Quick Form (HITL)** node.
- That node is never exercised during the dialog, so the grader's `uip maestro flow debug` was the *first* thing to ever run the flow — it suspended on the human task and hit the **600s timeout**.
- The runtime criterion scored **0** → task **0.714**, penalizing a design choice the task never forbade rather than the flow's logic.

## Fix (simulation layer only)

| | Before | After |
|---|---|---|
| withheld fact | "You do not require the project to execute before signing off." | "You want to see it actually produce a number when it runs before you sign off." |
| stop rule | End the moment the flow is reported "built". | Don't sign off until the agent shows a run that produced a 1–6 (one nudge to run it); no-scope-creep guard kept. |

## Why not the grader

The debug criterion is kept exactly as-is — a real completed run is the bar we want. The defect was the *simulated user's acceptance behavior*: a real non-technical stakeholder wouldn't accept "click this form to see your roll" and would want to watch it produce a number. Fixing the persona surfaces the hang in-dialog and forces convergence on a non-interactive flow.

## Not over-steering

Wording is outcome-level ("run it", "produce a number 1 through 6") — no node types, no "don't use a form". The agent keeps full design freedom; base knowledge already covers that a random dice roll shouldn't block on a human. The skill itself is untouched.

## Validation

- `yaml.safe_load` parses clean; constraints intact; no implementation-leaking terms in the new stop rule.
- Traced end-to-end: correct non-interactive flow → grader debug completes → criterion passes (1.0); HITL-gated flow → hang surfaces in-dialog → agent must fix, else the task fails correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
