### PR TITLE
fix(tests): repoint the model-options vacuity guard at the Python mock

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
@@ -83,10 +83,14 @@ success_criteria:
     pass_threshold: 1.0
 
   # Without this, re-pointing the mock's sink leaves the seeded log clean and the
-  # guard above passes vacuously.
+  # guard above passes vacuously. Asserts the FLAT_LOG assignment because
+  # calls.log is the sink graded above. Coupled to mock source text (the
+  # documented weak fallback — no `uip` call is guaranteed in a correct run, so
+  # there is no positive control): keep in sync with
+  # ../_shared/mock_template/mocks/uip when that mock is refactored.
   - type: file_contains
     description: "Mock still records invocations to the graded calls.log (guard is not vacuous)"
     path: "mocks/uip"
-    includes: ['>> "$(dirname "$0")/calls.log"']
+    includes: ['FLAT_LOG = os.path.join(MOCK_DIR, "calls.log")']
     weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

`list_model_options` scored **0.91** in the [2026-08-04 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-08-04_04-13-14?tags=uipath-ixp) with every substantive check green. Only its vacuity guard failed:

```yaml
path: "mocks/uip"
includes: ['>> "$(dirname "$0")/calls.log"']
```

That asserts the **sh** mock's redirect. #2375 (Aug 3) rewrote `mocks/uip` in Python and deleted that line, so the criterion can no longer pass. Weights are `1.5+1.5+3.0+1.0+3.0+1.0 = 11.0`; losing the 1.0 gives `10.0/11.0 = 0.909` — exactly the observed score.

This task (#2361) landed Jul 30, four days before the rewrite. #2375 updated the mock README — which even documents this trap ("It broke once already") — but missed the task.

## Fix

Assert the Python mock's `FLAT_LOG` assignment instead. `calls.log` is the sink the guard above grades, so this names the coupling directly. The comment now points at the mock so the next refactor catches it.

**Not a blanket rename.** `mock_template_ambiguous` and `mock_template_taxonomy` are still sh mocks and legitimately keep the old redirect — both are overlays listed *second*, so they shadow the Python mock in the two tasks that use them.

## Verification

- Asserted string is byte-exact present in `_shared/mock_template/mocks/uip`
- YAML parses; total weight unchanged at 11.0, so the task returns to 1.00
- No local coder-eval run: it is not installed in my environment. This PR touches a task YAML, so the smoke workflow will execute the task itself — that is the real passing-run signal here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)