### PR TITLE
MST-13189: remove stale case priority in sdd of tests

### DIFF
--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/fixtures/sdd.md
@@ -33,7 +33,6 @@
 | Case Name | AgedInvoiceResolution |
 | Case Description | Registers an aged invoice case, triages it, captures AP ownership, and closes it, with interrupting SLA-escalation and automation-incident lanes. Compact connector-free proof-of-value variant. |
 | Case Identifier | Type: constant. Prefix: AIR |
-| Priority | Choiceset: Low, Medium, High, Critical — Default: High |
 | Case-Level SLA | 90 m |
 | SLA Type | time-based |
 | SLA Title | Case Resolution SLA |

--- a/tests/tasks/uipath-maestro-case/athena_cm_event/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/athena_cm_event/fixtures/sdd.md
@@ -23,7 +23,6 @@
 | Case Name | AthenaCMEventCase |
 | Case Description | Coordinates three operational stages for an event-directed case. |
 | Case Identifier | Type: external. Source: `=vars.InstanceExternalId` |
-| Priority | Choiceset: Normal — Default: Normal |
 | Case-Level SLA | 10 d |
 | SLA Type | time-based |
 | Case App | Enabled |

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_activity/connector_activity.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_activity/connector_activity.yaml
@@ -37,7 +37,6 @@ initial_prompt: |
   | Case Name | ConnectorActivityCase |
   | Case Description | Single-node case that posts a Slack message via a connector activity. |
   | Case Identifier | Type: constant. Prefix: CAC |
-  | Priority | Choiceset: Low, Medium, High — Default: Medium |
   | Case-Level SLA | — |
   | SLA Type | — |
 

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
@@ -42,7 +42,6 @@ initial_prompt: |
   | Case Name | ConnectorWaitCase |
   | Case Description | Case whose first task is event-triggered by an inbound Outlook 365 email before the case waits for the same event. |
   | Case Identifier | Type: constant. Prefix: CWC |
-  | Priority | Choiceset: Low, Medium, High — Default: Medium |
   | Case-Level SLA | — |
   | SLA Type | — |
 

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/fixtures/sdd.md
@@ -39,7 +39,6 @@
 | Case Name | ExpenseReimbursementRunnable |
 | Case Description | Handles an employee-submitted expense from submission through manager and finance approval to payment and close-out, ending in Approved, Rejected, or Withdrawn. Fully-automated runnable variant bound to generic tenant resources. |
 | Case Identifier | Type: constant. Prefix: EXP |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | 15 m |
 | SLA Type | time-based |
 | Case App | Disabled |

--- a/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/golden_rebuild/cm_golden_expense/fixtures/sdd.md
@@ -28,7 +28,6 @@
 | Case Name | Coding-Agent-CM-Golden-Expense-Reporting-Manual-Case |
 | Case Description | Manages an employee expense request end to end: automated analysis (agent → process → RPA), manager approval with a rework exception lane, an API-workflow call and a child case, an event-driven stage entered by an inbound HTTP webhook, a user-selected routing stage, and a final completion-delay stage. |
 | Case Identifier | Type: constant. Prefix: `EXP` |
-| Priority | — |
 | Case-Level SLA | 1 h |
 | SLA Type | time-based |
 | Case App | Enabled |

--- a/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
@@ -33,7 +33,6 @@ initial_prompt: |
   | Case Name | InvoiceReviewCase |
   | Case Description | Reviews an invoice and records the decision. |
   | Case Identifier | Prefix: IRC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_01_action_schema_design.yaml
@@ -46,7 +46,6 @@ initial_prompt: |
   | Case Name | VendorPOReviewCase |
   | Case Description | Procurement officer reviews a vendor purchase order. |
   | Case Identifier | Prefix: VPR, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: High |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -234,6 +234,6 @@ post_run:
 
 run_limits:
   expected_turns: 94
-  task_timeout: 900
+  task_timeout: 1200
   max_turns: 120
