### PR TITLE
WIP fix(tests): stop coder-eval agent plugin mount from exposing tests/

### DIFF
--- a/.github/workflows/activation-gate.yml
+++ b/.github/workflows/activation-gate.yml
@@ -93,12 +93,24 @@ jobs:
       - name: Install coder-eval
         run: uv pip install --system "coder-eval==${{ steps.ceref.outputs.version }}"
 
+      # Agent's plugin view must exclude tests/ — activation.yaml's
+      # `plugins[].path` is `$SKILLS_PLUGIN_PATH`. See smoke-skills.yml's
+      # equivalent step for why (leaks the answer key otherwise). tempdir
+      # driver has no container jail, so this is defense-in-depth here
+      # rather than a hard boundary, but kept consistent.
+      - name: Build tests-excluded skills copy for agent plugin mount
+        run: |
+          rm -rf /tmp/skills
+          mkdir -p /tmp/skills
+          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+
       - name: Run activation gate
         env:
           # Pass matrix value via env (not direct ${{ }} interpolation in run:)
           # to avoid shell expansion of any special chars in the skill name.
           SKILL: ${{ matrix.skill }}
           SKILLS_REPO_PATH: ${{ github.workspace }}
+          SKILLS_PLUGIN_PATH: /tmp/skills
           API_BACKEND: bedrock
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/activation-gate.yml
+++ b/.github/workflows/activation-gate.yml
@@ -102,7 +102,12 @@ jobs:
         run: |
           rm -rf /tmp/skills
           mkdir -p /tmp/skills
-          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+          # plugins/ and AGENTS.md are also excluded: both are committed
+          # symlinks (plugins/uipath -> .., AGENTS.md -> CLAUDE.md) that tar
+          # fails to recreate on the Windows runner (dangling-target-order /
+          # ELOOP on the self-referential marketplace link); neither is needed
+          # by the `type: local` plugin loader, which reads the repo root directly.
+          tar --exclude='./tests' --exclude='./.git' --exclude='./plugins' --exclude='./AGENTS.md' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
 
       - name: Run activation gate
         env:

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -242,7 +242,12 @@ jobs:
         run: |
           rm -rf /tmp/skills
           mkdir -p /tmp/skills
-          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+          # plugins/ and AGENTS.md are also excluded: both are committed
+          # symlinks (plugins/uipath -> .., AGENTS.md -> CLAUDE.md) that tar
+          # fails to recreate on the Windows runner (dangling-target-order /
+          # ELOOP on the self-referential marketplace link); neither is needed
+          # by the `type: local` plugin loader, which reads the repo root directly.
+          tar --exclude='./tests' --exclude='./.git' --exclude='./plugins' --exclude='./AGENTS.md' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
 
       # TASK_GLOBS here is the partition-resolved list of *file paths* (not
       # globs). Word-splitting is intentional — do not quote.
@@ -526,7 +531,12 @@ jobs:
         run: |
           rm -rf /tmp/skills
           mkdir -p /tmp/skills
-          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+          # plugins/ and AGENTS.md are also excluded: both are committed
+          # symlinks (plugins/uipath -> .., AGENTS.md -> CLAUDE.md) that tar
+          # fails to recreate on the Windows runner (dangling-target-order /
+          # ELOOP on the self-referential marketplace link); neither is needed
+          # by the `type: local` plugin loader, which reads the repo root directly.
+          tar --exclude='./tests' --exclude='./.git' --exclude='./plugins' --exclude='./AGENTS.md' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
 
       # Run tasks one at a time on Windows: Helm state leaks between tasks
       # (stale Studio session, locked NuGet cache), so the loop kills Helm

--- a/.github/workflows/run-coder-eval.yml
+++ b/.github/workflows/run-coder-eval.yml
@@ -232,11 +232,24 @@ jobs:
           CE_PASSWORD:              ${{ secrets.UIPATH_BOT_PASSWORD }}
         run: bash .github/scripts/refresh-auth.sh
 
+      # Agent's plugin view must exclude tests/ — nightly.yaml's
+      # `plugins[].path` is `$SKILLS_PLUGIN_PATH`, mounted read-only into the
+      # agent's container at the same path (docker_runner.py auto-mount). If
+      # this pointed at the full checkout (like SKILLS_REPO_PATH, still used
+      # below for grading's run_command criteria), the agent under test
+      # could read tests/tasks/**/*.yaml — its own success_criteria/answers.
+      - name: Build tests-excluded skills copy for agent plugin mount
+        run: |
+          rm -rf /tmp/skills
+          mkdir -p /tmp/skills
+          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+
       # TASK_GLOBS here is the partition-resolved list of *file paths* (not
       # globs). Word-splitting is intentional — do not quote.
       - name: Run coder-eval
         env:
           SKILLS_REPO_PATH:         ${{ github.workspace }}
