### PR TITLE
fix(uipath-solution): make eval tasks deterministic for headless agents

### DIFF
--- a/tests/tasks/uipath-solution/diagnose_bindings_not_imported_integration.yaml
+++ b/tests/tasks/uipath-solution/diagnose_bindings_not_imported_integration.yaml
@@ -2,24 +2,78 @@ task_id: skill-solution-diagnose-bindings-not-imported
 description: >
   Integration test (diagnose mode): agent root-causes a refresh that reports
   success but imports 0 bindings — caused by bindings_v2.json sitting at the
-  wrong path. Local reasoning task — no tenant interaction.
+  wrong path. Seeded-fixture task — pre_run uses only local CLI verbs, no
+  tenant interaction.
 
   Ground truth verified against references/scenarios/failure-modes.md row
   "Refresh imports 0 of N bindings, no warnings" → bindings_v2.json not at
   expected path (project root, not nested) → move it to
   <ProjectName>/bindings_v2.json (agent validate regenerates it for agent
   projects).
+
+  Why a fixture (nightly 2026-08-07): without a workspace the symptom is
+  under-determined — a solution whose project was never registered ALSO
+  yields success + 0 imports + no warnings (refresh returns silently when
+  the .uipx lists no projects), so the judge rejected a defensible
+  alternative diagnosis and the task flip-flopped run to run. The seeded
+  workspace (registered project + nested bindings_v2.json) plus the
+  prompt's registration statement make the ground truth unique and reward
+  actually inspecting the workspace.
 tags: [uipath-solution, integration, mode:diagnose, lifecycle:discover]
 
 run_limits:
   expected_turns: 8
 
+pre_run:
+  - command: |
+      set -e
+      uip solution init InvoiceOps --output json
+      mkdir -p InvoiceOps/BillingBot/config
+      cat > InvoiceOps/BillingBot/project.uiproj << 'EOF'
+      {
+        "Name": "BillingBot",
+        "ProjectType": "Process"
+      }
+      EOF
+      # singular `project` is the version-proof spelling: primary verb before
+      # the cli#3067 plural rename, hidden alias after it
+      uip solution project add InvoiceOps/BillingBot InvoiceOps/InvoiceOps.uipx --output json
+      cat > InvoiceOps/BillingBot/config/bindings_v2.json << 'EOF'
+      {
+        "version": "2.0",
+        "resources": [
+          {
+            "resource": "queue",
+            "key": "InvoiceQueue",
+            "value": {
+              "name": { "defaultValue": "InvoiceQueue", "isExpression": false },
+              "folderPath": { "defaultValue": "Shared", "isExpression": false }
+            }
+          },
+          {
+            "resource": "queue",
+            "key": "EscalationQueue",
+            "value": {
+              "name": { "defaultValue": "EscalationQueue", "isExpression": false },
+              "folderPath": { "defaultValue": "Shared", "isExpression": false }
+            }
+          }
+        ]
+      }
+      EOF
+    timeout: 120
+
 initial_prompt: |
-  I ran `uip solution resources refresh` on my solution. It reported
+  My UiPath solution is in ./InvoiceOps, and my BillingBot project is
+  registered in it — `uip solution projects list` shows BillingBot, so
+  registration is not the problem.
+
+  I ran `uip solution resources refresh` on the solution. It reported
   success, but it imported 0 of my project's bindings — and there were no
   warnings or errors. The bindings clearly exist in my project.
 
-  Why did refresh import nothing, and how do I fix it?
+  Have a look at the workspace. Why did refresh import nothing, and how
+  do I fix it?
 
 success_criteria:
   - type: skill_triggered
@@ -32,20 +86,23 @@ success_criteria:
     description: "Agent identifies wrong bindings_v2.json path and prescribes moving it to the project root"
     include_agent_output: true
     prompt: |
-      Evaluate ONLY the agent's final reply. Ground truth: refresh imports
-      0 bindings with no warnings when `bindings_v2.json` is not at the
-      expected location — it must live at the PROJECT ROOT
-      (`<ProjectName>/bindings_v2.json`), not nested in a subfolder. The
-      fix is to move the file to the project root (for agent projects,
-      `agent validate` / `uipath agent validate` regenerates it there),
-      then re-run refresh.
+      Evaluate ONLY the agent's final reply. Ground truth (matches the
+      seeded workspace): the bindings file sits at
+      `InvoiceOps/BillingBot/config/bindings_v2.json`, but refresh scans
+      only the solution root and each registered project's ROOT — the
+      expected location is `InvoiceOps/BillingBot/bindings_v2.json`;
+      nested copies are silently ignored, which is why refresh succeeds
+      with 0 imports and no warnings. The fix is to move the file to the
+      project root (for agent projects, `agent validate` /
+      `uipath agent validate` regenerates it there), then re-run refresh.
 
       Score 1.0 if the reply identifies that `bindings_v2.json` is in the
       wrong place / not at the project root as the cause AND prescribes
       moving it to the project root (or regenerating it there) and
       re-running refresh. English or Romanian both fine.
 
