### PR TITLE
test(flow): restore scaffold_multinode run_limits dropped by #2534

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -89,3 +89,9 @@ success_criteria:
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
+
+run_limits:
+  expected_turns: 24
+  max_turns: 40
+  turn_timeout: 900
+  task_timeout: 900


### PR DESCRIPTION
Review follow-up on merged #2534 (inline comment `3754351040`): the criteria migration swallowed the trailing `run_limits` block in `ixp/scaffold_multinode.yaml`, silently raising the task's budget to the experiment defaults (max_turns 200 / task_timeout 1200 vs the intended 40 / 900s) — a cost and pass-rate-comparability regression.

This restores the exact pre-#2534 block (verified against `git show 7a5c251a2~1:.../scaffold_multinode.yaml`). Config-only; no criteria touched, so no eval dispatch — the evidence is the diff itself. Audited the other 16 migrated files for the same failure mode: only this one had trailing content after its final criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