+          SKILLS_PLUGIN_PATH:       /tmp/skills
           API_BACKEND:              bedrock
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION:               ${{ secrets.AWS_REGION }}
@@ -503,6 +516,18 @@ jobs:
           uip rpa list-instances --output json 2>&1 || true
           taskkill //F //IM UiPath.Studio.Helm.exe 2>/dev/null || true
 
+      # Agent's plugin view must exclude tests/ — smoke-windows.yaml's
+      # `plugins[].path` is `$SKILLS_PLUGIN_PATH`. See the Linux job's
+      # equivalent step above for why (leaks the answer key otherwise).
+      # tempdir driver has no container jail, so this is defense-in-depth
+      # here rather than a hard boundary, but kept consistent.
+      - name: Build tests-excluded skills copy for agent plugin mount
+        shell: bash
+        run: |
+          rm -rf /tmp/skills
+          mkdir -p /tmp/skills
+          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+
       # Run tasks one at a time on Windows: Helm state leaks between tasks
       # (stale Studio session, locked NuGet cache), so the loop kills Helm
       # between tasks. j=1 by construction.
@@ -514,6 +539,7 @@ jobs:
       - name: Run coder-eval (Windows)
         env:
           SKILLS_REPO_PATH:         ${{ github.workspace }}
+          SKILLS_PLUGIN_PATH:       /tmp/skills
           API_BACKEND:              bedrock
           AWS_BEARER_TOKEN_BEDROCK: ${{ secrets.AWS_BEARER_TOKEN_BEDROCK }}
           AWS_REGION:               ${{ secrets.AWS_REGION }}

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -272,9 +272,22 @@ jobs:
           uip rpa list-instances --output json 2>&1 || true
           taskkill //F //IM UiPath.Studio.Helm.exe 2>/dev/null || true
 
+      # Agent's plugin view must exclude tests/ — smoke-windows.yaml's
+      # `plugins[].path` is `$SKILLS_PLUGIN_PATH`. See smoke-skills.yml's
+      # equivalent step for why (leaks the answer key otherwise). tempdir
+      # driver has no container jail, so this is defense-in-depth here
+      # rather than a hard boundary, but kept consistent.
+      - name: Build tests-excluded skills copy for agent plugin mount
+        shell: bash
+        run: |
+          rm -rf /tmp/skills
+          mkdir -p /tmp/skills
+          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+
       - name: Run RPA smoke tests
         env:
           SKILLS_REPO_PATH: ${{ github.workspace }}
+          SKILLS_PLUGIN_PATH: /tmp/skills
           # Route the agent through AWS Bedrock. The Anthropic workspace
           # hit its API usage limit (resets 2026-05-01), so DirectRoute
           # is blocked. Bedrock has a separate quota.

--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -282,7 +282,12 @@ jobs:
         run: |
           rm -rf /tmp/skills
           mkdir -p /tmp/skills
-          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+          # plugins/ and AGENTS.md are also excluded: both are committed
+          # symlinks (plugins/uipath -> .., AGENTS.md -> CLAUDE.md) that tar
+          # fails to recreate on the Windows runner (dangling-target-order /
+          # ELOOP on the self-referential marketplace link); neither is needed
+          # by the `type: local` plugin loader, which reads the repo root directly.
+          tar --exclude='./tests' --exclude='./.git' --exclude='./plugins' --exclude='./AGENTS.md' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
 
       - name: Run RPA smoke tests
         env:

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -396,9 +396,22 @@ jobs:
               uip agent guardrails list --output json
             '
 
+      # Agent's plugin view must exclude tests/ — smoke.yaml's
+      # `plugins[].path` is `$SKILLS_PLUGIN_PATH`, mounted read-only into the
+      # agent's container at the same path (docker_runner.py auto-mount). If
+      # this pointed at the full checkout (like SKILLS_REPO_PATH, still used
+      # below for grading's run_command criteria), the agent under test
+      # could read tests/tasks/**/*.yaml — its own success_criteria/answers.
+      - name: Build tests-excluded skills copy for agent plugin mount
+        run: |
+          rm -rf /tmp/skills
+          mkdir -p /tmp/skills
+          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+
       - name: Run smoke tests
         env:
           SKILLS_REPO_PATH: ${{ github.workspace }}
+          SKILLS_PLUGIN_PATH: /tmp/skills
           # Route the agent through AWS Bedrock. The Anthropic workspace
           # hit its API usage limit (resets 2026-05-01), so DirectRoute
           # is blocked. Bedrock has a separate quota.

--- a/.github/workflows/smoke-skills.yml
+++ b/.github/workflows/smoke-skills.yml
@@ -406,7 +406,12 @@ jobs:
         run: |
           rm -rf /tmp/skills
           mkdir -p /tmp/skills
