### PR TITLE
chore: refresh uip CLI catalog (1.200.0-dev.8116)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-05T05:07:17Z",
-  "cli_version": "1.200.0-dev.8093",
+  "generated_at": "2026-08-06T05:06:36Z",
+  "cli_version": "1.200.0-dev.8116",
   "verbs": [
     "admin",
     "admin audit",
@@ -623,6 +623,7 @@
     "maestro bpmn debug-instance continue",
     "maestro bpmn debug-instance create",
     "maestro bpmn debug-instance incidents",
+    "maestro bpmn debug-instance status",
     "maestro bpmn debug-instance variables",
     "maestro bpmn debug-instance variables-all",
     "maestro bpmn debug-instance variables-set",
@@ -811,6 +812,7 @@
     "maestro flow debug-instance continue",
     "maestro flow debug-instance create",
     "maestro flow debug-instance incidents",
+    "maestro flow debug-instance status",
     "maestro flow debug-instance variables",
     "maestro flow debug-instance variables-all",
     "maestro flow debug-instance variables-set",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.200.0-dev.8116`. The catalog has 1429 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.