### PR TITLE
docs(uipath-ixp): align the retrain wait with the contract the tasks state

### DIFF
--- a/skills/uipath-ixp/SKILL.md
+++ b/skills/uipath-ixp/SKILL.md
@@ -99,8 +99,8 @@ If the user provides a taxonomy file, use `--skip-taxonomy` and `import-taxonomy
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Metrics don't change after a prompt update | Re-evaluation hasn't completed | Wait ~2 minutes for retrain. |
-| ModelVersion doesn't advance | Retrain still in progress | Any change to model inputs (labellings OR instructions) triggers a full retrain. Wait ~2 min then retry. |
+| Metrics don't change after a prompt update | Re-evaluation hasn't completed | Wait out the retrain — [Improve Prompts Guide § Waiting for retrain](references/improve-prompts-guide.md#waiting-for-retrain). |
+| ModelVersion doesn't advance | Retrain still in progress | Any change to model inputs (labellings OR instructions) triggers a full retrain. Re-read metrics under the **bounded** wait in [Improve Prompts Guide § Waiting for retrain](references/improve-prompts-guide.md#waiting-for-retrain) — fixed interval, capped number of checks, then stop. Never poll indefinitely. |
 | Field instructions conflict with label_def instructions | `fields update-prompts` only edits per-field instructions, NOT the parent label_def instructions | Before iterating, read the label_def `instructions` and update them with `groups update-prompts` if they contradict the per-field prompts. |
 | A confirmed line item now reads back as the first row, or the other rows' `Occurrence` numbers shifted | Expected: the read returns annotation↔prediction matched pairs first, so confirmed rows sort ahead of unconfirmed ones | Nothing to fix — values and page locations are unchanged. Re-run `get-predictions` before the next per-occurrence call and target the row by its values (Critical Rule 18). |
 | A second `--occurrence` call landed on the wrong row, or `unconfirm --occurrence N` no-ops | Indices came from a read taken *before* an earlier confirm renumbered the group | Re-read `get-predictions` between per-occurrence writes, or issue them as one `--updates` call. |

--- a/skills/uipath-ixp/references/cli-reference.md
+++ b/skills/uipath-ixp/references/cli-reference.md
@@ -66,7 +66,7 @@ Validation differs by command:
 - `documents upload` rejects an unsupported file with `Unsupported file type "<ext>"` before any network call.
 - `projects create` scans only the top level of `<folder-path>` (sub-folders are ignored), silently skips unsupported files, and fails only when **no** supported files exist (`No supported documents found in <folder>`).
 
-Each upload triggers a retrain — wait ~2 min before reading metrics or predictions for new docs.
+Each upload triggers a retrain — wait it out before reading metrics or predictions for new docs, under the bounded wait in [Improve Prompts Guide § Waiting for retrain](improve-prompts-guide.md#waiting-for-retrain).
 
 ### Uploading documents to an existing project
 

--- a/skills/uipath-ixp/references/improve-prompts-guide.md
+++ b/skills/uipath-ixp/references/improve-prompts-guide.md
@@ -38,20 +38,34 @@ The user may specify a max number of iterations (default: 3). Track:
 
 Do NOT re-read the taxonomy or sample documents between iterations — use what you already have. Only re-read metrics after each instruction update + retrain cycle. This assumes no one modifies the taxonomy or documents externally during the loop. If the user mentions changes were made in the web UI, re-fetch the taxonomy and document list before continuing.
 
+## Waiting for retrain
+
+Every change to model inputs — labellings, instructions, document upload/delete, taxonomy edits — triggers a full retrain. Metrics read mid-retrain are *pre*-change scores and corrupt every downstream comparison, so wait before each metrics read.
+
+**Bounded wait. Poll on a fixed interval; never poll indefinitely:**
+
+1. Record `ModelVersion` from the last metrics read BEFORE the change.
+2. Wait 2 minutes, then read `uip ixp projects get-metrics <project-name> --output json`.
+3. `ModelVersion` **greater than** the recorded value → retrain is done, proceed. Any increment counts. Do NOT wait for a specific number: queued input changes can bump the version by more than one, so waiting for exactly *N*+1 polls until the budget dies when the server jumps straight to *N*+2.
+4. Otherwise repeat step 2 — **2 minutes between checks, 5 checks in total** (10 minutes). Do NOT use a single long sleep, and do NOT escalate or shorten the interval between checks.
+5. Still unchanged after the 5th check → **stop polling** and report that the retrain did not complete. Metrics you carry forward predate the change: label them as such, never present them as the post-change measurement, and never roll back instructions on a comparison against them.
+
+A read that fails counts against the budget like any other attempt, and never restarts it.
+
 ## Step 1 — Setup (once, before the loop)
 
 ### 1a. Get baseline metrics
 
-If documents were just labelled (or uploaded, or the taxonomy was edited), wait ~2 minutes for the resulting retrain to complete before reading metrics. Reading mid-retrain captures *pre*-change scores and corrupts every downstream comparison.
+If documents were just labelled (or uploaded, or the taxonomy was edited), wait out the resulting retrain before reading metrics — apply the bounded wait in [Waiting for retrain](#waiting-for-retrain).
 
 ```bash
 mkdir -p /tmp/ixp/<project-name>/{docs,text,taxonomies,prompts}
 uip ixp projects get-metrics <project-name> --output json
 ```
 
-Note the `ModelVersion` from this baseline read — later iterations check that it advances after each `fields update-prompts` / `groups update-prompts` (see step 2e). If the value here looks identical to a known pre-labelling version, the retrain may still be in flight; wait another 60 seconds and re-fetch.
+Note the `ModelVersion` from this baseline read — later iterations check that it advances after each `fields update-prompts` / `groups update-prompts` (see step 2e). If the value here looks identical to a known pre-labelling version, the retrain may still be in flight; re-fetch under the bounded wait in [Waiting for retrain](#waiting-for-retrain), then proceed with whatever it returns.
 
-Save the full per-field `Fields` array as `baseline_metrics`. This is the starting point you compare against. (For a validated model, get-metrics Data is flat — `Fields`/`FieldGroups`/`ValidatedDocuments` are top-level. An unvalidated model returns `Data: { Metrics: null }` instead — wait for retrain and re-fetch.)
+Save the full per-field `Fields` array as `baseline_metrics`. This is the starting point you compare against. (For a validated model, get-metrics Data is flat — `Fields`/`FieldGroups`/`ValidatedDocuments` are top-level. An unvalidated model returns `Data: { Metrics: null }` instead — re-fetch under the bounded wait above.)
 
 **Correlating metrics to field names:** The metrics `Fields` array returns `FieldId` but not the field name. To map them, join against the taxonomy's `field` entries:
 
@@ -96,7 +110,7 @@ The `download` command auto-detects format and appends the correct extension —
 
 ### 1e. Check for unlabelled documents
 
-Compare the document list against the metrics. If the metrics show fewer `ValidatedDocuments` than the total document count, some documents have no confirmed labellings (e.g., newly added documents). Review and label them first using the [Label Documents Guide](label-documents-guide.md), then wait ~2 minutes for retrain and re-fetch metrics before starting the loop.
+Compare the document list against the metrics. If the metrics show fewer `ValidatedDocuments` than the total document count, some documents have no confirmed labellings (e.g., newly added documents). Review and label them first using the [Label Documents Guide](label-documents-guide.md), then re-fetch metrics under the bounded wait in [Waiting for retrain](#waiting-for-retrain) before starting the loop.
 
 ---
 
@@ -135,7 +149,7 @@ For each REFINE field with **Recall < 0.5**, check whether the problem is a bad 
    - If yes, the model may have predicted it correctly but it wasn't confirmed in a previous round → re-fetch predictions and review those fields again
    - If the field is genuinely not visible in the document → it's a prompt/recall issue, handle with instruction changes
 
-**If you find previously skipped predictions that are actually correct**, confirm them now using `labelling confirm --fields` for those specific documents and fields. Wait ~2 minutes for retrain and re-fetch metrics before continuing.
+**If you find previously skipped predictions that are actually correct**, confirm them now using `labelling confirm --fields` for those specific documents and fields, then re-fetch metrics under the bounded wait in [Waiting for retrain](#waiting-for-retrain) before continuing.
 
 **If no labelling gaps are found**, proceed directly to writing instructions.
 
@@ -212,17 +226,17 @@ Compare the number of fields in each updated label_def against the previous vers
 
 ### 2d. Review and confirm predictions for all documents
 
-Wait ~2 minutes for the model to retrain with the updated instructions, then review predictions for all documents using the [Label Documents Guide](label-documents-guide.md). The updated prompts should produce better predictions — review each document's predictions against the actual content and confirm the correct ones. Documents with incorrect predictions are skipped (their old labels remain).
+Wait out the retrain triggered by the updated instructions ([Waiting for retrain](#waiting-for-retrain)), then review predictions for all documents using the [Label Documents Guide](label-documents-guide.md). The updated prompts should produce better predictions — review each document's predictions against the actual content and confirm the correct ones. Documents with incorrect predictions are skipped (their old labels remain).
 
 ### 2e. Wait and get new metrics
 
-Wait ~2 minutes for the model to retrain with the new labellings, then:
+Wait out the retrain triggered by the new labellings ([Waiting for retrain](#waiting-for-retrain)), then:
 
 ```bash
 uip ixp projects get-metrics <project-name> --output json
 ```
 
-If `ModelVersion` hasn't advanced since the last check, wait another 60 seconds and retry.
+If `ModelVersion` hasn't advanced since the last check, keep re-reading under that same bounded budget. When the budget runs out, record the metrics you have and move on to step 2f — do NOT stall the iteration waiting for a version bump.
 
 ### 2f. Compare and decide
 
@@ -246,7 +260,7 @@ uip ixp fields update-prompts <project-name> \
   --output json
 ```
 
