### PR TITLE
test(ixp): pre-create the project so name-resolution grades resolution

### DIFF
--- a/tests/tasks/uipath-ixp/_shared/setup_resolve_project.py
+++ b/tests/tasks/uipath-ixp/_shared/setup_resolve_project.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Pre-run setup for skill-ixp-integration-name-resolution: create THIS run's
+project on the live tenant and hand the agent only its TITLE.
+
+Setup creates it, not the agent, because `projects create` returns
+`Data.ProjectName` — an agent that creates its own project already holds the Name
+and has no Title to resolve, which is what the task grades.
+
+Writes to the sandbox CWD:
+  project_title.txt  the Title, and only the Title — the agent's starting point
+  report.json        {"project_name": "<Name>"} for cleanup_project.py post_run
+
+Exits non-zero on any failure (pre_run defaults to fail_on_error=True): the agent
+must not run against a half-built fixture.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import uuid
+
+
+INVOICES = ("csi_tower_invoice.png", "hp_tax_invoice.png", "york_solutions_invoice.png")
+TAXONOMY = "taxonomy.json"
+
+
+def die(msg):
+    print(f"ERROR: {msg}")
+    sys.exit(1)
+
+
+def run(cmd, timeout=180):
+    print("+ " + " ".join(cmd))
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except Exception as e:
+        die(f"could not invoke {' '.join(cmd)}: {e}")
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[:300]
+        die(f"exit {proc.returncode} from {' '.join(cmd)}: {detail}")
+    return proc.stdout or ""
+
+
+def stage_invoices(root):
+    """Copy the three invoices into a directory of their own.
+
+    `projects create <title> <folder>` bulk-uploads the folder's top level, so
+    staging pins the upload set even if the fixture template later grows another
+    supported document at the sandbox root.
+    """
+    staged = tempfile.mkdtemp(prefix="ixp_resolve_")
+    for name in INVOICES:
+        src = os.path.join(root, name)
+        if not os.path.exists(src):
+            die(f"fixture missing: {src}")
+        shutil.copy2(src, os.path.join(staged, name))
+    return staged
+
+
+def main():
+    root = os.getcwd()
+    title = f"codereval-integ-resolve-{uuid.uuid4().hex[:8]}"
+
+    out = run(["uip", "ixp", "projects", "create", title, stage_invoices(root), "--skip-taxonomy", "--output", "json"])
+    try:
+        name = json.loads(out)["Data"]["ProjectName"]
+    except Exception as e:
+        die(f"no Data.ProjectName in create output ({e}): {out.strip()[:300]}")
+
+    # Before anything else can fail: a project that exists must stay cleanable.
+    with open(os.path.join(root, "report.json"), "w") as f:
+        json.dump({"project_name": name}, f)
+
+    taxonomy = os.path.join(root, TAXONOMY)
+    if not os.path.exists(taxonomy):
+        die(f"fixture missing: {taxonomy}")
+    run(["uip", "ixp", "projects", "import-taxonomy", name, taxonomy, "--output", "json"])
+
+    # Written LAST: its presence means the fixture is complete.
+    with open(os.path.join(root, "project_title.txt"), "w") as f:
+        f.write(title + "\n")
+
+    print(f"OK: seeded title={title} name={name}")
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -2,10 +2,23 @@ task_id: skill-ixp-integration-name-resolution
 description: >
   Integration: name/title resolution on a live tenant. The agent must resolve
   user-facing references to the ids the CLI needs — a document by FILENAME →
-  DocumentId via `documents list`, and a project by its TITLE → Name via
+  DocumentId via `documents list`, and the project by its TITLE → Name via
   `projects list` — rather than passing the human label straight through. The
   resolution step is the integration part; smokes pass the id in the prompt.
+
+  pre_run creates the project and gives the agent ONLY its Title, in
+  project_title.txt. That split is what makes the project-side resolution real:
+  `projects create` returns Data.ProjectName, so while the agent did the creating
+  it already held the Name, and the `projects list` criterion passed 3 of 4
+  nightlies on incidental orientation rather than on resolution.
+
+  Setup also writes report.json for the post_run cleanup, so that file is no
+  longer graded: the harness writes it, not the agent.
 tags: [uipath-ixp, integration, mode:operate]
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/setup_resolve_project.py"
+    timeout: 300
 
 run_limits:
   max_turns: 48
@@ -26,18 +39,15 @@ sandbox:
 
 initial_prompt: |
   Use the tenant I'm already signed into (check I'm logged in; don't
-  re-authenticate). Set up an invoice project from the files in `./fixtures/` —
-  import the taxonomy and upload the three invoices — and give it a unique title
-  `codereval-integ-resolve-<random-suffix>` so concurrent runs don't collide.
+  re-authenticate).
 
