### PR TITLE
docs(maestro-flow): add file to the input-variable type enum; teach IxP fileRef wiring

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
+++ b/skills/uipath-maestro-flow/references/author/references/editing-operations-json.md
@@ -260,7 +260,7 @@ Use `Edit` to add an entry to `variables.globals`:
 {
   "id": "<VARIABLE_ID>",
   "direction": "in|out|inout",
-  "type": "string|number|boolean|object|array",
+  "type": "string|number|boolean|object|array|file",
   "defaultValue": "<OPTIONAL_DEFAULT>",
   "description": "<OPTIONAL_DESCRIPTION>"
 }
@@ -268,6 +268,7 @@ Use `Edit` to add an entry to `variables.globals`:
 
 For `out` variables: add output mapping to **every reachable End node** (see below).
 For `inout` variables: add `variableUpdates` entries on nodes that modify the state.
+Attachment-carrying inputs MUST use `"type": "file"` — `"object"` breaks attachment binding and faults IxP extraction with `[430002]` (see [plugins/ixp/impl.md#debug](plugins/ixp/impl.md#debug)).
 
 See [variables-and-expressions.md](../../shared/variables-and-expressions.md) for the full schema, type system, and scoping rules.
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
@@ -203,7 +203,7 @@ sufficient. There is no version of this node where omitting `outputs` is correct
 1. **`inputs.model` MUST be present and MUST be copied from `Data.Node.inputDefaults.model`.** Copy the blob verbatim — do not abbreviate, do not omit fields, do not invent fields that aren't there. The current deployment-node blob is `{ id, modelName, modelDisplayName, folderKey, folderName, folderPath, description }`; source every field from the actual `registry get` response, not from memory (older docs showed `fullyQualifiedName` / `kind` / `type` / `detailsUrl` / `async*` fields — these are NOT present on deployment nodes; do not add them). The `schema-definition` form section binds `inputs.model` to the `ixp-model-taxonomy` custom component, which destructures `modelName` and `folderKey` out of it. If `inputs.model` is undefined, clicking the node in Studio Web crashes the property panel with `Cannot destructure property 'modelName' of 't' as it is undefined` — and `flow validate` fails on it too (`ixp-node`: `inputs.model must be an object with non-empty string modelName and folderKey`).
    - **`inputs.model.modelName` MUST be a non-empty string.** For many published/OOB deployments `inputDefaults.model.modelName` comes back `null`, with the name carried in `inputDefaults.model.modelDisplayName` instead. When `modelName` is `null`/empty, set `inputs.model.modelName` to `modelDisplayName`. This is NOT synthesis — `modelDisplayName` is the model's own name from the same blob (and matches the flat `inputDefaults.modelName`). The `ixp-node` validator rejects a `null`/empty `inputs.model.modelName` (`flow validate` fails), and Studio Web crashes on it.
 2. **Flat mirrors stay alongside `inputs.model`.** `modelName`, `projectName`, `folderKey`, `folderName` are surfaced as disabled text fields in the `ixp-model` form section and are read directly from `inputs.*`, not from `inputs.model.*`.
-3. **`fileRef` is the only schema-required input** (`inputDefinition.required: ["fileRef"]`). Use `=js:$vars.<upstream>.output.<field>` per Critical Rule #13.
+3. **`fileRef` is the only schema-required input** (`inputDefinition.required: ["fileRef"]`). Use `=js:$vars.<upstream>.output.<field>` per Critical Rule #13. The upstream `<field>` variable MUST be declared `type: "file"` — `type: "object"` breaks attachment binding and faults extraction even when the `fileRef` expression itself is correct. See [Wiring `fileRef`](#wiring-fileref--file-variable-bound-to-the-trigger).
 4. **`outputs.output` AND `outputs.error` MUST both be present** — copy the fixed four-field literals from [Final shape](#final-shape); they are identical for every IxP node and need no `registry get` lookup. **`flow validate` hard-fails on the omission** — `ixp-node` emits `[nodes[<nodeId>].outputs.output] outputs.output must be present on the instance`, and the matching error for `outputs.error`.
 5. **No top-level `model` on the instance.** Studio Web–authored .flow files never carry one; the BPMN-format `model` envelope (with `context`, `version`, `inputs`, `outputs`) is emitted at serialize time only.
 6. **`inputs` MUST NOT contain `digitizationMode`, `documentTaxonomy`, `attachmentId`, `fileName`, or `mimeType`.** These five fields were on a prior schema and have been removed from the standalone IxP node. Including them is the most common training-data-recall mistake. The serializer defaults `digitizationMode` to `fileUpload` internally — there is no scenario where you should set it on the instance.
@@ -216,6 +216,34 @@ The `definitions[]` entry is copied verbatim from `registry get` (`Data.Node`) �
 ### `inputs.fileRef` vs the emitted `model.inputs[]` body
 
 `inputs.fileRef` is the source of truth. At BPMN serialize time, `packages/services/src/serialization/uipath-extension.ts:handleIxpExtraction` wraps the value into a `model.inputs[]` entry with target `bodyField` and body `{"downloadedFileOutput": <fileRef>}`. Edit `inputs.fileRef` only; never hand-edit the BPMN body.
+
+### Wiring `fileRef` — file variable bound to the trigger
+
+The canonical canvas-produced shape is a flow `in` variable of `type: "file"` bound to the trigger via `triggerNodeId`, with the IxP node's `fileRef` referencing it through the trigger's output:
+
+```json
+"variables": {
+  "globals": [
+    {
+      "id": "disputedInvoice",
+      "direction": "in",
+      "type": "file",
+      "triggerNodeId": "start"
+    }
+  ]
+}
+```
+
+Then on the IxP node:
+
+```json
+"inputs": {
+  "fileRef": "=js:$vars.start.output.disputedInvoice",
+  ...
+}
+```
+
+Populate that variable at runtime with `uip maestro flow debug --attachment <variableId>=<localPath>` (example: `--attachment disputedInvoice=./path/to/invoice.pdf`). The CLI uploads the file and binds it as a `{ ID, FullName, MimeType, Metadata }` Attachment object — keys are case-sensitive; `ID` is uppercase, not `Id`. The flag is repeatable; the `<variableId>` (left of `=`) must match a `variables.globals[]` entry's `id` — see [cli-commands.md — Pre-flight](../../../../shared/cli-commands.md#pre-flight---attachment-binding). Do not declare the variable as `type: "object"`, do not reference it as `=js:$vars.<variableId>` directly without the trigger output path, and do not pass a bare GUID/URL/path/`.ID`/`.FullName`.
 
 ### Optional `attachment` input (Orchestrator job attachments)
 
@@ -338,6 +366,7 @@ IxP also exposes classifier models (type `Classifier`) that label documents rath
 | Empty `$vars.{nodeId}.output` | Model's taxonomy doesn't match the document, or extraction silently returned no fields | Inspect the raw API response via `$vars.{nodeId}.error` first; if no error, run the extraction against the same document on the IxP product UI to compare |
 | `fileRef` not resolving | Expression references an upstream variable that isn't wired, or the upstream node didn't produce a file output | Verify the upstream node exports a file reference and that the `=js:$vars.{upstreamId}.output.<field>` expression matches |
 | `[430002] Invalid input on document extraction operation` at debug | `fileRef` bound to the attachment's `.ID` (or another scalar) instead of the attachment object — `flow validate` does not catch this | Bind the whole object: `=js:$vars.<upstream>.output.<attachment>` — drop the `.ID` |
+| `[430002] Invalid input on document extraction operation` at debug, backend detail `'downloadedFileOutput' is missing the required 'ID' field` | The `fileRef` expression is correct, but the source flow input is declared `"type": "object"` instead of `"type": "file"` — the attachment has nowhere to bind, so the variable holds a plain JSON object | Declare the input `type: "file"`. See [Wiring `fileRef`](#wiring-fileref--file-variable-bound-to-the-trigger). |
 | Extraction failed | Underlying IxP model errored (unsupported MIME type, corrupted file, service-side failure) | Check `$vars.{nodeId}.error.detail` for the IxP service response |
 | `uip maestro flow node configure` rejects with "not a connector type node" | Expected — IxP is not a connector. | Edit `inputs.*` in the `.flow` JSON directly. |
 | Studio Web: "Cannot destructure property 'modelName' of 't' as it is undefined" when clicking the node | `inputs.model` blob is missing or undefined. The `schema-definition` form section binds `inputs.model` to the `ixp-model-taxonomy` component, which destructures `modelName` and `folderKey` out of it. When `inputs.model` is missing, the destructure throws. | Copy `definition.inputDefaults.model` verbatim into the node instance's `inputs.model`. The blob carries `id`, `modelName`, `modelDisplayName`, `folderKey`, `folderName`, `folderPath`, `description`. See [JSON Structure](#json-structure). |


### PR DESCRIPTION
## Summary

CI run 30851925419 attempt 3: the resolution build declared its PDF input `"type": "object"` and faulted at IxP extraction with `[430002]` (`'downloadedFileOutput' is missing the required 'ID' field`) — the `fileRef` expression itself was correct. One-change from the passing build: `"object"` → `"file"` on the variable declaration.

Root cause is doc-induced, twice over:

1. `editing-operations-json.md`'s variable type enumeration — the doc an agent reads while writing the declaration — listed `string|number|boolean|object|array` with **no `file`**. The agent picked the closest documented type.
2. The IxP references never taught the file-input contract, while `summarize/` and `batch-transform/` teach it fully — right contract, wrong rooms for an IxP-path build.

`file` is first-class: flow-schema maps `type: "file"` → the `job-attachment` schema, the debug `--attachment` pre-flight requires it, and every passing resolution build declares it.

## Changes

- `editing-operations-json.md`: enumeration now includes `file` + one MUST-sentence with the `[430002]` consequence and a pointer to the IxP reference
- `ixp/impl.md`: Authoring rule #3 extended (source variable MUST be `file`); new "Wiring `fileRef`" section mirroring the canonical shape the summarize/batch-transform docs already use (declaration JSON, `fileRef` line, `--attachment` example, the case-sensitive `{ID, FullName, MimeType, Metadata}` contract, anti-patterns); new `[430002]` troubleshooting row keyed on the exact backend detail string, distinguishing this cause from the existing `.ID`-binding row

## Testing

- Docs-only change; links and anchors verified against existing files (`#attachment-preflight`, `cli-commands.md` pre-flight)
- Failure evidence: run 30851925419 attempt-3 artifact; passing reference: 2026-07-31 archived build (identical flow, `"type": "file"`)
