### PR TITLE
feat(uipath-coded-apps): document the in-memory Validation Station paths

### DIFF
--- a/skills/uipath-coded-apps/references/create-web-app.md
+++ b/skills/uipath-coded-apps/references/create-web-app.md
@@ -225,7 +225,7 @@ const records = await entities.getAllRecords('<entity-id>'); // entity ID is a U
 
 Method signatures come from the installed types (`node_modules/@uipath/uipath-typescript/dist/<subpath>/index.d.ts`); per-method scopes from the shipped `node_modules/@uipath/uipath-typescript/docs/oauth-scopes.md` — see [oauth-scopes.md](oauth-scopes.md) for bundles and the lookup protocol.
 
-If the user wants a **Document Understanding validation UI** (review/correct extraction results), embed the Validation Station widget — see [widgets/validation-station.md](widgets/validation-station.md). When the document comes from a storage bucket the required scope is `OR.Buckets` (plus `OR.Tasks` if the widget completes an Action Center task on save) — add to the `scope` field in `uipath.json` during Step 4. If your backend already holds the document data, the in-memory path needs neither.
+If the user wants a **Document Understanding validation UI** (review/correct extraction results), embed the Validation Station widget — see [widgets/validation-station.md](widgets/validation-station.md). `OR.Buckets` is required when the document comes from a storage bucket; the in-memory path drops it. `OR.Tasks` is required whenever the app completes an Action Center task on save, on either data path. Add to the `scope` field in `uipath.json` during Step 4.
 
 When implementing specific SDK services, read the corresponding reference:
 

--- a/skills/uipath-coded-apps/references/create-web-app.md
+++ b/skills/uipath-coded-apps/references/create-web-app.md
@@ -225,7 +225,7 @@ const records = await entities.getAllRecords('<entity-id>'); // entity ID is a U
 
 Method signatures come from the installed types (`node_modules/@uipath/uipath-typescript/dist/<subpath>/index.d.ts`); per-method scopes from the shipped `node_modules/@uipath/uipath-typescript/docs/oauth-scopes.md` — see [oauth-scopes.md](oauth-scopes.md) for bundles and the lookup protocol.
 
