### PR TITLE
test(maestro-case): harden checkers and a few tests

### DIFF
--- a/tests/tasks/uipath-maestro-case/_shared/case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/case_check.py
@@ -22,7 +22,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, NoReturn, Sequence
 
 
 def find_caseplan(pattern: str = "**/caseplan.json") -> str:
@@ -102,7 +102,7 @@ def find_tasks_of_type(plan: dict, task_type: str) -> list[dict]:
 
 def assert_validate_passes(caseplan_path: str, *, timeout: int = 60) -> None:
     cmd = ["uip", "maestro", "case", "validate", caseplan_path, "--output", "json"]
-    r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    r = _run(cmd, timeout=timeout, what="uip maestro case validate")
     if r.returncode != 0:
         _fail(
             f"uip maestro case validate exit {r.returncode}\n"
@@ -362,8 +362,26 @@ def _stringify(v: Any) -> str:
     return json.dumps(v, default=str)
 
 
-def _fail(msg: str):
+def _fail(msg: str) -> NoReturn:
     sys.exit(f"FAIL: {msg}")
+
+
+def _run(cmd: Sequence[str], *, timeout: int, what: str) -> subprocess.CompletedProcess[str]:
+    """``subprocess.run`` that reports a timeout as a FAIL, not a traceback.
+
+    ``TimeoutExpired`` carries partial output as bytes even under ``text=True``,
+    so decode defensively.
+    """
+    try:
+        return subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout, check=False
+        )
+    except subprocess.TimeoutExpired as e:
+        out, err = (
+            s.decode("utf-8", "replace") if isinstance(s, bytes) else (s or "")
+            for s in (e.stdout, e.stderr)
+        )
+        _fail(f"{what} timed out after {timeout}s\nstdout: {out}\nstderr: {err}")
 
 
 def _get_ci(mapping: Any, *candidate_keys: str, default: Any = None) -> Any:
@@ -491,7 +509,7 @@ def start_debug(
         "--output", "json",
     ]
     already_refreshed = os.path.isdir(os.path.join(solution_dir, "resources"))
-    r = subprocess.run(refresh_cmd, capture_output=True, text=True, timeout=refresh_timeout)
+    r = _run(refresh_cmd, timeout=refresh_timeout, what="uip solution resources refresh")
     if r.returncode != 0:
         # CLI 1.197-alpha: refresh is not idempotent — re-running it over its own
         # output fails with "Node already added to the graph" (RetryWillNotFix).
@@ -508,7 +526,7 @@ def start_debug(
         "uip", "maestro", "case", "debug", project_dir,
         "--log-level", "debug", "--output", "json",
     ]
