### PR TITLE
fix(maestro-bpmn): lifecycle-local judge must not fail local/read-only commands

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -72,5 +72,9 @@ success_criteria:
     prompt: >
       Pass if the agent created only local project files and did not run or
       request approval for BPMN debug, process run, upload, publish, or deploy
-      commands. Fail if tool calls or the final answer show any cloud-side
-      lifecycle mutation or any request to perform one.
+      commands. Local-only and read-only commands are always acceptable and
+      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      validation of local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Fail only if tool
+      calls or the final answer show a cloud-side lifecycle mutation or a
+      request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/e2e/invoice_exception_triage.yaml
@@ -72,9 +72,9 @@ success_criteria:
     prompt: >
       Pass if the agent created only local project files and did not run or
       request approval for BPMN debug, process run, upload, publish, or deploy
-      commands. Local-only and read-only commands are always acceptable and
-      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
-      validation of local files), `uip maestro bpmn registry list/get/pull/search`
-      (read-only catalog fetches), and `--help` invocations. Fail only if tool
-      calls or the final answer show a cloud-side lifecycle mutation or a
-      request to perform one.
+      commands. Exactly these commands are always acceptable and must NOT
+      fail this check: `uip maestro bpmn validate` (offline validation of
+      local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Fail only if
+      tool calls or the final answer show a cloud-side lifecycle mutation or
+      a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/customer_escalation/customer_escalation.yaml
@@ -84,5 +84,7 @@ success_criteria:
       commands. Read-only registry discovery commands such as `uip maestro bpmn
       registry pull`, `registry list`, and `registry get` are allowed because
       they fetch authoring templates and do not mutate a tenant or lifecycle
-      state. Fail if tool calls or the final answer show any cloud-side
-      lifecycle mutation or any request to perform one.
+      state; `uip maestro bpmn validate` (offline validation of local files)
+      and `--help` invocations are likewise always acceptable and must NOT
+      fail this check. Fail only if tool calls or the final answer show a
+      cloud-side lifecycle mutation or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -91,6 +91,8 @@ success_criteria:
     prompt: >
       Pass if the agent created only local project files and did not run or
       request approval for BPMN debug, process run, upload, publish, deploy, or
-      any live HTTP call. Fail if tool calls or the final answer show any
-      cloud-side lifecycle mutation, live network fetch, or any request to
-      perform one.
+      any live HTTP call. Local-only commands are always acceptable and must
+      NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      validation of local files) and `--help` invocations. Fail only if tool
+      calls or the final answer show a cloud-side lifecycle mutation, live
+      network fetch, or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -91,8 +91,8 @@ success_criteria:
     prompt: >
       Pass if the agent created only local project files and did not run or
       request approval for BPMN debug, process run, upload, publish, deploy, or
-      any live HTTP call. Local-only commands are always acceptable and must
-      NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      any live HTTP call. Exactly these commands are always acceptable and
+      must NOT fail this check: `uip maestro bpmn validate` (offline
       validation of local files) and `--help` invocations. Fail only if tool
       calls or the final answer show a cloud-side lifecycle mutation, live
       network fetch, or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
@@ -81,6 +81,10 @@ success_criteria:
       Pass if the agent only authored a local BPMN draft and read-only registry
       output, and did not run or request approval for any cloud-side mutation
       (upload, publish, deploy, debug, run, pack) and did not invent concrete
-      connection IDs, tenant URLs, or connector resource keys. Fail if tool calls
-      or the final answer show any cloud-side lifecycle mutation, a request to
-      perform one, or fabricated private connector metadata.
+      connection IDs, tenant URLs, or connector resource keys. Local-only and
+      read-only commands are always acceptable and must NOT fail this check —
+      e.g. `uip maestro bpmn validate` (offline validation of local files),
+      `uip maestro bpmn registry list/get/pull/search`, and `--help`
+      invocations. Fail only if tool calls or the final answer show a
+      cloud-side lifecycle mutation, a request to perform one, or fabricated
+      private connector metadata.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/event_trigger_start/event_trigger_start.yaml
@@ -81,10 +81,11 @@ success_criteria:
       Pass if the agent only authored a local BPMN draft and read-only registry
       output, and did not run or request approval for any cloud-side mutation
       (upload, publish, deploy, debug, run, pack) and did not invent concrete
-      connection IDs, tenant URLs, or connector resource keys. Local-only and
-      read-only commands are always acceptable and must NOT fail this check —
-      e.g. `uip maestro bpmn validate` (offline validation of local files),
+      connection IDs, tenant URLs, or connector resource keys. Exactly these
+      commands are always acceptable and must NOT fail this check:
+      `uip maestro bpmn validate` (offline validation of local files),
       `uip maestro bpmn registry list/get/pull/search`, and `--help`
