### PR TITLE
docs(uipath-tasks): follow-up on catalogs/data review comments

### DIFF
--- a/skills/uipath-tasks/references/task-catalogs.md
+++ b/skills/uipath-tasks/references/task-catalogs.md
@@ -1,13 +1,19 @@
 # Task Catalogs Reference
 
-Task catalogs group tasks and define their retention policy. Folder-scoped: a
-catalog created in one folder is invisible from another. Catalog IDs are numeric.
+A task catalog is a reusable, folder-scoped definition that buckets related tasks
+and configures how they behave: data retention (delete or archive the tasks after
+a retention period), encryption of task data, and labels. Every task is associated
+with at most one catalog, and it inherits that catalog's configuration when it is
+linked through its metadata (`tasks metadata --catalog-id`). A catalog created in one folder is invisible from
+another, and catalog IDs are numeric. See the
+[Action Center documentation](https://docs.uipath.com/automation-cloud/docs/actions).
 
 ## Folder scoping
 
-Every catalog command is folder-scoped. Pass `--folder-id <id>`, or omit it on an
-interactive terminal to pick a folder from a list. `--folder-id` is required when
-stdout is not a TTY (coding agents, CI) — pass it explicitly there.
+Every catalog command needs a folder. In an interactive terminal you can omit
+`--folder-id` and pick a folder from a list. In a non-interactive run (a coding
+agent or CI, where no picker can be shown) you must pass `--folder-id <id>`
+explicitly, otherwise the command fails.
 
 ## List
 
@@ -66,8 +72,8 @@ Success `Code: TaskCatalogUpdated`.
 | Flag | Values | Notes |
 |------|--------|-------|
 | `--retention-action` | `Delete`, `Archive` | The two accepted retention actions |
-| `--retention-period` | days (positive integer) | Days before the action fires |
-| `--retention-bucket-id` | numeric | Storage bucket ID — required when the action is `Archive` |
+| `--retention-period` | 1 to 180 (days) | Days before the action fires. Must be between 1 and 180; a value outside that range is rejected with an API error. |
+| `--retention-bucket-id` | numeric | Storage bucket ID, required when the action is `Archive` |
 
 > `Archive` moves tasks into a storage bucket at the retention limit, so it needs
 > a `--retention-bucket-id`. `Delete` needs no bucket.

--- a/skills/uipath-tasks/references/task-data.md
+++ b/skills/uipath-tasks/references/task-data.md
@@ -1,9 +1,10 @@
 # Task Data Reference
 
-Task data is the business/form field payload attached to a task (e.g. the values
-an approver reviews). Folder-scoped: pass `--folder-id <id>`, or omit it on an
-interactive terminal to pick a folder (required when stdout is not a TTY). Task
-IDs are numeric.
+Task data is the business/form field payload attached to a task: a JSON object of
+key/value pairs whose keys are the task's schema fields (the values an approver
+reviews). Folder-scoped: pass `--folder-id <id>`, or omit it in an interactive
+terminal to pick a folder (in a non-interactive run you must pass `--folder-id`).
+Task IDs are numeric.
 
 ## Get data
 
@@ -15,7 +16,14 @@ Success `Code: TaskData`, `Data` holds the task's field values.
 
 ## Save data
 
-`--data` is required and must be a JSON object.
+`--data` is required and must be a JSON object of key/value pairs matching the
+task's schema.
+
+> **Save replaces the whole payload; it does not upsert or merge.** Any field you
+> omit is dropped. Never save an empty or partial object unless the user explicitly
+> asked for it, and confirm with the user first, otherwise you will overwrite the
+> existing task data. Get the current data first (`tasks data get`) and edit from
+> that.
 
 ```bash
 uip tasks data save <task-id> \
@@ -31,8 +39,7 @@ Success `Code: TaskDataSaved`.
 Save routes to a type-specific endpoint: App tasks, Form tasks, and generic
 tasks each save through a different Orchestrator path. The command resolves the
 task type for you (it looks the task up when the type is not already known), so
-you do not pass a type flag — just the task ID, folder, and `--data`.
+you do not pass a type flag, just the task ID, folder, and `--data`.
 
 > Save only fields the task's schema accepts. Saving unknown fields, or saving to
-> a completed task, fails — get the task first (`tasks data get <task-id>`) to see the
-> current shape.
+> a completed task, fails.


### PR DESCRIPTION
Follow-up to #2562, addressing @dushyant-uipath's review comments on the `uipath-tasks` references:

- **task-catalogs.md**: added a definition of what a task catalog is (from the Action Center docs) and a docs link.
- **task-catalogs.md**: clarified the folder-scoping sentence (interactive picker vs explicit `--folder-id` in non-interactive runs).
- **task-catalogs.md**: noted the retention period is a positive integer whose range the service enforces (out-of-range rejected).
- **task-data.md**: made the key/value shape explicit (keys are the task schema) and warned that Save replaces the whole payload (no upsert/merge), so never save an empty or partial object without confirming with the user.

Jira: https://uipath.atlassian.net/browse/ACTN-11600

🤖 Generated with [Claude Code](https://claude.com/claude-code)