### PR TITLE
fix(governance): stop the drift smoke prompt from asserting auth will fail

### DIFF
--- a/tests/tasks/uipath-governance/compliance-pack/drift_restore_smoke.yaml
+++ b/tests/tasks/uipath-governance/compliance-pack/drift_restore_smoke.yaml
@@ -9,7 +9,12 @@ description: >
   "restore", they ask for posture, and the drift data is what turns the answer
   into a restore offer.
 
-  Platform note: uip commands fail with auth errors - expected.
+  Platform note: in CI the tenant is live and these commands succeed; locally
+  they fail with auth errors. The prompt must not assert either way — telling
+  the agent "auth errors expected" made it grep output.txt for auth keywords,
+  hit the words "unauthorized"/"forbidden" in the ISO 42001 control prose that
+  `catalog get` returns, and abort before running coverage (run
+  2026-08-07_04-44-12).
 tags: [uipath-governance, smoke, mode:operate, lifecycle:setup, feature:compliance]
 
 sandbox:
@@ -36,8 +41,13 @@ initial_prompt: |
   (use `> output.txt 2>&1` for the first command, `>> output.txt 2>&1` for the rest).
 
   Important:
-  - uip CLI is not connected to a live tenant - auth errors expected.
-  - Run each command once, capture output, move on. Do NOT retry or login.
+  - A uip command may fail with an auth error. If one does, carry on with the
+    remaining steps - do NOT retry or login.
+  - Decide whether a command succeeded from the `Result` field of that command's
+    own JSON response. Do NOT search the accumulated output.txt for words like
+    "unauthorized" or "forbidden" - the ISO 42001 control descriptions contain
+    them as ordinary policy text, so that check reports failure on a good run.
+  - Run each command once, capture output, move on.
   - Always pass --output json.
   - Do NOT prompt for confirmation - this is an automated test.
 


### PR DESCRIPTION
Claude Run: https://github.com/UiPath/skills/actions/runs/31177079428
Codex Run: https://github.com/UiPath/skills/actions/runs/31177044215
Antigravity Run: https://github.com/UiPath/skills/actions/runs/31177103092

## Problem

CI run [`2026-08-07_04-44-12`](https://coder-evalboard.uipath-dev.com/runs/2026-08-07_04-44-12/skill-governance-compliance-drift-restore) failed `skill-governance-compliance-drift-restore` at 0.583 — the agent aborted at turn 1 without running `state coverage` or `state get`, the two graded commands.

**Root cause is the prompt, not the skill.** The prompt asserted *"uip CLI is not connected to a live tenant - auth errors expected"* — false in CI, where smoke sandboxes have live tenant auth (the task's own `pre_run` enables the pack via the API). Primed by the false premise, the agent (codex/gpt-5.6-terra):

1. Ran `catalog get` → succeeded, writing 97KB of ISO 42001 control prose to `output.txt`
2. Verified its "expected auth failure" with `rg -q 'Unauthorized|...|forbidden' output.txt`
3. False-positived on ordinary policy text (*"forbiddenApps, forbiddenUrls"*, *"unauthorized actions"*)
4. Concluded the tenant was unauthenticated — over an output.txt that starts with `"Result": "Success"` — and stopped

The task passed its Aug 2 local runs only because the premise was *true* there (no auth → tiny output.txt → no landmine). Aug 7 was its first contact with a live tenant. The skill needs no change: it keys on HTTP 403/401 status and never teaches keyword-grepping.

## Fix

Prompt-only change to `drift_restore_smoke.yaml`:

- Stop asserting auth will fail — auth errors are *possible*, not promised
- Direct success-checking to each response's own JSON `Result` field
- Explicitly call out the keyword-grep-over-output.txt as a false-positive trap
- Record the failure mode in the description's platform note

No criteria changed.

## Verification

Local rerun on the exact failing variant — **codex / gpt-5.6-terra**, live authenticated tenant, pack active (same trigger condition as CI):

- **6/6 criteria passed, weighted score 1.000** (was 0.583)
- Agent ran the full `catalog get` → `state coverage` → `state get` flow, checked `Result` fields via jq/node (no keyword grep), and gated `state restore` on `Data.Summary.DriftedControlCount > 0` — the drift→restore routing this task exists to prove
- No wrong-direction mutations (`aops-policy update` / `state disable` both absent)