-          tar --exclude='./tests' --exclude='./.git' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
+          # plugins/ and AGENTS.md are also excluded: both are committed
+          # symlinks (plugins/uipath -> .., AGENTS.md -> CLAUDE.md) that tar
+          # fails to recreate on the Windows runner (dangling-target-order /
+          # ELOOP on the self-referential marketplace link); neither is needed
+          # by the `type: local` plugin loader, which reads the repo root directly.
+          tar --exclude='./tests' --exclude='./.git' --exclude='./plugins' --exclude='./AGENTS.md' -C "${GITHUB_WORKSPACE}" -cf - . | tar -C /tmp/skills -xf -
 
       - name: Run smoke tests
         env:

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,8 +1,12 @@
 .PHONY: help install all smoke smoke_rpa e2e tags
 
 SKILLS_REPO_PATH ?= $(shell cd .. && pwd)
+# Agent's mounted plugin view. CI builds a tests/-excluded copy of the repo
+# and points this at it (closes the answer-key leak); local dev defaults it
+# to the full checkout since there's no adversarial grading boundary here.
+SKILLS_PLUGIN_PATH ?= $(SKILLS_REPO_PATH)
 VENV := .venv
-CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) $(VENV)/bin/coder-eval
+CODER_EVAL := SKILLS_REPO_PATH=$(SKILLS_REPO_PATH) SKILLS_PLUGIN_PATH=$(SKILLS_PLUGIN_PATH) $(VENV)/bin/coder-eval
 TASKS := $(shell find tasks -name '*.yaml' -type f)
 TASK_PARALLELISM ?= 1
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -62,11 +62,12 @@ make test-uipath-maestro-flow
 
 # Run a single task file
 SKILLS_REPO_PATH=$(cd .. && pwd) \
+SKILLS_PLUGIN_PATH=$(cd .. && pwd) \
   .venv/bin/coder-eval run tasks/uipath-maestro-flow/smoke/init_validate.yaml \
   -e experiments/default.yaml
 ```
 
-The `SKILLS_REPO_PATH` environment variable defaults to the parent directory (repo root) when using `make`.
+The `SKILLS_REPO_PATH` environment variable defaults to the parent directory (repo root) when using `make`. `SKILLS_PLUGIN_PATH` (the agent's mounted plugin view) defaults to the same value locally; CI points it at a `tests/`-excluded copy so the agent under test can't read its own answer key — see `.github/workflows/*.yml`.
 
 ### Parallelism
 
@@ -520,6 +521,7 @@ runs/
 4. **Re-run a single task with verbose output:**
    ```bash
    SKILLS_REPO_PATH=$(cd .. && pwd) \
+   SKILLS_PLUGIN_PATH=$(cd .. && pwd) \
      .venv/bin/coder-eval run tasks/uipath-maestro-flow/smoke/init_validate.yaml \
      -e experiments/default.yaml -v
    ```

--- a/tests/experiments/activation.yaml
+++ b/tests/experiments/activation.yaml
@@ -48,8 +48,13 @@ defaults:
     # decision toward "don't invoke".
     allowed_tools: [Skill, Bash, Read, Write, Edit, Glob, Grep]
     plugins:
+      # Agent's mounted view of the repo, deliberately narrower than
+      # SKILLS_REPO_PATH — SKILLS_PLUGIN_PATH excludes tests/ so the agent
+      # under test can't read its own answer key. Not a hard isolation
+      # boundary under driver:tempdir (no container jail), but kept
+      # consistent with the docker-driver experiments.
       - type: local
-        path: $SKILLS_REPO_PATH
+        path: $SKILLS_PLUGIN_PATH
     ignore_patterns: []
 
   # Drop <sandbox>/{node_modules,.npm-prefix,.venv} so preserved artifacts stay slim

--- a/tests/experiments/default.yaml
+++ b/tests/experiments/default.yaml
@@ -21,8 +21,12 @@ defaults:
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
+      # Agent's mounted view of the repo, deliberately narrower than
+      # SKILLS_REPO_PATH (which grading's run_command criteria still use
+      # to find tests/**/_shared helpers) — SKILLS_PLUGIN_PATH excludes
+      # tests/ so the agent under test can't read its own answer key.
       - type: "local"
-        path: "$SKILLS_REPO_PATH"
+        path: "$SKILLS_PLUGIN_PATH"
     ignore_patterns: []
 
   # Sandbox cleanup between tasks. Tasks that upload Studio Web solutions

--- a/tests/experiments/nightly.yaml
+++ b/tests/experiments/nightly.yaml
@@ -15,6 +15,7 @@ defaults:
       image: skills-image:latest
       env_passthrough_extra:
         - SKILLS_REPO_PATH
