### PR TITLE
fix(case): fix single statement broken into multiple lines

### DIFF
--- a/skills/uipath-maestro-case/assets/templates/sdd-template.md
+++ b/skills/uipath-maestro-case/assets/templates/sdd-template.md
@@ -6,10 +6,7 @@
 
 ## Instructions for SDD Generation
 
-You are generating an **SDD — a case definition blueprint** (NOT a traditional
-solution design document). Every section maps directly to what the UiPath Case
-Designer actually consumes. A developer reading this document should be able to
-build the case in the Case Designer without guessing.
+You are generating an **SDD — a case definition blueprint** (NOT a traditional solution design document). Every section maps directly to what the UiPath Case Designer actually consumes. A developer reading this document should be able to build the case in the Case Designer without guessing.
 
 **Inputs:**
 - Phase 0 interview answers (free-text + AskUserQuestion picks) — primary source
@@ -245,12 +242,7 @@ DO NOT include in Configuration:
 - Meta notes like `No required event parameters` or `No user filter` (absence is the default; the skill discovers required params at `case spec` time).
 - Connector activity slug, HTTP method, or any spec-discovered detail.
 
-> **Tenant object starts are still event triggers.** If the user says a case starts
-> when a tenant case-entity / data-object record is created, author
-> `Intsvc.EventTrigger` with that object name as Source. Do NOT downgrade to
-> `Manual` just because the eval sandbox or current tenant may not have the
-> object provisioned. Planning/implementation preserve unresolved event triggers
-> as placeholders.
+> **Tenant object starts are still event triggers.** If the user says a case starts when a tenant case-entity / data-object record is created, author `Intsvc.EventTrigger` with that object name as Source. Do NOT downgrade to `Manual` just because the eval sandbox or current tenant may not have the object provisioned. Planning/implementation preserve unresolved event triggers as placeholders.
 
 ### Case Exit Conditions
 

--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -215,12 +215,7 @@ Procedure:
 3. **Inventory finalize.** After last T-entry, Edit the inventory section with class-by-class counts (per §4.0 cross-check table).
 4. **`registry-resolved.json`.** Same section-batched discipline — one Read per section, N Edit-appends, no re-Read between siblings.
 
-**T-entry heading contract.** Every declaration is its own level-two heading in
-the exact form `## T<n>: <action>`. Do not use level-three-or-deeper headings
-for T-entries, and do not nest a task beneath a stage's T-entry. A task
-heading must quote its display name, for example
-`## T08: Add wait-for-timer task "First Step" to "Process"`. This keeps the
-plan independently addressable by Phase 2 and by plan validators.
+**T-entry heading contract.** Every declaration is its own level-two heading in the exact form `## T<n>: <action>`. Do not use level-three-or-deeper headings for T-entries, and do not nest a task beneath a stage's T-entry. A task heading must quote its display name, for example `## T08: Add wait-for-timer task "First Step" to "Process"`. This keeps the plan independently addressable by Phase 2 and by plan validators.
 
 Why: section-batched round-trips keep tool-call transcript reviewable, preserve rollback granularity at section boundary, allow mid-run interruption recovery via re-Read + resume from next un-applied T-entry, and surface omissions before they propagate — without paying a per-T-entry Read tax that inflates inference latency by ~5s per turn.
 
@@ -385,19 +380,8 @@ Treat the generated `tasks.md` as approved and proceed directly to Phase 2 by de
 
 Re-read `tasks.md` before proceeding to Phase 2 (see [implementation.md](implementation.md)); context may have compacted during planning. `tasks.md` is complete handoff artifact — all resolved IDs, inputs, outputs, and references captured there.
 
-**Plan-shape gate.** Before Phase 2, re-read every §4.6 task T-entry itself
-(not the §4.7 condition entries) and confirm it literally contains its own
-`- activation-mode:` line and its own `- entry-rule:` line — **exactly one of
-each, colocated on the task's own T-entry** — and that the pair is legal for
-that mode. Re-run the §4.6 Activation-mode audit over the finished plan,
-covering all six modes, not just `sequential`.
+**Plan-shape gate.** Before Phase 2, re-read every §4.6 task T-entry itself (not the §4.7 condition entries) and confirm it literally contains its own `- activation-mode:` line and its own `- entry-rule:` line — **exactly one of each, colocated on the task's own T-entry** — and that the pair is legal for that mode. Re-run the §4.6 Activation-mode audit over the finished plan, covering all six modes, not just `sequential`.
 
-**Known failure pattern:** deferring the rule to a *separate* §4.7
-task-entry-condition entry (`rule-type:`) does not satisfy this gate —
-`caseplan.json` can end up fully correct while `tasks.md` itself still fails
-this check, because §4.6 and §4.7 are graded as separate artifacts. See
-[task-entry-conditions/planning.md § Phase 1 Plan Presentation Contract](plugins/conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract)
-for the compliant §4.6 shape.
+**Known failure pattern:** deferring the rule to a *separate* §4.7 task-entry-condition entry (`rule-type:`) does not satisfy this gate — `caseplan.json` can end up fully correct while `tasks.md` itself still fails this check, because §4.6 and §4.7 are graded as separate artifacts. See [task-entry-conditions/planning.md § Phase 1 Plan Presentation Contract](plugins/conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract) for the compliant §4.6 shape.
 
-Correct the plan before building; validation of `caseplan.json` cannot detect
-a malformed Phase 1 handoff.
+Correct the plan before building; validation of `caseplan.json` cannot detect a malformed Phase 1 handoff.

--- a/skills/uipath-maestro-case/references/sdd-generation-rules.md
+++ b/skills/uipath-maestro-case/references/sdd-generation-rules.md
@@ -329,12 +329,7 @@ Required whenever **any** SLA is configured — case, stage, or `action` task. O
 
 > Variable mapping (which trigger payload field populates which case variable) is declared in **§1.5 Case Variables** via the `sourceTriggers` / `sourceFields` columns — NOT in this table. The Triggers table only identifies and configures each trigger; payload extraction is owned by Case Variables.
 
-> **Tenant object starts are not Manual.** If the user says a case starts when a
-> tenant case-entity / data-object record is created, record an
-> `Intsvc.EventTrigger` row with the object name as Source. Missing tenant
-> provisioning, absent local registry data, or unresolved connection details
-> become an unresolved event trigger / placeholder later; they are never a reason
-> to change the SDD trigger type to `Manual`.
+> **Tenant object starts are not Manual.** If the user says a case starts when a tenant case-entity / data-object record is created, record an `Intsvc.EventTrigger` row with the object name as Source. Missing tenant provisioning, absent local registry data, or unresolved connection details become an unresolved event trigger / placeholder later; they are never a reason to change the SDD trigger type to `Manual`.
 
 Unresolved `Intsvc.EventTrigger` resolution (`connectionId` / `activityTypeId` missing) → `high`-severity review item.
 


### PR DESCRIPTION
some single statements were broken into multiple lines, sometimes it may have impact on the result, especially for codex