### PR TITLE
test(agents): grade five coder_eval tasks by outcome, not surface details

### DIFF
--- a/tests/tasks/uipath-agents/_shared/langgraph_assertions.py
+++ b/tests/tasks/uipath-agents/_shared/langgraph_assertions.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+import ast
 import json
 import sys
 from pathlib import Path
+
+# Keyword names LangGraph accepts for the schemas passed to `StateGraph`.
+# The first positional argument is the state schema.
+_INPUT_KEYWORDS = ("input", "input_schema")
+_OUTPUT_KEYWORDS = ("output", "output_schema")
+_IO_KEYWORDS = _INPUT_KEYWORDS + _OUTPUT_KEYWORDS
+_SCHEMA_KEYWORDS = _IO_KEYWORDS + ("state_schema",)
 
 
 def assert_langgraph_config(root: Path, module: Path) -> None:
@@ -29,3 +37,138 @@ def assert_langgraph_config(root: Path, module: Path) -> None:
             f"({', '.join(sorted(expected_targets))}); got {graphs!r}"
         )
     print(f"OK: langgraph.json registers {module.name}:graph")
+
+
+def _base_name(node: ast.expr) -> str | None:
+    """Last name segment of a class base (`pydantic.BaseModel` -> `BaseModel`)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _pydantic_models(tree: ast.Module) -> set[str]:
+    """Names of classes in this module that subclass `BaseModel`."""
+    return {
+        node.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ClassDef)
+        and any(_base_name(base) == "BaseModel" for base in node.bases)
+    }
+
+
+def _defined_classes(tree: ast.Module) -> set[str]:
+    """Names of every class defined in this module."""
+    return {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+
+
+def _state_graph_call(tree: ast.Module) -> ast.Call | None:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and _base_name(node.func) == "StateGraph":
+            return node
+    return None
+
+
+def _exports_compiled_graph(tree: ast.Module) -> bool:
+    """True when the module assigns a top-level `graph` from `.compile(...)`."""
+    for stmt in tree.body:
+        targets: list[ast.expr] = []
+        if isinstance(stmt, ast.Assign):
+            targets = list(stmt.targets)
+        elif isinstance(stmt, ast.AnnAssign):
+            targets = [stmt.target]
+        if not any(isinstance(t, ast.Name) and t.id == "graph" for t in targets):
+            continue
+        value = stmt.value
+        if isinstance(value, ast.Call) and _base_name(value.func) == "compile":
+            return True
+        # `graph = builder` / `graph = some_factory()` still exports something
+        # importable; only a bare `graph = None` is meaningless.
+        if value is not None and not (
+            isinstance(value, ast.Constant) and value.value is None
+        ):
+            return True
+    return False
+
+
+def assert_graph_module_shape(path: Path) -> None:
+    """Assert the module has LangGraph agent shape, ignoring class names.
+
+    Class names are not an invariant — `references/coded/frameworks/
+    agent-patterns.md` explicitly allows `Input`/`Output` or
+    `GraphInput`/`GraphOutput` or anything else. What matters:
+
+      1. A `StateGraph(...)` is constructed.
+      2. Its positional state schema is a class defined in the module
+         (`TypedDict` state is idiomatic LangGraph, so `BaseModel` is
+         not required there).
+      3. Its `input`/`input_schema`/`output`/`output_schema` keywords
+         resolve to Pydantic `BaseModel` subclasses defined in the
+         module — those two are what `uip codedagent init` turns into
+         the entrypoint schema.
+      4. The output schema differs from the input schema, so the
+         agent's input and output shapes are separately typed.
+      5. The module exports a top-level `graph`.
+    """
+    if not path.is_file():
+        sys.exit(f"FAIL: Missing {path}")
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except SyntaxError as exc:
+        sys.exit(f"FAIL: {path.name} is not valid Python: {exc}")
+
+    call = _state_graph_call(tree)
+    if call is None:
+        sys.exit(f"FAIL: {path.name} does not construct a StateGraph")
+
+    models = _pydantic_models(tree)
+    classes = _defined_classes(tree)
+    schemas: dict[str, str] = {}
+    if call.args:
+        schemas["state"] = ast.unparse(call.args[0])
+    for keyword in call.keywords:
+        if keyword.arg in _SCHEMA_KEYWORDS:
+            schemas[keyword.arg] = ast.unparse(keyword.value)
+
+    state = schemas.get("state") or schemas.get("state_schema")
+    if state is not None and state not in classes:
+        sys.exit(
+            f"FAIL: {path.name} passes StateGraph state schema `{state}`, which is "
+            f"not a class defined in the module (found: {sorted(classes) or 'none'})"
+        )
+
+    io_schemas = {k: v for k, v in schemas.items() if k in _IO_KEYWORDS}
+    non_models = sorted({v for v in io_schemas.values() if v not in models})
+    if non_models:
+        sys.exit(
+            f"FAIL: {path.name} passes StateGraph input/output schema(s) "
+            f"{non_models} that are not Pydantic BaseModel subclasses defined in "
+            f"the module (found models: {sorted(models) or 'none'})"
+        )
+
+    outputs = {io_schemas[k] for k in _OUTPUT_KEYWORDS if k in io_schemas}
+    if not outputs:
+        sys.exit(
+            f"FAIL: {path.name} declares no output schema — pass "
+            f"`output_schema=<PydanticModel>` to StateGraph so the agent's "
+            f"output shape is typed for `uip codedagent init`."
+        )
+    inputs = {io_schemas[k] for k in _INPUT_KEYWORDS if k in io_schemas} or {state}
+    if outputs & inputs:
+        sys.exit(
+            f"FAIL: {path.name} uses the same model for input and output "
+            f"({sorted(outputs & inputs)}) — declare distinct input and "
+            f"output schemas."
+        )
+
+    if not _exports_compiled_graph(tree):
+        sys.exit(
+            f"FAIL: {path.name} does not export a top-level `graph` — the "
+            f"runtime resolves the agent through `<file>:graph`."
+        )
+
+    print(
+        f"OK: {path.name} declares Pydantic input/output schemas "
+        f"({', '.join(f'{k}={v}' for k, v in schemas.items())}) and exports `graph`"
+    )

--- a/tests/tasks/uipath-agents/_shared/test_two_turn_outputs.py
+++ b/tests/tasks/uipath-agents/_shared/test_two_turn_outputs.py
@@ -1,0 +1,132 @@
+"""Unit tests for the two-local-turns helper.
+
+The regression these lock in: a transcript line carries a label
+(`Reply:   hello there echo`) that the line scan cannot distinguish from
+the reply, so corroboration must drop the labelled variant rather than
+fail the whole run. A real llamaindex trajectory that saved both turn
+inputs, both outputs *and* a labelled transcript failed the smoke test
+because of it.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _shared.two_turn_outputs import assert_two_local_turns  # noqa: E402
+
+TRANSCRIPT = (
+    "chat-agent — local chat transcript\n"
+    "===================================\n\n"
+    "Turn 1\n  Message: hello there\n  Reply:   hello there echo\n\n"
+    "Turn 2\n  Message: what time is it\n  Reply:   what time is it echo\n"
+)
+
+
+def turn_input(message: str) -> str:
+    return json.dumps(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "contentParts": [
+                        {"mimeType": "text/plain", "data": {"inline": message}}
+                    ],
+                }
+            ]
+        }
+    )
+
+
+def project(tmp_path: Path, files: dict[str, str]) -> Path:
+    for name, body in files.items():
+        (tmp_path / name).write_text(body)
+    return tmp_path
+
+
+def test_accepts_turn_files_plus_labelled_transcript(tmp_path: Path) -> None:
+    """The exact shape that failed CI: outputs *and* a labelled transcript."""
+    root = project(
+        tmp_path,
+        {
+            "turn1.json": turn_input("hello there"),
+            "turn2.json": turn_input("what time is it"),
+            "turn1-output.json": json.dumps({"response": "hello there echo"}),
+            "turn2-output.json": json.dumps({"response": "what time is it echo"}),
+            "chat-replies.txt": TRANSCRIPT,
+        },
+    )
+    assert_two_local_turns(root)
+
+
+def test_accepts_labelled_transcript_alone(tmp_path: Path) -> None:
+    """No JSON outputs — the transcript carries both messages and replies."""
+    assert_two_local_turns(project(tmp_path, {"chat-replies.txt": TRANSCRIPT}))
+
+
+def test_accepts_json_turn_files_alone(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        {
+            "t1.json": turn_input("hello there"),
+            "t1-out.json": json.dumps({"response": "hello there echo"}),
+            "t2.json": turn_input("what time is it"),
+            "t2-out.json": json.dumps({"response": "what time is it echo"}),
+        },
+    )
+    assert_two_local_turns(root)
+
+
+def test_accepts_message_containing_a_colon(tmp_path: Path) -> None:
+    """Label stripping must not eat a colon that belongs to the message."""
+    root = project(
+        tmp_path,
+        {
+            "t1.json": turn_input("time: now"),
+            "t1-out.json": json.dumps({"response": "time: now echo"}),
+            "t2.json": turn_input("hello there"),
+            "t2-out.json": json.dumps({"response": "hello there echo"}),
+        },
+    )
+    assert_two_local_turns(root)
+
+
+def test_rejects_fabricated_replies(tmp_path: Path) -> None:
+    """Replies with no submitted message behind them do not count."""
+    root = project(tmp_path, {"out.txt": "hello there echo\nwhat time is it echo\n"})
+    with pytest.raises(SystemExit) as exc:
+        assert_two_local_turns(root)
+    assert "uncorroborated" in str(exc.value)
+
+
+def test_rejects_single_turn(tmp_path: Path) -> None:
+    root = project(
+        tmp_path,
+        {
+            "turn1.json": turn_input("hello there"),
+            "turn1-output.json": json.dumps({"response": "hello there echo"}),
+        },
+    )
+    with pytest.raises(SystemExit) as exc:
+        assert_two_local_turns(root)
+    assert "found 1" in str(exc.value)
+
+
+def test_one_turn_saved_in_many_places_counts_once(tmp_path: Path) -> None:
+    """Copies of a single turn must not inflate the turn count."""
+    root = project(
+        tmp_path,
+        {
+            "turn1.json": turn_input("hello there"),
+            "turn1-output.json": json.dumps({"response": "hello there echo"}),
+            "copy.txt": "Reply: hello there echo\n",
+            "copy2.log": "Reply: hello there echo\n",
+        },
+    )
+    with pytest.raises(SystemExit) as exc:
+        assert_two_local_turns(root)
+    assert "found 1" in str(exc.value)