-      Score 0.0 if it blames a CLI bug, auth, an empty solution, or fails
-      to point at the bindings_v2.json location as the cause.
+      Score 0.0 if it blames a CLI bug, auth, project registration (the
+      project IS registered here), an empty solution, or fails to point at
+      the bindings_v2.json location as the cause.
     weight: 3.0
     pass_threshold: 0.7

--- a/tests/tasks/uipath-solution/diagnose_bindings_not_imported_integration.yaml
+++ b/tests/tasks/uipath-solution/diagnose_bindings_not_imported_integration.yaml
@@ -65,8 +65,8 @@ pre_run:
 
 initial_prompt: |
   My UiPath solution is in ./InvoiceOps, and my BillingBot project is
-  registered in it — `uip solution projects list` shows BillingBot, so
-  registration is not the problem.
+  registered in it — I double-checked the project list, so registration
+  is not the problem.
 
   I ran `uip solution resources refresh` on the solution. It reported
   success, but it imported 0 of my project's bindings — and there were no

--- a/tests/tasks/uipath-solution/project_add_integration.yaml
+++ b/tests/tasks/uipath-solution/project_add_integration.yaml
@@ -5,6 +5,13 @@ description: >
   confirms it appears in the manifest. Covers the project-registration
   surface that all current tests skip (every other task uses empty
   solutions). Runs entirely in the sandbox tempdir — no tenant interaction.
+
+  The prompt deliberately carries a runtime signal ("cross-platform") and a
+  don't-block instruction: the scaffolded project is incidental to the
+  tested surface, and without a framework signal uipath-rpa SKILL.md Rule
+  2a mandates AskUserQuestion — which dead-ends a headless eval (nightly
+  2026-08-07: agent stopped at "Windows or cross-platform?" and never ran
+  projects add).
 tags: [uipath-solution, integration, mode:build, lifecycle:setup]
 
 run_limits:
@@ -15,9 +22,13 @@ initial_prompt: |
 
   1. Create a new UiPath solution called "OrderFlow" in the current
      directory.
-  2. Scaffold a separate project on disk (outside the solution), then
-     register that EXISTING project into the OrderFlow solution.
+  2. Scaffold a separate project on disk (outside the solution) — a
+     minimal cross-platform one is fine — then register that EXISTING
+     project into the OrderFlow solution.
   3. Tell me which projects are registered in the solution afterwards.
+
+  Pick sensible defaults for anything I haven't pinned down — please take
+  it all the way through without stopping to ask me questions.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-solution/resources_refresh_integration.yaml
+++ b/tests/tasks/uipath-solution/resources_refresh_integration.yaml
@@ -6,6 +6,13 @@ description: >
   core sync mechanism (Critical Rule "refresh before pack/upload") that
   every binding-dependent test relies on implicitly but none asserts.
   Runs entirely in the sandbox tempdir — no tenant interaction.
+
+  The prompt deliberately carries a runtime signal ("cross-platform") and a
+  don't-block instruction: the scaffolded project is incidental to the
+  tested surface, and without a framework signal uipath-rpa SKILL.md Rule
+  2a mandates AskUserQuestion — which dead-ends a headless eval (nightly
+  2026-08-07: agent stopped at "which runtime should I register?" and never
+  ran resources refresh).
 tags: [uipath-solution, integration, mode:build, lifecycle:setup]
 
 run_limits:
@@ -15,10 +22,14 @@ initial_prompt: |
   I'm preparing a UiPath solution for packaging.
 
   1. Create a new UiPath solution called "BillingSuite" and register a
-     project into it.
+     project into it — scaffold a minimal cross-platform project if you
+     need one.
   2. Make sure the solution's bundled resources / bindings are synced to
      the current solution state so it's ready to pack.
   3. Confirm the resources are in sync and tell me you're ready to pack.
+
+  Pick sensible defaults for anything I haven't pinned down — please take
+  it all the way through without stopping to ask me questions.
 
 success_criteria:
   - type: command_executed


### PR DESCRIPTION
## Why

Nightly `2026-08-07_04-44-12` (codex/gpt-5.6-terra) scored uipath-solution 17/22. Root-causing the run zip showed 3 of the 5 failures were task-determinism problems, not skill or CLI defects (the other 2: a tenant-side stuck install and a 600s model hang — nothing to fix here):