-  turn_timeout: 900
+  turn_timeout: 1200

--- a/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_02_result_downstream.yaml
@@ -43,7 +43,6 @@ initial_prompt: |
   | Case Name | ExpenseApprovalCase |
   | Case Description | Reviews and records an employee expense decision. |
   | Case Identifier | Prefix: EAC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_03_boolean_decision.yaml
@@ -47,7 +47,6 @@ initial_prompt: |
   | Case Name | VendorApprovalCase |
   | Case Description | Compliance officer reviews a new vendor for onboarding. |
   | Case Identifier | Prefix: VAC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/quality_04_skeleton_completion_report.yaml
@@ -54,7 +54,6 @@ initial_prompt: |
   | Case Name | ContractReviewCase |
   | Case Description | Legal reviewer approves a contract before close. |
   | Case Identifier | Prefix: CRC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_01_action_task_placed.yaml
@@ -34,7 +34,6 @@ initial_prompt: |
   | Case Name | InvoiceApprovalCase |
   | Case Description | Tracks an invoice through manager approval. |
   | Case Identifier | Prefix: IAC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_02_stage_exit_on_action.yaml
@@ -44,7 +44,6 @@ initial_prompt: |
   | Case Name | PurchaseApprovalCase |
   | Case Description | Tracks a purchase through manager approval and recording. |
   | Case Identifier | Prefix: PAC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-case/hitl/smoke_03_multi_outcome_routing.yaml
@@ -48,7 +48,6 @@ initial_prompt: |
   | Case Name | LeaveRequestCase |
   | Case Description | Manager review of an employee leave request. |
   | Case Identifier | Prefix: LRC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/io_binding/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/io_binding/fixtures/sdd.md
@@ -11,7 +11,6 @@ forms against existing deterministic tenant resources.
 | Case Name | IoBindingCase |
 | Case Description | Sequential task I/O binding matrix using existing tenant resources. |
 | Case Identifier | Prefix: IOB, Type: constant |
-| Priority | Choiceset: Low, Medium, High - Default: Medium |
 | Case-Level SLA | 1 d |
 | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
+++ b/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
@@ -29,7 +29,6 @@ initial_prompt: |
   | Case Name | TimerLogCase |
   | Case Description | Two-stage timer flow. |
   | Case Identifier | Prefix: TLC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/branching_exit/branching_exit.yaml
@@ -48,7 +48,6 @@ initial_prompt: |
   | Case Name | BranchingExit |
   | Case Description | Triage stage routes to one of three downstream branches via stage-exit conditions covering wait-for-user, exit-only with marks-complete:false, and exit-only with marks-complete:true. |
   | Case Identifier | Prefix: BE, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/case_exit_full/case_exit_full.yaml
@@ -36,7 +36,6 @@ initial_prompt: |
   | Case Name | CaseExitFull |
   | Case Description | Three-stage linear flow with three case-exit conditions covering three rule-types and both marks-case-complete shapes. |
   | Case Identifier | Prefix: CEF, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/exception_stage/exception_stage.yaml
@@ -48,7 +48,6 @@ initial_prompt: |
   | Case Name | ExceptionStage |
   | Case Description | One regular Process stage plus two secondary stages (Issues returns to origin; Critical exits the case). |
   | Case Identifier | Prefix: ES, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/fan_in_join/fan_in_join.yaml
@@ -48,7 +48,6 @@ initial_prompt: |
   | Case Name | FanInJoin |
   | Case Description | Diamond topology Triage → {Validate, Enrich} → Join; four skeleton tasks cover four distinct plugin types; Validate is an empty pass-through branch. |
   | Case Identifier | Prefix: FIJ, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/in_arg_trigger_bind/in_arg_trigger_bind.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/in_arg_trigger_bind/in_arg_trigger_bind.yaml
@@ -45,7 +45,6 @@ initial_prompt: |
   | Case Name | InArgTriggerBind |
   | Case Description | Two triggers; two In-args bound to different triggers via sourceTriggers. |
   | Case Identifier | Prefix: IAT, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/linear_three_stages/linear_three_stages.yaml
