### PR TITLE
fix(uipath-automationhub): correct publish-process required fields from live alpha validation

### DIFF
--- a/skills/uipath-automationhub/references/api-endpoints.md
+++ b/skills/uipath-automationhub/references/api-endpoints.md
@@ -54,12 +54,34 @@ Body:
 ```json
 { "idea_flow_id": <id>, "user_inputs": { "<AssessmentType>": { "<section-ahid>": { "<question-key>": { "value": "<v>" } } } } }
 ```
-`user_inputs` **must** contain a question whose key contains `OVERVIEW_NAME` with a non-empty value (the process name; enforced by validation middleware).
+**Do not POST `data.user_inputs` verbatim** — its example values are placeholders that the API rejects. Replace each with a real value; in particular resolve a **valid** `OVERVIEW_CATEGORY` id (the template's `1` → `Invalid Category Id`) and real `answer_option` codes (a placeholder code → backend `co_question_answer_option_value` crash).
+
+**Required fields (Business Process, `idea_flow_id`=7), verified live** — note the backend enforces owner + submitter even though the schema's `required` flags omit them:
+
+| Key | Section | Shape |
+|---|---|---|
+| `OVR-OVERVIEW_NAME` | `ah-section-ovr-0-0` | `{"value":"…"}` |
+| `OVR-OVERVIEW_DESCRIPTION` | `ah-section-ovr-0-0` | `{"value":"…"}` |
+| `OVR-OVERVIEW_CATEGORY` | `ah-section-ovr-0-0` | `{"value":<valid id>}` |
+| `OVR-PROCESS_DOCUMENTS` | `ah-section-ovr-0-0` | `{"value":["<answer_option code>"]}` |
+| `OVR-PROCESS_OWNER` | `ah-section-ovr-0-0` | `"<email>"` (direct string) |
+| `OVR-OVERVIEW_PROCESS_SUBMITTER` | `ah-section-ovr-0-1` | `"<email>"` (direct string) |
+
+When a required field is missing the API may return `errorDetails: {}` (no field named) with `"Please fill in all the required information"` — that is almost always the un-flagged owner/submitter.
 
 **Response 201** — the created process object **at the top level** (not nested): `process_id`, `process_uuid`, `process_name`, … Record `process_id`. *(Used by the publish flow.)*
 
 ### POST `/automations/{process_id}/documents`
-Attach a document to a process. **Link-based** (a link/embed URL + metadata), not a raw file upload — byte upload is a separate `media` endpoint that is not usable yet. Body fields are governed by `open-api-service` `ProcessDocumentValidator` (`src/models/schema/processDocumentRequest.schema.ts`); the known fields are the document **name**, an **embed/link URL** (`embed_link`), and a **document type id** (`document_type_id`). Confirm the exact required fields against that schema before finalizing. Returns the created `document_id`. *(Used by the publish flow.)*
+Attach a document to a process. **Link-based** (a link/embed URL + metadata), not a raw file upload — byte upload is a separate `media` endpoint that is not usable yet. Governed by `open-api-service` `ProcessDocumentValidator` (`src/models/schema/processDocumentRequest.schema.ts`). **Required fields, verified live:**
+
+```json
+{ "document_title": "…", "document_description": "…", "document_type_id": 1, "embed_link": "https://…" }
+```
+
+- `document_title` (**not** `document_name`), `document_description`, `document_type_id` are all required by the schema.
+- Plus **exactly one** of `embed_link` or `file` — enforced in the handler (not the schema), so omitting both 400s with `"One and only one of embed_link or file need to be specified."` Use `embed_link`.
+
+Returns the created `document_id`. *(Used by the publish flow.)*
 
 ### GET `/automations?search=<text>&limit=<n>&offset=<n>`
 Search/list processes. Returns a paged list (results under a resource key, e.g. `processes`, or a bare array). Use to resolve a name → `process_id`. *(Used by the get flow.)*

--- a/skills/uipath-automationhub/references/publish-process.md
+++ b/skills/uipath-automationhub/references/publish-process.md
@@ -38,16 +38,29 @@ curl -s -H "Authorization: Bearer $ACCESS_TOKEN" \
 
 Parse `data.properties.schema.properties` for the field catalog (Assessment Type > Section > Question; note types, required flags, enum `answer_option` codes/labels) and keep `data.user_inputs` as the payload template. The process-name question (key contains `OVERVIEW_NAME`) is **required**.
 
+> ⚠️ **Do NOT POST `data.user_inputs` verbatim.** The template ships **example/placeholder values that the API rejects** — e.g. `OVERVIEW_CATEGORY: 1` (→ `Invalid Category Id`), a placeholder `PROCESS_DOCUMENTS` answer-option that triggers a backend `co_question_answer_option_value` crash, and `First.last@example.com` owner/submitter emails. Treat the template as **shape only** and replace every value with a real one (below).
+
 ## Step 4: Assemble the process payload
 
-Gather the process fields — from the caller's supplied data (e.g. a Process Scribe hand-off object) or by asking the user. Then build `user_inputs` from the template:
+Gather the process fields — from the caller's supplied data (e.g. a Process Scribe hand-off object) or by asking the user. Then build `user_inputs` using the template's **structure** but **real values**:
 - Place each value in its `AssessmentType > section > question` slot.
-- Follow the template's wrapping per field: most are `{ "value": <v> }`; owner/submitter questions take a direct string.
-- Convert enum labels to their `answer_option` codes; send integers as numbers.
-- Include only sections that have at least one populated field.
-- The `OVERVIEW_NAME` question **must** be present and non-empty.
+- Follow the template's wrapping per field: most are `{ "value": <v> }`; owner/submitter questions take a **direct string** (no `value` wrapper).
+- Convert enum labels to their `answer_option` codes taken from that field's own `enum` in the schema — **never** reuse the template's placeholder code. Send integers as numbers.
+- **Category** (`OVERVIEW_CATEGORY`) must be a **valid category id on this tenant**, not the template's `1`. Resolve one by reading `categories[].category_id` (and `subcategories`) from an existing process (`GET /automations/{anyId}`), or ask the user.
+- **Owner/submitter emails must be real, provisioned AH users** on this tenant (a bad address 400s).
 
-Show the user a concise preview (name + key fields, and "show raw JSON" on request) and get a confirm before writing.
+**Required fields for `idea_flow_id` = Business Process** (verified live — the backend enforces owner + submitter even though the schema's `required` flags do **not** list them):
+
+| Question (key) | Section | Shape | Value |
+|---|---|---|---|
+| `OVR-OVERVIEW_NAME` | `ah-section-ovr-0-0` | `{"value": "<name>"}` | process name, non-empty |
+| `OVR-OVERVIEW_DESCRIPTION` | `ah-section-ovr-0-0` | `{"value": "<desc>"}` | description |
+| `OVR-OVERVIEW_CATEGORY` | `ah-section-ovr-0-0` | `{"value": <int>}` | **valid** category id |
+| `OVR-PROCESS_DOCUMENTS` | `ah-section-ovr-0-0` | `{"value": ["<answer_option code>"]}` | code from the field's `enum` |
+| `OVR-PROCESS_OWNER` | `ah-section-ovr-0-0` | `"<email>"` (direct string) | real AH user |
+| `OVR-OVERVIEW_PROCESS_SUBMITTER` | `ah-section-ovr-0-1` | `"<email>"` (direct string) | real AH user |
+
+Include only sections that have at least one populated field. Show the user a concise preview (name + key fields, and "show raw JSON" on request) and get a confirm before writing.
 
 ## Step 5: Create the process
 
@@ -61,7 +74,11 @@ curl -s -w "\n%{http_code}" -X POST \
 where `$PAYLOAD` is `{ "idea_flow_id": <id>, "user_inputs": { … } }`.
 
 - **201** → read `process_id` from the **top level** of the response (not nested in `data`). Keep it for Step 6.
-- **400** → show the offending field/value; fix and retry (commonly a missing `OVERVIEW_NAME` or a bad enum code).
+- **400** → fix and retry. The message shapes seen live:
+  - `errorDetails: { "<question>": ["An answer selection is required…"] }` → that required field is missing/empty; add it.
+  - `errorDetails: {}` with `"Please fill in all the required information"` → a required field the API **won't name** is missing — almost always **owner** (`OVR-PROCESS_OWNER`) or **submitter** (`OVR-OVERVIEW_PROCESS_SUBMITTER`). Send the full required set from Step 4.
+  - `"Invalid Category Id."` → `OVERVIEW_CATEGORY` isn't a real category on this tenant (see Step 4).
+  - `Cannot set properties of undefined (setting 'co_question_answer_option_value')` → an enum field carries an invalid `answer_option` code (you left a template placeholder in). Use a code from that field's `enum`.
 - **401** → re-authenticate. **409** → duplicate name; ask the user for a new name or stop.
 
 ## Step 6: Attach documents (PDD/SDD)
@@ -76,7 +93,16 @@ curl -s -w "\n%{http_code}" -X POST \
   "$BASE_URL/$ORG/$TENANT/automationhub_/api/v1/openapi/automations/$PROCESS_ID/documents"
 ```
 
-Build `$DOC_PAYLOAD` per `ProcessDocumentValidator` (document name + `embed_link` + `document_type_id`; confirm required fields against `processDocumentRequest.schema.ts`). Record each returned `document_id`. On 400, surface the validation message and continue with the remaining documents.
+Build `$DOC_PAYLOAD` per `ProcessDocumentValidator` — verified-live required fields:
+
+```json
+{ "document_title": "PDD - <name>", "document_description": "<desc>", "document_type_id": <int>, "embed_link": "https://…" }
+```
+
+- `document_title`, `document_description`, `document_type_id` are all required (note the field is `document_title`, **not** `document_name`).
+- You **must** also supply **exactly one** of `embed_link` or `file` — this is enforced in the handler, not the JSON schema, so it 400s with `"One and only one of embed_link or file need to be specified."` if omitted. This skill uses `embed_link` (link-based); byte upload via `file` is not usable yet.
+
+Record each returned `document_id`. On 400, surface the validation message and continue with the remaining documents.
 
 > Raw file-byte upload is not supported here (the `media` endpoint is not usable yet). Attach documents by link/URL. If the caller only has bytes, host them first and pass the link.
 


### PR DESCRIPTION
## What

Follow-up to #2506. I ran the `uipath-automationhub` **publish** flow end-to-end against a **real alpha AH tenant** using a plain cloud user token (`uip login`, no admin OpenAPI token). It works — but the publish reference had three inaccuracies that made the first several `POST /idea-from-schema` attempts fail. This corrects them so a coding agent gets it right the first time.

## Live test result

| Call | Result |
|---|---|
| `GET /idea-flows` / `idea-schema` / `automations` / `automations/{id}/documents` | ✅ 200 (read path) |
| `POST /idea-from-schema` | ✅ 201 — process created |
| `POST /automations/{id}/documents` + read-back | ✅ 201 — document attached & listed |

Auth confirmed: cloud bearer token, **no** `x-ah-openapi-auth` (the `automation-cloud` mode).

## Fixes

1. **Don't POST `data.user_inputs` verbatim.** The schema's template ships placeholder values the API rejects: `OVERVIEW_CATEGORY: 1` → `Invalid Category Id`; a placeholder `PROCESS_DOCUMENTS` answer-option → backend crash `Cannot set properties of undefined (setting 'co_question_answer_option_value')`; `First.last@example.com` owner/submitter. Template is **shape only**; every value must be real.
2. **Document the true required set for Business Process** — name, description, a **valid** category id, a real `PROCESS_DOCUMENTS` `answer_option` code, **plus owner + submitter**. The backend enforces owner/submitter even though the schema's `required` flags omit them; when missing it returns `errorDetails: {}` with a generic message (no field named).
3. **Fix the document attach fields** — `document_title` (not `document_name`), `document_description`, `document_type_id`, **plus exactly one of `embed_link`/`file`** (handler-enforced, not in the JSON schema; omitting both → `"One and only one of embed_link or file need to be specified."`).

## Scope

Docs-only (`references/publish-process.md`, `references/api-endpoints.md`). No behavior/code change; smoke tests unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)