### PR TITLE
feat(uipath-insights): teach filter discovery and add filters smoke eval

### DIFF
--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uipath-insights
-description: "UiPath Insights job monitoring via `uip insights` — query job execution metrics, failure analysis, and process performance. Covers job KPIs, failure reasons, completion trends, process breakdowns. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa."
-when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details'. Also 'uip insights', 'insights jobs'. NOT for starting/stopping jobs (uipath-platform), NOT for root-cause debugging of a specific job error (uipath-troubleshoot), NOT for queue metrics (not yet supported)."
+description: "UiPath Insights job monitoring via `uip insights` — query job execution metrics, failure analysis, and process performance. Covers job KPIs, failure reasons, completion trends, process breakdowns. Also filter discovery — folders, processes, queues, and machines with recent activity, for choosing exact scope before alerts or filtered queries. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa."
+when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details', 'which folders can you see', 'what processes are active', 'find the folder key', 'discover queues', 'which machines reported', 'filter-folders', 'filter-processes'. Also 'uip insights', 'insights jobs'. NOT for starting/stopping jobs (uipath-platform), NOT for root-cause debugging of a specific job error (uipath-troubleshoot), NOT for queue item metrics (queue discovery is supported via filter-queues; metrics are not)."
 allowed-tools: Bash, Read
 ---
 
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read
 
 Insights provides analytics and monitoring for UiPath automation execution. This skill covers **job monitoring** — querying aggregated job execution data for dashboards, health checks, and failure investigation.
 
-All operations go through `uip insights jobs <subcommand> --output json`.
+Job monitoring goes through `uip insights jobs <subcommand> --output json`; scope discovery goes through the `uip insights filter-*` groups.
 
 ---
 
@@ -20,6 +20,7 @@ All operations go through `uip insights jobs <subcommand> --output json`.
 - Monitoring job execution trends over time (completed/uncompleted timelines)
 - Getting per-process performance breakdowns
 - Drilling into specific failure details for investigation
+- Discovering which folders, processes, queues, or machines have recent activity, to pick an exact scope (see Filter Discovery Commands)
 
 > **Not in scope:** Starting, stopping, or managing individual jobs (use `uip or jobs` via uipath-platform). Root-cause debugging of a specific job's error (use uipath-troubleshoot). Queue item metrics, robot utilization, or dashboard CRUD (not yet available in CLI).
 
@@ -47,7 +48,7 @@ uip login tenant set MyTenant
 
 ## Critical Rules
 
-1. **A time range is always required.** Every `uip insights jobs` command needs either `--time-range <minutes>` (relative) or both `--started-after <epoch-ms>` and `--started-before <epoch-ms>` (absolute). Without one, the command fails. For absolute ranges, pass literal epoch-millisecond numbers, resolved beforehand (see Workflow: Absolute Time Range). Common values:
+1. **A time range is always required — for `jobs` commands only.** Every `uip insights jobs` command needs either `--time-range <minutes>` (relative) or both `--started-after <epoch-ms>` and `--started-before <epoch-ms>` (absolute). Without one, the command fails. `filter-*` commands take no time flags at all (see Filter Discovery Commands). For absolute ranges, pass literal epoch-millisecond numbers, resolved beforehand (see Workflow: Absolute Time Range). Common values:
    - `--time-range 60` — last 1 hour
    - `--time-range 1440` — last 24 hours
    - `--time-range 10080` — last 7 days
@@ -163,6 +164,45 @@ uip insights jobs failure-details --time-range 1440 --output json
 
 ---
 