@@ -48,7 +48,6 @@ initial_prompt: |
   | Case Name | LinearThreeStages |
   | Case Description | Three regular stages chained linearly behind a manual trigger; exercises stage-entry conditions, parallel wait-for-timer tasks, and the full Variable / In / Out argument trio. |
   | Case Identifier | Prefix: LTS, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/multi_trigger/multi_trigger.yaml
@@ -45,7 +45,6 @@ initial_prompt: |
   | Case Name | MultiTrigger |
   | Case Description | Three case-level triggers (manual + two timer triggers) each fire the case into a single Run stage. |
   | Case Identifier | Prefix: MT, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/sla_with_escalation/sla_with_escalation.yaml
@@ -55,7 +55,6 @@ initial_prompt: |
   | Case Name | SlaWithEscalation |
   | Case Description | Root-level SLA with two conditional overrides (Urgent 30min, Standard 5d) and a default of 3w; Resolve stage carries an Urgent 2w conditional override plus its own 1m default. |
   | Case Identifier | Prefix: SWE, Type: constant |
-  | Priority | Choiceset: Urgent, Standard - Default: Standard |
   | Case-Level SLA | 3w (default) |
   | SLA Type | Conditional (two condition-driven overrides + default) |
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/task_dependency_chain/task_dependency_chain.yaml
@@ -49,7 +49,6 @@ initial_prompt: |
   | Case Name | TaskDependencyChain |
   | Case Description | Three-stage flow exercising task-driven stage completion, runs-sequentially / adhoc / selected-tasks-completed task-entry rules, and a non-timer skeleton task in a downstream stage. |
   | Case Identifier | Prefix: TDC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | Not specified |
   | SLA Type | Not specified |
 

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/fixtures/sdd.draft.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft/fixtures/sdd.draft.md
@@ -32,7 +32,6 @@ A Case Definition Blueprint for the Helix end-to-end candidate hiring process â€
 | Case Name | CandidateInterview |
 | Case Description | Manages the end-to-end hiring lifecycle for a candidate at Helix, from application receipt through recruiter screening, technical evaluation, optional onsite interview loop, compensation debrief, offer issuance via DocuSign, and final employee record creation in Workday. |
 | Case Identifier | Type: constant. Prefix: CI |
-| Priority | Choiceset: Low, Medium, High, Critical â€” Default: Medium |
 | Case-Level SLA | 42 d |
 | SLA Type | time-based |
 

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/fixtures/sdd.draft.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_loan/fixtures/sdd.draft.md
@@ -36,7 +36,6 @@ Rejected).
 | Case Name | LoanOrigination |
 | Case Description | Manages the end-to-end origination lifecycle for commercial term loans at Accrual Capital, from initial application receipt through funding or adverse disposition. Covers ~600 loans per month in the $1M–$25M range with a 30–45 day target lifecycle. |
 | Case Identifier | Type: constant. Prefix: LO |
-| Priority | Choiceset: Low, Medium, High, Critical — Default: Medium |
 | Case-Level SLA | 45 d |
 | SLA Type | time-based |
 

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_picker/fixtures/sdd.draft.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_picker/fixtures/sdd.draft.md
@@ -21,7 +21,6 @@ A Case Definition Blueprint for onboarding a new supplier at Northwind: collect 
 | Case Name | VendorOnboarding |
 | Case Description | Onboards a new supplier at Northwind from document collection through vendor approval, with a manually-launched compliance hold lane. |
 | Case Identifier | Type: constant. Prefix: VO |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | — |
 | SLA Type | — |
 

