### PR TITLE
test(hitl): stop gating validate checks on the literal --output json flag

### DIFF
--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -69,7 +69,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_01_invoice_approval_greenfield.yaml
@@ -69,7 +69,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -59,7 +59,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_02_ai_escalation_brownfield.yaml
@@ -59,7 +59,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_03_gdpr_compliance_greenfield.yaml
@@ -61,7 +61,7 @@ success_criteria:
   - type: command_executed
     description: "Agent ran flow validate during the session"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow after all changes"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_04_multi_hitl_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow after all changes"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_05_expense_approval_brownfield.yaml
@@ -72,7 +72,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -60,7 +60,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_06_invoice_approval_greenfield_simple.yaml
@@ -60,7 +60,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/e2e_07_apptask_brownfield.yaml
@@ -64,7 +64,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated after wiring"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_04_all_handles.yaml
@@ -43,7 +43,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated after wiring"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
@@ -38,7 +38,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_05_priority_and_timeout.yaml
@@ -38,7 +38,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -34,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
+++ b/tests/tasks/uipath-human-in-the-loop/quality_07_runtime_vars.yaml
@@ -34,7 +34,7 @@ success_criteria:
   - type: command_executed
     description: "Agent validated the flow"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
+    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate\s+(?!.*--help\b)\S+'
     min_count: 1
     weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

Ten `command_executed` criteria in the uipath-human-in-the-loop suite gate "Agent validated the flow" on the pattern `(uip|\$UIP)\s+(maestro\s+)?flow\s+validate.*--output\s+json`. The `--output json` flag is outcome-invisible, so the pattern docks agents that reach the same validated result without typing the flag — `.claude/rules/test-writing.md` forbids exactly this gate ("Never add a gating command_executed check on `--output json`"). Observed in the wild: the #2534 verification run (antigravity) scored `Matched 0/1` on this criterion.

Related cases already fixed on main: `flow-solution-select-ask` no longer gates on the Claude-Code-only `AskUserQuestion` tool, and the `evaluate/*` flow tasks dropped their `--output json` gates — this PR closes out the last evidence-backed instances in the flow/hitl suites.

## Fix

Drop `.*--output\s+json` from the gating pattern in all 10 YAMLs; the criterion still gates on the behavior (`flow validate` executed). One line per file, no weights or thresholds changed.

## Out of scope (for owners)

`uipath-test` (10 criteria) and `uipath-coded-apps` (4 criteria) embed `--output json` in their gating command patterns too. Left untouched — different CODEOWNERS; flagging for those owners to decide.

## Verification

`run-coder-eval.yml` from this branch on `quality_04_all_handles`, `quality_07_runtime_vars`, `e2e_06_invoice_approval_greenfield_simple` across claude / codex / antigravity — links to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