--- a/tests/tasks/uipath-agents/_shared/two_turn_outputs.py
+++ b/tests/tasks/uipath-agents/_shared/two_turn_outputs.py
@@ -19,12 +19,24 @@ Extraction order:
 Source files (`.py`) are skipped: the workflow itself contains the
 f-string that builds the suffix.
 
-Each reply is then **corroborated**: its message part must occur at
-least twice across the project's files — once as the message that was
+A transcript line carries a label (`Reply:   hello there echo`), which
+the line scan cannot tell from the reply itself, so each labelled match
+also yields an unlabelled variant. Corroboration then decides which of
+the two is real.
+
+Each reply is **corroborated**: its message part must occur at least
+twice across the project's files — once as the message that was
 submitted (an input file, a transcript's user turn, the runtime's
-`__uipath` state) and once inside the reply itself. A reply hand-written
-without a corresponding submitted message occurs only once and fails.
-Corroboration scans bytes, so binary runtime state counts too.
+`__uipath` state) and once inside the reply itself. Corroboration scans
+bytes, so binary runtime state counts too.
+
+Corroboration is a **filter**, not a veto: uncorroborated candidates are
+dropped and the corroborated ones counted, so extraction noise (a label
+the scan kept, a reply quoted in prose) cannot fail a run that really
+chatted twice. A hand-written reply with no submitted message behind it
+is dropped and therefore does not count toward `min_turns`. Replies that
+differ only by a leading label collapse to the shortest form, so one turn
+saved in several places counts once.
 """
 
 from __future__ import annotations
@@ -44,6 +56,9 @@ TEXT_SUFFIXES = {".txt", ".log", ".md", ".out", ".jsonl"}
 # `{...}` / `$...` markers mean the line is a template or command, not a reply.
 TEMPLATE_MARKERS = ("{", "}", "$")
 ECHO_LINE = re.compile(r"([^\"'\n\r]{1,200}?)" + re.escape(SUFFIX) + r"(?=[\"'.,\s]|$)")
+# A transcript label the line scan would otherwise keep as part of the
+# reply: `Reply:   hello there echo`, `assistant: ... echo`, `- Out: ...`.
+LABEL_PREFIX = re.compile(r"^[-*\s]*[A-Za-z][\w .\-]{0,30}:\s*")
 
 
 def _candidate_files(root: Path) -> list[Path]:
@@ -89,8 +104,11 @@ def _replies_from_text(path: Path) -> list[str]:
         reply = (match.group(1) + SUFFIX).strip()
         if any(marker in reply for marker in TEMPLATE_MARKERS):
             continue
-        if reply != SUFFIX.strip():
-            replies.append(reply)
+        # Keep both forms — corroboration picks whichever is the real
+        # reply, so a labelled transcript and a bare reply both work.
+        for candidate in (reply, LABEL_PREFIX.sub("", reply).strip()):
+            if candidate != SUFFIX.strip():
+                replies.append(candidate)
     return replies
 
 
@@ -134,30 +152,39 @@ def corroborated_replies(root: Path, replies: dict[str, list[str]]) -> dict[str,
     return counts
 
 
+def _collapse_labelled(replies: set[str]) -> set[str]:
+    """Drop replies that are another reply plus a leading label."""
+    return {
+        reply
+        for reply in replies
+        if not any(other != reply and reply.endswith(other) for other in replies)
+    }
+
+
 def assert_two_local_turns(root: Path, min_turns: int = 2) -> None:
     found = collect_echo_replies(root)
     counts = corroborated_replies(root, found)
-    uncorroborated = sorted(r for r, n in counts.items() if n < 2)
-    if uncorroborated and len(found) >= min_turns:
-        sys.exit(
-            "FAIL: reply(ies) "
-            + ", ".join(repr(r) for r in uncorroborated)
-            + " have no submitted message on disk — the message part occurs only "
-            "inside the reply itself. A real `uip codedagent run` turn leaves the "
-            "message in its input file, transcript, or runtime state."
-        )
-    if len(found) < min_turns:
+    turns = _collapse_labelled({reply for reply, n in counts.items() if n >= 2})
+    if len(turns) < min_turns:
+        dropped = sorted(reply for reply, n in counts.items() if n < 2)
         detail = (
             "; ".join(f"{reply!r} in {sorted(set(files))}" for reply, files in found.items())
             or "none"
         )
         sys.exit(
             f"FAIL: expected at least {min_turns} distinct echoed replies "
-            f"(`<message>{SUFFIX}`) saved under {root}, found {len(found)}: {detail}. "
-            "The agent must chat locally twice with two different messages and "
+            f"(`<message>{SUFFIX}`) saved under {root} with their submitted message "
+            f"also on disk, found {len(turns)}. Extracted: {detail}."
+            + (
+                f" Dropped as uncorroborated (message part occurs only inside the "
+                f"reply itself): {', '.join(repr(r) for r in dropped)}."
+                if dropped
+                else ""
+            )
+            + " The agent must chat locally twice with two different messages and "
             "save each reply."
         )
     print(
-        f"OK: {len(found)} distinct echoed replies from local chat turns, each with a "
-        f"submitted message on disk: {sorted(found)}"
+        f"OK: {len(turns)} distinct echoed replies from local chat turns, each with a "
+        f"submitted message on disk: {sorted(turns)}"
     )

--- a/tests/tasks/uipath-agents/_shared/two_turn_outputs.py
+++ b/tests/tasks/uipath-agents/_shared/two_turn_outputs.py
@@ -1,0 +1,163 @@
+"""Assert a conversational coded agent produced two distinct local turns.
+
+Grades the *outcome* of chatting twice, not how many Bash calls the
+agent used: `command_executed` with `min_count: 2` counts matching tool
+invocations, so an agent that chains both `uip codedagent run` calls in
+one shell command is docked for a task it completed correctly.
+
+An echo agent's reply is `"<message> echo"`. Two turns with two
+different messages therefore leave two distinct echoed replies on disk.
+This helper collects them from the files the agent saved and requires at
+least two.
+
+Extraction order:
+
+  1. JSON files — every string value ending in ` echo` (recursive walk).
+  2. Plain-text files (`.txt`, `.log`, `.md`, `.out`, `.jsonl`) — line
+     scan, for agents that tee replies instead of writing JSON.
+
+Source files (`.py`) are skipped: the workflow itself contains the
+f-string that builds the suffix.
+
+Each reply is then **corroborated**: its message part must occur at
+least twice across the project's files — once as the message that was
+submitted (an input file, a transcript's user turn, the runtime's
+`__uipath` state) and once inside the reply itself. A reply hand-written
+without a corresponding submitted message occurs only once and fails.
+Corroboration scans bytes, so binary runtime state counts too.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SUFFIX = " echo"
+MAX_BYTES = 1_000_000
+# Corroboration reads runtime state files, which are larger than the
+# reply files the extractor looks at.
+MAX_CORROBORATION_BYTES = 20_000_000
+SKIP_DIRS = {".venv", ".uipath", ".agent", ".claude", "node_modules", "__pycache__", ".git"}
+TEXT_SUFFIXES = {".txt", ".log", ".md", ".out", ".jsonl"}
+# `{...}` / `$...` markers mean the line is a template or command, not a reply.
+TEMPLATE_MARKERS = ("{", "}", "$")
+ECHO_LINE = re.compile(r"([^\"'\n\r]{1,200}?)" + re.escape(SUFFIX) + r"(?=[\"'.,\s]|$)")
+
+
+def _candidate_files(root: Path) -> list[Path]:
+    files: list[Path] = []
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        if any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+            continue
+        if path.suffix not in {".json"} | TEXT_SUFFIXES:
+            continue
+        if path.stat().st_size > MAX_BYTES:
+            continue
+        files.append(path)
+    return files
+
+
+def _echo_strings(node: object) -> list[str]:
+    if isinstance(node, str):
+        return [node] if node.endswith(SUFFIX) and len(node) > len(SUFFIX) else []
+    if isinstance(node, dict):
+        return [s for v in node.values() for s in _echo_strings(v)]
+    if isinstance(node, list):
+        return [s for v in node for s in _echo_strings(v)]
+    return []
+
+
+def _replies_from_json(path: Path) -> list[str]:
+    try:
+        doc = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError, OSError):
+        return []
+    return _echo_strings(doc)
+
+
+def _replies_from_text(path: Path) -> list[str]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+    replies = []
+    for match in ECHO_LINE.finditer(text):
+        reply = (match.group(1) + SUFFIX).strip()
+        if any(marker in reply for marker in TEMPLATE_MARKERS):
+            continue
+        if reply != SUFFIX.strip():
+            replies.append(reply)
+    return replies
+
+
+def collect_echo_replies(root: Path) -> dict[str, list[str]]:
+    """Map each distinct echoed reply to the files it was found in."""
+    found: dict[str, list[str]] = {}
+    for path in _candidate_files(root):
+        replies = _replies_from_json(path) if path.suffix == ".json" else []
+        if not replies:
+            replies = _replies_from_text(path)
+        for reply in replies:
+            found.setdefault(reply.strip(), []).append(str(path.relative_to(root)))
+    return found
+
+
+def _message_occurrences(root: Path, message: str) -> int:
+    """Count byte occurrences of `message` across the project's files."""
+    needle = message.encode("utf-8")
+    total = 0
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        parts = path.relative_to(root).parts
+        if any(part in SKIP_DIRS for part in parts) or path.suffix == ".py":
+            continue
+        try:
+            if path.stat().st_size > MAX_CORROBORATION_BYTES:
+                continue
+            total += path.read_bytes().count(needle)
+        except OSError:
+            continue
+    return total
+
+
+def corroborated_replies(root: Path, replies: dict[str, list[str]]) -> dict[str, int]:
+    """Map each reply to how often its message part occurs project-wide."""
+    counts = {}
+    for reply in replies:
+        message = reply[: -len(SUFFIX)]
+        counts[reply] = _message_occurrences(root, message) if message else 0
+    return counts
+
+
+def assert_two_local_turns(root: Path, min_turns: int = 2) -> None:
+    found = collect_echo_replies(root)
+    counts = corroborated_replies(root, found)
+    uncorroborated = sorted(r for r, n in counts.items() if n < 2)
+    if uncorroborated and len(found) >= min_turns:
+        sys.exit(
+            "FAIL: reply(ies) "
+            + ", ".join(repr(r) for r in uncorroborated)
+            + " have no submitted message on disk — the message part occurs only "
+            "inside the reply itself. A real `uip codedagent run` turn leaves the "
+            "message in its input file, transcript, or runtime state."
+        )
+    if len(found) < min_turns:
+        detail = (
+            "; ".join(f"{reply!r} in {sorted(set(files))}" for reply, files in found.items())
+            or "none"
+        )
+        sys.exit(
+            f"FAIL: expected at least {min_turns} distinct echoed replies "
+            f"(`<message>{SUFFIX}`) saved under {root}, found {len(found)}: {detail}. "
+            "The agent must chat locally twice with two different messages and "
+            "save each reply."
+        )
+    print(
+        f"OK: {len(found)} distinct echoed replies from local chat turns, each with a "
+        f"submitted message on disk: {sorted(found)}"
+    )