-    r = subprocess.run(debug_cmd, capture_output=True, text=True, timeout=timeout)
+    r = _run(debug_cmd, timeout=timeout, what="uip maestro case debug")
     if r.returncode != 0:
         _fail(
             f"case debug exit {r.returncode}\nstdout: {r.stdout}\nstderr: {r.stderr}"

--- a/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_case_check.py
@@ -10,6 +10,7 @@ opt-out). A checker must not depend on which CLI build the eval image runs.
 """
 
 import os
+import subprocess
 import sys
 
 import pytest
@@ -114,3 +115,21 @@ def test_run_debug_gate_still_rejects_incomplete(monkeypatch):
     monkeypatch.setattr(case_check, "start_debug", lambda **kw: {"FinalStatus": "Faulted"})
     with pytest.raises(SystemExit, match="Case did not complete"):
         run_debug()
+
+
+def test_timeout_reports_fail_not_traceback(monkeypatch):
+    """A CLI that outruns its timeout must exit FAIL, with the partial output.
+
+    ``TimeoutExpired`` carries bytes even under ``text=True`` on POSIX, so the
+    handler has to decode before formatting.
+    """
+    def timing_out(cmd, **kw):
+        raise subprocess.TimeoutExpired(cmd, kw["timeout"], output=b"half a payload\xff")
+
+    monkeypatch.setattr(case_check.subprocess, "run", timing_out)
+    with pytest.raises(SystemExit) as excinfo:
+        case_check.assert_validate_passes("caseplan.json", timeout=7)
+
+    msg = str(excinfo.value)
+    assert "uip maestro case validate timed out after 7s" in msg
+    assert "half a payload" in msg

--- a/tests/tasks/uipath-maestro-case/athena_cm_event/check_athena_cm_event_plan.py
+++ b/tests/tasks/uipath-maestro-case/athena_cm_event/check_athena_cm_event_plan.py
@@ -51,7 +51,7 @@ def task_section(plan: str, task_name: str) -> str:
 
 def field(section: str, name: str, task_name: str) -> str:
     match = re.search(
-        rf"(?im)^-\s*(?:\*\*)?{re.escape(name)}:(?:\*\*)?\s*"
+        rf"(?im)^(?:-\s*)?(?:\*\*)?{re.escape(name)}:(?:\*\*)?\s*"
         rf"`?([a-z][a-z0-9-]*)(?:\([^\n)]*\))?`?\s*$",
         section,
     )

--- a/tests/tasks/uipath-maestro-case/athena_cm_event/test_checkers.py
+++ b/tests/tasks/uipath-maestro-case/athena_cm_event/test_checkers.py
@@ -207,7 +207,12 @@ closes on required-stages-completed.
         caseplan.parent.mkdir(parents=True)
         caseplan.write_text(json.dumps(plan), encoding="utf-8")
 
-    def write_tasks_md(self, *, rewrite_a2_as_sequential: bool = False) -> None:
+    def write_tasks_md(
+        self,
+        *,
+        rewrite_a2_as_sequential: bool = False,
+        bullet_prefix: bool = True,
+    ) -> None:
         contracts = {
             "StageATask1": ("parallel", "current-stage-entered", None),
             "StageATask2": (
@@ -222,12 +227,13 @@ closes on required-stages-completed.
             "StageCTask3": ("conditional-gate", "selected-tasks-completed", "StageCTask2"),
         }
         sections = []
+        prefix = "- " if bullet_prefix else ""
         for index, (task_name, (mode, rule, selected)) in enumerate(contracts.items(), 1):
             rendered_rule = f'{rule}("{selected}")' if selected else rule
             sections.append(
                 f'## T{index}: Add process task "{task_name}" to "Stage"\n\n'
-                f"- activation-mode: {mode}\n"
-                f"- entry-rule: {rendered_rule}\n"
+                f"{prefix}activation-mode: {mode}\n"
+                f"{prefix}entry-rule: {rendered_rule}\n"
             )
         tasks = self.workdir / "tasks" / "tasks.md"
         tasks.parent.mkdir()
@@ -245,6 +251,11 @@ closes on required-stages-completed.
 
     def test_plan_checker_accepts_authored_task_entry_rules(self) -> None:
         self.write_tasks_md()
+        result = run(PLAN_CHECK, self.workdir)
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_plan_checker_accepts_plain_task_entry_fields(self) -> None:
+        self.write_tasks_md(bullet_prefix=False)
         result = run(PLAN_CHECK, self.workdir)
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 

--- a/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
+++ b/tests/tasks/uipath-maestro-case/single_node/process/process.yaml
@@ -6,7 +6,7 @@ description: >
   `type: "process"` task. Validates the resulting case file and runs
   `uip maestro case debug` end-to-end, asserting only that the case
   finalStatus is `Completed`.
-tags: [uipath-maestro-case, e2e, lifecycle:generate, shape:single-node, feature:registry]
+tags: [uipath-maestro-case, e2e, mode:build, lifecycle:generate, shape:single-node, feature:registry]
 max_iterations: 1
 
 run_limits:
@@ -95,6 +95,11 @@ initial_prompt: |
   debug` yourself — the test harness runs it. Do NOT ask for approval,
   confirmation, or feedback. Build end-to-end in a single pass and finish
   with `uip maestro case validate` passing on the resulting caseplan.json.
+
+  Resolve `ProcurementProcess` from `processOrchestration-index.json`; this
+  fixture contains the exact entry there. Use `process-index.json` only as a
+  fallback, and do not write a placeholder — use the resolved `entityKey` as
+  the task's `taskTypeId`.
 
 success_criteria:
   - type: run_command


### PR DESCRIPTION
test(maestro-case): harden checkers and close the operate-mode coverage gap

Checker robustness:
- case_check.py routes every CLI call through a _run helper that turns a
  TimeoutExpired into a FAIL with the partial output, instead of a raw
  traceback the eval harness reports as a checker crash. TimeoutExpired
  carries bytes even under text=True, so the handler decodes defensively.
- The athena_cm_event plan checker now accepts task entry fields written
  without a leading "- " bullet; agents render the contract both ways and
  the line-anchored regex was rejecting the plain form.

Both are covered by new unit tests.

Task fixes:
- single_node/process gains the missing mode:build tag and a prompt hint
  that ProcurementProcess resolves from processOrchestration-index.json,
  the recurring cause of a placeholder taskTypeId.

