### PR TITLE
docs(uipath-coded-apps): separate testing and governed deploy lanes

### DIFF
--- a/skills/uipath-coded-apps/SKILL.md
+++ b/skills/uipath-coded-apps/SKILL.md
@@ -33,10 +33,10 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 ## Critical Rules
 
 1. **Identify the app type before doing anything else.** Ask as a structured choice (Rule 18): **Coded Web App** — custom frontend deployed to UiPath Cloud · **Coded Action App** — form for Action Center human task reviews. The two paths diverge on scaffolding, redirect URI, and publish flag — do not guess.
-2. **Always check login status first.** Run `uip login status --output json` before any cloud command. If not logged in, run `uip login`.
-3. **Never skip the build step.** Run `npm run build` after scaffolding (to verify the scaffold compiles) and again before `pack` or `push` (to produce the deployable `dist/`). Verify `dist/` exists each time.
-4. **Pack → Publish → Deploy order is required.** Each step depends on the previous one producing its output.
-5. **Bump the version for re-publish.** If the same version already exists in Orchestrator, publish will fail.
+2. **Always check login status first.** Run `uip login status --output json` before any cloud command. Deployment must bind and verify an exact named profile, control plane, org, and tenant. If not logged in, run `uip login` for the intended environment.
+3. **Build before packaging source.** Run `npm run build` after scaffolding and again before packaging a source-built candidate. An explicit synthetic Alpha/Staging test may deploy an already-built or already-published candidate as-is, but only after hashing and auditing that exact candidate and recording that the build was skipped. Never use that exception as production evidence.
+4. **Use Build → Pack → Publish → Deploy for a new candidate.** A reconciled upgrade may deploy an exact already-published candidate without rebuilding, repacking, or republishing. Do not repeat an earlier stage merely because a later external write returned an ambiguous result.
+5. **Choose versions before external writes.** If a version already exists, select and verify a different version before packing. Never silently auto-bump, repack, or republish in response to a conflict.
 6. **Action apps require `-t Action` on publish.** Run `uip codedapp publish -t Action` (not the default `Web` type).
 7. **Never handle access tokens manually.** Do not pass, print, parse, source, or set cached access tokens. Use `uip login` and supported `uip codedapp` commands; the CLI manages authentication.
 8. **Base URL must use the API subdomain.** `https://api.uipath.com` not `https://cloud.uipath.com`. See the table below.
@@ -51,6 +51,10 @@ Build, debug, and deploy UiPath Coded Web Applications and Coded Action Apps usi
 17. **Never call `sdk.initialize()` in an action app.** That is web-app-only — it starts a PKCE OAuth redirect. Action apps run in Action Center's iframe with a host-injected session: construct `new UiPath()` (no args) and use it directly. See [create-action-app.md](references/create-action-app.md) `src/uipath.ts`.
 18. **Never make the user type magic phrases.** Whenever you ask the user to pick between known options (app type, build/edit/deploy intent, OAuth setup, deploy pinning), present a **structured choice** via the host coding agent's native question tool (selectable options) when one exists. Mechanics: one option per choice with a short bold label + one-line description of what picking it does; put the recommended option **first** and suffix its label "(Recommended)"; keep to **at most 4 options** (reserve one slot for an escape option like *Make changes* / *Cancel* when applicable). If there are 5+ candidates, or the host agent has no question tool, render a plain numbered list instead and accept the number or the option label as the answer. A free-text reply must always remain valid (e.g. a plan-change request) and takes precedence over the options. **Exception — never put a question in the same response as a long output:** plan-approval gates are free-text by design (the plan ends with "confirm or tell me what to change"); structured questions fire only on later, short turns. See `references/dashboards/plugins/build/impl.md`.
 19. **Never guess SDK method signatures — read the installed types.** The authoritative reference for method names, parameters, return types, and usage examples is `node_modules/@uipath/uipath-typescript/dist/<subpath>/index.d.ts` (full JSDoc; matches the installed SDK version exactly). Before calling a service you have not used in this session, Read its `.d.ts`. If `node_modules` is absent, run the install step first — the app cannot build without it. The `references/sdk/*.md` files deliberately do NOT list signatures; they cover only scopes, calling conventions, and traps the types cannot express. See [references/sdk/imports.md](references/sdk/imports.md) for the missing-capability protocol. **Boundary: read the `.d.ts`, never the compiled bundle.** `dist/*.mjs` / `*.js` is minified implementation, not API — reading it dead-ends. A grep with no output **confirms absence**; treat a genuine gap as unsupported (use the documented alternative) rather than escalating the search into the bundle.
+20. **Classify the deployment lane before publishing.** The direct quick path is only for an explicitly requested, internal, synthetic-data test in Alpha or Staging. Production, customer data, or any release-trust requirement uses a governed release with reviewed source/artifact/config bindings, an approval record, an immutable receipt, and post-deploy verification. Ambiguity defaults to governed.
+21. **Choose `create` or `upgrade` explicitly from remote evidence.** `.uipath/app.config.json`, `.dashboard/state.json`, and prior console output are repairable local hints, not proof of remote state. A create requires an unused route and no matching deployment; an upgrade requires the exact existing deployment, route, current version, and candidate version. Stop when remote inventory cannot prove one case.
+22. **Treat external writes as indeterminate until reconciled.** After `publish` or `deploy` starts, a timeout, interruption, 5xx, HTML response, or nonzero exit may have changed remote state. Do not blindly retry, auto-bump, change or omit the route, delete/recreate the app, or fall back from upgrade to create. Re-read remote state and form a fresh operation.
+23. **A route is immutable after create.** Pass the reviewed `--path-name` only for a proven create. Never invent a random suffix after a collision. For a proven upgrade, preserve the exact route and omit `--path-name`; if the CLI reports `routing name must be unique`, stop and reconcile the target rather than retrying with different flags.
 
 ## Disambiguation — Apps vs Dashboards
 
@@ -123,19 +127,12 @@ uip login status --output json         # check if logged in
 uip login                              # interactive OAuth (opens browser)
 uip login --authority https://alpha.uipath.com   # non-production environments
 
-# Client-credentials (headless/CI) — MUST include Apps.Read Apps.Write or publish's
-# "Registering coded app" step fails with 401 even though package upload succeeds.
-# OR.Default alone is NOT sufficient — it covers Orchestrator but not the Apps service.
-uip login \
-  --client-id <id> \
-  --client-secret <secret> \
-  --organization <org> \
-  --tenant <tenant> \
-  --scope "OR.Folders OR.Execution OR.Administration Apps.Read Apps.Write" \
-  --authority https://alpha.uipath.com   # omit --authority for production
+# Headless/CI — provision the credential through the runner's secure profile setup,
+# never in command arguments or logs. Then verify the exact named profile.
+uip login status --profile <profile-name> --output json
 ```
 
-> **The `uip login` session scope is separate from the app's runtime OAuth scopes.** The scopes in `uipath.json` are what the *deployed app* requests at runtime (see [oauth-scopes.md](references/oauth-scopes.md)). The `--scope` on `uip login` above is what the *CLI session* needs to call the Apps registration API during `uip codedapp publish`. `uip codedapp publish` does two things: uploads the package (needs Orchestrator scopes) **and** registers the coded app (needs `Apps.Read Apps.Write`). Omitting the Apps scopes lets the upload succeed but silently 401s the registration.
+> **The CLI session scope is separate from the app's runtime OAuth scopes.** The scopes in `uipath.json` are what the *deployed app* requests at runtime (see [oauth-scopes.md](references/oauth-scopes.md)). A headless profile used for `uip codedapp publish` must include Orchestrator package scopes plus `Apps.Read Apps.Write`: publish uploads the package and then registers the coded app with a different service. Omitting Apps scopes can let upload succeed before registration fails. Configure credentials through the secure runner/profile mechanism, never through command arguments or committed files.
 
 ## SDK Config (web app)
 
@@ -157,15 +154,34 @@ To change any of these values, edit `uipath.json`.
 | Staging | `https://staging.api.uipath.com` |
 | Alpha | `https://alpha.api.uipath.com` |
 
-## Quick Deploy (Full Pipeline)
+## Deployment Lanes
 
-**Do NOT pause between steps to ask "should I continue?" — execute the full pipeline. Only stop if you need auth credentials or an app name.**
+### Testing-only quick path
 
-1. **Auth** — `uip login status --output json`. If not logged in, ask the user for their environment and run `uip login`. If using **client credentials** (headless/CI), always include `Apps.Read Apps.Write` in `--scope` — required by the Apps service registration inside `uip codedapp publish`. `OR.Default` alone covers Orchestrator (package upload) but not Apps registration; omitting them causes a silent 401 on the second half of publish.
-2. **Build** — `npm run build`. Verify `ls dist/`.
-3. **Pack** — `uip codedapp pack dist -n <name> --version <version>`. Produces `.uipath/<name>.<version>.nupkg`. Bump version if previously published.
-4. **Publish** — `uip codedapp publish` (add `-t Action` for action apps). Verify `cat .uipath/app.config.json`.
-5. **Deploy** — `uip codedapp deploy -n <name> --folder-key <GUID>`. Resolve the GUID from the chosen folder: a personal workspace (`Type == "Personal"`), a named existing folder, or a freshly `uip or folders create`d one — via `uip or folders list --output json`. Dashboards additionally choose a **deploy mode** (standalone / governance-pinned / governance) that sets `--tags`; see [dashboards deploy impl](references/dashboards/plugins/deploy/impl.md). Never let the command go interactive. Share the app URL with the user.
+Use the direct CLI pipeline without a second approval only when the user explicitly requests a test deployment and all of these are true. That explicit request is the operation authorization; do not ask for a separate plan hash. Ask again only if authoritative preflight materially changes the target, intent, route, or candidate.
+
+- Target is the exact UiPath Alpha or Staging control plane.
+- App is internal/authenticated and contains synthetic data only.
+- The exact org, tenant, folder, OAuth client, route, CLI/profile, candidate version, and built bytes are recorded.
+- The operation is explicitly `create` or `upgrade`, supported by fresh remote evidence.
+- An automatic testing receipt records the artifact/config hashes, waived gates, every external-write result, and post-deploy checks. It must say `production_eligible: false` and `release_evidence: false`.
+
+Dirty or uncommitted source is allowed in this lane because the exact built bytes are authoritative. Record Git HEAD and worktree status for context; do not present them as provenance. If the exact candidate is already published, deploy it without rebuilding or republishing.
+
+The stock `uip codedapp` 1.198.0 commands do not include deployment `list` or `get`. Use an approved inventory-capable deployment helper or Apps API runtime for the required remote preflight and post-verification; never extract a bearer token manually. If that capability is unavailable, stop before the write.
+
+For a new source-built test candidate, execute the full pipeline after preflight; do not pause between steps for another approval:
+
+1. **Auth** — verify a named profile with `uip login status --profile <name> --output json` and confirm the control plane, org, and tenant.
+2. **Build and bind** — run `npm run build`, audit `dist/`, and hash the exact directory and runtime configuration.
+3. **Pack** — run `uip codedapp pack dist -n <name> --version <version> -o .uipath`, then verify and hash the candidate package from the filesystem. (`pack` uses `--output` for its directory, so do not use `--output json` here.)
+4. **Publish** — run `uip codedapp publish -n <name> --version <version> --profile <name> --output json` (add `-t Action` for action apps). A failed or interrupted publish is indeterminate until remote reconciliation.
+5. **Deploy** — use the exact version, client, folder, tags, and profile. Add `--path-name` only for a remotely proven create; omit it for a remotely proven upgrade. Never let the command go interactive.
+6. **Verify** — re-read the exact remote deployment and verify its route, assets, authentication, and an app-specific smoke test before calling it deployed.
+
+### Governed release
+
+Use a governed release for Production, customer data, or any request that expects durable release evidence. Bind clean reviewed source, exact dist/package/runtime hashes, CLI/profile/target identity, create-or-upgrade remote evidence, a reviewed approval, an immutable receipt, and rollback authority. Do not substitute the testing-only quick path or its receipt. See [pack-publish-deploy.md](references/pack-publish-deploy.md) for both lanes and their failure boundaries.
 
 ## SDK Module Imports
 
