### PR TITLE
test(uipath-ixp): require a real improvement retrain, and budget for it

### DIFF
--- a/tests/tasks/uipath-ixp/e2e/check_full_lifecycle.py
+++ b/tests/tasks/uipath-ixp/e2e/check_full_lifecycle.py
@@ -1,16 +1,28 @@
 #!/usr/bin/env python3
 """Verify the IXP full-lifecycle e2e artifacts.
 
-Grades artifact integrity, NOT whether the model's F1 improved. On the ~3-doc
-fixture set a single flipped prediction moves a field's F1 by a large fraction,
-so a small regression tolerance is noise the agent doesn't control, not signal.
+Grades artifact integrity and that the improvement round-trip actually happened,
+NOT whether the model's F1 improved. On the ~3-doc fixture set a single flipped
+prediction moves a field's F1 by a large fraction, so a regression tolerance is
+noise the agent doesn't control, not signal — the F1 delta is printed but never
+gates.
+
 Asserts: artifacts present & well-formed; Fields[] populated; ModelVersion an int
-and not backwards; target field resolves to a numeric F1 in both snapshots. The F1
-delta is printed but never gates. An advanced version with byte-identical Fields[]
-only WARNs — on the coarse fixture a genuine retrain can flip no prediction, so
-identical metrics are the same noise this check refuses to grade, and it cannot be
-told from a counter bump by the artifacts alone. "Did the agent run the improve loop"
-(update-prompts, two metric fetches, publish) is graded from `calls.log`.
+that **strictly advances** from baseline to improved; target field resolves to a
+numeric F1 in both snapshots.
+
+The strict advance is what verifies the retrain waits. The lifecycle has three:
+after upload (predictions appear), after confirming labellings (the first version
+trains and validates), and after the prompt update (the second version). Only two
+version points are observable — a project with no confirmed labellings has no
+trained model at all, so `get-metrics` returns `not_found` and there is nothing to
+number. But a *validated* baseline can only exist if predictions arrived and labels
+were confirmed and trained, so requiring `improved > baseline` transitively proves
+all three waits completed.
+
+An advanced version with byte-identical Fields[] still only WARNs — on the coarse
+fixture a genuine retrain can flip no prediction, and that is the same noise this
+check refuses to grade.
 """
 from __future__ import annotations
 
@@ -104,7 +116,11 @@ def main() -> int:
     if improved_version < baseline_version:
         log_fail(f"ModelVersion went backwards ({baseline_version} -> {improved_version}) — improved_metrics is stale, from another project, or swapped")
     if improved_version == baseline_version:
-        log_info(f"ModelVersion unchanged at {baseline_version} — no new version yet (acceptable)")
+        log_fail(
+            f"ModelVersion unchanged at {baseline_version} — improved_metrics was captured before the "
+            "post-update retrain produced a new version, so it is the baseline re-read and no "
+            "improvement round-trip is demonstrated. Wait for the version to advance before capturing."
+        )
     else:
         log_info(f"ModelVersion advanced {baseline_version} -> {improved_version}")
         # Advanced version + byte-identical Fields[] *can* be a copied snapshot with the counter

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -53,9 +53,11 @@ initial_prompt: |
   - `target_field.json` — the field you chose to improve, exactly:
       {"field_id": "<FieldId from metrics>", "name": "<name from taxonomy>"}
   - `improved_metrics.json` — full metrics response after the
-    improvement and retrain. If retrain has not completed after a few
-    minutes of polling, capture the current metrics and proceed rather
-    than waiting indefinitely.
+    improvement and retrain. Capture it only once the retrain has
+    produced a NEW model version: its `ModelVersion` must be higher
+    than `baseline_metrics.json`'s. Re-reading the baseline version
+    does not count. If the version has not advanced by the end of the
+    documented bounded wait, stop and report rather than capturing.
 
   - The `uip` CLI is already authenticated.
   - Do NOT ask for approval, confirmation, or feedback; do NOT pause

--- a/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/e2e/full_lifecycle.yaml
@@ -8,9 +8,19 @@ description: >
   Exercises every reference file in the skill end-to-end.
 tags: [uipath-ixp, e2e, mode:build, lifecycle:setup]
 
+# task_timeout matches the training-heavy integration tasks. #1818 raised those
+# from 3000 to 6000 because training took longer than the budget allowed; this
+# task was never given the same treatment, and it waits for MORE retrains than
+# any of them — three (after upload, after confirming labellings, after the
+# prompt update) against two for publish_lifecycle / versions_and_metrics and
+# one for labelling_correctness. At 2400 that was 800s per wait where its
+# siblings get 3000-3600, so a single wait running to the documented ceiling
+# left almost nothing for the document reads, confirms and publish. 6000 keeps
+# it the tightest of the four per wait (2000s) while making the retrains this
+# task now REQUIRES to complete affordable.
 run_limits:
   max_turns: 120
