### PR TITLE
chore: refresh uip CLI catalog (1.200.0-dev.8116)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-06T05:06:36Z",
+  "generated_at": "2026-08-07T04:43:58Z",
   "cli_version": "1.200.0-dev.8116",
   "verbs": [
     "admin",
@@ -550,6 +550,9 @@
     "is triggers",
     "is triggers describe",
     "is triggers objects",
+    "is typecache",
+    "is typecache activities",
+    "is typecache packages",
     "is webhooks",
     "is webhooks config",
     "ixp",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.200.0-dev.8116`. The catalog has 1432 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.