### PR TITLE
fix(tests): accept regex/positional deterministic rules; drop outlier catalog max_count

### DIFF
--- a/skills/uipath-review/references/agents/guardrails/guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/guardrails-review.md
@@ -96,6 +96,9 @@ else:
 - **CACHE_MISS**: fetch and save: `uip agent guardrails catalog --output json > .guardrails-catalog-cache.json`
   (the CLI writes both success and error JSON to stdout — do not add `2>&1`).
 
+**Never invoke `uip agent guardrails catalog` a second time in the same review.** Every later read — a quick
+look, a `python3`/`jq` parse, a re-check — goes through `.guardrails-catalog-cache.json`, not a fresh CLI call.
+
 ### Guardrails List (NEVER cached — tenant-specific)
 
 ```bash

--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/check_deterministic.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/check_deterministic.py
@@ -38,6 +38,21 @@ def keyword(call: ast.Call, name: str) -> ast.expr | None:
     return next((item.value for item in call.keywords if item.arg == name), None)
 
 
+def positional_or_keyword(call: ast.Call, index: int, name: str) -> ast.expr | None:
+    """Like `keyword`, but also accepts the argument passed positionally at `index`.
+
+    `CustomValidator`'s `rule` is a regular (positional-or-keyword) constructor
+    parameter, so `CustomValidator(lambda args: ...)` is as valid as
+    `CustomValidator(rule=lambda args: ...)` — both bind the same parameter.
+    """
+    found = keyword(call, name)
+    if found is not None:
+        return found
+    if len(call.args) > index:
+        return call.args[index]
+    return None
+
+
 def is_call(node: ast.expr | None, name: str) -> bool:
     return isinstance(node, ast.Call) and call_name(node.func) == name
 
@@ -65,8 +80,22 @@ def contains_string_literal(node: ast.AST, value: str) -> bool:
     )
 
 
-def checks_secret_customer_id(node: ast.Lambda | ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
-    """Return whether a callable contains `"secret" in <customer_id expression>`."""
+def contains_substring_literal(node: ast.AST, value: str) -> bool:
+    """Return whether any string constant under `node` contains `value` (casefolded).
+
+    Looser than `contains_string_literal` — a regex pattern carries `secret` inside
+    delimiters (e.g. `r"\\bsecret\\b"`), so an exact-match check would never fire.
+    """
+    return any(
+        isinstance(item, ast.Constant)
+        and isinstance(item.value, str)
+        and value.casefold() in item.value.casefold()
+        for item in ast.walk(node)
+    )
+
+
+def checks_secret_customer_id_membership(node: ast.AST) -> bool:
+    """Return whether `node` contains `"secret" in <customer_id expression>`."""
     for item in ast.walk(node):
         if not isinstance(item, ast.Compare):
             continue
@@ -80,6 +109,30 @@ def checks_secret_customer_id(node: ast.Lambda | ast.FunctionDef | ast.AsyncFunc
             ):
                 return True
     return False
+
+
+def checks_secret_customer_id_regex(node: ast.AST) -> bool:
+    """Return whether `node` contains a `re.search`/`re.match`/`re.fullmatch` call
+    whose pattern argument mentions "secret" and whose target argument references
+    `customer_id` — the regex-based equivalent of the membership check above (e.g.
+    `re.search(r"\\bsecret\\b", str(tool_input.get("customer_id", "")), re.IGNORECASE)`).
+    """
+    for item in ast.walk(node):
+        if not isinstance(item, ast.Call) or call_name(item.func) not in ("search", "match", "fullmatch"):
+            continue
+        args = item.args
+        if len(args) < 2:
+            continue
+        pattern, target = args[0], args[1]
+        if contains_substring_literal(pattern, "secret") and contains_reference(target, "customer_id"):
+            return True
+    return False
+
+
+def checks_secret_customer_id(node: ast.Lambda | ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return whether a callable checks customer_id for "secret" — either via
+    `"secret" in <expr>` membership, or an equivalent `re.search`/`match`/`fullmatch`."""
+    return checks_secret_customer_id_membership(node) or checks_secret_customer_id_regex(node)
 
 
 def resolve_rule(
@@ -142,7 +195,7 @@ def valid_decorator(
             if not is_call(validator, "CustomValidator"):
                 continue
             assert isinstance(validator, ast.Call)
-            rule = keyword(validator, "rule")
+            rule = positional_or_keyword(validator, 0, "rule")
             resolved = resolve_rule(rule, functions) if rule is not None else None
             if (
                 resolved is not None

--- a/tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py
@@ -89,6 +89,49 @@ def test_accepts_decorator_rule_with_docstring(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_accepts_positional_inline_lambda_rule(tmp_path: Path) -> None:
+    """Codex gpt-5.6-terra's actual output, rep 0 of a 2026-08-06 x5 validation run:
+    `rule` passed positionally to CustomValidator instead of as `rule=...`. It's a
+    regular positional-or-keyword constructor parameter, so both bind identically."""
+    result = run_checker(
+        tmp_path,
+        """
+        @guardrail(
+            validator=CustomValidator(
+                lambda args: "secret" in str(args.get("customer_id", "")).lower()
+            ),
+            action=BlockAction(detail="blocked"),
+        )
+        @tool
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_positional_named_rule(tmp_path: Path) -> None:
+    """Same gap, named-function form (rep 1 of the same validation run)."""
+    result = run_checker(
+        tmp_path,
+        """
+        def contains_secret_customer_id(data: dict) -> bool:
+            return "secret" in data.get("customer_id", "").lower()
+
+        @guardrail(
+            validator=CustomValidator(contains_secret_customer_id),
+            action=BlockAction(detail="blocked"),
+        )
+        @tool
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_rejects_secret_function_not_wired_as_rule(tmp_path: Path) -> None:
     result = run_checker(
         tmp_path,
@@ -132,6 +175,66 @@ def test_rejects_variable_named_secret_without_secret_literal(tmp_path: Path) ->
             *UiPathDeterministicGuardrailMiddleware(
                 tools=[lookup_account_info],
                 rules=[misleading_rule],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode != 0
+    assert "callable rule checking customer_id for 'secret'" in result.stderr
+
+
+def test_accepts_regex_based_rule(tmp_path: Path) -> None:
+    """Codex gpt-5.6-terra's actual output (2026-08-04 rerun): a named function using
+    `re.search` with a word-boundary pattern instead of a plain `in` membership check."""
+    result = run_checker(
+        tmp_path,
+        """
+        import re
+
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def contains_secret_customer_id(tool_input: dict) -> bool:
+            \"\"\"Return whether a tool input has the standalone word 'secret' in its ID.\"\"\"
+            return bool(
+                re.search(
+                    r"\bsecret\b",
+                    str(tool_input.get("customer_id", "")),
+                    flags=re.IGNORECASE,
+                )
+            )
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[contains_secret_customer_id],
+                action=BlockAction(detail="blocked"),
+            ),
+        ]
+        """,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_rejects_regex_rule_checking_wrong_field(tmp_path: Path) -> None:
+    result = run_checker(
+        tmp_path,
+        """
+        import re
+
+        def lookup_account_info(customer_id: str) -> str:
+            return customer_id
+
+        def checks_account_name(data: dict) -> bool:
+            return bool(re.search(r"secret", data.get("account_name", "")))
+
+        middleware = [
+            *UiPathDeterministicGuardrailMiddleware(
+                tools=[lookup_account_info],
+                rules=[checks_account_name],
                 action=BlockAction(detail="blocked"),
             ),
         ]

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_audit_logging/lowcode_review_guardrail_audit_logging.yaml
@@ -61,7 +61,6 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    max_count: 1
     require_success: true
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_content_safety/lowcode_review_guardrail_content_safety.yaml
@@ -60,7 +60,6 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    max_count: 1
     require_success: true
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
+++ b/tests/tasks/uipath-review/agents/lowcode_review_guardrail_misapplied/lowcode_review_guardrail_misapplied.yaml
@@ -62,7 +62,6 @@ success_criteria:
     tool_name: "Bash"
     command_pattern: 'uip\s+agent\s+guardrails\s+catalog'
     min_count: 1
-    max_count: 1
     require_success: true
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## What changed?

Two independent test-authoring bugs found while re-running the guardrail-tagged tasks from the `2026-08-04_04-13-14` nightly run (7 originally-failing tasks, verified live on Claude Sonnet 5 + Codex gpt-5.6-terra):

**1. `check_deterministic.py` only recognized one implementation style (`aa0465214`)**

The checker's `checks_secret_customer_id()` only matched `"secret" in <customer_id expr>` with `rule=` passed as a keyword. Two other equally valid styles were rejected:
- `re.search`/`match`/`fullmatch`-based rules (word-boundary, case-insensitive — arguably stronger than plain substring matching) produce no `ast.Compare`/`In` node.
- `rule` passed **positionally** to `CustomValidator(lambda args: ...)` instead of `CustomValidator(rule=lambda args: ...)` — `rule` is a regular positional-or-keyword constructor parameter, so both forms bind identically, but the checker only ever looked for the keyword.

Found the regex gap from the nightly run's Codex Terra transcript; found the positional gap **during this PR's own 5x validation run** — 2 of 5 Terra replicates used the positional form in the same batch, proving it's a real, recurring pattern, not a one-off (I'd dismissed an earlier single sighting of this as noise before seeing the 2/5 rate).

Added `checks_secret_customer_id_regex()` and `positional_or_keyword()`, composed with the existing check. 4 new unit tests (10/10 total pass), including both real failing artifacts replayed byte-exact through the fixed checker.

**2. Outlier `max_count: 1` on the catalog-fetch criterion (`2a601edc1`)**

`content_safety`, `misapplied`, and `audit_logging` (lowcode review) gate on "fetched the live catalog" with `max_count: 1` — but the other four sibling tasks in the same file family (`action_ineffective` x2, coded `misapplied`, coded `recommended`) only require `min_count: 1`, no upper bound. This inconsistency turned a minor, harmless model habit (peek at the catalog with `| head -N`, then separately redirect to a file to parse it — two literal invocations) into a hard failure. `content_safety` and `audit_logging` both failed exactly this way in the nightly run.

Dropped `max_count: 1` from all three, aligning with the rest of the family — `min_count: 1` + `require_success: true` still gates on the catalog actually being fetched. Also added one explicit line to `guardrails-review.md` Step 0 ("never invoke the catalog a second time — every later read goes through the cache file") as defense in depth.

## How has this been tested?

Live-validated with `--repeats 5` on both harnesses, isolated tempdir sandboxes, pinned Coder Eval v0.9.1 (matches this repo's `.coder-eval-version`):

| Task | Claude Sonnet 5 | Codex gpt-5.6-terra |
|---|---|---|
| `content_safety` | 5/5 | 4/5 |
| `misapplied` (lowcode) | 5/5 | 3/5 |
| `audit_logging` | 5/5 | 5/5 |
| `deterministic` (after both checker fixes) | 5/5 | 5/5 |

**40/40 clean on every criterion this PR touches.** The 3 Terra shortfalls above are a single **pre-existing, unrelated** flake — `uip agent review` returning `"error: unknown command 'review'"` (exit 3) in the Codex tempdir sandbox, intermittently (also hit 1/7 unrelated Terra runs earlier the same day, ~15% base rate). Not caused by, or fixed in, this PR — flagging for whoever owns Codex sandbox provisioning in coder_eval.

- `python3 -m pytest tests/tasks/uipath-agents/coded/guardrails/deterministic/test_check_deterministic.py` — 10/10 pass
- `python3 -m py_compile` on both edited Python files; `git diff --check` clean
- Rebased onto latest `main` with zero file overlap in the 2 commits gained since branching

## Are there any breaking changes?

- [x] None
- [ ] Under Feature Flag
- [ ] DB migrations
- [ ] API removals