@@ -175,7 +191,7 @@ See [references/sdk/imports.md](references/sdk/imports.md) for the lookup protoc
 
 ### App Config (`.uipath/app.config.json`)
 
-Created by `publish`, consumed by `deploy`. Contains `appName`, `systemName`, `appType`, `deploymentId`, `appUrl`. Do not delete `.uipath/` between publish and deploy.
+Created by `publish`, consumed by `deploy`. Contains `appName`, `systemName`, `appType`, `deploymentId`, `appUrl`. Preserve it between publish and deploy, but treat it as a repairable cache: compare it with remote inventory before choosing create or upgrade.
 
 ### Action Schema (`action-schema.json`)
 
@@ -194,6 +210,8 @@ See [references/debug.md](references/debug.md) for detailed diagnosis steps.
 | `No packages found` | No `.nupkg` in `.uipath/` | Run `pack` first |
 | Login fails / redirect error | OAuth misconfiguration | See [debug.md](references/debug.md) |
 | API calls fail with 401/CORS | Wrong base URL | Use `https://api.uipath.com` not `cloud.uipath.com` |
+| `routing name must be unique` | Create/upgrade target or route was inferred incorrectly | Stop. Reconcile remote deployment and route state; never randomize or omit the route and retry. |
+| Publish/deploy timed out or returned 5xx/HTML | External write is indeterminate | Re-read remote package/deployment state before forming a fresh operation; never blind-retry. |
 
 > **Folder identifier names differ across CLI and SDK.** The CLI uses `UIPATH_FOLDER_KEY` / `--folder-key` (string) and applies only to `uip codedapp deploy`. SDK methods use different parameters: Maestro services (`MaestroProcesses`, `ProcessInstances`, `Cases`) take `folderKey` (string GUID), Orchestrator services (`Assets`, `Queues`, `Buckets`, `Processes`) take `folderId` (number). Do not pass the CLI env var into SDK calls. To bridge from a Maestro `folderKey` to an Orchestrator `folderId`, see [sdk/maestro.md](references/sdk/maestro.md) — and **never** `parseInt(folderKey)`, the GUID is not numeric.
 
@@ -202,12 +220,12 @@ See [references/debug.md](references/debug.md) for detailed diagnosis steps.
 When you finish a task, report only what's applicable to the work actually done:
 
 1. **What was done** — files created, edited, or deleted (list paths); CLI commands run
-2. **Stage reached** — one of: scaffolded / built / packed / published / deployed
+2. **Stage reached** — one of: scaffolded / built / packed / published / deployed-for-testing / governed-deployed
 3. **Artifacts produced** (report only the ones that actually exist):
    - `dist/` — if `npm run build` was run
    - `.uipath/<name>.<version>.nupkg` — if `pack` was run
    - `.uipath/app.config.json` with `deploymentId` — if `publish` was run
-   - Live deployment URL (`appUrl` from `app.config.json`) — if `deploy` was run
+   - Deployment URL (`appUrl` from `app.config.json`) — if `deploy` ran and remote verification passed; label testing-only URLs as nonproduction
    - External Application client ID — if one was created this session
 4. **Next steps**, depending on where the task stopped:
    - **Scaffolded only:** `cd <app-name> && npm run dev` to run locally
@@ -225,4 +243,4 @@ These pitfalls are not already covered by the Critical Rules. For rules stated a
 
 - **Don't import service classes from the package root** — use the subpath (e.g., `@uipath/uipath-typescript/assets`).
 - **Don't use the deprecated dot-chain `sdk.entities.getAll()`** — use constructor DI: `new Entities(sdk)`.
-- **Don't delete `.uipath/` between `publish` and `deploy`** — `deploy` reads `app.config.json` written by `publish`.
+- **Don't treat `.uipath/app.config.json` as remote authority** — preserve it for `deploy`, then verify every identity and version against remote state.

--- a/skills/uipath-coded-apps/references/commands-reference.md
+++ b/skills/uipath-coded-apps/references/commands-reference.md
@@ -26,7 +26,7 @@ uip codedapp push [project-id] [options]
 | `--base-url <url>` | UiPath base URL | From `.env` |
 | `--org-id <id>` | Organization ID | From `.env` |
 | `--tenant-id <id>` | Tenant ID | From `.env` |
-| `--access-token <token>` | Access token | From `.env` |
+| `--access-token <token>` | Supported CLI override; agents must not pass or log tokens manually—use `--profile` | From `.env` |
 
 **Examples:**
 
@@ -74,7 +74,7 @@ uip codedapp pull [project-id] [options]
 | `--base-url <url>` | UiPath base URL | From `.env` |
 | `--org-id <id>` | Organization ID | From `.env` |
 | `--tenant-id <id>` | Tenant ID | From `.env` |
-| `--access-token <token>` | Access token | From `.env` |
+| `--access-token <token>` | Supported CLI override; agents must not pass or log tokens manually—use `--profile` | From `.env` |
 
 **Examples:**
 
@@ -110,16 +110,18 @@ uip codedapp pack <dist> [options]
 | `-n, --name <name>` | Package name | Prompted interactively |
 | `-v, --version <version>` | Package version | `1.0.0` |
 | `-o, --output <dir>` | Output directory for `.nupkg` | `./.uipath` |
-| `-a, --author <author>` | Package author | `UiPath Developer` |
+| `--author <author>` | Package author | `UiPath Developer` |
 | `--description <desc>` | Package description | Prompted |
 | `--main-file <file>` | Main entry file | `index.html` |
 | `--content-type <type>` | Content type: `webapp`, `library`, `process` | `webapp` |
 | `--dry-run` | Preview packaging without creating the file | `false` |
-| `--reuse-client` | Reuse existing clientId from uipath.json | `false` |
-| `--base-url <url>` | UiPath base URL | From `.env` |
-| `--org-id <id>` | Organization ID | From `.env` |
-| `--tenant-id <id>` | Tenant ID | From `.env` |
-| `--access-token <token>` | Access token | From `.env` |
+| `--repository-url <url>` | Source repository recorded for traceability | None |
+| `--repository-commit <sha>` | Source commit recorded for traceability | None |
+| `--repository-branch <branch>` | Source branch recorded for traceability | None |
+| `--repository-type <type>` | Repository type; defaults to `git` with a repository URL | None |
+| `--release-notes <text>` | Package release notes | None |
+| `--project-url <url>` | Automation Hub idea URL | None |
+| `--profile <name>` | Named CLI profile; accepted as a global option but pack does not need cloud authentication | Active/default profile |
 
 **Examples:**
 
@@ -137,7 +139,7 @@ uip codedapp pack dist -o ./packages
 uip codedapp pack dist --dry-run
 
 # Pack with all options
-uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "Production app" --main-file app.html
+uip codedapp pack dist -n my-webapp --version 1.0.0 --author "My Team" --description "Production app" --main-file app.html
 ```
 
 **Output:**
@@ -170,12 +172,14 @@ uip codedapp publish [options]
 | `-n, --name <name>` | Package name (non-interactive selection) | Auto-select or prompted |
 | `-v, --version <version>` | Package version (requires `--name`) | Latest |
 | `-t, --type <type>` | App type: `Web` or `Action` | `Web` |
+| `--personal-workspace` | Publish to the current user's Personal Workspace feed | Tenant feed |
 | `--uipath-dir <dir>` | Directory containing `.nupkg` files | `./.uipath` |
 | `--base-url <url>` | UiPath base URL | From `.env` |
 | `--org-id <id>` | Organization ID | From `.env` |
 | `--tenant-id <id>` | Tenant ID | From `.env` |
 | `--tenant-name <name>` | Tenant name (required for registration) | From `.env` |
-| `--access-token <token>` | Access token | From `.env` |
+| `--access-token <token>` | Supported CLI override; agents must not pass or log tokens manually—use `--profile` | From `.env` |
+| `--profile <name>` | Named authenticated CLI profile | Active/default profile |
 
 **Examples:**
 
@@ -217,12 +221,12 @@ Published App Details:
 
 ## `uip codedapp deploy`
 
-Deploy or upgrade a coded app in UiPath. Automatically detects whether to perform a fresh deployment or upgrade.
+Deploy or upgrade a coded app in UiPath. The CLI can auto-detect, but agents must choose and verify the intent before execution.
 
-- **Fresh deploy**: App has not been deployed before → deploys version 1
-- **Upgrade**: App is already deployed → upgrades to the latest published version
+- **Create**: fresh remote inventory proves the deployment is absent and the exact route is unused; pass `--path-name`.
+- **Upgrade**: fresh remote inventory proves the exact deployment, system name, route, current version, and candidate; omit `--path-name` and preserve the route.
 
-App name is resolved from: `--name` flag → `.uipath/app.config.json` → interactive prompt.
+App name is resolved from: `--name` flag → `.uipath/app.config.json` → interactive prompt. This resolution is convenience, not remote-state proof. Treat local config as a repairable hint and never let it decide create versus upgrade.
 
 ```bash
 uip codedapp deploy [options]
