### PR TITLE
fix(tests): drop sandbox.driver tempdir from ixp conditional_unconfirm (unblocks Task Driver Gate)

### DIFF
--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -18,7 +18,6 @@ run_limits:
   expected_turns: 6
 
 sandbox:
-  driver: tempdir
   mock_path_dirs: [mocks]
   template_sources:
     - {type: template_dir, path: ../_shared/mock_template}


### PR DESCRIPTION
## Problem

The **Task Driver Gate** ("No task pins sandbox.driver tempdir") is red on **every open PR** (#2501–#2505). The gate full-scans `tests/tasks` with **no `paths:` filter**, so a single offending file fails it repo-wide:

```
FAIL — tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml:21 pins sandbox.driver: tempdir
```

## Root cause

- Gate PR #2210 removed all `driver: tempdir` overrides and added this gate to block reintroduction.
- `conditional_unconfirm.yaml` was added later by #2009 **with** `driver: tempdir`, slipping past the gate.

The sandbox driver is chosen by the run environment (docker on the Linux nightly slice, tempdir forced on the Windows slice via the `windows` tag), never by the task — pinning `tempdir` runs the task on the toolless host and breaks tool-backed `uip` commands.

## Fix

Remove the one `driver: tempdir` line. The rest of the `sandbox:` block (`mock_path_dirs`, `template_sources`) is unchanged and still valid.

## Verification

```
$ python3 scripts/check-task-driver.py tests/tasks
OK — no task pins `sandbox.driver: tempdir`.
```

YAML still parses (`safe_load` OK); all 4 success criteria intact. This is test-harness config only — no change to what the task grades.

Once merged, the gate goes green on every open PR on re-run (GitHub checks run the PR-merged-into-main commit), so no rebases needed.

cc @cezara98t @paul-ciobanu @misupantea-uipath @andrei-uipath @alexandrujircan (IXP test owners)

🤖 Generated with [Claude Code](https://claude.com/claude-code)