### PR TITLE
chore(skill): group uipath-process-mining in skills.sh.json (unblocks all PRs)

### DIFF
--- a/skills.sh.json
+++ b/skills.sh.json
@@ -38,6 +38,7 @@
         "uipath-test",
         "uipath-governance",
         "uipath-insights",
+        "uipath-process-mining",
         "uipath-tasks",
         "uipath-mcp-servers"
       ]


### PR DESCRIPTION
## What

Adds `uipath-process-mining` to the **Platform & Operations** grouping in `skills.sh.json`.

## Why

`main` is red on the `Validate skills.sh.json against skills/` gate right now:

```
1 finding(s):

  uipath-process-mining: exists on disk but is in no grouping — it would render
  ungrouped on skills.sh. Add it to the right section by hand (placement is an
  editorial call, so --fix will not guess).
```

The grouping gate (`scripts/check-skills-sh.py` + `skills.sh.json`) landed after #2252 merged, so the skill has been on disk with no grouping entry ever since. Because the check walks the whole `skills/` tree rather than the diff, it fails on **every** open PR, not just ones touching Process Mining — which is why this is split out into its own one-line PR instead of riding along on #2411.

Without it the skill would also render ungrouped on skills.sh.

## Placement

Next to `uipath-insights`: both are analytics surfaces operated through the `uip` CLI — Insights for job metrics, Process Mining for process metrics. `check-skills-sh.py` deliberately refuses to guess placement, so say the word if **Authoring** reads better for a skill that also authors data mappings and dbt models.

## Test plan

`python3 scripts/check-skills-sh.py` → `OK — 25 skills grouped across 4 section(s).`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