--- a/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
+++ b/tests/tasks/uipath-agents/coded/bindings_multi_entrypoint/bindings_multi_entrypoint.yaml
@@ -1,13 +1,12 @@
 task_id: skill-agents-bindings-multi-entrypoint
 description: >
-  Bindings sync over a project with two entrypoints. Per the
-  bindings-reference Step 4, when `entry-points.json` has multiple
-  entrypoints the resolver must either ask which entrypoint each
-  resource binds to (`AskUserQuestion`) or leave the entrypoint
-  field off the binding. The check accepts any consistent outcome —
-  the load-bearing assertion is that no binding ends up with a
-  fabricated `EntryPointUniqueId` that doesn't match either real
-  entrypoint.
+  Bindings sync over a project with two entrypoints. The prompt
+  pre-answers bindings-reference Step 4's disambiguation — the agent
+  is told to pick any declared entrypoint rather than ask — so the
+  run must reach Step 5 and write both bindings. The check accepts
+  either declared entrypoint (or an omitted entrypoint field); the
+  load-bearing assertion is that no binding ends up with a fabricated
+  `EntryPointUniqueId` that doesn't match either real entrypoint.
 tags: [uipath-agents, e2e, coded, lifecycle:generate, feature:bindings]
 
 run_limits:
@@ -21,6 +20,10 @@ pre_run:
 initial_prompt: |
   I have a uipath coded agent in the current directory. Can you sync its
   `bindings.json` so it reflects the resources the code uses?
