### PR TITLE
fix(uipath-insights): forbid loops and shell variables over insights subcommands

### DIFF
--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -260,7 +260,7 @@ The end boundary is exclusive: "July 1st to July 5th" inclusive means `--started
 
 - **Don't call `uip insights jobs` without a time range.** The server returns a 500 with a misleading success-shaped response. Always pass `--time-range` or `--started-after`/`--started-before`.
 - **Don't embed `$(date ...)` or shell variables in `uip insights` flag values.** Resolve times in a separate command first, then pass literal epoch-millisecond numbers. Literal values make the executed command auditable and immune to platform `date` differences.
-- **Don't chain multiple `uip insights` subcommands with `&&` or `;` in one invocation.** Run each subcommand as its own command so each one's exit status and output are attributable.
+- **Don't chain, loop, or parameterize `uip insights` subcommands in one invocation.** Run each subcommand as its own command with the subcommand name written literally — no `&&`/`;` chains, no `for` loops, no shell variables holding the subcommand name. One command per invocation keeps each subcommand's exit status and output attributable.
 - **Don't start, stop, or manage individual jobs.** This skill is for monitoring and analytics only. Use `uip or jobs start/stop` via uipath-platform to manage jobs.
 - **Don't construct raw API calls to the Insights endpoint.** The CLI handles auth headers (`X-UiPath-Internal-AccountName`, `X-UiPath-Internal-TenantName`), URL construction, and error handling. Hand-rolling `curl` or `fetch` calls will miss these.
 - **Don't retry on auth errors.** If `uip insights jobs` returns 401 or "Not logged in", the fix is `uip login`, not retrying the same command.


### PR DESCRIPTION
Related to [IN-13526](https://uipath.atlassian.net/browse/IN-13526) (same failure family as #2396).

## Summary

`skill-insights-smoke-all-commands` failed the 2026-07-30 and 2026-08-02 nightlies on codex/gpt-5.6-terra at 0.125 for a reason that is not an agent capability problem: the agent ran all seven `uip insights jobs` subcommands correctly, but inside one bash for-loop, so none of the seven literal `command_executed` patterns matched.

## What was going wrong

The task grades the literal Bash command string with seven patterns of the form:

```
uip\s+insights\s+jobs\s+summary\s+
```

The agent's single invocation was:

```bash
for subcommand in summary completed-timeline uncompleted-timeline top-failures failures-by-reason process-details failure-details; do
  uip insights jobs "$subcommand" --time-range 1440 --output json
done
```

Every subcommand executed and returned real data, but the graded string contains `"$subcommand"`, never a literal subcommand name, so all seven criteria scored 0/1 and only `skill_triggered` passed.

#2396 added anti-pattern bullets for `$(date ...)` substitution and `&&`/`;` chaining, but a loop variable holding the subcommand name slipped through the same gap.

## Fix (SKILL.md)

One line: the existing "don't chain subcommands" bullet in **What NOT to Do** is generalized to forbid loops and shell variables holding the subcommand name — run each subcommand as its own invocation with the name written literally. Beyond grading, one command per invocation keeps each subcommand's exit status and output attributable.

No test change: the seven patterns grade the right thing (each subcommand demonstrably invoked); the skill was permitting a trajectory that hides correct behavior from them.

## Verification

Real coder-eval runs against this branch's SKILL.md:

- **codex/gpt-5.6-terra** (the agent/model that failed the nightlies): 1.000, 8/8 criteria. Trajectory shows seven separate literal invocations, no loop. Run `2026-08-03_09-13-45`.
- **claude-code/claude-sonnet-4-6** (anthropic_direct): 1.000, 8/8 criteria. Run `2026-08-03_08-48-37`.


[IN-13526]: https://uipath.atlassian.net/browse/IN-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