-Wait ~2 minutes for retrain. On the next iteration, try a **different approach** for the regressed fields only (different wording, shorter instruction, fewer examples).
+Wait out the retrain ([Waiting for retrain](#waiting-for-retrain)). On the next iteration, try a **different approach** for the regressed fields only (different wording, shorter instruction, fewer examples).
 
 **Rollback caveat:** Rollback restores the previous instructions but the model needs to retrain. Expect only **partial recovery** — prefer small-scope iterations (few fields at a time).
 


### PR DESCRIPTION
## What this is

An alignment. The skill's retrain-wait guidance contradicted the contract three integration tasks already state, so the guide is brought into line with them.

`labelling_correctness`, `publish_lifecycle` and `versions_and_metrics` all say, verbatim:

> poll the project's training status on a fixed interval — wait 2 min between checks, up to 5 checks. Do NOT use a single long sleep or escalating waits … if it's still training after 5 checks, stop and report rather than waiting longer.

The skill said something different in each file it mentioned waiting:

| Where | What it said |
|---|---|
| `improve-prompts-guide.md` 2e | "If `ModelVersion` hasn't advanced, wait another 60 seconds and retry" |
| `improve-prompts-guide.md` 1a | "wait another 60 seconds and re-fetch" |
| `SKILL.md` pitfalls | "Wait ~2 min then retry" |
| `cli-reference.md` | "wait ~2 min" |

An unbounded loop, a varying interval, and no terminal condition — restated across three files in different wording.

## Change

One `## Waiting for retrain` section carrying the tasks' contract:

1. Record `ModelVersion` before the change
2. Wait 2 minutes, then read `get-metrics`
3. Version **greater than** the recorded one → proceed
4. Otherwise repeat — **2 minutes between checks, 5 checks in total** (10 minutes); no long sleep, no escalating or shortened interval
5. Still unchanged after the 5th check → **stop polling** and report that the retrain did not complete

All **ten** wait references across the three files now point at that section, and the interval and check count appear **only** there. Restating them per file is how the wording drifted apart to begin with, so the `SKILL.md` pitfalls link out rather than repeating numbers.

Two details worth noting:

- Step 3 tests **greater than**, not a specific next number. Queued input changes can bump the version by more than one, so waiting for exactly *N*+1 would poll until the budget dies when the server jumps to *N*+2.
- A read that fails counts against the budget, so errored attempts are not free retries.

## This is not a fix for the nightly failure

`full_lifecycle` scored 0.00 (timeout) in the [2026-08-04 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-08-04_04-13-14?tags=uipath-ixp), and **this PR does not fix that**:

- A run whose retrain does not finish inside the window fails with or without this change — and once #2448 requires the version to advance, capturing a stale snapshot is a failure rather than a pass.
- A run whose retrain *does* finish inside the window would have finished under the previous text too.

What changes is the failure mode: a bounded stop with "retrain did not complete" in the report and partial credit on the rest, instead of a turn-timeout error that scores 0.00 and explains nothing. Diagnostic value, not a score change.

The cause of that 0.00 — an authentication dropout that disrupted the reads, or a genuinely slow retrain — is unresolved and not addressed here. Running `skill-ixp-e2e-full-lifecycle` is what would distinguish the two.

## Why land it anyway

An unbounded retry loop hangs a real user's session on a stuck retrain, and [`.claude/rules/skill-review.md`](.claude/rules/skill-review.md) requires "max retry count specified" and "the agent knows when to stop". That holds regardless of any test.

## What I checked

Static only:

- No unbounded retry loops remain — `wait another N seconds` / `then retry` return nothing
- Every added link resolves; target file **and** heading anchor both checked
- `hooks/validate-skill-descriptions.sh` passes (727 chars; frontmatter untouched)
- No timing or frequency claims in the diff — there is no measurement behind one

3 files, +26/−12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
