### PR TITLE
feat(uipath-agents): BYO guardrails for low-code and coded agents [AL-513]

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
@@ -54,6 +54,8 @@ uip agent guardrails list --output json
 
 Build a lookup of `{ validatorId: status }` from the `Data` array. You will use this to filter recommendations.
 
+> **`Validator` is not unique — key on `(Validator, IsByo)`, not `Validator` alone.** A tenant with a bring-your-own (BYOG) configuration for a validator has two entries sharing the same `Validator` name — one built-in, one BYO (`IsByo: true`, carrying `ByoValidatorName`/`ByoConnectionId`/`ByoConfigurationId`). Collapsing them loses the distinction and can point the discovery/wiring flow at the wrong entry. See [guardrails.md § BYO (bring-your-own) validators](guardrails.md#byo-bring-your-own-validators).
+
 > **Catalog vs. list — the key distinction:** The catalog lists all guardrails that exist on the platform (with rich metadata for reasoning). The guardrails list returns only those accessible to this tenant. Only recommend validators where `Status == "Available"` in the list.
 
 ### SDK Documentation (NEVER skipped — Python class names)
@@ -114,6 +116,8 @@ For **each entry** in the catalog (`guardrails[]` array from the cached JSON):
 5. If the validator is a candidate: use the catalog entry's `examples[].config` to determine the appropriate scope, stage, action, and parameters. Translate `validator_parameters` shape to the Python `Validator(...)` / `Middleware(...)` constructor arguments using the SDK docs from Step 0.
 
 Do **not** apply predetermined knowledge about which guardrail maps to which schema field. Let the catalog entry's authored fields drive every recommendation decision.
+
+> **Built-in vs. BYO — default to built-in.** When a matched validator has both a built-in entry and one or more `Available` BYO (`IsByo: true`) entries, recommend the standard SDK validator/middleware (built-in) by default, and mention a BYO alternative exists. Only wire in a specific BYO configuration when the user names it or asks for BYO explicitly — see [guardrails.md § BYO (bring-your-own) validators](guardrails.md#byo-bring-your-own-validators) for how that's actually referenced in code.
 
 ### Step 3 — De-duplicate Overlapping Validators
 
@@ -235,7 +239,7 @@ For each existing guardrail discovered in the Python file (Step 1 from Recommend
 
 ### Correctness Check
 
-From the SDK docs and the catalog, look up the validator class referenced in the code:
+From the SDK docs and the catalog, look up the validator class referenced in the code. **If the guardrails list has more than one entry sharing the referenced `Validator` name** (built-in plus BYOG), disambiguate by whether the code wires a BYO validator construct (`ByoValidator(...)` or `UiPathByoGuardrailMiddleware(...)`, identified by its `validator_name`) or the plain SDK validator/middleware class — match against the corresponding list entry's `IsByo` before reading `Parameters`/scopes for that entry.
 
 | Aspect | What to check |
 |--------|---------------|
@@ -295,3 +299,4 @@ python3 -c "import ast; ast.parse(open('graph.py').read())"
 13. **Class names and enum names come from the SDK docs** — never invent them. The SDK evolves; relying on memory produces stale code. For **import paths**, use the `langchain/guardrails/` page when the agent is LangChain (paths live in `uipath_langchain.guardrails`); for every other framework use the `core/guardrails/` page (paths live in `uipath.platform.guardrails`). See Rule 8.
 14. **Read [guardrails.md](guardrails.md) before writing any Python** — the middleware spread (`*`), decorator placement above `@tool` / factory, factory refactor, and import-source rules are specified there and cannot be safely inferred.
 15. **`EscalateAction` is the human-in-the-loop option only when the SDK docs expose it** — recommend it when the user wants a person to review/approve a flagged item rather than hard-block it. It requires a **deployed Action App** declared in `bindings.json` (`app_name` / `app_folder_path`) through the coded-agent bindings sync workflow; if the docs, app, or binding prerequisite is unavailable, fall back to Block/Log and say so — never silently drop the requested escalation. See Step 6 and [guardrails.md § Escalation action (HITL)](guardrails.md#escalation-action-human-in-the-loop).
+16. **`Validator` is not unique — disambiguate built-in vs. BYO by `IsByo` before matching on name.** A tenant can have both a built-in and one or more BYOG entries sharing the same `Validator` name. Key any lookup on `(Validator, IsByo)`, and default recommendations/wiring to the built-in SDK validator/middleware unless the user names a BYO configuration or asks for BYO. Never fabricate the BYO validator construct from memory — see [guardrails.md § BYO (bring-your-own) validators](guardrails.md#byo-bring-your-own-validators).

--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -57,6 +57,87 @@ If the requested validator has `Status != "Available"` → tell the user and sto
 
 ---
 
+## BYO (bring-your-own) validators
+
+A validator can be fulfilled by a tenant-registered **external** provider (a "BYOG" configuration — e.g. Azure AI Content Safety, Databricks AI Guardrails) instead of UiPath's own built-in implementation. Registration is admin-side — Admin → AI Trust Layer → Guardrails Configurations, or `uip guardrails byo-configurations create` (see [uipath-platform § BYO Guardrail Configurations](/uipath:uipath-platform)); this section covers wiring an already-registered BYOG configuration into agent code.
+
+**Same rule as [Step 0](#step-0--fetch-official-documentation): confirm the constructor signature against the fetched SDK docs before writing code, and never invent arguments.** The two constructs below exist today; if a future fetch shows one missing or renamed, follow the fetched page and say so rather than writing what's here from memory.
+
+### Which construct exists where
+
+| Construct | Style | Ships in | Notes |
+|---|---|---|---|
+| `UiPathByoGuardrailMiddleware` | middleware | `uipath_langchain.guardrails` **only** | LangChain/LangGraph agents only — there is no framework-agnostic middleware. |
+| `ByoValidator` | decorator | `uipath.platform.guardrails` (**core**), re-exported by `uipath_langchain.guardrails` | Framework-agnostic class, so BYO is **not** LangChain-only. |
+
+> **BYO is not LangChain-only** — a common wrong inference, because the core SDK docs page historically omitted `ByoValidator`. The class is in core. What *is* LangChain-only is the middleware.
+>
+> The usual [Imports Pattern](#imports-pattern) rule still governs which module you import from: a LangChain agent imports from `uipath_langchain.guardrails` (adapter registration — see Critical Rule 8), everything else from `uipath.platform.guardrails`. And on a framework with no published adapter, the decorator carries the same silent-no-op risk it does for every other validator — that caveat belongs to the decorator *mechanism*, not to BYO.
+
+**Wire format** — both styles emit the same thing: `validatorType: "byo"` plus `byoValidatorName: "<name>"`. That is the identical field a low-code `agent.json` guardrail uses to pin a BYO configuration, so coded and low-code agents reference BYOG the same way.
+
+Discovery steps (in addition to the fetched docs):
+
+1. Confirm a BYOG configuration exists for the desired validator and get its identifying value:
+   ```bash
+   uip agent guardrails list --byo --output json
+   ```
+   Read `ByoValidatorName` from the matching entry — the validator name is the **only** value the code passes; it is unique across the tenant, and the platform resolves the underlying connection server-side from the stored configuration. Do not pass a connection id, and never guess or fabricate the name.
+2. Before wiring it in, cross-check the configuration's health on the admin side:
+   ```bash
+   uip guardrails byo-configurations list --output json
+   ```
+   Confirm `Enabled: true` and `ValidConnection: true` for the matching `ValidatorName`. A disabled configuration or a broken connection means the guardrail will fail at runtime (or silently fall back, depending on `FallbackOnUiPath`) — tell the user rather than wiring it in anyway. The admin-side fix (re-enable via `update <id> --enabled`, repoint the connection via `update <id> --connection-id`) is covered by [uipath-platform § BYO Guardrail Configurations](/uipath:uipath-platform).
+
+### BYO middleware (LangChain only)
+
+`validator_name`, `scopes`, and `action` are all required. `validator_parameters` is optional passthrough — BYO parameter schemas are connector-defined, so read the ids and allowed values from that entry's `Parameters` array in the discovery output rather than guessing. Spread with `*` like every other middleware.
+
+```python
+from uipath_langchain.guardrails import (
+    BlockAction,
+    UiPathByoGuardrailMiddleware,
+)
+from uipath.core.guardrails import GuardrailScope
+
+*UiPathByoGuardrailMiddleware(
+    validator_name="my-pii-guardrail",   # ByoValidatorName from `guardrails list --byo`
+    scopes=[GuardrailScope.AGENT],
+    action=BlockAction(),
+),
+```
+
+For Tool scope, pass the tool objects as usual:
+
+```python
+*UiPathByoGuardrailMiddleware(
+    validator_name="my-pii-guardrail",
+    scopes=[GuardrailScope.TOOL],
+    action=BlockAction(),
+    tools=[lookup_account_info],   # required whenever TOOL is in scopes
+),
+```
+
+### BYO decorator (any framework)
+
+The validator name is the **first positional argument**; `parameters` is keyword-only. Scope comes from the decorated target (`@tool` → Tool, LLM factory → Llm, agent factory → Agent), exactly as for the built-in validators.
+
+```python
+from uipath_langchain.guardrails import BlockAction, ByoValidator, guardrail
+
+byog_pii = ByoValidator("my-pii-guardrail")
+
+@guardrail(validator=byog_pii, action=BlockAction())
+def create_support_agent():
+    return create_agent(model=llm, tools=[lookup_account_info])
+```
+
+On a non-LangChain framework the same code works with `from uipath.platform.guardrails import BlockAction, ByoValidator, guardrail` — subject to the adapter caveat above.
+
+**Stages:** BYO validator capabilities are connector-defined and can't be known statically, so no stage restriction is applied — all stages are supported, and the middleware defaults to `PRE_AND_POST`.
+
+---
+
 ## Step 1 — Style Choice
 
 If the user has not specified **middleware** or **decorator**, ask before generating any code. Do not implement both unless explicitly asked.
@@ -178,7 +259,11 @@ Pass `scopes=[GuardrailScope.LLM]` or `[GuardrailScope.AGENT]`. No `tools=`.
 
 ### Stage is fixed by the validator — no `stage=` on middleware
 
-Middleware classes take **no `stage` argument**. Each validator's stage is fixed: input validators (`user_prompt_attacks`, `prompt_injection`, input PII) run PRE; `intellectual_property` runs POST (output-only). Adding `stage=GuardrailExecutionStage....` to a middleware call raises `TypeError`. Only the **decorator** (`@guardrail`) accepts `stage=`.
+Middleware classes for the **fixed-stage** validators take no `stage` argument: `UiPathUserPromptAttacksMiddleware`, `UiPathPromptInjectionMiddleware` (both PRE-only) and `UiPathIntellectualPropertyMiddleware` (POST-only). Passing `stage=` to those raises `TypeError` — their stage is a property of the validator, not a choice.
+
+> Validators whose stage genuinely varies **do** accept `stage=` on the middleware (defaulting to `PRE_AND_POST`) — PII, harmful content, LLM-as-judge, deterministic, and BYO. Confirm against the fetched `langchain/guardrails/` page for the validator you're wiring rather than assuming either way.
+
+For BYO middleware specifically, see [BYO (bring-your-own) validators](#byo-bring-your-own-validators).
 
 ### Intellectual property (output-only) middleware
 
@@ -210,6 +295,8 @@ Runs at POST (checks the LLM's output) — fixed by the validator, not a paramet
 ## Decorator Style — Code Patterns
 
 Full documentation and examples: [Core Guardrails](https://uipath.github.io/uipath-python/core/guardrails/)
+
+For a bring-your-own (BYOG) validator, see [BYO (bring-your-own) validators](#byo-bring-your-own-validators) — `ByoValidator` slots into the same `@guardrail(validator=..., action=...)` shape as the built-ins.
 
 ### Tool scope — decorate the `@tool` function
 
@@ -398,3 +485,4 @@ For non-LangChain frameworks, there is no published adapter yet, so the decorato
 15. **`EscalateAction` requires a deployed Action App** referenced by `app_name` + `app_folder_path` and declared as an `app` resource in **`bindings.json`** — discover it with `uip solution resources list --kind App`, resolve duplicate names by folder, pass the literal name/folder in code (not env vars), and sync bindings with [../../lifecycle/bindings-reference.md](../../lifecycle/bindings-reference.md). Route the task with `TaskRecipient` when the user names a reviewer. See [Escalation action (HITL)](#escalation-action-human-in-the-loop).
 16. **Verify the escalation app schema when tenant access is available** — the app must expose the guardrail review inputs/outputs/outcomes listed in the prerequisite section. If the schema cannot be verified in a local smoke task, say that runtime readiness is unverified.
 17. **A HITL guardrail suspends, it doesn't block.** On violation `EscalateAction` suspends via `interrupt(CreateEscalation(...))`; it terminates **only on Reject** (Approve resumes). Verify by confirming the run suspends + a task is created — never expect a "block" for an escalation guardrail (Rule for the [verification step](#verify-guardrails-are-actually-wired-mandatory-after-writing-for-langchain-ml-guardrails)).
+18. **BYO: pass the validator name and nothing else, and get that name from discovery — never from memory.** `ByoValidatorName` comes from `uip agent guardrails list --byo`; there is **no connection-id argument** in either construct (the platform resolves the connection server-side from the configuration). Pick the construct by style, not by framework: `UiPathByoGuardrailMiddleware` is LangChain-only, while `ByoValidator` is a **core** class (`uipath.platform.guardrails`) re-exported by `uipath_langchain.guardrails` — so **BYO is not LangChain-only**, and a subagent or stale doc claiming otherwise is wrong. Import per Rule 8 regardless. Cross-check `Enabled`/`ValidConnection` via `uip guardrails byo-configurations list` before wiring one in. See [BYO (bring-your-own) validators](#byo-bring-your-own-validators).

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails-recommend.md
@@ -49,6 +49,8 @@ uip agent guardrails list --output json
 
 Build a lookup of `{ validatorId: status }` from the `Data` array. You will use this in Steps 2 and 5 to filter recommendations.
 
+> **`Validator` is not unique — key the lookup on `(Validator, IsByo)`, not `Validator` alone.** A tenant with a bring-your-own (BYOG) configuration for a validator sees two entries sharing the same `Validator` name — one built-in (`IsByo` absent/false), one BYO (`IsByo: true`, carrying `ByoValidatorName`/`ByoConfigurationId`/etc.). Collapsing them into a single `{ validatorId: status }` key silently picks whichever entry happens to win the collision and can validate against the wrong `Parameters`/`AllowedScopes`. See [guardrails.md § BYO (bring-your-own) guardrails](guardrails.md#byo-bring-your-own-guardrails).
+
 > **Catalog vs. list — the key distinction:** The catalog lists all guardrails that exist on the platform (with rich metadata for reasoning). The guardrails list returns only those accessible to this tenant. Only recommend validators where `Status == "Available"` in the list.
 
 ---
@@ -120,6 +122,8 @@ For **each entry** in the catalog (`guardrails[]` array from the cached JSON):
 5. If the validator is a candidate: use the catalog entry's `examples[].config` to determine the appropriate scope, stage, action, and parameters. The example config is the authoritative template for parameter shape.
 
 Do **not** apply predetermined knowledge about which guardrail maps to which schema field. Let the catalog entry's authored fields drive every recommendation decision.
+
+> **Built-in vs. BYO — default to built-in.** When a matched validator has both a built-in entry and one or more `Available` BYO (`IsByo: true`) entries in the guardrails list, recommend the built-in implementation (omit `byoValidatorName`) by default, and mention that a BYO alternative exists. Only recommend a specific BYO configuration when the user names it or asks for BYO explicitly.
 
 ### Step 3 — De-duplicate Overlapping Validators
 
@@ -221,7 +225,7 @@ For each existing guardrail in `agent.json`'s `guardrails[]`:
 
 ### Correctness Check
 
-Run `uip agent guardrails list --output json` (from Step 0) and find the matching validator by `Validator` name. The `Parameters` array is the authoritative source for all validation rules:
+Run `uip agent guardrails list --output json` (from Step 0) and find the matching validator by `Validator` name. **If more than one entry shares that `Validator` name** (a built-in plus one or more BYOG entries), disambiguate before reading `Parameters`: the guardrail JSON carries `byoValidatorName` when it targets a specific BYO configuration — match on that against the list entries' `ByoValidatorName`; if the guardrail JSON has no `byoValidatorName`, it targets the built-in entry (`IsByo` absent/false). Validating against the wrong entry's `Parameters` produces false correctness findings. The `Parameters` array (of the correctly matched entry) is the authoritative source for all validation rules:
 
 | CLI field | What to check |
 |-----------|---------------|
@@ -275,3 +279,4 @@ If the user asks to fix identified issues: apply corrections to `agent.json`, ru
 12. **All map-enum keys must exactly match the corresponding enum-list values** — no extra or missing keys. This is the most common correctness error.
 13. **Read [guardrails.md](guardrails.md) before writing any JSON** — discriminator fields, PascalCase constraints, and parameter shapes are specified there and cannot be safely inferred.
 14. **Do NOT use TaskCreate, TaskUpdate, or other task-tracking tools for guardrail edits.** Edit `agent.json` directly — task management tools add bookkeeping turns without benefit and push runs over their turn budget.
+15. **`Validator` is not unique — disambiguate built-in vs. BYO by `IsByo` before matching on name.** A tenant can have both a built-in and one or more BYOG entries sharing the same `Validator` name. Key any lookup on `(Validator, IsByo)`, and when an existing guardrail carries `byoValidatorName`, match it against `ByoValidatorName` — not `Validator` alone — before reading `Parameters`/`AllowedScopes` for correctness or recommendation. Default recommendations to the built-in entry unless the user asks for BYO. See [guardrails.md § BYO (bring-your-own) guardrails](guardrails.md#byo-bring-your-own-guardrails).

--- a/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/lowcode/capabilities/guardrails/guardrails.md
@@ -625,8 +625,20 @@ Run `uip agent guardrails list --output json` to get the authoritative list. Onl
 | `GuardrailStages[scope]` | Valid execution stages for that scope |
 | `Parameters[].Id` | `validatorParameters[].id` |
 | `Parameters[].Type` | `validatorParameters[].$parameterType` |
+| `IsByo` | Disambiguates a bring-your-own (BYOG) entry from a built-in one — see [BYO (bring-your-own) guardrails](#byo-bring-your-own-guardrails) below. Not itself a JSON field. |
+| `ByoValidatorName` | `byoValidatorName` value — include this field to pin the guardrail to this exact BYO configuration. Required whenever more than one entry shares this `Validator` name (a built-in plus one or more BYOG configurations). |
 
 > **Important:** PII entity names use PascalCase (`"Email"`, not `"email_address"`). Harmful content categories use PascalCase (`"Hate"`, not `"hate"`). Scope values use PascalCase (`"Agent"`, `"Llm"`, `"Tool"`).
+
+## BYO (bring-your-own) guardrails
+
+A validator can be fulfilled by a tenant-registered **external** provider (a "BYOG" configuration — e.g. Azure AI Content Safety, Databricks AI Guardrails) instead of, or alongside, UiPath's own built-in implementation. A tenant admin registers these at Admin → AI Trust Layer → Guardrails Configurations or via `uip guardrails byo-configurations create`; see [uipath-platform § BYO Guardrail Configurations](/uipath:uipath-platform) for the admin-side lifecycle commands (`uip guardrails byo-configurations list|create|update|delete`).
+
+- **`Validator` is not unique.** A tenant with a BYOG `harmful_content` configuration sees **two** entries named `harmful_content` in `uip agent guardrails list` output — one built-in, one BYO. Use `IsByo` to tell them apart; never assume a single match.
+- **Filter to BYO-only entries** with `uip agent guardrails list --byo --output json` when the user specifically wants to see or target a BYO-backed validator.
+- **BYO entries carry extra fields**: `ByoValidatorName`, `ByoConnectionId`, `ByoConfigurationId`, `ByoConnectorName`, `ByoConnectorKey`, `FolderKey` — alongside the same `Parameters`/`AllowedScopes`/`GuardrailStages`/`Status` shape a built-in entry has.
+- **To author a guardrail against a specific BYO configuration**, build the `builtInValidator` guardrail exactly as for a built-in validator (same `validatorType`, same `validatorParameters` from that entry's `Parameters`), and add `byoValidatorName` set to that entry's `ByoValidatorName`. Omit it to use the built-in implementation. (`ByoConfigurationId` is the configuration's own admin-side id — useful for cross-referencing `uip guardrails byo-configurations list`, but it is not what the guardrail JSON carries; `ByoValidatorName` is unique per tenant and is the value that pins it.)
+- **`Status: "Disabled"` on a BYO entry** means the tenant switched that specific configuration off — the entry still shows (it doesn't vanish), so a disabled BYOG configuration is distinguishable from one that was never set up. Do not author a guardrail against a `Disabled` BYO entry; treat it the same as `Unauthorised` (skip, tell the user).
 
 ## Full Examples
 
@@ -1030,6 +1042,7 @@ Add the `guardrails` array at the agent.json root level alongside `settings`, `m
 18. **Do not attempt OR logic within a single guardrail** — all rules and all fields within a guardrail are combined with AND. OR is not supported. To achieve OR behavior, create separate guardrails — one per condition branch.
 19. **Do not generate guardrails targeting unsupported tool types** — `matchNames` can only reference tools of supported types: agent, process, activity, builtInTool, ixpTool, or Integration Service connector. Do not generate guardrails with `matchNames` targeting other tool types.
 20. **Do not omit `matchNames` to target "all tools"** — always explicitly list every tool resource name in `matchNames`. Read the agent's `resources/` directory first. If the agent has no tool resources, do not add the guardrail.
+21. **Do not assume `Validator` is unique** — a tenant can have both a built-in and one or more bring-your-own (BYOG) entries sharing the same `Validator` name. Always check `IsByo` before treating two same-named entries as a duplicate or conflict, and set `byoValidatorName` when targeting a specific BYO entry. See [BYO (bring-your-own) guardrails](#byo-bring-your-own-guardrails).
 
 ## Walkthrough
 

--- a/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
@@ -94,6 +94,8 @@ uip agent guardrails list --output json
 
 Build a `{ validatorId: status }` lookup from the `Data` array (use only `Status == "Available"`).
 
+> **`Validator` is not unique — key on `(Validator, IsByo)`, not `Validator` alone.** A tenant with a bring-your-own (BYOG) configuration for a validator has two entries sharing the same `Validator` name — one built-in, one BYO (`IsByo: true`). If the code wires a BYO validator construct, match it against the `IsByo: true` entry (by its `ByoValidatorName` — tenant-unique; the code passes no connection id), not the built-in one, before reading `Parameters`/scopes. See [uipath-agents coded guardrails.md § BYO (bring-your-own) validators](/uipath:uipath-agents).
+
 ### SDK Docs (required when Step 0 needs Python class names)
 
 Coded agents reference guardrails by **Python class name** (`UiPathPIIDetectionMiddleware`, `PIIValidator`), not by
@@ -154,6 +156,8 @@ Resolve the entry `.py` (the `langgraph.json` `graphs` value's file, else `main.
 ## Audit Mode — existing guardrails (findings are defects)
 
 For each wired guardrail the review CLI did **not** flag, run the checks below.
+
+> **A BYO-backed guardrail's tenant entry showing `Status: "Disabled"` is a configuration switch, not a wiring bug.** It means the tenant admin turned that specific BYOG configuration off (Admin → AI Trust Layer → Guardrails Configurations) — don't re-diagnose the code as a wiring/import defect. If the wired guardrail targets that disabled configuration, it can't protect; treat it like targeting an `Unauthorised` validator and note it in the report.
 
 ### Actionability Check → `CODED_GUARDRAIL_ACTION_INEFFECTIVE`
 

--- a/skills/uipath-review/references/agents/guardrails/guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/guardrails-review.md
@@ -110,6 +110,8 @@ uip agent guardrails list --output json
 
 Build a `{ validatorId: status }` lookup from the `Data` array (use only `Status == "Available"`).
 
+> **`Validator` is not unique — key on `(Validator, IsByo)`, not `Validator` alone.** A tenant with a bring-your-own (BYOG) configuration for a validator has two entries sharing the same `Validator` name — one built-in, one BYO (`IsByo: true`). Collapsing them can point Audit Mode's Correctness/Actionability comparison at the wrong entry's `Parameters`/`AllowedScopes`. When the reviewed guardrail JSON carries `byoValidatorName`, match it against that entry's `ByoValidatorName`, not `Validator` alone. See [uipath-agents guardrails.md § BYO (bring-your-own) guardrails](/uipath:uipath-agents).
+
 ### If the catalog is unavailable
 
 If the catalog output contains `"Code": "GuardrailCatalogUnavailable"` (or the CLI is unavailable), **do not
@@ -128,6 +130,8 @@ guess**:
 
 For each guardrail in `agent.json`'s `guardrails[]` that the review CLI did **not** flag format-invalid, read
 its `validator`, `selector.scopes`, and action `$actionType`, then run two checks.
+
+> **A BYO-backed guardrail's tenant entry showing `Status: "Disabled"` is a configuration switch, not a format problem.** It means the tenant admin turned that specific BYOG configuration off (Admin → AI Trust Layer → Guardrails Configurations) — don't re-diagnose it as a schema/discriminator issue. If the agent's guardrail targets that disabled configuration (via `byoValidatorName`), it functions the same as targeting an `Unauthorised` validator — treat it as unable to protect and note it in the report.
 
 ### Actionability Check → `LC_GUARDRAIL_ACTION_INEFFECTIVE`
 

--- a/skills/uipath-troubleshoot/references/products/agents/playbooks/guardrail-violation.md
+++ b/skills/uipath-troubleshoot/references/products/agents/playbooks/guardrail-violation.md
@@ -29,6 +29,7 @@ What can cause it:
 - Recent rule tightening or action change from Log/Escalate to Block — behavior change is immediate and silent
 - Overly broad pattern matches legitimate content (common business terms, structured JSON fields)
 - OOB validators (PII detection, harmful content, prompt injection, user prompt attacks) at agent or LLM scope — these run automatically when enabled and require no custom rules
+- A bring-your-own (BYOG) guardrail whose tenant configuration is disabled, or whose underlying Integration Service connection is broken — behavior depends on `FallbackOnUiPath`: `true` falls back to the built-in validator, `false` fails the guardrail check outright
 
 > **Filter and Log do not fault the job.** Filter removes `excludedFields` from the payload; `updatedInput`/`updatedOutput` appear on the evaluation span; execution continues. Agent may behave unexpectedly if required fields are stripped. Log records the match; `severityLevel` appears on the evaluation span; execution continues. Neither produces `TERMINATION_GUARDRAIL_VIOLATION`.
 
@@ -68,6 +69,15 @@ What can cause it:
 
    Replace `<GUARDRAIL_NAME>` with guardrailName value from step 3.
 
+   If the matched entry has `"IsByo": true`, cross-check the underlying BYOG configuration's health before assuming the rule/catalog itself is the cause:
+
+   ```bash
+   uip guardrails byo-configurations list --output json \
+     --output-filter "[?ValidatorName == '<ByoValidatorName>' || Id == '<ByoConfigurationId>'].{Enabled: Enabled, ValidConnection: ValidConnection, FallbackOnUiPath: FallbackOnUiPath}"
+   ```
+
+   `Enabled: false` or `ValidConnection: false` means the violation traces back to the BYOG configuration itself (disabled or dead connection), not the rule's logic — see Resolution below.
+
    Then fetch catalog entry:
 
    ```bash
@@ -102,6 +112,8 @@ What can cause it:
 **Filter causing unexpected behavior (not a fault):** Inspect `updatedInput`/`updatedOutput` on the evaluation span from step 3 to see which fields were removed. Verify the agent handles absent fields gracefully. Add fallback logic if required fields can be stripped.
 
 **Recent rule regression:** Check last-modified date in AgentBuilder or Flow → Guardrails. Restore the prior rule definition or disable the rule temporarily. Document the rollback and review rule scope with the guardrail policy team.
+
+**BYO guardrail connection dead or configuration disabled:** If step 4's BYOG check showed `ValidConnection: false`, the underlying Integration Service connection is broken — repair it directly (`uip is connections get <connection-id>`; see [uipath-platform § BYO Guardrail Configurations § Diagnostics](/uipath:uipath-platform)). If `Enabled: false`, the tenant admin switched the configuration off — confirm with them whether that was intentional before re-enabling it with `uip guardrails byo-configurations update <configuration-id> --enabled` (or Admin → AI Trust Layer → Guardrails Configurations). Re-test with the previously blocked input after either fix.
 
 Refresh and validate after any rule or agent change:
 

--- a/tests/tasks/uipath-agents/coded/guardrails/byog_decorator/byog_decorator.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/byog_decorator/byog_decorator.yaml
@@ -1,0 +1,60 @@
+task_id: skill-agent-guardrail-coded-byog-decorator
+description: >
+  Decorator-style bring-your-own guardrail (BYOG) for a coded agent. A simple
+  LangGraph customer support agent is seeded with no guardrails; it already has a
+  create_support_agent() factory. The tenant has a BYOG configuration registered
+  (admin-side); the user asks to route the agent's PII checks through it using the
+  decorator style. Verifies the agent stacks @guardrail with ByoValidator — pinned
+  to the configuration by its validator name, blocking on violations — over a real
+  factory function rather than reaching for the built-in PII validator.
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:edit, guardrail]
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+  # Disallow the subagent-dispatch tool. It is NOT gated by allowed_tools, and a
+  # dispatched subagent carries none of this skill's context. For BYO the failure
+  # is especially subtle: `ByoValidator` really does live in
+  # uipath.platform.guardrails, so a subagent recommending that import is
+  # technically right about the module and still wrong for a LangChain agent
+  # (Rule 8 — the no-op path that skips adapter registration). Force inline
+  # research where the loaded skill's import rule still applies.
+  disallowed_tools: ["Task"]
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/SimpleCodedAgent
+
+initial_prompt: |
+  I have a coded LangGraph agent in graph.py that handles customer support questions.
+  The agent is built in a create_support_agent() factory function.
+
+  Our admin has registered a bring-your-own guardrail configuration on the tenant
+  called `byog-smoke-agent-pin` — it's PII detection served by our own external
+  provider, and we want the agent's PII checks to go through it rather than the
+  UiPath built-in one. Add it at Agent scope using the decorator style, and block
+  on violations.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation. Complete the entire task
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent invoked the uipath-agents skill (not claude-api or another skill)"
+    skill_name: "uipath-agents"
+    expected_skill: "uipath-agents"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "BYOG decorator guardrail correctly added to graph.py"
+    command: "python3 $TASK_DIR/check_byog_decorator.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 11
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/byog_decorator/check_byog_decorator.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/byog_decorator/check_byog_decorator.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Check that a BYOG decorator guardrail was correctly added to graph.py.
+
+Validates:
+- graph.py still parses as Python
+- A @guardrail(validator=ByoValidator(...), action=BlockAction(...)) decorator
+- ByoValidator is pinned to the tenant's configuration by validator name
+  ("byog-smoke-agent-pin") — the point of the test. The name is the first
+  positional parameter, but accept the keyword form too since the SDK signature
+  is positional-or-keyword.
+- The decorated target is a real factory in the fixture (create_support_agent or
+  create_llm). Decorating a plain helper silently no-ops at runtime (Rules 4/5).
+- ByoValidator is imported from uipath_langchain.guardrails, not
+  uipath.platform.guardrails. Both re-export the same class — ByoValidator is
+  genuinely a core class — but only the adapter import registers the LangChain
+  adapter, so the platform import type-checks and then silently no-ops (Rule 8).
+
+Local AST helpers mirror check_deterministic.py; _shared only exports the
+middleware-spread helpers.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+GRAPH = Path("graph.py")
+
+VALIDATOR = "ByoValidator"
+VALIDATOR_NAME = "byog-smoke-agent-pin"
+# Factories the fixture actually defines; decorating anything else won't wrap.
+VALID_TARGETS = {"create_support_agent", "create_llm"}
+
+
+def read() -> str:
+    if not GRAPH.is_file():
+        sys.exit(f"FAIL: {GRAPH} not found in {Path.cwd()}")
+    return GRAPH.read_text()
+
+
+def check(condition: bool, msg: str) -> None:
+    if not condition:
+        sys.exit(f"FAIL: {msg}")
+
+
+def call_name(call: ast.Call) -> str | None:
+    fn = call.func
+    if isinstance(fn, ast.Attribute):
+        return fn.attr
+    if isinstance(fn, ast.Name):
+        return fn.id
+    return None
+
+
+def keyword(call: ast.Call, name: str) -> ast.expr | None:
+    for kw in call.keywords:
+        if kw.arg == name:
+            return kw.value
+    return None
+
+
+def positional_or_keyword(call: ast.Call, index: int, name: str) -> ast.expr | None:
+    """A parameter passed either positionally at *index* or by keyword *name*."""
+    if len(call.args) > index:
+        return call.args[index]
+    return keyword(call, name)
+
+
+def is_call(node: ast.expr | None, name: str) -> bool:
+    return isinstance(node, ast.Call) and call_name(node) == name
+
+
+def const_str(node: ast.expr | None) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def resolve_validator(node: ast.expr | None, assigns: dict) -> ast.Call | None:
+    """The ByoValidator call, inline or via a one-level variable assignment."""
+    if is_call(node, VALIDATOR):
+        assert isinstance(node, ast.Call)
+        return node
+    if isinstance(node, ast.Name):
+        target = assigns.get(node.id)
+        if is_call(target, VALIDATOR):
+            return target
+    return None
+
+
+def imported_from(tree: ast.AST, symbol: str) -> str | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == symbol:
+                    return node.module
+    return None
+
+
+def main() -> None:
+    src = read()
+    try:
+        tree = ast.parse(src, filename=str(GRAPH))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph.py no longer parses as Python: {exc}")
+
+    assigns: dict = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assigns[target.id] = node.value
+
+    # --- find @guardrail decorators wrapping a ByoValidator ---
+    found: list[tuple[str, ast.Call, ast.Call]] = []  # (target fn, decorator, validator)
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            if not isinstance(dec, ast.Call) or call_name(dec) != "guardrail":
+                continue
+            validator = resolve_validator(keyword(dec, "validator"), assigns)
+            if validator is not None:
+                found.append((node.name, dec, validator))
+
+    if not found:
+        any_guardrail = any(
+            isinstance(n, ast.Call) and call_name(n) == "guardrail"
+            for n in ast.walk(tree)
+        )
+        check(
+            False,
+            f"no @guardrail(validator={VALIDATOR}(...)) decorator found"
+            + (
+                " — a @guardrail decorator exists but its validator is not "
+                f"{VALIDATOR}; the built-in validator was likely used instead"
+                if any_guardrail
+                else f" ({VALIDATOR} is never wired)"
+            ),
+        )
+    print(f"OK: @guardrail with {VALIDATOR} found")
+
+    # --- pinned to the seeded BYOG configuration (the point of the test) ---
+    pinned = [
+        (fn, dec, v)
+        for (fn, dec, v) in found
+        if const_str(positional_or_keyword(v, 0, "validator_name")) == VALIDATOR_NAME
+    ]
+    if not pinned:
+        seen = [
+            const_str(positional_or_keyword(v, 0, "validator_name"))
+            for (_, _, v) in found
+        ]
+        check(
+            False,
+            f"no {VALIDATOR} pinned to the tenant's BYOG configuration. Expected "
+            f'validator name "{VALIDATOR_NAME}", got: {seen}',
+        )
+    target_fn, decorator, _ = pinned[0]
+    print(f'OK: pinned to the BYOG configuration ("{VALIDATOR_NAME}")')
+
+    # --- block action ---
+    check(
+        is_call(keyword(decorator, "action"), "BlockAction"),
+        "action=BlockAction(...) not found on the @guardrail decorator — the user "
+        "asked to block on violations",
+    )
+    print("OK: action=BlockAction(...)")
+
+    # --- decorating something that actually gets wrapped ---
+    check(
+        target_fn in VALID_TARGETS,
+        f"@guardrail is on {target_fn!r}, which is not a factory the runtime wraps. "
+        f"Decorate one of {sorted(VALID_TARGETS)} — an agent/LLM factory — or the "
+        "guardrail silently no-ops",
+    )
+    print(f"OK: decorates {target_fn}() (a real factory)")
+
+    # --- adapter import (Rule 8) ---
+    module = imported_from(tree, VALIDATOR)
+    check(module is not None, f"{VALIDATOR} is used but never imported")
+    check(
+        module == "uipath_langchain.guardrails",
+        f"{VALIDATOR} imported from {module!r} — it is a core class, so that import "
+        "type-checks, but a LangChain agent must import from "
+        "'uipath_langchain.guardrails' so the adapter registers; otherwise the "
+        "guardrail silently no-ops",
+    )
+    print("OK: imported from uipath_langchain.guardrails")
+
+    print("OK: BYOG decorator guardrail correctly added to graph.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/coded/guardrails/byog_middleware/byog_middleware.yaml
+++ b/tests/tasks/uipath-agents/coded/guardrails/byog_middleware/byog_middleware.yaml
@@ -1,0 +1,52 @@
+task_id: skill-agent-guardrail-coded-byog-middleware
+description: >
+  Middleware-style bring-your-own guardrail (BYOG) for a coded agent. A simple
+  LangGraph customer support agent is seeded with no guardrails. The tenant already
+  has a BYOG configuration registered (admin-side); the user asks to route the
+  agent's PII checks through it. Verifies the agent wires
+  UiPathByoGuardrailMiddleware — pinned to the configuration by validator_name,
+  spread into create_agent(), with a block action — rather than reaching for the
+  built-in PII validator.
+tags: [uipath-agents, e2e, coded, mode:build, lifecycle:edit, guardrail]
+
+agent:
+  allowed_tools: ["Skill", "Bash", "Read", "Write", "Edit", "Glob", "Grep", "WebFetch"]
+  # Disallow the subagent-dispatch tool. It is NOT gated by allowed_tools, and a
+  # dispatched subagent carries none of this skill's context. For BYO the failure
+  # is especially subtle: `ByoValidator` really does live in
+  # uipath.platform.guardrails, so a subagent recommending that import is
+  # technically right about the module and still wrong for a LangChain agent
+  # (Rule 8 — the no-op path that skips adapter registration). Force inline
+  # research where the loaded skill's import rule still applies.
+  disallowed_tools: ["Task"]
+
+sandbox:
+  template_sources:
+    - type: template_dir
+      path: ../_fixtures/SimpleCodedAgent
+
+initial_prompt: |
+  I have a coded LangGraph agent in graph.py that handles customer support questions.
+
+  Our admin has registered a bring-your-own guardrail configuration on the tenant
+  called `byog-smoke-agent-pin` — it's PII detection served by our own external
+  provider, and we want the agent's PII checks to go through it rather than the
+  UiPath built-in one. Add it at Agent scope using the middleware style, and block
+  on violations.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation. Complete the entire task
+  end-to-end in a single pass.
+
+success_criteria:
+  - type: run_command
+    description: "BYOG middleware guardrail correctly added to graph.py"
+    command: "python3 $TASK_DIR/check_byog_middleware.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 10
+  turn_timeout: 1200

--- a/tests/tasks/uipath-agents/coded/guardrails/byog_middleware/check_byog_middleware.py
+++ b/tests/tasks/uipath-agents/coded/guardrails/byog_middleware/check_byog_middleware.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Check that a BYOG middleware guardrail was correctly added to graph.py.
+
+Validates:
+- graph.py still parses as Python
+- UiPathByoGuardrailMiddleware is spread (*) into create_agent(middleware=[...])
+- It is pinned to the tenant's configuration via validator_name="byog-smoke-agent-pin"
+  — the point of the test. A built-in validator (UiPathPIIDetectionMiddleware) or a
+  wrong/absent name means the BYO configuration was not actually wired.
+- action=BlockAction(...)
+- Imported from uipath_langchain.guardrails, not uipath.platform.guardrails
+  (Rule 8: the platform import type-checks but skips LangChain adapter
+  registration, so the guardrail silently no-ops). The middleware only exists in
+  the adapter package, so a platform import is also just wrong.
+"""
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+)
+from _shared.guardrail_middleware import (  # noqa: E402
+    call_kwarg,
+    call_name,
+    spread_middleware_calls,
+)
+
+GRAPH = Path("graph.py")
+
+MIDDLEWARE = "UiPathByoGuardrailMiddleware"
+VALIDATOR_NAME = "byog-smoke-agent-pin"
+
+
+def read() -> str:
+    if not GRAPH.is_file():
+        sys.exit(f"FAIL: {GRAPH} not found in {Path.cwd()}")
+    return GRAPH.read_text()
+
+
+def check(condition: bool, msg: str) -> None:
+    if not condition:
+        sys.exit(f"FAIL: {msg}")
+
+
+def const_str(node: ast.expr | None) -> str | None:
+    """The literal str value of a node, or None if it isn't a string constant."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def is_call(node: ast.expr | None, name: str) -> bool:
+    return isinstance(node, ast.Call) and call_name(node) == name
+
+
+def imported_from(tree: ast.AST, symbol: str) -> str | None:
+    """Module a symbol was imported from, or None if it is never imported."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == symbol:
+                    return node.module
+    return None
+
+
+def main() -> None:
+    src = read()
+    try:
+        tree = ast.parse(src, filename=str(GRAPH))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: graph.py no longer parses as Python: {exc}")
+
+    # --- the middleware is spread into the middleware list ---
+    # spread_middleware_calls accepts both `[*Cls(...)]` and `m = Cls(...); [*m]`.
+    byo_calls = [c for c in spread_middleware_calls(tree) if call_name(c) == MIDDLEWARE]
+    if not byo_calls:
+        spread = sorted({call_name(c) or "?" for c in spread_middleware_calls(tree)})
+        check(
+            False,
+            f"{MIDDLEWARE} not spread with * into the middleware list "
+            f"(accepts inline `[*{MIDDLEWARE}(...)]` or a variable "
+            f"`m = {MIDDLEWARE}(...); middleware=[*m]`). "
+            f"Spread middleware found: {spread or 'none'}",
+        )
+    print(f"OK: {MIDDLEWARE} spread with * into the middleware list")
+
+    # --- pinned to the seeded BYOG configuration (the point of the test) ---
+    pinned = [
+        c for c in byo_calls
+        if const_str(call_kwarg(c, "validator_name")) == VALIDATOR_NAME
+    ]
+    if not pinned:
+        seen = [const_str(call_kwarg(c, "validator_name")) for c in byo_calls]
+        check(
+            False,
+            f"no {MIDDLEWARE} pinned to the tenant's BYOG configuration. Expected "
+            f'validator_name="{VALIDATOR_NAME}", got: {seen}',
+        )
+    call = pinned[0]
+    print(f'OK: pinned to the BYOG configuration (validator_name="{VALIDATOR_NAME}")')
+
+    # --- block action ---
+    check(
+        is_call(call_kwarg(call, "action"), "BlockAction"),
+        "action=BlockAction(...) not found on the BYOG middleware — the user asked "
+        "to block on violations",
+    )
+    print("OK: action=BlockAction(...)")
+
+    # --- adapter import (Rule 8) ---
+    module = imported_from(tree, MIDDLEWARE)
+    check(
+        module is not None,
+        f"{MIDDLEWARE} is used but never imported",
+    )
+    check(
+        module == "uipath_langchain.guardrails",
+        f"{MIDDLEWARE} imported from {module!r} — a LangChain agent must import "
+        "guardrail symbols from 'uipath_langchain.guardrails' so the adapter "
+        "registers; otherwise the guardrail silently no-ops",
+    )
+    print("OK: imported from uipath_langchain.guardrails")
+
+    print("OK: BYOG middleware guardrail correctly added to graph.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/byog_pinning.yaml
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/byog_pinning.yaml
@@ -1,0 +1,74 @@
+task_id: skill-agent-guardrail-byog-pinning
+description: >
+  BYO guardrail pinning on an existing agent. The sandbox is pre-seeded
+  with the Web Research Briefing solution (shared _fixtures copy,
+  guardrails empty), and a selective `uip` shim (mock_template/mocks/uip)
+  serves the discovery call — `uip agent guardrails list` returns a BYO
+  pii_detection entry named byog-smoke-agent-pin alongside the built-in
+  entry sharing the same Validator name — while every other uip command
+  (refresh/validate) passes through to the real CLI. The user only asks
+  to add their already-configured BYO guardrail to the agent. Verifies
+  the agent discovers the BYO entry (rather than assuming), disambiguates
+  it from the same-named built-in, and authors a builtInValidator
+  guardrail pinned via byoValidatorName — not a plain built-in guardrail
+  or an invented name. Discovery is mocked because the task's scope is
+  authoring, not tenant lifecycle: BYOG configurations can no longer be
+  seeded per-run (create probes the connection server-side, no skip
+  flag), and the graded behavior never executes the guardrail.
+tags: [uipath-agents, smoke, mode:build, lifecycle:edit, low-code, guardrail]
+
+run_limits:
+  expected_turns: 12
+
+sandbox:
+  mock_path_dirs: [mocks]
+  template_sources:
+    - {type: template_dir, path: mock_template}
+    - {type: template_dir, path: ../_fixtures/WebResearchBriefingSolution}
+
+initial_prompt: |
+  Our admin registered a bring-your-own guardrail configuration named
+  `byog-smoke-agent-pin` — PII detection served by our external guardrail
+  provider.
+
+  Add a PII detection guardrail to my web research agent at
+  WebResearchBriefingSolution/WebResearchBriefingAgent that runs through
+  that BYO configuration — it should block email addresses and phone
+  numbers in the agent's output, with a 0.5 threshold for each.
+
+  Do NOT publish, upload, or deploy. Do NOT ask for approval,
+  confirmation, or feedback. Do NOT pause between planning and
+  implementation. Complete the entire task end-to-end in a single pass.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent discovered the BYO entry via uip agent guardrails list (--byo or full list)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+guardrails\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent refreshed the project to regenerate derived files"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+refresh'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent validated the project"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+agent\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Guardrail added to the fixture agent and pinned to the BYO configuration (byoValidatorName == byog-smoke-agent-pin; block action; PascalCase entities)"
+    command: "python3 $TASK_DIR/check_byog_pinning.py"
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/check_byog_pinning.py
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/check_byog_pinning.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""BYO guardrail pinning check.
+
+Validates that the agent authored a builtInValidator guardrail for
+pii_detection in agent.json that is pinned to the BYO configuration the
+mocked discovery served (see mock_template/mocks/uip):
+
+  - guardrails array exists and is non-empty
+  - At least one guardrail has $guardrailType == "builtInValidator"
+    and validatorType == "pii_detection"
+  - That guardrail carries byoValidatorName == "byog-smoke-agent-pin" —
+    NOT byoConfigurationId, which is not a field the guardrail schema
+    uses. The mocked list also contains a built-in entry with the same
+    Validator name, so a missing/wrong byoValidatorName means the agent
+    failed to disambiguate and pinned the built-in instead.
+  - entities are PascalCase and include Email + PhoneNumber
+  - action.$actionType == "block"
+
+Pure agent.json assertions — no tenant call. The expected name is the
+constant the mock serves; keep the two in sync.
+"""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(os.getcwd()) / "WebResearchBriefingSolution" / "WebResearchBriefingAgent"
+AGENT = ROOT / "agent.json"
+
+VALIDATOR_NAME = "byog-smoke-agent-pin"
+REQUIRED_ENTITIES = {"Email", "PhoneNumber"}
+
+
+def load(path: Path) -> dict:
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        return json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        sys.exit(f"FAIL: {path} is not valid JSON: {e}")
+
+
+def find_param(params: list, param_id: str) -> dict | None:
+    for p in params:
+        if isinstance(p, dict) and p.get("id") == param_id:
+            return p
+    return None
+
+
+def main() -> None:
+    agent = load(AGENT)
+
+    guardrails = agent.get("guardrails")
+    if not isinstance(guardrails, list) or len(guardrails) == 0:
+        sys.exit(
+            "FAIL: agent.json.guardrails must be a non-empty array, "
+            f"got {type(guardrails).__name__}: {guardrails!r}"
+        )
+    print(f"OK: guardrails array has {len(guardrails)} entry/entries")
+
+    pii = [
+        g for g in guardrails
+        if g.get("$guardrailType") == "builtInValidator"
+        and g.get("validatorType") == "pii_detection"
+    ]
+    if not pii:
+        types = [
+            (g.get("$guardrailType"), g.get("validatorType"))
+            for g in guardrails
+        ]
+        sys.exit(
+            'FAIL: no guardrail with $guardrailType == "builtInValidator" '
+            f'and validatorType == "pii_detection". Got: {types}'
+        )
+
+    # --- the BYO pin (the point of this test) ---
+    pinned = [g for g in pii if g.get("byoValidatorName") == VALIDATOR_NAME]
+    if not pinned:
+        pins = [g.get("byoValidatorName") for g in pii]
+        sys.exit(
+            f"FAIL: no pii_detection guardrail pinned to the BYO "
+            f"configuration. Expected byoValidatorName == {VALIDATOR_NAME!r}, "
+            f"got: {pins} — the agent likely authored the built-in validator "
+            "instead of the BYO-backed one, or invented a name."
+        )
+    g = pinned[0]
+    print(f"OK: guardrail pinned to BYO configuration {VALIDATOR_NAME!r}")
+
+    action = g.get("action")
+    if not isinstance(action, dict) or action.get("$actionType") != "block":
+        sys.exit(
+            'FAIL: guardrail.action.$actionType must be "block", '
+            f"got {action!r}"
+        )
+    print('OK: action.$actionType == "block"')
+
+    params = g.get("validatorParameters")
+    if not isinstance(params, list):
+        sys.exit(f"FAIL: validatorParameters must be an array, got {params!r}")
+    entities_param = find_param(params, "entities")
+    if entities_param is None:
+        ids = [p.get("id") for p in params if isinstance(p, dict)]
+        sys.exit(
+            'FAIL: validatorParameters missing parameter with id == "entities". '
+            f"Got ids: {ids}"
+        )
+    entities_value = entities_param.get("value")
+    if not isinstance(entities_value, list):
+        sys.exit(f"FAIL: entities parameter.value must be an array, got {entities_value!r}")
+    missing = REQUIRED_ENTITIES - set(entities_value)
+    if missing:
+        sys.exit(
+            f"FAIL: entities must include {sorted(REQUIRED_ENTITIES)}, "
+            f"missing: {sorted(missing)}. Got: {entities_value}"
+        )
+    snake = [
+        e for e in entities_value
+        if isinstance(e, str) and ("_" in e or e[:1].islower())
+    ]
+    if snake:
+        sys.exit(
+            f"FAIL: entity names must be PascalCase (not snake_case). Invalid: {snake}"
+        )
+    print(f"OK: entities = {entities_value} (PascalCase, includes required)")
+
+    print("OK: BYO-pinned pii_detection guardrail is valid")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/mock_template/mocks/uip
+++ b/tests/tasks/uipath-agents/lowcode/guardrails/byog_pinning/mock_template/mocks/uip
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Selective `uip` shim for the byog_pinning smoke task.
+
+Intercepts exactly one command — `uip agent guardrails list` — and serves a
+canned tenant response containing the BYO guardrail entry the task's prompt
+references (`byog-smoke-agent-pin`, pii_detection), alongside the built-in
+`pii_detection` entry sharing the same `Validator` name, so the agent must
+disambiguate via `IsByo`/`ByoValidatorName` exactly as the skill teaches.
+`--byo` filters to the BYO entry only, mirroring the real CLI.
+
+Every other invocation exec's the REAL `uip` found later on PATH —
+`agent init` / `refresh` / `validate` are local operations that must
+actually run for the task's artifacts and checks to exist.
+
+Why mock discovery at all: the task's scope is the skill's authoring
+behavior (pin an already-configured BYO guardrail in agent.json), not
+tenant lifecycle. A real BYOG configuration can no longer be seeded
+per-run (`byo-configurations create` probes the connection server-side,
+no skip flag), and the shared smoke tenant has no guardrail-capable
+connection — mocking the read-only discovery call removes that tenant
+dependency entirely while leaving the graded behavior untouched.
+
+`mock_path_dirs: [mocks]` PATH-prepends this script's directory inside the
+sandbox. Linux smoke only (no `windows` tag on the task), hence no
+`uip.cmd` twin — same as the ixp mock.
+"""
+
+import json
+import os
+import shutil
+import sys
+
+MOCK_DIR = os.path.dirname(os.path.abspath(__file__))
+
+BYO_ENTRY = {
+    "Validator": "pii_detection",
+    "IsByo": True,
+    "Status": "Available",
+    "AllowedScopes": ["Agent", "Llm", "Tool"],
+    "GuardrailStages": {
+        "Agent": ["PreExecution", "PostExecution"],
+        "Llm": ["PreExecution", "PostExecution"],
+        "Tool": ["PreExecution", "PostExecution"],
+    },
+    "DisplayName": "PII Detection",
+    "Description": (
+        "Detects personally identifiable information. Served by the "
+        "tenant's external bring-your-own guardrail provider."
+    ),
+    "ByoValidatorName": "byog-smoke-agent-pin",
+    "ByoConnectionId": "18fb337c-29b7-4162-a9e8-0c05b01cf4df",
+    "ByoConfigurationId": "e5723bb8-fbc2-4317-c7d7-08de803bc010",
+    "ByoConnectorName": "Azure AI Content Safety",
+    "ByoConnectorKey": "uipath-azure-contentsafety",
+    "FolderKey": "627fe423-5c73-464a-abff-41fdaad6ac19",
+    "Parameters": [
+        {
+            "Type": "enum-list",
+            "Id": "entities",
+            "Required": True,
+            "DefaultValue": ["Email", "PhoneNumber"],
+            "Options": [
+                "Email",
+                "PhoneNumber",
+                "Person",
+                "Address",
+                "USSocialSecurityNumber",
+            ],
+            "DisplayName": "Entities",
+            "Description": "PII entity types to detect.",
+        },
+        {
+            "Type": "map-enum",
+            "Id": "entityThresholds",
+            "Required": True,
+            "DefaultValue": {"Email": 0.5, "PhoneNumber": 0.5},
+            "KeySource": "entities",
+            "Min": 0,
+            "Max": 1,
+            "DisplayName": "Per-entity threshold",
+            "Description": "Confidence threshold (0-1) per selected entity.",
+        },
+    ],
+}
+
+BUILTIN_ENTRY = {
+    "Validator": "pii_detection",
+    "IsByo": False,
+    "Status": "Available",
+    "AllowedScopes": ["Agent", "Llm", "Tool"],
+    "GuardrailStages": {
+        "Agent": ["PreExecution", "PostExecution"],
+        "Llm": ["PreExecution", "PostExecution"],
+        "Tool": ["PreExecution", "PostExecution"],
+    },
+    "DisplayName": "PII Detection",
+    "Description": (
+        "Detects personally identifiable information using Azure "
+        "Cognitive Services (UiPath built-in)."
+    ),
+    "Parameters": BYO_ENTRY["Parameters"],
+}
+
+
+def real_uip():
+    path = os.environ.get("PATH", "")
+    parts = [
+        p for p in path.split(os.pathsep)
+        if p and os.path.abspath(p) != MOCK_DIR
+    ]
+    return shutil.which("uip", path=os.pathsep.join(parts))
+
+
+def main():
+    args = sys.argv[1:]
+    literal = [a for a in args if not a.startswith("-")]
+    if literal[:3] == ["agent", "guardrails", "list"]:
+        data = [BYO_ENTRY] if "--byo" in args else [BUILTIN_ENTRY, BYO_ENTRY]
+        print(json.dumps({
+            "Result": "Success",
+            "Code": "GuardrailDefinitionsList",
+            "Data": data,
+        }, indent=2))
+        return 0
+    real = real_uip()
+    if not real:
+        sys.stderr.write("uip (shim): real uip CLI not found on PATH\n")
+        return 127
+    os.execv(real, [real] + args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed?

Documents bring-your-own guardrails (BYOG) for **both agent types** and adds tests for the thread users actually hit: adding a BYOG guardrail to an agent they already have. Ticket: AL-513.

BYOG lets a tenant serve a validator from its own external provider (Azure AI Content Safety, Databricks, a custom connector) instead of UiPath's built-in implementation. An admin registers the configuration; agents reference it by name. None of the agent-authoring side was documented.

**Docs (7 files)**

- **`uipath-agents` low-code** — `Validator` is not unique once a BYOG configuration exists (a tenant sees two `pii_detection` entries, one built-in and one BYO, disambiguated by `IsByo`), the `--byo` filter, the extra `Byo*` fields, and how to pin a guardrail with `byoValidatorName`.
- **`uipath-agents` coded** — the BYO section was previously a gate with the API left unresolved: it named no class and told the agent to *stop and report BYO unavailable*, which now reads as a false negative. It now carries:
  - an availability table — `UiPathByoGuardrailMiddleware` is LangChain-adapter only; `ByoValidator` is a **core** class re-exported by the adapter, so **BYO is not LangChain-only**;
  - worked examples for both middleware and decorator styles, with source-verified signatures;
  - the wire format both emit — `validatorType: "byo"` + `byoValidatorName`, the same field low-code pins with, so the two halves converge;
  - Critical Rule 18 rewritten, plus pointers from the Middleware and Decorator style sections.
- **Both `guardrails-recommend` files** — key validator lookups on `(Validator, IsByo)`, not `Validator` alone, or a same-named built-in and BYO entry collide and correctness checks read the wrong entry's `Parameters`/`AllowedScopes`. Default recommendations to the built-in unless the user asks for BYO.
- **`uipath-review`** (both guardrail files) — the same disambiguation, plus: `Status: Disabled` on a BYO entry is a tenant configuration switch, not a schema defect — don't re-diagnose it as one.
- **`uipath-troubleshoot`** — BYOG as a cause of a guardrail violation, how to cross-check configuration health, and the resolution path for a disabled configuration or dead connection.

**Corrections found while writing the above**

- `byoConfigurationId` was never a real authoring field — `ByoValidatorName` is what both low-code and coded agents reference. Swept everywhere.
- Dropped the last "the BYO construct carries a connection id" claim, which contradicted the same file, Rule 18, and the review skill. No connection id exists in either API; the platform resolves it server-side.
- The coded doc claimed middleware never accepts `stage=`. Source shows five do (PII, harmful content, LLM-as-judge, deterministic, BYO); only the three fixed-stage validators don't. Pre-existing bug, corrected in place.

**Tests (7 files) — adding BYOG to an existing agent**

Three tasks, all editing a pre-built fixture with **no scaffolding graded**, so the score reflects only the BYOG wiring. All three tagged `lifecycle:edit` (they edit an existing agent rather than scaffolding one).

| Task | Tier | What it grades |
|---|---|---|
| `lowcode/guardrails/byog_pinning` | `smoke` | `byoValidatorName` pinned in the shared `WebResearchBriefingSolution` fixture's `agent.json` |
| `coded/guardrails/byog_middleware` | `e2e` | `UiPathByoGuardrailMiddleware` spread into `create_agent()` on the `SimpleCodedAgent` fixture |
| `coded/guardrails/byog_decorator` | `e2e` | `ByoValidator` + `@guardrail` over a real factory on the same fixture |

- **The low-code task mocks discovery**, which is what removes the tenant dependency entirely — no feature flag, no fixture registration, no create-time connection probe. A selective `uip` shim (`mock_path_dirs`, following the ixp mock pattern) serves `uip agent guardrails list` with a BYO entry **alongside the same-named built-in**, forcing the `IsByo` disambiguation the skill teaches; every other `uip` command passes through to the real CLI.
- **Both coded tasks assert the adapter import** — the failure BYO is most exposed to, because `ByoValidator` genuinely lives in `uipath.platform.guardrails`, making a wrong-but-plausible import easy to land (that import type-checks and then silently no-ops). Both carry `disallowed_tools: ["Task"]` for the same reason: a dispatched subagent has no skill context and previously regressed exactly this.

## How has this been tested?

- **AST checkers validated against 14 controls** — 4 positive (inline and variable middleware spread; positional and keyword validator name) and 10 negative (built-in substituted for BYO, wrong name, wrong action, non-factory decoration target, wrong import module, unparseable source). Every negative fails at the intended assertion with an actionable message.
- **Two-model runs per the [Run Skill Smoke Tests](https://uipath.atlassian.net/wiki/spaces/AGOV/pages/90973078487/Run+Skill+Smoke+Tests) runbook — all six green.** Generated artifacts (`agent.json` / `graph.py`) inspected in each run rather than trusting the score alone.

  | Task | claude-sonnet-5 | gpt-5.6-terra |
  |---|---|---|
  | `byog_pinning` | SUCCESS 1.000 (86s) | SUCCESS 1.000 (132s) |
  | `byog_middleware` | SUCCESS 1.000 (181s) | SUCCESS 1.000 (196s) |
  | `byog_decorator` | SUCCESS 1.000 (362s) | SUCCESS 1.000 (150s) |

- **Stability — 3 repeats per task, 9/9 replicates `SUCCESS` at 1.000** (claude-sonnet-5). No flakes, no partial scores.

  | Task | Replicates passed |
  |---|---|
  | `byog_pinning` | 3/3 @ 1.000 |
  | `byog_middleware` | 3/3 @ 1.000 |
  | `byog_decorator` | 3/3 @ 1.000 |

- `scripts/check-cli-verbs.py` and `scripts/check-task-driver.py` clean on every touched file.
- **Note on CI coverage:** the PR smoke gate selects `^tags:.*\bsmoke\b`, so only `byog_pinning` runs on this PR. The two coded tasks are `e2e` (matching all eight of their siblings) and run on the daily/weekly cadence. Happy to retag them `smoke` if per-PR gating is preferred.

## Upstream SDK fixes (merged)

The coded docs describe a surface that needed two upstream corrections first; both are merged:

- **UiPath/uipath-python#1854** — adds the missing `ByoValidator` section (and stages-table entry) to the core guardrails page. Its absence is what made BYO look LangChain-only, and is why the signatures here were verified against SDK source rather than the rendered docs.
- **UiPath/uipath-langchain-python#1033** — drops a stale docstring line telling readers to pass an Integration Service connection id to `UiPathByoGuardrailMiddleware`; no such parameter exists (AL-510 removed it), and its own `Args` block already said the connection resolves server-side.

## Related

The **admin** side of BYOG — `uip guardrails byo-configurations` (list/create/update/delete), i.e. registering the configuration in the first place — is a separate PR, #2550, so this one doesn't need `uipath-platform` CODEOWNERS approval. Cross-references here go through the skill-level `/uipath:uipath-platform` link, so there's no merge-order dependency.

## Are there any breaking changes?

- [x] None