+
+  The project has more than one entrypoint. Do not ask me which one to bind
+  each resource to — pick any of the declared entrypoints yourself. Any of
+  them is fine.
 
   Do NOT publish, upload, or deploy. Complete the task end-to-end. Only stop
   if there is a critical blocker you cannot resolve.

--- a/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/check_two_local_turns.py
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/check_two_local_turns.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Assert the LangGraph chat agent ran locally for two distinct turns.
+
+Outcome-based replacement for a `command_executed` count of
+`uip codedagent run`: see `_shared/two_turn_outputs.py`.
+
+Exits 0 on PASS, with a `FAIL: ...` message otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.project_root import find_project_root  # noqa: E402
+from _shared.two_turn_outputs import assert_two_local_turns  # noqa: E402
+
+ROOT = find_project_root("chat-agent")
+
+if not ROOT.is_dir():
+    sys.exit(f"FAIL: project directory {ROOT} does not exist")
+
+assert_two_local_turns(ROOT)

--- a/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_langgraph/conversational_agent_langgraph.yaml
@@ -5,7 +5,7 @@ description: >
   `langgraph.json` entry-point config, and that the agent ran locally
   for two turns. Lazy-LLM-init invariant (Critical Rule C4) still
   applies.
-tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-langgraph]
+tags: [uipath-agents, smoke, mode:build, coded, lifecycle:generate, feature:conversational, feature:framework-langgraph]
 
 run_limits:
   expected_turns: 20
