### PR TITLE
fix(troubleshoot): re-anchor prompt fault timing to the run so frozen fixtures stop drifting

### DIFF
--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-click-noop-simulate/task.yaml
@@ -41,9 +41,10 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My ClassicClaimsSubmit job in folder Finance finished Successful last night,
-  but it never clicked the Submit button in our Java claims app — the claim
-  stayed in Draft. There was no error at all. Why did it silently do nothing?
+  My ClassicClaimsSubmit job in folder Finance finished Successful on its
+  most recent run, but it never clicked the Submit button in our Java claims
+  app — the claim stayed in Draft. There was no error at all. Why did it
+  silently do nothing?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/classic-typeinto-field-not-cleared/task.yaml
@@ -41,9 +41,10 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My VendorOnboarding job in folder Finance finished Successful last night, but
-  the bank account number it wrote to the vendor record is wrong — it does not
-  match the value we gave it, and there was no error at all. Why?
+  My VendorOnboarding job in folder Finance finished Successful on its most
+  recent run, but the bank account number it wrote to the vendor record is
+  wrong — it does not match the value we gave it, and there was no error at
+  all. Why?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-delete-range-invalid-syntax/task.yaml
@@ -50,8 +50,8 @@ initial_prompt: |
   My Orchestrator job just faulted with
   `System.ArgumentException: The range is invalid`.
   Pinned job key: dd111111-cccc-dddd-eeee-ffffaaaabbbb. It's a Delete
-  Range activity and it worked yesterday when the workbook had data —
-  failed today on a freshly-recreated workbook. What's wrong?
+  Range activity and it worked on the previous run when the workbook had
+  data — then failed on a freshly-recreated workbook. What's wrong?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-rr-sheet-case/task.yaml
@@ -49,8 +49,8 @@ initial_prompt: |
   `UiPath.Excel.BusinessException: The sheet with the name 'data' does not exist.`
   Pinned job key: bb222222-7777-8888-9999-000011112222. The sheet
   DOES exist — I just opened the workbook and it's right there. The
-  same workflow worked yesterday on my dev machine. Why is the
-  Robot saying the sheet is missing?
+  same workflow worked on my dev machine. Why is the Robot saying
+  the sheet is missing?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-scope-orphan-process-lock/task.yaml
@@ -50,7 +50,7 @@ initial_prompt: |
   My Orchestrator job just faulted with
   `UiPath.Excel.BusinessException: Failed opening the Excel file. Possible reasons: file is corrupt, already used by another process or password protected.`
   Pinned job key: aa555555-cccc-dddd-eeee-ffffaaaabbbb. The file isn't
-  corrupt — it opened fine yesterday and there's no password on it.
+  corrupt — it opened fine on the previous run and there's no password on it.
   Why can't the robot open it now?
 
 success_criteria:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-formula-prefix/task.yaml
@@ -52,7 +52,7 @@ initial_prompt: |
   `System.Runtime.InteropServices.COMException (0x800A03EC): Application-defined or object-defined error.`
   Pinned job key: ee333333-cccc-dddd-eeee-ffffaaaabbbb. It's a Write
   Range writing 312 scraped HR records to a directory workbook.
-  Yesterday's run with the same workflow and same workbook
+  The previous run with the same workflow and same workbook
   succeeded. What changed?
 
 success_criteria:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/excel-write-range-uninitialized-datatable/task.yaml
@@ -51,7 +51,7 @@ initial_prompt: |
   My Orchestrator job just faulted with
   `System.NullReferenceException: Object reference not set to an instance of an object.`
   Pinned job key: ee111111-cccc-dddd-eeee-ffffaaaabbbb. It's a Write
