### PR TITLE
fix(tests): unblock flow paginated_reference_lookup from connection-selection gate

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml
@@ -28,7 +28,11 @@ initial_prompt: |
   trigger. It should send a Slack message saying "hello from coder-eval"
   to the channel named `simple` using Slack's "Send Message to Channel"
   activity.
-  For Slack, use the connection name `is-sandboxes`.
+  For Slack, use the connection name `is-sandboxes`. If more than one
+  connection matches that name, use any enabled one.
+  Validate the flow when you're done.
+  Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
+  planning and implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## Problem

The `skill-flow-paginated-reference-lookup` task (`tests/tasks/uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml`) scores **0/5** — but not for the reason it tests. It targets the `curated_channels` pagination behavior added in #1059 (ENGCE-58198); the agent never reaches it.

**Root cause (traced against skills as source of truth):** channel resolution needs `--connection-id`, so **connection selection strictly precedes** the pagination loop. The eval tenant has multiple enabled connections named `is-sandboxes` (in `uipath-maestro-flow` and `uipath-maestro-case` folders), and the default one is not in the user's personal workspace. Per `connections.md` → *Selecting a Connection*, the silent auto-select rule therefore cannot fire, so the guidance (correctly) mandates *"present connections to the user … let the user confirm."* The agent obeyed and asked *"Which one should the Flow use?"*.

This is a **single-turn eval** (`simulation: null`, no user simulator), so the clarifying question ends the run before pagination, validate, or flow creation ever happen → all 5 gating criteria fail.

The `resources.md` pagination guidance (#1059) is intact and correct — it's simply never exercised.

## Fix

Make the prompt autonomous so connection selection can't pre-empt the pagination path under test:

- Reuse this suite's established HITL autonomy directive (*"Do NOT ask for approval, confirmation, or feedback … single pass"*).
- Authorize picking **any enabled** `is-sandboxes` when several match — robust to tenant pollution; the success criteria don't check which folder, and both enabled connections are the same Slack workspace.
- Add an explicit **validate** instruction — `uip maestro flow validate` is a gating criterion the old prompt never requested (sibling `drive_to_slack.yaml` already does this).

## Why this doesn't weaken the test

The regression it guards against is *abandoning pagination after page 1*. If that regresses, the `run list … curated_channels` (`min_count: 2`) and `nextPage=` (`min_count: 1`) command-count criteria still fail. The autonomy directive only removes the **connection-selection** false negative; it does not touch pagination detection.

## Verification

YAML validated (`safe_load` OK, 5 criteria intact). Full end-to-end re-run not possible locally — requires the live UiPath tenant, the codex/`gpt-5.6-terra` backend, and the docker harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)