+        - SKILLS_PLUGIN_PATH
         - BEDROCK_MODEL
         - TASK_PARALLELISM
         - UIPATH_CLI_ENABLE_ENV_AUTH
@@ -39,8 +40,12 @@ defaults:
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
+      # Agent's mounted view of the repo, deliberately narrower than
+      # SKILLS_REPO_PATH (which grading's run_command criteria still use
+      # to find tests/**/_shared helpers) — SKILLS_PLUGIN_PATH excludes
+      # tests/ so the agent under test can't read its own answer key.
       - type: "local"
-        path: "$SKILLS_REPO_PATH"
+        path: "$SKILLS_PLUGIN_PATH"
     ignore_patterns: []
 
   # Sandbox cleanup between tasks. Tasks that upload Studio Web solutions

--- a/tests/experiments/smoke-windows.yaml
+++ b/tests/experiments/smoke-windows.yaml
@@ -23,8 +23,14 @@ defaults:
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
+      # Agent's mounted view of the repo, deliberately narrower than
+      # SKILLS_REPO_PATH (which grading's run_command criteria still use
+      # to find tests/**/_shared helpers) — SKILLS_PLUGIN_PATH excludes
+      # tests/ so the agent under test can't read its own answer key. Not
+      # a hard isolation boundary under driver:tempdir (no container jail),
+      # but kept consistent with the docker-driver experiments.
       - type: "local"
-        path: "$SKILLS_REPO_PATH"
+        path: "$SKILLS_PLUGIN_PATH"
     ignore_patterns: []
 
   # Sandbox cleanup between tasks (preserved artifacts stay slim; concurrent

--- a/tests/experiments/smoke.yaml
+++ b/tests/experiments/smoke.yaml
@@ -17,6 +17,7 @@ defaults:
       image: skills-image:latest
       env_passthrough_extra:
         - SKILLS_REPO_PATH
+        - SKILLS_PLUGIN_PATH
         - BEDROCK_MODEL
         - TASK_PARALLELISM
         - UIPATH_CLI_ENABLE_ENV_AUTH
@@ -39,8 +40,12 @@ defaults:
     system_prompt: |
       You are a coding agent. Do not access files in sibling runs/* directories. Everywhere else is permitted.
     plugins:
+      # Agent's mounted view of the repo, deliberately narrower than
+      # SKILLS_REPO_PATH (which grading's run_command criteria still use
+      # to find tests/**/_shared helpers) — SKILLS_PLUGIN_PATH excludes
+      # tests/ so the agent under test can't read its own answer key.
       - type: "local"
-        path: "$SKILLS_REPO_PATH"
+        path: "$SKILLS_PLUGIN_PATH"
     ignore_patterns: []
 
   # Sandbox cleanup between tasks (preserved artifacts stay slim; concurrent


### PR DESCRIPTION
## Summary
- The agent under test loads `$SKILLS_REPO_PATH` as its Claude Code plugin, and coder_eval bind-mounts that path read-only into the agent's sandbox at the same absolute path. Since `SKILLS_REPO_PATH` is the full checkout, the agent could browse `tests/tasks/**/*.yaml` and read its own `success_criteria` — a leak letting it game grading.
- Introduces a new `SKILLS_PLUGIN_PATH` env var for the plugin mount, pointed at a `tests/`-excluded copy built fresh in each CI workflow (`tar --exclude=tests --exclude=.git`). `SKILLS_REPO_PATH` is left untouched everywhere else, since 251 `run_command` grading criteria resolve `tests/tasks/**/_shared/*.py` helpers through it host-side and must keep working unchanged.
- Applied to all 5 places that reference the plugin path (`tests/experiments/{default,smoke,nightly,smoke-windows,activation}.yaml`) and all 5 GH workflow spots that invoke `coder-eval run`. Only `smoke.yaml`/`nightly.yaml` (`driver: docker`) get a real isolation boundary from this; the `tempdir`-driver paths (`default.yaml`, `smoke-windows.yaml`, `activation.yaml`) get the same treatment for consistency but it's defense-in-depth there (no container jail to leak past).
- `tests/Makefile` defaults `SKILLS_PLUGIN_PATH` to `SKILLS_REPO_PATH` so local `make` runs keep working unchanged (no adversarial grading boundary for a dev's own machine).

## Test plan
- [ ] `smoke-skills.yml` full non-Windows smoke suite passes (triggered by `tests/experiments/smoke.yaml` + workflow-file changes)
- [ ] `smoke-rpa-skills.yml` full Windows RPA smoke suite passes (triggered by `tests/experiments/` + workflow-file changes)
- [ ] `activation-gate.yml` `detect` job runs cleanly (no SKILL.md frontmatter changed, so `gate` job stays skipped)
- [ ] Spot-check a `run_command` criterion under `nightly.yaml`/`smoke.yaml` still resolves its `_shared/*.py` helper correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)