### PR TITLE
test(ixp): unbreak list-model-options, red on every run since the mock rewrite

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/mock_template/README.md
+++ b/tests/tasks/uipath-ixp/_shared/mock_template/README.md
@@ -63,13 +63,19 @@ which can false-match commands merely quoted in heredocs, comments, or prose.
 
 Log-based negative guards MUST pair with a positive control — a log line a
 correct run is guaranteed to produce — otherwise re-pointing the mock's sink
-makes every negative guard pass vacuously. Only when no invocation is guaranteed
-in a correct run, fall back to a harness-integrity criterion asserting
-`mocks/uip` still contains `JSON_LOG = os.path.join(MOCK_DIR, "calls.jsonl")`.
-That fallback is weak — static source text, brittle against cosmetic mock
-refactors. It broke once already: it previously asserted the sh mock's
-`>> "$(dirname "$0")/calls.log"` redirect, which the Python rewrite deleted.
-Prefer a real positive control wherever a correct run makes any call at all.
+makes every negative guard pass vacuously.
+
+Where no invocation is GUARANTEED in a correct run, the guard carries no positive
+control. Say so in a comment and add no criterion for it.
+
+Exclude the specific verb a task traps, never every invocation. Both sinks are
+seeded, so `calls.log` always exists (a file-absent check cannot stand in for
+"made no call"), and correct runs call unrelated verbs while orienting.
+
+Do NOT assert static text in `mocks/uip` — a `FLAT_LOG =`/`JSON_LOG =` line, or
+the old `>> "$(dirname "$0")/calls.log"` redirect. It cannot tell a moved sink
+from a reformat: the sh → Python rewrite deleted that redirect and pinned
+`list_model_options` at 0.909 for six nightlies, never passing.
 
 Integration/e2e tasks use `live_calls_template`; its wrapper writes the same two
 sinks in the same format, then delegates unchanged to the real CLI.

--- a/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_model_options.yaml
@@ -11,9 +11,9 @@ description: >
   retrieve, not a claim about work performed. The guard reads the mock's calls.log
   rather than Bash text because a correct answer quotes `configure-model --model
   <id>` and may cite `list-models` to contrast it, which a text regex false-matches.
-  A correct run makes no `uip` call, so no guaranteed log line exists for the
-  positive control the mock README requires — hence its documented fallback, a
-  harness-integrity assertion on the log sink.
+  No `uip` call is guaranteed in a correct run, so the guard carries no positive
+  control. Correct runs DO call other verbs, so it excludes the trap verb only,
+  never every invocation.
 
   Distinct from pick_capable_model / change_model_variant: both mutate a project
   via configure-model; this enumerates the catalog and mutates nothing.
@@ -73,20 +73,18 @@ success_criteria:
     pass_threshold: 1.0
 
   # Log of ACTUAL executions: quoting the verb to contrast it is fine, running it
-  # is not. `includes:` only proves the log exists and is readable.
+  # is not. Trap verb only, not every invocation — calls.log is seeded (always
+  # exists) and correct runs call other verbs.
+  #
+  # Move this to calls.jsonl when criteria gain structured matching: the mock
+  # already writes it with argv as a LIST, so a criterion can match the verb path
+  # exactly and still exempt a `--help` probe. Neither is expressible as a
+  # substring over the flat line, and jsonl is seeded EMPTY, so "made no call" is
+  # assertable directly instead of via a seed-line include.
   - type: file_contains
     description: "Agent did NOT mistake the catalog for version listing: mock call log has no executed `projects list-models`"
     path: "mocks/calls.log"
     includes: ["# seeded by mock_template"]
     excludes: ["uip ixp projects list-models"]
     weight: 3.0
-    pass_threshold: 1.0
-
-  # Without this, re-pointing the mock's sink leaves the seeded log clean and the
-  # guard above passes vacuously.
-  - type: file_contains
-    description: "Mock still records invocations to the graded calls.log (guard is not vacuous)"
-    path: "mocks/uip"
-    includes: ['>> "$(dirname "$0")/calls.log"']
-    weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
`skill-ixp-list-model-options-smoke` has **never passed**, and not because of the agent.

## Cause

A harness-integrity criterion greps the mock's *source* for an **sh redirect** that the sh → Python rewrite deleted:

```yaml
path: "mocks/uip"                                # the mock SCRIPT, not the log
includes: ['>> "$(dirname "$0")/calls.log"']     # grep -cF -> 0
```

The mock now records with `open(FLAT_LOG, "a", ...)`, so the string can never match. The criterion scores 0 on every run whatever the agent does; weight 1.0 of 11.0 caps the task at 10/11 = **0.9091**.

| run | model | result | failing criterion |
|---|---|---|---|
| Aug 4 | claude-sonnet-5 | FAILURE 0.9091 | sink assertion |
| Aug 5 | gemini-3.5-flash | FAILURE 0.9091 | sink assertion |
| Aug 6 | gpt-5.6-terra | FAILURE 0.9091 | sink assertion |
| Aug 7 | gpt-5.6-terra | FAILURE 0.9091 | sink assertion |
| Aug 10 | gpt-5.6-terra | FAILURE 0.9091 | sink assertion |
| Aug 11 | claude-sonnet-5 | FAILURE 0.9091 | sink assertion |

Six nightlies, three models, identical score, the other five criteria at 1.0 throughout. It went unnoticed because 0.909 reads as a near-miss rather than a broken assertion.

## Fix — delete it, don't re-anchor it

The criterion existed to stop the `list-models` guard passing vacuously if the mock's sink moved. It cannot do that job: static source text can't distinguish a moved sink (what it guards) from a reformat or a port (harmless). It fires on maintenance and reports it as a near-miss, which is worse than not having it.

Also corrects the task's claim that a correct run makes no `uip` call. None is *guaranteed*, so the guard carries no positive control — but the Aug 11 run scored full marks on content having run `projects list` and `configure-model --help`. Hence the guard excludes the trap verb only: an empty-log assertion would fail correct runs, and `calls.log` is seeded so a file-absent check never works either.

## Upgrade path, recorded in the task

The flat log is the weak part. The mock **already writes `calls.jsonl`** with `argv` as a list, so once criteria gain structured matching this guard can match the verb path exactly *and* exempt a `--help` probe — neither expressible as a substring over the flat line. That sink is seeded EMPTY, so "made no call" becomes directly assertable instead of riding on a seed-line `includes`.

## Verification

| | before | after |
|---|---|---|
| Aug 11 real artifacts | 0.9091 FAILURE | **1.0000 SUCCESS** |
| run executing `projects list-models` | — | guard **0.5 → FAIL** |

5 criteria, weight 10.0. `check-cli-verbs.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
