### PR TITLE
test(uipath-insights): add e2e coverage for the jobs commands

### DIFF
--- a/tests/tasks/uipath-insights/_shared/envelope_check.py
+++ b/tests/tasks/uipath-insights/_shared/envelope_check.py
@@ -168,13 +168,36 @@ def probe_live_cli(timeout: int = LIVE_PROBE_TIMEOUT) -> bool:
     return True
 
 
+def _get_ci(mapping, *candidate_keys: str, default=None):
+    """Case-insensitively read the first present candidate key from ``mapping``.
+
+    The envelope wrapper's ``Result``/``Code``/``Data`` casing IS the shipped
+    contract and stays literally asserted in `check_envelope`. The keys INSIDE
+    ``Data`` are not what these checkers grade, so runtime-payload reads go
+    through this accessor (same pattern as `_get_ci` in
+    uipath-maestro-flow/_shared/flow_check.py): a camelCase ``processName``
+    would otherwise return nothing silently and skip the report-grounding
+    branch while the task still passes.
+    """
+    if not isinstance(mapping, dict):
+        return default
+    lowered = {k.lower(): k for k in mapping.keys() if isinstance(k, str)}
+    for candidate in candidate_keys:
+        actual = lowered.get(candidate.lower())
+        if actual is not None:
+            return mapping[actual]
+    return default
+
+
 def process_names(data) -> list:
     """Process names carried by a jobs envelope's `Data.ProcessName`.
 
     The row columns come back as arrays that are sometimes nested one level per
     grouping bucket (`JobCountByTime` is `[[1]]` on the same response), so
     collect strings at any depth and drop blanks. Empty list when the column is
-    absent or null, which is what an empty window returns.
+    absent or null, which is what an empty window returns. The column is read
+    case-insensitively so a serialization change to camelCase can't silently
+    turn a populated window into an empty-looking one.
     """
     names: list = []
 
@@ -187,5 +210,5 @@ def process_names(data) -> list:
                 walk(item)
 
     if isinstance(data, dict):
-        walk(data.get("ProcessName"))
+        walk(_get_ci(data, "ProcessName"))
     return names

