### PR TITLE
fix(uipath-test): steer workflow-impact task to the working test-set …

### DIFF
--- a/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
+++ b/tests/tasks/uipath-test/integration_developer_workflow_impact.yaml
@@ -24,7 +24,8 @@ initial_prompt: |
   break before I hit "merge". Please query the **SHIP** project in Test
   Manager and tell me:
 
-  - Which test sets contain test cases that exercise these two workflows
+  - Which test sets contain test cases that exercise these two workflows —
+    go through the project's test sets and check what's in each one
     (look for names mentioning "Shipment Creation", "Route Optimization",
     "Carrier Selection", or "Delivery Routing")
   - The full list of test cases in those affected test sets, with their


### PR DESCRIPTION
…traversal [TMHUB-32404]

The 2026-08-03 nightly failed this task on codex/gpt-5.6-terra (0.47): the agent chose the test-case-first traversal and called `uip tm testcases list-testsets` six times, each crashing with `testCasesApi.testCasesGetAssignedTestSets is not a function`, so test-set membership and execution history were never retrieved.

Root cause is a CLI defect, not a task defect: the generated test-manager-sdk has no such method because
`swagger/filtered-swagger.json` (the SDK generation input) omits `/api/v2/{projectId}/testcases/{id}/assignedtestsets`; the swagger operationId is also `TestCases_GetTestSetsByTestCaseId`, so the call site name never matched a generated method. Tracked separately for UiPath/cli.

claude-sonnet-5 passes this task because it picks the test-set-first traversal (`testsets list` → `testsets list-testcases` per set). This change adds a goal-level line to the prompt so every model walks that path — no command or flag names, and criteria are untouched.

Verified: codex/gpt-5.6-terra now scores 1.00 with the same traversal claude uses (GH run 30880820479).

[TMHUB-32404]: https://uipath.atlassian.net/browse/TMHUB-32404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