@@ -231,25 +235,30 @@ uip codedapp deploy [options]
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-n, --name <name>` | App name | From `.uipath/app.config.json` or prompted |
-| `-v, --version <version>` | Target a specific **published** version (different semantic from `pack`/`publish` `-v`, which is the package version) | Latest |
+| `--path-name <name>` | Permanent hosted route; use only for a proven create | Tool default |
+| `--client-id <id>` | Exact non-confidential OAuth client override | Tool/config default |
+| `-v, --version <version>` | Exact **published** candidate to deploy (different semantic from `pack`/`publish` `-v`) | Latest |
 | `--base-url <url>` | UiPath base URL | From `.env` |
 | `--org-id <id>` | Organization ID | From `.env` |
 | `--org-name <name>` | Organization name (used for app URL) | From `.env` |
 | `--tenant-id <id>` | Tenant ID | From `.env` |
 | `--folder-key <key>` | UiPath folder key | From `UIPATH_FOLDER_KEY` env var |
-| `--access-token <token>` | Access token | From `.env` |
+| `--access-token <token>` | Supported CLI override; agents must not pass or log tokens manually—use `--profile` | From `.env` |
+| `--tags <tags>` | Comma-separated categorization labels | None |
+| `--profile <name>` | Named authenticated CLI profile | Active/default profile |
 
 **Examples:**
 
 ```bash
-# Deploy (uses app name from .uipath/app.config.json)
-uip codedapp deploy
+# Proven create: exact route is unused
+uip codedapp deploy -n my-webapp --version 1.0.0 \
+  --path-name my-webapp --client-id <client-guid> \
+  --folder-key <folder-guid> --profile <profile> --output json
 
-# Deploy with explicit app name
-uip codedapp deploy -n my-webapp
-
-# Deploy with folder key
-uip codedapp deploy -n my-webapp --folder-key my-folder-key
+# Proven upgrade: preserve the route by omitting --path-name
+uip codedapp deploy -n my-webapp --version 1.1.0 \
+  --client-id <client-guid> --folder-key <folder-guid> \
+  --profile <profile> --output json
 ```
 
 **Fresh deploy output:**
@@ -270,15 +279,22 @@ uip codedapp deploy -n my-webapp --folder-key my-folder-key
 - New deploy: `POST /{org}/apps_/default/api/v1/default/models/{systemName}/publish/versions/1/deploy`
 - Upgrade: `POST /{org}/apps_/default/api/v1/default/models/deployed/apps/updateToLatestAppVersionBulk`
 
+### Deployment safety boundary
+
+- Direct CLI deployment without a second approval is testing-only: explicit internal synthetic-data testing in Alpha or Staging, exact candidate/target binding, automatic receipt, and post-deploy verification.
+- Production, customer data, or durable release evidence requires a governed plan and immutable receipt.
+- A publish/deploy timeout, interruption, 5xx, HTML response, or nonzero exit is indeterminate until remote reconciliation. Never blind-retry, auto-bump, randomize or omit the route, delete/recreate, or fall back from upgrade to create.
+
 ---
 
 ## Common Options
 
-All cloud commands accept these override options (values default to `.env` file):
+Cloud commands expose these target/authentication overrides (availability varies by subcommand; prefer an exact named profile):
 
 | Option | Description |
 |--------|-------------|
 | `--base-url <url>` | UiPath base URL |
 | `--org-id <id>` | Organization ID |
 | `--tenant-id <id>` | Tenant ID |
-| `--access-token <token>` | Access token |
+| `--access-token <token>` | Supported CLI override, but agents must not pass or log tokens manually; use `--profile` |
+| `--profile <name>` | Named authenticated CLI profile |

--- a/skills/uipath-coded-apps/references/dashboards/CAPABILITY.md
+++ b/skills/uipath-coded-apps/references/dashboards/CAPABILITY.md
@@ -115,17 +115,16 @@ For a compiler-managed dashboard, read `primitives/incremental-editor.md` in the
 Read: references/dashboards/plugins/deploy/impl.md  *(from skill root)*
 ```
 
-Read this file in parallel with:
+Do not run login status or any other CLI command yet. The deploy plugin binds a named profile after the lane-specific authorization point; checking an unnamed/default session here would contradict that boundary.
 
-```bash
-uip login status --output json
-```
+### Step 2 — Present the lane-specific deployment summary
 
-**Do not run any other commands until you have read the deploy plugin and presented the plan to the user.**
+Read `.dashboard/state.json` in memory to get the app name, version, and intended routing name. Treat its deployment block as a local hint, not remote authority. First classify the release lane and deployment target per `plugins/deploy/impl.md` Step 0:
 
-### Step 2 — Present the deploy plan (pure text, zero CLI calls)
+- **Testing-only** only when the user explicitly requests an internal, synthetic-data deployment to Alpha or Staging.
+- **Governed** for Production, customer data, durable release evidence, or ambiguity.
 
-Read `.dashboard/state.json` in memory to get the app name, version, and routing name. First determine the deployment target — **governance/admin dashboard** vs **standard dashboard app** — per `plugins/deploy/impl.md` Step 0. The folder line and the pin question depend on it.
+The folder line and pin question depend on the governance/admin versus standard dashboard target. Create versus upgrade remains proposed until post-authorization remote preflight proves it.
 
 ```
 Your **[Dashboard Name]** is ready to be deployed.
@@ -133,7 +132,9 @@ Your **[Dashboard Name]** is ready to be deployed.
 📦  Version:    [current] → [bumped]
 🔗  URL path:   [routing-name]
 📁  Folder:     [AdminDashboards (governance) | user-chosen folder (standard)]
-🔄  Type:       Fresh deploy  OR  Updating existing deployment
+👤  Profile:    [named CLI profile; exact org/tenant verified before writes]
+🛡️  Lane:       Testing-only (Alpha/Staging synthetic)  OR  Governed release
+🔄  Intent:     Proposed create/upgrade; remote preflight required
 
 📌  (governance only) Do you want to pin this dashboard to the Governance UI?
    → "deploy and pin" — visible in the Governance section
@@ -144,11 +145,14 @@ A standard dashboard deploys to a user-chosen folder with no pin question — se
 
 > ⚠️ Pinning surfaces the dashboard in the Governance section, which is an **Agentic Governance preview** feature — it only takes effect if the org is enrolled in the preview. When offering the pin, say so; either way the dashboard deploys and is reachable at its URL. See `plugins/deploy/impl.md` Step 4 / Step 10.
 
-**HALT. Do not run any CLI command until the user confirms.**
+Authorization differs by lane:
+
+- **Testing-only** — the user's explicit request to deploy an internal synthetic dashboard to Alpha/Staging is the deployment authorization. Present the summary, then continue without a second plan-hash or confirmation reply when target, mode, and folder are already supplied. Ask only for a missing material choice; that question is not a second release approval.
+- **Governed** — end with `Confirm to deploy, or tell me what to change.` and HALT. Run no CLI command until the user confirms the reviewed plan.
 
 ### Step 3 — Follow plugins/deploy/impl.md
 
-After user confirms, follow every step in `plugins/deploy/impl.md` exactly as written. Do not invent steps, do not run `uip tools list`, do not run `npm run build` before the plan is confirmed.
+For an authorized testing-only request, or after governed confirmation, follow every step in `plugins/deploy/impl.md` exactly as written. Do not invent steps or run `npm run build` before that authorization point. The deploy plugin may run `uip tools list` after authorization when it needs to establish the documented Orchestrator-folder prerequisite.
 
 ---
 
@@ -165,10 +169,10 @@ This skill only handles dashboard building, editing, and deploying. For anything
 - **Never** show raw tool call outputs to the user — read results in context, surface only meaningful information
 - **Never** echo raw event names (WIDGET_READY, TSC_PASS, BUILD_RESULT, etc.) — translate them to clean progress lines
 - **Never** show intermediate bash command outputs between the user's request and the plan — the plan is the first visible output
-- **Never** call any tool — including the question/option tool — in the same response as the plan. The plan is pure text; the user replies to it; structured setup questions (OAuth, deploy pin) fire only after approval and only for details the user hasn't already given
-- **Never** run ANY CLI command before presenting the plan and getting user confirmation
+- **Never** put a tool call or setup question in the same response as a governed plan; the user must reply first. A testing-only execution summary has no approval question and may continue into the deploy plugin in the same turn when every material choice is already supplied.
+- **Never** run a CLI command before presenting the deployment summary. Governed releases also require a confirmation reply; an explicit eligible testing-only request is already authorized and requires no second reply.
 - **Never** improvise deploy steps — always read `plugins/deploy/impl.md` first
-- **Never** run `uip tools list`, `npm run build`, or any command not in the relevant impl.md
+- **Never** run `uip tools list`, `npm run build`, or another command unless the relevant impl.md calls for it after authorization
 - **Never** use `"agent-health-dashboard"` (routing slug) as the `-n` flag — always use the human-readable display name from state.json
 - **Never** run `uip codedapp publish` without `-n` and `--version` flags
 - **Never** fetch the live SDK docs URL — it takes 60–90s
@@ -176,4 +180,6 @@ This skill only handles dashboard building, editing, and deploying. For anything
 - **Never** run directory exploration via ANY shell — `ls`, `find`, `dir`, `Get-ChildItem`, `tree`, glob loops. Memory or prior-session hints are not a reason to explore; the state.json check is the only existing-work probe
 - **Never** read files one at a time
 - **Never** commit generated dashboard files
-- **Never** auto-deploy without explicit user confirmation
+- **Never** classify an ambiguous deployment as testing-only; testing requires an explicit synthetic Alpha/Staging request
+- **Never** use `.dashboard/state.json` as proof of create/upgrade or remote route ownership
+- **Never** auto-deploy from ambiguous wording. An explicit eligible testing-only deployment request counts as confirmation; governed or materially changed plans require a confirmation reply.

--- a/skills/uipath-coded-apps/references/dashboards/plugins/deploy/impl.md
+++ b/skills/uipath-coded-apps/references/dashboards/plugins/deploy/impl.md
@@ -2,41 +2,44 @@
 
 Publishes a built dashboard to Automation Cloud as a Coded Web App.
 
-**Pipeline order:** Production build → Pack → Publish → Deploy.
+**New-candidate order:** Build → Pack → Publish → Deploy. An exact already-published testing candidate may go directly to a reconciled upgrade without rebuilding or republishing.
 
 > **What the user should see:** The deploy plan (Step 3), the mode/folder choices (Step 4), progress ticks, and the final URL. All other steps are silent — run commands, read outputs in context, never echo raw JSON or bash output to the user.
 
 ---
 
-## Pre-flight
+## Pre-flight inputs (deferred)
 
-Verify login and read state.json:
+Do not run a login or cloud command merely because this file was opened. First classify the lane and present the Step 3 governed plan or testing-only execution summary. Step 4a runs the named-profile login check after the applicable authorization point.
 
-```bash
-uip login status --output json
-```
-
-Check `Data.Status === "Logged in"`. If not, stop and ask the user to run `uip login`.
-
-Read current deployment state from `.dashboard/state.json` — extract `app.name`, `app.routingName`, `app.semver`, `deployment.systemName`, `deployment.folderKey`, `deployment.folderName`, `deployment.pinnedToGovernance`.
+Read current deployment state from `.dashboard/state.json` — extract `app.name`, `app.routingName`, `app.semver`, `deployment.systemName`, `deployment.folderKey`, `deployment.folderName`, `deployment.pinnedToGovernance`. These values propose a plan; they do not prove remote state.
 
 If `routingName` is empty: tell the user to run the build first.
 
 ---
 
-## Step 0 — Classify deploy type
+## Step 0 — Classify lane and proposed intent
 
-- `deployment.systemName` is empty → **Fresh deploy**
-- `deployment.systemName` is set → **Upgrade** — keep the mode and folder from the prior deploy (`deployment.pinnedToGovernance` + `deployment.folderName`/`folderKey`); the plan re-confirms but Step 4 asks nothing.
+Classify the release lane first:
+
+- **Testing-only** — only when the user explicitly requests an internal, synthetic-data deployment to UiPath Alpha or Staging. Dirty source may be used, but exact built bytes/configuration are authoritative and the receipt must state `production_eligible: false` and `release_evidence: false`.
+- **Governed** — Production, customer data, durable release evidence, or any ambiguity. Require reviewed source/artifact/config hashes, an approval record, immutable receipt, rollback authority, and post-deploy verification.
+
+Then derive a **proposed** intent from local state for the plan:
+
+- `deployment.systemName` empty → proposed **Create**
+- `deployment.systemName` present → proposed **Upgrade**; tentatively keep the prior mode and folder
+
+Do not execute from this proposal. Step 4a must prove the exact create or upgrade from fresh remote inventory. A missing local system name does not prove the app is absent; a present value does not prove that deployment still exists.
 
 ---
 
 ## Step 1 — Set the publish version
 
-The version used for pack + publish (Steps 7–8) is `NEXT_SEMVER`, derived by deploy type:
+The candidate version used for pack + publish (Steps 7–8) is selected before external writes:
 
-- **Fresh deploy** (`deployment.systemName` empty): first publish — use `app.semver` as-is. `NEXT_SEMVER = <CURRENT_SEMVER>` (no bump; the version doesn't exist yet).
-- **Upgrade** (`deployment.systemName` set): the current version is **already published**, so you **MUST** bump before pack/publish — re-publishing the same version fails with "version already exists". This bump is mandatory, not optional; never pack/publish an upgrade at `<CURRENT_SEMVER>`. Compute the next patch:
+- **Proposed create**: propose `app.semver` as `NEXT_SEMVER`.
+- **Proposed upgrade**: propose the next patch as `NEXT_SEMVER`:
 
   ```bash
   node -e "
