### PR TITLE
fix(maestro-flow): guard RPA node discovery against brand-name search misses

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/rpa/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/rpa/impl.md
@@ -11,6 +11,10 @@ uip maestro flow registry pull --force
 uip maestro flow registry search "uipath.core.rpa-workflow" --output json
 ```
 
+Search the **node-type token** `uipath.core.rpa-workflow` — this lists every published RPA workflow — then pick the one you need by its `resourceKey` / folder path and description. Do **not** search by the process name from the request: `registry search` matches the Orchestrator **release name**, which is frequently unrelated to the name the user uses or the folder the process lives in. The requested name often appears only in the folder path, so a keyword search for it returns nothing even though the process exists. Match on the folder path inside `resourceKey`, not on a name keyword.
+
+**An empty result is not authoritative — do not conclude the process is unpublished.** Before treating "not found" as real, confirm all three hold: (a) you searched the `uipath.core.rpa-workflow` token, not a name keyword; (b) `registry pull --force` ran first; (c) you scanned the returned folder paths and descriptions for the target, not just the display names. Only then is the process genuinely absent. Jumping to the local-scaffold fallback on a name-search miss builds a flow that validates but has nothing real to run.
+
 **In-solution (local, no login required):**
 
 ```bash
@@ -101,15 +105,17 @@ Add one entry per `(resourceKey, propertyAttribute)` pair. Share entries across 
 
 > For the resolution mechanics and why these entries are required, see [file-format.md — Bindings](../../../../shared/file-format.md#bindings--orchestrator-resource-bindings-top-level-bindings).
 
-## If the RPA Process Does Not Exist Yet
+## If the RPA Process Is Genuinely Not Published
 
-Tell the user to create the RPA project inside the same solution using `uipath-rpa`. Once the project exists as a sibling in the `.uipx` solution, discover it with `uip maestro flow registry list --local --output json` and wire it directly — no publish required.
+Reach this path only after the empty-result confirmation in [Discovery](#discovery) — a brand-name search miss does not qualify. When the process truly does not exist on the tenant and no sibling RPA project provides it, tell the user to create the RPA project inside the same solution using `uipath-rpa`. Once the project exists as a sibling in the `.uipx` solution, discover it with `uip maestro flow registry list --local --output json` and wire it directly — no publish required.
+
+A freshly scaffolded RPA project has no implementation, so the wired flow will pass `flow validate` but fault the moment it is debugged or run (`Robot.JobUnexpectedExitCode`) until `uipath-rpa` fills in the actual workflow. A validated flow is not a working one.
 
 ## Debug
 
 | Error | Cause | Fix |
 | --- | --- | --- |
-| Node type not found in registry | Process not published or registry stale | If in same solution: run `registry list --local`. Otherwise: run `uip login` then `uip maestro flow registry pull --force` |
+| Node type not found in registry | Searched by process name (matches release name, not folder), process not published, or registry stale | Search the `uipath.core.rpa-workflow` token and match on folder path — not a name keyword. If in same solution: run `registry list --local`. Otherwise: run `uip login` then `uip maestro flow registry pull --force` |
 | Input schema mismatch | Inputs don't match `inputDefinition` | Run `registry get` and check required inputs in `inputDefinition.properties` |
 | Process execution failed | Underlying RPA process errored | Check `$vars.{nodeId}.error` for details |
 | Mock placeholder still in flow | Process not yet replaced | Follow the mock replacement workflow above |


### PR DESCRIPTION
## What

Hardens the maestro-flow RPA plugin discovery guidance so an agent does not fabricate a local RPA workflow when a published one exists but was searched for by the wrong name.

File: `skills/uipath-maestro-flow/references/author/references/plugins/rpa/impl.md`

## Why

The `skill-flow-rpa` eval (`tests/tasks/uipath-maestro-flow/single_node/rpa`) fails at the execution criterion. Trace of the failing run:

1. The task expects the flow to discover and wire the pre-published `ProjectEuler` RPA process, then `flow debug` returns the real problem-123 title `prime square remainders`. The canary reference flow wires exactly that process.
2. On the tenant the process is published with Orchestrator **release name `RPA Workflow`** inside folder `Shared/uipath-maestro-flow/ProjectEuler RPA`. The brand string "ProjectEuler" only appears in the folder path.
3. `registry search` matches the release name, so the agent's searches for `ProjectEuler` and `Euler` returned `Data: []`.
4. The agent read that as "not published" and followed the skill's local-scaffold fallback, wiring a fresh local RPA project with an empty `folderPath`.
5. That project has no real implementation, so `flow debug` faulted with `Robot.JobUnexpectedExitCode` (exit `0x00000033`). The output never held a title, so the check failed. Final weighted score 0.375 (validate passed, execution failed).

The sibling case skill already documents this exact release-name-vs-folder-name mismatch (`uipath-maestro-case/.../rpa/planning.md`), and the connector path already has an "empty result is not authoritative" guard. The flow RPA path had neither, and instead pointed straight at the local-scaffold fallback.

## The fix

- Search the `uipath.core.rpa-workflow` node-type token and match on folder path, never on a brand keyword. Explain why the release name diverges from the brand.
- Add an "empty result is not authoritative" confirmation before concluding a process is unpublished.
- Gate the local-scaffold fallback behind that confirmation, and note that a scaffolded project must be implemented before the flow will actually run (a validated flow is not a working one).

Kept to the single file the agent actually reads during implementation; no duplicate prose added elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)