+## Filter Discovery Commands
+
+Four discovery groups expose scope candidates with recent Insights activity:
+
+```bash
+uip insights filter-folders list --output json     # {FolderName, FolderKey} rows
+uip insights filter-processes list --output json   # {ProcessName, FolderKey} rows
+uip insights filter-queues list --output json      # {QueueName, FolderKey} rows
+uip insights filter-machines list --output json    # {MachineName, MachineKey} rows
+```
+
+Rules that differ from the jobs commands:
+
+1. **No time flags.** The backend applies its own fixed 30-day activity window. `--time-range` is rejected as an unknown option. Do not add it.
+2. **`--limit` / `--offset` paginate client-side.** Default limit is 50; `Pagination.Total` and `HasMore` show whether more rows exist.
+3. **Empty is normal and is not proof of absence.** An empty result means no visible activity in the last 30 days for the current caller. Never tell the user a resource does not exist based on filter output.
+4. **Results are permission-bounded.** Folders, processes, and queues are restricted to folders the caller can access; machines are tenant-wide.
+
+### Workflow: discover before you act
+
+Before any command that takes a folder key, process name, machine name, or (future) alert scope:
+
+```bash
+# 1. Discover candidates
+uip insights filter-folders list --output json
+
+# 2. Match the user's words against FolderName values. If Pagination
+#    shows HasMore: true, page with --offset (or raise --limit) until
+#    every row has been seen BEFORE concluding anything is absent.
+#    Multiple matches -> ask the user which one. Zero matches across
+#    all pages -> report that nothing with that name was active in the
+#    last 30 days and ask for more detail. Never guess or fabricate a key.
+
+# 3. Use the exact key from the response
+uip insights jobs summary --time-range 1440 --folder-key "<FolderKey from step 1>" --output json
+```
+
+---
+
 ## Workflow: Investigate Job Health
 
 Follow this pattern when a user asks about automation health or job failures:
@@ -214,7 +254,7 @@ uip insights jobs failures-by-reason --time-range 1440 \
   --output json
 ```
 
-To discover available folder keys, use `uip or folders list --output json` (from the uipath-platform skill).
+To discover available folder keys, use `uip or folders list --output json` (from the uipath-platform skill), or `uip insights filter-folders list --output json` for folders with recent Insights activity — usually the right scope source for monitoring tasks, since the Orchestrator list shows all folders the caller can administer.
 
 ---
 

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -169,10 +169,10 @@ uip insights jobs failure-details --time-range 1440 --output json
 Four discovery groups expose scope candidates with recent Insights activity:
 
 ```bash
-uip insights filter-folders list --output json     # {folderName, folderKey} rows
-uip insights filter-processes list --output json   # {processName, folderKey} rows
-uip insights filter-queues list --output json      # {queueName, folderKey} rows
-uip insights filter-machines list --output json    # {machineName, machineKey} rows
+uip insights filter-folders list --output json     # {FolderName, FolderKey} rows
+uip insights filter-processes list --output json   # {ProcessName, FolderKey} rows
+uip insights filter-queues list --output json      # {QueueName, FolderKey} rows
+uip insights filter-machines list --output json    # {MachineName, MachineKey} rows
 ```
 
 Rules that differ from the jobs commands:
@@ -190,7 +190,7 @@ Before any command that takes a folder key, process name, machine name, or (futu
 # 1. Discover candidates
 uip insights filter-folders list --output json
 
-# 2. Match the user's words against folderName values. If Pagination
+# 2. Match the user's words against FolderName values. If Pagination
 #    shows HasMore: true, page with --offset (or raise --limit) until
 #    every row has been seen BEFORE concluding anything is absent.
 #    Multiple matches -> ask the user which one. Zero matches across
@@ -198,7 +198,7 @@ uip insights filter-folders list --output json
 #    last 30 days and ask for more detail. Never guess or fabricate a key.
 
 # 3. Use the exact key from the response
-uip insights jobs summary --time-range 1440 --folder-key "<folderKey from step 1>" --output json
+uip insights jobs summary --time-range 1440 --folder-key "<FolderKey from step 1>" --output json
 ```
 
 ---

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -169,10 +169,10 @@ uip insights jobs failure-details --time-range 1440 --output json
 Four discovery groups expose scope candidates with recent Insights activity:
 
 ```bash
-uip insights filter-folders list --output json     # {FolderName, FolderKey} rows
-uip insights filter-processes list --output json   # {ProcessName, FolderKey} rows
-uip insights filter-queues list --output json      # {QueueName, FolderKey} rows
-uip insights filter-machines list --output json    # {MachineName, MachineKey} rows
+uip insights filter-folders list --output json     # {folderName, folderKey} rows
+uip insights filter-processes list --output json   # {processName, folderKey} rows
+uip insights filter-queues list --output json      # {queueName, folderKey} rows
+uip insights filter-machines list --output json    # {machineName, machineKey} rows
 ```
 
 Rules that differ from the jobs commands:
