### PR TITLE
fix(sprint-cut): grant actions:write so the publish dispatch is not 403'd

### DIFF
--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -43,6 +43,10 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # `gh workflow run publish.yml` (POST /actions/workflows/{id}/dispatches)
+  # needs this. An explicit block sets every unlisted scope to `none`, so
+  # omitting it 403s the dispatch and the cut publishes nothing.
+  actions: write
 
 # GitHub cron runs in UTC and cannot express "every two Sundays" — fire every
 # Sunday, then gate on the 14-day cadence anchor (mirrors UiPath/cli).


### PR DESCRIPTION
## Problem

Every real sprint cut since the cadence began has published **nothing**. The latest ([run 31298700323](https://github.com/UiPath/skills/actions/runs/31298700323), line 1.200) died on the first API call of the publish step:

```
Dispatching publish.yml channel=dev on release/v1.200...
could not create workflow dispatch event: HTTP 403: Resource not accessible by integration
  (https://api.github.com/repos/UiPath/skills/actions/workflows/289749925/dispatches)
```

`sprint-release-cut.yml` declares an explicit `permissions:` block, which sets every **unlisted** scope to `none`. `gh workflow run` → `POST /actions/workflows/{id}/dispatches` requires `actions: write`, which was missing.

`publish.yml`'s own `push: branches: ['release/v*']` trigger cannot cover for this: the release branch is pushed with `GITHUB_TOKEN`, so GitHub's recursion guard suppresses it — which is precisely why the cut dispatches explicitly. Dispatch blocked + push trigger suppressed = zero publishes.

```
gh run list --workflow publish.yml --branch release/v1.200  →  []
```

## Scope of the outage

The 14-day cadence gate makes most Sunday runs skip *before* the publish step and report green, which hid this. Filtering to actual release Sundays:

| Date | Line | Result |
|---|---|---|
| 2026-07-12 | 1.198 | ❌ HTTP 403 |
| 2026-07-26 | 1.199 | ❌ HTTP 403 |
| 2026-08-09 | 1.200 | ❌ HTTP 403 |

`release/v1.199` was later published by a manual dispatch; **1.200 is still unpublished**.

## Why it regressed

This same one-line fix was authored in #1729 and approved, but closed in favour of the larger rewrite in #1735. #1735 was also closed, and the rewrite that finally landed (#2162) carried the old permissions block forward — so `actions: write` has never been on `main`:

```
git log -S"actions: write" origin/main -- .github/workflows/sprint-release-cut.yml  →  (empty)
```

## Fix

Add `actions: write` to the permissions block, with a comment recording why it is load-bearing so a future rewrite does not drop it again.

## Recovering the 1.200 line

This PR does not backfill 1.200. Publish it manually:

```bash
gh workflow run publish.yml --ref release/v1.200 -f channel=dev
gh workflow run publish.yml --ref release/v1.200 -f channel=preview
```

## Verification

- YAML parses (`yaml.safe_load`)
- Diff is 4 added lines in one file; no behavioural change beyond the granted scope
- Not end-to-end verifiable before merge: the scheduled cut reads the workflow from `main`, so the 403 can only be confirmed gone on the next cadence Sunday (or a `minor_override` dispatch after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)