@@ -45,9 +48,7 @@ The version used for pack + publish (Steps 7–8) is `NEXT_SEMVER`, derived by d
   " <CURRENT_SEMVER>
   ```
 
-  This gives `NEXT_SEMVER`. Pack (Step 7) and Publish (Step 8) MUST pass `--version "<NEXT_SEMVER>"`.
-
-Step 8 (Publish) still auto-bumps and retries on a 409 / "already exists" as a backstop — but on an Upgrade you bump here first; do not skip the bump and rely on the retry alone.
+  This gives a proposal only. Step 4a must prove the exact candidate version is not already published before pack. If it conflicts, stop and present a revised version before any write. Never auto-bump in response to a publish failure.
 
 ---
 
@@ -69,9 +70,9 @@ Recommend a mode from `.dashboard/state.json` `widgets`:
 
 **Folder** — three options: **Personal workspace** · **Existing folder** (user names it) · **Create a new folder**. Recommend:
 - **Governance modes → `AdminDashboards`** (the governance home; provisioned in Step 5).
-- **Standalone → Personal workspace** (zero-config, private to the user).
+- **Standalone → an existing shared team folder such as `Shared`** (team-visible without governance role provisioning). Offer Personal workspace as the private alternative.
 
-**Upgrade short-circuit:** if `deployment.systemName` is set, keep the state-implied mode (`deployment.pinnedToGovernance` + the tags used before) and folder (`deployment.folderName`/`folderKey`). Step 4 asks nothing.
+**Proposed-upgrade short-circuit:** if `deployment.systemName` is set, tentatively keep the state-implied mode (`deployment.pinnedToGovernance` + the tags used before) and folder (`deployment.folderName`/`folderKey`). Step 4 asks nothing unless Step 4a finds a remote discrepancy.
 
 **Capture user wording:** if the request already names a mode ("as a governance dashboard, pinned") and/or a folder ("in a new folder called X" / "to my personal workspace"), treat those as settled — the matching Step-4 question is skipped.
 
@@ -84,14 +85,15 @@ Recommend a mode from `.dashboard/state.json` `widgets`:
 ```
 Your **<APP_NAME>** is ready to be deployed.
 
-📦  Version:    <SEMVER> → <NEXT_SEMVER>   (or "1.0.0 (first publish)" on a fresh deploy)
+📦  Version:    <SEMVER> → <NEXT_SEMVER>   (or "1.0.0 (first publish)" on a proposed create)
 🔗  URL path:   <ROUTING_NAME>
+🛡️  Lane:       <TESTING_ONLY_OR_GOVERNED>
 🎯  Mode:       <MODE_LABEL>   (recommended — <why>, or "kept from last deploy" on upgrade)
 📁  Folder:     <FOLDER_LABEL>   (recommended — <why>)
-🔄  Type:       Fresh deploy  OR  Updating existing deployment
+🔄  Intent:     Proposed Create OR Upgrade — remote preflight required
 ```
 
-**Governance mode + fresh deploy + shared-folder target** — also show:
+**Governance mode + proposed create + shared-folder target** — also show:
 ```
 ⚠️  Governance deploy provisions the <FOLDER_LABEL> folder and grants Administrators
     Folder Administrator on it — an elevated permission the coding agent will ask you
@@ -105,7 +107,9 @@ Your **<APP_NAME>** is ready to be deployed.
 ```
 **Standalone, or ANY Personal-workspace target** — show no elevated-permissions warning (deploying there assigns no roles).
 
-End the deploy plan with: `Confirm to deploy, or tell me what to change.` — **pure text, no tool calls in this response. HALT.**
+For **governed**, end the plan with `Confirm to deploy, or tell me what to change.` — pure text, no tool calls in this response, then HALT.
+
+For **testing-only**, the user's explicit eligible Alpha/Staging synthetic deployment request is authorization. Present the same content as an execution summary and continue without a second reply when mode and folder are already settled. If a material choice is missing, ask only that choice and wait; do not request a plan hash.
 
 ---
 
@@ -113,11 +117,13 @@ End the deploy plan with: `Confirm to deploy, or tell me what to change.` — **
 
 On the user's reply:
 - **Change request / cancel** → handle it; re-present the plan if changed.
-- **Upgrade** (`systemName` set) → skip both questions; go to Step 5 with the kept mode/folder.
+- **Proposed upgrade** (`systemName` set) → skip both questions; go to Step 4a with the kept mode/folder.
 
-Otherwise this is a **fresh deploy**: ask the two SHORT structured-choice questions below (SKILL.md Rule 18), recommended option first and suffixed "(Recommended)". **Never** put them in the same message as the plan — they fire on this later, short turn.
+For an already-authorized testing-only request, apply the same branches immediately after its execution summary. Ask only questions whose values were not supplied by the request.
 
-> **When an interactive user is present, ALWAYS present Question 1 (mode) on a fresh deploy.** The Step-2 inference only decides which option is pre-marked "(Recommended)" — with a human present it does **NOT** let you silently auto-pick a mode. Deploying as *standalone* without asking is a bug: an agent-health / jobs / KPI dashboard is merely *recommended* standalone, but the user may deliberately want it as a governance dashboard, so show all three and let them choose. A bare "deploy" / "confirm" / "yes" does **not** settle the mode — ask.
+Otherwise this is a **proposed create**: ask the two SHORT structured-choice questions below (SKILL.md Rule 18), recommended option first and suffixed "(Recommended)". **Never** put them in the same message as the plan — they fire on this later, short turn.
+
+> **When an interactive user is present, ALWAYS present Question 1 (mode) on a proposed create.** The Step-2 inference only decides which option is pre-marked "(Recommended)" — with a human present it does **NOT** let you silently auto-pick a mode. Deploying as *standalone* without asking is a bug: an agent-health / jobs / KPI dashboard is merely *recommended* standalone, but the user may deliberately want it as a governance dashboard, so show all three and let them choose. A bare "deploy" / "confirm" / "yes" does **not** settle the mode — ask.
 >
 > **Skip Question 1 ONLY when:** (a) the user's wording already named the mode ("deploy as a governance dashboard, pinned" / "just deploy as a standalone app"); or (b) the user told you not to ask / to proceed without confirmation, or the run is non-interactive / automated (e.g. CI) — then use the **recommended** mode and proceed without asking (never block a headless deploy on a question). The **same two carve-outs** govern Question 2 (folder): ask when interactive, otherwise use the recommended folder.
 
@@ -145,11 +151,46 @@ Free-text replies (including a bare folder name) remain valid and take precedenc
 
 ---
 
+## Step 4a — Prove the remote operation (read-only)
+
+Verify the exact named profile first:
+
+```bash
+uip login status --profile "<CLI_PROFILE>" --output json
+```
+
+Check `Data.Status === "Logged in"`. If not, stop and ask the user to authenticate that profile. Bind its control plane, org, and tenant; do not reuse a default session whose target is ambiguous.
+
+Before folder provisioning, publish, or deploy, query the authenticated target's authoritative app/package inventory through an approved inventory-capable deployment helper or Apps API runtime. The stock `uip codedapp` 1.198.0 surface exposes `init`, `pack`, `publish`, `deploy`, `push`, and `pull`, but no deployment `list`/`get`; it cannot satisfy this preflight by itself. Never obtain or print a bearer token to compensate. If no approved inventory-capable path is available, stop; local files are not an acceptable fallback.
+
+Bind and compare the exact control plane, org, tenant, named profile, app/package name, OAuth client, intended route, folder, current deployment/system identity, current version, candidate version, and app type.
+
+- **Create** passes only when there is no matching deployment and the exact route is unused.
+- **Upgrade** passes only when one exact existing deployment matches the local candidate's system identity, permanent route, folder, client, and current version.
+- The candidate version must be the exact reviewed version and must not already exist before a new publish.
+- Testing-only additionally requires Alpha or Staging, internal authentication, and synthetic data. Otherwise stop or reclassify as governed.
+
+If authoritative evidence changes the proposed intent, mode, folder, route, current version, or candidate version, re-present the corrected plan and wait for confirmation—even in testing-only. Never silently switch create↔upgrade.
+
+Start the lane's receipt before the first external write. A testing-only run creates its automatic receipt without a second hash approval. A governed run requires its reviewed approval and immutable receipt first.
+
+---
+
 ## Step 5 — Resolve and provision the chosen folder
 
 Resolve the chosen folder to `folderKey` and persist `deployment.folderKey`/`folderName` in `.dashboard/state.json`.
 
-**If `deployment.folderKey` is already set** (upgrade / prior run) — skip this entire step.
+After authorization, confirm the Orchestrator tool prerequisite:
+
+```bash
+uip tools list --output json
+# Only when the returned inventory lacks orchestrator-tool:
+uip tools install @uipath/orchestrator-tool
+```
+
+This is the only `uip tools list` use permitted by the dashboard capability. If installation fails, stop before folder operations rather than improvising a portal path.
+
+**If Step 4a verified the existing deployment's exact `folderKey`** (upgrade) — skip this entire step. A local folder key alone is insufficient.
 
 **Governance mode targeting a SHARED folder** (AdminDashboards, or any user-named/newly-created shared folder — anything except Personal workspace) — provision via the script (silent — no output to user until "<FOLDER_NAME> folder is ready"):
 
@@ -196,7 +237,9 @@ Capture `Data.Key`. If it fails "already exists," resolve the existing folder's 
 
 ---
 
-## Step 6 — Production build
+## Step 6 — Build or bind the candidate
+
+For a source-built candidate:
 
 ```bash
 cd <PROJECT_DIR> && npm run build
