### PR TITLE
fix(process-mining): grade the real add-table verb and fix required tags

### DIFF
--- a/tests/tasks/uipath-process-mining/add_table_queryable.yaml
+++ b/tests/tasks/uipath-process-mining/add_table_queryable.yaml
@@ -1,7 +1,7 @@
 task_id: skill-pm-add-table-queryable
 description: >
   Critical Rule 1: to make a custom analytical dbt model queryable, register it
-  as a Case-linked data-model table with `apps model add-table` and RE-INGEST.
+  as a Case-linked data-model table with `apps data-model add-table` and RE-INGEST.
   Tests the headline rule of the skill and the mistake it exists to prevent —
   repurposing the pre-registered `Tags` / `Due_dates` entities to smuggle an
   unrelated aggregate through, which corrupts those features and fights their
@@ -13,7 +13,7 @@ description: >
 
   Command-construction only — no live tenant. Commands fail with auth errors;
   what matters is which commands the agent chooses.
-tags: [uipath-process-mining, mode:build, lifecycle:extend, data-model, add-table]
+tags: [uipath-process-mining, integration, mode:build, lifecycle:setup, data-model, add-table]
 
 run_limits:
   expected_turns: 8
@@ -49,7 +49,7 @@ success_criteria:
   - type: command_executed
     description: "Agent registered the custom model as a data-model table"
     tool_name: "Bash"
-    command_pattern: 'uip\s+pm\s+apps\s+model\s+add-table\b.*--file\b'
+    command_pattern: 'uip\s+pm\s+apps\s+data-model\s+add-table\b.*--file\b'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-process-mining/app_types_discovery_smoke.yaml
+++ b/tests/tasks/uipath-process-mining/app_types_discovery_smoke.yaml
@@ -8,7 +8,7 @@ description: >
   Platform note: runs without an authenticated tenant — commands will
   fail with auth errors. That is acceptable; what matters is that the
   agent loads the skill and invokes the right discovery command.
-tags: [uipath-process-mining, smoke, mode:diagnose, discover, app-types]
+tags: [uipath-process-mining, smoke, mode:diagnose, lifecycle:discover, app-types]
 
 run_limits:
   expected_turns: 4

--- a/tests/tasks/uipath-process-mining/mapping_fix_in_place.yaml
+++ b/tests/tasks/uipath-process-mining/mapping_fix_in_place.yaml
@@ -16,7 +16,7 @@ description: >
   to edit when the unauthenticated `data-mapping get` cannot return one — without
   it the agent correctly refuses to push a garbage file and the run stalls after
   the `get`.
-tags: [uipath-process-mining, mode:fix, lifecycle:maintain, custom, data-mapping]
+tags: [uipath-process-mining, integration, mode:diagnose, lifecycle:setup, custom, data-mapping]
 
 run_limits:
   expected_turns: 8

--- a/tests/tasks/uipath-process-mining/query_group_by_sugar.yaml
+++ b/tests/tasks/uipath-process-mining/query_group_by_sugar.yaml
@@ -8,7 +8,7 @@ description: >
 
   Command-construction only — no live tenant. Commands fail with auth errors;
   what matters is the shape of the query the agent constructs.
-tags: [uipath-process-mining, mode:diagnose, query, aggregate]
+tags: [uipath-process-mining, smoke, mode:diagnose, lifecycle:discover, query, aggregate]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-process-mining/transform_fix_apply_not_reingest.yaml
+++ b/tests/tasks/uipath-process-mining/transform_fix_apply_not_reingest.yaml
@@ -13,7 +13,7 @@ description: >
 
   Command-construction only — no live tenant. Commands fail with auth errors;
   what matters is which commands the agent chooses.
-tags: [uipath-process-mining, mode:fix, lifecycle:maintain, transformations, custom]
+tags: [uipath-process-mining, integration, mode:diagnose, lifecycle:setup, transformations, custom]
 
 run_limits:
   expected_turns: 8


### PR DESCRIPTION
Split out of #2544 (part 1 of 2). The linter change that would have *caught* this
is in the companion PR; this one is the eval-set fix on its own.

