### PR TITLE
fix: add fallback for non existent DTL values (#ENGCE-59542)

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md
@@ -139,7 +139,7 @@ cat <metadataFile path from response>
 
 The full metadata contains:
 - **`availableOperations[].method`** and **`availableOperations[].path`** — HTTP method and API endpoint path. Same value as `connectorMethodInfo.method` / `.path` from `registry get`.
-- **`parameters`** — query and path parameters (may include required params not in `requestFields`, e.g. `send_as` for Slack)
+- **`parameters`** — query and path parameters (may include required params not in `requestFields`, e.g. `send_as` for Slack). Parameters carry `reference` objects too — scan them in Step 4 exactly like body fields.
 - **`requestFields`** — body fields with `name`, `type`, `required`, `description`, and `reference` objects for ID resolution. Pair these field names with the `path` above (e.g. `messageToSend` for Slack `/send_message_to_channel_v2`).
 - **`responseFields`** — response schema
 
@@ -155,7 +155,9 @@ Run this before Step 5 (validate required fields) and reuse the same parent-fiel
 
 ### Step 4 — Resolve reference fields
 
-Check `requestFields` from the metadata for fields with a `reference` object — these require ID lookup from the connector's live data. Use `uip is resources run list` to resolve them:
+Check **BOTH `requestFields` AND `parameters`** from the metadata for entries with a `reference` object — these require ID lookup from the connector's live data. Use `uip is resources run list` to resolve them:
+
+> **References are NOT body-field-only.** Query and path parameters carry `reference` objects too, and on some connectors the activity's PRIMARY input is a required **path parameter** whose `reference` is the design-time lookup behind a Studio Web dropdown. Scanning only `requestFields` misses it — the node then configures and passes `flow validate` with an unverified value and 404s at runtime. The same `reference` blocks appear on `connectorMethodInfo.parameters[]` in `registry get` output (with or without `--connection-id`) — when projecting parameter metadata for inspection, always include the `reference` key, not just `name`/`required`/`design.component`.
 
 > **Resolve every reference field freshly, against the current `--connection-id`, immediately before `node configure` (Step 6)** — even if you think you already know the ID from a previous flow. Reference IDs are connection-scoped and reused values fault silently at runtime. See [Reference IDs Are Connection-Scoped (CRITICAL)](../../../../../../uipath-platform/references/integration-service/reference-resolution.md#reference-ids-are-connection-scoped-critical) for the full mechanism and failure mode, and the top-level Anti-Patterns in [SKILL.md](../../../../../SKILL.md).
 
@@ -167,6 +169,8 @@ uip is resources run list "uipath-salesforce-slack" "curated_channels?types=publ
 ```
 
 The `<id>` in `--connection-id "<id>"` MUST be the connection bound to **this** flow (the one picked in Step 1), not any other connection you've used in another flow. Use the resolved IDs (not display names) — from this very `run list` call — in the flow's node `inputs`. When multiple matches exist, ask the user, with one option per match plus **"Something else"** as the last option (see the dropdown question rule in [SKILL.md](../../../../../SKILL.md)).
+
+> **Zero matches on a user-supplied value** — if the completed lookup (`Data.Pagination.HasMore` is `"false"`) finds no entry matching a value the user provided, do NOT configure the node with it silently. Ask the user, presenting the closest candidates as options plus **"Something else"** as the last option (see the dropdown question rule in [SKILL.md](../../../../../SKILL.md)). Proceed with the unverified value only if the user confirms it.
 
 > **Filter server-side before paginating.** If the field's `reference` carries a `filterPattern` (e.g. Teams `userId`: `"$filter=startswith(userPrincipalName,'{filter}')"`), substitute the search term for `{filter}` and pass the result as `--query` — one targeted call instead of walking a large directory. `filterPattern` appears only in `is resources describe` output; the flow `registry get` reference object strips it (keeps only `objectName`/`lookupValue`/`lookupNames`/`path`/`childPath`), so read it from the Step 3 describe metadata. Guessed params (`searchTerm=`/`where=`/`filter=`) are silently ignored. See [reference-resolution.md — Search References (filterPattern)](../../../../../../uipath-platform/references/integration-service/reference-resolution.md#search-references-filterpattern).
 

--- a/skills/uipath-platform/references/integration-service/reference-resolution.md
+++ b/skills/uipath-platform/references/integration-service/reference-resolution.md
@@ -33,7 +33,7 @@ A reused reference ID:
 
 ## Reference Fields (CRITICAL)
 
-Some fields in the describe `requestFields` have a `reference` section — their value must be looked up from another resource before executing.
+Entries in the describe `requestFields` AND `parameters` (query/path parameters) can have a `reference` section — their value must be looked up from another resource before executing. Scan both arrays: on some connectors the activity's primary input is a path parameter with a reference, and scanning only `requestFields` misses it.
 
 ### Reference structure
 
@@ -61,10 +61,12 @@ Some fields in the describe `requestFields` have a `reference` section — their
 | **`reference.filterPattern`** | Search endpoint pattern — substitute the user's input into `{filter}` and pass as `--query`. See [Search References](#search-references-filterpattern). |
 | **`reference.childPath`** | Scoped child path — used for drill-down references (e.g., folder subfolders) |
 
+> **`objectName` fallback.** If `run list <reference.objectName>` returns 404, the connector uses a symbolic objectName the runner can't resolve (e.g. Data Service `system` → "Entity system does not exist"). Retry with the resource segment of `reference.path`: `/standard-objects` → `run list "<connector-key>" "standard-objects"`.
+
 ### Resolution workflow
 
 ```bash
-# 1. Describe → find fields with "reference" in requestFields
+# 1. Describe → find entries with "reference" in requestFields AND parameters
 uip is resources describe "<connector-key>" "<resource>" \
   --connection-id "<id>" --operation Create --output json
 
@@ -96,6 +98,8 @@ User says: "Send a message to #general"
 4. **Use** the `lookupValue` (`id`) → `"C02CAP3LAAG"` in the `--body`
 
 **Present options to the user** when multiple matches exist. Always use the resolved `lookupValue` (not display names) in `--body` or `--query`.
+
+**Zero matches:** if the completed lookup (`Data.Pagination.HasMore` is `"false"`) finds no entry matching the user's value, do not execute with it — ask the user, presenting the closest candidates as options. Proceed with the unverified value only if the user confirms it.
 
 ---
 


### PR DESCRIPTION
## Problem

Design-time lookup (DTL) / reference fields were documented as living only in `requestFields` (body fields). On some connectors the activity's primary input is a **path parameter** carrying a `reference` object — e.g. the entity picker on Data Service Query Entity Records. An agent following the docs scans `requestFields`, finds no references, and skips resolution entirely: the node then configures and passes `flow validate` with an unverified value and 404s at runtime.

Two adjacent gaps surfaced by the same investigation:

- `run list <reference.objectName>` can 404 when the connector uses a symbolic objectName (e.g. Data Service `system`), with no documented recovery.
- No rule covered the zero-matches case: a user-supplied value that the completed lookup cannot verify was silently passed through to `node configure`.

## Changes

**`skills/uipath-maestro-flow/references/author/references/plugins/connector/impl.md`**
- Step 3 metadata bullet: `parameters` carry `reference` objects too — scan them in Step 4 like body fields.
- Step 4: scan **both `requestFields` and `parameters`**; new callout on path-parameter references (configures cleanly, 404s at runtime) and on keeping the `reference` key when projecting parameter metadata.
- Step 4: new **zero-matches rule** — when the completed lookup finds no entry matching a user-supplied value, do not configure silently; ask the user with the closest candidates plus "Something else", proceed only on confirmation.
- Debug tip 5: check `parameters` for `reference` objects, not just `required: true`.

**`skills/uipath-platform/references/integration-service/reference-resolution.md`**
- Reference Fields intro: references live in `requestFields` AND `parameters`; scan both.
- New `objectName` fallback: on 404, retry with the resource segment of `reference.path` (`/standard-objects` → `standard-objects`).
- Resolution workflow: step 1 comment covers both arrays; new zero-matches rule mirroring the connector plugin.

## Validation

Two live agent runs against the alpha tenant (Data Service `query-entity-records`, entity `non-existent-entity`):

1. **Detection/resolution run** — agent found the `reference` on the `entityName` path parameter, applied the `standard-objects` fallback after the `system` 404, completed the lookup (`HasMore: "false"`), and surfaced entity-not-found as its top finding before configuring.
2. **Ask-gate run** — agent stopped at the new zero-matches rule before `node configure` (node left unconfigured, no bindings), quoting the rule verbatim and producing the candidates + "Something else" question.

## Screenshots

### Non-existent DTL parameter

<img width="1512" height="327" alt="image" src="https://github.com/user-attachments/assets/fe745ae6-b1d9-4f1f-9497-661fdd28f973" />


### Non-existent DTL field

<img width="1512" height="327" alt="image" src="https://github.com/user-attachments/assets/11e9a1ab-bfc6-4bd8-a93f-031ba9a2b17c" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