@@ -218,6 +261,8 @@ process.stdout.write(html.includes('uipath:org-name') ? 'CONFIG_OK' : 'CONFIG_MI
 
 If it prints `CONFIG_MISSING`, `uipath.json` lacked `orgName` at build time — re-run the build (the build script writes `uipath.json`) and re-check. **Never deploy a `CONFIG_MISSING` bundle** — it loads blank in the browser. **Skip this check for template builds** (Step 7b) — a tenant-neutral template intentionally omits the org name.
 
+For an explicitly requested testing-only "deploy as-is" operation, an existing `dist/` or exact already-published candidate may be used without rebuilding. Hash and audit the exact bytes and runtime configuration, record the skipped build in the automatic testing receipt, and never claim source provenance or production readiness. If the candidate is already published and Step 4a identified it exactly, skip Steps 7–8; do not repack or republish it.
+
 ---
 
 ## Step 7 — Pack (silent)
@@ -225,8 +270,10 @@ If it prints `CONFIG_MISSING`, `uipath.json` lacked `orgName` at build time — 
 `-n` is the **friendly Title Case display name** (state.json `app.name`, e.g. `"Jobs Health Dashboard"`) — **never the routing slug.** The CLI sanitizes it to a slug (`jobshealthdashboard`) internally for package matching, but uses the friendly name as the display name in the catalog and Governance UI. Passing the slug makes the dashboard show up as `jobshealthdashboard`; the friendly name reads "Jobs Health Dashboard". Use the **same** `-n` for pack, publish, and deploy.
 
 ```bash
-cd <PROJECT_DIR> && uip codedapp pack dist -n "<APP_NAME>" --version "<NEXT_SEMVER>" --output json
+cd <PROJECT_DIR> && uip codedapp pack dist -n "<APP_NAME>" --version "<NEXT_SEMVER>" -o .uipath
 ```
+
+Verify and hash the resulting `.nupkg` directly. `pack` uses `--output` for its output directory, so do not pass `--output json` to this subcommand.
 
 ---
 
@@ -248,17 +295,19 @@ This stages a **tenant-neutral** modify-face (`intent.json`, `src/`, config file
 
 ---
 
-## Step 8 — Publish (silent)
+## Step 8 — Publish once (silent)
 
 ```bash
-cd <PROJECT_DIR> && uip codedapp publish -n "<APP_NAME>" --version "<NEXT_SEMVER>" --output json
+cd <PROJECT_DIR> && uip codedapp publish \
+  -n "<APP_NAME>" \
+  --version "<NEXT_SEMVER>" \
+  --profile "<CLI_PROFILE>" \
+  --output json
 ```
 
 Read the JSON output (silent — no output shown until success or error):
-- **Success** (`Result === "Success"`)→ extract `DeploymentVersion`, continue
-- **Contains "409" or "already exists"** → bump version once more, re-pack, retry publish (up to 4 attempts total)
-- **Contains "5xx" or HTML** → this is a transient gateway error; wait 10 seconds and retry (up to 4 attempts)
-- **Other error** → surface it to the user, stop
+- **Success** (`Result === "Success"`) → extract `DeploymentVersion`. Poll authoritative read-only inventory until that exact candidate is visible/indexed, then continue.
+- **Any non-success, timeout, interruption, 409, 5xx, or HTML response** → mark the write indeterminate, stop this operation, and reconcile remote package/app state. Do not auto-bump, repack, or retry in the same run.
 
 ---
 
@@ -269,52 +318,51 @@ Set tags from the chosen **mode** (Step 2/4):
 - **Governance, pinned** → tags = `"governance,dashboard"`
 - **Governance, not pinned** → tags = `"governance"`
 
-Two flags differ from pack/publish — getting these wrong is the most common deploy failure:
+Bind the exact candidate and target:
 
-- **No `--version` on deploy.** The CLI resolves the latest published version itself. Passing `--version` triggers a false `"...has not been published yet"` error.
-- **`--path-name` only on a FRESH deploy.** It sets the URL slug the first time. On an **upgrade** the routing name already exists — re-passing `--path-name` errors with `"routing name must be unique"`.
+- **Always pass `--version <NEXT_SEMVER>`.** Wait for authoritative inventory to show that exact candidate before deploy. Never omit it merely to select an unreviewed Latest version.
+- **Pass `--path-name` only on a proven Create.** It permanently sets the URL route.
+- **Omit `--path-name` on a proven Upgrade.** Preserve and verify the existing route.
+- Pass the exact non-confidential OAuth client from the audited runtime configuration and the named authenticated profile.
 
-**Fresh deploy** (`deployment.systemName` was empty):
+**Create** (proved by Step 4a):
 
 ```bash
 cd <PROJECT_DIR> && uip codedapp deploy \
   -n "<APP_NAME>" \
+  --version "<NEXT_SEMVER>" \
   --path-name "<ROUTING_NAME>" \
+  --client-id "<CLIENT_ID>" \
   --folder-key "<FOLDER_KEY>" \
   --tags "<TAGS>" \
+  --profile "<CLI_PROFILE>" \
   --output json
 ```
 
-**Upgrade** (`deployment.systemName` is set — omit `--path-name`):
+**Upgrade** (proved by Step 4a; omit `--path-name`):
 
 ```bash
 cd <PROJECT_DIR> && uip codedapp deploy \
   -n "<APP_NAME>" \
+  --version "<NEXT_SEMVER>" \
+  --client-id "<CLIENT_ID>" \
   --folder-key "<FOLDER_KEY>" \
   --tags "<TAGS>" \
+  --profile "<CLI_PROFILE>" \
   --output json
 ```
 
 Read the JSON output:
-- **Success** → extract `SystemName` and `AppUrl`, continue
-- **Contains "indexing" or "not been published"** → platform propagation delay after publish. Show `↻ App is indexing — retrying in 10 seconds (attempt N/3)…`. Wait 10 seconds and retry (up to 3 times). If all 3 fail, surface the error and stop.
-- **(Fresh deploy only) Contains "conflict", "already exist", or "name must be unique"** → the routing slug is taken; generate a new suffix and retry the fresh deploy (keep `--path-name`):
-
-```bash
-node -e "
-const base   = process.argv[1].replace(/-[a-z0-9]{4}$/, '')
-const suffix = Math.random().toString(36).slice(2, 6)
-process.stdout.write(base + '-' + suffix)
-" <ROUTING_NAME>
-```
-
-Use the new routing name in a fresh deploy call. Retry up to 3 times.
-
-- **Other error** → surface it to the user, stop
+- **Success** → extract `SystemName` and `AppUrl`, then continue to authoritative post-verification.
+- **Any non-success, timeout, interruption, indexing error, conflict, 5xx, HTML response, or `routing name must be unique`** → mark the write indeterminate, stop this operation, and reconcile the exact remote deployment/version/route. Never retry with a random route, omitted route, omitted version, delete/recreate, or create fallback.
 
 ---
 
-## Step 10 — Update state.json
+## Step 10 — Verify remotely, then update state.json
+
+Re-read the authoritative deployment before writing local state. Require the exact org, tenant, folder, deployment/system identity, version, route, client, tags, and URL from Steps 4a and 9. Verify the route and referenced assets, authentication, and an app-specific smoke test. If verification fails, leave local state unchanged and record `deployed_unverified` (testing) or the governed failure state.
+
+Only after all checks pass, update `.dashboard/state.json` atomically:
 
 ```bash
 node -e "
@@ -337,12 +385,24 @@ fs.renameSync(fp + '.tmp', fp)
 
 ## Step 11 — Report
 
+For a governed release that passed every acceptance check:
+
 ```
 🎉 **<APP_NAME>** is live.
 
 <APP_URL>
 
 Version <NEXT_SEMVER> · <FOLDER_NAME>
+```
+
+For testing-only:
+
+```
+**<APP_NAME>** is deployed for synthetic Alpha/Staging testing.
+
+<APP_URL>
+
+Version <NEXT_SEMVER> · <FOLDER_NAME> · Not production eligible
 ```
 
 **(governance only)**
@@ -360,21 +420,23 @@ Always: "To update after making changes, say 'deploy this dashboard' again."
 | "Folder Administrator" role not found | Run `uip or roles list --output json` and show the user the available roles |
 | Administrators group not found | List groups from the response, ask user which to use |
 | Build fails | Show the error — dev credentials are always restored |
-| Publish 409 | Auto-bump version and retry (up to 4 times) |
-| Publish 5xx / HTML | Wait 10s and retry (up to 4 times) |
-| Deploy "indexing" / "not been published" (with NO `--version` passed) | Propagation delay — show retry ticker, wait 10s, retry up to 3 times |
-| Deploy "not been published" but you passed `--version` | Remove `--version` from the deploy call — deploy resolves the latest version itself |
-| Deploy "routing name must be unique" on an upgrade | You passed `--path-name` on an upgrade — omit it; routing already exists |
-| Deploy path-name conflict (fresh deploy) | Generate new suffix, retry deploy only (pack/publish already done) |
+| Publish 409 / version exists | Stop and reconcile whether the exact publish occurred. Select a different version only in a new reviewed operation; never auto-bump. |
+| Publish/deploy timeout, interruption, 5xx, HTML, or nonzero exit | Treat the external write as indeterminate; reconcile remote state and stop the current operation. |
+| Candidate is not indexed | Poll authoritative read-only inventory before deploy. Do not issue and retry a deploy while indexing is unresolved. |
+| Deploy `routing name must be unique` on upgrade | Stop and reconcile the exact deployment target. Omit `--path-name` only in a fresh, proved upgrade operation; never blind-retry. |
+| Deploy route conflict on create | Stop and present an intentional plan change. Never generate a suffix or omit the reviewed route. |
 | "Agentic Governance is a preview feature and is not enabled for your organization" (on a pinned/governance deploy) | Not a deploy failure — the app IS deployed and reachable at its URL. Governance pinning is preview-gated: the pin just won't surface in the Governance section until the org is enrolled. Report success with the URL, add the preview note (Step 11), and tell the user to contact their UiPath representative for preview access. Do NOT retry or bump the version. |
 | state.json missing | Tell user to run the build first |
 
 ## Rules
 
 - `-n` is the **friendly Title Case display name** (state.json `app.name`, e.g. "Jobs Health Dashboard") — same across pack, publish, deploy. Never the routing slug: the CLI slugifies it for package matching but shows the friendly name in the catalog/Governance UI.
-- `--version` goes on **pack and publish only — NOT deploy.** Deploy resolves the latest published version; passing `--version` causes a false "has not been published yet" error.
-- `--path-name` goes on **fresh deploy only** — it sets the URL slug. On an upgrade the routing already exists; re-passing it errors "routing name must be unique."
+- `--version` goes on pack, publish, and deploy so the exact candidate stays bound. Prove it is indexed before deploy; never omit it to select Latest.
+- `--path-name` goes on a remotely proved Create only. Omit it on a remotely proved Upgrade while preserving and post-verifying the existing route.
 - Routing name is permanent after the first successful deploy.
+- `.dashboard/state.json` and `.uipath/app.config.json` are repairable projections, not remote authority.
+- Never auto-upsert, auto-bump, randomize a route, omit a reviewed route/version, delete/recreate, or blind-retry an indeterminate external write.
+- Testing-only is explicit, internal, synthetic, and limited to Alpha/Staging with an automatic non-production receipt. All other deployments default to governed.
 - Always include `--tags`, sourced from the chosen **mode**: standalone → `dashboard`; governance, not pinned → `governance`; governance, pinned → `governance,dashboard`.
 - Choose **mode** and **folder** as two independent decisions (Steps 2–4). Mode sets `--tags`; only a governance mode targeting a **shared** folder provisions `setup-admin-folder.mjs` and assigns elevated roles. A Personal-workspace target never provisions roles; standalone never provisions roles.
-- Recommend the mode from state.json metrics and the folder from the mode (governance→AdminDashboards, standalone→Personal workspace); the user overrides either via the Step-4 structured choice or free-text.
+- Recommend the mode from state.json metrics and the folder from the mode (governance→AdminDashboards, standalone→an existing shared team folder such as `Shared`); offer Personal workspace as the private alternative. The user overrides either via the Step-4 structured choice or free-text.

--- a/skills/uipath-coded-apps/references/dashboards/primitives/state-file.md
+++ b/skills/uipath-coded-apps/references/dashboards/primitives/state-file.md
@@ -56,9 +56,10 @@ Per-project metadata. Read at every build start. Written by build script on succ
 2. `widgets` is a map of `{ hash, tier, metric, template, module, intentMetric }` — not a string array.
    - `intentMetric` is pure metadata (no `fnBody`) — title, display hints, tier, name. Used by CHANGE/REBUILD to regenerate without the original `intent.json`.
    - `module` is the relative path to the durable data-fetch code (e.g. `"metrics/agent-health.ts"`). The live source lives at `src/metrics/<name>.ts` in the project.
-3. `routingName` never changes once set. Not even on upgrades.
+3. `routingName` is the intended permanent route once remotely created. A local value does not reserve or prove ownership of that route.
 4. `hash` used for hand-edit detection — compare to current file before CHANGE/REMOVE.
-5. `deployment.systemName` set by deploy plugin on first deploy.
+5. `deployment.*` is a repairable local projection, never remote authority. Before choosing create or upgrade, re-read the remote deployment and verify system name, route, folder, current version, and candidate version. A missing local `systemName` does not prove create; a present value does not prove upgrade.
 6. `buildStatus` is `"in-progress"` from early in the build (so deploy can find app metadata even after a failed build) and `"complete"` on success.
 7. `timeRange` is the dashboard default window — incremental edits fall back to it when a CHANGE delta has no `timeRange`.
 8. `regime` is `"compiler-managed"` (default — declarative, edited via the structured edit-script) or `"ejected"` (full-source, edited free-form by the agent). The edit-script **refuses** to run on an ejected project (emits `EJECTED_PROJECT`). Eject is one-way: the `EJECT` op flips it and it never reverts. A template builds straight to `"ejected"`. Absent/legacy state with no `regime` is treated as `"compiler-managed"`. See [customization.md](customization.md#regimes-compiler-managed-vs-ejected).
+9. `folderKey`/`folderName` may record the user's selected target before deployment, but they remain intent only. Update outcome fields (`systemName`, `deployVersion`, `appUrl`, `lastDeployedAt`) only after remote post-deploy verification confirms the exact deployment, version, route, and URL. Write atomically. A failed or interrupted deploy leaves outcome fields unchanged and requires remote reconciliation before a fresh operation.

--- a/skills/uipath-coded-apps/references/debug.md
+++ b/skills/uipath-coded-apps/references/debug.md
@@ -16,6 +16,8 @@ The only time to fall back to the [manual portal steps](oauth-client-setup.md#ma
 
 **HARD RULE**: Do not edit any file, env var, or external config until **Step 0** has produced a concrete observation — a specific URL, console error, HTTP status, or on-page error text. Guessing at fixes when you don't know the failing layer wastes tool calls and introduces regressions.
 
+**RELEASE-BOUNDARY RULE**: Before changing `uipath.json`, an External Application, a route, or deployment metadata, identify whether the app is an explicit synthetic Alpha/Staging test or a governed release. A configuration change invalidates a governed deployment plan; re-bind and re-approve it. For testing, re-hash the exact configuration and start a new testing receipt. Never patch configuration and blindly resume an interrupted publish/deploy.
+
 ---
 
 ## Step 0: Reproduce the Failure
@@ -252,6 +254,8 @@ Match the observation to the correct fix section. **Jump directly to the matchin
 | App renders, API returns **404** | Wrong endpoint, wrong folder, or resource doesn't exist | Verify base URL, folder, and resource id |
 | Network / CORS error in console | Wrong base URL | *API Calls Fail with CORS Error* |
 | Deployed app URL returns `404` | Vite base path / routing | *`404` After Deploy / App Not Found* |
+| Deploy returns `routing name must be unique` | Route collision or create/upgrade mismatch | *Deploy / Publish Failure Boundary* |
+| Publish/deploy times out, returns 5xx/HTML, or exits nonzero | External write is indeterminate | *Deploy / Publish Failure Boundary* |
 
 **If no row matches or the observation is inconclusive**, continue to Step 1 for config-level diagnosis.
 
@@ -358,6 +362,24 @@ rm ~/.uipath-skills/playwright/clear-state.mjs 2>/dev/null
 
 ## Common Issues and Fixes
 
+### Deploy / Publish Failure Boundary
+
+`publish` and `deploy` are external writes. A timeout, interruption, 5xx, HTML response, or nonzero exit does not prove that nothing changed. Before any new write:
+
+1. Re-read remote package, app, deployment, version, and route state.
+2. Compare it with the exact org, tenant, folder, OAuth client, package/version, deployment/system identity, and intended route.
+3. Choose a fresh explicit operation: `create` only when the deployment is absent and route unused; `upgrade` only when the exact existing deployment and route match.
+4. Re-bind changed evidence. A governed release needs a new reviewed approval; a testing-only Alpha/Staging run needs a new automatic testing receipt.
+
+Never auto-bump/repack after a publish conflict, repeat a possibly completed write, generate a random route, omit a reviewed route to make a create succeed, delete/recreate, or fall back from upgrade to create.
+
+For `routing name must be unique`:
+
+- **Proven create** — the route is occupied. Stop and ask for an intentional plan change; do not invent a suffix.
+- **Proven upgrade** — preserve the existing route and omit `--path-name`. If the error persists, the CLI/local config is not targeting the reconciled deployment; stop rather than retry with different flags.
+
+`.uipath/app.config.json` and `.dashboard/state.json` help locate candidates but never prove remote state.
+
 ### `redirect_uri_mismatch` / Login Loop
 
 **Cause:** The redirect URI the SDK sends (from the `uipath:redirect-uri` meta tag — locally the `redirectUri` in `uipath.json`) is not registered in the UiPath External Application, or does not match the URL the app is actually served from.
@@ -380,7 +402,7 @@ rm ~/.uipath-skills/playwright/clear-state.mjs 2>/dev/null
 
 Fall back to [manual steps](oauth-client-setup.md#add-redirect-uris-to-an-existing-app-1) only if the CLI can't run (not authenticated / `403`).
 
-> Production redirect URIs are registered automatically by `uip codedapp deploy`. If they're missing on the External Application after a deploy, the same CLI update can add them.
+> Hosted redirect URIs are normally registered by `uip codedapp deploy`, but verify them rather than assuming registration completed. If they are missing after a deploy, treat the deployment as incomplete. Updating the External Application invalidates governed approval evidence or requires a new testing receipt before another deployment attempt.
 
 ### `invalid_scope` Error in Auth URL
 
@@ -495,7 +517,7 @@ Check the browser console for the error. Common causes: missing `@uipath/coded-a
 1. `vite.config.ts` must have `base: './'` (not `'/<routing-name>/'` — the platform handles URL routing via its Cloudflare Worker).
 2. If the app uses a client-side router (React Router, Vue Router), the basename must use `getAppBase()` from `@uipath/uipath-typescript` — not a hardcoded path. `getAppBase()` reads the `uipath:app-base` meta tag injected by the platform at runtime and falls back to `'/'` locally.
 
-After fixing, rebuild (`npm run build`) and re-deploy (`uip codedapp deploy`). If 404 persists, check that `deploy` returned a valid `appUrl` in `.uipath/app.config.json`.
+After fixing, rebuild and package an explicit new candidate. Reconcile remote deployment state before publishing or deploying it; do not treat the prior failed deploy as proof that no write occurred. A valid `appUrl` in `.uipath/app.config.json` is a hint, not acceptance — verify the remote deployment, route, and referenced assets.
 
 ---
 
@@ -511,4 +533,4 @@ For any create or update of an External Application (adding redirect URIs, addin
 Key constants to remember:
 - Dev redirect URIs: `http://localhost:5173` and `http://localhost:5173/` (register both)
 - Action apps redirect URI: `https://cloud.uipath.com/<orgName>/<tenantName>/actions_`
-- Production web-app URIs are registered automatically by `uip codedapp deploy` — do not add them manually.
+- Hosted web-app URIs are normally registered by `uip codedapp deploy`. Verify them after deployment; if remediation changes the External Application, re-bind release evidence before another write.

--- a/skills/uipath-coded-apps/references/oauth-client-setup.md
+++ b/skills/uipath-coded-apps/references/oauth-client-setup.md
@@ -4,6 +4,8 @@ Create and update UiPath External Applications (OAuth clients) with the **`uip a
 
 > **CLI-first.** Do NOT drive the admin portal with browser automation. Every create/update below is one CLI call. Fall back to the [Manual portal steps](#manual-portal-fallback) ONLY when the CLI can't run (see [When the CLI can't be used](#when-the-cli-cant-be-used)).
 
+> **Deployment evidence boundary.** Creating or updating an External Application changes deployable configuration. If a governed deployment plan already exists, stop and regenerate its client/config hashes and approval after the change. For an explicit synthetic Alpha/Staging test, start a new automatic testing receipt. Never modify a client and resume an interrupted publish/deploy as though the reviewed inputs were unchanged.
+
 ## Prerequisites
 
 1. Install the admin tool (provides the `uip admin external-apps` commands): `uip tools install admin-tool`
@@ -43,7 +45,7 @@ uip admin external-apps create "<APP_NAME>" \
 ```
 
 - Register the redirect **with and without** the trailing slash — the SDK may send either.
-- Production redirect URIs are registered automatically by `uip codedapp deploy` — do not add them here.
+- Hosted redirect URIs are normally registered by `uip codedapp deploy`. Do not pre-add them for a planned create; verify them after deployment and treat missing registration as an incomplete deploy.
 - Parse `id` from the JSON response — that is the **Client ID**. Write it to `uipath.json` as `clientId`.
 
 ## Add redirect URIs to an existing app
@@ -101,7 +103,7 @@ A missing scope name (`scope not found`) is NOT a fallback trigger — fix the n
 3. Set **Application name** to `<app name>`
 4. Select **"Non-Confidential application"** (required for browser/PKCE flow)
 5. For each resource, click **"Add scopes"**, pick the resource, check the required scopes, confirm
-6. Add the localhost redirect URIs (with and without trailing slash) in **Redirect URL**, pressing Enter after each. Production URIs are registered by `uip codedapp deploy`.
+6. Add the localhost redirect URIs (with and without trailing slash) in **Redirect URL**, pressing Enter after each. Hosted URIs are normally registered by `uip codedapp deploy` and must be verified afterward.
 7. Click **"Add"** and copy the generated **Application ID** (a UUID) — this is the Client ID
 8. Write the Client ID into `uipath.json` → `clientId`
 

--- a/skills/uipath-coded-apps/references/pack-publish-deploy.md
+++ b/skills/uipath-coded-apps/references/pack-publish-deploy.md
@@ -1,6 +1,70 @@
 # Pack / Publish / Deploy Guide
 
-Complete guide for packaging, publishing, and deploying UiPath Coded Web Applications to production.
+Guide for packaging, publishing, and deploying UiPath Coded Web Applications through either an explicit testing-only lane or a governed release lane.
+
+## Choose the lane before publishing
+
+| Lane | Eligible use | Required boundary |
+|------|--------------|-------------------|
+| **Testing-only quick path** | User explicitly requests an internal, synthetic-data deployment to UiPath Alpha or Staging | Bind the exact target, profile, client, route, candidate bytes, and `create`/`upgrade` intent in an automatic testing receipt. Dirty source is allowed but is not provenance. No second approval is required. |
+| **Governed release** | Production, customer data, or any request for durable release evidence | Use reviewed source, exact dist/package/runtime hashes, remote target evidence, explicit approval, immutable receipt, rollback authority, and post-deploy verification. |
+
+Ambiguity defaults to governed. The testing lane must state `production_eligible: false` and `release_evidence: false`; it cannot be promoted into a governed receipt after execution.
+
+Before either lane writes remotely, choose one intent:
+
+- **Create** — fresh remote inventory proves there is no matching deployment and the exact route is unused.
+- **Upgrade** — fresh remote inventory proves the exact existing deployment, system name, route, current version, and candidate version.
+
+`.uipath/app.config.json`, dashboard state, and prior command output are local hints only. If remote evidence cannot establish exactly one intent, stop. Never use automatic upsert behavior as the decision maker.
+
+The stock `uip codedapp` 1.198.0 surface has no deployment `list` or `get`. It may execute a preflighted `publish`/`deploy`, but it cannot establish authoritative create/upgrade state by itself. Use an approved inventory-capable deployment helper or Apps API runtime without exposing bearer tokens. If none is available, stop before the write.
+
+### Automatic testing receipt
+
+Before the first external write, create a new receipt at `.uipath/testing-evidence/<UTC>-<app>-<version>.json` (or an equivalently ignored release-evidence directory) and atomically claim the exact candidate/target in `<receipt>.claim` using create-if-absent semantics. Verify the directory is ignored with `git check-ignore`; if it is tracked or not ignored, choose an ignored evidence directory before continuing. Use policy version `codedapp-testing-only/1.0`. Minimum fields:
+
+- `kind: "uipcodedappdeploy.testing-receipt"`, `schemaVersion: "1.0"`
+- `authorization.mode: "explicit_testing_request"`
+- Exact environment/control plane, org, tenant, folder, profile, CLI version/path, app/package, client, route, intent, candidate version, and artifact/config hashes
+- Git HEAD and worktree-status digest as context only
+- `data_classification: "synthetic_only"`, `production_eligible: false`, `release_evidence: false`
+- Fixed waived gates and non-waivable policy version
+- Per-stage timestamps/results and one terminal status: `failed_prewrite`, `publish_indeterminate`, `published_not_deployed`, `deploy_indeterminate`, `deployed_unverified`, or `succeeded_testing`
+
+For `codedapp-testing-only/1.0`, record these exact sorted arrays; do not invent or omit values:
+
+```json
+{
+  "waived_gates": [
+    "absent_backend_and_realtime_certification",
+    "clean_source_provenance",
+    "full_multi_role_and_pilot_certification",
+    "independent_release_approval",
+    "protected_release_environment",
+    "rebuild_and_full_suite_for_exact_audited_candidate",
+    "second_plan_hash_approval",
+    "signed_production_receipt"
+  ],
+  "nonwaivable_gates": [
+    "alpha_or_staging_target",
+    "automatic_receipt_and_atomic_claim",
+    "bundle_audit_and_postdeploy_verification",
+    "exact_target_profile_client_route_and_artifact_binding",
+    "explicit_create_or_upgrade",
+    "internal_authenticated_access",
+    "no_route_mutation_delete_recreate_or_blind_retry",
+    "no_secret_exposure",
+    "synthetic_data_only"
+  ]
+}
+```
+
+Do not include `plan_hash`, `approved_plan_hash`, tokens, secrets, environment dumps, or unredacted response bodies. Release the candidate claim only after a handled pre-write failure. Retain it after any possible external write. There is no resume: reconciliation plus a fresh explicit testing request creates a new receipt.
+
+Use SHA-256. Hash package files as exact bytes; hash runtime JSON after UTF-8 canonical serialization with sorted keys; hash `dist/` as the sorted list of relative paths plus each file's SHA-256 and size so timestamps and archive metadata cannot change the identity. Write receipt updates to a sibling temporary file, flush, then atomically rename.
+
+This skill documents but does not fabricate a governed executor. If the environment does not provide a reviewed approval/receipt/rollback implementation for governed release, stop and report that release gate rather than writing an ad hoc JSON file.
 
 ## Pipeline Overview
 
@@ -18,6 +82,8 @@ Each step depends on the previous one:
 - **Publish** needs the `.nupkg` file (from pack)
 - **Deploy** needs the app registration (from publish)
 
+The exception is an exact already-published candidate selected after remote reconciliation: deploy that candidate directly rather than rebuilding or republishing it.
+
 ## Pack
 
 Package the app build output into a `.nupkg` file with UiPath metadata.
@@ -29,7 +95,7 @@ Package the app build output into a `.nupkg` file with UiPath metadata.
 uip codedapp pack dist
 
 # Pack with all options specified
-uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "Production app"
+uip codedapp pack dist -n my-webapp --version 1.0.0 --author "My Team" --description "Production app"
 ```
 
 ### Options
@@ -40,12 +106,11 @@ uip codedapp pack dist -n my-webapp --version 1.0.0 -a "My Team" --description "
 | `-n, --name <name>` | Package name | Prompted |
 | `-v, --version <version>` | Package version | `1.0.0` |
 | `-o, --output <dir>` | Output directory for `.nupkg` | `./.uipath` |
-| `-a, --author <author>` | Package author | `UiPath Developer` |
+| `--author <author>` | Package author | `UiPath Developer` |
 | `--description <desc>` | Package description | Prompted |
 | `--main-file <file>` | Main entry file | `index.html` |
 | `--content-type <type>` | `webapp`, `library`, or `process` | `webapp` |
 | `--dry-run` | Preview without creating | `false` |
-| `--reuse-client` | Reuse clientId from `uipath.json` | `false` |
 
 ### Content Types
 
@@ -69,9 +134,7 @@ The `.nupkg` includes auto-generated UiPath metadata files:
 
 ### OAuth Client ID
 
-Pack manages the `uipath.json` SDK config file, which includes the OAuth client ID for the deployed app:
-- First pack: creates a new non-confidential client ID
-- Subsequent packs: use `--reuse-client` to keep the existing client ID from `uipath.json`
+`pack` does not create, select, or reuse an OAuth client. Configure the non-confidential client in `uipath.json`, verify it against the target tenant, and pass the exact client explicitly to `deploy` with `--client-id <GUID>` when required. If the client or its scopes/redirects change after a governed plan is approved, invalidate that plan and re-bind the configuration. For testing, re-hash the configuration and start a new testing receipt.
 
 ### Dry Run
 
@@ -151,7 +214,7 @@ After publish, `.uipath/app.config.json` stores the registration:
 }
 ```
 
-This file is consumed by `deploy` to resolve the app name automatically. **Do not delete `.uipath/` between publish and deploy.**
+This file is consumed by `deploy` to resolve the app name automatically. Preserve it between publish and deploy, but do not treat it as remote authority. Compare its system/deployment identifiers with fresh remote inventory before choosing `create` or `upgrade`.
 
 ### Multiple Packages
 
@@ -169,16 +232,20 @@ uip codedapp publish -n my-webapp --version 2.0.0
 
 ## Deploy
 
-Deploy or upgrade a coded app in UiPath. The command auto-detects whether to perform a fresh deployment or upgrade an existing one.
+Deploy or upgrade a coded app in UiPath. The CLI can auto-detect, but an agent must not delegate the create/upgrade decision to that behavior: prove the intended operation from remote state first.
 
 ### Basic Usage
 
 ```bash
-# Deploy (uses app.config.json)
-uip codedapp deploy
+# Proven create: bind route, client, version, folder, and profile
+uip codedapp deploy -n my-webapp --version 1.0.0 \
+  --path-name my-webapp --client-id <client-guid> \
+  --folder-key <folder-guid> --profile <profile> --output json
 
-# Deploy with explicit name
-uip codedapp deploy -n my-webapp
+# Proven upgrade: preserve the existing route by omitting --path-name
+uip codedapp deploy -n my-webapp --version 1.1.0 \
+  --client-id <client-guid> --folder-key <folder-guid> \
+  --profile <profile> --output json
 ```
 
 ### Options
@@ -186,21 +253,39 @@ uip codedapp deploy -n my-webapp
 | Option | Description | Default |
 |--------|-------------|---------|
 | `-n, --name <name>` | App name | From `app.config.json` or prompted |
-| `-v, --version <version>` | Target a **specific published version** (different semantic from `pack`/`publish`'s `-v`). **Prefer omitting it** — let it default to Latest. Passing a version that the catalog hasn't finished indexing yields a misleading `"...has not been published yet"` error. | Latest |
+| `-v, --version <version>` | Exact published candidate to deploy. Verify it is indexed before deployment; never omit this merely to select an unreviewed Latest version. | Latest |
 | `--folder-key <key>` | UiPath folder **key** (GUID, not the name). **Always pass explicitly** — see below. | From `UIPATH_FOLDER_KEY` env var, else interactive (avoid) |
 | `--org-name <name>` | Organization name (for app URL) | From `.env` |
+| `--path-name <name>` | Permanent hosted route; pass only for a proven create | Generated/defaulted by tool |
+| `--client-id <id>` | Exact non-confidential OAuth client | Tool/config default |
+| `--tags <tags>` | Comma-separated categorization tags | None |
+| `--profile <name>` | Named authenticated CLI profile | Active/default profile |
 
-### Fresh Deploy vs. Upgrade
+### Create vs. Upgrade
 
-| Scenario | Behavior |
-|----------|----------|
-| **First deploy** | Deploys version 1 of the app |
-| **Already deployed** | Upgrades to the latest published version |
+| Intent | Preconditions | Route handling |
+|--------|---------------|----------------|
+| **Create** | Exact deployment absent and route unused in fresh remote inventory | Pass the reviewed `--path-name`; a collision stops the operation |
+| **Upgrade** | Exact deployment/system/route/current version match fresh remote inventory | Omit `--path-name`; preserve and verify the existing route |
 
 The command resolves the app name from:
 1. `--name` flag (highest priority)
 2. `.uipath/app.config.json` (created by `publish`)
 3. Interactive prompt (fallback)
+
+Resolution convenience is not authorization. Always pass the name and all available target flags explicitly. For upgrades, verify that the local config identifies the same remote deployment before executing.
+
+### External-write failure boundary
+
+Once `publish` or `deploy` starts, a timeout, interruption, 5xx, HTML response, or nonzero exit may still have changed remote state. Do not immediately retry. Re-read remote package/deployment state and create a fresh operation from the reconciled result.
+
+Never respond to a conflict by:
+
+- Auto-bumping and republishing an unreviewed version.
+- Generating a random route or omitting the intended route.
+- Deleting and recreating the deployment.
+- Falling back from upgrade to create.
+- Assuming `.uipath/app.config.json` proves what happened remotely.
 
 ### Folder Key
 
@@ -235,8 +320,8 @@ match = next((x for x in d['Data'] if x['Name'] == 'Shared'), None)
 print(match['Key'] if match else '')
 ")
 
-# 3. Deploy with the resolved key
-uip codedapp deploy -n my-webapp --folder-key "$FOLDER_KEY"
+# 3. Bind the key into the separately preflighted create or upgrade operation
+test -n "$FOLDER_KEY" && printf '%s\n' "$FOLDER_KEY"
 ```
 
 If the name is ambiguous (multiple matches) or not found, surface an error to the user — do NOT fall through to interactive selection.
@@ -270,55 +355,60 @@ echo "UIPATH_FOLDER_KEY=$FOLDER_KEY" >> .env
 
 ---
 
-## Full Pipeline Examples
+## Pipeline Examples
 
-### First-Time Deployment
+### Testing-only Alpha/Staging create
+
+The user must explicitly request a synthetic/internal test. Record an automatic testing receipt and confirm the route is unused before these writes.
 
 ```bash
-# 1. Authenticate
-uip login
+# 1. Authenticate with an exact non-production profile
+uip login status --profile "$PROFILE" --output json
 
 # 2. Build the app
 npm run build
 
-# 3. Pack
-uip codedapp pack dist -n my-webapp
+# 3. Pack an explicit version
+uip codedapp pack dist -n my-webapp --version 1.0.0 -o .uipath
 
-# 4. Publish
-uip codedapp publish
+# 4. Publish the exact candidate
+uip codedapp publish -n my-webapp --version 1.0.0 --profile "$PROFILE" --output json
 
-# 5. Deploy
-uip codedapp deploy
+# 5. Create on the preflighted route
+uip codedapp deploy -n my-webapp --version 1.0.0 \
+  --path-name my-webapp --client-id "$CLIENT_ID" \
+  --folder-key "$FOLDER_KEY" --profile "$PROFILE" --output json
 ```
 
-### Version Update
+### Testing-only Alpha/Staging upgrade
+
+Re-read and match the exact existing deployment before executing. The route is immutable and therefore omitted.
 
 ```bash
-# 1. Make changes and rebuild
+# 1. Build and pack the chosen candidate version
 npm run build
+uip codedapp pack dist -n my-webapp --version 2.0.0 -o .uipath
 
-# 2. Pack with bumped version
-uip codedapp pack dist -n my-webapp --version 2.0.0
+# 2. Publish the exact candidate
+uip codedapp publish -n my-webapp --version 2.0.0 --profile "$PROFILE" --output json
 
-# 3. Publish new version
-uip codedapp publish
-
-# 4. Deploy (auto-detects upgrade)
-uip codedapp deploy
+# 3. Upgrade the reconciled deployment; never pass or change its route
+uip codedapp deploy -n my-webapp --version 2.0.0 \
+  --client-id "$CLIENT_ID" --folder-key "$FOLDER_KEY" \
+  --profile "$PROFILE" --output json
 ```
 
-### CI/CD Pipeline
+### Governed CI/CD release
+
+The reviewed plan supplies the exact values and hashes below. The named profile must be provisioned securely before the job; never put a client secret or bearer token in command arguments.
 
 ```bash
-# Non-interactive flow with explicit options — every flag passed, no prompts.
-# --scope MUST include Apps.Read Apps.Write, or publish's "Registering coded app"
-# step 401s even though the package upload succeeds (see publish internals above).
-uip login --client-id $CLIENT_ID --client-secret $CLIENT_SECRET \
-  --scope "OR.Folders OR.Execution OR.Administration Apps.Read Apps.Write"
 npm run build
-uip codedapp pack dist -n my-webapp --version $VERSION
-uip codedapp publish -n my-webapp --version $VERSION
-uip codedapp deploy -n my-webapp --folder-key $FOLDER_KEY
+uip codedapp pack dist -n "$APP_NAME" --version "$VERSION" -o .uipath
+uip codedapp publish -n "$APP_NAME" --version "$VERSION" --profile "$PROFILE" --output json
+uip codedapp deploy -n "$APP_NAME" --version "$VERSION" \
+  --client-id "$CLIENT_ID" --folder-key "$FOLDER_KEY" \
+  --profile "$PROFILE" --output json
 ```
 
 ### Agent flow (user provides folder name only)
@@ -330,8 +420,10 @@ FOLDER_KEY=$(uip or folders list --output json \
 
 [ -z "$FOLDER_KEY" ] && { echo "Folder '$USER_FOLDER_NAME' not found"; exit 1; }
 
-# 2. Deploy non-interactively with the resolved key
-uip codedapp deploy -n my-webapp --folder-key "$FOLDER_KEY"
+# 2. Use the key in the separately preflighted create or upgrade command
+uip codedapp deploy -n "$APP_NAME" --version "$VERSION" \
+  --client-id "$CLIENT_ID" --folder-key "$FOLDER_KEY" \
+  --profile "$PROFILE" --output json
 ```
 
 ---
@@ -341,9 +433,11 @@ uip codedapp deploy -n my-webapp --folder-key "$FOLDER_KEY"
 | Problem | Cause | Solution |
 |---------|-------|----------|
 | `No packages found` | Missing `.nupkg` | Run `uip codedapp pack` first |
-| `Version already exists` | Same version published | Bump version: `-v 2.0.0` |
+| `Version already exists` | Candidate version conflicts with remote state | Reconcile whether the attempted publish succeeded. If it did not, select and review a new version before packing; never auto-bump and retry. |
 | `App not found` on deploy | App not published | Run `uip codedapp publish` first |
 | `Folder key required` / deploy hangs on prompt | Missing folder key | Resolve via `uip or folders list --output json`, then run `uip codedapp deploy --folder-key <key> ...` (or `UIPATH_FOLDER_KEY=<key>` env-var prefix). |
 | `Missing tenant name` on publish | `UIPATH_TENANT_NAME` not set | Set in `.env` or pass `--tenant-name` |
 | `dist/ not found` | App not built | Run `npm run build` |
-| Pack shows wrong clientId | Stale `uipath.json` | Use `--reuse-client` or delete `uipath.json` |
+| OAuth client is wrong | `uipath.json`, deploy flags, or remote client differ | Stop; verify the exact client and target. Re-bind governed evidence or begin a new testing receipt before changing configuration. |
+| `routing name must be unique` | Route is occupied or upgrade was misclassified | Stop and reconcile remote state. Never randomize or omit a reviewed route and retry. |
+| Publish/deploy timeout, 5xx, HTML, or interruption | External write may have succeeded | Treat as indeterminate; inspect remote state before forming a fresh operation. |


### PR DESCRIPTION
## Summary
- classify direct coded-app deployment as explicit synthetic Alpha/Staging testing only
- keep governed deployment as the default for ambiguity, production, or release-trust needs
- bind create versus upgrade to remote evidence and prohibit random-route, delete/recreate, blind retry, and local-state authority
- remove the unsupported --reuse-client guidance and align commands with uip 1.198.0

## Validation
- changed-file link and Markdown-fence checks
- repository skill description/status checks
- focused deployment-policy assertions
- independent forward-use review: PASS

The testing receipt is explicitly nonproduction and is not release evidence.