### PR TITLE
chore: refresh uip CLI catalog (1.200.0-dev.8173)

### DIFF
--- a/assets/uip-catalog-snapshot.json
+++ b/assets/uip-catalog-snapshot.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-08-07T04:43:58Z",
-  "cli_version": "1.200.0-dev.8116",
+  "generated_at": "2026-08-08T04:29:32Z",
+  "cli_version": "1.200.0-dev.8173",
   "verbs": [
     "admin",
     "admin audit",
@@ -457,7 +457,10 @@
     "gov compliance-packs state restore",
     "guardrails",
     "guardrails byo-configurations",
+    "guardrails byo-configurations create",
+    "guardrails byo-configurations delete",
     "guardrails byo-configurations list",
+    "guardrails byo-configurations update",
     "insights",
     "insights jobs",
     "insights jobs completed-timeline",


### PR DESCRIPTION
Automated refresh against `@uipath/cli@1.200.0-dev.8173`. The catalog has 1435 reachable verbs after installing all available plugins.

Merges automatically once all checks pass (handled by `automerge-catalog-refresh.yml`). If a check fails, the failure is real drift (a CLI release removed/renamed a verb still referenced in skill docs or task YAMLs); investigate the gate annotations and either sweep the docs or, if the verb is intentionally retired, add it to `.claude/rules/cli-renames.md`. `/lint-task` and the CLI Verb Gate will surface the affected references.