### PR TITLE
docs(maestro-flow): note refresh shell-ifies the parent .flow for inline agents

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/inline-agent/impl.md
@@ -401,6 +401,8 @@ uip maestro flow validate <FlowName>.flow --output json
 
 > Current validator requirement: `uip maestro flow validate` rejects flows whose `uipath.agent.autonomous` node lacks non-empty `inputs.systemPrompt` / `inputs.userPrompt`. Include placeholder values on the flow node, but keep the canonical prompts in the inline agent's `agent.json`.
 
+> **Refresh also shell-ifies the parent `.flow` (self-contained flows).** When a flow was authored self-contained in Studio Web, its `.flow` embeds the inline agent's prompts/model/guardrails and each resource node's config **inline** (not just in the `<projectId>/` sidecar). Since you edit the **sidecar**, that stale embed would shadow your edits when the flow is re-opened in Studio Web (the embed wins over the sidecar on load). So `uip agent refresh --inline-in-flow` strips this agent's embedded config back out of the parent `.flow` — leaving only structural inputs (`source`, `agentInputVariables`, etc.) on the agent node and `{source, detail, itemsDescription}` on its resource nodes — so Studio Web re-hydrates the cluster from your freshly-written sidecar on import. It is **scoped to the agent being refreshed** (siblings untouched), a **no-op** for flows authored from scratch via the CLI (already shells), and **best-effort** (a failure never fails refresh). When it acts, the JSON output carries `FlowShellified: true` and `FlowResourceNodesStripped: <n>`. You author the sidecar (`agent.json` + `resources/`); refresh keeps the `.flow` a shell — do not hand-embed prompts/config back into the flow node.
+
 ## Debug
 
 | Error | Cause | Fix |


### PR DESCRIPTION
Documents that `uip agent refresh --inline-in-flow` shell-ifies the parent `.flow` — it strips the refreshed inline agent's embedded config back to a legacy shell (structural inputs on the agent node, `{source, detail, itemsDescription}` on resource nodes). So authors know refresh keeps the `.flow` a shell, hydration comes from the sidecar on Studio Web import, and they should not hand-embed prompts/config back into the flow node.

Adds one blockquote note to the inline-agent plugin's `impl.md` (Refresh & Validate section).

Companion to the CLI change: UiPath/cli#3423.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