@@ -190,7 +190,7 @@ Before any command that takes a folder key, process name, machine name, or (futu
 # 1. Discover candidates
 uip insights filter-folders list --output json
 
-# 2. Match the user's words against FolderName values. If Pagination
+# 2. Match the user's words against folderName values. If Pagination
 #    shows HasMore: true, page with --offset (or raise --limit) until
 #    every row has been seen BEFORE concluding anything is absent.
 #    Multiple matches -> ask the user which one. Zero matches across
@@ -198,7 +198,7 @@ uip insights filter-folders list --output json
 #    last 30 days and ask for more detail. Never guess or fabricate a key.
 
 # 3. Use the exact key from the response
-uip insights jobs summary --time-range 1440 --folder-key "<FolderKey from step 1>" --output json
+uip insights jobs summary --time-range 1440 --folder-key "<folderKey from step 1>" --output json
 ```
 
 ---

--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -9,7 +9,7 @@ allowed-tools: Bash, Read
 
 Insights provides analytics and monitoring for UiPath automation execution. This skill covers **job monitoring** — querying aggregated job execution data for dashboards, health checks, and failure investigation.
 
-Job monitoring goes through `uip insights jobs <subcommand> --output json`; scope discovery goes through the `uip insights filter-*` groups.
+Job monitoring goes through `uip insights jobs <subcommand> --output json`; scope discovery goes through the `uip insights filter-*` groups. <!-- uip-check-skip -->
 
 ---
 

--- a/skills/uipath-insights/references/investigation-playbook-guide.md
+++ b/skills/uipath-insights/references/investigation-playbook-guide.md
@@ -106,12 +106,11 @@ uip insights jobs summary \
 User asks about a specific Orchestrator folder.
 
 ```bash
-# Step 1: Find the folder key — Insights-active folders first
+# Step 1: Find the folder key. Two sources return the same GUID:
+# Insights-active folders (last 30 days): GUID is the folderKey field
 uip insights filter-folders list --output json
-# Look for the folder's FolderKey in the output.
-# Fallback for folders without recent activity (requires uipath-platform):
+# Fallback, full folder inventory (requires uipath-platform): GUID is the Key field
 uip or folders list --output json
-# There the GUID is the folder's Key field (not FolderKey)
 
 # Step 2: Query insights with folder filter
 uip insights jobs summary --time-range 1440 \

--- a/skills/uipath-insights/references/investigation-playbook-guide.md
+++ b/skills/uipath-insights/references/investigation-playbook-guide.md
@@ -107,7 +107,7 @@ User asks about a specific Orchestrator folder.
 
 ```bash
 # Step 1: Find the folder key. Two sources return the same GUID:
-# Insights-active folders (last 30 days): GUID is the folderKey field
+# Insights-active folders (last 30 days): GUID is the FolderKey field
 uip insights filter-folders list --output json
 # Fallback, full folder inventory (requires uipath-platform): GUID is the Key field
 uip or folders list --output json

--- a/skills/uipath-insights/references/investigation-playbook-guide.md
+++ b/skills/uipath-insights/references/investigation-playbook-guide.md
@@ -106,9 +106,12 @@ uip insights jobs summary \
 User asks about a specific Orchestrator folder.
 
 ```bash
-# Step 1: Find the folder key (requires uipath-platform)
+# Step 1: Find the folder key — Insights-active folders first
+uip insights filter-folders list --output json
+# Look for the folder's FolderKey in the output.
+# Fallback for folders without recent activity (requires uipath-platform):
 uip or folders list --output json
-# Look for the folder's Key (GUID) in the output
+# There the GUID is the folder's Key field (not FolderKey)
 
 # Step 2: Query insights with folder filter
 uip insights jobs summary --time-range 1440 \
@@ -141,5 +144,5 @@ This means:
 | User wants to start/stop/restart a specific job | `uipath-platform` (`uip or jobs start`) |
 | User wants to read the logs of a failed job | `uipath-platform` (`uip or jobs logs`) |
 | User wants to debug why a specific job error happened | `uipath-troubleshoot` |
-| User wants to find a folder key to filter by | `uipath-platform` (`uip or folders list`) |
+| User wants to find a folder key to filter by | `uip insights filter-folders list` (Insights-active folders), or `uipath-platform` (`uip or folders list`) for the full folder inventory |
 | User wants to fix the code that's causing failures | `uipath-rpa` or `uipath-agents` |

--- a/tests/tasks/activation/uipath-insights.jsonl
+++ b/tests/tasks/activation/uipath-insights.jsonl
@@ -23,3 +23,7 @@
 {"id": "uipath-insights-023", "prompt": "What's the job timeline looking like for completed runs?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-024", "prompt": "Show me insights on automation health across all folders", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-025", "prompt": "Show me job metrics grouped by folder across all tenants", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-026", "prompt": "Which folders have had automation activity recently?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-027", "prompt": "Find the folder key for the Finance folder in Insights.", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-028", "prompt": "Which machines show recent job activity in Insights?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-029", "prompt": "Show me which queues have been active recently.", "expected_skill": "uipath-insights"}

--- a/tests/tasks/uipath-insights/filters/smoke.yaml
+++ b/tests/tasks/uipath-insights/filters/smoke.yaml
@@ -76,12 +76,16 @@ success_criteria:
   - type: command_not_executed
     description: "Agent did not pass time flags to filter commands"
     tool_name: "Bash"
-    # (?:[^&;|\n]|\\\n)* instead of .* : the grader compiles patterns with
-    # re.DOTALL, so .* would bleed across command separators and false-fail a
-    # batched call like `filter-folders list ... && jobs summary --time-range ...`.
-    # The \\\n alternative still matches backslash-newline continuations, the
-    # style the SKILL.md examples use, so a continued invocation can't slip past.
-    command_pattern: 'uip\s+insights\s+filter-\S+\s+list(?:[^&;|\n]|\\\n)*--(time-range|started-after|started-before)'
+    # Not .* : the grader compiles patterns with re.DOTALL, so .* would bleed
+    # across command separators and false-fail a batched call like
+    # `filter-folders list ... && jobs summary --time-range ...`. Excluding
+    # & ; | is not enough on its own, because the grader also matches a
+    # shlex-normalized haystack where newlines collapse to spaces
+    # (coder_eval/criteria/command_executed.py, _normalize_shell), so a
+    # newline-separated batch survives a [^&;|\n] class. The `uip` lookahead
+    # stops the scan at the next invocation, which is what holds on the
+    # normalized haystack. Same construct as the alerts and rbac smoke tasks.
+    command_pattern: 'uip\s+insights\s+filter-\S+\s+list(?:(?!uip\s)[^&;|])*--(time-range|started-after|started-before)'
     max_count: 0
     weight: 1.5
     pass_threshold: 1.0
@@ -89,7 +93,10 @@ success_criteria:
   - type: command_executed
     description: "Advisory: agent used --output json on discovery commands"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+filter-\S+\s+list\s+.*--output\s+json'
+    # Same non-bleeding construct as the negative criterion above: a bare .*
+    # under re.DOTALL would credit an --output json belonging to a different
+    # chained command. [\s=] accepts the --output=json spelling.
+    command_pattern: 'uip\s+insights\s+filter-\S+\s+list(?:(?!uip\s)[^&;|])*--output[\s=]+json'
     min_count: 2
     weight: 1.0
     pass_threshold: 0

--- a/tests/tasks/uipath-insights/filters/smoke.yaml
+++ b/tests/tasks/uipath-insights/filters/smoke.yaml
@@ -1,0 +1,81 @@
+task_id: skill-insights-smoke-filter-discovery
+description: >
+  Smoke test: agent uses the uipath-insights skill to discover valid
+  scope candidates before acting. Given a prompt about finding folders,
+  processes, queues, and machines to scope an investigation, the agent
+  should run all four filter discovery commands instead of guessing
+  identifiers, and treat an empty result as normal rather than an
+  error. The CLI is authenticated; the tenant may or may not have
+  recent activity, and both are valid outcomes.
+tags: [uipath-insights, smoke, mode:build, lifecycle:discover]
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  I want to set up monitoring scoped to whatever we actually run. Find
+  out which folders, processes, queues, and machines have had Insights
+  activity recently, and give me their names plus the exact keys the
+  commands return alongside them, so I can pick a scope. If nothing shows up in
+  a category, say so and move on. If the output says more rows exist,
+  page through them before you summarize. Run each discovery command at
+  most once per page; do not retry failures.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected_skill: "uipath-insights"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran filter-folders list to discover folders"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+filter-folders\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran filter-processes list to discover processes"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+filter-processes\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran filter-queues list to discover queues"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+filter-queues\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran filter-machines list to discover machines"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+filter-machines\s+list'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not pass time flags to filter commands"
+    tool_name: "Bash"
+    # [^&;|\n]* instead of .* : the grader compiles patterns with re.DOTALL,
+    # so .* would bleed across command separators and false-fail a batched
+    # call like `filter-folders list ... && jobs summary --time-range ...`
+    command_pattern: 'uip\s+insights\s+filter-\S+\s+list[^&;|\n]*--(time-range|started-after|started-before)'
+    max_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Advisory: agent used --output json on discovery commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+filter-\S+\s+list\s+.*--output\s+json'
+    min_count: 2
+    weight: 1.0
+    pass_threshold: 0

--- a/tests/tasks/uipath-insights/filters/smoke.yaml
+++ b/tests/tasks/uipath-insights/filters/smoke.yaml
@@ -7,7 +7,7 @@ description: >
   identifiers, and treat an empty result as normal rather than an
   error. The CLI is authenticated; the tenant may or may not have
   recent activity, and both are valid outcomes.
-tags: [uipath-insights, smoke, mode:build, lifecycle:discover]
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
 
 run_limits:
   expected_turns: 10
@@ -61,13 +61,27 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # command_executed only greps the command string, so the four criteria above
+  # pass even when the verbs don't exist in the installed CLI. This gate
+  # re-runs one discovery command at grading time and requires exit 0, so the
+  # task can only pass against a CLI that actually ships filter-*.
+  - type: run_command
+    description: "CLI path is real: filter-folders list exits 0 against the live tenant"
+    command: "uip insights filter-folders list --output json"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
   - type: command_not_executed
     description: "Agent did not pass time flags to filter commands"
     tool_name: "Bash"
-    # [^&;|\n]* instead of .* : the grader compiles patterns with re.DOTALL,
-    # so .* would bleed across command separators and false-fail a batched
-    # call like `filter-folders list ... && jobs summary --time-range ...`
-    command_pattern: 'uip\s+insights\s+filter-\S+\s+list[^&;|\n]*--(time-range|started-after|started-before)'
+    # (?:[^&;|\n]|\\\n)* instead of .* : the grader compiles patterns with
+    # re.DOTALL, so .* would bleed across command separators and false-fail a
+    # batched call like `filter-folders list ... && jobs summary --time-range ...`.
+    # The \\\n alternative still matches backslash-newline continuations, the
+    # style the SKILL.md examples use, so a continued invocation can't slip past.
+    command_pattern: 'uip\s+insights\s+filter-\S+\s+list(?:[^&;|\n]|\\\n)*--(time-range|started-after|started-before)'
     max_count: 0
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-insights/smoke_critical_rules.yaml
+++ b/tests/tasks/uipath-insights/smoke_critical_rules.yaml
@@ -41,16 +41,21 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
+  # Negative patterns use [^&;|\n]* and \b, not .* : the grader compiles with
+  # re.DOTALL, so .* bleeds across command separators (a legitimate insights
+  # call batched with an out-of-scope command would false-fail), bare `start`
+  # matches --started-after, and bare `queue` matches the now-taught
+  # filter-queues discovery command.
   - type: command_not_executed
     description: "Agent did NOT run uip insights for starting a job (out of scope)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights.*start|uip\s+insights.*Invoice_Processing'
+    command_pattern: 'uip\s+insights[^&;|\n]*\bstart\b|uip\s+insights[^&;|\n]*Invoice_Processing'
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_not_executed
-    description: "Agent did NOT run uip insights for queue metrics (not supported)"
+    description: "Agent did NOT run uip insights jobs for queue metrics (not supported)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights.*queue'
+    command_pattern: 'uip\s+insights\s+jobs[^&;|\n]*queue'
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
Related to [IN-13523](https://uipath.atlassian.net/browse/IN-13523).

### What

Teaches the four filter discovery command groups landing in [UiPath/cli#3449](https://github.com/UiPath/cli/pull/3449): `filter-folders`, `filter-processes`, `filter-queues`, `filter-machines`, each with a `list` subcommand. `SKILL.md` gets filter hooks in `description`/`when_to_use`, a Filter Discovery Commands section (four rules: no time flags, client-side `--limit`/`--offset`, empty is not proof of absence, results are permission-bounded) and a discover-before-you-act workflow; Critical Rule 1 is scoped to `jobs` commands only. `references/investigation-playbook-guide.md` routes folder-key lookups through `filter-folders list` first, with `uip or folders list` as the fallback. Adds `tests/tasks/uipath-insights/filters/smoke.yaml` and activation rows 026-029. The five jobs smoke tasks, the e2e tasks from #2551, and `BASELINES_PCT` are untouched.

### Why

The commands ship in [UiPath/cli#3449](https://github.com/UiPath/cli/pull/3449) (review approved, merge pending). Without skill guidance, agents guess folder keys or pass `--time-range` to commands that reject it; the discovery workflow makes them page through results before concluding a resource is absent. The backend applies a fixed 30-day activity window, which is why the skill frames empty results as "no recent activity", not "does not exist".

### Scope

Skill content, one smoke task, four activation positives. E2e-depth coverage for these commands lives in the cli repo (`scenarios/insights-tool/filter-discovery.md` S1-S8 and `filter-discovery.e2e.test.ts`, both on cli#3449); this skill already has its e2e slice in #2551. The activation baseline (`BASELINES_PCT`) is deliberately not edited here; re-measuring recall with the new rows is the follow-up once a baseline entry exists for this skill.

### Testing

- `scripts/check-cli-verbs.py` and `scripts/check-task-driver.py` both pass on the new smoke task, run 2026-08-10.
- The skill stays inside its size budgets. The frontmatter description is 492 characters against the 1024 cap. Description plus when_to_use is 1242 characters, and Claude Code truncates at 1536. SKILL.md is 316 lines, about 3.8k tokens against the 5k budget.
- The smoke task itself has not been run. It cannot pass yet; see Limitations.

### Limitations

`skill-insights-smoke-filter-discovery` has no passing run yet, and cannot have one: the four commands exist only on cli#3449, and the PR smoke gate installs `@uipath/cli@dev`, which picks them up only when that PR merges to `cli/main`. The 2026-08-06 catalog snapshot (`1.200.0-dev.8116`) carries 0 filter verbs, consistent with that. A real passing-run claim will be added to this PR once the commands are on `cli/main`; this PR should not merge before that run exists.

Activation recall is not re-measured. The activation gate skips `uipath-insights` until a `BASELINES_PCT` entry exists, so rows 026-029 are inert for gating until the baseline lands.

### How to Review

The Filter Discovery Commands section in `SKILL.md` carries the weight, especially the no-time-flags rule and the empty-is-not-absence rule, which are the two mistakes agents actually make with these commands. The playbook edits are routing, and the smoke YAML is a criteria list.

### Checklist

- [x] Tests added/updated for new logic — the filters smoke task; run evidence pending cli#3449 merge, see Limitations
- [x] No secrets or credentials in code
- [x] Commits follow conventional format
- [x] PR ≤ 400 lines

### CI note

The smoke gate (`smoke-skills.yml`) will fail this PR's filters task until cli#3449 merges, since the `@uipath/cli@dev` install cannot have the commands before then. The `lint-tasks.yml` advisory may also flag the missing passing-run claim; both resolve with the post-merge run described in Limitations.


[IN-13523]: https://uipath.atlassian.net/browse/IN-13523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