--- a/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_reject/fixtures/sdd.draft.md
+++ b/tests/tasks/uipath-maestro-case/phase_0_finalize_draft_reject/fixtures/sdd.draft.md
@@ -22,7 +22,6 @@ A Case Definition Blueprint for reviewing a community grant application at River
 | Case Name | GrantReview |
 | Case Description | Reviews a community grant application at Rivermark Foundation from eligibility review through award or rejection. |
 | Case Identifier | Type: constant. Prefix: GR |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | — |
 | SLA Type | — |
 

--- a/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_action_case_sdd_only/fixtures/sdd.md
@@ -11,7 +11,6 @@
 | Case Name | PortableActionCaseHandoff |
 | Case Description | Plans resolved and unresolved Action App tasks plus a child-case task while treating this SDD as authoritative over any stale registry cache. |
 | Case Identifier | Type: constant. Prefix: PAC |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | — |
 | SLA Type | — |
 | Case App | Disabled |

--- a/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_sdd_only/fixtures/sdd.md
@@ -11,7 +11,6 @@
 | Case Name | CrossMachineRegistryHandoff |
 | Case Description | Runs two existing tenant resources from an approved SDD whose Phase 0 registry cache was not transferred. |
 | Case Identifier | Type: constant. Prefix: XMH |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | — |
 | SLA Type | — |
 | Case App | Disabled |

--- a/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/fixtures/sdd.md
+++ b/tests/tasks/uipath-maestro-case/registry_handoff_stale_runnable/fixtures/sdd.md
@@ -11,7 +11,6 @@
 | Case Name | StaleRunnableRegistryHandoff |
 | Case Description | Runs two existing tenant resources from an approved SDD whose staged Phase-0 registry cache named the runnable resources differently (stale). |
 | Case Identifier | Type: constant. Prefix: SRH |
-| Priority | Choiceset: Low, Medium, High — Default: Medium |
 | Case-Level SLA | — |
 | SLA Type | — |
 | Case App | Disabled |

--- a/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/agent/agent.yaml
@@ -32,7 +32,6 @@ initial_prompt: |
   | Case Name | AgentSingleCase |
   | Case Description | Single-node case that runs the CountLetters agent on a fixed input word. |
   | Case Identifier | Prefix: ASC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/api_workflow/api_workflow.yaml
@@ -32,7 +32,6 @@ initial_prompt: |
   | Case Name | ApiWorkflowSingleCase |
   | Case Description | Single-node case that invokes the NameToAgeFixed2 API workflow with a fixed name. |
   | Case Identifier | Prefix: AWS, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/case_management/case_management.yaml
@@ -34,7 +34,6 @@ initial_prompt: |
   | Case Name | ParentCaseSingle |
   | Case Description | Single-node case that spawns the published CaseTest child case as a nested case task. |
   | Case Identifier | Prefix: PCS, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -33,7 +33,6 @@ initial_prompt: |
   | Case Name | ProcessSingleCase |
   | Case Description | Single-node case that runs the ProcurementProcess process. |
   | Case Identifier | Prefix: PSC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/rpa/rpa.yaml
@@ -32,7 +32,6 @@ initial_prompt: |
   | Case Name | RpaSingleCase |
   | Case Description | Single-node case that runs the ProjectEuler RPA workflow on a fixed problem number. |
   | Case Identifier | Prefix: RSC, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | 1 d |
   | SLA Type | Static |
 

--- a/tests/tasks/uipath-maestro-case/single_node/run_once_envelope/run_once_envelope.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/run_once_envelope/run_once_envelope.yaml
@@ -37,7 +37,6 @@ initial_prompt: |
   | Case Name | RunOnceEnvelopeCase |
   | Case Description | Holds a record under retention review with a frozen snapshot, a recurring reminder, and an escalation hold. |
   | Case Identifier | Prefix: RO, Type: constant |
-  | Priority | Choiceset: Low, Medium, High - Default: Medium |
   | Case-Level SLA | - |
   | SLA Type | - |
 


### PR DESCRIPTION
Remove stale case priority in sdd.md in case coder eval tests. When using sonnet-5, it would keep searching and thinking for the stale priority, waste time and tokens, and eventually make many tests fail.