@@ -19,7 +19,9 @@ initial_prompt: |
   chain `uip codedagent setup --force` before every uip codedagent
   command (new, init, run).
 
-  once it's running, chat with it twice locally so I can see it works.
+  once it's running, chat with it twice locally — two different
+  messages — and save each reply to a file in the project so I can see
+  both replies.
 
   no publishing, no deploys, no evals — and please don't burn time on
   TaskCreate/TaskUpdate planning. just bang it out end-to-end and stop
@@ -45,11 +47,23 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # Supporting: the local run went through the CLI. Count is 1, not 2 —
+  # `command_executed` counts Bash tool calls, so an agent that chains
+  # both runs in one shell command still ran two turns. The turn count
+  # is graded by outcome below.
   - type: command_executed
-    description: "Agent ran the agent locally twice (two chat turns)"
+    description: "Agent ran the agent locally with uip codedagent run"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+run'
-    min_count: 2
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Two distinct local chat turns produced echoed replies"
+    command: "python3 $TASK_DIR/check_two_local_turns.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/check_two_local_turns.py
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/check_two_local_turns.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Assert the LlamaIndex chat agent ran locally for two distinct turns.
+
+Outcome-based replacement for a `command_executed` count of
+`uip codedagent run`: see `_shared/two_turn_outputs.py`.
+
+Exits 0 on PASS, with a `FAIL: ...` message otherwise.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.project_root import find_project_root  # noqa: E402
+from _shared.two_turn_outputs import assert_two_local_turns  # noqa: E402
+
+ROOT = find_project_root("chat-agent")
+
+if not ROOT.is_dir():
+    sys.exit(f"FAIL: project directory {ROOT} does not exist")
+
+assert_two_local_turns(ROOT)

--- a/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/conversational_agent_llamaindex.yaml
+++ b/tests/tasks/uipath-agents/coded/conversational_agent_llamaindex/conversational_agent_llamaindex.yaml
@@ -5,7 +5,7 @@ description: >
   `llama_index.json` entry-point config, and that the agent ran locally
   for two turns. Lazy-LLM-init invariant (Critical Rule C4) still
   applies.
-tags: [uipath-agents, smoke, coded, lifecycle:generate, feature:conversational, feature:framework-llamaindex]
+tags: [uipath-agents, smoke, mode:build, coded, lifecycle:generate, feature:conversational, feature:framework-llamaindex]
 
 run_limits:
   expected_turns: 22
@@ -19,7 +19,9 @@ initial_prompt: |
   chain `uip codedagent setup --force` before every uip codedagent
   command (new, init, run).
 
-  once it's running, chat with it twice locally so I can see it works.
+  once it's running, chat with it twice locally — two different
+  messages — and save each reply to a file in the project so I can see
+  both replies.
 
   no publishing, no deploys, no evals — and please don't burn time on
   TaskCreate/TaskUpdate planning. just bang it out end-to-end and stop
@@ -45,11 +47,23 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # Supporting: the local run went through the CLI. Count is 1, not 2 —
+  # `command_executed` counts Bash tool calls, so an agent that chains
+  # both runs in one shell command still ran two turns. The turn count
+  # is graded by outcome below.
   - type: command_executed
-    description: "Agent ran the agent locally twice (two chat turns)"
+    description: "Agent ran the agent locally with uip codedagent run"
     tool_name: "Bash"
     command_pattern: 'uip\s+codedagent\s+run'
-    min_count: 2
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Two distinct local chat turns produced echoed replies"
+    command: "python3 $TASK_DIR/check_two_local_turns.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task/check_hitl_create_task.py
@@ -73,7 +73,7 @@ def _module_constants(tree: ast.Module) -> dict[str, object]:
             and isinstance(node.value, ast.Constant)
             and isinstance(node.target, ast.Name)
         ):
-            # Annotated constant, e.g. ``APP_NAME: str = "RefundReview"``.
+            # Annotated constant, e.g. ``APP_NAME: str = "ExpenseReview"``.
             consts[node.target.id] = node.value.value
     return consts
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/check_hitl_create_task_with_app.py
@@ -5,13 +5,13 @@ Asserts:
   1. `main.py` imports `interrupt` from `langgraph.types`.
   2. `main.py` imports `CreateTask` from `uipath.platform.common`.
   3. At least one `interrupt(CreateTask(...))` call site exists.
