### PR TITLE
Extend uipath-tasks skill: catalogs, comments, labels, metadata, data

### DIFF
--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: uipath-tasks
-description: "UiPath Action Center human-in-the-loop tasks via `uip tasks` — list, assign, complete approval/validation tasks. For authoring HITL nodes in flows/agents→uipath-human-in-the-loop. For Orchestrator→uipath-platform, codedapp→uipath-coded-apps. Skip Document Understanding."
+description: "UiPath Action Center human-in-the-loop tasks via `uip tasks`: list, assign, complete, plus task catalogs, comments, labels, metadata, and task data (get/save). For authoring HITL nodes in flows/agents→uipath-human-in-the-loop. For Orchestrator→uipath-platform, codedapp→uipath-coded-apps. Skip Document Understanding."
 when_to_use: "User says 'approve task', 'pending approval', 'pending action item', 'review action', 'list my tasks', 'reassign task' in an Orchestrator/Action Center context. NOT for TaskCreate/TaskUpdate (general session-task tracking) or Document Understanding validation."
 user-invocable: true
 ---
@@ -54,6 +54,11 @@ uip login tenant set MyTenant
 - Assigning, reassigning, or unassigning tasks to users
 - Completing tasks with action outcomes and data payloads
 - Querying which users have task permissions in a folder
+- Managing task catalogs (list, get, create, update) and their retention policy
+- Reading and adding task comments
+- Setting task labels
+- Editing task metadata (title, priority, catalog association)
+- Getting and saving task data
 
 > **Not in scope:** Orchestrator queues or queue items (use `uip or`), Document Understanding model training, or Action Center app development (use `uip codedapp`).
 
@@ -131,6 +136,14 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 
 8. **Do not complete already-completed tasks.** Check the task `status` field — if it is `Completed`, inform the user.
 
+9. **Folder ID for catalogs/comments/labels/metadata/data.** These commands are folder-scoped. Pass `--folder-id`, or omit it on an interactive terminal to pick from a list. It is required in non-interactive runs (agents, CI) — always pass it explicitly there.
+
+10. **Retention actions are `Delete` or `Archive`.** `Archive` also needs `--retention-bucket-id`. `--encrypted` is create-only and cannot be changed on update.
+
+11. **Labels replace the full set.** `tasks labels --labels` overwrites all labels on the task — include every label to keep, and pass `[]` to clear them all.
+
+12. **`data save` takes no type flag.** The command resolves the task type itself; pass the task ID, `--folder-id`, and `--data` (a JSON object).
+
 ---
 
 ## Task Navigation
@@ -149,6 +162,16 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 | Complete a task | `tasks complete <task-id> --type <type> --folder-id <id>` |
 | Complete with action | `tasks complete <task-id> --type FormTask --folder-id <id> --action "Approve" --data '{...}'` |
 | List assignable users | `tasks users <folder-id>` |
+| List task catalogs | `tasks catalogs list --folder-id <id>` |
+| Get a catalog | `tasks catalogs get <catalog-id> --folder-id <id>` |
+| Create a catalog | `tasks catalogs create --name <name> --folder-id <id>` |
+| Update a catalog | `tasks catalogs update <catalog-id> --folder-id <id>` |
+| List task comments | `tasks comments list <task-id> --folder-id <id>` |
+| Add a comment | `tasks comments add <task-id> --text <text> --folder-id <id>` |
+| Set task labels | `tasks labels <task-id> --labels '[{"name":"urgent"}]' --folder-id <id>` |
+| Edit task metadata | `tasks metadata <task-id> --folder-id <id> [--title --priority --catalog-id]` |
+| Get task data | `tasks data get <task-id> --folder-id <id>` |
+| Save task data | `tasks data save <task-id> --data '{...}' --folder-id <id>` |
 
 ---
 
@@ -203,4 +226,7 @@ For deeper guidance, read these files only when needed:
 - `references/task-lifecycle.md` — Listing and getting tasks, type-hint endpoint routing, and the full discover→assign→complete workflow
 - `references/task-completion.md` — Completion endpoint routing, required fields per task type
 - `references/task-assignment.md` — Assign, reassign, unassign patterns and user discovery
+- `references/task-catalogs.md` — Task catalog list/get/create/update and retention policy
+- `references/task-metadata.md` — Editing task metadata, plus task comments and labels
+- `references/task-data.md` — Getting and saving task data, and save type routing
 - `references/action-center-urls.md` — Canonical Action Center URL patterns; **read this before constructing or sharing any task deep-link** (the portal-UI misclassifies tenant-less URLs as "Orchestrator not enabled")

