### PR TITLE
fix(maestro-flow): guard against wholesale Write clobbering CLI-owned connector bindings

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -85,7 +85,7 @@ Reach for `jq` / `python3` only when JMESPath cannot express the operation (mult
 ### Why scripting is approval-gated
 
 - `Edit` on nested JSON is fragile. Indented sibling fields, trailing commas, and quote styles all break the exact-match constraint. One byte of drift, no edit applied.
-- Whole-file `Write` is safe but lossy — every field has to round-trip through chat, and large `.flow` files (>500 lines once layout, definitions, and bindings settle) blow the read budget. Use `Write` only for new flows or full reshapes.
+- Whole-file `Write` is lossy — every field has to round-trip through chat, and large `.flow` files (>500 lines once layout, definitions, and bindings settle) blow the read budget. Use `Write` only for new flows or full reshapes; on a flow with connector / managed-HTTP nodes it silently clobbers CLI-owned `bindings[]` / `inputs.detail` (invisible to `flow validate`) — `Edit` in place instead.
 - `python3 -c` / heredoc is a fallback for structural rewrites that are too brittle for `Edit` and too large for safe whole-file `Write`. Use it only after surfacing the trade-offs and getting explicit user approval.
 
 ---

--- a/skills/uipath-maestro-flow/references/author/references/editing-operations.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations.md
@@ -8,7 +8,7 @@ Strategy selection and shared concepts for modifying `.flow` files. Direct `.flo
 >
 > 1. **CLI-managed carve-outs only** → use the relevant plugin workflow for connector activity, connector-trigger, or managed HTTP operations when the CLI populates product-managed state (`inputs.detail`, `bindings_v2.json`, connection resources).
 > 2. **Any structural `.flow` mutation** (add/delete OOTB nodes, add/delete edges, add/edit variables, in-place value tweaks, output mapping, subflows, scheduled triggers, non-connector resources, inline-agent node/wiring) → `Edit`.
-> 3. **Wholesale file rewrite** (only when ≥70% of nodes change, e.g., scaffolding from a template) → `Write`.
+> 3. **Wholesale file rewrite** (only when ≥70% of nodes change, e.g., scaffolding from a template) → `Write` — but never on a flow that already contains CLI-owned nodes (connector, connector-trigger, managed HTTP): the rewrite clobbers their CLI-owned `bindings[]` / `inputs.detail`, and `flow validate` won't catch it. Use `Edit` (rung 2), or re-run `node configure` afterward.
 > 4. **Anything else** → STOP and ask the user. A scripting language is a last resort: surface the trade-offs (state bypass, opaque diff, no interruption point) and present finite options — typically **Use `Edit` instead** / **Use `Write` (full rewrite)** / **Approve the script for this change** / **Cancel** / **Something else**. Only proceed after the user explicitly approves that path for this specific change. See the dropdown question rule in [SKILL.md](../../../SKILL.md).
 
 ### Why not Python / Node / jq / sed?


### PR DESCRIPTION
## Motivation

The `skill-flow-slack-weather-pipeline` maestro-flow eval fails repeatedly (multiple times/week). Root cause from a FAILURE artifact: `flow debug` faults at the first connector node with `[102001] Integration Services resource not found`.

The flow's top-level `bindings[]` was malformed — the two connections (Slack + Open-Meteo) collapsed into a single shared `FolderKey` binding pointing at the wrong folder. The agent produced this by using a wholesale **`Write`** to drop user-owned script/end nodes onto a flow whose connector `bindings[]` were **CLI-owned** — the full-file rewrite reproduced-and-broke those bindings. `flow validate` passed (it never checks `bindings[]`); only `flow debug` caught it.

The skill already warns about this "validate passes, debug fails on bindings" shape — but **only for user-owned resource nodes** (`CAPABILITY.md`). There was no equivalent guardrail for **connector** nodes at the decision point the agent hit: `Write` vs `Edit`.

## Change

Docs-only. Adds the guardrail where the choice is made, kept to the principle (mechanism specifics already live in `connector/impl.md`):

- **`editing-operations.md`** — Tool Selection Ladder rung 3: never wholesale-`Write` a flow that already contains CLI-owned connector / connector-trigger / managed-HTTP nodes; it clobbers their `bindings[]` / `inputs.detail` and `flow validate` won't catch it. Use `Edit`, or re-run `node configure` after.
- **`editing-operations-json.md`** — drops the misleading "`Write` is **safe** but lossy" claim and notes the same clobber.

No test changes — `check_slack_weather_pipeline.py` is a legitimate end-to-end debug+verdict check; the defect was in the produced artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