-  4. The `CreateTask` call targets `app_name="RefundReview"`,
-     `app_folder_path="Shared/uipath-agents/RefundReview"` (where the app
+  4. The `CreateTask` call targets `app_name="RefundReviewApp"`,
+     `app_folder_path="Shared/uipath-agents/RefundReviewSol"` (where the app
      is deployed on the codereval tenant).
   5. `main.py` does NOT use `CreateEscalation` (that's a different pattern
      covered by hitl_create_task — keep them disjoint).
-  6. `bindings.json` declares the `app` resource for `RefundReview` /
-     `Shared/uipath-agents/RefundReview`.
+  6. `bindings.json` declares the `app` resource for `RefundReviewApp` /
+     `Shared/uipath-agents/RefundReviewSol`.
   7. A top-level `graph =` variable is exported.
   8. `langgraph.json` exists at the resolved project root and points at
      the exported graph.
@@ -39,8 +39,8 @@ from _shared.bindings_assertions import (  # noqa: E402
 
 ROOT = find_project_root("refund-gate")
 
-APP_NAME = "RefundReview"
-APP_FOLDER = "Shared/uipath-agents/RefundReview"
+APP_NAME = "RefundReviewApp"
+APP_FOLDER = "Shared/uipath-agents/RefundReviewSol"
 
 
 def fail(msg: str) -> None:
@@ -68,7 +68,7 @@ def module_constants(tree: ast.Module) -> dict[str, object]:
             and isinstance(node.value, ast.Constant)
             and isinstance(node.target, ast.Name)
         ):
-            # Annotated constant, e.g. ``APP_NAME: str = "RefundReview"``.
+            # Annotated constant, e.g. ``APP_NAME: str = "RefundReviewApp"``.
             consts[node.target.id] = node.value.value
     return consts
 

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -14,14 +14,16 @@ max_iterations: 1
 initial_prompt: |
   Can you build me a uipath coded agent in LangGraph for handling refunds?
   Call it refund-gate, put it in a refund-gate folder. The idea: anything
-  over $500 needs a human to sign off first. Someone on the Compliance team
-  reviews it in their RefundReview app (that's in the
-  Shared/uipath-agents/RefundReview folder) - show them the customer, the
-  amount, and why the refund's being asked for.
-  Once they decide, carry on with their call and whatever note they left.
-  Anything $500 or under just goes through. And please make sure the
-  RefundReview app is actually hooked up, otherwise it can't send them the
-  request.
+  over $500 has to be reviewed by a person before it goes through. Open a
+  review task for the Compliance team (compliance@example.com) in their
+  RefundReviewApp app, deployed to the Orchestrator folder
+  Shared/uipath-agents/RefundReviewSol - it's a normal Action Center review
+  task, not an escalation - show them the customer, the amount, and why the
+  refund's being asked for.
+  Once they submit, carry on with the call they made and whatever note they
+  left. Anything $500 or under just goes through. And please make sure the
+  RefundReviewApp app is actually hooked up, otherwise it can't send them
+  the request.
 
   No need to run or deploy it, just build it. Run it all the way through
   and only stop if you hit something you genuinely can't get past.
@@ -51,7 +53,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "LangGraph config, interrupt(CreateTask) shape (not CreateEscalation), correct app targeting, RefundReview app binding in Shared/uipath-agents/RefundReview"
+    description: "LangGraph config, interrupt(CreateTask) shape (not CreateEscalation), correct app targeting, RefundReviewApp app binding in Shared/uipath-agents/RefundReviewSol"
     command: "python3 $TASK_DIR/check_hitl_create_task_with_app.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
+++ b/tests/tasks/uipath-agents/coded/langgraph_classifier/check_langgraph_classifier.py
@@ -13,10 +13,11 @@ Checks performed:
   2. The project has either `langgraph.json` (Pattern A — recommended)
      OR `uipath.json` with a `functions.graph` entry (Pattern B). Both
      are valid per the LangGraph integration guide.
-  3. `main.py` (or `graph.py`) defines `GraphInput`/`GraphOutput`
-     Pydantic models, exports a top-level `graph` variable, and has
-     NO module-level UiPath* construction (`UiPathChat`,
-     `UiPathAzureChatOpenAI`, etc.).
+  3. `main.py` (or `graph.py`) wires a `StateGraph` to distinct
+     Pydantic input/output models, exports a top-level `graph`
+     variable, and has NO module-level UiPath* construction
+     (`UiPathChat`, `UiPathAzureChatOpenAI`, etc.). Model *names* are
+     not asserted — `agent-patterns.md` allows any naming.
   4. `entry-points.json` has one entrypoint whose schemas mention
      `text` (input) and `category` (output) — proves `uip codedagent
      init` ran AFTER the Pydantic models were written.
@@ -36,6 +37,7 @@ from pathlib import Path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.bindings_assertions import load_bindings  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
+from _shared.langgraph_assertions import assert_graph_module_shape  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("support-classifier")
@@ -84,13 +86,7 @@ def find_graph_module() -> Path:
 
 
 def check_graph_module(path: Path) -> None:
-    text = _read_text(path)
-    for needle in ("GraphInput", "GraphOutput", "graph"):
-        if needle not in text:
-            sys.exit(f"FAIL: {path.name} is missing `{needle}`")
-    if "StateGraph" not in text and "CompiledStateGraph" not in text:
-        sys.exit(f"FAIL: {path.name} does not reference StateGraph / CompiledStateGraph")
-    print(f"OK: {path.name} defines GraphInput, GraphOutput, and a graph variable")
+    assert_graph_module_shape(path)
     violations = find_module_level_llm_clients(path)
     if violations:
         sys.exit("FAIL: " + " | ".join(violations))
@@ -148,8 +144,8 @@ def check_entry_points() -> None:
                 f'fields. Got: {raw}'
             )
     print(
-        "OK: entry-points.json schemas reflect the GraphInput/GraphOutput "
-        "fields (text, category)"
+        "OK: entry-points.json schemas reflect the declared input/output "
+        "model fields (text, category)"
     )
 
 