--- a/tests/tasks/uipath-insights/_shared/envelope_check.py
+++ b/tests/tasks/uipath-insights/_shared/envelope_check.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""Shared envelope validation helpers for the uipath-insights e2e checkers.
+
+`uip insights` success envelopes are PascalCased by the CLI formatter, so
+callers assert `Result`/`Code`/`Data`, not `result`/`code`. Code strings come
+from cli/packages/insights-tool/src/commands/jobs.ts. No envelope check asserts
+Data content: the shared tenant's job history grows over time, so both empty and
+populated windows must pass structurally. `has_signal` and `process_names` read
+Data only so callers can tell an empty window from a populated one and can
+cross-check an agent-written report against what the CLI actually returned.
+
+Checkers import this module via a sys.path insert relative to their own file
+(coder_eval runs them as `python3 $TASK_DIR/<checker>.py` with the sandbox as
+cwd, so a plain relative import would not resolve).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Ceiling for the live probe's own subprocess, kept under the run_command
+# timeouts in the task YAMLs so a hung CLI reports through our diagnostic
+# instead of being killed by the criterion. Cold first calls have been observed
+# at ~21s against a live tenant.
+LIVE_PROBE_TIMEOUT = 45
+
+# Envelope Code string per subcommand, from jobs.ts.
+CODES = {
+    "summary.json": "InsightsJobsSummary",
+    "completed-timeline.json": "InsightsJobsCompletedTimeline",
+    "uncompleted-timeline.json": "InsightsJobsUncompletedTimeline",
+    "top-failures.json": "InsightsJobsTopFailures",
+    "failures-by-reason.json": "InsightsJobsFailuresByReason",
+    "process-details.json": "InsightsJobsProcessDetails",
+    "failure-details.json": "InsightsJobsFailureDetails",
+}
+
+
+def load_envelope(name: str):
+    """Load a saved envelope file; print a FAIL diagnostic and return None on
+    any problem so every failure names the file and the reason."""
+    path = Path(name)
+    if not path.exists():
+        print(f"FAIL: {name} does not exist", file=sys.stderr)
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"FAIL: {name} is not valid JSON: {e}", file=sys.stderr)
+        return None
+    if data is None:
+        print(
+            f"FAIL: {name} parses to JSON null — expected a response envelope object",
+            file=sys.stderr,
+        )
+        return None
+    return data
+
+
+def _error_context(data: dict) -> str:
+    """CLI-supplied failure text, trimmed, as a suffix for a FAIL line."""
+    parts = []
+    for field in ("Message", "Instructions"):
+        value = data.get(field)
+        if isinstance(value, str) and value.strip():
+            parts.append(f"{field}: {value.strip()[:300]}")
+    return f" — {' | '.join(parts)}" if parts else ""
+
+
+def check_envelope(name: str, data, code: str) -> bool:
+    if not isinstance(data, dict):
+        print(f"FAIL: {name} is not a JSON object (got {type(data).__name__})", file=sys.stderr)
+        return False
+    ok = True
+    if data.get("Result") != "Success":
+        # Error envelopes carry Message + Instructions and no Code (jobs.ts
+        # executeJobsEndpoint), so echo both: it separates "tenant has no
+        # Insights entitlement / bad auth" from a genuine test regression
+        # without opening the artifact.
+        print(
+            f"FAIL: {name} Result != 'Success' (got {data.get('Result')!r})"
+            f"{_error_context(data)}",
+            file=sys.stderr,
+        )
+        ok = False
+    if data.get("Code") != code:
+        print(f"FAIL: {name} Code != {code!r} (got {data.get('Code')!r})", file=sys.stderr)
+        ok = False
+    if "Data" not in data:
+        print(f"FAIL: {name} missing 'Data' field", file=sys.stderr)
+        ok = False
+    return ok
+
+
+def has_signal(value) -> bool:
+    """True when Data carries any non-empty, non-zero content."""
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return any(has_signal(v) for v in value)
+    if isinstance(value, dict):
+        return any(has_signal(v) for v in value.values())
+    return True
+
+
+def probe_live_cli(timeout: int = LIVE_PROBE_TIMEOUT) -> bool:
+    """Issue one real read so a tenant that cannot answer Insights queries fails
+    with the CLI's own message rather than looking like a bad artifact.
+
+    A read-only command surface leaves no tenant state behind, so unlike the
+    platform tasks there is nothing to re-query for what the agent did. This
+    probe answers the narrower question the saved files cannot: does this tenant
+    answer `uip insights jobs` at all. Envelope shape only — Data is never read,
+    so the assertion holds on an empty window.
+
+    One minute of history keeps the call cheap; the window is irrelevant to the
+    shape being asserted.
+    """
+    argv = ["uip", "insights", "jobs", "summary", "--time-range", "60", "--output", "json"]
+    printable = " ".join(argv)
+    label = f"live probe ({printable})"
+    try:
+        proc = subprocess.run(argv, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        print(f"FAIL: {label} could not run — no `uip` on PATH", file=sys.stderr)
+        return False
+    except subprocess.TimeoutExpired:
+        print(f"FAIL: {label} timed out after {timeout}s", file=sys.stderr)
+        return False
+
+    if not proc.stdout.strip():
+        # stderr is where auth and connectivity failures land; trimmed because a
+        # stack trace or token-bearing URL would otherwise reach the CI log.
+        detail = proc.stderr.strip()[:200] or "no output on either stream"
+        print(
+            f"FAIL: {label} wrote nothing to stdout (exit {proc.returncode}): {detail}",
+            file=sys.stderr,
+        )
+        return False
+
+    try:
+        envelope = json.loads(proc.stdout)
+    except json.JSONDecodeError as e:
+        print(f"FAIL: {label} did not return JSON: {e}", file=sys.stderr)
+        return False
+
+    # A rejected read is the expected shape of "this tenant can't answer", and
+    # its envelope carries no Code or Data, so report the cause once instead of
+    # letting check_envelope add two lines of noise about the missing fields.
+    if isinstance(envelope, dict) and envelope.get("Result") != "Success":
+        print(
+            f"FAIL: {label} was rejected by the tenant (Result "
+            f"{envelope.get('Result')!r}){_error_context(envelope)}",
+            file=sys.stderr,
+        )
+        return False
+
+    if not check_envelope(label, envelope, CODES["summary.json"]):
+        return False
+    print(f"OK: {label} returned {CODES['summary.json']}")
+    return True
+
+
+def process_names(data) -> list:
+    """Process names carried by a jobs envelope's `Data.ProcessName`.
+
+    The row columns come back as arrays that are sometimes nested one level per
+    grouping bucket (`JobCountByTime` is `[[1]]` on the same response), so
+    collect strings at any depth and drop blanks. Empty list when the column is
+    absent or null, which is what an empty window returns.
+    """
+    names: list = []
+
+    def walk(value) -> None:
+        if isinstance(value, str):
+            if value.strip():
+                names.append(value.strip())
+        elif isinstance(value, list):
+            for item in value:
+                walk(item)
+
+    if isinstance(data, dict):
+        walk(data.get("ProcessName"))
+    return names

--- a/tests/tasks/uipath-insights/envelope-contract/all_commands_envelope_e2e.yaml
+++ b/tests/tasks/uipath-insights/envelope-contract/all_commands_envelope_e2e.yaml
@@ -48,7 +48,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran summary with the 24-hour window (or an absolute epoch-ms range)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+summary\s.*--(time-range[=\s]+1440|started-after[=\s]+\d{13})'
+    command_pattern: 'uip\s+insights\s+jobs\s+summary\s(?:[^&;|\n]|\\\n)*--(time-range[=\s]+1440|started-after[=\s]+\d{13})'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -56,7 +56,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran completed-timeline with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+completed-timeline\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+completed-timeline\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran uncompleted-timeline with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+uncompleted-timeline\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+uncompleted-timeline\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran top-failures with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -80,7 +80,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran failures-by-reason with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -88,7 +88,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran process-details with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+process-details\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+process-details\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -96,7 +96,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran failure-details with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0
@@ -124,7 +124,7 @@ success_criteria:
   - type: command_executed
     description: "Advisory: agent used --output json on the queries"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s.*--output[=\s]+json'
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s(?:[^&;|\n]|\\\n)*--output[=\s]+json'
     min_count: 2
     weight: 1.0
     pass_threshold: 0

--- a/tests/tasks/uipath-insights/envelope-contract/all_commands_envelope_e2e.yaml
+++ b/tests/tasks/uipath-insights/envelope-contract/all_commands_envelope_e2e.yaml
@@ -1,0 +1,130 @@
+task_id: skill-insights-all-commands-envelope-e2e
+description: >
+  E2E test: agent uses the uipath-insights skill to run all seven jobs
+  subcommands against the live tenant and save each full response
+  envelope to a file. Verifies the shipped contract — every envelope
+  returns Result "Success" with the exact per-subcommand Code — which
+  the smoke tier never grades: smoke_all_commands only asserts the
+  command strings were attempted, regardless of outcome. Distinct from
+  it in grading: each subcommand must be invoked with a real time window
+  AND its envelope must come back structurally correct against the live
+  tenant. A read-only surface leaves no tenant state to re-query, so the
+  invocations are gated on the harness's turn records (which the agent
+  cannot write to) and the checker issues one live read of its own, so an
+  unentitled tenant fails with the CLI's own message rather than looking
+  like bad artifacts. Data-agnostic: empty Data passes structurally.
+tags: [uipath-insights, e2e, mode:operate, lifecycle:discover]
+
+run_limits:
+  expected_turns: 24
+  turn_timeout: 600
+
+initial_prompt: |
+  Give me the complete picture of the last 24 hours of job executions,
+  using every jobs query this CLI surface offers.
+
+  For each query, save the full response envelope (not just its Data)
+  to a JSON file in the current directory named after the subcommand:
+  `summary.json`, `completed-timeline.json`, `uncompleted-timeline.json`,
+  `top-failures.json`, `failures-by-reason.json`, `process-details.json`,
+  `failure-details.json`. Redirect the command output straight to the
+  file rather than pasting it.
+
+  Then reply with a short recap: which queries returned data and which
+  came back empty. Empty is a valid answer, not an error.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-insights skill and follow its workflow.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected_skill: "uipath-insights"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran summary with the 24-hour window (or an absolute epoch-ms range)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+summary\s.*--(time-range[=\s]+1440|started-after[=\s]+\d{13})'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran completed-timeline with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+completed-timeline\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran uncompleted-timeline with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+uncompleted-timeline\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran top-failures with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failures-by-reason with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran process-details with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+process-details\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failure-details with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Summary envelope saved"
+    path: "summary.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Process-details envelope saved"
+    path: "process-details.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "All 7 envelope files exist, parse, and carry Result=Success with the exact per-subcommand Code; a live CLI read confirms the tenant answers Insights queries; empty Data passes structurally"
+    command: "python3 $TASK_DIR/check_all_commands_envelope.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on the queries"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s.*--output[=\s]+json'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 0