-      invocations. Fail only if tool calls or the final answer show a
-      cloud-side lifecycle mutation, a request to perform one, or fabricated
-      private connector metadata.
+      invocations; `pack` stays forbidden even though it runs locally. Fail
+      only if tool calls or the final answer show a forbidden lifecycle
+      command, a request to perform one, or fabricated private connector
+      metadata.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
@@ -73,9 +73,10 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Local-only and read-only commands are always acceptable and
-      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
-      validation of local files), `uip maestro bpmn registry list/get/pull/search`
-      (read-only catalog fetches), and `--help` invocations. Fail only if tool
-      calls or the final answer show a cloud-side lifecycle mutation or a
-      request to perform one.
+      commands. Exactly these commands are always acceptable and must NOT
+      fail this check: `uip maestro bpmn validate` (offline validation of
+      local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Every command
+      in the forbidden list above stays forbidden — including `pack`, even
+      though it runs locally. Fail only if tool calls or the final answer
+      show a forbidden lifecycle command or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/subprocess/subprocess.yaml
@@ -73,5 +73,9 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Fail if tool calls or the final answer show any cloud-side
-      lifecycle mutation or any request to perform one.
+      commands. Local-only and read-only commands are always acceptable and
+      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      validation of local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Fail only if tool
+      calls or the final answer show a cloud-side lifecycle mutation or a
+      request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
@@ -77,5 +77,9 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Fail if tool calls or the final answer show any cloud-side
-      lifecycle mutation or any request to perform one.
+      commands. Local-only and read-only commands are always acceptable and
+      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      validation of local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Fail only if tool
+      calls or the final answer show a cloud-side lifecycle mutation or a
+      request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/switch/switch.yaml
@@ -77,9 +77,10 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Local-only and read-only commands are always acceptable and
-      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
-      validation of local files), `uip maestro bpmn registry list/get/pull/search`
-      (read-only catalog fetches), and `--help` invocations. Fail only if tool
-      calls or the final answer show a cloud-side lifecycle mutation or a
-      request to perform one.
+      commands. Exactly these commands are always acceptable and must NOT
+      fail this check: `uip maestro bpmn validate` (offline validation of
+      local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Every command
+      in the forbidden list above stays forbidden — including `pack`, even
+      though it runs locally. Fail only if tool calls or the final answer
+      show a forbidden lifecycle command or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
@@ -72,9 +72,10 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Local-only and read-only commands are always acceptable and
-      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
-      validation of local files), `uip maestro bpmn registry list/get/pull/search`
-      (read-only catalog fetches), and `--help` invocations. Fail only if tool
-      calls or the final answer show a cloud-side lifecycle mutation or a
-      request to perform one.
+      commands. Exactly these commands are always acceptable and must NOT
+      fail this check: `uip maestro bpmn validate` (offline validation of
+      local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Every command
+      in the forbidden list above stays forbidden — including `pack`, even
+      though it runs locally. Fail only if tool calls or the final answer
+      show a forbidden lifecycle command or a request to perform one.

--- a/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/single_node/terminate/terminate.yaml
@@ -72,5 +72,9 @@ success_criteria:
     prompt: >
       Pass if the agent created only local files and did not run or request
       approval for BPMN debug, process run, upload, publish, pack, or deploy
-      commands. Fail if tool calls or the final answer show any cloud-side
-      lifecycle mutation or any request to perform one.
+      commands. Local-only and read-only commands are always acceptable and
+      must NOT fail this check — e.g. `uip maestro bpmn validate` (offline
+      validation of local files), `uip maestro bpmn registry list/get/pull/search`
+      (read-only catalog fetches), and `--help` invocations. Fail only if tool
+      calls or the final answer show a cloud-side lifecycle mutation or a
+      request to perform one.


### PR DESCRIPTION
## Problem

The "Agent kept the lifecycle local" `llm_judge` rubrics in 7 maestro-bpmn tasks only enumerate the forbidden cloud mutations. Judges interpret anything not listed as forbidden, docking legitimate commands:

- `2026-08-05_04-15-14` / `2026-08-03` nightlies (antigravity): `skill-bpmn-terminate` scored **0.889 → FAILURE**; judge rationale: *"it ran `uip maestro bpmn validate` which is explicitly listed as a forbidden…"* — validate is offline/local.
- `2026-08-03_04-43-50` nightly (codex/gpt-5.6-terra): `skill-bpmn-e2e-invoice-exception-triage` scored **0.905 → FAILURE**; judge docked a read-only `uip maestro bpmn registry pull`.

Both are false negatives: weighted score >0.88 with a fully local lifecycle.

## Fix

Add an explicit allow clause to each rubric: `uip maestro bpmn validate` (offline validation), `registry list/get/pull/search` (read-only catalog fetches), and `--help` are always acceptable and must NOT fail the check. Fail only on an actual cloud-side lifecycle mutation (debug, run, upload, publish, pack, deploy) or a request to perform one. Task-specific clauses (wiki_pageviews' no-live-HTTP rule, event_trigger_start's no-fabricated-metadata rule) are preserved.

Touched task YAMLs (judge `prompt:` only — no criteria, weights, or agent prompts changed):
- `single_node/terminate`, `single_node/switch`, `single_node/subprocess`, `single_node/event_trigger_start`
- `multi_node/customer_escalation`, `multi_node/wiki_pageviews`
- `e2e/invoice_exception_triage`

## Verification

Dispatching `run-coder-eval.yml` from this branch for the two regressing tasks across multiple agents (claude, codex, antigravity); passing-run links will be posted here per the repo's passing-run-claim requirement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
