### PR TITLE
docs(solution): correct what deploy run does when the folder name is taken

### DIFF
--- a/skills/uipath-solution/references/pack-and-deploy.md
+++ b/skills/uipath-solution/references/pack-and-deploy.md
@@ -122,7 +122,7 @@ Key options:
 | `-n, --name <name>` | Deployment name (required) | -- |
 | `--package-name <name>` | Published solution package name (required) | -- |
 | `--package-version <version>` | Package version to deploy (required) | -- |
-| `--folder-name <name>` | New Orchestrator folder to create (required) | -- |
+| `--folder-name <name>` | New Orchestrator folder to create (required). Always creates; a taken name is collision-renamed, never reused — see [`deploy run` Always Creates a New Folder](#deploy-run-always-creates-a-new-folder) | -- |
 | `--parent-folder-path <path>` | Parent folder under which the new folder is created | -- |
 | `--parent-folder-key <key>` | Parent folder key (GUID, alternative to `--parent-folder-path`) | -- |
 | `--config-file <path>` | Configuration file from `deploy config get` | -- |
@@ -315,9 +315,30 @@ These are different commands with different destinations:
 | `solution publish` | Solution feed | For deployment via `deploy run` |
 | `solution upload` | Studio Web | For browser-based editing |
 
-### `deploy run` Creates a New Folder
+### `deploy run` Always Creates a New Folder
 
-`--folder-name` specifies a folder to **create**, not an existing folder to deploy into. If the folder already exists, deployment will fail. Use `--parent-folder-path` to set the parent folder where the new folder is created.
+`--folder-name` specifies a folder to **create**, not an existing folder to deploy into. Use `--parent-folder-path` to set the parent folder where the new folder is created.
+
+**Re-running with a name that is already taken does not fail and does not reuse the folder** — Orchestrator collision-renames the new one (`MySolution` → `MySolution 1`) and the deployment lands there. Repeated deploys therefore accumulate `MySolution 1`, `MySolution 2`, … The CLI reads the resolved folder back and reports where the deployment actually went, so always trust `Data.FolderPath` in the response over the name you passed.
+
+**There is no way to deploy into a pre-existing folder.** The install API takes `solutionRootFolderName` — a name, not a folder key — so the target cannot be addressed. This matters when the folder you want already holds hand-provisioned assets, an IXP folder-deployment, or an assigned robot: the deployment will land somewhere else and runtime resolution then fails on the missing resources.
+
+Two ways around it:
+
+```bash
+# A. Let deploy create the folder FIRST, then provision into it.
+uip solution deploy run --name my-deployment --package-name my-package \
+  --package-version 1.0.0 --folder-name MySolution --output json
+# → read Data.FolderPath / Data.FolderKey from the response, then create the
+#   assets, folder-deploy IXP, and assign the robot into THAT folder.
+
+# B. Skip solution deploy and bind each piece into the existing folder.
+uip or packages upload ./piece.nupkg --output json
+uip or processes create --package-key <id> --package-version <ver> \
+  --folder-key <existing-folder-key> --output json
+```
+
+Option A is preferred — it keeps the solution deployment intact. Option B loses the solution grouping, so use it only when the folder's existing contents cannot be recreated.
 
 ### `--parent-folder-path` is the Parent
 


### PR DESCRIPTION
UV-15346. Docs-only — the CLI needs no change here, and the reason is the point.

## What was wrong

`pack-and-deploy.md` said: *"If the folder already exists, deployment will fail."*

It doesn't. Orchestrator collision-renames the new folder (`MySolution` → `MySolution 1`) and deploys there. `deploy-run-service.ts` already compensates for this — it reads the resolved folder back precisely because the name it asked for may not be the name it got (UV-15393).

That wrong sentence is the whole trap in UV-15346. The reporter ran `deploy run` ~8 times expecting either success or an error, got 8 new empty folders, and every deployment landed away from the folder that actually held the assets, the IXP folder-deployment and the assigned robot — so runtime resolution failed on missing resources.

## What the doc now says

- Re-running with a taken name neither fails nor reuses: it collision-renames and accumulates `MySolution 1`, `MySolution 2`, …
- Trust `Data.FolderPath` in the response over the name passed in.
- **Deploying into a pre-existing folder is not possible**, and why: `PipelinesInstallRequest` takes `solutionRootFolderName` — a name, not a folder key — plus an optional parent path. There is no field that can address an existing folder, so this is an API-contract limitation, not a missing CLI flag.
- The two workarounds, with the preferred one first: let `deploy run` create the folder and provision into what it returns (keeps the solution deployment intact), or bind each piece with `or packages upload` + `or processes create --folder-key <existing>` (loses the solution grouping).
- The `--folder-name` row in the options table now points at that section instead of implying a plain create.

## Verification

Read from the source of truth rather than from the ticket: the six fields of `PipelinesInstallRequest` in `packages/pipelines-sdk`, and the collision-rename comment plus `resolveInstalledFolder` fallback in `deploy-run-service.ts`.

Not verified live: I did not run two real deploys against the same folder name to watch the rename happen. The API contract settles the "can it target an existing folder" question on its own, and the rename behaviour is already documented in the CLI's own workaround and was observed 8 times by the reporter. Flagging it so the claim's basis is clear.

Paired CLI work for the other two tickets in this batch: UiPath/cli#3350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)