### PR TITLE
docs(skill-status): mark uipath-troubleshoot as stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 | `uipath-solution` | Preview |
 | `uipath-tasks` | Preview |
 | `uipath-test` | In-development |
-| `uipath-troubleshoot` | Preview |
+| `uipath-troubleshoot` | Stable |
 
 **Status legend:**
 - **Stable** — Stable, production-ready surface; safe for production.

--- a/assets/skill-status.json
+++ b/assets/skill-status.json
@@ -215,7 +215,7 @@
       "last_synced": null
     },
     "uipath-troubleshoot": {
-      "status": "preview",
+      "status": "stable",
       "confluence": {
         "page_id": null,
         "url": null


### PR DESCRIPTION
Sets `uipath-troubleshoot` to `stable` in `assets/skill-status.json` and regenerates the README status table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)