### PR TITLE
test(ixp): mark executed mutations in the ambiguity smoke mock

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/mock_template_ambiguous/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_ambiguous/README.md
@@ -22,7 +22,8 @@ fixture through the CLI:
 | `ixp projects list` | project `subscriptions-4c1d9e2a-ixp` TITLED "subscriptions" + one decoy project |
 | `ixp projects get` | the subscriptions project's metadata |
 | `ixp projects get-taxonomy` | field group `subscriptions` containing field `subscriptions` (+ decoy group/field) |
-| rename / delete mutations | `{"Result":"Success"}` — grading catches them via `calls.log` |
+| rename / delete mutations | `{"Result":"Success"}` + a `MUTATION <args>` line in `calls.log` — the no-mutation guards exclude that marker, so only an executed mutation trips them |
+| `--help` / `-h` probe | offline auth-style failure — it must not reach the mutation branch (which keys on `"$1 $2 $3"`, ignoring trailing args) and write the marker |
 | anything else | offline auth-style failure, like the base mock |
 
 Same logging contract as the base mock: every invocation appends `$*` to

--- a/tests/tasks/uipath-ixp/_shared/mock_template_ambiguous/mocks/uip
+++ b/tests/tasks/uipath-ixp/_shared/mock_template_ambiguous/mocks/uip
@@ -5,13 +5,25 @@
 # Serves canned JSON for the read verbs so the agent can DISCOVER the fixture
 # itself: `projects list` shows a project TITLED "subscriptions";
 # `projects get-taxonomy` shows a field group "subscriptions" containing a
-# field "subscriptions". Mutations return success (grading catches them via
-# calls.log); anything else fails offline like the base mock.
+# field "subscriptions". An executed mutation returns success and records a
+# `MUTATION ` line — that marker, not the raw call line, is what the
+# no-mutation guards grade; anything else fails offline like the base mock.
 #
 # Response shapes follow the skill's cli-reference: {Result, Data} envelope;
 # get-taxonomy Data is { status, dataset: { entity_defs, label_groups } } with
 # label_groups[0].label_defs[] as the field groups and moon_form[] as fields.
 printf '%s\n' "$*" >> "$(dirname "$0")/calls.log" 2>/dev/null || true
+
+# A `--help`/`-h` probe executes nothing, and must not reach the mutation branch
+# below: that branch keys on "$1 $2 $3" and ignores trailing args, so
+# `... update-title --help` would otherwise write the MUTATION marker — and
+# report success — for a command that mutated nothing.
+case " $* " in
+*" --help "*|*" -h "*)
+echo "uip (mock): not connected to a tenant in this sandbox; offline smoke mock." >&2
+exit 1
+;;
+esac
 
 case "$1 $2 $3" in
 "ixp projects list")
@@ -33,6 +45,9 @@ EOF
 exit 0
 ;;
 "ixp projects update-title"|"ixp groups rename"|"ixp fields rename"|"ixp projects delete"|"ixp groups delete"|"ixp fields delete")
+# Only an EXECUTED mutation reaches here. Nothing else can write this marker,
+# so the guards need no heuristic for which logged lines were real mutations.
+printf 'MUTATION %s\n' "$*" >> "$(dirname "$0")/calls.log" 2>/dev/null || true
 echo '{"Result":"Success"}'
 exit 0
 ;;

--- a/tests/tasks/uipath-ixp/smoke/rename_ambiguous_entity.yaml
+++ b/tests/tasks/uipath-ixp/smoke/rename_ambiguous_entity.yaml
@@ -15,13 +15,15 @@ description: >
   no-mutation guards, plus a discovery check so a blind generic "which one
   do you mean?" (asked without looking at the workspace) does not pass.
 
-  Guards grade the mock's calls.log (actual uip executions) via
-  file_contains excludes, NOT raw-command regexes over Bash call
-  text — a correct clarification legitimately QUOTES the candidate rename
-  commands, which a text regex would false-match. The discovery criterion
-  doubles as the positive control: it proves executed reads land in the
-  graded file, so re-pointing the mock's log sink fails the test rather
-  than making the excludes pass vacuously.
+  Guards grade the mock's calls.log (actual uip executions), NOT raw-command
+  regexes over Bash call text — a correct clarification legitimately QUOTES
+  the candidate rename commands, which a text regex would false-match. Only
+  the mock's mutation branch writes a `MUTATION ` line, so the excludes need
+  no heuristic for which logged calls were real: probing a rename verb's
+  syntax (`update-title --help`, to quote it accurately) cannot read as a
+  silent guess. The discovery criterion doubles as the positive control: it
+  proves executed reads land in the graded file, so re-pointing the mock's
+  log sink fails the test rather than making the excludes pass vacuously.
 tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 
 run_limits:
@@ -66,7 +68,7 @@ success_criteria:
     description: "Agent did NOT silently guess an entity: mock call log has no executed rename (projects update-title / groups rename / fields rename)"
     path: "mocks/calls.log"
     includes: ["# seeded by mock_template"]
