### PR TITLE
fix(case): align task activation planners

### DIFF
--- a/skills/uipath-maestro-case/references/planning.md
+++ b/skills/uipath-maestro-case/references/planning.md
@@ -315,23 +315,29 @@ Every task entry includes at least:
 - **runOnlyOnce** — from sdd.md (default `false` if not specified). Phase 0-generated SDDs should always state `Run Only Once: Yes/No`; when a user-authored SDD omits it, use the frontend/default-new-task behavior (`false`) and do not infer `true` from task type.
 - **isRequired** — from sdd.md (default `true` if not specified)
 - **order** — authoring order in `tasks.md` (`after T05`, etc.). It is not allowed to carry execution semantics by itself; execution is carried by `activation-mode` + `entry-rule`.
-- **lane** — integer task-set index, default increments per task within the stage starting at 0 for structural/layout compatibility. Lane does not express sequencing by itself; it controls the inner `data.tasks[lane][]` grouping only after `activation-mode` and `entry-rule` are decided. For a strict sequential chain, use consecutive single-task lanes (`[[A], [B], [C]]`) and never reuse a lane. Reuse the same lane only for tasks intentionally modeled as parallel siblings (`activation-mode: parallel`, `entry-rule: current-stage-entered`, same lane, and rationale says why they run together as `[[A, B], [C]]`).
+- **lane** — integer task-set index, default increments per task within the stage starting at 0 for structural/layout compatibility. Lane does not express sequencing by itself; it controls the inner `data.tasks[lane][]` grouping only after `activation-mode` and `entry-rule` are decided. For a strict sequential chain, use consecutive single-task lanes (`[[A], [B], [C]]`) and never reuse a lane. Reuse a lane only for explicit sibling grouping: independent stage-start siblings use `parallel` + `current-stage-entered`; siblings after the same immediate predecessor use `parallel-after-predecessor` + `runs-sequentially` and share that same next lane (`[[A], [B, C], [D]]`). The rationale must explain why the siblings run together.
 - **verify** — what the execution phase should check after running
 
 Additional fields are plugin-specific; read the plugin's `planning.md` before filling the entry.
 
 > **Activation-mode audit before writing §4.7.** After §4.6 is drafted and before any condition T-entry is written, scan every stage's task list and make the task mode visible in the plan:
 >
-> **Authority order:** an explicit rule in the supplied/approved SDD wins. This audit verifies the handoff; it does not redesign or normalize authored rules. Use the derivation bullets below only when authoring from source behavior that has no explicit task-entry rule.
+> **Authority order:** an explicit rule in the supplied/approved SDD wins. This audit verifies the handoff; it does not redesign or normalize authored rules. Use the derivation matrix below only when authoring from source behavior that has no explicit task-entry rule.
 >
-> - Contiguous ordered work in one stage (`then`, `after`, `before`, `in order`, direct previous-step wording, or an upstream prerequisite) → every task in that ordered run gets `activation-mode: sequential` and `entry-rule: runs-sequentially`, including the first task, unless the SDD explicitly declares another legal rule.
-> - Independent work that starts with the stage → `activation-mode: parallel`, `entry-rule: current-stage-entered`, and rationale says why the tasks are independent.
-> - Connector/event callback wait → `activation-mode: event-triggered`, usually `entry-rule: wait-for-connector`.
-> - User-launched optional work → `activation-mode: adhoc`, `entry-rule: adhoc`, `isRequired: false`.
-> - Branch convergence, fan-in, decision-result routing, or a non-immediate dependency → `activation-mode: fan-in` or `conditional-gate`, `entry-rule: selected-tasks-completed`, with the selected tasks named.
+> Task type says **what** a task does; `activation-mode` and `entry-rule` say **when** it starts. A task type never supplies its activation semantics.
+>
+> | activation-mode | entry-rule / rule-type | Required grouping or selector contract |
+> |---|---|---|
+> | `sequential` | `runs-sequentially` | A strict chain uses consecutive single-task lanes. |
+> | `parallel` | `current-stage-entered` | Independent stage-start siblings may share one lane. |
+> | `parallel-after-predecessor` | `runs-sequentially` | Siblings after the same immediate predecessor share the same next lane/task set. |
+> | `event-triggered` | The explicitly authored event/condition rule, normally `wait-for-connector` | Preserve the authored event configuration; do not infer this mode from task type. |
+> | `adhoc` | `adhoc` | Set `isRequired: false`; the user launches the task. |
+> | `fan-in` | `selected-tasks-completed` | Preserve the authored selected tasks and convergence rationale. |
+> | `conditional-gate` | The explicitly authored gate rule | Preserve every authored selector and gate expression. |
 >
 > While authoring a new SDD, do not invent `selected-tasks-completed` merely because a task follows the immediately previous task; model a plain contiguous run as `runs-sequentially`. Once an SDD is supplied or approved, however, preserve every explicit `selected-tasks-completed` row and selector in `tasks.md` and `caseplan.json`; planning is not a second design pass. Map that task to `conditional-gate` or `fan-in` as its authored rationale supports, never to `sequential`.