-  task_timeout: 2400
+  task_timeout: 6000
   turn_timeout: 1800
 
 # driver: docker (NOT tempdir) is required. `uip ixp` ships as the separate


### PR DESCRIPTION
## Problem

The full-lifecycle e2e could pass without ever observing a second model version — no improvement round-trip demonstrated.

Two things allowed it. The checker:

```python
if improved_version == baseline_version:
    log_info(f"ModelVersion unchanged at {baseline_version} — no new version yet (acceptable)")
```

and the task prompt, which actively *instructed* that outcome:

> `improved_metrics.json` — full metrics response after the improvement and retrain. **If retrain has not completed after a few minutes of polling, capture the current metrics and proceed rather than waiting indefinitely.**

So `improved_metrics.json` could be a re-read of the baseline and still score the 5.0 integrity criterion.

## Fix

Require a strict advance — `improved ModelVersion > baseline` — and change the prompt to match, so the graded behavior and the instruction agree:

> Capture it only once the retrain has produced a NEW model version: its `ModelVersion` must be higher than `baseline_metrics.json`'s. Re-reading the baseline version does not count.

## Why this verifies all three waits

The lifecycle waits three times — after upload (predictions appear), after confirming labellings (first version trains and validates), after the prompt update (second version). Only **two** version points are observable: per the CLI reference, a project with no confirmed labellings has no trained model at all, so `get-metrics` returns `not_found` and the post-upload wait has nothing to number.

The strict advance covers all three anyway, transitively:

| Wait | Proven by |
|---|---|
| after upload | a validated baseline requires predictions to have arrived to confirm labels against |
| after confirming labellings | baseline has populated `Fields[]` and an int `ModelVersion` |
| after the prompt update | `improved > baseline` |

## History: this changes a day-one decision, not later erosion

I initially wrote this up as reverting part of #1865. That was wrong. The tolerance is **original**, from #1202 (2026-06-09), the commit that added the task:

```python
log_info(f"ModelVersion unchanged at {baseline_version} - re-label produced no new training signal (acceptable)")
```

`git log -S'capture the current metrics'` shows the prompt sentence came from #1202 as well. Both were the author's original design.

The two later PRs relaxed different things and are untouched here:

| PR | What it relaxed | Still in effect? |
|---|---|---|
| #1814 (Jul 2) | stopped grading F1 direction | yes - delta printed, never gated |
| #1865 (Jul 6) | advanced version + identical `Fields[]`: fail -> warn | yes - still only WARNs |

Those hold up: one flipped prediction swings F1 on a 3-document fixture. A version bump is a server-side fact, not fixture noise, which is why it can be gated without reintroducing that flakiness.

**The claim being rejected** is the original rationale - "re-label produced no new training signal". The task requires `fields update-prompts`, and the skill documents in two places (SKILL.md pitfalls, cli-reference) that any change to model inputs *including instructions* triggers a full retrain. If that is accurate, a completed retrain always advances the version, so an unchanged version means the capture happened too early or `update-prompts` did not take effect - both real failures.

**Risk if the original comment was right instead:** if instruction updates do *not* trigger a retrain, and a re-label confirms identical labels, a correct run could legitimately show no new version and would now fail. The skill's documented behaviour is the basis for gating; if the run shows otherwise, that is the thing to revisit.
## Second commit: the budget this task never got

Requiring a real retrain is pointless if the task cannot afford to wait for one. `full_lifecycle` waits for **three** retrains on the smallest budget of any training-heavy IXP task:

| Task | retrain waits | `task_timeout` | per wait |
|---|---|---|---|
| `labelling_correctness` | 1 | 3600 | 3600s |
| `publish_lifecycle` | 2 | 6000 | 3000s |
| `versions_and_metrics` | 2 | 6000 | 3000s |
| `full_lifecycle` (before) | **3** | **2400** | **800s** |
| `full_lifecycle` (after) | 3 | 6000 | 2000s |

#1818 raised the integration tasks from 3000 to 6000 because training took longer than the budget allowed. This task never got the same treatment. At 800s per wait, one wait running to the documented 5-check ceiling consumed 600s and left almost nothing for three document reads, the confirms and the publish.

6000 matches the highest sibling and still leaves this the tightest of the four per wait. Gating on a real retrain while budgeting 800s for it would only convert a false pass into a false failure.

**This is also the most likely explanation for the 0.00** that the version gate alone does not address, and it is better evidenced than anything in the guide: the task was under-budgeted by roughly 4x per wait against the standard its own siblings were raised to.
## What I checked

Static only — the task has not been re-run:

- `check_full_lifecycle.py` parses; the gate is now `log_fail`
- `full_lifecycle.yaml` parses; 13 criteria, total weight 23.5 (unchanged)
- No `capture the current metrics` / `waiting indefinitely` instruction remains in the prompt

Running `skill-ixp-e2e-full-lifecycle` is what would show whether the retrains complete inside the window on the staging tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