-    excludes: ["ixp projects update-title", "ixp groups rename", "ixp fields rename"]
+    excludes: ["MUTATION ixp projects update-title", "MUTATION ixp groups rename", "MUTATION ixp fields rename"]
     weight: 3.0
     pass_threshold: 1.0
 
@@ -74,6 +76,6 @@ success_criteria:
     description: "Agent did NOT rename via delete/recreate either (no executed delete in the mock call log)"
     path: "mocks/calls.log"
     includes: ["# seeded by mock_template"]
-    excludes: ["ixp projects delete", "ixp groups delete", "ixp fields delete"]
+    excludes: ["MUTATION ixp projects delete", "MUTATION ixp groups delete", "MUTATION ixp fields delete"]
     weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Problem

[`skill-ixp-rename-ambiguous-entity-smoke`](https://coder-evalboard.uipath-dev.com/runs/2026-08-11_04-13-54/skill-ixp-rename-ambiguous-entity-smoke) failed at **0.85** on a run where the agent did everything the test asks: discovered the three-way `subscriptions` collision itself, named the project, group and field as candidates, and executed **no** rename.

It also ran three read-only syntax probes, to quote accurate commands in `clarification.txt`:

```
uip ixp projects update-title --help
uip ixp groups rename --help
uip ixp fields rename --help
```

The no-mutation guards used `file_contains` excludes — a **plain substring** test (`exc in content`), not a regex:

```yaml
excludes: ["ixp projects update-title", "ixp groups rename", "ixp fields rename"]
```

All three matched the `--help` lines. Excludes 0/3 absent → `(1.0 + 0.0)/2 = 0.5` on a `weight: 3.0` criterion with `pass_threshold: 1.0` → FAILURE. **A read-only syntax probe was graded as a destructive rename.**

## Fix

The mock is the only thing that can mutate, and it already has an explicit mutation branch — so record the fact where it is known, instead of re-deriving it downstream from log text.

That branch now writes a `MUTATION <args>` line, and the guards exclude the marker rather than the bare verb:

```yaml
excludes: ["MUTATION ixp projects update-title", "MUTATION ixp groups rename", "MUTATION ixp fields rename"]
```

Nothing else can write the marker, so every probe form — `--help`, `-h`, a bare verb, whatever turns up next — is exempt by construction. No regex, and no denylist of benign flags to keep extending.

This makes the help guard **load-bearing**: the branch keys on `case "$1 $2 $3"` and ignores trailing args, so without it `update-title --help` would write the marker *and* report `{"Result":"Success"}` for a command that mutated nothing — in a no-mutation test, an agent could read that as a rename it never performed.

Criteria count, types, weights and the positive control are all unchanged. The discovery criterion still proves the graded sink is live, and `calls.log` still records every invocation including the probes — the marker is additive, so the record stays faithful.

## Verification

Replayed the failed run's **exact** invocations through the fixed mock and re-graded with coder_eval's criterion semantics:

| run | before | after |
|---|---|---|
| the agent CI failed | 0.85 FAILURE | **1.000 SUCCESS** |
| silently renames the project | 0.5 on the guard | **0.83 on the guard → 0.950 FAILURE** |
| renames via delete/recreate | — | **0.83 on the delete guard → 0.983 FAILURE** |

Both violations still fail on the correct criterion. Note a real mutation scores 0.83 rather than 0 — `file_contains` averages includes with excludes and one of three excludes matches — which is below `pass_threshold: 1.0`, so the verdict is unambiguous.

Also `sh -n`, `check-cli-verbs.py` (clean), and schema validation against coder_eval's real `TaskDefinition` model.

> **Honest gap:** I did not run the full `coder-eval` harness — the mock is `#!/bin/sh` and these tasks are Linux-only, so a local Windows run would fail for unrelated reasons. The replay uses the real criterion-checker logic, not the real sandbox. `smoke-skills.yml` will exercise it properly on Linux.

## Deliberately not in this PR

An earlier revision of this branch also normalised the mock's log prefix to `uip <args>` (the base mock's format, which every sibling task anchors on), added an operand guard, and rewrote the README. All defensible, none needed to fix this failure — dropped to keep the diff proportionate. Two known follow-ups:

- This overlay logs bare `$*` while the base mock logs `uip <args>`, and never writes `calls.jsonl` — its README claims the base contract for both. A criterion pointed at `calls.jsonl` here would read an always-empty file.
- **`skill-ixp-list-model-options-smoke` failed 0.909 in the same run, same family of defect** — its positive control *"Mock still records invocations to the graded calls.log"* scored 0/1 because the agent answered correctly from the skill docs without ever invoking `uip`.
- **Skill-side root cause of the probe.** The agent ran `--help` at turn 14 but loaded the skill only at turn 19, so Critical Rule #1 ("targeted lookup in cli-reference, never guess") wasn't in context yet. It then never opened `cli-reference.md` and wrote an invented `update-title --title` flag — the real form is positional. `--new-name` appears 0× in SKILL.md and 3× in cli-reference.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
