### PR TITLE
test(maestro-flow): honest fail-fast and advisory messages for invoice-lookup

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/advisory_billing_invoice_lookup.py
@@ -88,8 +88,10 @@ def main():
     expr = str(queryp["queryExpression"])
     if not query_references_input(detail, "invoiceNumber"):
         fail(
-            f"queryExpression is {expr!r} and its filterVariables do not reference the flow's "
-            f"`invoiceNumber` input. A constant filter makes the three offline rungs meaningless"
+            f"queryExpression is {expr!r}, likely a hand-authored =js: concat. filterVariables "
+            f"has no placeholder for invoiceNumber. Author the filter via --detail.filter so "
+            f"the CLI compiles it: dynamic operands become {{var_...}} placeholders in "
+            f"filterVariables"
         )
     # A CEQL string literal must be single-quoted; an unquoted RHS parses as
     # subtraction server-side and 400s (the `sql-where` grammar fil-run enforces).

--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_invoice_lookup/billing_invoice_lookup.yaml
@@ -46,7 +46,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
   - type: run_command
-    description: Check script debugs all three malformed inputs; each resolves to MCS-2026-04872 with 8 line items
+    description: Check script debugs three malformed inputs (fail-fast); every exercised input must resolve to MCS-2026-04872 with 8 line items
     command: python3 $TASK_DIR/check_billing_invoice_lookup.py
     timeout: 600
     expected_exit_code: 0


### PR DESCRIPTION
## Why

Two messages in the invoice-lookup task mislead triage on red runs:

1. The debug criterion description said **all three malformed inputs; each resolves** — the check script fails fast, so a failing run exercises only the first input.
2. The structural advisory called a runtime-computed filter **constant** — its actual check is a missing `filterVariables` placeholder for the input. On the 2026-08-12 nightly this message sent triage down a false path for a filter the run data proved dynamic.

## What changed

Two strings, zero logic: the YAML criterion `description` (fail-fast stated) and the advisory's `fail()` message (names the mechanism check and the `--detail.filter` fix). Weights, thresholds, commands, and all checker logic byte-identical.

Verified: `py_compile` clean, YAML parses, `git diff` touches only the two files.