### PR TITLE
chore(skills): promote platform and rpa to stable (GA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-maestro-flow` | In-development |
 | `uipath-mcp-servers` | In-development |
 | `uipath-planner` | Preview |
-| `uipath-platform` | Preview |
+| `uipath-platform` | Stable |
 | `uipath-process-mining` | Preview |
 | `uipath-review` | Preview |
-| `uipath-rpa` | Preview |
+| `uipath-rpa` | Stable |
 | `uipath-solution` | Preview |
 | `uipath-tasks` | Preview |
 | `uipath-test` | In-development |

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -151,7 +151,7 @@
       "last_synced": null
     },
     "uipath-platform": {
-      "status": "preview",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null
@@ -175,7 +175,7 @@
       "last_synced": null
     },
     "uipath-rpa": {
-      "status": "preview",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null


### PR DESCRIPTION
Scoped down to the two skills with the strongest, most direct evidence — a dedicated GA announcement each, both checked off in the Confluence tracker ([`CA/pages/90537722003`](https://uipath.atlassian.net/wiki/spaces/CA/pages/90537722003)). The other candidates from earlier passes on this PR (`uipath-troubleshoot`, `uipath-insights`, `uipath-coded-apps`, `uipath-tasks`) have real GA evidence too, but are left for their own owners to promote.

## Evidence

| Skill | Evidence | Status change |
|---|---|---|
| `uipath-rpa` | Dedicated announcement "UiPath for Coding Agents — RPA Support is now Generally Available" (2026-08-03). Tracker: GA 2026-07-27, checked off. | preview → **stable** |
| `uipath-platform` | This is what "Operate" means in the 2026-08-04 "Operate, Admin, and Govern" GA announcement. The announcement's own setup link (`docs.uipath.com/uipath-cli/.../coding-agents-operate`) documents exactly this skill's scope — folders, users/roles, licenses, machines, sessions, processes/packages, jobs, assets, credential stores, queues, buckets, libraries, triggers, webhooks, IS connections, audit logs. The tracker's "Operate, Administer and Govern" row lists the same surface across its DevCon and Public Preview milestones before GA. | preview → **stable** |

## Deliberately not touched

- **`uipath-admin`** — the 2026-08-04 announcement GA's only "User Accounts and Robot Accounts management" under Admin; explicitly defers OMS, Local Groups, Roles/AuthZ, SSO, Audit, Policies, External Apps, PATs, Tenant Tags — most of what this skill actually covers.
- **`uipath-governance`** — its real scope (AOps policies, ISO 42001 compliance) is the "Agentic Governance (Compliance Pack + Dashboard-as-Code)" item the announcement explicitly defers, and a separate announcement confirms it's still in Private Preview.
- **`uipath-agents`**, **`uipath-ixp`**, **`uipath-test`**, and the Maestro skills — tracker shows Public Preview only, GA targeted 2026-09-15.
- **`uipath-solution`** — real signal ("Deployment Lifecycle" shows up in Operate's scope) but no dedicated confirmation found either way.

## Mechanics

Same minimal pattern as prior promotions (see #1983): flip `status` in `assets/skill-status.json`, regenerate the README table via `scripts/check-skill-status.py --write-readme`. No `SKILL.md` content changed — `check-skill-status.py` confirms no stale preview markers in either skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
