### PR TITLE
chore(rpa): bump UIA MIN_VERSION to stable 26.10.2 [release/v1.199]

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -34,7 +34,7 @@ One UIA activity set covers every UI target:
 
 ## UIA Prerequisites
 
-**Required package:** `UiPath.UIAutomation.Activities` — minimum version (`<MIN_VERSION>`): **`26.10.2-alpha.12792334`**, from the internal UiPath NuGet feed (prerelease flag needed). The `uip rpa uia` CLI, the package docs, and the UIA skills require `<MIN_VERSION>` or newer — before any UIA work, check the installed version in `project.json` under `dependencies`. Do not hardcode the version from memory; this section is the only source of truth.
+**Required package:** `UiPath.UIAutomation.Activities` — minimum version (`<MIN_VERSION>`): **`26.10.2`**, from the official UiPath NuGet feed (no prerelease flag needed). The `uip rpa uia` CLI, the package docs, and the UIA skills require `<MIN_VERSION>` or newer — before any UIA work, check the installed version in `project.json` under `dependencies`. Do not hardcode the version from memory; this section is the only source of truth.
 
 **Upgrades require explicit user consent.** Never install or upgrade UIA silently. Consent comes from one of:
 


### PR DESCRIPTION
Backport of #2527 to `release/v1.199`.

`UiPath.UIAutomation.Activities` `26.10.2` is now published as a stable release on the official UiPath NuGet feed. Updates the `<MIN_VERSION>` gate in `skills/uipath-rpa/SKILL.md` § UIA Prerequisites from the internal-feed alpha (`26.10.2-alpha.12792334`) to the stable build, and drops the "internal feed / prerelease flag needed" caveat.

Clean cherry-pick of `0e6e5a54d` — the line was identical on this branch. Single source of truth; no other file hardcodes the UIA version.