- **skill-solution-project-add** and **skill-solution-resources-refresh**: both prompts require scaffolding an incidental project but give no runtime signal. Without one, uipath-rpa SKILL.md Rule 2a mandates `AskUserQuestion` (Windows vs cross-platform) — so the agent stopped mid-task to ask, and a headless eval has no user to answer. Both tasks died with `Projects: 0` and the graded verbs never ran. (They were mature all July; #2246 changed their hashes, and 2026-08-07 was the first live re-validation.)
- **skill-solution-diagnose-bindings-not-imported**: fixture-less, the symptom "refresh succeeds, 0 imports, no warnings" is under-determined — a solution whose project was never registered produces the *identical* silent result (`syncResourcesFromBindings` returns early when the `.uipx` lists no projects). The judge only accepts the misplaced-`bindings_v2.json` diagnosis, so a defensible "project not registered" answer scored 0 and the task flip-flopped (fail 07-10, pass 07-15, fail 08-07).

## What

- **project-add / resources-refresh prompts**: the incidental project is now "a minimal cross-platform one", plus a closing "pick sensible defaults — don't stop to ask me questions" instruction (same spirit as existing tasks' "take it all the way through in one go"). This is a runtime *signal*, not a recipe — the skill still has to map cross-platform → `--target-framework Portable` itself. Descriptions document why the signal is deliberate.
- **diagnose-bindings-not-imported**: new `pre_run` seeds a real workspace with local-only CLI verbs (still tempdir-gate compatible): `uip solution init InvoiceOps`, minimal `project.uiproj` (same shape as the CLI's own e2e fixture), `uip solution project add`, and a two-queue `bindings_v2.json` deliberately nested at `BillingBot/config/`. Prompt now states the project IS registered and asks the agent to inspect the workspace; the judge grades against the seeded layout and explicitly rejects the (now factually false) registration diagnosis. `pre_run` uses the singular `project add` spelling — primary verb before the cli#3067 plural rename, hidden alias after — so it works on every CLI line.

## Verification

Ran the seeded fixture end-to-end against the real CLI:
- broken state: `uip solution resources refresh` → `Success, Imported: 0, Warnings: []` — exactly the prompt's symptom, with the project registered in the `.uipx`;
- after moving the file to the project root (the graded fix): `Created: 2`.

All three YAMLs parse; graders for project-add / resources-refresh are unchanged.

## Passing runs (post-open validation)

- **Codex / gpt-5.6-terra — the exact config that failed the nightly** — three scoped `run-coder-eval.yml` dispatches on this branch (repeated to account for gpt-5.6 run-to-run variance): **9/9 task-passes, every task SUCCESS at score 1.000** (project-add 4/4 criteria, resources-refresh 4/4, diagnose-bindings 2/2; seeded fixture ran cleanly in the Linux sandbox each time). Runs: [#1](https://github.com/UiPath/skills/actions/runs/31381827672), [#2](https://github.com/UiPath/skills/actions/runs/31383333583), [#3](https://github.com/UiPath/skills/actions/runs/31383983229) (run #3 is on the tip including the review-feedback commit). Baseline for comparison: all three failed on nightly `2026-08-07_04-44-12`, and diagnose-bindings had been flip-flopping since July.
- **Claude (local, tempdir driver)**: project-add **SUCCESS 1.000**, resources-refresh **SUCCESS 1.000**. The bindings task's `pre_run` cannot execute on the local Windows tempdir driver (coder_eval spawns `pre_run` via cmd.exe — pre-existing harness limitation affecting every POSIX `pre_run` task); it is covered by the Linux CI run above.

### Control side: the failure reproduces on `main`

Nightly [`2026-08-10_04-43-31`](https://coder-evalboard.uipath-dev.com/runs/2026-08-10_04-43-31?tags=uipath-solution) (same agent, `main`, without this PR) is the control:

- **project-add: Failed 0.21** and **resources-refresh: Failed 0.15** — byte-identical weighted scores to 2026-08-07. The run zip shows the same causal chain in both: the agent reads `uipath-solution/SKILL.md`, finds it needs a project, reads **`uipath-rpa/SKILL.md`**, and immediately blocks — *"`OrderFlow` was created. Which RPA target should the separate project use: **Windows** or **Portable (cross-platform)**?"* / *"`BillingSuite` has been created, but I need one choice before creating its RPA project: should it target **Windows** or **Cross-platform (Portable)** runtime?"*. Both stop right after `solution init`, so `Projects` stays 0 and the graded verb never runs. That ordering (rpa SKILL.md read → block) is Rule 2a firing, not generic model hesitation, and it makes the failure **deterministic, not flaky** — it costs 2 tasks every night until the prompts carry a runtime signal. Only the target-framework question is ever asked, which is exactly what the "cross-platform" signal answers.
- **deploy-activate-standalone: Passed** and **deploy-uninstall: Passed** — confirms those two 08-07 failures were the one-off tenant/model flakes diagnosed above, with nothing to fix.
- **diagnose-bindings: Passed 0.93** — passing *this* night, having failed 08-07 and 07-10: exactly the flip-flop the seeded fixture removes (this branch scores it 1.000 in all three dispatches).

Net: `main` 20/22 with a repeating 2-task deterministic loss; this branch takes those two back and de-flakes the third.

Copilot's inline note (plural `projects list` spelling pinned in the prompt) addressed in aab90a602.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
