### PR TITLE
fix(tests): unstarve three uipath-agents smoke tasks (max_turns -> 60)

### DIFF
--- a/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
@@ -8,7 +8,8 @@ description: >
 tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-langgraph]
 
 run_limits:
-  expected_turns: 20
+  expected_turns: 40
+  max_turns: 60
 
 initial_prompt: |
   hey, can you set up a tiny LangGraph chat agent here called

--- a/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
+++ b/tests/tasks/uipath-agents/coded/is_smoke/is_smoke.yaml
@@ -11,8 +11,8 @@ description: >
 tags: [uipath-agents, smoke, coded, mode:build, lifecycle:generate, feature:integration-service]
 
 run_limits:
-  expected_turns: 20
-  max_turns: 30
+  expected_turns: 40
+  max_turns: 60
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
+++ b/tests/tasks/uipath-agents/lowcode/context_prompt_reference/context_prompt_reference.yaml
@@ -13,8 +13,8 @@ description: >
 tags: [uipath-agents, smoke, mode:build, low-code]
 
 run_limits:
-  expected_turns: 20
-  max_turns: 30
+  expected_turns: 40
+  max_turns: 60
   turn_timeout: 1200
 
 initial_prompt: |


### PR DESCRIPTION
## Why

The uipath-agents smoke suite is flaking below the 95% gate because three tasks keep hitting `MAX_TURNS_EXHAUSTED` with high partial scores and zero failed commands — pure turn starvation, the same disease #2349 and #2234 fixed for other tasks.

Evidence from PR #1694's three smoke runs (26/29, 27/29, 27/29 — a different failure set each time) plus PR #1801's run:

| Task | max_turns | Starvation evidence |
|------|-----------|--------------------|
| `skill-agents-coded-is-smoke` | 30 (below the smoke experiment default of 40) | Starved twice in a row; score 0.84, 0 failed commands, only the doc-read criterion left |
| `skill-agent-context-prompt-reference` | 30 | Starved on #1694's run **and** #1801's run; mid-flow at score 0.41 after creating agent.json + the context resource |
| `skill-agent-coded-conversational-langgraph` | 40 (inherited) | Starved on #1694's rerun |

## What

Raise all three to `expected_turns: 40` / `max_turns: 60`, matching #2349's precedent for `eval_custom_evaluator`. No prompt or criteria changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)