--- a/skills/uipath-tasks/references/task-catalogs.md
+++ b/skills/uipath-tasks/references/task-catalogs.md
@@ -1,0 +1,73 @@
+# Task Catalogs Reference
+
+Task catalogs group tasks and define their retention policy. Folder-scoped: a
+catalog created in one folder is invisible from another. Catalog IDs are numeric.
+
+## Folder scoping
+
+Every catalog command is folder-scoped. Pass `--folder-id <id>`, or omit it on an
+interactive terminal to pick a folder from a list. `--folder-id` is required when
+stdout is not a TTY (coding agents, CI) — pass it explicitly there.
+
+## List
+
+```bash
+# List catalogs in a folder (fetches all pages if --limit omitted)
+uip tasks catalogs list --folder-id <folder-id> --output json
+
+# Cap the number returned
+uip tasks catalogs list --folder-id <folder-id> --limit 20 --output json
+```
+
+Success `Code: TaskCatalogList`, `Data` is an array.
+
+## Get
+
+```bash
+uip tasks catalogs get <catalog-id> --folder-id <folder-id> --output json
+```
+
+Success `Code: TaskCatalogDetails`.
+
+## Create
+
+`--name` is required. `--encrypted` is create-only (the API forbids changing
+encryption after creation).
+
+```bash
+uip tasks catalogs create \
+  --name "Invoices" \
+  --folder-id <folder-id> \
+  --description "Invoice approvals" \
+  --retention-action Delete \
+  --retention-period 90 \
+  --output json
+```
+
+Success `Code: TaskCatalogCreated`.
+
+## Update
+
+Read-modify-write: any field not passed keeps its current value. `--name` is
+optional on update. `--encrypted` is not offered (immutable).
+
+```bash
+uip tasks catalogs update <catalog-id> \
+  --folder-id <folder-id> \
+  --name "Invoices 2026" \
+  --retention-period 120 \
+  --output json
+```
+
+Success `Code: TaskCatalogUpdated`.
+
+## Retention
+
+| Flag | Values | Notes |
+|------|--------|-------|
+| `--retention-action` | `Delete`, `Archive` | The two accepted retention actions |
+| `--retention-period` | days (positive integer) | Days before the action fires |
+| `--retention-bucket-id` | numeric | Storage bucket ID — required when the action is `Archive` |
+
+> `Archive` moves tasks into a storage bucket at the retention limit, so it needs
+> a `--retention-bucket-id`. `Delete` needs no bucket.

--- a/skills/uipath-tasks/references/task-data.md
+++ b/skills/uipath-tasks/references/task-data.md
@@ -1,0 +1,38 @@
+# Task Data Reference
+
+Task data is the business/form field payload attached to a task (e.g. the values
+an approver reviews). Folder-scoped: pass `--folder-id <id>`, or omit it on an
+interactive terminal to pick a folder (required when stdout is not a TTY). Task
+IDs are numeric.
+
+## Get data
+
+```bash
+uip tasks data get <task-id> --folder-id <folder-id> --output json
+```
+
+Success `Code: TaskData`, `Data` holds the task's field values.
+
+## Save data
+
+`--data` is required and must be a JSON object.
+
+```bash
+uip tasks data save <task-id> \
+  --folder-id <folder-id> \
+  --data '{"amount":1200,"approved":true}' \
+  --output json
+```
+
+Success `Code: TaskDataSaved`.
+
+## Type routing
+
+Save routes to a type-specific endpoint: App tasks, Form tasks, and generic
+tasks each save through a different Orchestrator path. The command resolves the
+task type for you (it looks the task up when the type is not already known), so
+you do not pass a type flag — just the task ID, folder, and `--data`.
+
+> Save only fields the task's schema accepts. Saving unknown fields, or saving to
+> a completed task, fails — get the task first (`tasks data get <task-id>`) to see the
+> current shape.