## Why

The process-mining eval set looked flaky across the two most recent nightly runs
([2026-08-05](https://coder-evalboard.uipath-dev.com/runs/2026-08-05_04-15-14),
[2026-08-10](https://coder-evalboard.uipath-dev.com/runs/2026-08-10_04-43-31)).
It wasn't flake. Only 2 of 6 tasks moved, each by exactly one criterion:

| Task | 2026-08-05 | 2026-08-10 |
|---|---|---|
| `skill-pm-add-table-queryable` | 1.0 | **0.778 FAILURE** |
| `skill-pm-custom-app-pipeline-e2e` | **0.833 FAILURE** | 1.0 |

## 1. `skill-pm-add-table-queryable` graded a verb that doesn't exist

The 3.0-weight criterion required `uip pm apps model add-table`. The catalog has
`uip pm apps data-model add-table`; `apps model` is the *semantic* model
(`fields` / `get` / `update`) and has no `add-table` child. The skill teaches the
correct verb in both `SKILL.md` (Rule 1) and `references/data-model.md`.

So the eval rewarded a hallucinated verb and penalised agents that followed the
skill:

- **08-05** — the agent typed `apps model add-table`, it errored, it retried with
  `apps data-model add-table`. The regex matched the *failed* attempt → passed.
- **08-10** — the agent went straight to the correct verb → matched nothing →
  0.778, FAILURE.

The green run was the wrong result. Fixed to `apps\s+data-model\s+add-table`,
and the same correction applied to the task description.

## 2. Tag hygiene

Five of six tasks were missing required tags or using values outside the closed
vocabularies in `tests/README.md` §Tag Taxonomy (`mode:fix`, `lifecycle:extend`,
`lifecycle:maintain` are not valid; `tier` was absent on four). Those tasks were
invisible to `make` targets, coverage reports and evalboard drilldown.

| Task | Before | After |
|---|---|---|
| `add_table_queryable` | `mode:build, lifecycle:extend` | `integration, mode:build, lifecycle:setup` |
| `app_types_discovery_smoke` | `smoke, mode:diagnose, discover` | `smoke, mode:diagnose, lifecycle:discover` |
| `mapping_fix_in_place` | `mode:fix, lifecycle:maintain` | `integration, mode:diagnose, lifecycle:setup` |
| `query_group_by_sugar` | `mode:diagnose` | `smoke, mode:diagnose, lifecycle:discover` |
| `transform_fix_apply_not_reingest` | `mode:fix, lifecycle:maintain` | `integration, mode:diagnose, lifecycle:setup` |

The two repair tasks follow the precedent set by
`uipath-api-workflow/diagnose/runtime_fix` (`mode:diagnose` for "here is an
error, fix it"), with `lifecycle:setup` because they mutate tenant state. The
bare `discover` tag duplicating `lifecycle:discover` was dropped.
`custom_app_pipeline_e2e` was already correct.

## Verification

Verified statically against the `uip` catalog (1.200.0-dev.8173): the corrected
verb `pm apps data-model add-table` is present, the old one is not.

**Passing-run claim:** the tasks were not re-run against a tenant for this PR —
the change is to a grader regex and to tags, neither of which alters agent
behaviour. `skill-pm-add-table-queryable` should be watched on the next nightly;
it is the one whose score this moves (0.778 → expected 1.0).

## Not addressed here

From the same investigation, deliberately out of scope:

- **The two runs aren't comparable.** 08-05 ran `gemini-3.5-flash` on `uip` 8093;
  08-10 ran `gpt-5.6-terra` on 8173, and `mapping_fix_in_place` gained two
  criteria in between. With **one replicate** per task, a single criterion flips
  the whole task. Pin the model or run ≥3 replicates before calling anything flaky.
- **`custom_app_pipeline_e2e`'s "inspect the transformations" criterion** is
  incidental to the task goal and cost the 08-05 run a FAILURE for no behavioural
  reason — drop it or make it advisory (`pass_threshold: 0`).
- **Coverage** — separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