-  Then:
-  - Delete the file `york_solutions_invoice.png`, then save the remaining document
-    list to `documents_after.json`.
-  - Rename that project to the same title with `-renamed` appended (i.e.
-    `codereval-integ-resolve-<random-suffix>-renamed`), then save the project's details to
-    `project_after.json`.
+  An invoice project already exists on that tenant. `./project_title.txt` holds
+  its title.
 
-  Right after the project is created, write `report.json` for cleanup: {"project_name": "<the ProjectName from the create response>"}.
+  - Delete the document `york_solutions_invoice.png` from that project, then save
+    the remaining document list to `documents_after.json`.
+  - Rename the project to its current title with `-renamed` appended, then save
+    the project's details to `project_after.json`.
 
 success_criteria:
   - type: file_matches_regex
@@ -56,11 +66,13 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # The Name is never given to the agent, so this lookup IS the resolution.
+  # `list(?=\s|$)` keeps the near-name `list-models` from satisfying it.
   - type: file_matches_regex
     description: "Listed projects to resolve Title → Name"
     path: "mocks/calls.log"
     pattern: >-
-      (?m)^(?:uip\s+ixp\s+projects\s+list)[^\r\n]*$
+      (?m)^(?:uip\s+ixp\s+projects\s+list(?=\s|$))[^\r\n]*$
     weight: 1.5
     pass_threshold: 1.0
 
@@ -81,12 +93,6 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "report.json written for post-run cleanup"
-    path: "report.json"
-    weight: 1.0
-    pass_threshold: 1.0
-
   # --- Outcome verification: resolution actually deleted the named doc + renamed the project ---
   - type: file_contains
     description: "york is gone from the list; the other two documents remain"
@@ -103,9 +109,8 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
-# Safety net: delete the project even if the agent's in-band cleanup never ran
-# (crash / MAX_TURNS before the final delete). Reads report.json; idempotent;
-# always exits 0 so it never fails the test.
+# Deletes the project pre_run created, reading setup's report.json — so it also
+# covers a run that crashed or hit MAX_TURNS. Always exits 0.
 post_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-ixp/_shared/cleanup_project.py"
     timeout: 60


### PR DESCRIPTION
## The `projects list` criterion wasn't grading resolution

It claims to grade Title → Name resolution. But the agent **created** the project, and `projects create` returns `Data.ProjectName` — so the Name was already in hand. The prompt even told it to capture that for `report.json`. The lookup was redundant work.

| run | model | result | |
|---|---|---|---|
| Aug 4 | claude-sonnet-5 | SUCCESS 1.0 | ran `projects list` **before** create — orientation |
| Aug 5 | gemini-3.5-flash | SUCCESS 1.0 | |
| Aug 10 | gpt-5.6-terra | SUCCESS 1.0 | |
| Aug 11 | claude-sonnet-5 | **FAILURE 0.8889** | went straight to create |

All four then used the Name from the create response. **None ever resolved a Title.** The passing runs passed incidentally; the failing one was just more direct.

## Fix

`pre_run` creates the project and writes only its **Title** to `project_title.txt`, so `projects list` becomes the only route to a Name. Also exercises Critical Rule 7 (commands take the Name, never the Title). The document half already worked — filename → DocumentId genuinely needs `documents list` — and is unchanged.

- `report.json` is now written by setup, so its `file_exists` criterion is gone: grading a harness-written file proves nothing. Weight 13.5 → 12.5.
- Guard tightened to `projects\s+list(?=\s|$)` so `list-models` can't satisfy it.
- Setup exits non-zero on failure, and writes `report.json` before the taxonomy import so a project that exists stays cleanable.

## Verification

Unit-tested with `subprocess.run` patched (which also guarantees no live call), against response shapes captured from the real runs:

| scenario | exit | `project_title.txt` | `report.json` |
|---|---|---|---|
| happy path | 0 | written | written |
| `create` fails | 1 | absent | absent |
| `import-taxonomy` fails | 1 | absent | **kept for cleanup** |

Stub asserts exactly three invoices staged, `--skip-taxonomy` passed, and the Name derived from the seeded Title. Plus `py_compile`, YAML parse, `check-cli-verbs.py` clean, regex checked against `list` / `list-models` / `list-versions`.

> **Not executed against a live tenant** — no credentials here, and this needs `driver: docker` plus a signed-in tenant. CI is the first real run of `pre_run`, and a mis-call there ERRORs the task rather than flaking, which is worse than the 1-in-4 it replaces. Worth sanity-running `setup_resolve_project.py` once with tenant access, or watching the first nightly.
>
> Cheaper alternative if that risk isn't wanted: delete the `projects list` criterion and accept no project-side resolution coverage — 1 line, no live-tenant surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