-If the user wants a **Document Understanding validation UI** (review/correct extraction results), embed the Validation Station widget — see [widgets/validation-station.md](widgets/validation-station.md). Required scope: `OR.Buckets` (plus `OR.Tasks` if the widget completes an Action Center task on save). Add to the `scope` field in `uipath.json` during Step 4.
+If the user wants a **Document Understanding validation UI** (review/correct extraction results), embed the Validation Station widget — see [widgets/validation-station.md](widgets/validation-station.md). When the document comes from a storage bucket the required scope is `OR.Buckets` (plus `OR.Tasks` if the widget completes an Action Center task on save) — add to the `scope` field in `uipath.json` during Step 4. If your backend already holds the document data, the in-memory path needs neither.
 
 When implementing specific SDK services, read the corresponding reference:
 

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -12,6 +12,8 @@ Package: [`@uipath/ui-widgets-validation-station`](https://www.npmjs.com/package
 
 **Two integration shapes.** The all-in-one `ValidationStation` component (standard layout, fastest — most apps want this) covers the sections below. When you need a **custom layout** — rearrange, hide, or embed individual panels (viewer, fields form, table editor, doc-type field, business rules) — the package also exports those as composable **subcomponents**. See [Compose-your-own layout: subcomponents](#compose-your-own-layout-subcomponents).
 
+**Layout is one axis; where the data comes from is the other.** Both shapes above fetch the document from a storage bucket. If your own backend already holds the taxonomy and extraction result, supply them directly and own every write instead — see [Integration: in-memory data](#integration-in-memory-data-no-storage-bucket).
+
 If the user just wants a generic form (no DU document), use the standard Action App form pattern in [../create-action-app.md](../create-action-app.md) instead.
 
 ## Critical Rules
@@ -21,7 +23,7 @@ If the user just wants a generic form (no DU document), use the standard Action 
 3. **Set `optimizeDeps.exclude: ['@uipath/du-validation-station-wc']` in `vite.config.ts`.** Vite's pre-bundler rewrites `import.meta.url` and breaks runtime asset resolution.
 4. **Body needs `light` or `dark` class** for theming. Match it to the `theme` prop. Action apps already manage this via `onInitTheme` from `CodedActionAppService.getTask()`.
 5. **`sdk` must already be initialized.** Pass the same `UiPath` instance produced by `useAuth()` (web app) or constructed in `src/uipath.ts` (action app). Do not construct a second SDK just for the widget — auth state will diverge.
-6. **Required SDK scopes:** `OR.Buckets` (the widget fetches the document and extraction artifacts from a storage bucket). Add `OR.Tasks` as well when the widget is rendered inside an Action Center task (action app, or web app that completes a task on save). Add to the `scope` field in `uipath.json` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
+6. **Required SDK scopes depend on where the document data comes from.** Bucket-backed paths need `OR.Buckets` — the widget fetches the document and extraction artifacts from a storage bucket. The in-memory path needs neither `OR.Buckets` nor an SDK instance, because the web component issues no HTTP calls (see [Integration: in-memory data](#integration-in-memory-data-no-storage-bucket)). Either way, add `OR.Tasks` when the app is rendered inside an Action Center task (action app, or web app that completes a task on save). Add to the `scope` field in `uipath.json` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
 7. **Widget does NOT surface failures.** `onSubmitComplete` / `onSaveAsDraftComplete` fire with `{ success: false, error }` on failure but render no toast — the host owns all UI feedback (toast, retry, log). Wire these callbacks or failures are silent.
 8. **Report-as-exception makes no API call.** `onReportExceptionComplete(documentId, reason)` only hands the host the data — it does NOT persist. The host must call `OrchestratorDuModule.submitExceptionReport(taskId, documentId, reason, { folderId })` itself, or the user's "Report as exception" click is a no-op. Needs `OR.Tasks`.
 
@@ -351,9 +353,191 @@ useEffect(() => {
 }, [isDark]);
 ```
 
+## Integration: in-memory data (no storage bucket)
+
+Both sections above read the document from a storage bucket. The underlying web component makes **no HTTP calls of its own** — when your backend already holds the document data, you can hand it over directly and keep every write. No `sdk`, no bucket, no `OR.Buckets`.
+
+**One question decides which way you go:**
+
+| Where the document data already is | Path |
+|---|---|
+| In a storage bucket, because a DU workflow ran `Create Document Validation Artifacts` and handed you a `ContentValidationData` descriptor | The bucket-backed sections above. This is the usual action-app case — keep it as the default. |
+| In your own backend — you hold the taxonomy and extraction result as objects | This section. |
+
+`ContentValidationData` is nothing but bucket coordinates and paths (`BucketId`, `FolderId`, `TaxonomyPath`, `DocumentObjectModelPath`, …), so if you were handed one, you are on the bucket path. Don't mix them.
+
+### Two in-memory shapes
+
+|  | A — subcomponents, pre-fetched | B — standalone element |
+|---|---|---|
+| Package | `@uipath/ui-widgets-validation-station` | `@uipath/du-validation-station-wc` |
+| Layout | custom — you place the panels | the standard all-in-one layout (fields + document viewer) |
+| Data goes in as | React props | JS properties on a custom element |
+| Persistence | raw request callbacks | typed DOM events |
+
+**The all-in-one `<ValidationStation>` component is not an option here.** Its props require `sdk: UiPath` and `data: ContentValidationData`, so it always fetches from a bucket. Shape B is the only in-memory route to that layout.
+
+### Shape A — subcomponents with host-built artifacts
+
+`artifacts` is a plain object. Build it yourself, pass it with `documentId`, and omit `sdk`/`data` — the hook then performs no fetch. Because there is no SDK context, **nothing is auto-persisted**: `onSubmitComplete` and `onSaveAsDraftComplete` never fire, and the raw request callbacks are your only signal.
+
+```typescript
+import { useMemo } from 'react';
+import {
+  DocumentViewer,
+  CompactFieldsForm,
+  ValidationStationLanguage,
+  type BucketArtifacts,
+  type CompactFieldsFormProps,
+} from '@uipath/ui-widgets-validation-station';
+
+// The request type lives in the WC package; reach it through the props type so you
+// don't have to depend on a transitive package.
+type SaveRequest = Parameters<NonNullable<CompactFieldsFormProps['onSaveValidatedDataRequest']>>[0];
+
+function ReviewScreen({ doc }: { doc: MyDocument }) {
+  // No bucket, no sdk — every field is something the host already has.
+  const artifacts = useMemo<BucketArtifacts>(
+    () => ({
+      taxonomy: doc.taxonomy,
+      extractionResult: doc.extractionResult,
+      dom: doc.dom,
+      text: doc.text,
+      original: doc.originalDataUrl, // base64 data URL
+      customizationInfo: undefined,
+    }),
+    [doc],
+  );
+
+  const shared = {
+    artifacts,
+    documentId: doc.id,
+    instanceId: `review-${doc.id}`, // links the panels — see the subcomponents section
+    theme: 'light' as const,        // keep the body class in sync — Critical Rule #4
+    language: ValidationStationLanguage.English,
+    persistent: false,
+  };
+
+  const handleSave = async (request: SaveRequest) => {
+    await myBackend.saveValidatedData(request.documentId, request.validatedData);
+  };
+
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: '1.3fr 1fr', gap: 8, height: '100%' }}>
+      <DocumentViewer {...shared} style={{ height: '100%' }} />
+      <CompactFieldsForm
+        {...shared}
+        // Defaults to true. Leave it on only if you also handle
+        // onSaveValidatedDataAsDraftRequest, or the draft button does nothing.
+        enableSaveAsDraft={false}
+        onSaveValidatedDataRequest={handleSave}
+      />
+    </div>
+  );
+}
+```
+
+Everything else in [Compose-your-own layout: subcomponents](#compose-your-own-layout-subcomponents) still applies — the shared `instanceId`, `persistent: false`, and hiding duplicated panels.
+
+### Shape B — the standalone element
+
+`<ui-du-validation-station-standalone-wc-element>` renders the standard layout from data you supply. Register the custom elements once at startup (or behind a route boundary), then mount the element and drive it imperatively.
+
+```typescript
+// src/vs/register.ts — side-effect imports; run once before mounting.
+import '@uipath/du-validation-station-wc/polyfills';
+import '@uipath/du-validation-station-wc/main';
+import '@uipath/du-validation-station-wc/styles.css';
+// Only if the host page does not already load Apollo fonts + Material Icons:
+import '@uipath/du-validation-station-wc/fonts.css';
+```
+
+```typescript
+import { useEffect, useRef } from 'react';
+import type {
+  IVsSaveValidatedDataRequest,
+  IVsSaveExceptionReportRequest,
+} from '@uipath/du-validation-station-wc';
+import '../vs/register';
+
+const TAG = 'ui-du-validation-station-standalone-wc-element';
+
+function DocumentReview({ doc }: { doc: MyDocument }) {
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    // Typed by the package's HTMLElementTagNameMap augmentation — no cast needed.
+    const el = document.createElement(TAG);
+
+    el.documentId = doc.id; // first — required before any data input
+    el.taxonomy = doc.taxonomy;
+    el.extractionResult = doc.extractionResult;
+    el.dom = doc.dom;
+    el.text = doc.text;
+    el.original = doc.originalDataUrl; // base64 data URL
+    el.theme = 'light';                // keep the body class in sync — Critical Rule #4
+    el.language = 'en';
+    el.isReadonly = false;
+
+    // The element persists nothing. These handlers ARE the save.
+    const onSave = (e: CustomEvent<IVsSaveValidatedDataRequest>) => {
+      void myBackend.saveValidatedData(e.detail.documentId, e.detail.validatedData);
+    };
+    const onException = (e: CustomEvent<IVsSaveExceptionReportRequest>) => {
+      void myBackend.reportException(e.detail.documentId, e.detail.exceptionReport);
+    };
+    el.addEventListener('saveValidatedDataRequest', onSave);
+    el.addEventListener('saveExceptionReportRequest', onException);
+
+    host.appendChild(el);
+    return () => {
+      el.removeEventListener('saveValidatedDataRequest', onSave);
+      el.removeEventListener('saveExceptionReportRequest', onException);
+      el.remove();
+    };
+  }, [doc]);
+
+  return <div ref={hostRef} style={{ height: '100%' }} />;
+}
+```
+
+**Data inputs** — all set as JS properties, never HTML attributes. Object types come from `@uipath/uipath-typescript/document-understanding`.
+
+| Property | Type | Notes |
+|---|---|---|
+| `documentId` | `string` | **Assign first.** Required before any data input is set. |
+| `taxonomy` | `DocumentTaxonomy` | Field definitions for this document. |
+| `extractionResult` | `ExtractionResult` | The *initial* result. Edits come back out on events; they are not written here. |
+| `dom` | `DocumentEntity` | Digitized document — drives bounding boxes and anchors. |
+| `text` | `string \| undefined` | Plain text. Supply to enable the text view. |
+| `original` | `string \| undefined` | The document itself as a **base64 data URL**. Supply to enable the document/canvas view. |
+| `customizationInfo` | `unknown` | Optional. Carries `ICustomizationInfoDTO`; no SDK type exists for it. |
+
+**Events the host owns.** Nothing here reaches the network on its own.
+
+| Event | `detail` | Host must |
+|---|---|---|
+| `saveValidatedDataRequest` | `{ documentId, validatedData, automaticExtractionResult, taxonomy }` | persist `validatedData` — otherwise Save is a no-op |
+| `saveValidatedDataAsDraftRequest` | `{ documentId, validatedData }` | store the in-progress result (set `enableSaveAsDraft = true` to expose the action) |
+| `saveExceptionReportRequest` | `{ documentId, exceptionReport }` | route the document to your exception flow |
+
+`addEventListener` / `removeEventListener` are overloaded per event name, so `e.detail` is typed without a cast. The edit/state events (`loaded`, `dirty`, `isValid`, `fieldValueSelected`, `fieldValueChanged`, `extractionResultChanged`, `businessRulesEvaluated`) are typed the same way; `extractionResultChanged` needs `options.emitDtoStateChanges = true`.
+
+**Two element-lifecycle rules:**
+
+- `taxonomy` and `extractionResult` are setup inputs. To show a **different document**, destroy the element and create a new one rather than re-assigning them.
+- If the element moves between DOM parents (portals, tab switches), use `<ui-du-validation-station-standalone-wc-persistent-element>` — it survives detachment — and call `forceDestroy()` when removing it for good, or the inner component leaks.
+
+**React version.** Coded App scaffolds pin React 19.2+, where object props can also go straight on the JSX tag. The `createElement` path above works on either version and guarantees `documentId` lands first, so prefer it. Under React 18 the JSX form is not an option at all — React serialises props to attributes and Angular Elements cannot deserialise object JSON.
+
+**Runtime assets are unchanged.** Same `optimizeDeps.exclude` and same copy/serve plugins as [Static Assets](#static-assets--vite-plugin) — this is the same web component. The one difference: here you register the custom elements yourself with the side-effect imports above, whereas the React wrapper does that for you.
+
 ## Compose-your-own layout: subcomponents
 
-When the standard layout doesn't fit — you need to rearrange panels, hide some, or embed one piece inside your own screen — the package also exports the Validation Station as **five composable subcomponents** plus a data hook, instead of the all-in-one `ValidationStation`. Same document, same bucket artifacts, same save flows; you own the layout.
+When the standard layout doesn't fit — you need to rearrange panels, hide some, or embed one piece inside your own screen — the package also exports the Validation Station as **five composable subcomponents** plus a data hook, instead of the all-in-one `ValidationStation`. Same document, same artifacts, same save flows; you own the layout.
 
 Exports (from the same `@uipath/ui-widgets-validation-station` package):
 
@@ -371,7 +555,7 @@ Exports (from the same `@uipath/ui-widgets-validation-station` package):
 Must-knows (all easy to get wrong):
 
 0. **Requires a package version that exports the subcomponents** (`@uipath/ui-widgets-validation-station >= 1.0.1`). Earlier versions export only `ValidationStation`.
-1. **Fetch artifacts once, share them.** Call `useBucketArtifacts` in the parent and pass the same `artifacts` object to all subcomponents. Calling it per-subcomponent re-downloads the same unchanged document once per panel.
+1. **Fetch artifacts once, share them.** Call `useBucketArtifacts` in the parent and pass the same `artifacts` object to all subcomponents. Calling it per-subcomponent re-downloads the same unchanged document once per panel. `artifacts` need not come from a bucket at all — a host that already holds the data builds the object itself and omits `sdk`/`data`, and no fetch happens (see [Integration: in-memory data](#integration-in-memory-data-no-storage-bucket)).
 2. **Only `CompactFieldsForm` gets `sdk`/`data`/`folderId`.** It owns persistence. The other four can take the pre-fetched `artifacts` only.
 3. **Set `persistent: false` for static layouts.** These panels sit in a fixed grid and are never re-parented. Leaving `persistent` on makes React StrictMode's throwaway unmount call `forceDestroy()`, tearing down the underlying element so it renders **blank**. Only set `persistent: true` if you actually move a subcomponent between DOM parents.
 4. **Drop duplicated panels via `options`.** When you render `CompactBusinessRules` / `CompactDocTypeField` standalone, tell the fields form to hide its built-in copies: `options={{ hideBusinessRules: true, hideDocumentTypeField: true, emitDtoStateChanges: true }}`. (`emitDtoStateChanges` is still required for save-as-draft, same as the monolithic widget.)
@@ -462,3 +646,11 @@ Subcomponents (compose-your-own layout) only:
 - **Do not give subcomponents different `instanceId`s** and expect them to sync — the shared id is what links the store; mismatched ids leave the panels independent.
 - **Do not render `CompactBusinessRules`/`CompactDocTypeField` standalone without hiding the form's built-in copies** (`options.hideBusinessRules` / `hideDocumentTypeField`) — you'll get each panel twice.
 - **Do not add your own Submit / Save-draft / Report-exception controls without hiding the form's built-in buttons** (`options.hideSubmitButton` / `hideReportAsExceptionButton`, and omit the `enableSaveAsDraft` prop) — `CompactFieldsForm` ships its own action bar, so every action renders twice. The controlled `save` / `discardChanges` props still drive the flows once the built-ins are hidden. (`enableSaveAsDraft` only exposes the built-in draft button; the controlled `save={{ validate: false }}` trigger keeps working via `options.emitDtoStateChanges`. There is no flag to hide the built-in discard control — drop your own Discard button if it would duplicate.)
+
+In-memory paths (no storage bucket) only:
+
+- **Do not reach for `<ValidationStation>` when the data is already in memory.** Its props require `sdk` + `data: ContentValidationData`, so it always fetches from a bucket. Use a subcomponent in pre-fetched mode, or the standalone element.
+- **Do not wait on `onSubmitComplete` / `onSaveAsDraftComplete` in pre-fetched mode.** With `sdk`/`data` omitted there is nothing to auto-persist, so neither ever fires. Handle `onSaveValidatedDataRequest` / `onSaveValidatedDataAsDraftRequest` instead.
+- **Do not set data inputs before `documentId`.** It is required first — assign it as the element's first property.
+- **Do not re-assign `taxonomy`/`extractionResult` to switch documents.** They are setup inputs; destroy the element and create a new one.
+- **Do not forget the side-effect imports on the standalone path.** Without them the custom element never upgrades and the panel renders empty, with no build error. The React wrapper does this registration for you; the raw element does not.

--- a/skills/uipath-coded-apps/references/widgets/validation-station.md
+++ b/skills/uipath-coded-apps/references/widgets/validation-station.md
@@ -23,7 +23,7 @@ If the user just wants a generic form (no DU document), use the standard Action 
 3. **Set `optimizeDeps.exclude: ['@uipath/du-validation-station-wc']` in `vite.config.ts`.** Vite's pre-bundler rewrites `import.meta.url` and breaks runtime asset resolution.
 4. **Body needs `light` or `dark` class** for theming. Match it to the `theme` prop. Action apps already manage this via `onInitTheme` from `CodedActionAppService.getTask()`.
 5. **`sdk` must already be initialized.** Pass the same `UiPath` instance produced by `useAuth()` (web app) or constructed in `src/uipath.ts` (action app). Do not construct a second SDK just for the widget — auth state will diverge.
-6. **Required SDK scopes depend on where the document data comes from.** Bucket-backed paths need `OR.Buckets` — the widget fetches the document and extraction artifacts from a storage bucket. The in-memory path needs neither `OR.Buckets` nor an SDK instance, because the web component issues no HTTP calls (see [Integration: in-memory data](#integration-in-memory-data-no-storage-bucket)). Either way, add `OR.Tasks` when the app is rendered inside an Action Center task (action app, or web app that completes a task on save). Add to the `scope` field in `uipath.json` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
+6. **`OR.Buckets` depends on where the document data comes from; `OR.Tasks` does not.** Bucket-backed paths need `OR.Buckets` — the widget fetches the document and extraction artifacts from a storage bucket. The in-memory path needs no `OR.Buckets`, and the widget itself needs no `UiPath` instance, because it issues no HTTP calls (see [Integration: in-memory data](#integration-in-memory-data-no-storage-bucket)). **Add `OR.Tasks` whenever your app completes an Action Center task on save** — action app, or web app that calls `task.complete()` — regardless of which data path you chose, and note a web app completing a task still needs its own `UiPath` instance to do so. Add to the `scope` field in `uipath.json` before first run; mismatch fails silently with 401/403. See [../oauth-scopes.md](../oauth-scopes.md).
 7. **Widget does NOT surface failures.** `onSubmitComplete` / `onSaveAsDraftComplete` fire with `{ success: false, error }` on failure but render no toast — the host owns all UI feedback (toast, retry, log). Wire these callbacks or failures are silent.
 8. **Report-as-exception makes no API call.** `onReportExceptionComplete(documentId, reason)` only hands the host the data — it does NOT persist. The host must call `OrchestratorDuModule.submitExceptionReport(taskId, documentId, reason, { folderId })` itself, or the user's "Report as exception" click is a no-op. Needs `OR.Tasks`.
 
@@ -355,7 +355,9 @@ useEffect(() => {
 
 ## Integration: in-memory data (no storage bucket)
 
-Both sections above read the document from a storage bucket. The underlying web component makes **no HTTP calls of its own** — when your backend already holds the document data, you can hand it over directly and keep every write. No `sdk`, no bucket, no `OR.Buckets`.
+Both sections above read the document from a storage bucket. The underlying web component makes **no HTTP calls of its own** — when your backend already holds the document data, you can hand it over directly and keep every write. No bucket, no `OR.Buckets`, and no `UiPath` instance for the widget.
+
+This drops the bucket requirement only. If your app completes an Action Center task on save it still needs `OR.Tasks` — and, in a web app, still needs its own `UiPath` instance to call `task.complete()`. See Critical Rule 6.
 
 **One question decides which way you go:**
 

--- a/tests/tasks/uipath-coded-apps/ui_validation_station_in_memory_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_validation_station_in_memory_smoke.yaml
@@ -1,0 +1,100 @@
+task_id: skill-coded-apps-ui-validation-station-in-memory-smoke
+description: >
+  Smoke test (mode:build): the host already holds every document artifact in
+  memory and owns persistence, so there is no storage bucket to read from.
+  The agent must reach the standalone web component documented in
+  `references/widgets/validation-station.md §Integration: in-memory data`
+  (`<ui-du-validation-station-standalone-wc-element>` from
+  `@uipath/du-validation-station-wc`) rather than the bucket-backed React
+  `<ValidationStation>`, whose props require an `sdk` plus a
+  `ContentValidationData` descriptor and therefore cannot render in-memory
+  data at all. Grades what breaks at runtime if the wrong path is taken:
+  (1) the custom elements are registered, or nothing renders;
+  (2) `documentId` and the viewer data inputs are supplied as properties;
+  (3) the save request is handled by the host, since the element issues no
+  HTTP call of its own;
+  (4) no bucket download is attempted.
+tags: [uipath-coded-apps, smoke, mode:build, lifecycle:generate]
+run_limits:
+  expected_turns: 10
+  turn_timeout: 600
+
+initial_prompt: |
+  Inside a UiPath Coded Action App, build the human-review screen for a
+  Document Understanding validation task.
+
+  Our own backend already put everything the reviewer needs on the Action
+  Center task payload: the taxonomy, the extraction result, the digitized
+  document, its plain text, and the original document as a base64 data URL.
+  Nothing has to be downloaded. Show the reviewer the standard Validation
+  Station layout — the document and the extraction fields side by side in one
+  panel.
+
+  When the reviewer saves, our app owns persistence: POST the validated
+  extraction result to `/api/validated-documents` and complete the task.
+
+  Author a single component at `src/components/DocumentReview.tsx` at the
+  sandbox root. Author the source only — do NOT run `uip` or `npm` commands.
+
+success_criteria:
+  - type: file_exists
+    description: "src/components/DocumentReview.tsx was created"
+    path: "src/components/DocumentReview.tsx"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Uses the web-component package directly (the React wrapper cannot render in-memory data)"
+    command: 'grep -q "@uipath/du-validation-station-wc" src/components/DocumentReview.tsx'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Registers the custom elements via the package side-effect entry point — without it the tag never upgrades and the panel renders empty"
+    command: 'grep -rq "du-validation-station-wc/main" src/'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Mounts the standalone validation-station element (fields + document in one panel, no HTTP calls of its own)"
+    command: 'grep -q "ui-du-validation-station-standalone-wc-element" src/components/DocumentReview.tsx'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Supplies documentId plus the viewer data inputs — the element has no other way to receive the document"
+    command: 'for n in documentId dom text original; do grep -q "$n" src/components/DocumentReview.tsx || exit 1; done'
+    timeout: 15
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Handles the save request — the element persists nothing, so an unhandled request makes Save a no-op"
+    command: 'grep -q "saveValidatedDataRequest" src/components/DocumentReview.tsx'
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Attempts no bucket download — the artifacts were already handed over, and a bucket read would need a scope this app has no reason to hold"
+    command: 'grep -rEq "BucketService|useBucketArtifacts|getReadUri|buckets\." src/'
+    timeout: 15
+    expected_exit_code: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Does NOT mount the bucket-backed <ValidationStation> component, whose props require sdk + ContentValidationData"
+    command: 'grep -Eq "<ValidationStation[[:space:]/>]" src/components/DocumentReview.tsx'
+    timeout: 10
+    expected_exit_code: 1
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-coded-apps/ui_validation_station_in_memory_smoke.yaml
+++ b/tests/tasks/uipath-coded-apps/ui_validation_station_in_memory_smoke.yaml
@@ -92,8 +92,8 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Does NOT mount the bucket-backed <ValidationStation> component, whose props require sdk + ContentValidationData"
-    command: 'grep -Eq "<ValidationStation[[:space:]/>]" src/components/DocumentReview.tsx'
+    description: "Does NOT mount the bucket-backed <ValidationStation> component, whose props require sdk + ContentValidationData. Comments are stripped first — naming it to explain why it was rejected is fine; mounting it is not."
+    command: 'sed "s://.*::" src/components/DocumentReview.tsx | grep -Ev "^[[:space:]]*(\*|/\*)" | grep -Eq "<ValidationStation[[:space:]/>]"'
     timeout: 10
     expected_exit_code: 1
     weight: 2.0


### PR DESCRIPTION
## What's wrong

Every data path on `references/widgets/validation-station.md` reaches the document through a storage bucket — Action App, Web App, and the subcomponents section, which describes itself as sharing "the same bucket artifacts". A coded app whose backend already holds the taxonomy, extraction result and document therefore has no documented way to use the widget.

Given exactly that situation, the assistant abandons the widget and hand-rolls the UI with `react-pdf` — the one thing §"When to Use" forbids. From its own generated file:

> Persistence is NOT delegated to the DU Validation Station widget (that widget owns its own bucket-backed save flow). This app owns persistence itself

Both packages already support the case. `@uipath/du-validation-station-wc` calls its standalone element "the recommended variant for external consumers — your backend stays in control of all I/O", and that element is named nowhere in this repo.

## What changed

A new section, **Integration: in-memory data (no storage bucket)**, for the two shapes that work:

- **Subcomponents, pre-fetched.** `SubcomponentDataSource` takes `artifacts` + `documentId` with `sdk`/`data` omitted, and then issues no request; `BucketArtifacts` is a plain object a host can build. Worth documenting: without an SDK context `canPersist` is false, so `onSubmitComplete`/`onSaveAsDraftComplete` never fire and the raw `onSaveValidatedDataRequest` family is the only signal.
- **`<ui-du-validation-station-standalone-wc-element>`** — the only in-memory route to the all-in-one layout, since `ValidationStationProps` requires `sdk` and `data`. Covers `documentId` first ("Required before any data inputs are set"), the six data inputs, the three host-owned save events, and element registration.

**Critical Rules change, per CONTRIBUTING.** Rule 6 required `OR.Buckets` unconditionally. That is false for a path issuing no HTTP call, and it costs a consumer a scope, an External App and a bucket they cannot use. The rule now splits the two scopes: `OR.Buckets` depends on the data path, while **`OR.Tasks` is required on either path** whenever the app completes an Action Center task on save — and a web app that completes a task still needs its own `UiPath` instance to do so. Nothing else in the section is touched. `create-web-app.md` carried the same unconditional claim and is corrected the same way, and two bucket-implying lines in the subcomponents section are narrowed.

## How to check

New eval task. Same prompt and agent; only the skill differs:

```
cd tests && make install
SKILLS_REPO_PATH=$(cd .. && pwd) .venv/bin/coder-eval run \
  tasks/uipath-coded-apps/ui_validation_station_in_memory_smoke.yaml \
  -e experiments/default.yaml
```

8/8, weighted 1.000 on this branch; 3/8, 0.314 with `SKILLS_REPO_PATH` on an unmodified `main`. Criteria grade generated source, not a self-report.

`npm run version:check`, `check-skill-status.py` and `check-cli-verbs.py` pass; `check-skill-verbs.py` reports the same two stale findings as `main`, both outside the edited file. Every name in the section was checked against the shipped types of `@uipath/du-validation-station-wc@1.0.0-rc.1` and `@uipath/ui-widgets-validation-station@1.0.1`, and both examples compile under `tsc --strict` with React 19.

cc @Raina451 @deepeshrai-tech @Sandeepan-Ghosh-0312 @swati354

Generated with [Claude Code](https://claude.com/claude-code)