--- a/skills/uipath-tasks/references/task-metadata.md
+++ b/skills/uipath-tasks/references/task-metadata.md
@@ -1,0 +1,69 @@
+# Task Metadata, Comments & Labels Reference
+
+Operations that annotate or reorganize an existing task. All are folder-scoped:
+pass `--folder-id <id>`, or omit it on an interactive terminal to pick a folder
+(required when stdout is not a TTY). Task IDs are numeric.
+
+## Edit metadata
+
+Change a task's title, priority, or catalog association. Pass only the fields to
+change; unspecified fields keep their current value.
+
+```bash
+# Retitle and raise priority
+uip tasks metadata <task-id> \
+  --folder-id <folder-id> \
+  --title "Urgent: invoice review" \
+  --priority High \
+  --output json
+
+# Associate the task with a catalog
+uip tasks metadata <task-id> --folder-id <folder-id> --catalog-id <catalog-id> --output json
+
+# Remove the catalog association
+uip tasks metadata <task-id> --folder-id <folder-id> --unset-catalog --output json
+```
+
+| Flag | Values |
+|------|--------|
+| `--title <text>` | New title |
+| `--priority <p>` | `Low`, `Medium`, `High`, `Critical` |
+| `--catalog-id <id>` | Associate a catalog (numeric ID) |
+| `--unset-catalog` | Remove the catalog association |
+| `--note <text>` | Comment recorded with the edit |
+
+`--catalog-id` and `--unset-catalog` are opposites — do not pass both. Success
+`Code: TaskMetadataEdited`.
+
+## Comments
+
+Comments are append-only, folder-scoped commentary on a task.
+
+```bash
+# List comments on a task
+uip tasks comments list <task-id> --folder-id <folder-id> --output json
+
+# Cap the number returned
+uip tasks comments list <task-id> --folder-id <folder-id> --limit 50 --output json
+
+# Add a comment (--text required)
+uip tasks comments add <task-id> --folder-id <folder-id> --text "Escalated to finance" --output json
+```
+
+List → `Code: TaskCommentList` (array). Add → `Code: TaskCommentCreated`.
+
+## Labels
+
+Labels are name/value pairs on a task. `--labels` takes a JSON array and is
+required. Saving **replaces** the full label set — pass every label you want to
+keep. Use `[]` to clear all labels.
+
+```bash
+# Set labels
+uip tasks labels <task-id> --folder-id <folder-id> --labels '[{"name":"urgent"}]' --output json
+
+# Clear all labels
+uip tasks labels <task-id> --folder-id <folder-id> --labels '[]' --output json
+```
+
+Success `Code: TaskLabelsSaved`.