-  Range activity. Nothing in the workflow changed since yesterday's
+  Range activity. Nothing in the workflow changed since the previous
   successful run — what's wrong?
 
 success_criteria:

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-browser-communication-failed/task.yaml
@@ -38,9 +38,10 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My nightly CustomerHubSync job from folder Shared faulted last night on the
-  Use Browser step. It has run on the same schedule and the same machine for
-  weeks and I haven't touched the automation. Can you investigate why?
+  My nightly CustomerHubSync job from folder Shared faulted on its most
+  recent scheduled run, on the Use Browser step. It has run on the same
+  schedule and the same machine for weeks and I haven't touched the
+  automation. Can you investigate why?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/activity-packages/uia-click-noop-simulate-tech/task.yaml
@@ -42,9 +42,10 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My ClaimsSubmit job in folder Finance finished Successful last night, but it
-  never clicked the Submit button in our Java claims app — the claim stayed in
-  Draft. There was no error at all. Why did it silently do nothing?
+  My ClaimsSubmit job in folder Finance finished Successful on its most
+  recent run, but it never clicked the Submit button in our Java claims app —
+  the claim stayed in Draft. There was no error at all. Why did it silently
+  do nothing?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/integration-service/rpa-is-connection-not-authorized-cns/task.yaml
@@ -36,7 +36,7 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  The LeadImport job in our CRM folder started failing this morning on every run. It ran fine for weeks and nobody changed the workflow. Can you troubleshoot?
+  The LeadImport job in our CRM folder started failing on every run. It ran fine for weeks and nobody changed the workflow. Can you troubleshoot?
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/credential-store-unavailable/task.yaml
@@ -49,7 +49,7 @@ reference:
 
 initial_prompt: |
   My SecurePortalBot jobs in the SecureOps folder started failing at
-  launch this morning — a teammate says one of their bots in the same
+  launch — a teammate says one of their bots in the same
   folder is failing the same way too. Can you find out why they won't start?
 
 success_criteria:

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/RESOLUTION.md
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/RESOLUTION.md
@@ -26,7 +26,7 @@ network, and RDP path are healthy. The fault is scoped to the
 `UIPATH\USER1` credential.
 
 **Why:** AD `PasswordLastSet` for `UIPATH\USER1` is
