### PR TITLE
fix(telemetry): stop sending session_id to uip track

### DIFF
--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -7,8 +7,9 @@ single flat JSON object to the hidden `uip track` CLI command, which forwards
 it through the CLI's own telemetry tracker as one `uip.skills.<event>`
 Application Insights event. A second, synchronous SessionStart step
 (`hooks/set-session-env.sh` / `.ps1`) exports the agent session id as
-`UIPATH_SESSION_ID` so native `uip` command telemetry carries the same
-`session_id` (see [Correlation](#correlation)). No local state file, no
+`UIPATH_SESSION_ID` so every `uip` process — command or `uip track` — reports
+the same session on App Insights' native `session_Id` (see
+[Correlation](#correlation)). No local state file, no
 session daemon — session-level metrics are computed at query time from the
 event stream.
 
@@ -118,15 +119,14 @@ Each event is an App Insights event named `uip.skills.<event>` (see
 
 | Field | Example | Notes |
 |-------|---------|-------|
-| `schemaVersion` | `2` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas. `2` added `eventName` / `session_source` / `reason` / `agent_model`, renamed `sessionId` → `session_id`, and dropped `environment` / `baseUrl` (CLI-stamped — see [Added by the CLI](#added-by-the-cli)) |
+| `schemaVersion` | `3` | Constant in the hook. JSON **number**. Bumped on any change to the key set, so App Insights can segment events emitted with older/churned schemas. `2` added `eventName` / `session_source` / `reason` / `agent_model`, renamed `sessionId` → `session_id`, and dropped `environment` / `baseUrl`; `3` dropped `session_id` too (all CLI-stamped — see [Added by the CLI](#added-by-the-cli)) |
 | `eventName` | `session-start` | Which lifecycle event this is (see [Events](#events)). Consumed by `uip track` to pick the `uip.skills.<event>` name; **not** emitted as an event property |
 | `toolName` | `Skill`, `Bash` | Claude Code tool. From the top-level `tool_name`. `tool-use` only |
 | `toolUseId` | `toolu_01ABC` | Unique per call — correlation key + ordering tiebreaker |
-| `session_id` | `b3f1...` | Claude Code `session_id` — the coding-agent session; session correlation key. Canonical snake_case, matching the CLI command stream; `uip track` still accepts the v1 `sessionId` spelling and maps it |
 | `subagentModel` | `opus` | From `tool_response.resolvedModel`, normalized to a family — `opus` / `sonnet` / `haiku` / `fable` (`other` if unrecognized). The context-window marker is dropped (`claude-opus-4-8[1m]` → `opus`). Set on an Agent-**spawn** event; empty otherwise |
 | `subagentType` | `general-purpose` | From `tool_input.subagent_type` — requested subagent type. Set on an Agent-**spawn** event; empty otherwise |
 | `agentType` | `Explore` | From the top-level `agent_type` — type of the subagent the call runs **inside**. Empty on a main-loop call |
-| `agent_model` | `claude-sonnet-5` | The session's **main** model, from the top-level `model` where the agent provides it — Claude Code sends it on `SessionStart` payloads, Codex on every hook event. Full sanitized slug (no family collapse — model-comparison views need version granularity); distinct from `subagentModel` (a spawned child's model family). Empty when the payload carries none; Claude sessions get full coverage at query time by joining on `session_id` from the `session-start` event |
+| `agent_model` | `claude-sonnet-5` | The session's **main** model, from the top-level `model` where the agent provides it — Claude Code sends it on `SessionStart` payloads, Codex on every hook event. Full sanitized slug (no family collapse — model-comparison views need version granularity); distinct from `subagentModel` (a spawned child's model family). Empty when the payload carries none; Claude sessions get full coverage at query time by joining on the native `session_Id` from the `session-start` event |
 | `skillName` | `uipath:uipath-platform` | From `tool_input.skill`. `Skill` calls only |
 | `uipSubcommand` | `solution publish` | First 1–2 verbs derived from `tool_input.command` — never the full command line, never `stdout` |
 | `fileExtension` | `.flow` | Derived from `tool_input.file_path`. File-tool calls only |
@@ -156,7 +156,7 @@ the PowerShell twin via a real `ConvertFrom-Json` parse):
 
 | Region | Fields |
 |--------|--------|
-| Envelope (top-level keys) | `toolName`, `toolUseId`, `session_id`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType`, `source` (→`session_source`, session-start), `reason` (session-end), `model` (→`agent_model`) |
+| Envelope (top-level keys) | `toolName`, `toolUseId`, `permissionMode`, `durationMs`, `effortLevel` (`effort.level`), `agentType`, `source` (→`session_source`, session-start), `reason` (session-end), `model` (→`agent_model`) |
 | `tool_input` | `skillName`, `uipSubcommand` (from `command`), `fileExtension` (from `file_path`), `subagentType` (from `subagent_type`, or `agent_type` on a Codex `spawn_agent` call — normalized to the same field so it never collides with the envelope `agent_type`) |
 | `tool_response` | `outcome` (`interrupted` / `success`), `subagentModel` (`resolvedModel`) |
 
@@ -219,7 +219,7 @@ attribution all work unchanged. Three differences are handled or accepted:
 Codex has no `Skill` tool, so `skillName` and the Skill-based attribution path
 never fire — Codex attribution relies on the `uip`-command and file-extension
 signals. The cross-agent handling itself changes no keys; the current key set
-is **schema v2** (see the [field table](#properties-sent-by-the-hook)). Events
+is **schema v3** (see the [field table](#properties-sent-by-the-hook)). Events
 are distinguished by agent through the CLI-stamped client/`source` context, not
 a hook field.
 
@@ -244,6 +244,7 @@ and a `source` value sent by the hook would be overridden:
 | Field | Notes |
 |-------|-------|
 | `source` | Always `skills-plugin` |
+| `session_Id` (native tag) / `session_id_source` | The session. Not a custom dimension: the CLI resolves one id per process — `UIPATH_SESSION_ID` first, else an inherited agent/terminal handle (`CLAUDE_CODE_SESSION_ID`, `CODEX_THREAD_ID`, …), else a per-process random id — and puts it on App Insights' native `ai.session.id` tag, with `session_id_source` (`declared` / `claude-code` / `codex` / `antigravity` / `terminal` / `random`) as a dimension. A session id sent by the hook is **rejected**, so the hook sends none (UiPath/cli#3431) |
 | `CloudUserId` / `CloudTenantId` / `CloudOrganizationId` | Authenticated UiPath cloud identity |
 | `environment` / `base_url` / `region` | Normalized from the CLI's **own** auth context at startup — always fresh, `base_url` reduced to its origin. Replaces the hook's former `environment` / `baseUrl` (schema v1), which came from a 1h-cached `uip login status` and could go stale |
 | `application_Version` | The `uip` CLI's own version (replaces the hook's former `cliVersion`) |
@@ -280,13 +281,16 @@ is absent from the payload, so query schemas stay stable:
 ## Correlation
 
 Session-level metrics need no local state file — they are query-time
-aggregations over events sharing `session_id`:
+aggregations over events sharing the native `session_Id` column (**not** a
+`customDimensions.session_id` — the hook sends no session id and the CLI puts
+its own on App Insights' `ai.session.id` tag; see
+[Added by the CLI](#added-by-the-cli)):
 
 | Metric | Query shape |
 |--------|-------------|
-| Tool calls per session | `count() by session_id` |
-| Session duration | `session-end` − `session-start` per `session_id` (fallback `max(timestamp) − min(timestamp)` where no `session-end`, e.g. Codex) |
-| Activation rate | sessions with ≥1 `tool-use` ÷ all `session-start`, by `session_id` |
+| Tool calls per session | `count() by session_Id` |
+| Session duration | `session-end` − `session-start` per `session_Id` (fallback `max(timestamp) − min(timestamp)` where no `session-end`, e.g. Codex) |
+| Activation rate | sessions with ≥1 `tool-use` ÷ all `session-start`, by `session_Id` |
 | Session outcome mix | `session-end` count by `reason`; sessions containing a `completion` with `outcome=failure` |
 | Time-to-first-skill | first `Skill` event − `session-start`, per session |
 | Retries | repeated `uipSubcommand` flipping `failure → ok`, ordered by `timestamp` then `toolUseId` |
@@ -296,21 +300,30 @@ aggregations over events sharing `session_id`:
 
 The synchronous SessionStart step (`hooks/set-session-env.sh` / `.ps1`) writes
 `export UIPATH_SESSION_ID='<session_id>'` to Claude Code's `CLAUDE_ENV_FILE`,
-so every `uip` command the agent runs inherits it and the CLI stamps the same
-`session_id` on **native command telemetry**. Skills events and
-command events then join on `session_id` — e.g. "commands per turn" or
+so every `uip` process the agent starts inherits it — both native commands and
+the `uip track` calls this hook pipes into — and each reports the same
+`session_Id`. Since schema v3 this export is the **only** thing that ties the
+two streams together (the hook itself sends no session id), and the join is on
+`session_Id` — e.g. "commands per turn" or
 "sessions whose skill invocation produced no successful build/operate command".
+Without it the CLI falls back to an inherited agent/terminal handle and then to
+a per-process random id, which splits a session's `uip track` calls apart.
 Safety: a host-provided `UIPATH_SESSION_ID` always wins (the step is a no-op
 when the variable is already set), the value is sanitized to `[A-Za-z0-9._-]`
 before being written into the sourced env file, and the step is not gated on
 `UIPATH_TELEMETRY_DISABLED` — writing a variable transmits nothing; the CLI's
 own gate governs whether any event carrying it is sent.
 
+The written value is capped and stripped to `[A-Za-z0-9._-]`, which matters
+because native App Insights tags skip the CLI's PII redactor — whatever ends up
+in `UIPATH_SESSION_ID` reaches the wire as written.
+
 This mechanism is **Claude Code-only**: Codex offers no env-file equivalent for
-hooks, and its `CODEX_THREAD_ID` matches the payload `session_id` only for the
-root thread (subagent threads carry their own thread id) — so native-command
-correlation is currently not available under Codex. Codex **skills events**
-still carry `session_id` and correlate with each other normally.
+hooks. Codex events still correlate with each other, and with Codex's own `uip`
+commands, through the CLI's inherited-handle fallback (`CODEX_THREAD_ID`) — but
+that id matches the payload `session_id` only for the root thread (subagent
+threads carry their own thread id), so a subagent's events land in a separate
+session.
 
 ## Reliability & performance
 

--- a/hooks/send-telemetry.ps1
+++ b/hooks/send-telemetry.ps1
@@ -20,7 +20,12 @@
 # the event name, the authenticated cloud identity, the `source:
 # "skills-plugin"` dimension, and — since UiPath/cli#2806 — the
 # environment/base_url/region base dimensions stamped fresh on every event
-# from its own auth context (so this hook sends no environment info). This
+# from its own auth context (so this hook sends no environment info). Since
+# UiPath/cli#3431 the CLI also owns the session id: it resolves one per process
+# (UIPATH_SESSION_ID, else an inherited agent/terminal handle) and puts it on
+# App Insights' native ai.session.id tag, and `uip track` no longer accepts a
+# session id from the payload — so this hook sends none. Correlation comes from
+# set-session-env.ps1, which exports UIPATH_SESSION_ID for the session. This
 # hook only derives + sanitizes fields and gates on the opt-out flag; value
 # sanitization stays the hook's responsibility because the CLI and skills
 # ship co-versioned.
@@ -31,7 +36,7 @@
 # JSON-shaped text (`"success":false`, `uip solution publish`, `.flow"`,
 # `"resolvedModel":"..."`). So the payload is parsed as real JSON
 # (ConvertFrom-Json) and each field is read ONLY from the region it lives in:
-#   ENVELOPE (top-level)  -> toolName, toolUseId, session_id, permissionMode,
+#   ENVELOPE (top-level)  -> toolName, toolUseId, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType,
 #                            source (-> session_source), reason (session-end),
 #                            model (-> agent_model; Claude sends it on
@@ -83,8 +88,11 @@ $ErrorActionPreference = 'SilentlyContinue'
 # eventName / session_source / reason / agent_model keys, renames
 # sessionId -> session_id (canonical casing, matches the CLI command stream,
 # UiPath/cli#2800), and drops environment/baseUrl (the CLI stamps fresh
-# environment/base_url/region base dimensions itself, UiPath/cli#2806).
-$SCHEMA_VERSION = 2
+# environment/base_url/region base dimensions itself, UiPath/cli#2806). v3:
+# drops session_id — the session is no longer a custom dimension; the CLI puts
+# its own per-process id on the native ai.session.id tag and `uip track`
+# rejects a payload session id (UiPath/cli#3431).
+$SCHEMA_VERSION = 3
 
 # --- extraction helpers ------------------------------------------------------
 
@@ -270,7 +278,6 @@ function Main {
   $hookEvent      = [string](Get-Prop $payload 'hook_event_name')
   $tool           = [string](Get-Prop $payload 'tool_name')
   $toolUseId      = [string](Get-Prop $payload 'tool_use_id')
-  $sessionId      = [string](Get-Prop $payload 'session_id')
   $permissionMode = [string](Get-Prop $payload 'permission_mode')
   $durationMs     = Get-Prop $payload 'duration_ms'
   $agentType      = [string](Get-Prop $payload 'agent_type')
@@ -364,7 +371,6 @@ function Main {
     @('effortLevel',    's', $effortLevel),
     @('skillsVersion',  's', $skillsVer),
     @('toolUseId',      's', $toolUseId),
-    @('session_id',     's', $sessionId),
     @('subagentModel',  's', $subagentModel),
     @('subagentType',   's', $subagentType),
     @('agentType',      's', $agentType),
@@ -383,7 +389,8 @@ function Main {
   # the uip.skills.<event> name, stamps source: "skills-plugin", attaches the
   # authenticated cloud identity + CLI app version, owns transport + flush,
   # redacts PII, and drops any non-scalar value (so a null durationMs
-  # disappears). Send no envelope and no `source` (the CLI overrides it).
+  # disappears). Send no envelope, no `source` (the CLI overrides it), and no
+  # session id (the CLI resolves its own and drops a payload one).
   #
   # `uip track` is never-fail (exits 0, emits nothing when telemetry is opted
   # out); piping to it is harmless even if the CLI is absent (the catch

--- a/hooks/send-telemetry.sh
+++ b/hooks/send-telemetry.sh
@@ -16,7 +16,12 @@
 # the event name, the authenticated cloud identity, the `source:
 # "skills-plugin"` dimension, and — since UiPath/cli#2806 — the
 # environment/base_url/region base dimensions stamped fresh on every event
-# from its own auth context (so this hook sends no environment info). This
+# from its own auth context (so this hook sends no environment info). Since
+# UiPath/cli#3431 the CLI also owns the session id: it resolves one per process
+# (UIPATH_SESSION_ID, else an inherited agent/terminal handle) and puts it on
+# App Insights' native ai.session.id tag, and `uip track` no longer accepts a
+# session id from the payload — so this hook sends none. Correlation comes from
+# set-session-env.sh, which exports UIPATH_SESSION_ID for the session. This
 # hook only derives + sanitizes fields and gates on the opt-out flag; value
 # sanitization stays the hook's responsibility because the CLI and skills
 # ship co-versioned.
@@ -27,7 +32,7 @@
 # contains JSON-shaped text (`"success":false`, `uip solution publish`,
 # `.flow"`, `"resolvedModel":"..."`). So a single string-aware awk pass walks
 # the JSON once and pulls each field ONLY from the region it lives in:
-#   ENVELOPE (top-level)  -> toolName, toolUseId, session_id, permissionMode,
+#   ENVELOPE (top-level)  -> toolName, toolUseId, permissionMode,
 #                            durationMs, effortLevel (effort.level), agentType,
 #                            source (-> session_source), reason (session-end),
 #                            model (-> agent_model; Claude sends it on
@@ -83,8 +88,11 @@ set +e
 # eventName / session_source / reason / agent_model keys, renames
 # sessionId -> session_id (canonical casing, matches the CLI command stream,
 # UiPath/cli#2800), and drops environment/baseUrl (the CLI stamps fresh
-# environment/base_url/region base dimensions itself, UiPath/cli#2806).
-SCHEMA_VERSION=2
+# environment/base_url/region base dimensions itself, UiPath/cli#2806). v3:
+# drops session_id — the session is no longer a custom dimension; the CLI puts
+# its own per-process id on the native ai.session.id tag and `uip track`
+# rejects a payload session id (UiPath/cli#3431).
+SCHEMA_VERSION=3
 
 # --- extraction ------------------------------------------------------------
 
@@ -99,7 +107,7 @@ extract_fields() {
   awk '
     function interesting(k, d, c) {
       if (d == 1)
-        return (k=="tool_name"||k=="tool_use_id"||k=="session_id"|| \
+        return (k=="tool_name"||k=="tool_use_id"|| \
                 k=="permission_mode"||k=="duration_ms"||k=="agent_type"|| \
                 k=="hook_event_name"||k=="source"||k=="reason"||k=="model")
       if (d == 2 && c == "input")
@@ -198,7 +206,7 @@ extract_fields() {
 # while loop runs in the current shell (here-doc, not a pipe), so the
 # assignments persist.
 read_fields() {
-  event=""; tool=""; tool_use_id=""; session_id=""; permission_mode=""
+  event=""; tool=""; tool_use_id=""; permission_mode=""
   duration_ms=""; agent_type=""; skill=""; command=""; file_path=""
   subagent_type=""; interrupted=""; success=""; resolved_model=""
   effort_level=""; response_seen=""; session_source=""; reason=""
@@ -209,7 +217,6 @@ read_fields() {
       hook_event_name)    event="$v" ;;
       tool_name)          tool="$v" ;;
       tool_use_id)        tool_use_id="$v" ;;
-      session_id)         session_id="$v" ;;
       permission_mode)    permission_mode="$v" ;;
       duration_ms)        duration_ms="$v" ;;
       agent_type)         agent_type="$v" ;;
@@ -381,7 +388,6 @@ permissionMode|s|$permission_mode
 effortLevel|s|$effort_level
 skillsVersion|s|$skills_ver
 toolUseId|s|$tool_use_id
-session_id|s|$session_id
 subagentModel|s|$subagent_model
 subagentType|s|$subagent_type
 agentType|s|$agent_type
@@ -458,7 +464,6 @@ main() {
   effort_level="$(san "$effort_level")"
   skills_ver="$(san "$skills_ver")"
   tool_use_id="$(san "$tool_use_id")"
-  session_id="$(san "$session_id")"
   subagent_model="$(san "$subagent_model")"
   subagent_type="$(san "$subagent_type")"
   agent_type="$(san "$agent_type")"
@@ -470,7 +475,8 @@ main() {
   # the uip.skills.<event> name, stamps source: "skills-plugin", attaches the
   # authenticated cloud identity + CLI app version, owns transport + flush,
   # redacts PII, and drops any non-scalar value (so a null durationMs
-  # disappears). Send no envelope and no `source` (the CLI overrides it).
+  # disappears). Send no envelope, no `source` (the CLI overrides it), and no
+  # session id (the CLI resolves its own and drops a payload one).
   #
   # Detached subshell ( cmd & ) survives this hook's exit so the agent never
   # waits. `uip track` is never-fail (exits 0, emits nothing when telemetry is

--- a/hooks/set-session-env.ps1
+++ b/hooks/set-session-env.ps1
@@ -6,10 +6,12 @@
 # Reads the SessionStart payload on stdin, takes its top-level `session_id`,
 # and appends `export UIPATH_SESSION_ID='<id>'` to $env:CLAUDE_ENV_FILE so
 # every subsequent shell tool subprocess — and therefore every `uip` command
-# the agent runs — inherits it. The CLI stamps that value as the `session_id`
-# dimension on native command telemetry (UiPath/cli#2800), which joins the
-# command stream with the skills events emitted by send-telemetry.ps1: both
-# streams then carry the same session id.
+# the agent runs — inherits it. The CLI puts that value on App Insights'
+# native `ai.session.id` tag (query it as `session_Id`) for every command it
+# runs, including the `uip track` calls made by send-telemetry.ps1
+# (UiPath/cli#3431) — so the command stream and the skills events share one
+# session id. This export is the ONLY way they correlate: since schema v3 the
+# telemetry hook sends no session id of its own.
 #
 # Registered SYNCHRONOUSLY in hooks.json (no "async": true): the write must
 # complete before the session's first shell call, or early `uip` commands

--- a/hooks/set-session-env.sh
+++ b/hooks/set-session-env.sh
@@ -8,10 +8,12 @@
 # Reads the SessionStart payload on stdin, takes its top-level `session_id`,
 # and appends `export UIPATH_SESSION_ID='<id>'` to $CLAUDE_ENV_FILE so every
 # subsequent Bash tool subprocess — and therefore every `uip` command the
-# agent runs — inherits it. The CLI stamps that value as the `session_id`
-# dimension on native command telemetry (UiPath/cli#2800), which joins the
-# command stream with the skills events emitted by send-telemetry.sh: both
-# streams then carry the same session id.
+# agent runs — inherits it. The CLI puts that value on App Insights' native
+# `ai.session.id` tag (query it as `session_Id`) for every command it runs,
+# including the `uip track` calls made by send-telemetry.sh (UiPath/cli#3431)
+# — so the command stream and the skills events share one session id. This
+# export is the ONLY way they correlate: since schema v3 the telemetry hook
+# sends no session id of its own.
 #
 # Registered SYNCHRONOUSLY in hooks.json (no "async": true): the write must
 # complete before the session's first Bash call, or early `uip` commands would

--- a/tests/scripts/test_send_telemetry_hook.py
+++ b/tests/scripts/test_send_telemetry_hook.py
@@ -14,8 +14,9 @@ forwards to ``uip track``. Covers:
   ``Stop``/``StopFailure``→``completion``;
 * the lifecycle fields ``session_source`` / ``reason`` / ``outcome`` and
   ``schemaVersion``;
-* the v2 key set — canonical ``session_id`` (not the v1 ``sessionId``) and no
-  ``environment`` / ``baseUrl`` (the CLI stamps its own base dimensions);
+* the v3 key set — no session id in any spelling (the CLI owns the session and
+  puts it on the native ``ai.session.id`` tag) and no ``environment`` /
+  ``baseUrl`` (the CLI stamps its own base dimensions);
 * Codex-shaped payloads — Codex fires ``SessionStart``/``Stop`` under the same
   names with a matching envelope, so mapping and fields work unchanged and
   Codex-only extras are never forwarded;
@@ -90,11 +91,10 @@ def test_session_start_maps_and_carries_source():
     )
     assert event["eventName"] == "session-start"
     assert event["session_source"] == "startup"
-    assert event["session_id"] == "sess-1"
     # The session's main model (envelope `model`) rides as agent_model —
     # full slug, not family-collapsed (UiPath/cli#2785).
     assert event["agent_model"] == "claude-sonnet-5"
-    assert event["schemaVersion"] == 2
+    assert event["schemaVersion"] == 3
 
 
 def test_session_end_carries_reason():
@@ -194,10 +194,13 @@ def test_post_tool_use_uipath_skill_maps_to_tool_use():
     assert event["outcome"] == "ok"
 
 
-def test_v2_key_set_has_no_env_fields_or_legacy_session_id():
-    """Schema v2 drops environment/baseUrl (the CLI stamps fresh
-    environment/base_url/region base dimensions itself, UiPath/cli#2806) and
-    sends only the canonical session_id spelling (UiPath/cli#2800)."""
+def test_v3_key_set_has_no_env_fields_and_no_session_id():
+    """Schema v3 sends no session id in any spelling: the CLI resolves one per
+    process from UIPATH_SESSION_ID (exported by set-session-env) and puts it on
+    App Insights' native ai.session.id tag, and `uip track` drops a payload
+    session id (UiPath/cli#3431). v2 already dropped environment/baseUrl — the
+    CLI stamps fresh environment/base_url/region dimensions itself
+    (UiPath/cli#2806)."""
     event = run_hook(
         {
             "hook_event_name": "SessionStart",
@@ -207,8 +210,11 @@ def test_v2_key_set_has_no_env_fields_or_legacy_session_id():
     )
     assert "environment" not in event
     assert "baseUrl" not in event
+    assert "session_id" not in event
     assert "sessionId" not in event
     assert "sessionSource" not in event
+    # The payload session id must not survive under any key.
+    assert "sess-1" not in event.values()
 
 
 # ── Autopilot / Delegate tool-name tests ───────────────────────────────────
@@ -367,8 +373,8 @@ def run_hook(payload, *, telemetry_disabled="0", expect_drop=False):
             "CLAUDE_PLUGIN_ROOT": str(REPO_ROOT),
             "CAPTURE_FILE": str(capture),
         }
-        # A UIPATH_SESSION_ID inherited from the CI env would override the
-        # payload session id — keep the hook's own behavior under test.
+        # The hook sends no session id (schema v3) and reads no session env;
+        # drop an inherited one so nothing about it can reach the payload.
         env.pop("UIPATH_SESSION_ID", None)
 
         subprocess.run(


### PR DESCRIPTION
The CLI dropped the `session_id` custom dimension in UiPath/cli#3431: session now lives only on App Insights' native `ai.session.id` tag, resolved per process from `UIPATH_SESSION_ID` (or an inherited agent/terminal handle), and `uip track` no longer accepts a session id from the payload. Both hook twins kept sending one, so it was assembled, sanitized, and thrown away on every event.

Drops the key from both twins and bumps `schemaVersion` to 3.

Correlation is unchanged in practice — `set-session-env.sh`/`.ps1` already exports `UIPATH_SESSION_ID`, so command events and `uip track` events land on the same `session_Id`; that export is now the only thing joining them. Under Codex (no env-file equivalent) events fall back to the CLI's inherited `CODEX_THREAD_ID`, which splits subagent threads into their own sessions.

Blast radius: additive to the wire format minus one key. Any query reading `customDimensions.session_id` on `uip.skills.*` events must switch to the native `session_Id` column — that break already shipped on the CLI side, this just stops feeding a dimension nothing reads.

Docs and the `set-session-env` header comments described the old dimension; both now describe the tag, and TELEMETRY.md notes that native tags skip the CLI's PII redactor, so whatever a host puts in `UIPATH_SESSION_ID` reaches the wire as written.

Verification: `pytest tests/scripts/test_send_telemetry_hook.py tests/scripts/test_set_session_env_hook.py` — 26 passed. The 26 skips are the pwsh twin (no pwsh on my machine), so the PowerShell edits are unverified locally; CI runs both twins on ubuntu. Also piped a `PostToolUse` payload carrying `session_id` through the bash hook with a stub `uip`: emitted object has no session key and `schemaVersion: 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
