### PR TITLE
test(coded-apps): accept all valid agent-discriminator spellings in job-classification check

### DIFF
--- a/tests/tasks/uipath-coded-apps/dashboard/_shared/check_dashboard.py
+++ b/tests/tasks/uipath-coded-apps/dashboard/_shared/check_dashboard.py
@@ -107,6 +107,10 @@ def main() -> None:
                         help="Substring that MUST appear across metric modules / generated code (repeatable)")
     parser.add_argument("--forbid-substr", action="append", default=[],
                         help="Substring that must NOT appear across metric modules / generated code (repeatable)")
+    parser.add_argument("--require-regex", action="append", default=[],
+                        help="Regex that MUST match across metric modules / generated code (repeatable). "
+                             "Use when several equally-valid spellings satisfy the requirement, e.g. "
+                             "\"(ProcessType|processType|packageType) eq 'Agent'\".")
     parser.add_argument("--require-starttime", action="store_true",
                         help="A named time constant must appear in metric modules (not inline Date arithmetic)")
     parser.add_argument("--require-state", action="store_true",
@@ -187,10 +191,13 @@ def main() -> None:
     code_surface = "\n".join(p.read_text(encoding="utf-8", errors="ignore") for p in scan_files)
     metric_surface = "\n".join(p.read_text(encoding="utf-8", errors="ignore") for p in metric_files)
 
-    # 6. require-substr / forbid-substr
+    # 6. require-substr / require-regex / forbid-substr
     for s in args.require_substr:
         check(s in code_surface,
               f"Required substring not found in metric modules / generated code: {s!r}")
+    for pat in args.require_regex:
+        check(re.search(pat, code_surface) is not None,
+              f"Required pattern not found in metric modules / generated code: {pat!r}")
     for s in args.forbid_substr:
         check(s not in code_surface,
               f"Forbidden substring present in metric modules / generated code: {s!r}")

--- a/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
+++ b/tests/tasks/uipath-coded-apps/dashboard/routing/dashboard_agent_job_classification.yaml
@@ -37,12 +37,16 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  # Correct agent-job classification: raw OData filter + no sourceType discriminator.
+  # Correct agent-job classification: filter on the agent discriminator, never sourceType.
+  # Accept all three equally-valid spellings — ProcessType (wire), processType (SDK
+  # camelCase), packageType (SDK mapped name; the skill's own canonical example, and
+  # the SDK rewrites it to processType in the filter). The old check required only the
+  # ProcessType spelling and false-failed correct code that used packageType/processType.
   - type: run_command
-    description: "Metric module filters jobs with ProcessType eq 'Agent' and does not use sourceType as the discriminator"
+    description: "Metric module filters jobs on the agent discriminator ((Process|process|package)Type eq 'Agent') and does not use sourceType"
     command: >
       python3 $SKILLS_REPO_PATH/tests/tasks/uipath-coded-apps/dashboard/_shared/check_dashboard.py
-      --min-metrics 1 --require-substr "ProcessType eq 'Agent'" --forbid-substr "sourceType"
+      --min-metrics 1 --require-regex "(ProcessType|processType|packageType) eq 'Agent'" --forbid-substr "sourceType"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## What

`uipath-coded-apps-dashboard-agent-job-classification` false-failed (gpt-5.6-terra, 0.5). The check hard-required the literal `ProcessType eq 'Agent'`:

```
--require-substr "ProcessType eq 'Agent'"
```

But there are **three equally-valid spellings** that all resolve to the same API field:
- `ProcessType` (wire name)
- `processType` (SDK camelCase)
- `packageType` (SDK mapped name — the skill's **own canonical example**, `orchestrator.md:41`; the SDK rewrites it to `processType` inside `filter`)

The agent wrote `"State eq 'Faulted' and packageType eq 'Agent'"` — straight from the skill's SDK reference, and correctly avoided the real trap (`sourceType`). But the check only accepts the `ProcessType` spelling, so it failed.

So the test passed or failed on **which valid spelling the model happened to type**, not on whether the code was right — earlier runs that wrote `ProcessType` passed; this one wrote `packageType` and failed. Same code, opposite result.

## Fix

- Add a `--require-regex` option to the shared `check_dashboard.py` (currently only literal substrings) — useful whenever several valid forms satisfy a requirement.
- Switch the criterion to `--require-regex "(ProcessType|processType|packageType) eq 'Agent'"`, keeping `--forbid-substr "sourceType"` (the real correctness guard).

## Verification

- The **exact generated code from the failing run** now passes the check (exit 0).
- All three spellings pass; `sourceType eq 'Agent'` still fails (both the regex miss and the forbid).
- `check_dashboard.py` parses.

Same principle as the sibling coded-apps fixes (#2376): grade the **behavior** (filters agent jobs by the discriminator, not `sourceType`), not one arbitrary spelling.

Generated with Claude Code