### PR TITLE
chore: change to centralized managed GitHub pool

### DIFF
--- a/.github/workflows/activation-gate.yml
+++ b/.github/workflows/activation-gate.yml
@@ -23,12 +23,12 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     outputs:
       skills: ${{ steps.detect.outputs.skills }}
       skip: ${{ steps.detect.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with: { fetch-depth: 0 }
 
       - id: detect
@@ -70,7 +70,7 @@ jobs:
     # a ready PR. workflow_dispatch has no draft flag → the != 'true' check
     # treats undefined as not-draft, so manual dispatch still runs the gate.
     if: needs.detect.outputs.skip != 'true' && github.event.pull_request.draft != true
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: ${{ matrix.skill }}
     timeout-minutes: 30
     strategy:
@@ -78,15 +78,15 @@ jobs:
       matrix:
         skill: ${{ fromJSON(needs.detect.outputs.skills) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
       # Pin coder_eval to tests/.coder-eval-version so the activation gate runs
       # the same engine as the smoke, ad-hoc, and nightly paths.
       - name: Resolve coder_eval pin
         id: ceref
         run: echo "version=$(tr -d '[:space:]' < tests/.coder-eval-version)" >> "$GITHUB_OUTPUT"
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with: { python-version: '3.13' }
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
       # Host coder-eval CLI = pinned wheel (coder_eval feed + ml-packages for
       # deps). Activation runs under the tempdir driver -- no agent image.

--- a/.github/workflows/automerge-catalog-refresh.yml
+++ b/.github/workflows/automerge-catalog-refresh.yml
@@ -26,7 +26,7 @@ permissions:
 
 jobs:
   automerge:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
       - name: Merge eligible refresh PRs
         env:

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -17,7 +17,7 @@ jobs:
       github.event.issue.pull_request &&
       (startsWith(github.event.comment.body, '/cherrypick') ||
        startsWith(github.event.comment.body, '/cherry-pick'))
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
     outputs:
@@ -53,7 +53,7 @@ jobs:
       (startsWith(github.event.comment.body, '/cherrypick') ||
        startsWith(github.event.comment.body, '/cherry-pick'))
     needs: cherry-pick-init
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
@@ -108,7 +108,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Checkout target branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           ref: ${{ needs.cherry-pick-init.outputs.branch }}
           fetch-depth: 0
@@ -251,7 +251,7 @@ jobs:
       (startsWith(github.event.comment.body, '/cherrypick') ||
        startsWith(github.event.comment.body, '/cherry-pick'))
     needs: [run-cherry-pick, cherry-pick-init]
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   claude-review:
     name: Claude Code Review
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 15
 
     # Only run on non-fork PRs (secrets required), or on @claude mentions from
@@ -41,14 +41,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Claude Code Action
         # Pinned to a full commit SHA (not @v1) so a moved tag cannot run
         # untrusted action code with our token/secrets. SHA = v1.0.160.
-        uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280 # v1.0.160
+        uses: anthropics/claude-code-action@4633baf5267540f3f8cb58b684f79901d564c280  # v1.0.160
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lint-tasks.yml
+++ b/.github/workflows/lint-tasks.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   lint-tasks:
     name: Lint changed task YAMLs
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 15
 
     # Skip drafts (only run when the PR is ready for review) and skip forks
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Claude Code Action
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@86180fa9e4d311eed10c9cc49854c53dab5d517a  # v1.0.184
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/path-to-ga-approval.yml
+++ b/.github/workflows/path-to-ga-approval.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   gate:
     name: path-to-ga approval
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 5
     env:
       # GitHub logins whose latest PR review may approve new path-to-ga tags.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,10 +52,10 @@ permissions:
 jobs:
   guard:
     name: Validate version sync
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22.x"
       # Fails if version-manifest.json has drifted from package.json.
@@ -71,13 +71,13 @@ jobs:
       github.repository == 'UiPath/skills'
       && ((github.event_name == 'push' && github.ref == 'refs/heads/main')
           || (github.event_name == 'workflow_dispatch' && github.event.inputs.channel == 'dev'))
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22.x"
           registry-url: "https://npm.pkg.github.com"
@@ -116,7 +116,7 @@ jobs:
       && ((github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/'))
           || (github.event_name == 'workflow_dispatch'
               && (github.event.inputs.channel == 'latest' || github.event.inputs.channel == 'preview')))
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     permissions:
       contents: read
       # OIDC trusted publishing — no NPM_TOKEN. The npmjs trusted publisher
@@ -125,8 +125,8 @@ jobs:
       # pushes publish through the same OIDC exchange as tags on main.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22.x"
 

--- a/.github/workflows/refresh-uip-catalog.yml
+++ b/.github/workflows/refresh-uip-catalog.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   refresh:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     env:
       # Turn off the CLI's startup version-sync: on a `-dev` CLI it would try to
       # re-align tools through the release-channel path (which can't resolve
@@ -19,7 +19,7 @@ jobs:
       # a corrupted/collapsed catalog.
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Check for existing open refresh PR
         id: check
@@ -40,12 +40,12 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         if: steps.check.outputs.exists != 'true'
         with:
           node-version: '20'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         if: steps.check.outputs.exists != 'true'
         with:
           python-version: '3.13'

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -67,7 +67,7 @@ on:
 # of runs (e.g. the same task across claude / codex / antigravity) at once.
 jobs:
   partition:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Partition globs by `windows` tag
     outputs:
       linux_globs:    ${{ steps.split.outputs.linux_globs }}
@@ -77,7 +77,7 @@ jobs:
       coder_eval_version: ${{ steps.ceref.outputs.version }}
       coder_eval_image_tag: ${{ steps.ceref.outputs.image_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       # Single source of truth for the coder_eval version: the pin in
       # tests/.coder-eval-version. A non-blank coder_eval_version input overrides
@@ -153,7 +153,7 @@ jobs:
     # ubuntu-latest (4 vCPU) handles ad-hoc single-task / small-folder runs at
     # the default `parallelism` (4); the larger tier is needed to raise -j for
     # the full nightly sweep to finish in ~30-45min instead of multi-hour.
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     # Full skills suite on the VM (~700 tasks, j=1) runs 3-4h. 330 min
     # covers worst-case stalls (one slow task pinning a slot, network
     # hiccups, etc.).
@@ -165,13 +165,13 @@ jobs:
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
       # Host coder-eval CLI = pinned wheel (coder_eval feed + ml-packages for
       # deps). The Linux docker driver still imports the selected agent class on
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coder-eval-linux-${{ github.run_id }}
           # ** so the pattern matches the replicate-index segment that
@@ -334,7 +334,7 @@ jobs:
   run-windows:
     needs: partition
     if: needs.partition.outputs.windows_count != '0'
-    runs-on: windows-latest
+    runs-on: uipath-windows-latest
     # Windows RPA tasks spin up Helm on each `uip rpa` call (30–60s each)
     # and run j=1 (Helm state leaks between concurrent tasks). Budget
     # mirrors smoke-rpa-skills.yml plus headroom for ad-hoc / e2e runs.
@@ -346,19 +346,19 @@ jobs:
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'
 
@@ -489,7 +489,7 @@ jobs:
 
       - name: Upload auth-debug artifacts
         if: always() && steps.auth.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: auth-debug-windows-${{ github.run_id }}
           path: ${{ github.workspace }}/auth-debug
@@ -585,7 +585,7 @@ jobs:
 
       - name: Upload eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coder-eval-windows-${{ github.run_id }}
           path: |

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -16,13 +16,13 @@ on:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Detect changed RPA skills
     outputs:
       task_globs: ${{ steps.detect.outputs.task_globs }}
       skip: ${{ steps.detect.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
@@ -81,7 +81,7 @@ jobs:
   smoke:
     needs: detect
     if: needs.detect.outputs.skip != 'true'
-    runs-on: windows-latest
+    runs-on: uipath-windows-latest
     # RPA smoke tasks spin up Helm on each `uip rpa` call (30–60s each). A
     # typical 3-task smoke run with cold Helm + three tasks runs ~25–40
     # min; bump the ceiling so we don't cancel mid-task.
@@ -93,7 +93,7 @@ jobs:
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       # Pin coder_eval to tests/.coder-eval-version so RPA smoke runs the same
       # engine as the skills smoke, ad-hoc, and nightly paths. shell: bash
@@ -103,17 +103,17 @@ jobs:
         shell: bash
         run: echo "version=$(tr -d '[:space:]' < tests/.coder-eval-version)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4.3.1
         with:
           dotnet-version: '8.0.x'
 
@@ -258,7 +258,7 @@ jobs:
       # post-mortem artifact even on success (baseline for comparison).
       - name: Upload auth-debug artifacts
         if: always() && steps.auth.outcome != 'skipped'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: auth-debug-${{ github.run_id }}
           path: ${{ github.workspace }}/auth-debug
@@ -356,7 +356,7 @@ jobs:
       # crash.
       - name: Upload HTML / JSON eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: eval-report-${{ github.run_id }}
           path: |

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -16,14 +16,14 @@ on:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Detect changed skills
     outputs:
       task_globs: ${{ steps.detect.outputs.task_globs }}
       skip: ${{ steps.detect.outputs.skip }}
       untested_skills: ${{ steps.detect.outputs.untested_skills }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 
@@ -259,12 +259,12 @@ jobs:
   warn-untested:
     needs: detect
     if: needs.detect.outputs.untested_skills != ''
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Warn about untested skills
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7.1.0
         with:
           script: |
             const skills = '${{ needs.detect.outputs.untested_skills }}';
@@ -296,7 +296,7 @@ jobs:
   e2e:
     needs: detect
     if: needs.detect.outputs.skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     # 18+ smoke tasks at ~1–2 min each + env setup. 60 min was getting
     # cancelled when the matrix grew + LLM reviewer was retrying on quota
     # exhaustion. 120 min covers worst-case reviewer-retry storms without
@@ -309,7 +309,7 @@ jobs:
     env:
       UIPATH_CLI_DISABLE_VERSION_SYNC: "1"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       # Single source of truth for the coder_eval version: the pin in
       # tests/.coder-eval-version. Consumed as the wheel version (host CLI) and
@@ -318,13 +318,13 @@ jobs:
         id: ceref
         run: echo "version=$(tr -d '[:space:]' < tests/.coder-eval-version)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: '20'
 
@@ -508,7 +508,7 @@ jobs:
 
       - name: Upload HTML / JSON eval report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: eval-report-${{ github.run_id }}
           # Use ** so the pattern still matches the replicate-index segment
@@ -624,14 +624,14 @@ jobs:
   # clean and the convention has bedded in.
   validate-task-schema:
     name: Validate task schema (advisory)
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     timeout-minutes: 8
     continue-on-error: true
     # Skip forks: the private-feed creds for the pinned coder-eval wheel aren't
     # available to forked PRs (matches the e2e job's secret requirements).
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       # Pin coder_eval to tests/.coder-eval-version so schema validation runs
       # against the same engine that actually executes the tasks.
@@ -639,11 +639,11 @@ jobs:
         id: ceref
         run: echo "version=$(tr -d '[:space:]' < tests/.coder-eval-version)" >> "$GITHUB_OUTPUT"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
 
       # Host coder-eval CLI = pinned wheel (coder_eval feed + ml-packages for
       # deps). `coder-eval plan` validates schemas on the runner -- no image.

--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -56,14 +56,14 @@ concurrency:
 
 jobs:
   cut:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
         with:
           node-version: "22.x"
 

--- a/.github/workflows/task-driver-gate.yml
+++ b/.github/workflows/task-driver-gate.yml
@@ -27,12 +27,12 @@ permissions:
 
 jobs:
   gate:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: No task pins sandbox.driver tempdir
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with: { python-version: '3.13' }
       - name: Install PyYAML
         run: pip install --quiet pyyaml

--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -14,12 +14,12 @@ on:
 
 jobs:
   pytest-flow-check:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: maestro-flow checker unit tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -30,12 +30,12 @@ jobs:
         run: pytest tests/tasks/uipath-maestro-flow/ -v
 
   pytest-case-check:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: maestro-case checker unit tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -46,12 +46,12 @@ jobs:
         run: pytest tests/tasks/uipath-maestro-case/ -v
 
   pytest-agents-check:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: uipath-agents checker unit tests
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -62,12 +62,12 @@ jobs:
         run: pytest tests/tasks/uipath-agents/ -v
 
   runtime-payload-casing-guard:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: runtime-payload key-casing contract guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -81,12 +81,12 @@ jobs:
         run: pytest tests/scripts/test_runtime_payload_key_casing.py -v
 
   catalog-build-guards:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: catalog build integrity guards
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 
@@ -100,12 +100,12 @@ jobs:
         run: pytest tests/scripts/test_catalog_build_guards.py -v
 
   telemetry-hook-tests:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: telemetry hook contract guard
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/validate-skill-status.yml
+++ b/.github/workflows/validate-skill-status.yml
@@ -14,12 +14,12 @@ permissions:
 
 jobs:
   validate-status:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Validate skill status manifest & README
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/validate-skills-sh.yml
+++ b/.github/workflows/validate-skills-sh.yml
@@ -13,12 +13,12 @@ permissions:
 
 jobs:
   validate-skills-sh:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Validate skills.sh.json against skills/
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: '3.13'
 

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -8,10 +8,10 @@ on:
 
 jobs:
   validate-descriptions:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Validate skill descriptions
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verb-gate.yml
+++ b/.github/workflows/verb-gate.yml
@@ -24,13 +24,13 @@ permissions:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: Detect changed skills
     outputs:
       skills: ${{ steps.detect.outputs.skills }}
       skip:   ${{ steps.detect.outputs.skip }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         with: { fetch-depth: 0 }
 
       - id: detect
@@ -66,7 +66,7 @@ jobs:
   gate:
     needs: detect
     if: needs.detect.outputs.skip != 'true'
-    runs-on: ubuntu-latest
+    runs-on: uipath-ubuntu-latest
     name: ${{ matrix.skill }}
     timeout-minutes: 5
     strategy:
@@ -74,8 +74,8 @@ jobs:
       matrix:
         skill: ${{ fromJSON(needs.detect.outputs.skills) }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with: { python-version: '3.13' }
 
       - name: Check verbs in skills/${{ matrix.skill }}


### PR DESCRIPTION
## Summary

Moves this repository's workflows to the centralized managed GitHub pool.

- Runner images are prefixed with `uipath-` in all workflow files
- e.g. `ubuntu-latest` → `uipath-ubuntu-latest`

## Changes

All workflow `.yml` files (including non-standard locations like `workflows-src/`) with static `runs-on` values are updated.
Dynamic expressions (`${{ ... }}`) and already-prefixed images are skipped.

## Action Version Pinning

All `uses:` references are pinned to the SHA of the latest release published ≥ **48h** ago.
This prevents supply-chain attacks via recently-published compromised versions.