--- a/tests/tasks/uipath-tasks/e2e_catalogs_and_annotations.yaml
+++ b/tests/tasks/uipath-tasks/e2e_catalogs_and_annotations.yaml
@@ -1,0 +1,157 @@
+task_id: skill-tasks-e2e-catalogs-annotations
+description: >
+  E2E write test: agent uses the uipath-tasks skill to run the new command
+  areas against a live Action Center tenant — a self-contained task catalog
+  lifecycle (list, create with a retention policy, get, update) and, when a task
+  is discovered, its annotation commands (get/save data, list/add comment, set
+  labels, edit metadata). Discovers its own folder and task from `tasks list`;
+  conditional steps are skipped cleanly when the tenant has no tasks. Exercises
+  the real Orchestrator endpoints, not fake IDs.
+tags: [uipath-tasks, e2e, mode:operate, lifecycle:setup, catalogs, annotations]
+
+run_limits:
+  expected_turns: 30
+  max_turns: 40
+
+initial_prompt: |
+  Exercise the Action Center task catalog and annotation commands against the
+  live tenant using the uipath-tasks skill. Produce JSON output, and target an
+  explicit folder on every command (this is a non-interactive run, so a folder
+  cannot be picked interactively). Task and catalog IDs are numeric.
+
+  Steps (run in order):
+
+  1. Confirm you are logged in and note the active organization and tenant. Do
+     not re-login — use the active session as-is.
+
+  2. Discover a folder to work in: list the tasks and take the folder of the
+     first task returned. Record it as FOLDER, and record that task's id as TASK
+     and its type. If no task is returned, list tasks as an admin and use a
+     folder from there. If you still cannot determine a folder, stop here.
+
+  3. Exercise the task catalog lifecycle in FOLDER:
+       a. List the catalogs in the folder.
+       b. Create a catalog with a short unique name, a Delete retention action,
+          and a 30-day retention period. Record the new catalog id as CATALOG.
+       c. Read that catalog back by its id.
+       d. Update the catalog's description.
+
+  4. Only if a TASK was discovered in step 2, annotate it in FOLDER (these are
+     safe, non-completing writes):
+       a. Read the task's data.
+       b. List the task's comments, then add a new comment to it.
+       c. Set a label on the task.
+       d. Record an edit note on the task's metadata.
+       e. Save a small JSON data payload to the task.
+       f. Associate the task with the CATALOG created in step 3, then remove
+          that association.
+
+  Rules:
+  - Do NOT ask for approval or pause between steps.
+  - Do NOT re-login. Use the active session as-is.
+  - Do NOT complete, assign, reassign, or unassign the task.
+  - Retention actions are only Delete or Archive.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent verified login status first"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+login\s+status'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed tasks to discover a folder"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+list'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed task catalogs in the folder"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+list\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created a catalog with a Delete retention policy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+create\s+.*--name\s+.*--retention-action\s+Delete'
+    min_count: 0
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent got the created catalog by ID"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+get\s+\d+\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated the catalog"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+update\s+\d+\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent read task data (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+data\s+get\s+\d+\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent saved task data (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+data\s+save\s+\d+\s+.*--data\s+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent listed comments (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+comments\s+list\s+\d+\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent edited metadata (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+metadata\s+\d+\s+.*--folder-id\s+\d+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a comment (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+comments\s+add\s+\d+\s+.*--text\s+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent set labels (when a task was discovered)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+labels\s+\d+\s+.*--labels\s+'
+    min_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not complete or reassign the task"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+(complete|assign|reassign|unassign)\s'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-tasks/smoke_catalogs.yaml
+++ b/tests/tasks/uipath-tasks/smoke_catalogs.yaml
@@ -1,0 +1,72 @@
+task_id: skill-tasks-smoke-catalogs
+description: >
+  Smoke test: agent uses the uipath-tasks skill to run the task catalog
+  commands offline — list catalogs in a folder, get a catalog by ID, create a
+  catalog with a retention policy, and update a catalog. Tests correct CLI verbs
+  and flags (--folder-id, --name, --retention-action Delete|Archive), and that
+  --output json is applied. Runs against fake IDs — auth errors are expected.
+tags: [uipath-tasks, smoke, mode:operate, lifecycle:setup, catalogs]
+
+run_limits:
+  expected_turns: 10
+  max_turns: 16
+
+initial_prompt: |
+  You are managing UiPath Action Center task catalogs. Perform each step in
+  order. Use --output json on every uip tasks command, and pass --folder-id 123
+  on every command (this is a non-interactive run, so the folder cannot be
+  picked interactively).
+
+  1. List task catalogs in folder ID 123.
+  2. Get catalog ID 55 in folder 123.
+  3. Create a catalog in folder 123 named "Invoices" with a retention action of
+     Delete and a retention period of 90 days.
+  4. Update catalog 55 in folder 123: rename it to "Invoices 2026".
+
+  Important:
+  - The uip CLI is NOT connected to a live tenant. Commands fail with auth
+    errors — that is expected. Run each command once and move on. Do NOT retry
+    or attempt to login. If a command is not recognized or returns an error, do
+    NOT investigate, retry, or run help — record the outcome and continue.
+  - Retention actions are only Delete or Archive. Do not use any other value.
+  - Do NOT invent other IDs. Use folder 123 and catalog 55 as given.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed task catalogs in a folder"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+list\s+.*--folder-id\s+123'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent got a catalog by ID"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+get\s+55\s+.*--folder-id\s+123'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent created a catalog with a Delete retention policy"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+create\s+.*--name\s+.*--retention-action\s+Delete'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent updated a catalog"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+catalogs\s+update\s+55\s+.*--folder-id\s+123'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not use an invalid retention action"
+    tool_name: "Bash"
+    command_pattern: '--retention-action\s+(None|Purge|Keep)'
+    weight: 1.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-tasks/smoke_task_attributes.yaml
+++ b/tests/tasks/uipath-tasks/smoke_task_attributes.yaml
@@ -1,0 +1,94 @@
+task_id: skill-tasks-smoke-attributes
+description: >
+  Smoke test: agent uses the uipath-tasks skill to run the task annotation
+  commands offline — list comments, add a comment, set labels (JSON array), and
+  edit metadata (title + priority). Tests correct CLI verbs and flags
+  (comments list, comments add --text, labels --labels, metadata --title/--priority),
+  and that --output json is applied. Runs against fake IDs — auth errors are
+  expected.
+tags: [uipath-tasks, smoke, mode:operate, lifecycle:setup, attributes]
+
+run_limits:
+  expected_turns: 12
+  max_turns: 18
+
+initial_prompt: |
+  You are annotating a UiPath Action Center task. Perform each step in order.
+  Use --output json on every uip tasks command, and pass --folder-id 123 on
+  every command (this is a non-interactive run, so the folder cannot be picked
+  interactively). Task IDs are numeric.
+
+  1. List the comments on task 7654321.
+  2. Add a comment to task 7654321 with the text "Escalated to finance".
+  3. Set labels on task 7654321 to a single label named "urgent". Labels are a
+     JSON array.
+  4. Edit metadata on task 7654321: set the title to "Urgent review" and the
+     priority to High.
+  5. Clear all labels on task 7654321 by passing an empty JSON array.
+  6. Associate task 7654321 with catalog ID 55, then in a separate command
+     remove the catalog association.
+
+  Important:
+  - The uip CLI is NOT connected to a live tenant. Commands fail with auth
+    errors — that is expected. Run each command once and move on. Do NOT retry
+    or attempt to login. If a command is not recognized or returns an error, do
+    NOT investigate, retry, or run help — record the outcome and continue.
+  - Do NOT invent other IDs. Use task 7654321 and folder 123 as given.
+  - Do NOT complete, assign, or delete the task.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent listed task comments"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+comments\s+list\s+7654321\s+.*--folder-id\s+123'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent added a comment with --text"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+comments\s+add\s+7654321\s+.*--text\s+'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent set labels with a JSON array"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+labels\s+7654321\s+.*--labels\s+'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent edited metadata with title and priority"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+metadata\s+7654321\s+.*--priority\s+High'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent cleared labels with an empty array"
+    tool_name: "Bash"
+    command_pattern: "uip\\s+tasks\\s+labels\\s+7654321\\s+.*--labels\\s+'?\\[\\]'?"
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent associated the task with a catalog"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+metadata\s+7654321\s+.*--catalog-id\s+55'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent removed the catalog association"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+metadata\s+7654321\s+.*--unset-catalog'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-tasks/smoke_task_data.yaml
+++ b/tests/tasks/uipath-tasks/smoke_task_data.yaml
@@ -1,0 +1,52 @@
+task_id: skill-tasks-smoke-data
+description: >
+  Smoke test: agent uses the uipath-tasks skill to get and save task data
+  offline — read a task's data, then save a JSON data payload. Tests correct CLI
+  verbs and flags (data get <task-id>, data save --data), that no task-type flag
+  is passed to data save, and that --output json is applied. Runs against fake IDs
+  — auth errors are expected.
+tags: [uipath-tasks, smoke, mode:operate, lifecycle:setup, data]
+
+run_limits:
+  expected_turns: 6
+  max_turns: 12
+
+initial_prompt: |
+  You are working with UiPath Action Center task data. Perform each step in
+  order. Use --output json on every uip tasks command, and pass --folder-id 123
+  on every command (this is a non-interactive run, so the folder cannot be
+  picked interactively). Task IDs are numeric.
+
+  1. Get the data for task 7654321.
+  2. Save data to task 7654321 with the JSON object {"amount":1200,"approved":true}.
+
+  Important:
+  - The uip CLI is NOT connected to a live tenant. Commands fail with auth
+    errors — that is expected. Run each command once and move on. Do NOT retry
+    or attempt to login. If a command is not recognized or returns an error, do
+    NOT investigate, retry, or run help — record the outcome and continue.
+  - Do NOT invent other IDs. Use task 7654321 and folder 123 as given.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent read task data"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+data\s+get\s+7654321\s+.*--folder-id\s+123'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent saved a JSON data payload"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+data\s+save\s+7654321\s+.*--data\s+'
+    min_count: 1
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not pass a --type flag to data save"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+data\s+save\s+.*--type\s+'
+    weight: 1.0
+    pass_threshold: 1.0


### PR DESCRIPTION
Extends the `uipath-tasks` skill and evals for the new `uip tasks` commands: catalogs, comments, labels, metadata, and data. Adds 3 references, 3 smoke evals, and 1 e2e eval.

**Verification:** every command these evals exercise was run live against the test tenant (`procodeapps`/`integrationtest`) and returned `Success` — catalogs create/get/update/list, data get/save, comments list/add, labels set/clear, metadata note/catalog-id/unset. Smoke evals run through coder-eval in CI. A full coder-eval pass of the e2e eval is gated on the CLI release, since the sandbox installs `@uipath/cli@latest`, which does not yet include these commands.

Jira: https://uipath.atlassian.net/browse/ACTN-11600

🤖 Generated with [Claude Code](https://claude.com/claude-code)