--- a/tests/tasks/uipath-insights/envelope-contract/check_all_commands_envelope.py
+++ b/tests/tasks/uipath-insights/envelope-contract/check_all_commands_envelope.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Validator for all_commands_envelope_e2e.yaml artifacts.
+
+All seven `uip insights jobs` subcommand envelopes must be saved and pass the
+shared structural checks (Result, exact Code, Data present). No size-bearing
+checks: failure-details grows without bound on busy tenants and is validated
+on the same structural terms as the rest.
+
+Also issues one live read of its own (`probe_live_cli`) so an unentitled or
+misconfigured tenant fails with the CLI's own message instead of looking like a
+run that saved bad files.
+
+Exit 0 on pass, 1 on fail. Reads from the task sandbox cwd (coder_eval
+invokes run_command criteria with cwd set to the sandbox root).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from envelope_check import CODES, check_envelope, load_envelope, probe_live_cli
+
+
+def main() -> int:
+    errors = 0
+
+    # First, so a tenant that cannot answer Insights queries names itself before
+    # the per-file diagnostics, which would otherwise read as bad artifacts.
+    if not probe_live_cli():
+        errors += 1
+
+    for fname, code in CODES.items():
+        data = load_envelope(fname)
+        if data is None or not check_envelope(fname, data, code):
+            errors += 1
+
+    if errors:
+        return 1
+    print("OK: all 7 envelopes valid (empty Data passes structurally)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-insights/job-health/check_job_health_investigation.py
+++ b/tests/tasks/uipath-insights/job-health/check_job_health_investigation.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Validator for job_health_investigation_e2e.yaml artifacts.
+
+The four saved envelopes must pass the shared structural checks (Result,
+exact Code, Data present) and the report must be non-trivial AND tied to the
+data the CLI actually returned: when `top-failures.json` names failing
+processes, the report has to name one of them. That is the check that stops
+the report from being graded on its own prose — a plausible-looking summary
+the agent invented cannot name a process the tenant reported.
+
+Data-agnostic both ways: an empty window is a structural pass, and both the
+numbers and process-name requirements apply only when the window has data —
+an honest "no job history" report carries neither.
+
+Also issues one live read of its own (`probe_live_cli`) so an unentitled or
+misconfigured tenant fails with the CLI's own message instead of looking like a
+run that saved bad files.
+
+Exit 0 on pass, 1 on fail. Reads from the task sandbox cwd (coder_eval
+invokes run_command criteria with cwd set to the sandbox root).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "_shared"))
+from envelope_check import (
+    CODES,
+    check_envelope,
+    has_signal,
+    load_envelope,
+    probe_live_cli,
+    process_names,
+)
+
+# The envelope whose Data names the failing processes the report is checked
+# against.
+TOP_FAILURES = "top-failures.json"
+
+EXPECTED = {
+    name: CODES[name]
+    for name in (
+        "summary.json",
+        TOP_FAILURES,
+        "failures-by-reason.json",
+        "failure-details.json",
+    )
+}
+
+# 120 keeps a compact empty-window report passing (the shared tenant is often
+# empty) while still rejecting placeholder output.
+REPORT = "job-health-report.md"
+REPORT_MIN_CHARS = 120
+
+
+def _check_report(empty_window: bool, failing_processes: list) -> bool:
+    path = Path(REPORT)
+    if not path.exists():
+        print(f"FAIL: {REPORT} does not exist", file=sys.stderr)
+        return False
+    text = path.read_text(encoding="utf-8")
+    if len(text.strip()) < REPORT_MIN_CHARS:
+        print(
+            f"FAIL: {REPORT} is trivial ({len(text.strip())} chars, need >= {REPORT_MIN_CHARS})",
+            file=sys.stderr,
+        )
+        return False
+    if empty_window:
+        return True
+    if not any(ch.isdigit() for ch in text):
+        print(
+            f"FAIL: {REPORT} contains no numbers — the window has data, expected counts or rates",
+            file=sys.stderr,
+        )
+        return False
+    if failing_processes:
+        haystack = text.lower()
+        if not any(name.lower() in haystack for name in failing_processes):
+            print(
+                f"FAIL: {REPORT} names none of the failing processes {TOP_FAILURES} reported "
+                f"({', '.join(failing_processes)}) — the report is not grounded in the query results",
+                file=sys.stderr,
+            )
+            return False
+    return True
+
+
+def main() -> int:
+    errors = 0
+    empty_window = True
+    failing_processes: list = []
+
+    # First, so a tenant that cannot answer Insights queries names itself before
+    # the per-file diagnostics, which would otherwise read as bad artifacts.
+    if not probe_live_cli():
+        errors += 1
+
+    for fname, code in EXPECTED.items():
+        data = load_envelope(fname)
+        if data is None or not check_envelope(fname, data, code):
+            errors += 1
+            continue
+        if has_signal(data.get("Data")):
+            empty_window = False
+        if fname == TOP_FAILURES:
+            failing_processes = process_names(data.get("Data"))
+
+    if not _check_report(empty_window, failing_processes):
+        errors += 1
+
+    if errors:
+        return 1
+    if empty_window:
+        print("OK: structural pass, empty window — all envelopes valid, no job history in range")
+    elif failing_processes:
+        print(
+            "OK: all envelopes valid, report present and names a failing process the CLI "
+            f"reported ({', '.join(failing_processes)})"
+        )
+    else:
+        print("OK: all envelopes valid, report present (no failing processes to cross-check)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-insights/job-health/job_health_investigation_e2e.yaml
+++ b/tests/tasks/uipath-insights/job-health/job_health_investigation_e2e.yaml
@@ -1,0 +1,108 @@
+task_id: skill-insights-job-health-investigation-e2e
+description: >
+  E2E test: agent uses the uipath-insights skill to run the full job-health
+  investigation journey against the live tenant — summary first, then
+  drill-down into top failures, failure reasons, and failure details —
+  and leaves behind the raw response envelopes plus a human-readable
+  report. Graded on command sequence and artifacts, not on data volume:
+  the shared tenant may have any amount of job history, so the check
+  script validates envelope structure (Result, Code, Data) and accepts
+  an empty window as a structural pass. The report is not graded on its
+  own prose: whenever top-failures names failing processes, the report
+  must name one of them, so an invented summary cannot pass.
+tags: [uipath-insights, e2e, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 24
+  turn_timeout: 600
+
+initial_prompt: |
+  Our automations have felt unreliable over the last week and I need to
+  know where we stand. Investigate the last 7 days of job executions:
+  how many jobs ran and how many succeeded, which process is failing
+  the most, and why it fails.
+
+  Leave evidence behind in the current directory:
+
+  - Save the full response envelope (not just its Data) of each query
+    you run to a JSON file named after the subcommand: `summary.json`,
+    `top-failures.json`, `failures-by-reason.json`, `failure-details.json`.
+    Redirect the command output straight to the file.
+  - Write `job-health-report.md` summarizing the overall success rate,
+    the worst processes, the most common failure reasons, and which
+    machines are affected.
+
+  If the window has no job history, say so in the report and still save
+  the response files — an empty window is a valid answer, not an error.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-insights skill and follow its workflow.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected_skill: "uipath-insights"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran summary with the 7-day window (or an absolute epoch-ms range)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+summary\s.*--(time-range[=\s]+10080|started-after[=\s]+\d{13})'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran top-failures with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran failures-by-reason with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent drilled into failure-details with a time-range flag"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s.*--(time-range|started-after)[=\s]+\d'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Investigation report written"
+    path: "job-health-report.md"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "Summary envelope saved"
+    path: "summary.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Saved envelopes carry Result=Success with the correct Code per subcommand; report is non-trivial and names a failing process the CLI reported; a live CLI read confirms the tenant answers Insights queries; empty window passes structurally"
+    command: "python3 $TASK_DIR/check_job_health_investigation.py"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on the queries"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s.*--output[=\s]+json'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 0

--- a/tests/tasks/uipath-insights/job-health/job_health_investigation_e2e.yaml
+++ b/tests/tasks/uipath-insights/job-health/job_health_investigation_e2e.yaml
@@ -50,7 +50,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran summary with the 7-day window (or an absolute epoch-ms range)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+summary\s.*--(time-range[=\s]+10080|started-after[=\s]+\d{13})'
+    command_pattern: 'uip\s+insights\s+jobs\s+summary\s(?:[^&;|\n]|\\\n)*--(time-range[=\s]+10080|started-after[=\s]+\d{13})'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -58,7 +58,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran top-failures with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+top-failures\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -66,7 +66,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran failures-by-reason with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+failures-by-reason\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -74,7 +74,7 @@ success_criteria:
   - type: command_executed
     description: "Agent drilled into failure-details with a time-range flag"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s.*--(time-range|started-after)[=\s]+\d'
+    command_pattern: 'uip\s+insights\s+jobs\s+failure-details\s(?:[^&;|\n]|\\\n)*--(time-range|started-after)[=\s]+\d'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0
@@ -102,7 +102,7 @@ success_criteria:
   - type: command_executed
     description: "Advisory: agent used --output json on the queries"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s.*--output[=\s]+json'
+    command_pattern: 'uip\s+insights\s+jobs\s+\S+\s(?:[^&;|\n]|\\\n)*--output[=\s]+json'
     min_count: 2
     weight: 1.0
     pass_threshold: 0


### PR DESCRIPTION
Related to [IN-13526](https://uipath.atlassian.net/browse/IN-13526).

### What

Adds the first e2e coverage for `uipath-insights`: two task YAMLs with their sidecar checkers (`envelope-contract/all_commands_envelope_e2e.yaml`, `job-health/job_health_investigation_e2e.yaml`, `check_all_commands_envelope.py`, `check_job_health_investigation.py`) plus a shared `_shared/envelope_check.py` holding the per-subcommand envelope `Code` strings from `jobs.ts`. Five new files, all under `tests/tasks/uipath-insights/`. The five existing smoke tasks, `SKILL.md`, and the references are untouched.

### Why

The repo requires at least one smoke and one e2e task per skill (`tests/README.md:269`) and this skill had only smoke. The five smoke tasks grade that command strings were attempted, regardless of outcome, so nothing currently grades whether `uip insights jobs` returns its shipped contract: `Result: Success` with the exact per-subcommand `Code`.

### Scope

The seven shipped Jobs commands only, read-only, no tenant mutation and therefore no cleanup. Nothing here teaches the proposed Filters, RBAC, or Alert commands as available. The Filters skill content and its smoke task are a separate PR that waits on those commands reaching `cli/main`.

### Testing

Ran both tasks locally and they passed. Run `2026-08-06_13-34-09`, claude-code agent, `uip 1.198.0`, coder_eval 0.8.10: `skill-insights-all-commands-envelope-e2e` 1.000 (12/12 criteria), `skill-insights-job-health-investigation-e2e` 1.000 (9/9). Four earlier runs also passed at 1.000: `2026-08-06_12-25-44`, `2026-08-06_12-13-08`, `2026-08-04_12-24-50`, `2026-08-04_12-29-42`. The last run had live job data, so the report-grounding assertion was exercised rather than skipped through the empty-window path. Checker failure paths exercised locally against synthesized artifacts: ungrounded report, rejected envelope, unparseable envelope, missing file, no `uip` on PATH, probe timeout. `scripts/check-task-driver.py` and `scripts/check-cli-verbs.py` are clean.

### Limitations

No pytest unit tests for the checkers. maestro-flow, maestro-case and uipath-agents ship them, but running them in CI needs a `paths:` entry and a job in `.github/workflows/test-helpers.yml`, outside this PR's ownership. Happy to follow up if the CI owners want it.

The checkers verify that each saved envelope is structurally correct and that the report is grounded in the CLI's response, but not that a given file is the response to its own command. Both tasks need a tenant that answers `uip insights jobs`; a tenant that rejects the read fails with the CLI's own `Message` and `Instructions` rather than degrading.

### How to Review

Start with the two `check_*.py` files and `_shared/envelope_check.py`. That is where the contract lives. The YAMLs are mostly criteria lists.

### Checklist

- [x] Tests added/updated for new logic — the change is the tests; run evidence above
- [x] No secrets or credentials in code
- [x] Commits follow conventional format
- [ ] PR ≤ 400 lines — 603 added lines; the five files are one slice, and a task YAML is not separable from its checker

### CI note

The PR gate runs only `smoke`-tagged tasks, so neither new task is exercised by CI on this PR. The local runs above are the evidence; nightly is where they run on a schedule.


[IN-13526]: https://uipath.atlassian.net/browse/IN-13526?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