### PR TITLE
fix(case): preserve connector wait activation

### DIFF
--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
@@ -40,12 +40,14 @@ Populate `outputs:` using the shared [I/O-binding output-list contract](../../va
   - <SDD output row, copied verbatim>
 - isRequired: true
 - runOnlyOnce: false
-- activation-mode: event-triggered   # required; normally event-triggered for a connector event wait
-- entry-rule: wait-for-connector   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <copy the supplied/approved SDD activation mode>
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>
 - order: after T<m>
 - lane: <n>
 - verify: Confirm task created with correct event parameters
 ```
+
+Task type never supplies activation semantics. Copy the SDD pair losslessly: a stage-entry listener uses `parallel` + `current-stage-entered`; a listener after an immediate predecessor uses `parallel-after-predecessor` + `runs-sequentially`; an event-gated task uses `event-triggered` + `wait-for-connector`; any other explicitly authored legal task-entry rule remains authoritative.
 
 ## Unresolved Fallback
 

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""ConnectorWaitCase: a RESOLVED wait-for-connector task is wired.
+"""ConnectorWaitCase: connector task type and activation stay independent.
 
 Asserts the connector-trigger plugin resolved a real Integration Service event
 into the caseplan (Rule 8 — no fabricated IDs) with the correct serviceType,
-rather than leaving a `data: {}` skeleton. Does NOT run debug: a
-wait-for-connector suspends waiting for a real external event.
+rather than leaving a `data: {}` skeleton, while preserving the typed task's
+positional entry rule. Does NOT run debug: a wait-for-connector suspends waiting
+for a real external event.
 """
 
 import os
@@ -29,6 +30,16 @@ def _find_task_by_label(plan: dict, label: str) -> dict:
         for task in iter_tasks(plan)
     ]
     sys.exit(f"FAIL: task {label!r} not found; saw {labels}")
+
+
+def _entry_rules(task: dict) -> list[dict]:
+    return [
+        rule
+        for condition in (task.get("entryConditions") or [])
+        for group in (condition.get("rules") or [])
+        for rule in (group or [])
+        if isinstance(rule, dict)
+    ]
 
 
 def main():
@@ -57,7 +68,26 @@ def main():
             f"got isRequired={event_task.get('isRequired')!r}"
         )
 
-    task = assert_task_type_present("wait-for-connector")
+    assert_task_type_present("wait-for-connector")
+    task = _find_task_by_label(plan, "Wait for reply email")
+    if task.get("type") != "wait-for-connector":
+        sys.exit(
+            "FAIL: 'Wait for reply email' must keep type='wait-for-connector'; "
+            f"got {task.get('type')!r}"
+        )
+    task_rules = _entry_rules(task)
+    if len(task_rules) != 1 or task_rules[0].get("rule") != "current-stage-entered":
+        sys.exit(
+            "FAIL: typed wait-for-connector task must preserve exactly one "
+            "current-stage-entered entry rule; "
+            f"got {task_rules!r}"
+        )
+    if "uipath" in task_rules[0]:
+        sys.exit(
+            "FAIL: typed wait-for-connector task's positional "
+            "current-stage-entered rule must not carry a connector uipath payload; "
+            f"got {task_rules[0].get('uipath')!r}"
+        )
     if task_is_skeleton(task):
         sys.exit(
             "FAIL: wait-for-connector task is a skeleton (missing data.typeId / "
@@ -81,7 +111,8 @@ def main():
         )
     print(
         f"OK: first task is event-triggered with wait-for-connector-only entry "
-        f"semantics; wait-for-connector task resolved "
+        f"semantics; typed wait-for-connector task preserves one positional "
+        f"current-stage-entered rule without connector uipath and is resolved "
         f"(displayName={task.get('displayName')!r}, "
         f"serviceType={svc}, connectorKey={ck!r}, typeId + connectionId set)"
     )

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
@@ -3,17 +3,20 @@ description: >
   Build a Case Management definition from an sdd.md whose first task is
   event-triggered via a `wait-for-connector` task-entry rule, followed by a
   `wait-for-connector` task (the 2nd previously-untested task type) that
-  suspends until an external Integration Service connector event arrives.
+  suspends until an external Integration Service connector event arrives while
+  preserving its supplied positional `current-stage-entered` activation rule.
   Exercises the connector-trigger plugin: `case spec --type trigger
   --input-details`, direct caseplan.json write of a resolved
   `type: "wait-for-connector"` node (`data.serviceType:
   "Intsvc.WaitForEvent"`, real `data.typeId` + `data.connectionId`), and the
   frontend event-triggered task mode where a first task keeps only
-  `wait-for-connector` and does not also get `current-stage-entered`. Stops at
-  validate + resolution assertions — NOT debug: a wait-for-connector suspends
-  waiting for a real event and validate cannot catch a mis-bound connector rule
-  (the skill's documented silent-failure surface). Requires cloud auth + a
-  healthy Integration Service connection for the named connector.
+  `wait-for-connector` and does not also get `current-stage-entered`, while the
+  typed connector-wait task keeps exactly one positional entry rule without a
+  connector payload. Stops at validate + resolution assertions — NOT debug: a
+  wait-for-connector suspends waiting for a real event and validate cannot catch
+  a mis-bound connector rule (the skill's documented silent-failure surface).
+  Requires cloud auth + a healthy Integration Service connection for the named
+  connector.
 tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:single-node, connector, feature:connector-trigger]
 max_iterations: 1
 
@@ -176,7 +179,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
+    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task whose sole entry rule remains current-stage-entered without a connector uipath payload (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
     command: "python3 $TASK_DIR/check_connector_wait.py"
     timeout: 60
     expected_exit_code: 0


### PR DESCRIPTION
## Context

The connector-trigger task planner was conflating **task type** with **task activation**. Its tasks.md example hardcoded every wait-for-connector task as:

- activation-mode: event-triggered
- entry-rule: wait-for-connector

That is not always correct. The wait-for-connector **task type** determines what the task does once armed: it waits for a connector event using connector configuration stored in the task data. The task-entry rule independently determines **when the listener is armed**, and the supplied or approved SDD remains authoritative.

Examples of valid activation pairs are:

- Stage-entry listener: parallel + current-stage-entered
- Listener created after an immediate predecessor: parallel-after-predecessor + runs-sequentially
- Event-gated task: event-triggered + wait-for-connector
- Any other explicitly authored legal task-entry rule remains unchanged

## Fix

- Replace the hardcoded activation pair in the connector-trigger planning template with placeholders that copy the activation mode and matching entry rule from the supplied or approved SDD.
- State explicitly that task type does not supply activation semantics.
- Preserve all existing connector resolution, connector task data, required fields, outputs, ordering, Rule 17 behavior, and unresolved fallback guidance.

## Regression scenario

The connector-wait coder-eval now proves the two concepts remain distinct in the same case:

1. **Process reply event**
   - Task type: process
   - Entry rule: wait-for-connector
   - The connector payload belongs on the event-gating entry rule.

2. **Wait for reply email**
   - Task type: wait-for-connector
   - Entry rule: current-stage-entered, copied from the SDD
   - The positional entry rule has no connector uipath payload.
   - The task data still contains the resolved Intsvc.WaitForEvent connector configuration, type ID, connection ID, and connector key.

This catches the original defect: a typed connector wait must not have its authored positional activation rewritten merely because its task type is wait-for-connector.

## Scope

This is a narrow bug fix, **not a skill-slimming or content-extraction change**. It changes only:

- skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
- tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
- tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py

No central planning authority, JSON implementation recipe, connector resolution/data behavior, fallback behavior, or Pillar-1 file is changed.

## Validation

- Writer checks: passed
- Changed-path and frozen Pillar-1 proofs: passed
- Task schema and CLI-verb lint: passed
- Skill quick validation: passed
- Fresh independent review: no findings
- Local connector-wait and Athena coder-evals: launched; final results pending
- Remote CM Golden Expense coder-eval on exact SHA 7bda7c608b423c32815165bdc40ec9bcf23dc03d: launched; final result pending