--- a/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/inline_is_connector_tool/inline_is_connector_tool.yaml
@@ -20,9 +20,9 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project "ResearchFlow" that runs an inline low-code
-  agent which can look things up on the web. Give the agent a tool so it can
-  run web searches on demand, and wire it into the flow. The solution should be
-  named "ResearchFlowSol".
+  agent which can look things up. Give the agent an Integration Service GenAI
+  tool so it can research questions on demand, and wire it into the flow. The
+  solution should be named "ResearchFlowSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
+++ b/tests/tasks/uipath-agents/lowcode/is_connector_tool/is_connector_tool.yaml
@@ -17,9 +17,9 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath low-code agent "ResearchAgent" that can look things up on the
-  web. Give it a tool so it can run web searches on demand. The solution should
-  be named "ResearchSol".
+  Create a UiPath low-code agent "ResearchAgent" that can look things up.
+  Give it a GenAI tool so it can research questions on demand. The solution
+  should be named "ResearchSol".
 
   Do NOT publish, upload, or deploy. Do NOT ask for approval,
   confirmation, or feedback. Do NOT pause between planning and

--- a/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
+++ b/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
@@ -74,7 +74,11 @@ success_criteria:
       the limitation), claims OpenAI Agents can produce a messages-free schema, or
       silently falls back to a plain Coded Function without explaining anything.
     weight: 3.0
-    pass_threshold: 0.8
+    # 0.75 passes: the graded invariants are "recognises the conflict" and
+    # "offers an alternative", both required by every band at 0.75 and up.
+    # Attribution varies run to run on the same model, so gating on it would
+    # make this smoke task flaky; the band keeps it visible in the score.
+    pass_threshold: 0.75
 
   - type: command_not_executed
     description: "Agent did not scaffold a project despite the infeasible request"

--- a/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
+++ b/tests/tasks/uipath-agents/strict_input_no_messages/strict_input_no_messages.yaml
@@ -4,9 +4,9 @@ description: >
   Agents coded agent but with a hard input contract — a single field and no
   `messages`. OpenAI Agents cannot express that (its runner forces a required
   `messages` field), so the agent must recognise the conflict, explain that
-  OpenAI Agents is not a fit, and suggest a different framework — without
-  scaffolding an OpenAI Agents project or silently falling back to a plain
-  function.
+  OpenAI Agents is not a fit — attributing the constraint to the OpenAI Agents
+  runner, not to UiPath — and suggest a different framework, without scaffolding
+  an OpenAI Agents project or silently falling back to a plain function.
 tags: [uipath-agents, smoke, mode:build, coded, lifecycle:discover, feature:framework-openai-agents]
 
 run_limits:
@@ -31,7 +31,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: llm_judge
-    description: "Agent recognises OpenAI Agents cannot satisfy a messages-free input and suggests an alternative"
+    description: "Agent recognises OpenAI Agents cannot satisfy a messages-free input, attributes the constraint to the OpenAI Agents runner, and suggests an alternative"
     include_agent_output: true
     prompt: |
       The user asked for an OpenAI Agents coded agent whose input is a single
@@ -44,14 +44,31 @@ success_criteria:
       and recommend a different coded-agent framework (e.g. LangGraph) that can
       express a messages-free, typed input contract.
 
+      Attribution matters. The constraint originates in the OpenAI Agents
+      runner/SDK; UiPath only surfaces it as the `messages` field in the
+      generated schema. Blaming UiPath or the platform inverts cause and surface
+      and implies switching frameworks would not help — which contradicts the
+      recommendation the agent is making.
+
+      Score the response in exactly one band:
+
       Score 1.0 if the agent clearly states that OpenAI Agents cannot produce an
       input schema without `messages` (so it cannot meet the named/non-chat input
-      contract) AND surfaces a different framework as the way to get it. It is
-      fine if the agent also offers a `messages`-based OpenAI Agents workaround as
-      an additional option — as long as the limitation is stated clearly and the
+      contract), attributes that constraint to the OpenAI Agents runner/SDK
+      (conversation-only input) rather than to UiPath, AND surfaces a different
+      framework as the way to get it. It is fine if the agent also offers a
+      `messages`-based OpenAI Agents workaround as an additional option — as long
+      as the limitation is stated clearly, attributed correctly, and the
       alternative is presented, that still scores 1.0.
-      Score 0.5 if the agent mentions the `messages` limitation but neither clearly
-      states OpenAI Agents cannot meet the contract nor surfaces an alternative.
+      Score 0.75 if the agent clearly states OpenAI Agents cannot meet the
+      contract AND surfaces a different framework, but attributes the `messages`
+      requirement to the wrong layer — e.g. says UiPath (or the platform, or
+      coded agents in general) requires `messages`, rather than the OpenAI Agents
+      runner. The conclusion and the alternative are right; the mechanism is
+      misdescribed.
+      Score 0.5 if the agent mentions the `messages` limitation but either does
+      not clearly state that OpenAI Agents cannot meet the contract, or does not
+      surface an alternative framework (or neither).
       Score 0.0 if the agent silently builds an OpenAI Agents project as if it
       satisfies the request (e.g. maps the input into `messages` without flagging
       the limitation), claims OpenAI Agents can produce a messages-free schema, or


### PR DESCRIPTION
Six `uipath-agents` coder_eval tasks failed for reasons that had nothing to do with the agent's work — the criteria graded surface details (shell-call count, class names, a stale deployed app), the task asked a question no one could answer, or the prompt steered at a connector the tenant cannot authorize. Each commit fixes one, with a verified passing run.

## Changes

**`grade conversational turns by outcome, not Bash-call count`** — `command_executed` counts tool calls, so chaining both `uip codedagent run` invocations into one shell command scored 1/2 on the two-turn criterion. Replaced with a `run_command` criterion asserting two distinct echoed replies exist on disk, corroborated by the message appearing where it was submitted. Adds the missing `mode:build` tag to both tasks.
Verified: 6 live runs, all 1.000 — both tasks under claude-code (claude-sonnet-5) and codex (gpt-5.6-sol), including a codex trajectory that chained both runs in one Bash call.

**`retarget hitl_create_task_with_app at the redeployed app`** — the task graded an app that no longer matches the codereval tenant, and its prompt matched the skill's `CreateEscalation` example verbatim, so the intended `CreateTask` pattern was unreachable. Points the checker at the redeployed `RefundReviewApp` and rewrites the prompt to name the Orchestrator folder and rule out escalation.
Verified: two consecutive local runs (codex / gpt-5.6-sol) at 1.000.