-`2026-05-11T07:14:00Z` (yesterday, per the initial report and the
+`2026-05-11T07:14:00Z` (per the initial report and the
 `_meta.ad_password_last_set_observed` annotation on
 `or users get`). The Orchestrator-stored credential record shows
 `PasswordLastSet: 2026-05-04T09:00:00Z` — seven days older than AD.

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/logon-failure-password-mismatch/task.yaml
@@ -50,10 +50,10 @@ reference:
 
 initial_prompt: |
   My InvoiceIngestor process has been faulting in Orchestrator
-  every time it runs since this morning — each job dies within a
+  every time it runs — each job dies within a
   second of starting. One thing that might be relevant: my AD admin rotated
-  the password for the UIPATH\USER1 service account yesterday
-  (2026-05-11). Can you investigate?
+  the password for the UIPATH\USER1 service account on
+  2026-05-11. Can you investigate?
 
 success_criteria:
   - type: skill_triggered
@@ -91,7 +91,7 @@ simulation:
     its investigation and trust its expertise. You only have the
     information you wrote in your initial report — no extra data.
     The only AD fact you know is that an AD admin rotated the
-    password for UIPATH\USER1 yesterday (2026-05-11). You do not
+    password for UIPATH\USER1 on 2026-05-11. You do not
     know the new password, you do not have AD console access, and
     you cannot run PowerShell on a domain controller.
   goal: |
@@ -102,7 +102,7 @@ simulation:
   constraints:
     - "If the agent asks whether to expand investigation scope (any new product domain such as orchestrator, identity, ad, system-activities, activity-packages, ui-automation), always answer Yes — pick the recommended / first / affirmative option."
     - "If the agent asks how to proceed when data is missing, tell it to proceed with best-effort findings using the evidence already gathered."
-    - "If the agent asks for the AD PasswordLastSet timestamp, repeat: the AD admin rotated the password yesterday (2026-05-11) — that is all you know."
+    - "If the agent asks for the AD PasswordLastSet timestamp, repeat: the AD admin rotated the password on 2026-05-11 — that is all you know."
     - "If the agent asks whether the account is locked, say you cannot check AD directly — point them at the Robot service logs and Orchestrator data."
     - "If the agent asks where the failing project's source or code is, tell it the project source is available in the current working directory."
     - "Never invent or provide new factual data — you don't know any details beyond your initial report, other than the project-source location noted above."

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/queue-items-failing-test/task.yaml
@@ -39,7 +39,7 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My ItemsQueue has 4 failed items today, please investigate.
+  My ItemsQueue has 4 failed items, please investigate.
 
 success_criteria:
   - type: skill_triggered

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-consecutive-system-exceptions/task.yaml
@@ -47,7 +47,7 @@ reference:
 
 initial_prompt: |
   My OrderReconciliation process in the OpsAutomation folder aborted
-  this morning with a "maximum number of consecutive system
+  with a "maximum number of consecutive system
   exceptions was reached" error. What actually caused it and how do I
   stop it happening again?
 

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-executor-service-disconnect/task.yaml
@@ -36,7 +36,7 @@ reference:
   file: RESOLUTION.md
 
 initial_prompt: |
-  My NightlyPost process in the Batch Ops folder faulted on last night's
+  My NightlyPost process in the Batch Ops folder faulted on its most recent
   scheduled run on BATCH-BOT-02 — it had been running for about a minute and
   then died. The previous nights ran fine on the same machine. Why did this
   run fail and what should I do?

--- a/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
+++ b/tests/tasks/uipath-troubleshoot/products/orchestrator/rpa-serverless-robot-units/task.yaml
@@ -38,7 +38,7 @@ reference:
 initial_prompt: |
   My InvoiceParse automation in the Cloud Robots folder won't start anymore —
   it goes straight to Faulted without ever running. It runs as a serverless
-  cloud robot. This started today and now every run fails. Why, and how do I
+  cloud robot. This started recently and now every run fails. Why, and how do I
   fix it?
 
 success_criteria:


### PR DESCRIPTION
## Problem

Troubleshoot scenario fixtures are frozen snapshots with hardcoded absolute timestamps. Sixteen scenarios paired those fixtures with a prompt that anchors the fault to the **calendar** - "This started today", "faulted last night", "started failing this morning", "it worked yesterday". The fixture date never moves; the calendar does, so the gap widens every day. It is now 15 to 83 days.

The mock dispatcher's matcher ignores `--created-after` / `--created-before`, so an agent that correctly scopes its query to the window the user described still receives the out-of-window job. From the agent's side that looks like a correlation failure, and the right response is to refuse to attribute the fault to it.

That is what happened on `rpa-serverless-robot-units`. The agent queried with a today-window, got a job 15 days old, and stopped:

> "the service returned an InvoiceParse fault timestamped 2026-07-19, not today, despite the requested 'today' window. I won't attribute today's incident to that older job."

It never reached `or jobs get` / `or jobs logs`, where the decisive `"Your tenant's assigned Robot Units have been exceeded"` message lives, and was then marked down for hedging - `0.850` against a `0.7` judge threshold. The behaviour was correct; the fixture was contradictory.

## Fix

Re-anchor every fault-timing claim to the run or the schedule instead of the calendar:

| Was | Now |
|---|---|
| "faulted **last night**" | "faulted on its **most recent** scheduled run" |
| "finished Successful **last night**" | "finished Successful on its **most recent** run" |
| "started failing **this morning**" | "started failing" |
| "This started **today**" | "This started **recently**" |
| "it worked **yesterday**" | "it worked on the **previous run**" |

No fixture, manifest, criterion, judge prompt or RESOLUTION root cause changes. The diagnostic content of every prompt is preserved - prior-success contrasts, recurrence, and the "nothing changed on my side" framing all stay.

`logon-failure-password-mismatch` is the one nuanced case: its absolute date `2026-05-11` **is** evidence (AD `PasswordLastSet` vs the Orchestrator credential record), so the date stays and only the now-false "yesterday" / "this morning" framing is dropped - in the prompt, the simulator persona, the simulator constraint, and the matching aside in `RESOLUTION.md`.

### Scope

16 scenarios, 17 files. A sweep of all 298 task YAMLs found 75 files containing a date word; 59 were left alone deliberately:

- **~52** are the user describing their own access, not the fault's timing - "I'm not on the Robot host right now and have no shell access, only Orchestrator". Unrelated to fixture dates, and rewriting them would change each scenario's constraints.
- **`excel-lookuprange-formula-cells`** - "Today's published price" is quoted error text and a workbook column semantic, not a timing claim.
- **`uia-napplicationcard-view-generation`**, **`is-activities-prerelease-not-found`** - design-time scenarios with no dated fixtures at all, so there is nothing to contradict.

## Validation

Agent arm matches the nightly: codex `gpt-5.6-terra`.

**CI `Run Coder Eval` - 16/16 succeeded.** 7 of the 16 carry `skip: true` and the workflow does not pass `--include-skipped`, so they were run from a throwaway `ci/eval-pr2427` ref with the skip removed (ref deleted afterwards).

| Scenario | CI |
|---|---|
| rpa-serverless-robot-units | 1.000 |
| rpa-is-connection-not-authorized-cns | 1.000 |
| credential-store-unavailable | 1.000 |
| rpa-consecutive-system-exceptions | 1.000 |
| classic-click-noop-simulate | 1.000 |
| rpa-executor-service-disconnect | 1.000 |
| uia-click-noop-simulate-tech | 1.000 |
| classic-typeinto-field-not-cleared | 1.000 |
| uia-browser-communication-failed | 0.925 |
| excel-rr-sheet-case | 1.000 |
| excel-write-range-uninitialized-datatable | 1.000 |
| excel-delete-range-invalid-syntax | 1.000 |
| queue-items-failing-test | 1.000 |
| excel-write-range-formula-prefix | 1.000 |
| excel-scope-orphan-process-lock | 0.962 |
| logon-failure-password-mismatch | 0.850 |

**Local (all 16, `--include-skipped`) - 15/16.** Nine at 1.000; six at 0.850 (all above the 0.7 judge threshold); one failure, `rpa-consecutive-system-exceptions` at 0.400.

That failure is **pre-existing and unrelated to this change** - a prompt-wording edit cannot affect folder-key selection, and the same commit scored 1.000 in CI. Re-run locally at n=3 it passed **3/3 (0.962 / 0.925 / 0.925)**. Cause: the folders-list fixture returns three folders, the mock ignores `--output-filter`, and the agent occasionally takes the first `Key` (the personal workspace) instead of `OpsAutomation`; `or jobs list --folder-key <wrong>` then matches no rule and `unmocked_default: []` reads as "no faulted jobs". One replicate shows the agent self-correcting mid-run - first `b2c8cb22…` → `unmocked_default`, then `a5b5c6d7…` → fixture. The 0.400 run is the case where it did not recover.

## Note for reviewers

The starvation pattern behind that flake is the same one this PR fixes, seen from a different angle - and it is the third instance found:

1. a process name used as a job key → no rule → `[]`
2. a correctly scoped `--created-after` window → out-of-window job (this PR)
3. a correctly scoped `--output-filter` → unfiltered list → wrong key → `[]`

In each case the mock ignores a filter flag and `unmocked_default: []` with `exit 0` is indistinguishable from a genuine empty result. Prompt wording only addresses case 2. The general fix - making `unmocked_default` return a non-zero exit so an unmatched or malformed query can never masquerade as "no results" - spans 244+ manifests and is deliberately out of scope here.

A durable alternative to this PR's approach would be shifting fixture timestamps relative to the run date at seal time, so "today" is always true and no prompt has to avoid the word. That is a shared-template change affecting every scenario and needs its own validation pass, so it is also not attempted here.