-> Before leaving §4.6, audit each stage's planned lanes: sequential tasks that form a strict chain MUST NOT share a lane with each other or with adhoc/event-driven/parallel work. If `activation-mode`/`entry-rule` conflicts with `lane`, the mode wins and the lane must be corrected. Same-lane grouping is reserved for intentionally parallel siblings, and the rationale must say why they run in parallel.
+> Before leaving §4.6, audit each stage's planned lanes: sequential tasks that form a strict chain MUST NOT share a lane with each other or with adhoc/event-driven/parallel work. If `activation-mode`/`entry-rule` conflicts with `lane`, the mode wins and the lane must be corrected. Same-lane grouping is reserved for intentional `parallel` or `parallel-after-predecessor` siblings, and the rationale must explain the grouping.
 
 > **Outputs are a lossless handoff, not a discovered-name summary.** Project each SDD Outputs table row through the common grammar in [`plugins/variables/io-binding/planning.md` § SDD Outputs table → `tasks.md` projection](plugins/variables/io-binding/planning.md#sdd-outputs-table-to-tasksmd-projection-mandatory), then preserve the resulting list item exactly. Schema discovery may add truly undeclared fields as bare items, but it must not rewrite an SDD row. An explicit equal-name extract such as `greeting -> greeting` stays exactly that; collapsing it to bare `greeting` changes the binding from "write the existing case variable" to "auto-mint a task output." Before the Step 5 approval gate, compare every SDD Outputs row to its task T-entry and fix any missing or changed operator/operand or leaked table placeholder.
 
@@ -382,7 +388,7 @@ Treat the generated `tasks.md` as approved and proceed directly to Phase 2 by de
 
 Re-read `tasks.md` before proceeding to Phase 2 (see [implementation.md](implementation.md)); context may have compacted during planning. `tasks.md` is complete handoff artifact — all resolved IDs, inputs, outputs, and references captured there.
 
-**Plan-shape gate.** Before Phase 2, re-read every §4.6 task T-entry itself (not the §4.7 condition entries) and confirm it literally contains its own `- activation-mode:` line and its own `- entry-rule:` line — **exactly one of each, colocated on the task's own T-entry** — and that the pair is legal for that mode. Re-run the §4.6 Activation-mode audit over the finished plan, covering all six modes, not just `sequential`.
+**Plan-shape gate.** Before Phase 2, re-read every §4.6 task T-entry itself (not the §4.7 condition entries) and confirm it literally contains its own `- activation-mode:` line and its own `- entry-rule:` line — **exactly one of each, colocated on the task's own T-entry** — and that the pair is legal for that mode. Re-run the §4.6 Activation-mode audit over the finished plan, covering all seven modes, not just `sequential`.
 
 **Known failure pattern:** deferring the rule to a *separate* §4.7 task-entry-condition entry (`rule-type:`) does not satisfy this gate — `caseplan.json` can end up fully correct while `tasks.md` itself still fails this check, because §4.6 and §4.7 are graded as separate artifacts. See [task-entry-conditions/planning.md § Phase 1 Plan Presentation Contract](plugins/conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract) for the compliant §4.6 shape.
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -68,14 +68,15 @@ This pair lives on the task's own §4.6 T-entry, not on this condition T-entry. 
 
 For every task-entry-condition T-entry, verify the task's `activation-mode` and this condition's `rule-type` agree:
 
-| activation-mode | Allowed rule-type |
-|---|---|
-| `sequential` | `runs-sequentially` |
-| `parallel` | `current-stage-entered` |
-| `event-triggered` | `wait-for-connector` or another explicitly authored event/condition rule |
-| `adhoc` | `adhoc` |
-| `fan-in` | `selected-tasks-completed` with multiple selected tasks or an explicit convergence rationale |
-| `conditional-gate` | `selected-tasks-completed` with a branch/non-immediate dependency rationale, or the explicitly authored gate rule |
+| activation-mode | entry-rule / rule-type | Required grouping or selector contract |
+|---|---|---|
+| `sequential` | `runs-sequentially` | A strict chain uses consecutive single-task lanes. |
+| `parallel` | `current-stage-entered` | Independent stage-start siblings may share one lane. |
+| `parallel-after-predecessor` | `runs-sequentially` | Siblings after the same immediate predecessor share the same next lane/task set. |
+| `event-triggered` | The explicitly authored event/condition rule, normally `wait-for-connector` | Preserve the authored event configuration; do not infer this mode from task type. |
+| `adhoc` | `adhoc` | Set `isRequired: false`; the user launches the task. |
+| `fan-in` | `selected-tasks-completed` | Preserve the authored selected tasks and convergence rationale. |
+| `conditional-gate` | The explicitly authored gate rule | Preserve every authored selector and gate expression. |
 
 During Phase 0 authoring, a plain immediate ordered run with no fan-in, branch, event, or non-immediate dependency rationale should be modeled as `activation-mode: sequential` with `rule-type: runs-sequentially`. During Phase 1, never use that heuristic to rewrite an explicit supplied/approved SDD row: preserve `selected-tasks-completed` and its selector as `conditional-gate` or `fan-in`, including when all tasks are placeholders.
 
@@ -91,7 +92,7 @@ For sequential tasks, preserve the frontend's ordered `data.tasks` structure, in
 ## T<n>: Add task-entry condition for "<task>" in "<stage>" — <summary>
 - target-stage: "<stage-name>"
 - target-task: "<task-name>"
-- activation-mode: sequential | parallel | event-triggered | adhoc | fan-in | conditional-gate
+- activation-mode: sequential | parallel | parallel-after-predecessor | event-triggered | adhoc | fan-in | conditional-gate
 - rationale: "<why this activation/sequencing mode fits>"
 - display-name: "<name>"                  # optional — omit when SDD Display Name cell is blank; impl defaults to "Entry Rule {N}"
 - rule-type: selected-tasks-completed

--- a/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/action/planning.md
@@ -84,8 +84,9 @@ Resolved action task. For the unresolved placeholder shape, see [placeholder-tas
 - outputs:
   - <SDD output row, copied verbatim>
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/agent/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/agent/planning.md
@@ -116,8 +116,9 @@ Shared contract — [create-inline-common.md § Failure](../create-inline-common
   - <SDD output row, copied verbatim>
 - runOnlyOnce: false
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/api-workflow/planning.md
@@ -129,8 +129,9 @@ Shared contract — [create-inline-common.md § Failure](../create-inline-common
   - <SDD output row, copied verbatim>
 - runOnlyOnce: false
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/case-management/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/case-management/planning.md
@@ -51,8 +51,9 @@ Mark `<UNRESOLVED: case "<name>" in folder "<folder>" not found in caseManagemen
   - <SDD output row, copied verbatim>
 - runOnlyOnce: false
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-activity/planning.md
@@ -194,8 +194,9 @@ Populate `outputs:` using the shared [I/O-binding output-list contract](../../va
   - <SDD output row, copied verbatim>
 - isRequired: true
 - runOnlyOnce: false
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>
 - verify: tasks.md `input-values` covers every `inputs.*[?required]` from the lean spec across `bodyFields`, `queryParameters`, `pathParameters` — see Step 5 above.

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
@@ -40,8 +40,9 @@ Populate `outputs:` using the shared [I/O-binding output-list contract](../../va
   - <SDD output row, copied verbatim>
 - isRequired: true
 - runOnlyOnce: false
-- activation-mode: <copy the supplied/approved SDD activation mode>
-- entry-rule: <copy the matching supplied/approved SDD task-entry rule>
+- activation-mode: <copy the supplied/approved SDD activation mode>  # sequential | parallel | parallel-after-predecessor | event-triggered | adhoc | fan-in | conditional-gate
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>  # legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>
 - verify: Confirm task created with correct event parameters

--- a/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/connector-trigger/planning.md
@@ -40,12 +40,14 @@ Populate `outputs:` using the shared [I/O-binding output-list contract](../../va
   - <SDD output row, copied verbatim>
 - isRequired: true
 - runOnlyOnce: false
-- activation-mode: event-triggered   # required; normally event-triggered for a connector event wait
-- entry-rule: wait-for-connector   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <copy the supplied/approved SDD activation mode>
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>
 - order: after T<m>
 - lane: <n>
 - verify: Confirm task created with correct event parameters
 ```
+
+Task type never supplies activation semantics. Copy the SDD pair losslessly: a stage-entry listener uses `parallel` + `current-stage-entered`; a listener after an immediate predecessor uses `parallel-after-predecessor` + `runs-sequentially`; an event-gated task uses `event-triggered` + `wait-for-connector`; any other explicitly authored legal task-entry rule remains authoritative.
 
 ## Unresolved Fallback
 

--- a/skills/uipath-maestro-case/references/plugins/tasks/process/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/process/planning.md
@@ -58,8 +58,9 @@ If no match is found across both cache files after `registry pull`:
   - <SDD output row, copied verbatim>
 - runOnlyOnce: false
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/rpa/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/rpa/planning.md
@@ -49,8 +49,9 @@ Mark `<UNRESOLVED: rpa "<name>" in folder "<folder>" not found in registry>`. Om
   - <SDD output row, copied verbatim>
 - runOnlyOnce: false
 - isRequired: true
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/tasks/wait-for-timer/planning.md
@@ -66,8 +66,9 @@ Ambiguous phrasing → **AskUserQuestion** with 2–3 candidate interpretations 
 - time-cycle: R/PT1H              # optional (overrides above)
 - isRequired: true
 - runOnlyOnce: false
-- activation-mode: <sequential|parallel|event-triggered|adhoc|fan-in|conditional-gate>   # required
-- entry-rule: <runs-sequentially|current-stage-entered|wait-for-connector|adhoc|selected-tasks-completed>   # required; must pair with activation-mode — see ../../conditions/task-entry-conditions/planning.md
+- activation-mode: <sequential|parallel|parallel-after-predecessor|event-triggered|adhoc|fan-in|conditional-gate>   # required
+- entry-rule: <copy the matching supplied/approved SDD task-entry rule>   # required; legality: ../../conditions/task-entry-conditions/planning.md#phase-1-plan-presentation-contract
+- rationale: "<copy the supplied/approved SDD rationale>"   # required
 - order: after T<m>
 - lane: <n>  # structural/layout position only; sequencing is the task entry rule plus data.tasks order.
 - verify: Confirm Result: Success, capture TaskId

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
@@ -9,7 +9,9 @@ for a real external event.
 """
 
 import os
+import re
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
@@ -19,6 +21,53 @@ from _shared.case_check import (  # noqa: E402
     read_caseplan,
     task_is_skeleton,
 )
+
+TASKS_PLAN = Path("tasks/tasks.md")
+
+
+def _task_plan_section(tasks_md: str, task_name: str) -> str:
+    pattern = re.compile(
+        rf'(?ims)^##\s+T\d+:(?![^\n]*\btask[- ]entry[- ]condition\b)'
+        rf'[^\n]*\btask\s+"{re.escape(task_name)}"[^\n]*\n'
+        rf'.*?(?=^##\s+T\d+:|\Z)'
+    )
+    matches = pattern.findall(tasks_md)
+    if len(matches) != 1:
+        sys.exit(
+            f"FAIL: tasks/tasks.md must contain exactly one task T-entry for "
+            f"{task_name!r}; found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _task_plan_field(section: str, task_name: str, field: str) -> str:
+    values = re.findall(rf"(?im)^-\s*{re.escape(field)}:\s*(.*?)\s*$", section)
+    if len(values) != 1:
+        sys.exit(
+            f"FAIL: tasks/tasks.md T-entry for {task_name!r} must contain exactly "
+            f"one {field!r} field; found {len(values)}"
+        )
+    return values[0].strip()
+
+
+def _assert_plan_activation() -> None:
+    if not TASKS_PLAN.is_file():
+        sys.exit(f"FAIL: {TASKS_PLAN} is missing; the Phase 1 plan is required")
+    tasks_md = TASKS_PLAN.read_text(encoding="utf-8", errors="ignore")
+    expected = {
+        "Process reply event": ("event-triggered", "wait-for-connector"),
+        "Wait for reply email": ("parallel", "current-stage-entered"),
+    }
+    for task_name, (expected_mode, expected_rule) in expected.items():
+        section = _task_plan_section(tasks_md, task_name)
+        activation_mode = _task_plan_field(section, task_name, "activation-mode")
+        entry_rule = _task_plan_field(section, task_name, "entry-rule")
+        if activation_mode != expected_mode or entry_rule != expected_rule:
+            sys.exit(
+                f"FAIL: tasks/tasks.md T-entry for {task_name!r} must preserve "
+                f"activation-mode: {expected_mode} with entry-rule: {expected_rule}; "
+                f"got activation-mode={activation_mode!r}, entry-rule={entry_rule!r}"
+            )
 
 
 def _find_task_by_label(plan: dict, label: str) -> dict:
@@ -109,10 +158,12 @@ def main():
             f"FAIL: expected connectorKey 'uipath-microsoft-outlook365'; got {ck!r} — "
             "agent may have resolved against the mock connector"
         )
+    _assert_plan_activation()
     print(
         f"OK: first task is event-triggered with wait-for-connector-only entry "
         f"semantics; typed wait-for-connector task preserves one positional "
-        f"current-stage-entered rule without connector uipath and is resolved "
+        f"parallel/current-stage-entered plan pair, has no connector uipath on "
+        f"that entry rule, and is resolved "
         f"(displayName={task.get('displayName')!r}, "
         f"serviceType={svc}, connectorKey={ck!r}, typeId + connectionId set)"
     )

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/check_connector_wait.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
-"""ConnectorWaitCase: a RESOLVED wait-for-connector task is wired.
+"""ConnectorWaitCase: connector task type and activation stay independent.
 
 Asserts the connector-trigger plugin resolved a real Integration Service event
 into the caseplan (Rule 8 — no fabricated IDs) with the correct serviceType,
-rather than leaving a `data: {}` skeleton. Does NOT run debug: a
-wait-for-connector suspends waiting for a real external event.
+rather than leaving a `data: {}` skeleton, while preserving the typed task's
+positional entry rule. Does NOT run debug: a wait-for-connector suspends waiting
+for a real external event.
 """
 
 import os
@@ -29,6 +30,16 @@ def _find_task_by_label(plan: dict, label: str) -> dict:
         for task in iter_tasks(plan)
     ]
     sys.exit(f"FAIL: task {label!r} not found; saw {labels}")
+
+
+def _entry_rules(task: dict) -> list[dict]:
+    return [
+        rule
+        for condition in (task.get("entryConditions") or [])
+        for group in (condition.get("rules") or [])
+        for rule in (group or [])
+        if isinstance(rule, dict)
+    ]
 
 
 def main():
@@ -57,7 +68,26 @@ def main():
             f"got isRequired={event_task.get('isRequired')!r}"
         )
 
-    task = assert_task_type_present("wait-for-connector")
+    assert_task_type_present("wait-for-connector")
+    task = _find_task_by_label(plan, "Wait for reply email")
+    if task.get("type") != "wait-for-connector":
+        sys.exit(
+            "FAIL: 'Wait for reply email' must keep type='wait-for-connector'; "
+            f"got {task.get('type')!r}"
+        )
+    task_rules = _entry_rules(task)
+    if len(task_rules) != 1 or task_rules[0].get("rule") != "current-stage-entered":
+        sys.exit(
+            "FAIL: typed wait-for-connector task must preserve exactly one "
+            "current-stage-entered entry rule; "
+            f"got {task_rules!r}"
+        )
+    if "uipath" in task_rules[0]:
+        sys.exit(
+            "FAIL: typed wait-for-connector task's positional "
+            "current-stage-entered rule must not carry a connector uipath payload; "
+            f"got {task_rules[0].get('uipath')!r}"
+        )
     if task_is_skeleton(task):
         sys.exit(
             "FAIL: wait-for-connector task is a skeleton (missing data.typeId / "
@@ -81,7 +111,8 @@ def main():
         )
     print(
         f"OK: first task is event-triggered with wait-for-connector-only entry "
-        f"semantics; wait-for-connector task resolved "
+        f"semantics; typed wait-for-connector task preserves one positional "
+        f"current-stage-entered rule without connector uipath and is resolved "
         f"(displayName={task.get('displayName')!r}, "
         f"serviceType={svc}, connectorKey={ck!r}, typeId + connectionId set)"
     )

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
@@ -3,17 +3,20 @@ description: >
   Build a Case Management definition from an sdd.md whose first task is
   event-triggered via a `wait-for-connector` task-entry rule, followed by a
   `wait-for-connector` task (the 2nd previously-untested task type) that
-  suspends until an external Integration Service connector event arrives.
+  suspends until an external Integration Service connector event arrives while
+  preserving its supplied positional `current-stage-entered` activation rule.
   Exercises the connector-trigger plugin: `case spec --type trigger
   --input-details`, direct caseplan.json write of a resolved
   `type: "wait-for-connector"` node (`data.serviceType:
   "Intsvc.WaitForEvent"`, real `data.typeId` + `data.connectionId`), and the
   frontend event-triggered task mode where a first task keeps only
-  `wait-for-connector` and does not also get `current-stage-entered`. Stops at
-  validate + resolution assertions — NOT debug: a wait-for-connector suspends
-  waiting for a real event and validate cannot catch a mis-bound connector rule
-  (the skill's documented silent-failure surface). Requires cloud auth + a
-  healthy Integration Service connection for the named connector.
+  `wait-for-connector` and does not also get `current-stage-entered`, while the
+  typed connector-wait task keeps exactly one positional entry rule without a
+  connector payload. Stops at validate + resolution assertions — NOT debug: a
+  wait-for-connector suspends waiting for a real event and validate cannot catch
+  a mis-bound connector rule (the skill's documented silent-failure surface).
+  Requires cloud auth + a healthy Integration Service connection for the named
+  connector.
 tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:single-node, connector, feature:connector-trigger]
 max_iterations: 1
 
@@ -176,7 +179,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
+    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task whose sole entry rule remains current-stage-entered without a connector uipath payload (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
     command: "python3 $TASK_DIR/check_connector_wait.py"
     timeout: 60
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
+++ b/tests/tasks/uipath-maestro-case/connector_features/connector_wait/connector_wait.yaml
@@ -99,6 +99,7 @@ initial_prompt: |
   ##### Task 1.1: Process reply event
 
   **Type:** process
+  **Activation Mode:** event-triggered
   **Description:** Placeholder process that is started by the inbound email event. This is the first task in the stage and is event-triggered, so its only task-entry rule is `wait-for-connector`; do not add `current-stage-entered`.
 
   **Entry Condition:**
@@ -126,6 +127,7 @@ initial_prompt: |
   ##### Task 1.2: Wait for reply email
 
   **Type:** wait-for-connector
+  **Activation Mode:** parallel
   **Description:** Suspend until an email is received on the Outlook 365 mailbox.
 
   **Entry Condition:**
@@ -179,7 +181,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task whose sole entry rule remains current-stage-entered without a connector uipath payload (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
+    description: "Caseplan has a first event-triggered task with wait-for-connector-only entry semantics and a RESOLVED wait-for-connector task whose sole entry rule remains current-stage-entered without a connector uipath payload; tasks/tasks.md preserves event-triggered/wait-for-connector for the process task and parallel/current-stage-entered for the typed connector wait (serviceType Intsvc.WaitForEvent, real typeId + connectionId, not a skeleton)"
     command: "python3 $TASK_DIR/check_connector_wait.py"
     timeout: 60
     expected_exit_code: 0

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/parallel_after_predecessor/check_parallel_after_predecessor.py
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/parallel_after_predecessor/check_parallel_after_predecessor.py
@@ -1,14 +1,17 @@
 #!/usr/bin/env python3
-"""ParallelAfterPredecessor: emitted `data.tasks` grouping for siblings after one predecessor.
+"""ParallelAfterPredecessor: planned and emitted grouping after one predecessor.
 
 `uip maestro case validate` accepts every grouping of a task set — a strict chain,
 a shared set, a shared set at index 0, and even mixed entry rules inside one set all
 return Status: Valid (probed on uip 1.198.0-preview.102). Grouping is therefore
-unenforced by the CLI, so these assertions read the emitted structure directly.
+unenforced by the CLI, so these assertions read both `tasks/tasks.md` and the emitted
+structure directly.
 """
 
 import os
+import re
 import sys
+from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.case_check import (  # noqa: E402
@@ -21,6 +24,7 @@ STAGE = "Issuing Permit"
 PREDECESSOR = "Collect Fees"
 SIBLINGS = ("Wait For Payment Confirmation", "Track Payment Deadline")
 DOWNSTREAM = "Generate Permit"
+TASKS_PLAN = Path("tasks/tasks.md")
 
 
 def fail(message: str) -> None:
@@ -64,6 +68,81 @@ def entry_rules(stage: dict, label: str) -> list[str]:
                         rules.append(rule.get("rule"))
                 return rules
     fail(f"task {label!r} not found when reading entry conditions")
+
+
+def task_plan_section(tasks_md: str, task_name: str) -> str:
+    pattern = re.compile(
+        rf'(?ims)^##\s+T\d+:(?![^\n]*\btask[- ]entry[- ]condition\b)'
+        rf'[^\n]*\btask\s+"{re.escape(task_name)}"[^\n]*\n'
+        rf'.*?(?=^##\s+T\d+:|\Z)'
+    )
+    matches = pattern.findall(tasks_md)
+    if len(matches) != 1:
+        fail(
+            f"tasks/tasks.md must contain exactly one T-entry for {task_name!r}; "
+            f"found {len(matches)}"
+        )
+    return matches[0]
+
+
+def task_plan_field(section: str, task_name: str, field: str) -> str:
+    values = re.findall(rf"(?im)^-\s*{re.escape(field)}:\s*(.*?)\s*$", section)
+    if len(values) != 1:
+        fail(
+            f"tasks/tasks.md T-entry for {task_name!r} must contain exactly one "
+            f"{field!r} field; found {len(values)}"
+        )
+    return values[0].strip()
+
+
+def assert_tasks_plan() -> int:
+    if not TASKS_PLAN.is_file():
+        fail(f"{TASKS_PLAN} is missing; the Phase 1 planning artifact is required")
+    tasks_md = TASKS_PLAN.read_text(encoding="utf-8", errors="ignore")
+    lanes: list[int] = []
+    for name in SIBLINGS:
+        section = task_plan_section(tasks_md, name)
+        activation_mode = task_plan_field(section, name, "activation-mode")
+        if activation_mode != "parallel-after-predecessor":
+            fail(
+                f"tasks/tasks.md T-entry for {name!r} must use "
+                f"activation-mode: parallel-after-predecessor; got {activation_mode!r}"
+            )
+        entry_rule = task_plan_field(section, name, "entry-rule")
+        if entry_rule != "runs-sequentially":
+            fail(
+                f"tasks/tasks.md T-entry for {name!r} must use "
+                f"entry-rule: runs-sequentially; got {entry_rule!r}"
+            )
+        lane = task_plan_field(section, name, "lane")
+        if re.fullmatch(r"\d+", lane) is None:
+            fail(
+                f"tasks/tasks.md T-entry for {name!r} must use a numeric lane; "
+                f"got {lane!r}"
+            )
+        lanes.append(int(lane))
+
+        rationale = task_plan_field(section, name, "rationale").strip("'\"").strip()
+        if not rationale or rationale.startswith("<"):
+            fail(
+                f"tasks/tasks.md T-entry for {name!r} must have a non-empty, "
+                "non-placeholder rationale"
+            )
+        if PREDECESSOR.lower() not in rationale.lower() or re.search(
+            r"(?i)\b(shared?|same|group(?:ed|ing)?|together|parallel|both)\b",
+            rationale,
+        ) is None:
+            fail(
+                f"tasks/tasks.md T-entry for {name!r} rationale must explain the "
+                f"shared predecessor/grouping after {PREDECESSOR!r}; got {rationale!r}"
+            )
+
+    if lanes[0] != lanes[1]:
+        fail(
+            f"tasks/tasks.md must assign both parallel-after-predecessor siblings "
+            f"the same numeric lane; got {lanes}"
+        )
+    return lanes[0]
 
 
 def main() -> None:
@@ -130,10 +209,18 @@ def main() -> None:
                         f"plus runs-sequentially, not duplicate sibling gates"
                     )
 
+    planned_lane = assert_tasks_plan()
+    if planned_lane != a:
+        fail(
+            f"tasks/tasks.md sibling lane {planned_lane} must equal the emitted "
+            f"data.tasks task-set index {a}"
+        )
     print(
         f"OK: {STAGE!r} emits [[{PREDECESSOR}], "
         f"[{SIBLINGS[0]}, {SIBLINGS[1]}], [{DOWNSTREAM}]] "
-        f"with runs-sequentially throughout"
+        f"with runs-sequentially throughout; tasks/tasks.md preserves both "
+        f"parallel-after-predecessor siblings in numeric lane {planned_lane} "
+        f"with shared-predecessor rationales"
     )
 
 

--- a/tests/tasks/uipath-maestro-case/multi_stages_tasks/parallel_after_predecessor/parallel_after_predecessor.yaml
+++ b/tests/tasks/uipath-maestro-case/multi_stages_tasks/parallel_after_predecessor/parallel_after_predecessor.yaml
@@ -188,7 +188,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Issuing Permit emits [[Collect Fees], [Wait For Payment Confirmation, Track Payment Deadline], [Generate Permit]]: the two independent siblings share one task set, that set comes after the Collect Fees set, Collect Fees is alone in its set, Generate Permit follows the sibling set, every task carries exactly one runs-sequentially entry rule, and neither sibling uses a selected-tasks-completed gate naming the predecessor"
+    description: "Issuing Permit emits [[Collect Fees], [Wait For Payment Confirmation, Track Payment Deadline], [Generate Permit]] with the two siblings grouped after Collect Fees, runs-sequentially throughout, and no duplicate selected-task gates; tasks/tasks.md gives both siblings activation-mode parallel-after-predecessor, entry-rule runs-sequentially, the same numeric lane matching the emitted sibling task-set index, and a non-empty rationale explaining the shared predecessor/grouping"
     command: "python3 $TASK_DIR/check_parallel_after_predecessor.py"
     timeout: 300
     expected_exit_code: 0


### PR DESCRIPTION
## Summary

This PR closes **D01 — task activation authority and planner parity** for `uipath-maestro-case`.

It makes task activation explicit and lossless across planning:

- task **type** continues to describe what a task does;
- `activation-mode` and the task-entry rule describe when it starts;
- an explicit rule and selectors from a supplied or approved SDD remain authoritative;
- Phase 1 derives activation only when the source behavior has no explicit task-entry rule.

## What changes

### Canonical seven-mode activation contract

The shared planning authority and task-entry-condition owner now expose the same seven legal modes:

| Activation mode | Task-entry behavior |
|---|---|
| `sequential` | `runs-sequentially`; strict chains use consecutive single-task lanes |
| `parallel` | `current-stage-entered`; independent stage-start siblings may share a lane |
| `parallel-after-predecessor` | `runs-sequentially`; siblings after one immediate predecessor share the same next lane/task set |
| `event-triggered` | preserves the explicitly authored event/condition rule, normally `wait-for-connector` |
| `adhoc` | `adhoc` with `isRequired: false` |
| `fan-in` | `selected-tasks-completed` with the authored selectors and convergence rationale |
| `conditional-gate` | preserves the explicitly authored gate and selectors |

All nine task planners—action, agent, API workflow, child case, connector activity, connector wait, process, RPA, and timer—now use the same compact task-plan schema:

- exactly one `activation-mode`;
- exactly one `entry-rule`;
- the numeric structural lane;
- the SDD rationale;
- a direct link to the task-entry-condition owner for mode/rule legality.

### Connector-wait regression

The imported connector regression fix prevents task type from overwriting activation semantics:

- **Process reply event** remains `event-triggered` with a `wait-for-connector` entry rule;
- typed **Wait for reply email** remains positional with its authored `parallel` + `current-stage-entered` pair;
- connector event resolution, type ID, connection ID, and task payload checks remain intact;
- the deterministic checker verifies both `tasks/tasks.md` plan pairs and emitted `caseplan.json` behavior.

This matters because `wait-for-connector` is both a valid task type and a valid rule type, but one does not imply the other.

### Parallel-after-predecessor regression

The focused regression now verifies both the planning artifact and emitted JSON:

- both siblings use `activation-mode: parallel-after-predecessor`;
- both use `entry-rule: runs-sequentially`;
- both share the same numeric lane;
- that lane equals the emitted `data.tasks` task-set index;
- each has a non-placeholder rationale explaining the shared predecessor/grouping;
- the emitted shape remains `[[A], [B, C], [D]]`, with no duplicate `selected-tasks-completed` gates.

### Scope and load

- Changes are limited to 11 planning files and four focused regression files.
- `SKILL.md` is byte-identical to the base (`58,396` bytes), so default skill load does not grow.
- Implementation authorities (`implementation.md`, task `impl-json.md` files, case editing, and SDD authorities) remain unchanged.
- Complete PR-head delta: 15 files, 244 insertions, 52 deletions.

## Validation

### Writer and repository checks

- `git diff --check` — passed
- exact 15-path write boundary — passed
- frozen/read-only implementation authorities byte-identical to base — passed
- all 9 planner schemas and both shared seven-mode matrices — passed
- both Python checkers compile — passed
- focused coder-eval YAML dry-run/schema validation — passed
- CLI verb validation — passed
- Markdown links: 143 relative links and 78 anchors resolve
- skill quick validation — passed
- Maestro Case checker suite — **111 passed, 14 skipped**

### Targeted coder-eval evidence

| Scenario | Runner / SHA | Result |
|---|---|---|
| Connector wait activation | Local / `cef4a719` | **4/4 criteria passed**, score **1.000**; validates connector resolution plus both planned activation pairs |
| Parallel after predecessor | Local artifact / `cef4a719` | `uip maestro case validate` passed; emitted sibling grouping, rule, lane, and rationale behavior verified against the preserved artifact |
| CM Golden Expense broad E2E | GitHub Actions / `cef4a719` | **7/7 criteria passed**, score **1.000**, 1/1 task succeeded — [workflow run](https://github.com/UiPath/skills/actions/runs/30972812294) |

Cleanup in the targeted runs attempted to delete locally generated, non-uploaded solution IDs and received `404 Not Found`; no deployed solution remained to clean up.

### PR CI

Current PR checks are green, including:

- CLI Verb Gate
- task schema validation
- Maestro Case checker unit tests
- skill smoke tests
- task-driver guard
- catalog/runtime/telemetry helper guards
- Socket security report

## Review status

Independent branch-only review converged with **no P0/P1 findings**. The PR remains draft pending normal code-owner review and approval.
