### PR TITLE
Declare the tests tree as isolated_paths in the nightly experiment

### DIFF
--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -29,6 +29,10 @@ defaults:
         - CODEX_BASE_URL
       extra_mounts:
         - ~/.uipath:/.uipath:rw
+      # Contract enforced by coder-eval: these paths must never be agent-visible.
+      # Requires coder_eval with isolated_paths support on the runner VM (coder_eval#96).
+      isolated_paths:
+        - "$SKILLS_REPO_PATH/tests"
 
   agent:
     # type omitted on purpose — the runner selects the harness via --type (codex/antigravity);


### PR DESCRIPTION
Declares `$SKILLS_REPO_PATH/tests` as agent-invisible in the nightly experiment, via the new `sandbox.docker.isolated_paths` field. Today the tests tree stays out of the agent's reach only as an implementation detail - the plugin bundle allowlist happens to exclude `tests/`. This one-hunk change turns that into a checked contract: coder-eval enforces the declaration fail-closed at run start, so a future change to the bundle allowlist or to the mount set fails the run instead of quietly widening what the evaluated agent can read.

## How it works

The coder_eval docker runner resolves each declared path (environment variables and `~` are expanded) and refuses to start the container if any agent-visible mount, or any entry in the plugin bundle manifest, falls under one of them. Private grader-side mounts are exempt, so the harness's own access is unaffected. A declared path that does not exist on the host has nothing to expose and passes. The declaration requires `driver: docker` (already set here) and `agent_isolation` enabled (the default). Full mechanism and algorithm: UiPath/coder_eval#96.

## Merge ordering

**DO NOT MERGE** until UiPath/coder_eval#87, #95, and #96 are merged **and** the coder-eval-runner VM's harness is updated. The docker config model is `extra="forbid"`, so a harness without `isolated_paths` support rejects the whole experiment file at load time and the nightly run fails before it starts. Draft status is intentional.

## Validation

Run from `tests/` in this branch's worktree, against a coder_eval checkout on `feat/isolated-paths-declaration` (the branch carrying #96), with `SKILLS_REPO_PATH` pointed at a skills checkout.

1. Schema resolution - `coder-eval plan tasks/uipath-agents/coded/is_smoke/is_smoke.yaml -e experiments/nightly.yaml` resolves the experiment and reports `All tasks are valid!`. Proves the edited YAML parses and resolves end to end.

2. Merge survival - a script calling coder_eval's own `load_experiment` + `resolve_task_for_variant` (the same 4-layer resolver the runner uses) against the `default` variant, for two task shapes:
   - `tasks/uipath-agents/coded/is_smoke/is_smoke.yaml`, which sets its own `sandbox:` block (`template_sources`)
   - `tasks/activation/activation.yaml`, which sets no `sandbox:` block at all

   Both resolve to `driver=docker`, `agent_isolation=True`, `image=skills-image:latest`, `extra_mounts=['~/.uipath:/.uipath:rw']` and `isolated_paths=['$SKILLS_REPO_PATH/tests']`. Proves the defaults-level declaration survives the deep merge and is not dropped by a task that supplies its own `sandbox:` block. No nightly task currently sets a `docker:` block of its own, so nothing overrides it.

3. Negative control - the same `plan` command against a pre-feature coder_eval checkout (release 0.9.5) fails with `defaults.sandbox.docker.isolated_paths - Extra inputs are not permitted [type=extra_forbidden]`. This is the concrete basis for the merge-ordering warning above.