**`grade LangGraph graph shape structurally, not by class name`** — the checker required the literal substrings `GraphInput`/`GraphOutput`, though `agent-patterns.md` allows either naming. Replaces the substring loop with an AST check (`assert_graph_module_shape`) asserting the real invariants: StateGraph construction, module-defined state schema, distinct module-defined Pydantic input/output models, exported top-level `graph`.
Verified: 4/4 on both harnesses across three naming schemes; exits 0 on the artifacts of the run that originally failed; all six LangGraph fixtures pass and four synthetic negatives still fail.

**`give the no-messages judge a band for wrong-layer attribution`** — the judge rubric had no band for "right conclusion, wrong mechanism" and its 0.5 band was an unreachable conjunction, so a correct refusal that blamed UiPath instead of the OpenAI Agents runner had no legal band and failed at 0.750. Adds an explicit 0.75 band, requires correct attribution for 1.0, and rewrites the 0.5 band as a disjunction.
Not verified against a live judge — no judge backend available locally (`llm_judge` needs Bedrock or `ANTHROPIC_API_KEY`); verification deferred to CI.

**`pre-answer the multi-entrypoint disambiguation in the prompt`** — bindings-reference Step 4 tells the resolver to ask which entrypoint each resource binds to when `entry-points.json` declares more than one, and sequences that ask *before* Step 5 writes `bindings.json`. In a non-interactive harness the agent asked, ended its turn, and never wrote anything — the run died after one turn with the fixture's empty skeleton intact, scoring 0.294. The codex variant also has no `AskUserQuestion` tool, so the skill's escape hatch does not exist for it. The task's description claimed asking was acceptable, but the checker requires both bindings present before it inspects `EntryPointUniqueId`, so the ask path could never pass. The prompt now tells the agent to pick any declared entrypoint, and the description matches what the checker accepts (either real entrypoint, or the field omitted; only a fabricated id fails).
Verified: two local runs at 1.000 under codex — gpt-5.6-sol (bound each resource to its own file's entrypoint) and gpt-5.6-terra, the model that originally failed (bound both to the first entrypoint).

**`steer the IS-connector prompts at a connector with a live connection`** — both IS-connector tasks asked for a tool that can "run web searches on the web". That pulls agents to `uipath-perplexity-perplexity`, which has no connection in the codereval tenant and cannot be authorized headlessly — `uip is connections create` returns `ConnectionAuthorizationPending` and the id never materializes, so agents bound a phantom connection, `uip solution resources refresh` resolved nothing, and the connection-resource assertion was unreachable. Both task descriptions already declare the dependency on `uipath-uipath-airdk` (GenAI Activities), which does have an enabled connection; the prompts now say so without naming the connector, leaving connector and activity discovery to the agent. The inline prompt names Integration Service explicitly — with "GenAI tool" alone, codex read it as a built-in capability and built a `uipath.agent.resource.tool.builtin.deep-rag` node, failing the checker's first assertion.
Verified: `inline_is_connector_tool` under claude-code (claude-sonnet-5) at 1.000 — connection resource provisioned by `uip solution resources refresh`, real connection id and folder key throughout, nothing hand-written. Same task under codex (gpt-5.6-terra) improves 0.611 → 0.722, failing only because it writes an empty `connection.id` into `resource.json` despite having looked the id up.

## Follow-up

The underlying skill gap in the last item is not fixed here: `references/coded/lifecycle/bindings-reference.md:93-99` still has no non-interactive fallback for the multi-entrypoint branch, so an agent without that prompt hint (or without `AskUserQuestion`) will still stall before writing. The task works around it rather than covering it.

## Not included

**The `role` crash in `uip agent refresh --inline-in-flow`.** A CLI bug, not a task defect: refresh throws `Cannot set properties of undefined (setting 'role')` when a chat-completion connector tool node (`uipath.agent.resource.tool.connector.uipath-perplexity-perplexity.chat-completion`) is wired to a `uipath.agent.autonomous` node's `tool` handle and its `definitions[]` entry is present. Bisected on a clean scaffold: removing the node, the definition, or the edge all clear it, and the same wiring with `uipath-uipath-airdk.web-search` succeeds and generates the resource. Worse, `uip agent validate --inline-in-flow` responds to the resulting drift with *"Run `uip agent refresh --inline-in-flow` to generate resource.json files"* — it directs the agent straight back into the crash. The prompt fix above sidesteps it by steering to airdk; the bug still needs filing against `agent-tool`.

**Two `check_inline_is_connector_tool.py` inaccuracies.** Its failure text tells agents to author `bindings_v2.json` manually, but for inline-in-flow that file is *generated* by `uip agent refresh --bindings-target` — the message is inherited from the standalone task and contradicts the skill. And the connection-resource assertion only checks that the directory is non-empty, so a hand-written stub satisfies it: in the standalone task's codex run the graded file was produced by a `Write` call, not by refresh, and the task still scored 1.000. Both worth tightening; neither touched here.

**Sandbox exposure.** `SKILLS_REPO_PATH` is the repo root, so `tests/` is inside the agent's reachable filesystem. In the standalone codex run the agent read `is_connector_tool.yaml` and `check_is_connector_tool.py` and ran the checker itself before finishing. Excluding `tests/` via `agent.ignore_patterns` would stop tasks grading against criteria the agent has read.

**A skill gap behind the remaining codex failure.** `references/lowcode/capabilities/integration-service.md:263` documents `uip is connections list "<connector-key>"` without `--all-folders`, so the enabled airdk connection — which lives in the `uipath-agents` folder — reads as absent. Claude recovered by adding the flag on its own; codex looked the id up and then wrote `"id": ""` anyway. The reference should require `--all-folders` and require carrying the discovered id, folder key, and name into `resource.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

