### PR TITLE
test(maestro-case): harden case eval grading and add entry-rule audit

### DIFF
--- a/skills/uipath-maestro-case/scripts/audit_plan.py
+++ b/skills/uipath-maestro-case/scripts/audit_plan.py
@@ -7,7 +7,8 @@ Usage:
 Read-only. Exit 0 = grammar-clean. Exit 1 = numbered findings on stderr;
 repair the plan with Write/Edit and re-run until clean. Enforces the compact
 `tasks/tasks.md` contract (planning.md § Compact no-build T-entry shape): `## T{N}: task "{Task Name}"` headings, one
-`field: value` per line, lanes on sequential runs, no registry-derived keys.
+`field: value` per line, legal `activation-mode` / `entry-rule` pairs, lanes on
+sequential runs, no registry-derived keys.
 `--sdd` additionally checks every `sla-status-change(...)` reference in the
 SDD for the 2-arg (breach) / 3-arg (at-risk) quoted shape.
 """
@@ -33,10 +34,33 @@ TASK_HEADING = re.compile(
 ANY_T_HEADING = re.compile(r"^## T\d+\s*[:.]", re.M)
 FORBIDDEN_KEYS = ["taskTypeId", "activityTypeId", "connectionId", "registry-resolved", "recipients-resolved"]
 
+# planning.md § Activation-mode audit — the six user-visible task modes plus
+# `parallel-after-predecessor`.
+ACTIVATION_MODES = {
+    "sequential", "parallel", "parallel-after-predecessor",
+    "event-triggered", "adhoc", "fan-in", "conditional-gate",
+}
+# plugins/conditions/task-entry-conditions/planning.md § activation-mode /
+# rule-type table, keyed by rule. Rules outside this map are explicitly
+# authored event/condition rules and pair with any mode that permits them.
+ENTRY_RULE_MODES = {
+    "runs-sequentially": {"sequential", "parallel-after-predecessor"},
+    "current-stage-entered": {"parallel"},
+    "adhoc": {"adhoc"},
+    "selected-tasks-completed": {"fan-in", "conditional-gate"},
+    "wait-for-connector": {"event-triggered"},
+}
+
 
 def field_value(section: str, field: str) -> str | None:
     match = re.search(rf"(?im)^\s*[-*]?\s*{re.escape(field)}\s*:\s*(.+)$", section)
     return match.group(1).strip() if match else None
+
+
+def rule_token(value: str | None) -> str | None:
+    """Leading canonical identifier, dropping any `("selector")` and trailing prose."""
+    match = re.match(r"[a-z][a-z0-9-]*", (value or "").strip().strip('`"\' ').casefold())
+    return match.group(0) if match else None
 
 
 def audit(path: Path) -> list[str]:
@@ -83,6 +107,21 @@ def audit(path: Path) -> list[str]:
                 findings.append(f"{label}: missing `{field}:` line{hint}")
 
         activation = (field_value(section, "activation-mode") or "").casefold()
+        mode = rule_token(activation)
+        rule = rule_token(field_value(section, "entry-rule"))
+        if mode is not None and mode not in ACTIVATION_MODES:
+            findings.append(
+                f"{label}: `activation-mode: {mode}` is not a task mode; use one of "
+                f"{', '.join(sorted(ACTIVATION_MODES))}"
+            )
+        elif mode is not None and rule in ENTRY_RULE_MODES:
+            allowed = ENTRY_RULE_MODES[rule]
+            if mode not in allowed:
+                findings.append(
+                    f"{label}: `activation-mode: {mode}` cannot carry `entry-rule: {rule}` — "
+                    f"that rule pairs with {' or '.join(sorted(allowed))} "
+                    f"(list position never normalizes an authored rule into another mode)"
+                )
         lane = field_value(section, "lane")
         if "sequential" in activation and (lane is None or not re.match(r"^\d+$", lane)):
             findings.append(f"{label}: sequential task needs an integer `lane:` line")

--- a/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
+++ b/tests/tasks/uipath-maestro-case/e2e_expense_runnable/expense_runnable_e2e.yaml
@@ -55,11 +55,14 @@ initial_prompt: |
     only `subType` (or be empty). Do not add `bindingsVersion` or
     `solutionsSupport`: those fields make `uip solution resources refresh` fail
     with "Node already added to the graph" in this eval environment.
-  - The SDD resource labels are aliases. In `bindings_v2.json`, use these deployed
-    resource keys and names exactly: `NameToAgeFixed2` → `API Workflow`,
-    `CountLetters` → `CountLetters`, `ProcurementProcess` →
-    `ProcurementProcess`, `ProjectEuler` → `RPA Workflow`, and `CaseTest` →
-    `Maestro Case`. Do not substitute an SDD alias for a deployed name.
+  - The SDD resource labels are aliases for deployed resource NAMES. Map alias →
+    deployed name exactly: `NameToAgeFixed2` → `API Workflow`, `CountLetters` →
+    `CountLetters`, `ProcurementProcess` → `ProcurementProcess`, `ProjectEuler` →
+    `RPA Workflow`, and `CaseTest` → `Maestro Case`. Do not substitute an SDD
+    alias for a deployed name. The alias on the left is NOT a resource key: keep
+    every `resourceKey` — and the matching `bindings_v2.json` `key` — as the
+    composite `<folderPath>.<deployed name>` (e.g.
+    `Shared/uipath-maestro-case/NameToAgeFixed2.API Workflow`).
   - Treat all hard stops after the SDD as pre-approved, including Phase 1
     planning approval, Phase 2 publish-for-review, and Phase 6 debug. Choose the
     continue / skip-publish path and keep going.

--- a/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
+++ b/tests/tasks/uipath-maestro-case/guardrails/artifact_safety_guard.yaml
@@ -195,7 +195,11 @@ success_criteria:
   - type: command_not_executed
     description: "Rule 13: no shell redirection into a skill artifact and no helper-script build-assembler (`> caseplan.json`, `| tee tasks.md`, `node build-caseplan.js`, `python gen.py`)"
     tool_name: "Bash"
-    command_pattern: '([<>]{1,2}\s*\S*(caseplan\.json|tasks\.md|bindings_v2\.json|entry-points\.json)|tee\b[^\n]*(caseplan\.json|tasks\.md)|(node|nodejs|python[0-9]?|bash|sh)\s+[^\n]*\.(js|mjs|cjs|py|sh)\b)'
+    # The script path must be the token immediately after the interpreter: agents wrap every
+    # command in `/bin/bash -lc '...'`, so `bash\s+[^\n]*\.sh` would match any command that merely
+    # mentions a script path (e.g. `rg ... audit_plan.py`). The lookahead exempts the skill's own
+    # read-only auditor, which planning.md mandates as the final plan gate.
+    command_pattern: '([<>]{1,2}\s*\S*(caseplan\.json|tasks\.md|bindings_v2\.json|entry-points\.json)|tee\b[^\n]*(caseplan\.json|tasks\.md)|\b(node|nodejs|python[0-9]?|bash|sh)\s+(?!\S*uipath-maestro-case/scripts/)\S+\.(js|mjs|cjs|py|sh)\b)'
     weight: 2.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
test(maestro-case): harden case eval grading and add entry-rule audit

Three fixes surfaced by expense-runnable and guardrail eval runs:

- audit_plan.py: validate `activation-mode` against the seven task modes
  and reject illegal `activation-mode`/`entry-rule` pairings (e.g.
  `sequential` + `current-stage-entered`). The auditor previously accepted
  any mode string and only checked lanes, so plans with a legal-looking but
  impossible pairing passed the final gate and failed downstream.

- expense_runnable_e2e.yaml: state that the SDD alias maps to a deployed
  resource NAME, not a key, and that `resourceKey` / `bindings_v2` `key`
  stay composite `<folderPath>.<deployed name>`. Agents were substituting
  the bare alias as the key, which passes `validate` but hangs at debug.

- artifact_safety_guard.yaml: anchor the helper-script pattern to the token
  immediately after the interpreter. Agents run everything through
  `/bin/bash -lc '...'`, so `bash\s+[^\n]*\.sh` fired on any command that
  merely mentioned a script path. Adds a lookahead exempting the skill's
  own read-only `audit_plan.py`, which planning.md mandates as the final
  plan gate.

