### PR TITLE
test(uipath-maestro-flow): e2e escalation Slack-outcome task

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -507,6 +507,8 @@ def assert_slack_message_posted(
     *,
     connector_key: str = "uipath-salesforce-slack",
     project_glob: str = "**/project.uiproj",
+    expected_channel: str | None = None,
+    must_contain: str | None = None,
 ) -> str:
     """Assert a Slack message was actually sent in this debug run.
 
@@ -579,19 +581,44 @@ def assert_slack_message_posted(
     # mapped slackMessageId must be one of them — so executing a Slack node while
     # mapping a different hard-coded ts is rejected.
     gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
-    node_ts: set = set()
+    matched_out = None
+    any_ts = False
     for e in completed:
         nid = _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")
         out = gvars.get(f"{nid}.output") if isinstance(gvars, dict) else None
-        for leaf in _leaves(out):
-            if isinstance(leaf, str) and _SLACK_TS_RE.match(leaf.strip()):
-                node_ts.add(leaf.strip())
-    if node_ts and text not in node_ts:
+        if not isinstance(out, (dict, list)):
+            continue
+        ts_leaves = {
+            str(x).strip()
+            for x in _leaves(out)
+            if isinstance(x, str) and _SLACK_TS_RE.match(str(x).strip())
+        }
+        if ts_leaves:
+            any_ts = True
+        if text in ts_leaves:
+            matched_out = out
+            break
+    if any_ts and matched_out is None:
         _fail_with_capture(
-            f"slackMessageId {text} does not match any executed Slack node's "
-            f"response ts {sorted(node_ts)}; the mapped ts was not produced by the "
-            "executed send"
+            f"slackMessageId {text} does not match any executed Slack node's response "
+            "ts; the mapped ts was not produced by the executed send"
         )
+
+    # Channel + content of the actual send (from the connector's own echoed
+    # response), so posting a generic message or to the wrong channel is rejected.
+    if matched_out is not None:
+        if expected_channel:
+            posted = str(_get_ci(matched_out, "channel", "Channel") or "")
+            if posted != expected_channel:
+                _fail_with_capture(
+                    f"Slack message posted to channel {posted!r}, expected {expected_channel!r}"
+                )
+        if must_contain:
+            content = " ".join(str(x) for x in _leaves(matched_out) if isinstance(x, str))
+            if must_contain not in content:
+                _fail_with_capture(
+                    f"posted Slack message does not contain {must_contain!r} — wrong content"
+                )
     return text
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -517,6 +517,29 @@ def _op_matches(hint: str, text: str) -> bool:
     return norm(hint) in norm(text)
 
 
+def _is_connector_node(n: dict) -> bool:
+    """True if ``n`` is ANY connector invocation — a native connector node, or a
+    connector-authenticated ``core.action.http`` proxy (authentication=connector +
+    a targetConnector/connectorKey + a bound connectionId). Connector-agnostic
+    (no key/op filter): used to reject error handlers that merely route into
+    another fallible connector, whichever form that connector takes."""
+    t = str(n.get("type", ""))
+    if "uipath.connector." in t:
+        return True
+    detail = (n.get("inputs") or {}).get("detail") or {}
+    if not isinstance(detail, dict):
+        return False
+    body = detail.get("bodyParameters") or {}
+    body = body if isinstance(body, dict) else {}
+    target = body.get("targetConnector") or body.get("connectorKey")
+    return bool(
+        t.lower().startswith("core.action.http")
+        and target
+        and str(body.get("authentication") or "").lower() == "connector"
+        and _non_empty_binding_value(detail.get("connectionId"))
+    )
+
+
 def _connector_node_ids(
     connector_key: str, project_glob: str, *, native_op_hint: str | None = None
 ) -> set:
@@ -559,19 +582,25 @@ def _connector_node_ids(
     return ids
 
 
-def find_node_output_field(payload: dict, field: str) -> "str | None":
-    """Return the first non-empty string value of ``field`` found in any node's
+def find_node_output_field(payload: dict, field: str, *, node_ids=None) -> "str | None":
+    """Return the first non-empty string value of ``field`` found in a node's
     ``.output`` object (``globals["<id>.output"]``). Used to require an
     intermediate Script output (e.g. ``nextSteps``) that the flow computes but
     does not map to a named End ``out``. The field name is matched
-    separator/case-insensitively (``next_steps`` matches ``nextSteps``)."""
+    separator/case-insensitively (``next_steps`` matches ``nextSteps``).
+
+    Pass ``node_ids`` to restrict the search to specific nodes (e.g. the executed
+    classification Script) so an unrelated/cosmetic node can't supply the value."""
     gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
     if not isinstance(gvars, dict):
         return None
+    allow = set(node_ids) if node_ids is not None else None
     norm = lambda s: re.sub(r"[^a-z0-9]", "", str(s).lower())
     want = norm(field)
     for k, v in gvars.items():
         if not (isinstance(k, str) and k.endswith(".output") and isinstance(v, dict)):
+            continue
+        if allow is not None and k[: -len(".output")] not in allow:
             continue
         for kk, vv in v.items():
             if isinstance(kk, str) and norm(kk) == want and isinstance(vv, str) and vv.strip():
@@ -582,19 +611,25 @@ def find_node_output_field(payload: dict, field: str) -> "str | None":
 _UNSET = object()
 
 
-def find_node_output_value(payload: dict, field: str) -> Any:
+def find_node_output_value(payload: dict, field: str, *, node_ids=None) -> Any:
     """Like :func:`find_node_output_field` but returns the raw value of any type
-    (bool, number, string) — the first non-None ``field`` found in any node's
+    (bool, number, string) — the first non-None ``field`` found in a node's
     ``.output``. Returns ``None`` when absent. Use for intermediate classification
     outputs like ``engineeringNeeded`` (a boolean) that aren't mapped to a named
-    End ``out``. Field name matched separator/case-insensitively."""
+    End ``out``. Field name matched separator/case-insensitively.
+
+    Pass ``node_ids`` to restrict the search to specific nodes (e.g. the executed
+    classification Script) so an unrelated/cosmetic node can't supply the value."""
     gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
     if not isinstance(gvars, dict):
         return None
+    allow = set(node_ids) if node_ids is not None else None
     norm = lambda s: re.sub(r"[^a-z0-9]", "", str(s).lower())
     want = norm(field)
     for k, v in gvars.items():
         if not (isinstance(k, str) and k.endswith(".output") and isinstance(v, dict)):
+            continue
+        if allow is not None and k[: -len(".output")] not in allow:
             continue
         for kk, vv in v.items():
             if isinstance(kk, str) and norm(kk) == want and vv is not None:
@@ -791,7 +826,9 @@ def assert_connector_error_handlers(
         adj[e.get("sourceNodeId")].append((str(e.get("sourcePort") or "").lower(), e.get("targetNodeId")))
 
     def is_connector(nid: str) -> bool:
-        return "uipath.connector." in str(nodes.get(nid, {}).get("type", ""))
+        # Native connector OR a connector-authenticated HTTP proxy — an error edge
+        # into either just invokes another fallible connector, not a real handler.
+        return _is_connector_node(nodes.get(nid, {}) or {})
 
     def reaches_terminating(start: str) -> bool:
         seen: set = set()
@@ -951,13 +988,21 @@ def assert_decision_branches_reach(
 
 
 def completed_connector_node_ids(
-    payload: dict, connector_key: str, *, project_glob: str = "**/project.uiproj"
+    payload: dict,
+    connector_key: str,
+    *,
+    project_glob: str = "**/project.uiproj",
+    native_op_hint: "str | None" = None,
 ) -> set:
     """Return the ids of ``connector_key`` nodes with a ``Completed``
     elementExecution in this run — i.e. which connector node actually fired.
     Used to prove branch routing across cases (escalation vs triage must fire
-    different nodes, not one dynamic node behind a cosmetic Decision)."""
-    ids = _connector_node_ids(connector_key, project_glob)
+    different nodes, not one dynamic node behind a cosmetic Decision).
+
+    ``native_op_hint`` pins the operation so a connector-mode HTTP proxy (whose
+    ``targetConnector`` is the bare key, with the op in the endpoint) is matched by
+    op — pass ``connector_key`` as the bare key and the op separately."""
+    ids = _connector_node_ids(connector_key, project_glob, native_op_hint=native_op_hint)
     els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
     return {
         _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -530,11 +530,20 @@ def assert_slack_message_posted(
             r"\d{9,11}\.\d{4,6}); the flow did not actually post to Slack"
         )
 
-    slack_ids = {
-        n.get("id")
-        for n in _iter_flow_nodes(project_glob)
-        if connector_key in str(n.get("type", ""))
-    }
+    # Slack node ids — a native connector node OR a connector-mode HTTP proxy
+    # targeting the connector (same shapes assert_flow_uses_connector_target
+    # accepts), so a valid HTTP-proxy Slack node isn't a false negative.
+    slack_ids: set = set()
+    for n in _iter_flow_nodes(project_glob):
+        t = str(n.get("type", ""))
+        if connector_key in t:
+            slack_ids.add(n.get("id"))
+            continue
+        detail = (n.get("inputs") or {}).get("detail") or {}
+        body = detail.get("bodyParameters") or {} if isinstance(detail, dict) else {}
+        target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
+        if t.lower().startswith("core.action.http") and target == connector_key.lower():
+            slack_ids.add(n.get("id"))
     if not slack_ids:
         _fail(f"no {connector_key} connector node found in the flow")
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -567,6 +567,7 @@ def assert_slack_message_posted(
     project_glob: str = "**/project.uiproj",
     expected_channel: str | None = None,
     must_contain: "str | list[str] | None" = None,
+    must_contain_loose: "str | list[str] | None" = None,
     send_op: str = "send-message-to-channel",
 ) -> str:
     """Assert a Slack message was actually sent in this debug run.
@@ -650,15 +651,26 @@ def assert_slack_message_posted(
                 _fail_with_capture(
                     f"Slack message posted to channel {posted!r}, expected {expected_channel!r}"
                 )
+        if must_contain or must_contain_loose:
+            content = " ".join(str(x) for x in _leaves(matched_out) if isinstance(x, str))
         if must_contain:
             required = [must_contain] if isinstance(must_contain, str) else list(must_contain)
-            content = " ".join(str(x) for x in _leaves(matched_out) if isinstance(x, str))
             missing = [s for s in required if s not in content]
             if missing:
                 _fail_with_capture(
                     f"posted Slack message is missing required text {missing} — the "
                     "message must carry every required field (severity, correlationId, "
                     "next steps), not just some"
+                )
+        if must_contain_loose:
+            loose = [must_contain_loose] if isinstance(must_contain_loose, str) else list(must_contain_loose)
+            # Separator/case-insensitive: the escalationPath enum "unknown_customer"
+            # matches a rendered "unknown customer" / "Unknown Customer" too.
+            missing_loose = [s for s in loose if not _op_matches(s, content)]
+            if missing_loose:
+                _fail_with_capture(
+                    f"posted Slack message is missing required field(s) {missing_loose} "
+                    "(separator/case-insensitive) — e.g. the escalationPath"
                 )
     return text
 
@@ -738,6 +750,37 @@ def assert_connector_error_handlers(
         _fail_with_capture(
             f"{connector_key} node(s) {missing} have no error-port handler edge; "
             "the flow does not degrade gracefully on a connector failure"
+        )
+
+
+def assert_connector_send_identity(
+    connector_key: str,
+    *,
+    expected: str = "user",
+    param: str = "send_as",
+    project_glob: str = "**/project.uiproj",
+    native_op_hint: "str | None" = None,
+) -> None:
+    """Assert every matching connector send node carries the requested identity
+    binding (``queryParameters.<param> == expected``, e.g. ``send_as == "user"``).
+    A node that sends as the default bot instead of the prompt-required ``user``
+    fails here even though its runtime response (ts/channel/content) looks the same."""
+    send_ids = {i for i in _connector_node_ids(connector_key, project_glob, native_op_hint=native_op_hint) if i}
+    if not send_ids:
+        _fail(f"no {connector_key} send node found to check {param!r} on")
+    bad = []
+    for n in _iter_flow_nodes(project_glob):
+        if n.get("id") not in send_ids:
+            continue
+        detail = (n.get("inputs") or {}).get("detail") or {}
+        qp = detail.get("queryParameters") if isinstance(detail, dict) else None
+        val = str((qp or {}).get(param, "")).strip().lower()
+        if val != expected.strip().lower():
+            bad.append((n.get("id"), val or None))
+    if bad:
+        _fail_with_capture(
+            f"{connector_key} send node(s) do not set {param}={expected!r}: {bad}; "
+            "the prompt requires sending as the requested identity"
         )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -475,42 +475,55 @@ def assert_output_value(payload: dict, expected: Any) -> None:
     )
 
 
-def normalized(value: Any) -> Any:
-    """Normalize a scalar output for equality comparison: trim strings, fold
-    case, and coerce the literal strings ``"true"``/``"false"`` to booleans.
-    Shared so per-task checkers don't each re-declare it."""
+def normalized(value: Any, *, case_fold: bool = True) -> Any:
+    """Normalize a scalar output for equality comparison: trim strings, coerce
+    ``"true"``/``"false"`` to booleans, and (by default) fold case for enum-like
+    values. Pass ``case_fold=False`` for OPAQUE identifiers (correlation ids,
+    Jira keys) that must match exactly."""
     if isinstance(value, str):
-        lowered = value.strip().casefold()
+        text = value.strip()
+        lowered = text.casefold()
         if lowered == "true":
             return True
         if lowered == "false":
             return False
-        return lowered
+        return lowered if case_fold else text
     return value
 
 
-def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
-    """Assert a named ``out`` variable is present, non-empty, and (after
-    :func:`normalized`) equals ``expected``. Shared across the escalation
-    checkers so the compare/normalize logic lives in one place."""
+def assert_named_equals(
+    payload: dict, name: str, expected: Any, *, case_sensitive: bool = False
+) -> None:
+    """Assert a named ``out`` variable is present, non-empty, and equals
+    ``expected``. Enum-like values compare case-insensitively; pass
+    ``case_sensitive=True`` for opaque identifiers (caseKey, jiraIssueKey)."""
     actual = assert_output_nonempty(payload, name)
-    if normalized(actual) != normalized(expected):
+    if normalized(actual, case_fold=not case_sensitive) != normalized(
+        expected, case_fold=not case_sensitive
+    ):
         _fail(f"output {name!r}: expected {expected!r}, got {actual!r}")
 
 
 _SLACK_TS_RE = re.compile(r"^\d{9,11}\.\d{4,6}$")
 
 
-def _connector_node_ids(connector_key: str, project_glob: str) -> set:
+def _connector_node_ids(
+    connector_key: str, project_glob: str, *, native_op_hint: str | None = None
+) -> set:
     """Node ids that reach ``connector_key`` — a native connector node OR a
     connector-mode ``core.action.http`` proxy carrying real connector auth
     (authentication=connector + non-empty connectionId + connectionFolderKey),
     the same shapes :func:`assert_flow_uses_connector_target` accepts. Shared so
-    the message check and the branch-routing check agree on what counts."""
+    the message check and the branch-routing check agree on what counts.
+
+    ``native_op_hint`` pins the operation: when set, a node counts only if the
+    hint (e.g. ``send-message-to-channel``) appears in its node type — so a Slack
+    *read/search* activity that merely contains ``connector_key`` is not accepted
+    as send/delivery evidence."""
     ids: set = set()
     for n in _iter_flow_nodes(project_glob):
         t = str(n.get("type", ""))
-        if connector_key in t:
+        if connector_key in t and (native_op_hint is None or native_op_hint in t):
             ids.add(n.get("id"))
             continue
         detail = (n.get("inputs") or {}).get("detail") or {}
@@ -519,12 +532,17 @@ def _connector_node_ids(connector_key: str, project_glob: str) -> set:
         body = detail.get("bodyParameters") or {}
         body = body if isinstance(body, dict) else {}
         target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
+        # For connector-mode HTTP proxies the operation lives in the endpoint, not
+        # the node type; pin via a serialized contains-check on the detail when a
+        # hint is given so a proxy to a read endpoint is likewise excluded.
+        op_ok = native_op_hint is None or native_op_hint.lower() in json.dumps(detail).lower()
         if (
             t.lower().startswith("core.action.http")
             and target == connector_key.lower()
             and str(body.get("authentication") or "").lower() == "connector"
             and _non_empty_binding_value(detail.get("connectionId"))
             and _non_empty_binding_value(detail.get("connectionFolderKey"))
+            and op_ok
         ):
             ids.add(n.get("id"))
     return ids
@@ -537,7 +555,8 @@ def assert_slack_message_posted(
     connector_key: str = "uipath-salesforce-slack",
     project_glob: str = "**/project.uiproj",
     expected_channel: str | None = None,
-    must_contain: str | None = None,
+    must_contain: "str | list[str] | None" = None,
+    send_op: str = "send-message-to-channel",
 ) -> str:
     """Assert a Slack message was actually sent in this debug run.
 
@@ -561,10 +580,12 @@ def assert_slack_message_posted(
             r"\d{9,11}\.\d{4,6}); the flow did not actually post to Slack"
         )
 
-    # Native connector node OR a connector-mode HTTP proxy carrying real auth.
-    slack_ids = _connector_node_ids(connector_key, project_glob)
+    # A Slack SEND node (native send-message-to-channel, or a connector-mode HTTP
+    # proxy to that op) — a read/search activity that returns a message object is
+    # not delivery evidence, so it is excluded via send_op.
+    slack_ids = _connector_node_ids(connector_key, project_glob, native_op_hint=send_op)
     if not slack_ids:
-        _fail(f"no connected {connector_key} node found in the flow")
+        _fail(f"no connected {connector_key} {send_op} node found in the flow")
 
     els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
     completed = [
@@ -619,10 +640,14 @@ def assert_slack_message_posted(
                     f"Slack message posted to channel {posted!r}, expected {expected_channel!r}"
                 )
         if must_contain:
+            required = [must_contain] if isinstance(must_contain, str) else list(must_contain)
             content = " ".join(str(x) for x in _leaves(matched_out) if isinstance(x, str))
-            if must_contain not in content:
+            missing = [s for s in required if s not in content]
+            if missing:
                 _fail_with_capture(
-                    f"posted Slack message does not contain {must_contain!r} — wrong content"
+                    f"posted Slack message is missing required text {missing} — the "
+                    "message must carry every required field (severity, correlationId, "
+                    "next steps), not just some"
                 )
     return text
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -653,6 +653,20 @@ def assert_node_type_executed(
         )
 
 
+def node_output_leaves(payload: dict, node_ids) -> set:
+    """String leaves of the given nodes' outputs (``globals["<id>.output"]``) —
+    used to tie a flow output back to the connector node that actually produced
+    it (e.g. a Jira key must appear in the executed Create Issue node's response)."""
+    gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
+    out: set = set()
+    for nid in node_ids:
+        v = gvars.get(f"{nid}.output") if isinstance(gvars, dict) else None
+        for x in _leaves(v):
+            if isinstance(x, str):
+                out.add(x.strip())
+    return out
+
+
 def _load_flow(project_glob: str) -> dict:
     """Load the single .flow next to the matched project.uiproj."""
     proj = _find_project(project_glob)

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -831,26 +831,28 @@ def assert_connector_error_handlers(
         return _is_connector_node(nodes.get(nid, {}) or {})
 
     def reaches_terminating(start: str) -> bool:
-        # A graceful path must reach a terminating node WITHOUT passing through any
-        # connector — a connector anywhere downstream can fault again. Connectors
-        # are neither counted as terminating nor traversed through.
+        # The handler's ENTIRE reachable subgraph must be connector-free and reach a
+        # terminating node. If ANY reachable branch enters a connector it can fault
+        # again instead of degrading gracefully, so the whole handler is rejected —
+        # a mixed handler (one branch to End, another into a connector) does not pass.
         seen: set = set()
         q = deque([start])
+        saw_terminating = False
         while q:
             n = q.popleft()
             if n in seen:
                 continue
             seen.add(n)
             if is_connector(n):
-                continue  # can fault again — not a graceful terminus, don't traverse it
+                return False  # any connector branch can fault → not graceful
             t = str(nodes.get(n, {}).get("type", "")).lower()
             outs = adj.get(n, [])
             if "end" in t or not outs:  # End node, or a non-connector dead-end handler
-                return True
+                saw_terminating = True
             for _, tgt in outs:
                 if tgt:
                     q.append(tgt)
-        return False
+        return saw_terminating
 
     bad = []
     for sid in sorted(nid for nid in node_ids if nid):

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -579,6 +579,29 @@ def find_node_output_field(payload: dict, field: str) -> "str | None":
     return None
 
 
+_UNSET = object()
+
+
+def find_node_output_value(payload: dict, field: str) -> Any:
+    """Like :func:`find_node_output_field` but returns the raw value of any type
+    (bool, number, string) — the first non-None ``field`` found in any node's
+    ``.output``. Returns ``None`` when absent. Use for intermediate classification
+    outputs like ``engineeringNeeded`` (a boolean) that aren't mapped to a named
+    End ``out``. Field name matched separator/case-insensitively."""
+    gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
+    if not isinstance(gvars, dict):
+        return None
+    norm = lambda s: re.sub(r"[^a-z0-9]", "", str(s).lower())
+    want = norm(field)
+    for k, v in gvars.items():
+        if not (isinstance(k, str) and k.endswith(".output") and isinstance(v, dict)):
+            continue
+        for kk, vv in v.items():
+            if isinstance(kk, str) and norm(kk) == want and vv is not None:
+                return vv
+    return None
+
+
 def assert_slack_message_posted(
     payload: dict,
     name: str,
@@ -748,28 +771,59 @@ def assert_connector_error_handlers(
     project_glob: str = "**/project.uiproj",
     native_op_hint: "str | None" = None,
 ) -> None:
-    """Assert every matching connector node has its ``error`` port wired to a
-    downstream handler — the graceful-degradation requirement. A connector node
-    whose ``error`` port is dangling (no outgoing edge) fails, so a flow that
-    omits the promised failure path cannot receive full credit."""
-    from collections import defaultdict
+    """Assert every matching connector node degrades gracefully on failure: its
+    ``error`` port must route to a NON-connector handler (not a self-loop back to
+    the failing node, and not another connector that can fault again) from which a
+    terminating node (End, or a node with no outgoing edge) is reachable. A
+    dangling error port, a self-loop, or an error edge into another connector all
+    fail, so a flow that only appears to handle failures cannot get full credit."""
+    from collections import defaultdict, deque
 
     flow = _load_flow(project_glob)
     edges = flow.get("edges") or []
+    nodes = {n.get("id"): n for n in (flow.get("nodes") or [])}
     node_ids = {i for i in _connector_node_ids(connector_key, project_glob, native_op_hint=native_op_hint) if i}
     if not node_ids:
         _fail(f"no {connector_key} node found to check error handlers on")
-    err_targets = defaultdict(set)
+
+    adj = defaultdict(list)
     for e in edges:
-        if str(e.get("sourcePort") or "").lower() == "error":
-            tgt = e.get("targetNodeId")
-            if tgt:
-                err_targets[e.get("sourceNodeId")].add(tgt)
-    missing = sorted(nid for nid in node_ids if not err_targets.get(nid))
-    if missing:
+        adj[e.get("sourceNodeId")].append((str(e.get("sourcePort") or "").lower(), e.get("targetNodeId")))
+
+    def is_connector(nid: str) -> bool:
+        return "uipath.connector." in str(nodes.get(nid, {}).get("type", ""))
+
+    def reaches_terminating(start: str) -> bool:
+        seen: set = set()
+        q = deque([start])
+        while q:
+            n = q.popleft()
+            if n in seen:
+                continue
+            seen.add(n)
+            t = str(nodes.get(n, {}).get("type", "")).lower()
+            outs = adj.get(n, [])
+            if "end" in t or not outs:  # End node, or a dead-end handler
+                return True
+            for _, tgt in outs:
+                if tgt:
+                    q.append(tgt)
+        return False
+
+    bad = []
+    for sid in sorted(nid for nid in node_ids if nid):
+        # Non-connector error targets, excluding a self-loop back to the send node.
+        handlers = [
+            t for p, t in adj.get(sid, [])
+            if p == "error" and t and t != sid and not is_connector(t)
+        ]
+        if not handlers:
+            bad.append((sid, "no non-connector error handler (dangling, self-loop, or into another connector)"))
+        elif not any(reaches_terminating(h) for h in handlers):
+            bad.append((sid, "error handler does not reach a terminating path"))
+    if bad:
         _fail_with_capture(
-            f"{connector_key} node(s) {missing} have no error-port handler edge; "
-            "the flow does not degrade gracefully on a connector failure"
+            f"{connector_key} node(s) do not degrade gracefully on failure: {bad}"
         )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -830,29 +830,37 @@ def assert_connector_error_handlers(
         # into either just invokes another fallible connector, not a real handler.
         return _is_connector_node(nodes.get(nid, {}) or {})
 
+    # EVERY branch of the handler must degrade gracefully: connector-free, acyclic,
+    # and terminating. A DFS with GRAY/BLACK coloring rejects (a) any connector on
+    # the path (can fault again), and (b) any cycle — a back-edge to a GRAY node is
+    # a loop that never completes. Returns True only when all reachable paths end at
+    # a terminating node, so a fork to End + a non-connector cycle no longer passes.
+    _GRAY, _BLACK = 1, 2
+
     def reaches_terminating(start: str) -> bool:
-        # The handler's ENTIRE reachable subgraph must be connector-free and reach a
-        # terminating node. If ANY reachable branch enters a connector it can fault
-        # again instead of degrading gracefully, so the whole handler is rejected —
-        # a mixed handler (one branch to End, another into a connector) does not pass.
-        seen: set = set()
-        q = deque([start])
-        saw_terminating = False
-        while q:
-            n = q.popleft()
-            if n in seen:
-                continue
-            seen.add(n)
+        color: dict = {}
+
+        def dfs(n: str) -> bool:
             if is_connector(n):
-                return False  # any connector branch can fault → not graceful
+                return False  # connector branch can fault → not graceful
+            color[n] = _GRAY
+            outs = [tgt for _, tgt in adj.get(n, []) if tgt]
             t = str(nodes.get(n, {}).get("type", "")).lower()
-            outs = adj.get(n, [])
-            if "end" in t or not outs:  # End node, or a non-connector dead-end handler
-                saw_terminating = True
-            for _, tgt in outs:
-                if tgt:
-                    q.append(tgt)
-        return saw_terminating
+            if "end" in t or not outs:  # End node, or non-connector dead-end handler
+                color[n] = _BLACK
+                return True
+            for tgt in outs:
+                c = color.get(tgt, 0)
+                if c == _GRAY:
+                    return False  # back-edge → cycle: this branch never terminates
+                if c == _BLACK:
+                    continue  # already validated as gracefully terminating
+                if not dfs(tgt):
+                    return False
+            color[n] = _BLACK
+            return True
+
+        return dfs(start)
 
     bad = []
     for sid in sorted(nid for nid in node_ids if nid):
@@ -992,6 +1000,55 @@ def assert_decision_branches_reach(
         f"no {decision_type!r} routes {sorted(a)} and {sorted(b)} through separate "
         "branches; the distinct Slack nodes are not the Decision's two outgoing paths"
     )
+
+
+def assert_distinct_branch_ends(
+    branch_a_nodes: set,
+    branch_b_nodes: set,
+    *,
+    end_type: str = "core.control.end",
+    project_glob: str = "**/project.uiproj",
+) -> None:
+    """Assert each branch reaches its OWN End node — the prompt's two-End-nodes
+    requirement. From the ``branch_a``/``branch_b`` nodes (e.g. the escalation vs
+    triage Slack sends) BFS downstream to reachable ``end_type`` nodes; require an
+    End reachable from A but not B AND one reachable from B but not A. A flow that
+    merges both branches into a single shared End (then conditionally maps the
+    timestamp) fails here."""
+    from collections import defaultdict, deque
+
+    flow = _load_flow(project_glob)
+    edges = flow.get("edges") or []
+    nodes = flow.get("nodes") or []
+    end_ids = {n.get("id") for n in nodes if end_type in str(n.get("type", ""))}
+    adj = defaultdict(list)
+    for e in edges:
+        adj[e.get("sourceNodeId")].append(e.get("targetNodeId"))
+
+    def reachable_ends(starts: set) -> set:
+        seen: set = set()
+        q = deque(s for s in starts if s)
+        found: set = set()
+        while q:
+            n = q.popleft()
+            if n in seen:
+                continue
+            seen.add(n)
+            if n in end_ids:
+                found.add(n)
+            for t in adj.get(n, []):
+                if t:
+                    q.append(t)
+        return found
+
+    ends_a = reachable_ends(set(branch_a_nodes))
+    ends_b = reachable_ends(set(branch_b_nodes))
+    if not (ends_a - ends_b) or not (ends_b - ends_a):
+        _fail_with_capture(
+            "escalation and triage branches do not each reach their OWN End node "
+            f"(escalation-reachable ends={sorted(ends_a)}, triage-reachable ends={sorted(ends_b)}); "
+            "the prompt requires two branch-specific End nodes, not a single merged End"
+        )
 
 
 def completed_connector_node_ids(

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -831,6 +831,9 @@ def assert_connector_error_handlers(
         return _is_connector_node(nodes.get(nid, {}) or {})
 
     def reaches_terminating(start: str) -> bool:
+        # A graceful path must reach a terminating node WITHOUT passing through any
+        # connector — a connector anywhere downstream can fault again. Connectors
+        # are neither counted as terminating nor traversed through.
         seen: set = set()
         q = deque([start])
         while q:
@@ -838,9 +841,11 @@ def assert_connector_error_handlers(
             if n in seen:
                 continue
             seen.add(n)
+            if is_connector(n):
+                continue  # can fault again — not a graceful terminus, don't traverse it
             t = str(nodes.get(n, {}).get("type", "")).lower()
             outs = adj.get(n, [])
-            if "end" in t or not outs:  # End node, or a dead-end handler
+            if "end" in t or not outs:  # End node, or a non-connector dead-end handler
                 return True
             for _, tgt in outs:
                 if tgt:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -475,6 +475,49 @@ def assert_output_value(payload: dict, expected: Any) -> None:
     )
 
 
+def normalized(value: Any) -> Any:
+    """Normalize a scalar output for equality comparison: trim strings, fold
+    case, and coerce the literal strings ``"true"``/``"false"`` to booleans.
+    Shared so per-task checkers don't each re-declare it."""
+    if isinstance(value, str):
+        lowered = value.strip().casefold()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return lowered
+    return value
+
+
+def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
+    """Assert a named ``out`` variable is present, non-empty, and (after
+    :func:`normalized`) equals ``expected``. Shared across the escalation
+    checkers so the compare/normalize logic lives in one place."""
+    actual = assert_output_nonempty(payload, name)
+    if normalized(actual) != normalized(expected):
+        _fail(f"output {name!r}: expected {expected!r}, got {actual!r}")
+
+
+_SLACK_TS_RE = re.compile(r"^\d{9,11}\.\d{4,6}$")
+
+
+def assert_slack_message_posted(payload: dict, name: str) -> str:
+    """Assert the named output holds a real Slack message timestamp (``ts``),
+    e.g. ``1786647595.771239`` — the value Slack's API returns only for a
+    message it actually accepted. Combined with a real
+    ``uipath-salesforce-slack`` connector node (assert_flow_uses_connector_target),
+    this rejects a flow that fakes delivery by mapping a hard-coded placeholder
+    (``"ok"``, ``"sent"``, ``"1"``) into the output. Returns the ts."""
+    value = assert_output_nonempty(payload, name)
+    text = str(value).strip()
+    if not _SLACK_TS_RE.match(text):
+        _fail(
+            f"output {name!r}={text!r} is not a Slack message ts (expected "
+            r"\d{9,11}\.\d{4,6}); the flow did not actually post to Slack"
+        )
+    return text
+
+
 def read_flow_input_vars(project_dir: str) -> list[str]:
     """Return the ordered list of input variable IDs declared on the first
     ``.flow`` file in ``project_dir``."""

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -653,6 +653,70 @@ def assert_node_type_executed(
         )
 
 
+def _load_flow(project_glob: str) -> dict:
+    """Load the single .flow next to the matched project.uiproj."""
+    proj = _find_project(project_glob)
+    flows = glob.glob(os.path.join(proj, "*.flow"))
+    if not flows:
+        _fail(f"no .flow file under {proj}")
+    return json.loads(open(flows[0], encoding="utf-8").read())
+
+
+def assert_decision_branches_reach(
+    branch_a_targets: set,
+    branch_b_targets: set,
+    *,
+    decision_type: str = "core.logic.decision",
+    project_glob: str = "**/project.uiproj",
+) -> None:
+    """Assert some ``decision_type`` node has TWO distinct outgoing ports whose
+    downstream reach separates ``branch_a_targets`` from ``branch_b_targets`` —
+    i.e. the Decision itself routes to the two target groups (all A reachable from
+    one port, all B from another, with no cross-contamination). Proves the two
+    groups are the Decision's branches, not just nodes that happened to fire on
+    different cases behind a cosmetic always-true Decision."""
+    from collections import defaultdict, deque
+
+    flow = _load_flow(project_glob)
+    edges = flow.get("edges") or []
+    nodes = flow.get("nodes") or []
+    decisions = [n.get("id") for n in nodes if decision_type in str(n.get("type", ""))]
+    if not decisions:
+        _fail(f"no {decision_type!r} node in the flow")
+
+    adj = defaultdict(list)
+    for e in edges:
+        adj[e.get("sourceNodeId")].append((e.get("sourcePort"), e.get("targetNodeId")))
+
+    def reach(start: str) -> set:
+        seen: set = set()
+        q = deque([start])
+        while q:
+            n = q.popleft()
+            if n in seen:
+                continue
+            seen.add(n)
+            for _, t in adj.get(n, []):
+                q.append(t)
+        return seen
+
+    a, b = set(branch_a_targets), set(branch_b_targets)
+    for d in decisions:
+        port_reach = defaultdict(set)
+        for port, tgt in adj.get(d, []):
+            port_reach[port].update(reach(tgt))
+        for pa, ra in port_reach.items():
+            if not a <= ra:
+                continue
+            for pb, rb in port_reach.items():
+                if pb != pa and b <= rb and not (a & rb) and not (b & ra):
+                    return  # clean two-branch separation via this Decision
+    _fail_with_capture(
+        f"no {decision_type!r} routes {sorted(a)} and {sorted(b)} through separate "
+        "branches; the distinct Slack nodes are not the Decision's two outgoing paths"
+    )
+
+
 def completed_connector_node_ids(
     payload: dict, connector_key: str, *, project_glob: str = "**/project.uiproj"
 ) -> set:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -559,6 +559,26 @@ def _connector_node_ids(
     return ids
 
 
+def find_node_output_field(payload: dict, field: str) -> "str | None":
+    """Return the first non-empty string value of ``field`` found in any node's
+    ``.output`` object (``globals["<id>.output"]``). Used to require an
+    intermediate Script output (e.g. ``nextSteps``) that the flow computes but
+    does not map to a named End ``out``. The field name is matched
+    separator/case-insensitively (``next_steps`` matches ``nextSteps``)."""
+    gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
+    if not isinstance(gvars, dict):
+        return None
+    norm = lambda s: re.sub(r"[^a-z0-9]", "", str(s).lower())
+    want = norm(field)
+    for k, v in gvars.items():
+        if not (isinstance(k, str) and k.endswith(".output") and isinstance(v, dict)):
+            continue
+        for kk, vv in v.items():
+            if isinstance(kk, str) and norm(kk) == want and isinstance(vv, str) and vv.strip():
+                return vv.strip()
+    return None
+
+
 def assert_slack_message_posted(
     payload: dict,
     name: str,

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -539,13 +539,25 @@ def assert_slack_message_posted(
         if connector_key in t:
             slack_ids.add(n.get("id"))
             continue
+        # Connector-mode HTTP proxy — accept ONLY when it carries real connector
+        # auth (same gate as assert_flow_uses_connector_target): a disconnected
+        # HTTP node with just targetConnector set must not qualify.
         detail = (n.get("inputs") or {}).get("detail") or {}
-        body = detail.get("bodyParameters") or {} if isinstance(detail, dict) else {}
+        if not isinstance(detail, dict):
+            continue
+        body = detail.get("bodyParameters") or {}
+        body = body if isinstance(body, dict) else {}
         target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
-        if t.lower().startswith("core.action.http") and target == connector_key.lower():
+        if (
+            t.lower().startswith("core.action.http")
+            and target == connector_key.lower()
+            and str(body.get("authentication") or "").lower() == "connector"
+            and _non_empty_binding_value(detail.get("connectionId"))
+            and _non_empty_binding_value(detail.get("connectionFolderKey"))
+        ):
             slack_ids.add(n.get("id"))
     if not slack_ids:
-        _fail(f"no {connector_key} connector node found in the flow")
+        _fail(f"no connected {connector_key} node found in the flow")
 
     els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
     completed = [

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -507,6 +507,16 @@ def assert_named_equals(
 _SLACK_TS_RE = re.compile(r"^\d{9,11}\.\d{4,6}$")
 
 
+def _op_matches(hint: str, text: str) -> bool:
+    """Separator- and case-insensitive operation match. A connector op is spelled
+    hyphenated in a native node type (``…send-message-to-channel``) but with
+    underscores (and a version suffix) in an HTTP-proxy endpoint path
+    (``/send_message_to_channel_v2``). Fold both to letters-only so either shape
+    of the same op matches."""
+    norm = lambda s: re.sub(r"[^a-z0-9]", "", str(s).lower())
+    return norm(hint) in norm(text)
+
+
 def _connector_node_ids(
     connector_key: str, project_glob: str, *, native_op_hint: str | None = None
 ) -> set:
@@ -523,7 +533,7 @@ def _connector_node_ids(
     ids: set = set()
     for n in _iter_flow_nodes(project_glob):
         t = str(n.get("type", ""))
-        if connector_key in t and (native_op_hint is None or native_op_hint in t):
+        if connector_key in t and (native_op_hint is None or _op_matches(native_op_hint, t)):
             ids.add(n.get("id"))
             continue
         detail = (n.get("inputs") or {}).get("detail") or {}
@@ -533,9 +543,10 @@ def _connector_node_ids(
         body = body if isinstance(body, dict) else {}
         target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
         # For connector-mode HTTP proxies the operation lives in the endpoint, not
-        # the node type; pin via a serialized contains-check on the detail when a
-        # hint is given so a proxy to a read endpoint is likewise excluded.
-        op_ok = native_op_hint is None or native_op_hint.lower() in json.dumps(detail).lower()
+        # the node type; pin via a separator-insensitive match on the serialized
+        # detail so a proxy to the documented /send_message_to_channel_v2 endpoint
+        # is accepted while a proxy to a read endpoint is excluded.
+        op_ok = native_op_hint is None or _op_matches(native_op_hint, json.dumps(detail))
         if (
             t.lower().startswith("core.action.http")
             and target == connector_key.lower()
@@ -678,6 +689,58 @@ def assert_node_type_executed(
         )
 
 
+def completed_node_ids_of_type(
+    payload: dict, type_hint: str, *, project_glob: str = "**/project.uiproj"
+) -> set:
+    """Return ids of flow nodes whose ``type`` contains ``type_hint`` that have a
+    ``Completed`` elementExecution in this run — the executed subset of that node
+    type. Used to tie structural checks (e.g. Decision branch routing) to the node
+    that actually ran, not merely one present in the source."""
+    ids = {
+        n.get("id")
+        for n in _iter_flow_nodes(project_glob)
+        if type_hint in str(n.get("type", ""))
+    }
+    els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
+    return {
+        _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")
+        for e in els
+        if _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId") in ids
+        and str(_get_ci(e, "status", "Status")).lower() == "completed"
+    }
+
+
+def assert_connector_error_handlers(
+    connector_key: str,
+    *,
+    project_glob: str = "**/project.uiproj",
+    native_op_hint: "str | None" = None,
+) -> None:
+    """Assert every matching connector node has its ``error`` port wired to a
+    downstream handler — the graceful-degradation requirement. A connector node
+    whose ``error`` port is dangling (no outgoing edge) fails, so a flow that
+    omits the promised failure path cannot receive full credit."""
+    from collections import defaultdict
+
+    flow = _load_flow(project_glob)
+    edges = flow.get("edges") or []
+    node_ids = {i for i in _connector_node_ids(connector_key, project_glob, native_op_hint=native_op_hint) if i}
+    if not node_ids:
+        _fail(f"no {connector_key} node found to check error handlers on")
+    err_targets = defaultdict(set)
+    for e in edges:
+        if str(e.get("sourcePort") or "").lower() == "error":
+            tgt = e.get("targetNodeId")
+            if tgt:
+                err_targets[e.get("sourceNodeId")].add(tgt)
+    missing = sorted(nid for nid in node_ids if not err_targets.get(nid))
+    if missing:
+        _fail_with_capture(
+            f"{connector_key} node(s) {missing} have no error-port handler edge; "
+            "the flow does not degrade gracefully on a connector failure"
+        )
+
+
 def node_output_leaves(payload: dict, node_ids) -> set:
     """String leaves of the given nodes' outputs (``globals["<id>.output"]``) —
     used to tie a flow output back to the connector node that actually produced
@@ -707,19 +770,33 @@ def assert_decision_branches_reach(
     *,
     decision_type: str = "core.logic.decision",
     project_glob: str = "**/project.uiproj",
+    executed_decision_ids: "set | None" = None,
 ) -> None:
     """Assert some ``decision_type`` node has TWO distinct outgoing ports whose
     downstream reach separates ``branch_a_targets`` from ``branch_b_targets`` —
     i.e. the Decision itself routes to the two target groups (all A reachable from
     one port, all B from another, with no cross-contamination). Proves the two
     groups are the Decision's branches, not just nodes that happened to fire on
-    different cases behind a cosmetic always-true Decision."""
+    different cases behind a cosmetic always-true Decision.
+
+    When ``executed_decision_ids`` is given, only Decisions that actually executed
+    in the run are considered candidates — so a second, unexecuted Decision that
+    merely has the two source edges cannot satisfy the check while routing really
+    happens through a cosmetic Decision elsewhere."""
     from collections import defaultdict, deque
 
     flow = _load_flow(project_glob)
     edges = flow.get("edges") or []
     nodes = flow.get("nodes") or []
     decisions = [n.get("id") for n in nodes if decision_type in str(n.get("type", ""))]
+    if executed_decision_ids is not None:
+        decisions = [d for d in decisions if d in executed_decision_ids]
+        if not decisions:
+            _fail_with_capture(
+                f"no EXECUTED {decision_type!r} node in the run "
+                f"(executed={sorted(i for i in executed_decision_ids if i)}); routing did "
+                "not go through a Decision that actually ran"
+            )
     if not decisions:
         _fail(f"no {decision_type!r} node in the flow")
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -582,7 +582,6 @@ def assert_slack_message_posted(
     # mapping a different hard-coded ts is rejected.
     gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
     matched_out = None
-    any_ts = False
     for e in completed:
         nid = _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")
         out = gvars.get(f"{nid}.output") if isinstance(gvars, dict) else None
@@ -593,12 +592,13 @@ def assert_slack_message_posted(
             for x in _leaves(out)
             if isinstance(x, str) and _SLACK_TS_RE.match(str(x).strip())
         }
-        if ts_leaves:
-            any_ts = True
         if text in ts_leaves:
             matched_out = out
             break
-    if any_ts and matched_out is None:
+    # A real send's response always carries its ts; require the mapped
+    # slackMessageId to be that response's ts. If no executed Slack node's output
+    # exposes this exact ts, the value was not produced by the executed send.
+    if matched_out is None:
         _fail_with_capture(
             f"slackMessageId {text} does not match any executed Slack node's response "
             "ts; the mapped ts was not produced by the executed send"
@@ -646,6 +646,27 @@ def assert_node_type_executed(
             f"no {type_hint!r} node executed in the debug trace (nodes {sorted(i for i in ids if i)}); "
             "it is present in the source but not on the executed path"
         )
+
+
+def completed_connector_node_ids(
+    payload: dict, connector_key: str, *, project_glob: str = "**/project.uiproj"
+) -> set:
+    """Return the ids of ``connector_key`` nodes with a ``Completed``
+    elementExecution in this run — i.e. which connector node actually fired.
+    Used to prove branch routing across cases (escalation vs triage must fire
+    different nodes, not one dynamic node behind a cosmetic Decision)."""
+    ids = {
+        n.get("id")
+        for n in _iter_flow_nodes(project_glob)
+        if connector_key in str(n.get("type", ""))
+    }
+    els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
+    return {
+        _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")
+        for e in els
+        if _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId") in ids
+        and str(_get_ci(e, "status", "Status")).lower() == "completed"
+    }
 
 
 def read_flow_input_vars(project_dir: str) -> list[str]:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -501,19 +501,55 @@ def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
 _SLACK_TS_RE = re.compile(r"^\d{9,11}\.\d{4,6}$")
 
 
-def assert_slack_message_posted(payload: dict, name: str) -> str:
-    """Assert the named output holds a real Slack message timestamp (``ts``),
-    e.g. ``1786647595.771239`` — the value Slack's API returns only for a
-    message it actually accepted. Combined with a real
-    ``uipath-salesforce-slack`` connector node (assert_flow_uses_connector_target),
-    this rejects a flow that fakes delivery by mapping a hard-coded placeholder
-    (``"ok"``, ``"sent"``, ``"1"``) into the output. Returns the ts."""
+def assert_slack_message_posted(
+    payload: dict,
+    name: str,
+    *,
+    connector_key: str = "uipath-salesforce-slack",
+    project_glob: str = "**/project.uiproj",
+) -> str:
+    """Assert a Slack message was actually sent in this debug run.
+
+    Two independent gates, so a flow can't fake delivery:
+
+    1. **Shape** — the named output is a Slack message ``ts``
+       (``\\d{9,11}\\.\\d{4,6}``, e.g. ``1786647595.771239``), rejecting a
+       hard-coded placeholder like ``"ok"`` / ``"sent"`` / ``"1"``.
+    2. **Trace** — at least one ``connector_key`` node in the flow has a
+       ``Completed`` ``elementExecution`` in the debug payload. A disconnected
+       or unexecuted connector node produces no such record, so a constant ``ts``
+       mapped past an idle node fails here. This is the "confirm the timestamp
+       came from an executed connector send" check.
+
+    Returns the ts."""
     value = assert_output_nonempty(payload, name)
     text = str(value).strip()
     if not _SLACK_TS_RE.match(text):
         _fail(
             f"output {name!r}={text!r} is not a Slack message ts (expected "
             r"\d{9,11}\.\d{4,6}); the flow did not actually post to Slack"
+        )
+
+    slack_ids = {
+        n.get("id")
+        for n in _iter_flow_nodes(project_glob)
+        if connector_key in str(n.get("type", ""))
+    }
+    if not slack_ids:
+        _fail(f"no {connector_key} connector node found in the flow")
+
+    els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
+    completed = [
+        e
+        for e in els
+        if _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId") in slack_ids
+        and str(_get_ci(e, "status", "Status")).lower() == "completed"
+    ]
+    if not completed:
+        _fail_with_capture(
+            f"no {connector_key} node completed in the debug trace "
+            f"(slack nodes {sorted(i for i in slack_ids if i)}); ts {text} did "
+            "not come from an executed Slack send"
         )
     return text
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -572,7 +572,53 @@ def assert_slack_message_posted(
             f"(slack nodes {sorted(i for i in slack_ids if i)}); ts {text} did "
             "not come from an executed Slack send"
         )
+
+    # Tie the mapped ts to an executed Slack node's OWN response. The runtime
+    # surfaces each node's output at globals["<nodeId>.output"]; a real send's
+    # response carries its ``ts``. If any executed Slack node exposes a ts, the
+    # mapped slackMessageId must be one of them — so executing a Slack node while
+    # mapping a different hard-coded ts is rejected.
+    gvars = _get_ci(_get_ci(payload, "variables", "Variables") or {}, "globals", "Globals") or {}
+    node_ts: set = set()
+    for e in completed:
+        nid = _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")
+        out = gvars.get(f"{nid}.output") if isinstance(gvars, dict) else None
+        for leaf in _leaves(out):
+            if isinstance(leaf, str) and _SLACK_TS_RE.match(leaf.strip()):
+                node_ts.add(leaf.strip())
+    if node_ts and text not in node_ts:
+        _fail_with_capture(
+            f"slackMessageId {text} does not match any executed Slack node's "
+            f"response ts {sorted(node_ts)}; the mapped ts was not produced by the "
+            "executed send"
+        )
     return text
+
+
+def assert_node_type_executed(
+    payload: dict, type_hint: str, *, project_glob: str = "**/project.uiproj"
+) -> None:
+    """Assert at least one flow node whose ``type`` contains ``type_hint`` has a
+    ``Completed`` ``elementExecution`` in this debug run — i.e. the node type is
+    actually on the executed path, not merely present-but-disconnected in the
+    source. Complements :func:`assert_flow_has_node_type` (source-only)."""
+    ids = {
+        n.get("id")
+        for n in _iter_flow_nodes(project_glob)
+        if type_hint in str(n.get("type", ""))
+    }
+    if not ids:
+        _fail(f"no node of type {type_hint!r} in the flow")
+    els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
+    if not any(
+        _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId") in ids
+        and str(_get_ci(e, "status", "Status")).lower() == "completed"
+        for e in els
+    ):
+        _fail_with_capture(
+            f"no {type_hint!r} node executed in the debug trace (nodes {sorted(i for i in ids if i)}); "
+            "it is present in the source but not on the executed path"
+        )
 
 
 def read_flow_input_vars(project_dir: str) -> list[str]:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -501,6 +501,35 @@ def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
 _SLACK_TS_RE = re.compile(r"^\d{9,11}\.\d{4,6}$")
 
 
+def _connector_node_ids(connector_key: str, project_glob: str) -> set:
+    """Node ids that reach ``connector_key`` — a native connector node OR a
+    connector-mode ``core.action.http`` proxy carrying real connector auth
+    (authentication=connector + non-empty connectionId + connectionFolderKey),
+    the same shapes :func:`assert_flow_uses_connector_target` accepts. Shared so
+    the message check and the branch-routing check agree on what counts."""
+    ids: set = set()
+    for n in _iter_flow_nodes(project_glob):
+        t = str(n.get("type", ""))
+        if connector_key in t:
+            ids.add(n.get("id"))
+            continue
+        detail = (n.get("inputs") or {}).get("detail") or {}
+        if not isinstance(detail, dict):
+            continue
+        body = detail.get("bodyParameters") or {}
+        body = body if isinstance(body, dict) else {}
+        target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
+        if (
+            t.lower().startswith("core.action.http")
+            and target == connector_key.lower()
+            and str(body.get("authentication") or "").lower() == "connector"
+            and _non_empty_binding_value(detail.get("connectionId"))
+            and _non_empty_binding_value(detail.get("connectionFolderKey"))
+        ):
+            ids.add(n.get("id"))
+    return ids
+
+
 def assert_slack_message_posted(
     payload: dict,
     name: str,
@@ -532,32 +561,8 @@ def assert_slack_message_posted(
             r"\d{9,11}\.\d{4,6}); the flow did not actually post to Slack"
         )
 
-    # Slack node ids — a native connector node OR a connector-mode HTTP proxy
-    # targeting the connector (same shapes assert_flow_uses_connector_target
-    # accepts), so a valid HTTP-proxy Slack node isn't a false negative.
-    slack_ids: set = set()
-    for n in _iter_flow_nodes(project_glob):
-        t = str(n.get("type", ""))
-        if connector_key in t:
-            slack_ids.add(n.get("id"))
-            continue
-        # Connector-mode HTTP proxy — accept ONLY when it carries real connector
-        # auth (same gate as assert_flow_uses_connector_target): a disconnected
-        # HTTP node with just targetConnector set must not qualify.
-        detail = (n.get("inputs") or {}).get("detail") or {}
-        if not isinstance(detail, dict):
-            continue
-        body = detail.get("bodyParameters") or {}
-        body = body if isinstance(body, dict) else {}
-        target = str((body.get("targetConnector") or body.get("connectorKey") or "")).lower()
-        if (
-            t.lower().startswith("core.action.http")
-            and target == connector_key.lower()
-            and str(body.get("authentication") or "").lower() == "connector"
-            and _non_empty_binding_value(detail.get("connectionId"))
-            and _non_empty_binding_value(detail.get("connectionFolderKey"))
-        ):
-            slack_ids.add(n.get("id"))
+    # Native connector node OR a connector-mode HTTP proxy carrying real auth.
+    slack_ids = _connector_node_ids(connector_key, project_glob)
     if not slack_ids:
         _fail(f"no connected {connector_key} node found in the flow")
 
@@ -655,11 +660,7 @@ def completed_connector_node_ids(
     elementExecution in this run — i.e. which connector node actually fired.
     Used to prove branch routing across cases (escalation vs triage must fire
     different nodes, not one dynamic node behind a cosmetic Decision)."""
-    ids = {
-        n.get("id")
-        for n in _iter_flow_nodes(project_glob)
-        if connector_key in str(n.get("type", ""))
-    }
+    ids = _connector_node_ids(connector_key, project_glob)
     els = _get_ci(payload, "elementExecutions", "Elements", "elements") or []
     return {
         _get_ci(e, "elementId", "ElementId", "nodeId", "NodeId")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -176,18 +176,32 @@ def main() -> None:
     # unrelated Script from supplying engineeringNeeded while the real classifier omits it.
     script_nodes = completed_node_ids_of_type(payload, "script")
     sev = (seed.get("expected") or {}).get("severity")
-    classify_ids = {
-        nid for nid in script_nodes
+    sev_scripts = [
+        nid for nid in sorted(n for n in script_nodes if n)
         if normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sev)
-    }
-    if not classify_ids:
+    ]
+    if not sev_scripts:
         _fail(f"no executed Script node produced the expected severity {sev!r} — cannot bind the classification checks")
-    for name, expected in (seed.get("expected_script") or {}).items():
-        actual = find_node_output_value(payload, name, node_ids=classify_ids)
-        if actual is None:
-            _fail(f"the classification Script did not compute {name!r} (required by the prompt)")
-        if normalized(actual) != normalized(expected):
-            _fail(f"Script output {name!r}: expected {expected!r}, got {actual!r}")
+    # Bind ALL classifications to ONE node: the same Script that produced the
+    # severity must ALSO carry the expected engineeringNeeded. A split across two
+    # cosmetic Scripts (one emits severity, another engineeringNeeded) fails.
+    expected_script = seed.get("expected_script") or {}
+
+    def carries_all(nid: str):
+        for name, expected in expected_script.items():
+            actual = find_node_output_value(payload, name, node_ids={nid})
+            if actual is None:
+                return f"{name!r} missing"
+            if normalized(actual) != normalized(expected):
+                return f"{name!r}={actual!r} (expected {expected!r})"
+        return None
+
+    if not any(carries_all(nid) is None for nid in sev_scripts):
+        detail = "; ".join(f"{nid}: {carries_all(nid)}" for nid in sev_scripts)
+        _fail(
+            "no single executed Script carries the expected severity AND the "
+            f"classification fields together — classification is split or missing ({detail})"
+        )
 
     print("PASS: escalation flow created a real Jira ticket with the expected classification")
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -30,8 +30,10 @@ from _shared.flow_check import (  # noqa: E402
     assert_named_equals,
     collect_outputs,
     completed_connector_node_ids,
+    find_node_output_value,
     get_last_debug_raw,
     node_output_leaves,
+    normalized,
     run_debug,
 )
 import jira_is  # noqa: E402
@@ -165,6 +167,16 @@ def main() -> None:
     # Opaque ids (caseKey) compare case-sensitively; enum-like values (severity) do not.
     for name, expected in (seed.get("expected") or {}).items():
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
+
+    # Classification the prompt requires the Script to compute but does not map to a
+    # named End out (engineeringNeeded) — verify it against the Script's own output
+    # so a flow that skips the required classification cannot pass on the ticket alone.
+    for name, expected in (seed.get("expected_script") or {}).items():
+        actual = find_node_output_value(payload, name)
+        if actual is None:
+            _fail(f"the flow's Script node did not compute {name!r} (required by the prompt)")
+        if normalized(actual) != normalized(expected):
+            _fail(f"Script output {name!r}: expected {expected!r}, got {actual!r}")
 
     print("PASS: escalation flow created a real Jira ticket with the expected classification")
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -39,6 +39,7 @@ import jira_is  # noqa: E402
 JIRA_KEY = "uipath-atlassian-jira"
 JIRA_CREATE_KEY = "uipath-atlassian-jira.create-issue"
 ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
+CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
 
 
 def _fail(msg: str) -> None:
@@ -147,12 +148,15 @@ def main() -> None:
 
     # Require the flow to actually EXPOSE the created key as jiraIssueKey (End
     # mapping present), not just create the ticket — harvesting the key from raw
-    # debug text must not substitute for the required output.
-    assert_named_equals(payload, "jiraIssueKey", match)
+    # debug text must not substitute for the required output. jiraIssueKey is an
+    # opaque tenant-issued identifier: compare case-sensitively (a lowercased
+    # variant must not pass).
+    assert_named_equals(payload, "jiraIssueKey", match, case_sensitive=True)
 
     # Named classification/correlation outputs the prompt requires (severity, caseKey).
+    # Opaque ids (caseKey) compare case-sensitively; enum-like values (severity) do not.
     for name, expected in (seed.get("expected") or {}).items():
-        assert_named_equals(payload, name, expected)
+        assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
     print("PASS: escalation flow created a real Jira ticket with the expected classification")
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -63,18 +63,25 @@ def main() -> None:
 
     conn = jira_is.connection_id()
 
-    # Record every candidate that actually exists in Jira BEFORE the summary
-    # assertion, so post_run teardown deletes them even if verification fails.
-    existing = [(k, f) for k in cands for f in [jira_is.get_issue(conn, k)] if f is not None]
-    if existing:
-        Path(".created_keys").write_text("\n".join(k for k, _ in existing) + "\n")
-
-    match = next((k for k, f in existing if correlation in str(f.get("summary", ""))), None)
-    if not match:
+    # Record ONLY keys proven to belong to this run — an issue whose summary
+    # carries this run's correlationId. This is written before the classification
+    # assertions so teardown still cleans up if a later assertion fails, while
+    # never deleting an unrelated pre-existing issue in the shared CE project
+    # (e.g. if a wrong flow echoed some other CE key into its output).
+    owned = [
+        k
+        for k in cands
+        for f in [jira_is.get_issue(conn, k)]
+        if f is not None and correlation in str(f.get("summary", ""))
+    ]
+    if owned:
+        Path(".created_keys").write_text("\n".join(owned) + "\n")  # this run's ticket(s) only
+    if not owned:
         _fail(
             f"none of {cands} is a Jira issue whose summary contains {correlation!r} — "
             "the flow did not create the expected escalation ticket"
         )
+    match = owned[0]
     print(f"OK: Jira ticket {match} exists and its summary carries {correlation!r}")
 
     # Classification outputs the prompt also requires (e.g. severity=Sev1).

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -19,6 +19,7 @@ import glob
 import json
 import os
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -28,6 +29,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro
 from _shared.flow_check import (  # noqa: E402
     assert_named_equals,
     collect_outputs,
+    completed_connector_node_ids,
     get_last_debug_raw,
     run_debug,
 )
@@ -55,8 +57,34 @@ def main() -> None:
     # whole flow on a transient poll error would create a duplicate ticket that
     # this checker (deriving keys from the final attempt) wouldn't see or clean
     # up. One attempt only; a genuine transient failure fails the run cleanly.
-    payload = run_debug(inputs=seed["inputs"], timeout=480, retries=1)
+    try:
+        payload = run_debug(inputs=seed["inputs"], timeout=480, retries=1)
+    except subprocess.TimeoutExpired as exc:
+        # The Create Issue node may have completed before the debug poll timed
+        # out. This connection is curated single-record (no JQL search to
+        # discover the key), so best-effort: scan the partial CLI output for a
+        # project-scoped key and record it so teardown deletes it anyway.
+        partial = "".join(
+            s.decode() if isinstance(s, bytes) else (s or "")
+            for s in (exc.stdout, exc.stderr)
+        )
+        keys = list(dict.fromkeys(re.findall(rf"\b{re.escape(project)}-\d+\b", partial)))
+        if keys:
+            Path(".created_keys").write_text("\n".join(keys) + "\n")
+        _fail(
+            f"flow debug timed out after {exc.timeout}s"
+            + (f"; recorded {keys} for teardown" if keys else "")
+        )
     print("OK: flow debug completed")
+
+    # Execution evidence: the Jira Create node must have actually executed in the
+    # debugged flow. A disconnected Jira node with a hard-coded key (issue created
+    # at authoring time) has no Completed elementExecution and fails here.
+    if not completed_connector_node_ids(payload, JIRA_KEY):
+        _fail(
+            f"no {JIRA_KEY} node completed in the debug trace — the debugged flow "
+            "did not execute the Create Issue activity"
+        )
 
     cands = [s for leaf in collect_outputs(payload) for s in [str(leaf).strip()] if ISSUE_KEY_RE.match(s)]
     cands += re.findall(rf"\b{re.escape(project)}-\d+\b", get_last_debug_raw() or "")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -51,7 +51,11 @@ def main() -> None:
         _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
     print(f"OK: flow references {JIRA_KEY}")
 
-    payload = run_debug(inputs=seed["inputs"], timeout=480)
+    # No whole-flow retries: this flow CREATES a Jira issue, so re-running the
+    # whole flow on a transient poll error would create a duplicate ticket that
+    # this checker (deriving keys from the final attempt) wouldn't see or clean
+    # up. One attempt only; a genuine transient failure fails the run cleanly.
+    payload = run_debug(inputs=seed["inputs"], timeout=480, retries=1)
     print("OK: flow debug completed")
 
     cands = [s for leaf in collect_outputs(payload) for s in [str(leaf).strip()] if ISSUE_KEY_RE.match(s)]

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -170,15 +170,22 @@ def main() -> None:
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
     # Classification the prompt requires the Script to compute but does not map to a
-    # named End out (engineeringNeeded) — verify it against the EXECUTED Script
-    # node's own output (scoped to completed Script nodes so a cosmetic/unrelated
-    # node can't supply it), so a flow that skips the required classification
-    # cannot pass on the ticket alone.
+    # named End out (engineeringNeeded) — verify it against the ONE classification
+    # Script: the executed Script whose own output carries the expected severity.
+    # Binding to that single node (not the set of all completed Scripts) stops an
+    # unrelated Script from supplying engineeringNeeded while the real classifier omits it.
     script_nodes = completed_node_ids_of_type(payload, "script")
+    sev = (seed.get("expected") or {}).get("severity")
+    classify_ids = {
+        nid for nid in script_nodes
+        if normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sev)
+    }
+    if not classify_ids:
+        _fail(f"no executed Script node produced the expected severity {sev!r} — cannot bind the classification checks")
     for name, expected in (seed.get("expected_script") or {}).items():
-        actual = find_node_output_value(payload, name, node_ids=script_nodes)
+        actual = find_node_output_value(payload, name, node_ids=classify_ids)
         if actual is None:
-            _fail(f"the flow's Script node did not compute {name!r} (required by the prompt)")
+            _fail(f"the classification Script did not compute {name!r} (required by the prompt)")
         if normalized(actual) != normalized(expected):
             _fail(f"Script output {name!r}: expected {expected!r}, got {actual!r}")
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -30,6 +30,7 @@ from _shared.flow_check import (  # noqa: E402
     assert_named_equals,
     collect_outputs,
     completed_connector_node_ids,
+    completed_node_ids_of_type,
     find_node_output_value,
     get_last_debug_raw,
     node_output_leaves,
@@ -39,7 +40,7 @@ from _shared.flow_check import (  # noqa: E402
 import jira_is  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
-JIRA_CREATE_KEY = "uipath-atlassian-jira.create-issue"
+JIRA_CREATE_OP = "create-issue"  # matched by op so a connector-proxy Create (op in endpoint) also counts
 ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
 CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
 
@@ -102,7 +103,7 @@ def main() -> None:
     # Execution evidence: the Jira CREATE-ISSUE node specifically must have
     # executed in the debugged flow (not merely any Jira node — a read op could
     # surface an authoring-time key). A disconnected/absent Create node fails here.
-    create_nodes = completed_connector_node_ids(payload, JIRA_CREATE_KEY)
+    create_nodes = completed_connector_node_ids(payload, JIRA_KEY, native_op_hint=JIRA_CREATE_OP)
     if not create_nodes:
         _fail(
             "no Jira Create-Issue node completed in the debug trace — the debugged "
@@ -169,10 +170,13 @@ def main() -> None:
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
     # Classification the prompt requires the Script to compute but does not map to a
-    # named End out (engineeringNeeded) — verify it against the Script's own output
-    # so a flow that skips the required classification cannot pass on the ticket alone.
+    # named End out (engineeringNeeded) — verify it against the EXECUTED Script
+    # node's own output (scoped to completed Script nodes so a cosmetic/unrelated
+    # node can't supply it), so a flow that skips the required classification
+    # cannot pass on the ticket alone.
+    script_nodes = completed_node_ids_of_type(payload, "script")
     for name, expected in (seed.get("expected_script") or {}).items():
-        actual = find_node_output_value(payload, name)
+        actual = find_node_output_value(payload, name, node_ids=script_nodes)
         if actual is None:
             _fail(f"the flow's Script node did not compute {name!r} (required by the prompt)")
         if normalized(actual) != normalized(expected):

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -25,7 +25,12 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)  # local jira_is
 sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
-from _shared.flow_check import collect_outputs, get_last_debug_raw, run_debug  # noqa: E402
+from _shared.flow_check import (  # noqa: E402
+    assert_named_equals,
+    collect_outputs,
+    get_last_debug_raw,
+    run_debug,
+)
 import jira_is  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
@@ -57,17 +62,26 @@ def main() -> None:
     print(f"OK: candidate keys from debug: {cands}")
 
     conn = jira_is.connection_id()
-    for key in cands:
-        fields = jira_is.get_issue(conn, key)
-        if fields and correlation in str(fields.get("summary", "")):
-            Path(".created_keys").write_text(key + "\n")  # for teardown
-            print(f"OK: Jira ticket {key} exists and its summary carries {correlation!r}")
-            print("PASS: escalation flow created a real Jira ticket")
-            return
-    _fail(
-        f"none of {cands} is a Jira issue whose summary contains {correlation!r} — "
-        "the flow did not create the expected escalation ticket"
-    )
+
+    # Record every candidate that actually exists in Jira BEFORE the summary
+    # assertion, so post_run teardown deletes them even if verification fails.
+    existing = [(k, f) for k in cands for f in [jira_is.get_issue(conn, k)] if f is not None]
+    if existing:
+        Path(".created_keys").write_text("\n".join(k for k, _ in existing) + "\n")
+
+    match = next((k for k, f in existing if correlation in str(f.get("summary", ""))), None)
+    if not match:
+        _fail(
+            f"none of {cands} is a Jira issue whose summary contains {correlation!r} — "
+            "the flow did not create the expected escalation ticket"
+        )
+    print(f"OK: Jira ticket {match} exists and its summary carries {correlation!r}")
+
+    # Classification outputs the prompt also requires (e.g. severity=Sev1).
+    for name, expected in (seed.get("expected") or {}).items():
+        assert_named_equals(payload, name, expected)
+
+    print("PASS: escalation flow created a real Jira ticket with the expected classification")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -61,16 +61,19 @@ def main() -> None:
     # up. One attempt only; a genuine transient failure fails the run cleanly.
     try:
         payload = run_debug(inputs=seed["inputs"], timeout=480, retries=1)
-    except subprocess.TimeoutExpired as exc:
-        # The Create Issue node may have completed before the debug poll timed
-        # out. This connection is curated single-record (no JQL search), so
-        # best-effort: scan the partial CLI output for project-scoped keys and
-        # record ONLY those whose summary carries this run's correlationId — never
-        # an unrelated pre-existing issue.
-        partial = "".join(
-            s.decode() if isinstance(s, bytes) else (s or "")
-            for s in (exc.stdout, exc.stderr)
-        )
+    except (subprocess.TimeoutExpired, SystemExit) as exc:
+        # ANY debug failure (timeout, a later-node fault, or a transient poll
+        # error surfaced by run_debug via SystemExit) may leave a Create Issue
+        # that already succeeded. This connection is curated single-record (no JQL
+        # search), so best-effort: from whatever debug output we have, record ONLY
+        # keys whose summary carries this run's correlationId (verified via
+        # get_issue) — never an unrelated pre-existing issue.
+        partial = get_last_debug_raw() or ""
+        if isinstance(exc, subprocess.TimeoutExpired):
+            partial += "".join(
+                s.decode() if isinstance(s, bytes) else (s or "")
+                for s in (exc.stdout, exc.stderr)
+            )
         cands = list(dict.fromkeys(re.findall(rf"\b{re.escape(project)}-\d+\b", partial)))
         owned = []
         if cands:
@@ -81,10 +84,12 @@ def main() -> None:
                     for f in [jira_is.get_issue(conn, k)]
                     if f is not None and correlation in str(f.get("summary", ""))
                 ]
-            except Exception:  # noqa: BLE001 — best-effort cleanup, never mask the timeout
+            except Exception:  # noqa: BLE001 — best-effort cleanup, never mask the failure
                 owned = []
         if owned:
             Path(".created_keys").write_text("\n".join(owned) + "\n")
+        if isinstance(exc, SystemExit):
+            raise  # preserve run_debug's original failure message
         _fail(
             f"flow debug timed out after {exc.timeout}s"
             + (f"; recorded this-run key(s) {owned} for teardown" if owned else "")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -31,11 +31,13 @@ from _shared.flow_check import (  # noqa: E402
     collect_outputs,
     completed_connector_node_ids,
     get_last_debug_raw,
+    node_output_leaves,
     run_debug,
 )
 import jira_is  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
+JIRA_CREATE_KEY = "uipath-atlassian-jira.create-issue"
 ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
 
 
@@ -61,29 +63,42 @@ def main() -> None:
         payload = run_debug(inputs=seed["inputs"], timeout=480, retries=1)
     except subprocess.TimeoutExpired as exc:
         # The Create Issue node may have completed before the debug poll timed
-        # out. This connection is curated single-record (no JQL search to
-        # discover the key), so best-effort: scan the partial CLI output for a
-        # project-scoped key and record it so teardown deletes it anyway.
+        # out. This connection is curated single-record (no JQL search), so
+        # best-effort: scan the partial CLI output for project-scoped keys and
+        # record ONLY those whose summary carries this run's correlationId — never
+        # an unrelated pre-existing issue.
         partial = "".join(
             s.decode() if isinstance(s, bytes) else (s or "")
             for s in (exc.stdout, exc.stderr)
         )
-        keys = list(dict.fromkeys(re.findall(rf"\b{re.escape(project)}-\d+\b", partial)))
-        if keys:
-            Path(".created_keys").write_text("\n".join(keys) + "\n")
+        cands = list(dict.fromkeys(re.findall(rf"\b{re.escape(project)}-\d+\b", partial)))
+        owned = []
+        if cands:
+            try:
+                conn = jira_is.connection_id()
+                owned = [
+                    k for k in cands
+                    for f in [jira_is.get_issue(conn, k)]
+                    if f is not None and correlation in str(f.get("summary", ""))
+                ]
+            except Exception:  # noqa: BLE001 — best-effort cleanup, never mask the timeout
+                owned = []
+        if owned:
+            Path(".created_keys").write_text("\n".join(owned) + "\n")
         _fail(
             f"flow debug timed out after {exc.timeout}s"
-            + (f"; recorded {keys} for teardown" if keys else "")
+            + (f"; recorded this-run key(s) {owned} for teardown" if owned else "")
         )
     print("OK: flow debug completed")
 
-    # Execution evidence: the Jira Create node must have actually executed in the
-    # debugged flow. A disconnected Jira node with a hard-coded key (issue created
-    # at authoring time) has no Completed elementExecution and fails here.
-    if not completed_connector_node_ids(payload, JIRA_KEY):
+    # Execution evidence: the Jira CREATE-ISSUE node specifically must have
+    # executed in the debugged flow (not merely any Jira node — a read op could
+    # surface an authoring-time key). A disconnected/absent Create node fails here.
+    create_nodes = completed_connector_node_ids(payload, JIRA_CREATE_KEY)
+    if not create_nodes:
         _fail(
-            f"no {JIRA_KEY} node completed in the debug trace — the debugged flow "
-            "did not execute the Create Issue activity"
+            "no Jira Create-Issue node completed in the debug trace — the debugged "
+            "flow did not execute the Create Issue activity"
         )
 
     cands = [s for leaf in collect_outputs(payload) for s in [str(leaf).strip()] if ISSUE_KEY_RE.match(s)]
@@ -115,6 +130,15 @@ def main() -> None:
         )
     match = owned[0]
     print(f"OK: Jira ticket {match} exists and its summary carries {correlation!r}")
+
+    # Tie the verified key to the executed Create-Issue node's OWN response — the
+    # created key must appear in that node's output, so a read op surfacing an
+    # authoring-time key (whose node is not the Create) cannot satisfy this.
+    if match not in node_output_leaves(payload, create_nodes):
+        _fail(
+            f"created key {match} is not in the executed Create-Issue node's output; "
+            "the debugged Create Issue did not produce this key"
+        )
 
     # Require the flow to actually EXPOSE the created key as jiraIssueKey (End
     # mapping present), not just create the ticket — harvesting the key from raw

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -114,12 +114,19 @@ def main() -> None:
         _fail(f"no Jira issue key (e.g. {project}-123) in flow debug outputs — the flow did not create a ticket")
     print(f"OK: candidate keys from debug: {cands}")
 
+    # Persist proven-created keys BEFORE the fallible tenant reread: any candidate
+    # that appears in the executed Create-Issue node's OWN output was created by
+    # THIS run, so teardown can delete it even if the tenant reread below fails
+    # transiently (jira_is.get_issue collapses a 5xx/auth envelope to None, which
+    # would otherwise leave owned empty and leak the issue in the shared CE project).
+    node_keys = [k for k in cands if k in node_output_leaves(payload, create_nodes)]
+    if node_keys:
+        Path(".created_keys").write_text("\n".join(node_keys) + "\n")
+
     conn = jira_is.connection_id()
 
-    # Record ONLY keys proven to belong to this run — an issue whose summary
-    # carries this run's correlationId. This is written before the classification
-    # assertions so teardown still cleans up if a later assertion fails, while
-    # never deleting an unrelated pre-existing issue in the shared CE project
+    # Tenant-confirm: the key belongs to this run — an issue whose summary carries
+    # this run's correlationId. Never deletes an unrelated pre-existing issue
     # (e.g. if a wrong flow echoed some other CE key into its output).
     owned = [
         k
@@ -127,8 +134,9 @@ def main() -> None:
         for f in [jira_is.get_issue(conn, k)]
         if f is not None and correlation in str(f.get("summary", ""))
     ]
-    if owned:
-        Path(".created_keys").write_text("\n".join(owned) + "\n")  # this run's ticket(s) only
+    created = list(dict.fromkeys(node_keys + owned))
+    if created:
+        Path(".created_keys").write_text("\n".join(created) + "\n")  # this run's ticket(s) only
     if not owned:
         _fail(
             f"none of {cands} is a Jira issue whose summary contains {correlation!r} — "

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -88,7 +88,12 @@ def main() -> None:
     match = owned[0]
     print(f"OK: Jira ticket {match} exists and its summary carries {correlation!r}")
 
-    # Classification outputs the prompt also requires (e.g. severity=Sev1).
+    # Require the flow to actually EXPOSE the created key as jiraIssueKey (End
+    # mapping present), not just create the ticket — harvesting the key from raw
+    # debug text must not substitute for the required output.
+    assert_named_equals(payload, "jiraIssueKey", match)
+
+    # Named classification/correlation outputs the prompt requires (severity, caseKey).
     for name, expected in (seed.get("expected") or {}).items():
         assert_named_equals(payload, name, expected)
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/check_escalation_jira_ticket.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Verify the escalation flow actually creates a Jira ticket.
+
+Outcome-based, tenant-confirmed (mirrors e2e/jira_create_issue):
+  1. A `.flow` references the uipath-atlassian-jira connector.
+  2. LIVE: `flow debug` on the seeded Sev1 case runs to Completed and emits a
+     Jira issue key (this creates a real issue).
+  3. TENANT: re-reading that key via curated_get_issue returns an issue whose
+     summary carries the seeded correlationId — proof the flow hit Jira and
+     created THIS run's ticket, not a fabricated output.
+
+The confirmed key is written to `.created_keys` so post_run teardown deletes it
+even if a later assertion fails.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)  # local jira_is
+sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
+from _shared.flow_check import collect_outputs, get_last_debug_raw, run_debug  # noqa: E402
+import jira_is  # noqa: E402
+
+JIRA_KEY = "uipath-atlassian-jira"
+ISSUE_KEY_RE = re.compile(r"^[A-Z][A-Z0-9]*-\d+$")
+
+
+def _fail(msg: str) -> None:
+    sys.exit(f"FAIL: {msg}")
+
+
+def main() -> None:
+    seed = json.loads(Path("seed.json").read_text())
+    correlation = seed["correlationId"]
+    project = seed["project_key"]
+
+    flows = glob.glob("**/*.flow", recursive=True)
+    if not any(JIRA_KEY in open(p, encoding="utf-8").read() for p in flows):
+        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    print(f"OK: flow references {JIRA_KEY}")
+
+    payload = run_debug(inputs=seed["inputs"], timeout=480)
+    print("OK: flow debug completed")
+
+    cands = [s for leaf in collect_outputs(payload) for s in [str(leaf).strip()] if ISSUE_KEY_RE.match(s)]
+    cands += re.findall(rf"\b{re.escape(project)}-\d+\b", get_last_debug_raw() or "")
+    cands = list(dict.fromkeys(cands))
+    if not cands:
+        _fail(f"no Jira issue key (e.g. {project}-123) in flow debug outputs — the flow did not create a ticket")
+    print(f"OK: candidate keys from debug: {cands}")
+
+    conn = jira_is.connection_id()
+    for key in cands:
+        fields = jira_is.get_issue(conn, key)
+        if fields and correlation in str(fields.get("summary", "")):
+            Path(".created_keys").write_text(key + "\n")  # for teardown
+            print(f"OK: Jira ticket {key} exists and its summary carries {correlation!r}")
+            print("PASS: escalation flow created a real Jira ticket")
+            return
+    _fail(
+        f"none of {cands} is a Jira issue whose summary contains {correlation!r} — "
+        "the flow did not create the expected escalation ticket"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -78,7 +78,7 @@ success_criteria:
   - type: run_command
     description: "Seeded Sev1 debug run creates a real Jira ticket whose summary carries the seeded correlationId (verified by re-reading the tenant)"
     command: "python3 $TASK_DIR/check_escalation_jira_ticket.py"
-    timeout: 1000
+    timeout: 1600
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -13,17 +13,13 @@ description: >
   Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
   `Shared/uipath-maestro-flow` reaching the `CE` / "Coder Eval" project (issue
   type Task). Targets live in the task's `jira_is.py`.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation]
 
 run_limits:
   expected_turns: 55
   max_turns: 120
   task_timeout: 2400
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py"
@@ -82,7 +78,7 @@ success_criteria:
   - type: run_command
     description: "Seeded Sev1 debug run creates a real Jira ticket whose summary carries the seeded correlationId (verified by re-reading the tenant)"
     command: "python3 $TASK_DIR/check_escalation_jira_ticket.py"
-    timeout: 900
+    timeout: 1000
     expected_exit_code: 0
-    weight: 6.0
+    weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -1,0 +1,88 @@
+task_id: skill-flow-e2e-escalation-jira-ticket
+description: >
+  E2E live Jira coverage for the escalation flow — the agent builds a
+  manual-trigger escalation-triage Flow that classifies severity and creates a
+  real Jira ticket for the escalation. The grader seeds a Sev1 case (unique
+  correlationId), runs `uip maestro flow debug --inputs`, and verifies the
+  OUTCOME by re-reading the created key from Jira: the issue exists and its
+  summary carries the seeded correlationId — proof the flow created THIS run's
+  ticket, not a fabricated key. The created issue is cleaned up in post_run.
+  A manual trigger is used because the Outlook email-received trigger is not
+  reliably debug-testable (see outlook_trigger_inbox / customer_escalation).
+
+  Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
+  `Shared/uipath-maestro-flow` reaching the `CE` / "Coder Eval" project (issue
+  type Task). Targets live in the task's `jira_is.py`.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-atlassian-jira, feature:escalation]
+
+run_limits:
+  expected_turns: 55
+  max_turns: 120
+  task_timeout: 2400
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py"
+    timeout: 60
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py"
+    timeout: 120
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+initial_prompt: |
+  Create a UiPath Maestro Flow named "EscalationJiraTicket" with a MANUAL trigger.
+  It triages a customer escalation and creates a Jira ticket for it.
+
+  Read `seed.json` in the current directory. Declare flow inputs matching the keys
+  under its `inputs`: senderEmail, senderDomain, subject, body, customerTier,
+  productionDown (boolean), workaroundAvailable (boolean), hasAttachments (boolean),
+  customerMatchStatus, isDuplicate (boolean), correlationId.
+
+  Steps:
+  1. A Script node classifies severity from the inputs (Sev1 = Enterprise tier AND
+     productionDown AND NOT workaroundAvailable; Sev2 = productionDown AND
+     workaroundAvailable; Sev3 otherwise) plus engineeringNeeded.
+  2. Create a Jira issue using the Atlassian Jira "Create Issue" connector activity.
+     Use the `project_key` and `issuetype_id` from `seed.json`. The issue summary
+     MUST include the `correlationId` verbatim (e.g. "[<severity>] <correlationId>
+     <subject>"). Use the Atlassian Jira connection in the `Shared/uipath-maestro-flow`
+     folder. If the Atlassian Jira connector isn't in your registry, STOP rather than
+     falling back to a generic HTTP request.
+  3. End the flow, exposing these `out` variables: severity, caseKey (= the incoming
+     correlationId), and jiraIssueKey (the created issue's key).
+
+  Validate the flow. Do NOT run or debug the flow — the grader executes it with the
+  seeded inputs. Do NOT ask for approval and do NOT pause; build end-to-end in a
+  single pass. Before starting, load the uipath-maestro-flow skill and follow its
+  workflow.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated EscalationJiraTicket Flow validates without errors"
+    command: "uip maestro flow validate EscalationJiraTicket/EscalationJiraTicket/EscalationJiraTicket.flow --output json"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Seeded Sev1 debug run creates a real Jira ticket whose summary carries the seeded correlationId (verified by re-reading the tenant)"
+    command: "python3 $TASK_DIR/check_escalation_jira_ticket.py"
+    timeout: 900
+    expected_exit_code: 0
+    weight: 6.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Minimal live Jira helper for this task — wraps `uip is resources run`.
+
+Self-contained (no shared module). Assumes `uip` is on PATH and logged in and
+that the connection + CE project exist — this is a tenant-gated e2e task.
+
+The connection is scoped to the curated single-record ops, so we create by
+body / get by id / delete by id — never a JQL search.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+CONNECTOR = "uipath-atlassian-jira"
+FOLDER_PATH = "Shared/uipath-maestro-flow"
+CONNECTION_NAME = "is-sandboxes-test@uipath.com-uipath-sandbox-380"
+PROJECT_KEY = "CE"        # "Coder Eval" project on uipath-sandbox-380
+ISSUETYPE_ID = "11457"    # "Task" issue type, scoped to the CE project
+
+
+def _run(*args: str) -> dict:
+    out = subprocess.run(
+        ["uip", *args, "--output", "json"],
+        capture_output=True, text=True, timeout=120,
+    ).stdout
+    return json.loads(out)
+
+
+def connection_id() -> str:
+    folder_key = _run("or", "folders", "get", FOLDER_PATH)["Data"]["Key"]
+    conns = _run("is", "connections", "list", CONNECTOR, "--folder-key", folder_key, "--refresh")["Data"]
+    return next(c["Id"] for c in conns if c["Name"] == CONNECTION_NAME)
+
+
+def create_issue(conn_id: str, summary: str) -> str:
+    body = {"fields": {"project": {"key": PROJECT_KEY}, "issuetype": {"id": ISSUETYPE_ID}, "summary": summary}}
+    return _run(
+        "is", "resources", "run", "create", CONNECTOR, "curated_create_issue",
+        "--connection-id", conn_id, "--body", json.dumps(body),
+    )["Data"]["key"]
+
+
+def get_issue(conn_id: str, key: str) -> dict | None:
+    """Return the issue's `fields` dict, or None if it doesn't exist (404)."""
+    env = _run(
+        "is", "resources", "run", "get", CONNECTOR, "curated_get_issue",
+        "--connection-id", conn_id,
+        "--query", f"project={PROJECT_KEY}&issuetype={ISSUETYPE_ID}&issueId={key}",
+    )
+    if env.get("Result") == "Failure":
+        return None
+    return env["Data"].get("fields", {})
+
+
+def delete_issue(conn_id: str, key: str) -> None:
+    """Delete an issue by key. A 404 (already gone) is a no-op."""
+    _run(
+        "is", "resources", "run", "delete", CONNECTOR, "issue",
+        "--connection-id", conn_id, "--query", f"issueId={key}",
+    )

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -15,6 +15,7 @@ import subprocess
 
 CONNECTOR = "uipath-atlassian-jira"
 FOLDER_PATH = "Shared/uipath-maestro-flow"
+FOLDER_NAME = "uipath-maestro-flow"  # leaf of FOLDER_PATH, as reported by connections list
 CONNECTION_NAME = "is-sandboxes-test@uipath.com-uipath-sandbox-380"
 PROJECT_KEY = "CE"        # "Coder Eval" project on uipath-sandbox-380
 ISSUETYPE_ID = "11457"    # "Task" issue type, scoped to the CE project
@@ -31,10 +32,14 @@ def _run(*args: str) -> dict:
 
 
 def connection_id() -> str:
-    # Resolve by connection name across all folders — avoids depending on
-    # `uip or folders get`, which can return a Failure envelope in CI.
+    # Resolve by (name, folder) across all folders — avoids depending on
+    # `uip or folders get` (which can return a Failure envelope in CI) while
+    # still scoping to the target folder so a same-named connection in another
+    # folder can't be picked by accident.
     conns = _run("is", "connections", "list", CONNECTOR, "--all-folders", "--refresh")["Data"]
-    return next(c["Id"] for c in conns if c["Name"] == CONNECTION_NAME)
+    scoped = [c for c in conns if c["Name"] == CONNECTION_NAME and c.get("Folder") == FOLDER_NAME]
+    # Fall back to name-only if the folder field isn't populated in this env.
+    return next(iter(c["Id"] for c in (scoped or conns) if c["Name"] == CONNECTION_NAME))
 
 
 def create_issue(conn_id: str, summary: str) -> str:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -23,17 +23,26 @@ ISSUETYPE_ID = "11457"    # "Task" issue type, scoped to the CE project
 
 
 def _issue_not_found(env: dict) -> bool:
-    """True only for a STRUCTURED HTTP 404 from the Jira provider — proof the
-    requested issue key is absent. A bare ``"404"`` substring or a generic
-    ``"not found"`` (which could mean the connection/activity is missing, not the
-    issue) is NOT accepted, so a prerequisite failure can't masquerade as a
-    confirmed deletion."""
+    """True only for an ISSUE-SPECIFIC not-found from the Jira operation — proof the
+    requested issue key is absent. Requires BOTH a structured HTTP 404 AND an
+    issue-scoped signal (the provider phrases a missing issue as e.g. "Issue does
+    not exist ..."). A bare ``"404"``/``"not found"`` substring, or a 404 that
+    refers to a missing connection/activity/other prerequisite (no issue mention),
+    is NOT accepted — so a prerequisite failure can't masquerade as a confirmed
+    issue deletion. Being strict is the safe direction here: a false negative only
+    makes teardown print WARN, while a false positive would leak the CE issue."""
     blob = json.dumps(env)
-    return bool(
+    structured_404 = bool(
         re.search(r"status code ['\"]?404\b", blob, re.I)
         or re.search(r'"providerErrorCode"\s*:\s*404\b', blob)
         or re.search(r'"statusCode"\s*:\s*"?404\b', blob)
     )
+    issue_specific = bool(
+        re.search(r"issue\s+(does\s+not\s+exist|not\s+found|no\s+longer\s+exists)", blob, re.I)
+        or re.search(r"(does\s+not\s+exist|not\s+found).{0,40}\bissue\b", blob, re.I)
+        or re.search(r"\bissueId\b", blob)
+    )
+    return structured_404 and issue_specific
 
 
 def _run(*args: str) -> dict:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -25,12 +25,15 @@ def _run(*args: str) -> dict:
         ["uip", *args, "--output", "json"],
         capture_output=True, text=True, timeout=120,
     ).stdout
-    return json.loads(out)
+    # Tolerate diagnostic/log lines the CLI may print before the JSON envelope.
+    i = out.find("{")
+    return json.loads(out[i:] if i > 0 else out)
 
 
 def connection_id() -> str:
-    folder_key = _run("or", "folders", "get", FOLDER_PATH)["Data"]["Key"]
-    conns = _run("is", "connections", "list", CONNECTOR, "--folder-key", folder_key, "--refresh")["Data"]
+    # Resolve by connection name across all folders — avoids depending on
+    # `uip or folders get`, which can return a Failure envelope in CI.
+    conns = _run("is", "connections", "list", CONNECTOR, "--all-folders", "--refresh")["Data"]
     return next(c["Id"] for c in conns if c["Name"] == CONNECTION_NAME)
 
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -75,6 +75,22 @@ def get_issue(conn_id: str, key: str) -> dict | None:
     return env["Data"].get("fields", {})
 
 
+def issue_absent(conn_id: str, key: str) -> bool:
+    """True ONLY when a tenant read CONFIRMS the issue does not exist (not-found /
+    404). False when it exists OR when the read itself failed (transient 5xx /
+    auth) — so teardown never treats an ambiguous read as proof of deletion.
+    Distinct from :func:`get_issue`, which collapses every failure to ``None``."""
+    env = _run(
+        "is", "resources", "run", "get", CONNECTOR, "curated_get_issue",
+        "--connection-id", conn_id,
+        "--query", f"project={PROJECT_KEY}&issuetype={ISSUETYPE_ID}&issueId={key}",
+    )
+    if str(env.get("Result", "")).lower() != "failure":
+        return False  # a successful read means the issue still exists
+    blob = json.dumps(env).lower()
+    return any(s in blob for s in ("404", "not found", "notfound", "does not exist", "no longer exists"))
+
+
 def delete_issue(conn_id: str, key: str) -> bool:
     """Delete an issue by key. Returns True only when deletion is CONFIRMED —
     either a success envelope, or a not-found/404 (already gone). Returns False

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -37,9 +37,22 @@ def connection_id() -> str:
     # still scoping to the target folder so a same-named connection in another
     # folder can't be picked by accident.
     conns = _run("is", "connections", "list", CONNECTOR, "--all-folders", "--refresh")["Data"]
-    scoped = [c for c in conns if c["Name"] == CONNECTION_NAME and c.get("Folder") == FOLDER_NAME]
-    # Fall back to name-only if the folder field isn't populated in this env.
-    return next(iter(c["Id"] for c in (scoped or conns) if c["Name"] == CONNECTION_NAME))
+    by_name = [c for c in conns if c["Name"] == CONNECTION_NAME]
+    scoped = [c for c in by_name if c.get("Folder") == FOLDER_NAME]
+    if scoped:
+        return scoped[0]["Id"]
+    # Only accept a name-only match when NO candidate reports folder metadata
+    # (older CLI / env). If folders ARE reported but none is the target folder,
+    # refuse to guess — a same-named connection elsewhere could be the wrong
+    # Jira account. Fail the prerequisite instead.
+    if any(c.get("Folder") for c in by_name):
+        raise SystemExit(
+            f"FAIL: no {CONNECTOR} connection named {CONNECTION_NAME!r} in folder "
+            f"{FOLDER_NAME!r}; candidates in folders {[c.get('Folder') for c in by_name]}"
+        )
+    if not by_name:
+        raise SystemExit(f"FAIL: no {CONNECTOR} connection named {CONNECTION_NAME!r}")
+    return by_name[0]["Id"]
 
 
 def create_issue(conn_id: str, summary: str) -> str:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -37,10 +37,13 @@ def _issue_not_found(env: dict) -> bool:
         or re.search(r'"providerErrorCode"\s*:\s*404\b', blob)
         or re.search(r'"statusCode"\s*:\s*"?404\b', blob)
     )
+    # Require the PROVIDER's error message to say the issue is absent — NOT a bare
+    # `issueId` token, which every get/delete request echoes in its own query and so
+    # would also appear on a connection/activity 404. Only Jira's own "Issue does
+    # not exist"-style message proves the requested issue key is gone.
     issue_specific = bool(
-        re.search(r"issue\s+(does\s+not\s+exist|not\s+found|no\s+longer\s+exists)", blob, re.I)
-        or re.search(r"(does\s+not\s+exist|not\s+found).{0,40}\bissue\b", blob, re.I)
-        or re.search(r"\bissueId\b", blob)
+        re.search(r"issue\s+(does\s+not\s+exist|not\s+found|no\s+longer\s+exists|is\s+not\s+found)", blob, re.I)
+        or re.search(r"(does\s+not\s+exist|not\s+found|no\s+longer\s+exists).{0,40}\bissue\b", blob, re.I)
     )
     return structured_404 and issue_specific
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -75,9 +75,17 @@ def get_issue(conn_id: str, key: str) -> dict | None:
     return env["Data"].get("fields", {})
 
 
-def delete_issue(conn_id: str, key: str) -> None:
-    """Delete an issue by key. A 404 (already gone) is a no-op."""
-    _run(
+def delete_issue(conn_id: str, key: str) -> bool:
+    """Delete an issue by key. Returns True only when deletion is CONFIRMED —
+    either a success envelope, or a not-found/404 (already gone). Returns False
+    for any other Failure envelope (transient 5xx / auth) so the caller can retry
+    or report instead of silently leaking the issue in the shared CE project."""
+    env = _run(
         "is", "resources", "run", "delete", CONNECTOR, "issue",
         "--connection-id", conn_id, "--query", f"issueId={key}",
     )
+    if str(env.get("Result", "")).lower() != "failure":
+        return True
+    # A Failure envelope: only a not-found means the issue is genuinely gone.
+    blob = json.dumps(env).lower()
+    return any(s in blob for s in ("404", "not found", "notfound", "does not exist", "no longer exists"))

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/jira_is.py
@@ -11,6 +11,7 @@ body / get by id / delete by id — never a JQL search.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 
 CONNECTOR = "uipath-atlassian-jira"
@@ -19,6 +20,20 @@ FOLDER_NAME = "uipath-maestro-flow"  # leaf of FOLDER_PATH, as reported by conne
 CONNECTION_NAME = "is-sandboxes-test@uipath.com-uipath-sandbox-380"
 PROJECT_KEY = "CE"        # "Coder Eval" project on uipath-sandbox-380
 ISSUETYPE_ID = "11457"    # "Task" issue type, scoped to the CE project
+
+
+def _issue_not_found(env: dict) -> bool:
+    """True only for a STRUCTURED HTTP 404 from the Jira provider — proof the
+    requested issue key is absent. A bare ``"404"`` substring or a generic
+    ``"not found"`` (which could mean the connection/activity is missing, not the
+    issue) is NOT accepted, so a prerequisite failure can't masquerade as a
+    confirmed deletion."""
+    blob = json.dumps(env)
+    return bool(
+        re.search(r"status code ['\"]?404\b", blob, re.I)
+        or re.search(r'"providerErrorCode"\s*:\s*404\b', blob)
+        or re.search(r'"statusCode"\s*:\s*"?404\b', blob)
+    )
 
 
 def _run(*args: str) -> dict:
@@ -87,8 +102,7 @@ def issue_absent(conn_id: str, key: str) -> bool:
     )
     if str(env.get("Result", "")).lower() != "failure":
         return False  # a successful read means the issue still exists
-    blob = json.dumps(env).lower()
-    return any(s in blob for s in ("404", "not found", "notfound", "does not exist", "no longer exists"))
+    return _issue_not_found(env)
 
 
 def delete_issue(conn_id: str, key: str) -> bool:
@@ -102,6 +116,5 @@ def delete_issue(conn_id: str, key: str) -> bool:
     )
     if str(env.get("Result", "")).lower() != "failure":
         return True
-    # A Failure envelope: only a not-found means the issue is genuinely gone.
-    blob = json.dumps(env).lower()
-    return any(s in blob for s in ("404", "not found", "notfound", "does not exist", "no longer exists"))
+    # A Failure envelope: only a structured 404 (issue absent) is a confirmed gone.
+    return _issue_not_found(env)

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
@@ -35,7 +35,7 @@ seed = {
         "isDuplicate": False,
         "correlationId": correlation,
     },
-    "expected": {"severity": "Sev1"},
+    "expected": {"severity": "Sev1", "caseKey": correlation},
 }
 Path("seed.json").write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
 print(f"OK: wrote seed (correlationId={correlation}, project={jira_is.PROJECT_KEY}, issuetype={jira_is.ISSUETYPE_ID})")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
@@ -36,6 +36,10 @@ seed = {
         "correlationId": correlation,
     },
     "expected": {"severity": "Sev1", "caseKey": correlation},
+    # Classification the Script must compute but the prompt does not map to a named
+    # End out — verified against the Script node's intermediate output. Sev1 (prod
+    # down, no workaround) ⇒ engineeringNeeded true.
+    "expected_script": {"engineeringNeeded": True},
 }
 Path("seed.json").write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
 print(f"OK: wrote seed (correlationId={correlation}, project={jira_is.PROJECT_KEY}, issuetype={jira_is.ISSUETYPE_ID})")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/seed.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""pre_run: seed a Sev1 escalation case for the Jira-ticket outcome eval.
+
+No live issue is created here — the agent's flow creates it when the grader runs
+`flow debug`. The unique tag lives in the correlationId, which the flow must echo
+into the Jira issue summary, so the check can prove the ticket the flow created
+(not a fabricated key) really exists in Jira.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+from pathlib import Path
+
+import jira_is
+
+tag = secrets.token_hex(4)
+correlation = f"ESC-JIRA-{tag}"
+seed = {
+    "tag": tag,
+    "project_key": jira_is.PROJECT_KEY,
+    "issuetype_id": jira_is.ISSUETYPE_ID,
+    "correlationId": correlation,
+    "inputs": {
+        "senderEmail": "jane.doe@acmecorp.com",
+        "senderDomain": "acmecorp.com",
+        "subject": "Production down: checkout API returning 500s",
+        "body": "Critical urgent outage, all users blocked.",
+        "customerTier": "Enterprise",
+        "productionDown": True,
+        "workaroundAvailable": False,
+        "hasAttachments": False,
+        "customerMatchStatus": "single",
+        "isDuplicate": False,
+        "correlationId": correlation,
+    },
+    "expected": {"severity": "Sev1"},
+}
+Path("seed.json").write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
+print(f"OK: wrote seed (correlationId={correlation}, project={jira_is.PROJECT_KEY}, issuetype={jira_is.ISSUETYPE_ID})")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""post_run: delete every issue the run created (keys in `.created_keys`).
+Idempotent and never fails the task."""
+
+import sys
+from pathlib import Path
+
+import jira_is
+
+try:
+    kf = Path(".created_keys")
+    keys = kf.read_text().split() if kf.is_file() else []
+    if keys:
+        conn = jira_is.connection_id()
+        for key in keys:
+            jira_is.delete_issue(conn, key)
+            print(f"OK: deleted {key}")
+    else:
+        print("OK: nothing to delete")
+except Exception as e:  # noqa: BLE001 — teardown must not fail the task
+    print(f"WARN: teardown ignored error: {e}")
+sys.exit(0)

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
@@ -19,8 +19,8 @@ try:
             ok = jira_is.delete_issue(conn, key)
             if not ok:
                 ok = jira_is.delete_issue(conn, key)
-            if not ok and jira_is.get_issue(conn, key) is None:
-                ok = True  # tenant read confirms it's gone
+            if not ok and jira_is.issue_absent(conn, key):
+                ok = True  # tenant read CONFIRMS a 404 (not just an ambiguous failure)
             print(f"OK: deleted {key}" if ok
                   else f"WARN: could NOT confirm deletion of {key} — may be leaked in CE project")
     else:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/teardown_jira.py
@@ -13,8 +13,16 @@ try:
     if keys:
         conn = jira_is.connection_id()
         for key in keys:
-            jira_is.delete_issue(conn, key)
-            print(f"OK: deleted {key}")
+            # Verify the delete actually happened; retry once on an unconfirmed
+            # (transient) failure, then confirm via a tenant reread before giving
+            # up. Only claim success on a confirmed deletion / not-found.
+            ok = jira_is.delete_issue(conn, key)
+            if not ok:
+                ok = jira_is.delete_issue(conn, key)
+            if not ok and jira_is.get_issue(conn, key) is None:
+                ok = True  # tenant read confirms it's gone
+            print(f"OK: deleted {key}" if ok
+                  else f"WARN: could NOT confirm deletion of {key} — may be leaked in CE project")
     else:
         print("OK: nothing to delete")
 except Exception as e:  # noqa: BLE001 — teardown must not fail the task

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -24,12 +24,14 @@ while _directory != os.path.dirname(_directory) and not os.path.isdir(
 sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
+    assert_connector_error_handlers,
     assert_decision_branches_reach,
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_node_type_executed,
     assert_slack_message_posted,
     completed_connector_node_ids,
+    completed_node_ids_of_type,
     run_debug,
 )
 
@@ -38,7 +40,7 @@ SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
 CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
 
 
-def verify_case(case: dict) -> set:
+def verify_case(case: dict) -> tuple:
     # retries=1: seven cases run serially, so a bounded per-case budget keeps the
     # total within the criterion timeout; a genuine transient failure fails cleanly.
     payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
@@ -62,9 +64,10 @@ def verify_case(case: dict) -> set:
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
     assert_node_type_executed(payload, "core.logic.decision")
     fired = completed_connector_node_ids(payload, SLACK_KEY)
+    executed_decisions = completed_node_ids_of_type(payload, "core.logic.decision")
     print(f"OK: {case['name']} produced the expected outcome"
           + (" + Slack message posted" if case.get("expect_slack") else ""))
-    return fired
+    return fired, executed_decisions
 
 
 def main() -> None:
@@ -80,10 +83,16 @@ def main() -> None:
 
     escalation_nodes: set = set()
     triage_nodes: set = set()
+    executed_decisions: set = set()
     for case in cases:
-        fired = verify_case(case)
+        fired, decisions = verify_case(case)
         target = escalation_nodes if case["expected"]["escalationPath"] == "escalation" else triage_nodes
         target.update(fired)
+        executed_decisions.update(decisions)
+
+    # Prompt requires each Slack node's error port wired to a handler for graceful
+    # degradation — assert that structurally so a flow omitting it can't get full credit.
+    assert_connector_error_handlers(SLACK_KEY, native_op_hint="send-message-to-channel")
 
     # The Decision must genuinely branch: escalation and triage paths post via
     # DIFFERENT Slack nodes. A single dynamic Slack node behind a cosmetic
@@ -99,9 +108,12 @@ def main() -> None:
             f"FAIL: escalation and triage cases fired the SAME Slack node(s) {overlap} — "
             "the Decision does not route to two distinct branches"
         )
-    # And prove those two nodes are the Decision's OWN outgoing branches (not just
-    # nodes that fired on different cases behind a cosmetic always-true Decision).
-    assert_decision_branches_reach(escalation_nodes, triage_nodes)
+    # And prove those two nodes are the Decision's OWN outgoing branches — and that
+    # the routing Decision is one that ACTUALLY EXECUTED (not a second, unexecuted
+    # Decision that merely has the two source edges behind a cosmetic always-true one).
+    assert_decision_branches_reach(
+        escalation_nodes, triage_nodes, executed_decision_ids=executed_decisions
+    )
     print(
         f"OK: a Decision routes escalation vs triage through separate branches "
         f"(escalation={sorted(escalation_nodes)}, triage={sorted(triage_nodes)})"

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -42,6 +42,9 @@ from _shared.flow_check import (  # noqa: E402
 SLACK_KEY = "uipath-salesforce-slack"
 SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
 CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
+# The four fields the prompt's single `classify` Script must return (caseKey is an
+# input echo, not a classification, so it's excluded).
+CLASSIFICATION_FIELDS = ("escalationPath", "severity", "engineeringNeeded", "responseMode")
 
 
 def verify_case(case: dict) -> tuple:
@@ -66,32 +69,36 @@ def verify_case(case: dict) -> tuple:
             must_contain=case["inputs"]["correlationId"],
             must_contain_loose=[case["expected"]["escalationPath"]],
         )
-    # The prompt requires ALL routing logic in ONE Script node. Bind the core
-    # classification (escalationPath + severity) to a single EXECUTED Script node:
-    # a flow that computes routing in Decision/End expressions with no Script, or
-    # splits escalationPath and severity across two nodes, has no single Script
-    # carrying both and fails here. (engineeringNeeded/responseMode are trivial
-    # derivations already verified as named outs above.)
+    # The prompt requires ALL routing logic in ONE Script that returns all four
+    # fields. Bind EVERY classification field (escalationPath, severity,
+    # engineeringNeeded, responseMode) to a single EXECUTED Script node: a flow that
+    # computes any of them in Decision/End expressions, or splits them across nodes,
+    # has no single Script carrying all four and fails here. (caseKey is an echo of
+    # the input correlationId, not a classification, so it is excluded.)
     script_nodes = completed_node_ids_of_type(payload, "script")
-    ep, sv = case["expected"]["escalationPath"], case["expected"]["severity"]
-    classifier_candidates = {
-        nid for nid in script_nodes if nid
-        and normalized(find_node_output_value(payload, "escalationPath", node_ids={nid})) == normalized(ep)
-        and normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sv)
-    }
+
+    def is_classifier(nid: str) -> bool:
+        return all(
+            normalized(find_node_output_value(payload, f, node_ids={nid})) == normalized(case["expected"][f])
+            for f in CLASSIFICATION_FIELDS
+        )
+
+    classifier_candidates = {nid for nid in script_nodes if nid and is_classifier(nid)}
     if not classifier_candidates:
         raise SystemExit(
-            f"FAIL: {case['name']}: no single executed Script computed both escalationPath "
-            f"({ep!r}) and severity ({sv!r}) — the prompt requires one classifier Script"
+            f"FAIL: {case['name']}: no single executed Script computed all of "
+            f"{CLASSIFICATION_FIELDS} together — the prompt requires one classifier Script "
+            "that returns every field (not split across nodes or derived in End/Decision)"
         )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
     assert_node_type_executed(payload, "core.logic.decision")
     fired = completed_connector_node_ids(payload, SLACK_KEY)
     executed_decisions = completed_node_ids_of_type(payload, "core.logic.decision")
+    completed_ends = completed_node_ids_of_type(payload, "core.control.end")
     print(f"OK: {case['name']} produced the expected outcome"
           + (" + Slack message posted" if case.get("expect_slack") else ""))
-    return fired, executed_decisions, classifier_candidates
+    return fired, executed_decisions, classifier_candidates, completed_ends
 
 
 def main() -> None:
@@ -107,12 +114,15 @@ def main() -> None:
 
     escalation_nodes: set = set()
     triage_nodes: set = set()
+    escalation_ends: set = set()
+    triage_ends: set = set()
     per_case_decisions: list = []
     per_case_classifiers: list = []
     for case in cases:
-        fired, decisions, classifiers = verify_case(case)
+        fired, decisions, classifiers, ends = verify_case(case)
         is_escalation = case["expected"]["escalationPath"] == "escalation"
         (escalation_nodes if is_escalation else triage_nodes).update(fired)
+        (escalation_ends if is_escalation else triage_ends).update(ends)
         per_case_decisions.append(decisions)
         per_case_classifiers.append(classifiers)
 
@@ -159,9 +169,26 @@ def main() -> None:
         escalation_nodes, triage_nodes, executed_decision_ids=routing_decisions
     )
 
-    # The prompt requires TWO End nodes — one per branch. Each Slack branch must
-    # reach its OWN End; a flow that merges both sends into a single shared End fails.
+    # The prompt requires TWO End nodes — one per branch. Two checks together close
+    # the "unused private End + shared merged End" gaming: (a) structurally, each
+    # Slack branch must reach an End the other doesn't; (b) at RUNTIME, the End that
+    # actually COMPLETED on escalation cases must be disjoint from the one completed
+    # on triage cases — so a flow where both real paths merge into one shared End
+    # (with cosmetic unused private Ends downstream) fails even though the static
+    # reachability differs.
     assert_distinct_branch_ends(escalation_nodes, triage_nodes)
+    if not escalation_ends or not triage_ends:
+        raise SystemExit(
+            "FAIL: expected both escalation and triage cases to complete an End node "
+            f"(escalation_ends={sorted(escalation_ends)}, triage_ends={sorted(triage_ends)})"
+        )
+    shared = escalation_ends & triage_ends
+    if shared:
+        raise SystemExit(
+            f"FAIL: escalation and triage cases completed the SAME End node(s) {sorted(shared)} — "
+            "both branches merge into one shared End; the prompt requires a distinct End per branch"
+        )
+    print(f"OK: branches complete distinct Ends (escalation={sorted(escalation_ends)}, triage={sorted(triage_ends)})")
     print(
         f"OK: a Decision routes escalation vs triage through separate branches "
         f"(escalation={sorted(escalation_nodes)}, triage={sorted(triage_nodes)})"

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -86,13 +86,12 @@ def main() -> None:
 
     escalation_nodes: set = set()
     triage_nodes: set = set()
-    escalation_decisions: set = set()
-    triage_decisions: set = set()
+    per_case_decisions: list = []
     for case in cases:
         fired, decisions = verify_case(case)
         is_escalation = case["expected"]["escalationPath"] == "escalation"
         (escalation_nodes if is_escalation else triage_nodes).update(fired)
-        (escalation_decisions if is_escalation else triage_decisions).update(decisions)
+        per_case_decisions.append(decisions)
 
     # Prompt requires each Slack node's error port wired to a handler for graceful
     # degradation, and every send to go out as `user` — assert both structurally so
@@ -115,11 +114,12 @@ def main() -> None:
             "the Decision does not route to two distinct branches"
         )
     # And prove those two nodes are the Decision's OWN outgoing branches — routed by
-    # ONE Decision that executed on BOTH sides. Requiring the routing Decision to be
-    # in the intersection (executed on an escalation case AND a triage case) blocks
-    # the split where a real Decision runs only for escalation while a separate
-    # cosmetic Decision runs on triage cases.
-    routing_decisions = escalation_decisions & triage_decisions
+    # ONE Decision that executed in EVERY case. The escalation-vs-triage split runs
+    # on every email, so the routing Decision is in the intersection of the
+    # completed-Decision sets across ALL cases. Intersecting across every case (not
+    # a per-group union) blocks the flow that routes two cases through the real
+    # Decision and the remaining five through other constructs.
+    routing_decisions = set.intersection(*per_case_decisions) if per_case_decisions else set()
     assert_decision_branches_reach(
         escalation_nodes, triage_nodes, executed_decision_ids=routing_decisions
     )

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -24,9 +24,9 @@ while _directory != os.path.dirname(_directory) and not os.path.isdir(
 sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
     assert_flow_uses_connector_target,
     assert_named_equals,
+    assert_node_type_executed,
     assert_slack_message_posted,
     run_debug,
 )
@@ -39,8 +39,11 @@ def verify_case(case: dict) -> None:
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected)
     if case.get("expect_slack"):
-        # Real Slack ts (not a placeholder) — every path posts a message.
+        # Real Slack ts, tied to an executed Slack node's own response.
         assert_slack_message_posted(payload, "slackMessageId")
+    # The task is tagged node:decision: routing must go through a Decision that
+    # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
+    assert_node_type_executed(payload, "core.logic.decision")
     print(f"OK: {case['name']} produced the expected outcome"
           + (" + Slack message posted" if case.get("expect_slack") else ""))
 
@@ -48,9 +51,6 @@ def verify_case(case: dict) -> None:
 def main() -> None:
     # The escalation alert must go through the real Slack connector.
     assert_flow_uses_connector_target(SLACK_KEY)
-    # The task is tagged node:decision and requires routing through a Decision —
-    # a flow that wires the classify Script straight to Slack must not pass.
-    assert_flow_has_node_type(["core.logic.decision"])
 
     seed_path = Path("seed.json")
     if not seed_path.is_file():

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -35,6 +35,7 @@ from _shared.flow_check import (  # noqa: E402
 
 SLACK_KEY = "uipath-salesforce-slack"
 SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
+CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
 
 
 def verify_case(case: dict) -> set:
@@ -42,15 +43,21 @@ def verify_case(case: dict) -> set:
     # total within the criterion timeout; a genuine transient failure fails cleanly.
     payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
     for name, expected in case["expected"].items():
-        assert_named_equals(payload, name, expected)
+        assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
     if case.get("expect_slack"):
-        # Real ts tied to the executed Slack node's response, posted to the right
-        # channel, with this case's correlationId in the message content.
+        # Real ts tied to the executed Slack SEND node's response, posted to the
+        # right channel, whose message carries this case's correlationId AND its
+        # classified severity (the alert must surface the classification, not just
+        # the id). Routing (escalation vs triage) is verified separately below via
+        # the decision-branch check, so it isn't re-asserted as message text here.
+        required = [case["inputs"]["correlationId"]]
+        if case["expected"].get("severity"):
+            required.append(case["expected"]["severity"])
         assert_slack_message_posted(
             payload,
             "slackMessageId",
             expected_channel=SLACK_CHANNEL,
-            must_contain=case["inputs"]["correlationId"],
+            must_contain=required,
         )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -24,6 +24,7 @@ while _directory != os.path.dirname(_directory) and not os.path.isdir(
 sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
+    assert_decision_branches_reach,
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_node_type_executed,
@@ -92,8 +93,11 @@ def main() -> None:
             f"FAIL: escalation and triage cases fired the SAME Slack node(s) {overlap} — "
             "the Decision does not route to two distinct branches"
         )
+    # And prove those two nodes are the Decision's OWN outgoing branches (not just
+    # nodes that fired on different cases behind a cosmetic always-true Decision).
+    assert_decision_branches_reach(escalation_nodes, triage_nodes)
     print(
-        f"OK: Decision routes to two distinct Slack branches "
+        f"OK: a Decision routes escalation vs triage through separate branches "
         f"(escalation={sorted(escalation_nodes)}, triage={sorted(triage_nodes)})"
     )
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -14,7 +14,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 # Walk up to the directory that holds `_shared` so the import resolves.
 _directory = os.path.dirname(os.path.abspath(__file__))
@@ -26,28 +25,12 @@ sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
-    assert_output_nonempty,
+    assert_named_equals,
+    assert_slack_message_posted,
     run_debug,
 )
 
 SLACK_KEY = "uipath-salesforce-slack"
-
-
-def normalized(value: Any) -> Any:
-    if isinstance(value, str):
-        lowered = value.strip().casefold()
-        if lowered == "true":
-            return True
-        if lowered == "false":
-            return False
-        return lowered
-    return value
-
-
-def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
-    actual = assert_output_nonempty(payload, name)
-    if normalized(actual) != normalized(expected):
-        raise SystemExit(f"FAIL: output {name!r}: expected {expected!r}, got {actual!r}")
 
 
 def verify_case(case: dict) -> None:
@@ -55,9 +38,10 @@ def verify_case(case: dict) -> None:
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected)
     if case.get("expect_slack"):
-        assert_output_nonempty(payload, "slackMessageId")
+        # Real Slack ts (not a placeholder) — every path posts a message.
+        assert_slack_message_posted(payload, "slackMessageId")
     print(f"OK: {case['name']} produced the expected outcome"
-          + (" + Slack alert posted" if case.get("expect_slack") else ""))
+          + (" + Slack message posted" if case.get("expect_slack") else ""))
 
 
 def main() -> None:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -32,15 +32,24 @@ from _shared.flow_check import (  # noqa: E402
 )
 
 SLACK_KEY = "uipath-salesforce-slack"
+SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
 
 
 def verify_case(case: dict) -> None:
-    payload = run_debug(inputs=case["inputs"], timeout=300)
+    # retries=1: seven cases run serially, so a bounded per-case budget keeps the
+    # total within the criterion timeout; a genuine transient failure fails cleanly.
+    payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected)
     if case.get("expect_slack"):
-        # Real Slack ts, tied to an executed Slack node's own response.
-        assert_slack_message_posted(payload, "slackMessageId")
+        # Real ts tied to the executed Slack node's response, posted to the right
+        # channel, with this case's correlationId in the message content.
+        assert_slack_message_posted(
+            payload,
+            "slackMessageId",
+            expected_channel=SLACK_CHANNEL,
+            must_contain=case["inputs"]["correlationId"],
+        )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
     assert_node_type_executed(payload, "core.logic.decision")

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -25,6 +25,7 @@ sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
     assert_connector_error_handlers,
+    assert_connector_send_identity,
     assert_decision_branches_reach,
     assert_flow_uses_connector_target,
     assert_named_equals,
@@ -48,17 +49,19 @@ def verify_case(case: dict) -> tuple:
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
     if case.get("expect_slack"):
         # Real ts tied to the executed Slack SEND node's response, posted to the
-        # right channel, whose message carries this case's correlationId. The
-        # orchestrator's severity taxonomy (e.g. "informational") is an internal
-        # classification label its prompt does not require verbatim in the alert
-        # text, so it is asserted as a named `out` (above), not as message content.
-        # Routing (escalation vs triage) is verified separately via the
-        # decision-branch check below.
+        # right channel, whose message carries this case's correlationId (exact)
+        # AND its escalationPath (prompt line 65 requires escalationPath +
+        # correlationId in every message). escalationPath is matched
+        # separator/case-insensitively so the enum "unknown_customer" also matches
+        # a rendered "unknown customer". The severity taxonomy (e.g.
+        # "informational") is an internal label the prompt does NOT require in the
+        # text, so it stays a named-out assertion, not message content.
         assert_slack_message_posted(
             payload,
             "slackMessageId",
             expected_channel=SLACK_CHANNEL,
             must_contain=case["inputs"]["correlationId"],
+            must_contain_loose=[case["expected"]["escalationPath"]],
         )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
@@ -83,16 +86,19 @@ def main() -> None:
 
     escalation_nodes: set = set()
     triage_nodes: set = set()
-    executed_decisions: set = set()
+    escalation_decisions: set = set()
+    triage_decisions: set = set()
     for case in cases:
         fired, decisions = verify_case(case)
-        target = escalation_nodes if case["expected"]["escalationPath"] == "escalation" else triage_nodes
-        target.update(fired)
-        executed_decisions.update(decisions)
+        is_escalation = case["expected"]["escalationPath"] == "escalation"
+        (escalation_nodes if is_escalation else triage_nodes).update(fired)
+        (escalation_decisions if is_escalation else triage_decisions).update(decisions)
 
     # Prompt requires each Slack node's error port wired to a handler for graceful
-    # degradation — assert that structurally so a flow omitting it can't get full credit.
+    # degradation, and every send to go out as `user` — assert both structurally so
+    # a flow omitting them can't get full credit.
     assert_connector_error_handlers(SLACK_KEY, native_op_hint="send-message-to-channel")
+    assert_connector_send_identity(SLACK_KEY, expected="user", native_op_hint="send-message-to-channel")
 
     # The Decision must genuinely branch: escalation and triage paths post via
     # DIFFERENT Slack nodes. A single dynamic Slack node behind a cosmetic
@@ -108,11 +114,14 @@ def main() -> None:
             f"FAIL: escalation and triage cases fired the SAME Slack node(s) {overlap} — "
             "the Decision does not route to two distinct branches"
         )
-    # And prove those two nodes are the Decision's OWN outgoing branches — and that
-    # the routing Decision is one that ACTUALLY EXECUTED (not a second, unexecuted
-    # Decision that merely has the two source edges behind a cosmetic always-true one).
+    # And prove those two nodes are the Decision's OWN outgoing branches — routed by
+    # ONE Decision that executed on BOTH sides. Requiring the routing Decision to be
+    # in the intersection (executed on an escalation case AND a triage case) blocks
+    # the split where a real Decision runs only for escalation while a separate
+    # cosmetic Decision runs on triage cases.
+    routing_decisions = escalation_decisions & triage_decisions
     assert_decision_branches_reach(
-        escalation_nodes, triage_nodes, executed_decision_ids=executed_decisions
+        escalation_nodes, triage_nodes, executed_decision_ids=routing_decisions
     )
     print(
         f"OK: a Decision routes escalation vs triage through separate branches "

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Run each seeded path case and verify its business outcome.
+
+Outcome-based: for every case the grader runs `flow debug --inputs` and asserts
+the expected `out` variables. For cases flagged `expect_slack`, it additionally
+asserts a non-empty `slackMessageId` — the escalation path must have actually
+posted a Slack alert (Slack only returns a message id when a message is really
+delivered), not merely reached the node.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Walk up to the directory that holds `_shared` so the import resolves.
+_directory = os.path.dirname(os.path.abspath(__file__))
+while _directory != os.path.dirname(_directory) and not os.path.isdir(
+    os.path.join(_directory, "_shared")
+):
+    _directory = os.path.dirname(_directory)
+sys.path.insert(0, _directory)
+
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_uses_connector_target,
+    assert_output_nonempty,
+    run_debug,
+)
+
+SLACK_KEY = "uipath-salesforce-slack"
+
+
+def normalized(value: Any) -> Any:
+    if isinstance(value, str):
+        lowered = value.strip().casefold()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return lowered
+    return value
+
+
+def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
+    actual = assert_output_nonempty(payload, name)
+    if normalized(actual) != normalized(expected):
+        raise SystemExit(f"FAIL: output {name!r}: expected {expected!r}, got {actual!r}")
+
+
+def verify_case(case: dict) -> None:
+    payload = run_debug(inputs=case["inputs"], timeout=300)
+    for name, expected in case["expected"].items():
+        assert_named_equals(payload, name, expected)
+    if case.get("expect_slack"):
+        assert_output_nonempty(payload, "slackMessageId")
+    print(f"OK: {case['name']} produced the expected outcome"
+          + (" + Slack alert posted" if case.get("expect_slack") else ""))
+
+
+def main() -> None:
+    # The escalation alert must go through the real Slack connector.
+    assert_flow_uses_connector_target(SLACK_KEY)
+
+    seed_path = Path("seed.json")
+    if not seed_path.is_file():
+        raise SystemExit("FAIL: seed.json is missing; pre_run did not complete")
+    cases = json.loads(seed_path.read_text(encoding="utf-8")).get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise SystemExit("FAIL: seed.json must contain at least one case")
+    for case in cases:
+        verify_case(case)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -27,12 +27,15 @@ from _shared.flow_check import (  # noqa: E402
     assert_connector_error_handlers,
     assert_connector_send_identity,
     assert_decision_branches_reach,
+    assert_distinct_branch_ends,
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_node_type_executed,
     assert_slack_message_posted,
     completed_connector_node_ids,
     completed_node_ids_of_type,
+    find_node_output_value,
+    normalized,
     run_debug,
 )
 
@@ -62,6 +65,25 @@ def verify_case(case: dict) -> tuple:
             expected_channel=SLACK_CHANNEL,
             must_contain=case["inputs"]["correlationId"],
             must_contain_loose=[case["expected"]["escalationPath"]],
+        )
+    # The prompt requires ALL routing logic in ONE Script node. Bind the core
+    # classification (escalationPath + severity) to a single EXECUTED Script node:
+    # a flow that computes routing in Decision/End expressions with no Script, or
+    # splits escalationPath and severity across two nodes, has no single Script
+    # carrying both and fails here. (engineeringNeeded/responseMode are trivial
+    # derivations already verified as named outs above.)
+    script_nodes = completed_node_ids_of_type(payload, "script")
+    ep, sv = case["expected"]["escalationPath"], case["expected"]["severity"]
+    classifier = next(
+        (nid for nid in sorted(n for n in script_nodes if n)
+         if normalized(find_node_output_value(payload, "escalationPath", node_ids={nid})) == normalized(ep)
+         and normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sv)),
+        None,
+    )
+    if classifier is None:
+        raise SystemExit(
+            f"FAIL: {case['name']}: no single executed Script computed both escalationPath "
+            f"({ep!r}) and severity ({sv!r}) — the prompt requires one classifier Script"
         )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
@@ -123,6 +145,10 @@ def main() -> None:
     assert_decision_branches_reach(
         escalation_nodes, triage_nodes, executed_decision_ids=routing_decisions
     )
+
+    # The prompt requires TWO End nodes — one per branch. Each Slack branch must
+    # reach its OWN End; a flow that merges both sends into a single shared End fails.
+    assert_distinct_branch_ends(escalation_nodes, triage_nodes)
     print(
         f"OK: a Decision routes escalation vs triage through separate branches "
         f"(escalation={sorted(escalation_nodes)}, triage={sorted(triage_nodes)})"

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -28,6 +28,7 @@ from _shared.flow_check import (  # noqa: E402
     assert_named_equals,
     assert_node_type_executed,
     assert_slack_message_posted,
+    completed_connector_node_ids,
     run_debug,
 )
 
@@ -35,7 +36,7 @@ SLACK_KEY = "uipath-salesforce-slack"
 SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
 
 
-def verify_case(case: dict) -> None:
+def verify_case(case: dict) -> set:
     # retries=1: seven cases run serially, so a bounded per-case budget keeps the
     # total within the criterion timeout; a genuine transient failure fails cleanly.
     payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
@@ -53,8 +54,10 @@ def verify_case(case: dict) -> None:
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.
     assert_node_type_executed(payload, "core.logic.decision")
+    fired = completed_connector_node_ids(payload, SLACK_KEY)
     print(f"OK: {case['name']} produced the expected outcome"
           + (" + Slack message posted" if case.get("expect_slack") else ""))
+    return fired
 
 
 def main() -> None:
@@ -67,8 +70,32 @@ def main() -> None:
     cases = json.loads(seed_path.read_text(encoding="utf-8")).get("cases")
     if not isinstance(cases, list) or not cases:
         raise SystemExit("FAIL: seed.json must contain at least one case")
+
+    escalation_nodes: set = set()
+    triage_nodes: set = set()
     for case in cases:
-        verify_case(case)
+        fired = verify_case(case)
+        target = escalation_nodes if case["expected"]["escalationPath"] == "escalation" else triage_nodes
+        target.update(fired)
+
+    # The Decision must genuinely branch: escalation and triage paths post via
+    # DIFFERENT Slack nodes. A single dynamic Slack node behind a cosmetic
+    # always-true Decision would make these sets overlap.
+    if not escalation_nodes or not triage_nodes:
+        raise SystemExit(
+            "FAIL: expected both escalation and triage cases to fire a Slack node "
+            f"(escalation={escalation_nodes}, triage={triage_nodes})"
+        )
+    overlap = escalation_nodes & triage_nodes
+    if overlap:
+        raise SystemExit(
+            f"FAIL: escalation and triage cases fired the SAME Slack node(s) {overlap} — "
+            "the Decision does not route to two distinct branches"
+        )
+    print(
+        f"OK: Decision routes to two distinct Slack branches "
+        f"(escalation={sorted(escalation_nodes)}, triage={sorted(triage_nodes)})"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -74,13 +74,12 @@ def verify_case(case: dict) -> tuple:
     # derivations already verified as named outs above.)
     script_nodes = completed_node_ids_of_type(payload, "script")
     ep, sv = case["expected"]["escalationPath"], case["expected"]["severity"]
-    classifier = next(
-        (nid for nid in sorted(n for n in script_nodes if n)
-         if normalized(find_node_output_value(payload, "escalationPath", node_ids={nid})) == normalized(ep)
-         and normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sv)),
-        None,
-    )
-    if classifier is None:
+    classifier_candidates = {
+        nid for nid in script_nodes if nid
+        and normalized(find_node_output_value(payload, "escalationPath", node_ids={nid})) == normalized(ep)
+        and normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sv)
+    }
+    if not classifier_candidates:
         raise SystemExit(
             f"FAIL: {case['name']}: no single executed Script computed both escalationPath "
             f"({ep!r}) and severity ({sv!r}) — the prompt requires one classifier Script"
@@ -92,7 +91,7 @@ def verify_case(case: dict) -> tuple:
     executed_decisions = completed_node_ids_of_type(payload, "core.logic.decision")
     print(f"OK: {case['name']} produced the expected outcome"
           + (" + Slack message posted" if case.get("expect_slack") else ""))
-    return fired, executed_decisions
+    return fired, executed_decisions, classifier_candidates
 
 
 def main() -> None:
@@ -109,11 +108,25 @@ def main() -> None:
     escalation_nodes: set = set()
     triage_nodes: set = set()
     per_case_decisions: list = []
+    per_case_classifiers: list = []
     for case in cases:
-        fired, decisions = verify_case(case)
+        fired, decisions, classifiers = verify_case(case)
         is_escalation = case["expected"]["escalationPath"] == "escalation"
         (escalation_nodes if is_escalation else triage_nodes).update(fired)
         per_case_decisions.append(decisions)
+        per_case_classifiers.append(classifiers)
+
+    # ONE classifier Script must classify EVERY case (prompt: ALL routing logic in
+    # one Script). Intersect the per-case candidates: a flow with path-specific
+    # Script nodes (a different classifier per case) has an empty intersection and fails.
+    common_classifier = set.intersection(*per_case_classifiers) if per_case_classifiers else set()
+    if not common_classifier:
+        raise SystemExit(
+            "FAIL: no single Script node classified every case — the prompt requires ALL "
+            "routing logic in ONE Script, but the cases were classified by different "
+            f"(path-specific) Scripts (per-case candidates: {[sorted(c) for c in per_case_classifiers]})"
+        )
+    print(f"OK: one classifier Script handled all cases: {sorted(common_classifier)}")
 
     # Prompt requires each Slack node's error port wired to a handler for graceful
     # degradation, and every send to go out as `user` — assert both structurally so

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -46,18 +46,17 @@ def verify_case(case: dict) -> set:
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
     if case.get("expect_slack"):
         # Real ts tied to the executed Slack SEND node's response, posted to the
-        # right channel, whose message carries this case's correlationId AND its
-        # classified severity (the alert must surface the classification, not just
-        # the id). Routing (escalation vs triage) is verified separately below via
-        # the decision-branch check, so it isn't re-asserted as message text here.
-        required = [case["inputs"]["correlationId"]]
-        if case["expected"].get("severity"):
-            required.append(case["expected"]["severity"])
+        # right channel, whose message carries this case's correlationId. The
+        # orchestrator's severity taxonomy (e.g. "informational") is an internal
+        # classification label its prompt does not require verbatim in the alert
+        # text, so it is asserted as a named `out` (above), not as message content.
+        # Routing (escalation vs triage) is verified separately via the
+        # decision-branch check below.
         assert_slack_message_posted(
             payload,
             "slackMessageId",
             expected_channel=SLACK_CHANNEL,
-            must_contain=required,
+            must_contain=case["inputs"]["correlationId"],
         )
     # The task is tagged node:decision: routing must go through a Decision that
     # actually executed — a disconnected Decision or a Script->Slack shortcut fails.

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/check_escalation_orchestrator_paths.py
@@ -24,6 +24,7 @@ while _directory != os.path.dirname(_directory) and not os.path.isdir(
 sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
+    assert_flow_has_node_type,
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_slack_message_posted,
@@ -47,6 +48,9 @@ def verify_case(case: dict) -> None:
 def main() -> None:
     # The escalation alert must go through the real Slack connector.
     assert_flow_uses_connector_target(SLACK_KEY)
+    # The task is tagged node:decision and requires routing through a Decision —
+    # a flow that wires the classify Script straight to Slack must not pass.
+    assert_flow_has_node_type(["core.logic.decision"])
 
     seed_path = Path("seed.json")
     if not seed_path.is_file():

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -1,28 +1,25 @@
 task_id: skill-flow-e2e-escalation-orchestrator-paths
 description: >
-  End-to-end, outcome-based test of the full customer-escalation orchestration,
-  driven down a specific path by seeded inputs. The agent builds a manual-trigger
-  orchestrator (the Outlook email-received trigger is not reliably debug-testable
-  — see outlook_trigger_inbox / customer_escalation notes) whose branching is
-  input-driven so the grader can steer any path via `flow debug --inputs`. This
-  first case seeds a Sev1 production-down escalation and verifies the OUTCOME: the
-  run completes on the escalation path, classifies Sev1 + engineering, preserves
-  the correlationId, and the Slack escalation alert was actually posted (non-empty
-  message id). Salesforce enrichment is stubbed (match status is an input), so no
-  Salesforce connection is required; Jira/Drive/Slack are real with error-degrade
-  so an enrichment hiccup cannot fault the run. Additional path cases (informational,
-  duplicate, unknown-customer, …) are added as further seed cases over time.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:switch, connector, uipath-salesforce-slack, feature:escalation]
+  End-to-end, outcome-based test of the customer-escalation orchestration, driven
+  down each branch by seeded inputs. The agent builds a manual-trigger orchestrator
+  (the Outlook email-received trigger is not reliably debug-testable — see
+  outlook_trigger_inbox / customer_escalation notes) whose branching is input-driven
+  so the grader can steer any path via `flow debug --inputs`. The grader runs six
+  seeded cases — Sev1/Sev2/Sev3 escalations and informational/duplicate/unknown-customer
+  triage — and for each verifies the OUTCOME: the run completes on the expected path
+  with the expected severity/engineering/responseMode, preserves the correlationId,
+  and a real Slack message was posted (escalation alert on the escalation path, triage
+  notice on the triage paths) — confirmed independently by deleting the posted message
+  by its timestamp. Salesforce is not called (match status is an input), so no
+  Salesforce connection is required; the Slack node is a real connector with an error
+  port so a Slack hiccup cannot fault the run.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:switch, connector, feature:escalation]
 
 run_limits:
   expected_turns: 80
   max_turns: 200
   task_timeout: 3600
   turn_timeout: 1800
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py"
@@ -101,7 +98,7 @@ success_criteria:
   - type: run_command
     description: "Seeded path cases: each drives its branch and produces the expected outcome; the escalation case actually posts a Slack alert (non-empty message id)"
     command: "python3 $TASK_DIR/check_escalation_orchestrator_paths.py"
-    timeout: 900
+    timeout: 2400
     expected_exit_code: 0
-    weight: 8.0
+    weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -4,9 +4,9 @@ description: >
   down each branch by seeded inputs. The agent builds a manual-trigger orchestrator
   (the Outlook email-received trigger is not reliably debug-testable — see
   outlook_trigger_inbox / customer_escalation notes) whose branching is input-driven
-  so the grader can steer any path via `flow debug --inputs`. The grader runs six
-  seeded cases — Sev1/Sev2/Sev3 escalations and informational/duplicate/unknown-customer
-  triage — and for each verifies the OUTCOME: the run completes on the expected path
+  so the grader can steer any path via `flow debug --inputs`. The grader runs five
+  seeded cases — Sev1/Sev2/Sev3 escalations and duplicate/unknown-customer triage,
+  all deterministic from the inputs — and for each verifies the OUTCOME: the run completes on the expected path
   with the expected severity/engineering/responseMode, preserves the correlationId,
   and a real Slack message was posted (escalation alert on the escalation path, triage
   notice on the triage paths) — confirmed independently by deleting the posted message
@@ -51,14 +51,12 @@ initial_prompt: |
          else customerMatchStatus == "none"      -> "unknown_customer"
          else customerMatchStatus == "multiple"  -> "multiple_matches"
          else isDuplicate is true                -> "duplicate"
-         else (no production impact AND the subject/body reads like a question)
-                                                 -> "informational"
          else                                    -> "escalation"
      - severity: only for "escalation" classify Sev1/Sev2/Sev3 —
-         Sev1 = Enterprise tier AND productionDown AND NOT workaroundAvailable
-                (also any productionDown with no workaround);
+         Sev1 = productionDown AND NOT workaroundAvailable;
          Sev2 = productionDown AND workaroundAvailable;
-         Sev3 = otherwise. For every non-"escalation" path, severity = "informational".
+         Sev3 = NOT productionDown.
+       For every non-"escalation" (triage) path, severity = "informational".
      - engineeringNeeded: true for Sev1/Sev2, otherwise false.
      - responseMode: "Draft" when escalationPath == "escalation", else "None".
   2. A Decision routes on whether escalationPath == "escalation".

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -15,10 +15,10 @@ description: >
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:switch, connector, uipath-salesforce-slack, feature:escalation]
 
 run_limits:
-  expected_turns: 70
-  max_turns: 140
-  task_timeout: 3000
-  turn_timeout: 1200
+  expected_turns: 80
+  max_turns: 200
+  task_timeout: 3600
+  turn_timeout: 1800
 
 sandbox:
   driver: tempdir
@@ -34,9 +34,9 @@ post_run:
 
 initial_prompt: |
   Build a UiPath Maestro Flow named "CustomerEscalationOrchestrator" (inside a
-  solution of the same name) with a MANUAL trigger. It orchestrates a customer
-  escalation end-to-end and its routing is driven entirely by the flow inputs so
-  it can be exercised deterministically.
+  solution of the same name) with a MANUAL trigger. It triages a customer
+  escalation and its routing is driven entirely by the flow inputs so it can be
+  exercised deterministically.
 
   Flow inputs (declare as `in` variables on the manual trigger):
   senderEmail, senderDomain, subject, body, customerTier, productionDown (boolean),
@@ -44,7 +44,7 @@ initial_prompt: |
   customerMatchStatus ("single" | "none" | "multiple"), isDuplicate (boolean),
   correlationId.
 
-  Routing:
+  Routing (use Script + Decision/Switch nodes):
   - If senderDomain is empty → triage (missing domain).
   - Else branch on customerMatchStatus: "none" → triage (unknown customer);
     "multiple" → triage (multiple matches); "single" → continue.
@@ -57,33 +57,29 @@ initial_prompt: |
       informational = no production impact and the message is just a question.
     Decide engineeringNeeded (true for Sev1/Sev2) and responseMode = "Draft".
   - informational → triage (light).
-  - Sev1/Sev2/Sev3 → escalation actions: create a Jira issue in project "CE",
-    upload a summary file to Google Drive, and (for Sev1/Sev2) do an engineering
-    handoff, then post a Slack escalation alert.
+  - Sev1/Sev2/Sev3 → escalation path.
 
-  Connectors (Integration Service): Jira create-issue, Google Drive upload-file,
-  and Slack "Send Message to channel" are REAL connector nodes. For Slack use the
-  connection named "is-sandboxes", channel "coding-agent-testing", send as `user`.
-  Wire each connector's error port to a small handler so a connector failure
-  degrades gracefully instead of faulting the whole flow. Salesforce is NOT called
-  — the customer match is taken from the customerMatchStatus input.
-
-  Post a Slack escalation alert on the escalation path and a Slack triage notice on
-  the triage paths (both to the same channel).
+  Slack (REQUIRED, real connector): post a Slack "Send Message to channel" alert
+  on the escalation path, and a Slack triage notice on the triage paths (both to
+  the same channel). Use the Slack connection named "is-sandboxes", channel
+  "coding-agent-testing", send as `user`. Wire the Slack node's error port to a
+  small handler so a Slack failure degrades gracefully. (Creating a Jira ticket or
+  uploading to Drive on the escalation path is OPTIONAL — not required for this
+  task.)
 
   Map these `out` variables (on every reachable End node):
-  - escalationPath   ("escalation" or the triage reason)
-  - severity         (Sev1 / Sev2 / Sev3 / informational)
-  - engineeringNeeded(boolean)
-  - responseMode     ("Draft")
+  - escalationPath   ("escalation" or the triage reason: missing_domain /
+                      unknown_customer / multiple_matches / duplicate / informational)
+  - severity         (Sev1 / Sev2 / Sev3 / informational; on triage paths where
+                      severity was not classified, map "informational")
+  - engineeringNeeded(boolean; false on triage paths)
+  - responseMode     ("Draft" on the escalation path, "None" on triage paths)
   - caseKey          = the incoming correlationId
-  - jiraIssueKey     = the created Jira issue key (empty if Jira degraded)
   - slackMessageId   = the identifier of the posted Slack message
 
   Validate the flow. Do NOT run or debug the flow — the grader executes it with
-  seeded inputs. Do NOT ask for approval and do NOT pause; build end-to-end in a
-  single pass. Before starting, load the uipath-maestro-flow skill and follow its
-  workflow.
+  seeded inputs. Do NOT ask for approval and do NOT pause; build end-to-end.
+  Before starting, load the uipath-maestro-flow skill and follow its workflow.
 
 success_criteria:
   - type: command_executed

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -67,13 +67,17 @@ initial_prompt: |
      "coding-agent-testing", send as `user`, and include escalationPath +
      correlationId in the message. Wire each Slack node's error port to a small
      handler so a Slack failure degrades gracefully.
-  4. End node(s) map these `out` variables (on every reachable End):
+  4. Use TWO End nodes — one the escalation branch reaches, one the triage branch
+     reaches. On EACH End, map `slackMessageId` from THAT branch's own Slack node's
+     output (escalation End ← escalation Slack node; triage End ← triage Slack node),
+     so slackMessageId is never empty regardless of which branch runs. Map the rest
+     on both Ends:
      - escalationPath   (from the classify script)
      - severity
      - engineeringNeeded (boolean)
      - responseMode
      - caseKey          = the incoming correlationId
-     - slackMessageId   = the id/ts of the posted Slack message
+     - slackMessageId   = the id/ts of the Slack message posted on this branch
 
   Salesforce/Jira/Drive are NOT part of this task — the match status is an input.
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -13,7 +13,7 @@ description: >
   by its timestamp. Salesforce is not called (match status is an input), so no
   Salesforce connection is required; the Slack node is a real connector with an error
   port so a Slack hiccup cannot fault the run.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:switch, connector, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:decision, connector, feature:escalation]
 
 run_limits:
   expected_turns: 80

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -41,41 +41,45 @@ initial_prompt: |
   customerMatchStatus ("single" | "none" | "multiple"), isDuplicate (boolean),
   correlationId.
 
-  Routing (use Script + Decision/Switch nodes):
-  - If senderDomain is empty → triage (missing domain).
-  - Else branch on customerMatchStatus: "none" → triage (unknown customer);
-    "multiple" → triage (multiple matches); "single" → continue.
-  - If isDuplicate is true → triage (duplicate).
-  - Otherwise classify severity from the inputs:
-      Sev1 = Enterprise tier AND productionDown AND NOT workaroundAvailable
-             (also treat any productionDown with no workaround as Sev1);
-      Sev2 = productionDown AND workaroundAvailable;
-      Sev3 = has production impact but not the above;
-      informational = no production impact and the message is just a question.
-    Decide engineeringNeeded (true for Sev1/Sev2) and responseMode = "Draft".
-  - informational → triage (light).
-  - Sev1/Sev2/Sev3 → escalation path.
+  Keep the flow small. Put ALL routing logic in ONE Script node, then use a single
+  Decision plus two Slack nodes — do not build a large graph of switches and
+  per-reason handler nodes.
 
-  Slack (REQUIRED, real connector): post a Slack "Send Message to channel" alert
-  on the escalation path, and a Slack triage notice on the triage paths (both to
-  the same channel). Use the Slack connection named "is-sandboxes", channel
-  "coding-agent-testing", send as `user`. Wire the Slack node's error port to a
-  small handler so a Slack failure degrades gracefully. (Creating a Jira ticket or
-  uploading to Drive on the escalation path is OPTIONAL — not required for this
-  task.)
+  1. A single Script node "classify" reads the inputs and returns:
+     - escalationPath:
+         senderDomain empty                      -> "missing_domain"
+         else customerMatchStatus == "none"      -> "unknown_customer"
+         else customerMatchStatus == "multiple"  -> "multiple_matches"
+         else isDuplicate is true                -> "duplicate"
+         else (no production impact AND the subject/body reads like a question)
+                                                 -> "informational"
+         else                                    -> "escalation"
+     - severity: only for "escalation" classify Sev1/Sev2/Sev3 —
+         Sev1 = Enterprise tier AND productionDown AND NOT workaroundAvailable
+                (also any productionDown with no workaround);
+         Sev2 = productionDown AND workaroundAvailable;
+         Sev3 = otherwise. For every non-"escalation" path, severity = "informational".
+     - engineeringNeeded: true for Sev1/Sev2, otherwise false.
+     - responseMode: "Draft" when escalationPath == "escalation", else "None".
+  2. A Decision routes on whether escalationPath == "escalation".
+  3. escalation branch -> post a Slack "Send Message to channel" alert.
+     other (triage) branch -> post a Slack "Send Message to channel" triage notice.
+     For both, use the Slack connection named "is-sandboxes", channel
+     "coding-agent-testing", send as `user`, and include escalationPath +
+     correlationId in the message. Wire each Slack node's error port to a small
+     handler so a Slack failure degrades gracefully.
+  4. End node(s) map these `out` variables (on every reachable End):
+     - escalationPath   (from the classify script)
+     - severity
+     - engineeringNeeded (boolean)
+     - responseMode
+     - caseKey          = the incoming correlationId
+     - slackMessageId   = the id/ts of the posted Slack message
 
-  Map these `out` variables (on every reachable End node):
-  - escalationPath   ("escalation" or the triage reason: missing_domain /
-                      unknown_customer / multiple_matches / duplicate / informational)
-  - severity         (Sev1 / Sev2 / Sev3 / informational; on triage paths where
-                      severity was not classified, map "informational")
-  - engineeringNeeded(boolean; false on triage paths)
-  - responseMode     ("Draft" on the escalation path, "None" on triage paths)
-  - caseKey          = the incoming correlationId
-  - slackMessageId   = the identifier of the posted Slack message
+  Salesforce/Jira/Drive are NOT part of this task — the match status is an input.
 
   Validate the flow. Do NOT run or debug the flow — the grader executes it with
-  seeded inputs. Do NOT ask for approval and do NOT pause; build end-to-end.
+  seeded inputs. Do NOT ask for approval and do NOT pause; build the flow directly.
   Before starting, load the uipath-maestro-flow skill and follow its workflow.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -1,0 +1,111 @@
+task_id: skill-flow-e2e-escalation-orchestrator-paths
+description: >
+  End-to-end, outcome-based test of the full customer-escalation orchestration,
+  driven down a specific path by seeded inputs. The agent builds a manual-trigger
+  orchestrator (the Outlook email-received trigger is not reliably debug-testable
+  — see outlook_trigger_inbox / customer_escalation notes) whose branching is
+  input-driven so the grader can steer any path via `flow debug --inputs`. This
+  first case seeds a Sev1 production-down escalation and verifies the OUTCOME: the
+  run completes on the escalation path, classifies Sev1 + engineering, preserves
+  the correlationId, and the Slack escalation alert was actually posted (non-empty
+  message id). Salesforce enrichment is stubbed (match status is an input), so no
+  Salesforce connection is required; Jira/Drive/Slack are real with error-degrade
+  so an enrichment hiccup cannot fault the run. Additional path cases (informational,
+  duplicate, unknown-customer, …) are added as further seed cases over time.
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:switch, connector, uipath-salesforce-slack, feature:escalation]
+
+run_limits:
+  expected_turns: 70
+  max_turns: 140
+  task_timeout: 3000
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py"
+    timeout: 30
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+initial_prompt: |
+  Build a UiPath Maestro Flow named "CustomerEscalationOrchestrator" (inside a
+  solution of the same name) with a MANUAL trigger. It orchestrates a customer
+  escalation end-to-end and its routing is driven entirely by the flow inputs so
+  it can be exercised deterministically.
+
+  Flow inputs (declare as `in` variables on the manual trigger):
+  senderEmail, senderDomain, subject, body, customerTier, productionDown (boolean),
+  workaroundAvailable (boolean), hasAttachments (boolean),
+  customerMatchStatus ("single" | "none" | "multiple"), isDuplicate (boolean),
+  correlationId.
+
+  Routing:
+  - If senderDomain is empty → triage (missing domain).
+  - Else branch on customerMatchStatus: "none" → triage (unknown customer);
+    "multiple" → triage (multiple matches); "single" → continue.
+  - If isDuplicate is true → triage (duplicate).
+  - Otherwise classify severity from the inputs:
+      Sev1 = Enterprise tier AND productionDown AND NOT workaroundAvailable
+             (also treat any productionDown with no workaround as Sev1);
+      Sev2 = productionDown AND workaroundAvailable;
+      Sev3 = has production impact but not the above;
+      informational = no production impact and the message is just a question.
+    Decide engineeringNeeded (true for Sev1/Sev2) and responseMode = "Draft".
+  - informational → triage (light).
+  - Sev1/Sev2/Sev3 → escalation actions: create a Jira issue in project "CE",
+    upload a summary file to Google Drive, and (for Sev1/Sev2) do an engineering
+    handoff, then post a Slack escalation alert.
+
+  Connectors (Integration Service): Jira create-issue, Google Drive upload-file,
+  and Slack "Send Message to channel" are REAL connector nodes. For Slack use the
+  connection named "is-sandboxes", channel "coding-agent-testing", send as `user`.
+  Wire each connector's error port to a small handler so a connector failure
+  degrades gracefully instead of faulting the whole flow. Salesforce is NOT called
+  — the customer match is taken from the customerMatchStatus input.
+
+  Post a Slack escalation alert on the escalation path and a Slack triage notice on
+  the triage paths (both to the same channel).
+
+  Map these `out` variables (on every reachable End node):
+  - escalationPath   ("escalation" or the triage reason)
+  - severity         (Sev1 / Sev2 / Sev3 / informational)
+  - engineeringNeeded(boolean)
+  - responseMode     ("Draft")
+  - caseKey          = the incoming correlationId
+  - jiraIssueKey     = the created Jira issue key (empty if Jira degraded)
+  - slackMessageId   = the identifier of the posted Slack message
+
+  Validate the flow. Do NOT run or debug the flow — the grader executes it with
+  seeded inputs. Do NOT ask for approval and do NOT pause; build end-to-end in a
+  single pass. Before starting, load the uipath-maestro-flow skill and follow its
+  workflow.
+
+success_criteria:
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Generated CustomerEscalationOrchestrator Flow validates without errors"
+    command: "uip maestro flow validate CustomerEscalationOrchestrator/CustomerEscalationOrchestrator/CustomerEscalationOrchestrator.flow --output json"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Seeded path cases: each drives its branch and produces the expected outcome; the escalation case actually posts a Slack alert (non-empty message id)"
+    command: "python3 $TASK_DIR/check_escalation_orchestrator_paths.py"
+    timeout: 900
+    expected_exit_code: 0
+    weight: 8.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -4,9 +4,10 @@ description: >
   down each branch by seeded inputs. The agent builds a manual-trigger orchestrator
   (the Outlook email-received trigger is not reliably debug-testable — see
   outlook_trigger_inbox / customer_escalation notes) whose branching is input-driven
-  so the grader can steer any path via `flow debug --inputs`. The grader runs five
-  seeded cases — Sev1/Sev2/Sev3 escalations and duplicate/unknown-customer triage,
-  all deterministic from the inputs — and for each verifies the OUTCOME: the run completes on the expected path
+  so the grader can steer any path via `flow debug --inputs`. The grader runs seven
+  seeded cases — Sev1/Sev2/Sev3 escalations and all four triage reasons
+  (missing_domain / unknown_customer / multiple_matches / duplicate), all
+  deterministic from the inputs — and for each verifies the OUTCOME: the run completes on the expected path
   with the expected severity/engineering/responseMode, preserves the correlationId,
   and a real Slack message was posted (escalation alert on the escalation path, triage
   notice on the triage paths) — confirmed independently by deleting the posted message
@@ -18,7 +19,7 @@ tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-nod
 run_limits:
   expected_turns: 80
   max_turns: 200
-  task_timeout: 3600
+  task_timeout: 5400
   turn_timeout: 1800
 
 pre_run:
@@ -100,7 +101,7 @@ success_criteria:
   - type: run_command
     description: "Seeded path cases: each drives its branch and produces the expected outcome; the escalation case actually posts a Slack alert (non-empty message id)"
     command: "python3 $TASK_DIR/check_escalation_orchestrator_paths.py"
-    timeout: 2400
+    timeout: 3000
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -2,12 +2,14 @@
 """Seed path cases for the escalation-orchestrator outcome eval.
 
 Each case pins the flow inputs that steer one branch and the outputs the grader
-asserts. `expect_slack: true` means the case runs the escalation path and must
-have actually posted a Slack alert (non-empty slackMessageId).
+asserts. `expect_slack: true` means the run must have actually posted a Slack
+message (escalation alert on the escalation path, triage notice on the triage
+paths) — a non-empty slackMessageId proves it.
 
-Start with the escalation → Slack path. Add more cases (informational, duplicate,
-unknown-customer, multiple-match) here as coverage grows — the checker iterates
-this list generically, so no checker change is needed to add a path.
+Every expected value below was verified by running the reference orchestrator
+through `uip maestro flow debug --inputs` on codereval/alpha. The checker
+iterates this list generically, so new paths (e.g. multiple-match, missing-domain,
+Sev2-with-attachments) drop in here with no checker change.
 """
 
 from __future__ import annotations
@@ -16,44 +18,87 @@ import json
 from pathlib import Path
 from uuid import uuid4
 
+_COMMON = {
+    "senderEmail": "jane.doe@acmecorp.com",
+    "senderDomain": "acmecorp.com",
+    "hasAttachments": False,
+}
+
+
+def _case(name, run_id, suffix, overrides, expected, expect_slack):
+    corr = f"ORCH-{run_id}-{suffix}"
+    inputs = {
+        **_COMMON,
+        "subject": "",
+        "body": "",
+        "customerTier": "Standard",
+        "productionDown": False,
+        "workaroundAvailable": False,
+        "customerMatchStatus": "single",
+        "isDuplicate": False,
+        "correlationId": corr,
+        **overrides,
+    }
+    return {
+        "name": name,
+        "expect_slack": expect_slack,
+        "inputs": inputs,
+        "expected": {**expected, "caseKey": corr},
+    }
+
 
 def build_seed() -> dict:
-    run_id = uuid4().hex[:12]
-    return {
-        "run_id": run_id,
-        "cases": [
-            {
-                "name": "enterprise-production-down-sev1-escalation",
-                "expect_slack": True,
-                "inputs": {
-                    "senderEmail": "jane.doe@acmecorp.com",
-                    "senderDomain": "acmecorp.com",
-                    "subject": "Production down: checkout API returning 500s",
-                    "body": "Critical urgent outage since 09:15 UTC, all users blocked.",
-                    "customerTier": "Enterprise",
-                    "productionDown": True,
-                    "workaroundAvailable": False,
-                    "hasAttachments": False,
-                    "customerMatchStatus": "single",
-                    "isDuplicate": False,
-                    "correlationId": f"ORCH-{run_id}-SEV1",
-                },
-                "expected": {
-                    "escalationPath": "escalation",
-                    "severity": "Sev1",
-                    "engineeringNeeded": True,
-                    "responseMode": "Draft",
-                    "caseKey": f"ORCH-{run_id}-SEV1",
-                },
-            }
-        ],
-    }
+    r = uuid4().hex[:12]
+    cases = [
+        # ── Escalation paths (Slack escalation alert) ──────────────────────
+        _case(
+            "sev1-enterprise-production-down", r, "SEV1",
+            {"subject": "Production down: checkout 500s", "body": "Critical urgent outage, all users blocked",
+             "customerTier": "Enterprise", "productionDown": True, "workaroundAvailable": False},
+            {"escalationPath": "escalation", "severity": "Sev1", "engineeringNeeded": True, "responseMode": "Draft"},
+            True,
+        ),
+        _case(
+            "sev2-degraded-with-workaround", r, "SEV2",
+            {"subject": "Degraded checkout", "body": "Slow but a workaround exists",
+             "productionDown": True, "workaroundAvailable": True},
+            {"escalationPath": "escalation", "severity": "Sev2", "engineeringNeeded": True, "responseMode": "Draft"},
+            True,
+        ),
+        _case(
+            "sev3-no-production-impact", r, "SEV3",
+            {"subject": "Report formatting off", "body": "The export looks wrong"},
+            {"escalationPath": "escalation", "severity": "Sev3", "engineeringNeeded": False, "responseMode": "Draft"},
+            True,
+        ),
+        # ── Triage paths (Slack triage notice) ─────────────────────────────
+        _case(
+            "informational-question", r, "INFO",
+            {"subject": "Quick question", "body": "I have a question about billing"},
+            {"escalationPath": "informational", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
+            True,
+        ),
+        _case(
+            "duplicate-escalation", r, "DUP",
+            {"subject": "Prod down", "body": "urgent", "customerTier": "Enterprise",
+             "productionDown": True, "workaroundAvailable": False, "isDuplicate": True},
+            {"escalationPath": "duplicate", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
+            True,
+        ),
+        _case(
+            "unknown-customer", r, "UNK",
+            {"subject": "Help", "body": "an issue", "customerMatchStatus": "none"},
+            {"escalationPath": "unknown_customer", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
+            True,
+        ),
+    ]
+    return {"run_id": r, "cases": cases}
 
 
 def main() -> None:
     path = Path("seed.json")
     path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
-    print(f"seeded {path}")
+    print(f"seeded {path} with {len(build_seed()['cases'])} path cases")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -85,6 +85,18 @@ def build_seed() -> dict:
             {"escalationPath": "unknown_customer", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
             True,
         ),
+        _case(
+            "missing-domain", r, "MD",
+            {"subject": "Help", "body": "an issue", "senderDomain": ""},
+            {"escalationPath": "missing_domain", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
+            True,
+        ),
+        _case(
+            "multiple-matches", r, "MULTI",
+            {"subject": "Help", "body": "an issue", "customerMatchStatus": "multiple"},
+            {"escalationPath": "multiple_matches", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
+            True,
+        ),
     ]
     return {"run_id": r, "cases": cases}
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -52,9 +52,13 @@ def build_seed() -> dict:
     cases = [
         # ── Escalation paths (Slack escalation alert) ──────────────────────
         _case(
-            "sev1-enterprise-production-down", r, "SEV1",
+            # Deliberately STANDARD tier: the orchestrator's Sev1 is tier-independent
+            # (productionDown AND NOT workaroundAvailable). A classifier that wrongly
+            # gates Sev1 on Enterprise (e.g. copied from the slack_alert task) would
+            # misclassify this Standard outage and fail.
+            "sev1-standard-production-down", r, "SEV1",
             {"subject": "Production down: checkout 500s", "body": "Critical urgent outage, all users blocked",
-             "customerTier": "Enterprise", "productionDown": True, "workaroundAvailable": False},
+             "customerTier": "Standard", "productionDown": True, "workaroundAvailable": False},
             {"escalationPath": "escalation", "severity": "Sev1", "engineeringNeeded": True, "responseMode": "Draft"},
             True,
         ),

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -73,12 +73,6 @@ def build_seed() -> dict:
         ),
         # ── Triage paths (Slack triage notice) ─────────────────────────────
         _case(
-            "informational-question", r, "INFO",
-            {"subject": "Quick question", "body": "I have a question about billing"},
-            {"escalationPath": "informational", "severity": "informational", "engineeringNeeded": False, "responseMode": "None"},
-            True,
-        ),
-        _case(
             "duplicate-escalation", r, "DUP",
             {"subject": "Prod down", "body": "urgent", "customerTier": "Enterprise",
              "productionDown": True, "workaroundAvailable": False, "isDuplicate": True},

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -96,9 +96,10 @@ def build_seed() -> dict:
 
 
 def main() -> None:
+    seed = build_seed()
     path = Path("seed.json")
-    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
-    print(f"seeded {path} with {len(build_seed()['cases'])} path cases")
+    path.write_text(json.dumps(seed, indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path} with {len(seed['cases'])} path cases")
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/seed.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Seed path cases for the escalation-orchestrator outcome eval.
+
+Each case pins the flow inputs that steer one branch and the outputs the grader
+asserts. `expect_slack: true` means the case runs the escalation path and must
+have actually posted a Slack alert (non-empty slackMessageId).
+
+Start with the escalation → Slack path. Add more cases (informational, duplicate,
+unknown-customer, multiple-match) here as coverage grows — the checker iterates
+this list generically, so no checker change is needed to add a path.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+
+def build_seed() -> dict:
+    run_id = uuid4().hex[:12]
+    return {
+        "run_id": run_id,
+        "cases": [
+            {
+                "name": "enterprise-production-down-sev1-escalation",
+                "expect_slack": True,
+                "inputs": {
+                    "senderEmail": "jane.doe@acmecorp.com",
+                    "senderDomain": "acmecorp.com",
+                    "subject": "Production down: checkout API returning 500s",
+                    "body": "Critical urgent outage since 09:15 UTC, all users blocked.",
+                    "customerTier": "Enterprise",
+                    "productionDown": True,
+                    "workaroundAvailable": False,
+                    "hasAttachments": False,
+                    "customerMatchStatus": "single",
+                    "isDuplicate": False,
+                    "correlationId": f"ORCH-{run_id}-SEV1",
+                },
+                "expected": {
+                    "escalationPath": "escalation",
+                    "severity": "Sev1",
+                    "engineeringNeeded": True,
+                    "responseMode": "Draft",
+                    "caseKey": f"ORCH-{run_id}-SEV1",
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    path = Path("seed.json")
+    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -75,20 +75,25 @@ def main() -> None:
     # that exact string in the posted message.
     script_nodes = completed_node_ids_of_type(payload, "script")
     sev = case["expected"]["severity"]
-    classify_ids = {
-        nid for nid in script_nodes
+    sev_scripts = [
+        nid for nid in sorted(n for n in script_nodes if n)
         if normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sev)
-    }
-    if not classify_ids:
+    ]
+    if not sev_scripts:
         raise SystemExit(
             f"FAIL: no executed Script node produced the expected severity {sev!r} — "
             "cannot bind the nextSteps check to the classification Script"
         )
-    next_steps = find_node_output_field(payload, "nextSteps", node_ids=classify_ids)
+    # Bind to ONE node: the same Script that produced severity must ALSO produce
+    # nextSteps, so the classification can't be split across cosmetic Scripts.
+    next_steps = next(
+        (ns for nid in sev_scripts for ns in [find_node_output_field(payload, "nextSteps", node_ids={nid})] if ns),
+        None,
+    )
     if not next_steps:
         raise SystemExit(
-            "FAIL: the classification Script did not produce a nextSteps value — the "
-            "prompt requires classifying a short next-steps string"
+            "FAIL: the Script that produced the expected severity did not also produce "
+            "a nextSteps value — the prompt requires classifying a short next-steps string"
         )
 
     # The Slack side effect, verified against the executed send's own response:

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -34,6 +34,7 @@ from _shared.flow_check import (  # noqa: E402
 
 SLACK_KEY = "uipath-salesforce-slack"
 SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
+CASE_SENSITIVE = {"caseKey", "jiraIssueKey"}  # opaque ids — exact-case match
 
 
 def main() -> None:
@@ -49,20 +50,25 @@ def main() -> None:
         raise SystemExit("FAIL: seed.json must contain exactly one case")
     case = cases[0]
 
-    payload = run_debug(inputs=case["inputs"], timeout=300)
+    # retries=1: this flow POSTS to the shared Slack channel, so a whole-flow
+    # retry on a transient poll/5xx failure would post a duplicate alert. One
+    # attempt only; a genuine transient failure fails the run cleanly.
+    payload = run_debug(inputs=case["inputs"], timeout=300, retries=1)
 
-    # Classification outcomes.
+    # Classification outcomes. Opaque identifiers (caseKey) compare
+    # case-sensitively; enum-like values (severity, engineeringNeeded) do not.
     for name, expected in case["expected"].items():
-        assert_named_equals(payload, name, expected)
+        assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
     # The Slack side effect, verified against the executed send's own response:
-    # a real ts from an executed Slack node, posted to the coding-agent-testing
-    # channel, whose message carries this run's correlationId.
+    # a real ts from an executed Slack SEND node, posted to the coding-agent-testing
+    # channel, whose message carries BOTH this run's correlationId and the severity
+    # (the alert must surface every required field, not just the id).
     assert_slack_message_posted(
         payload,
         "slackMessageId",
         expected_channel=SLACK_CHANNEL,
-        must_contain=case["inputs"]["correlationId"],
+        must_contain=[case["inputs"]["correlationId"], case["expected"]["severity"]],
     )
 
     print(

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Execute the seeded Sev1 escalation case and verify the Slack alert was sent.
+
+Outcome-based, not "did it run": beyond a green `finalStatus`, this asserts the
+Slack `Send Message to channel` activity actually posted — the flow surfaces the
+posted message's identifier as the `slackMessageId` out variable, and a Slack
+API call only returns a message id when a message was really delivered. The
+classification outputs (severity, engineeringNeeded, caseKey) are checked too so
+a flow that posts to Slack but misclassifies still fails.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# Walk up to the directory that holds `_shared` so the import works regardless
+# of how deep this task lives under tests/tasks/uipath-maestro-flow/.
+_directory = os.path.dirname(os.path.abspath(__file__))
+while _directory != os.path.dirname(_directory) and not os.path.isdir(
+    os.path.join(_directory, "_shared")
+):
+    _directory = os.path.dirname(_directory)
+sys.path.insert(0, _directory)
+
+from _shared.flow_check import (  # noqa: E402
+    assert_flow_uses_connector_target,
+    assert_output_nonempty,
+    run_debug,
+)
+
+SLACK_KEY = "uipath-salesforce-slack"
+
+
+def normalized(value: Any) -> Any:
+    if isinstance(value, str):
+        lowered = value.strip().casefold()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        return lowered
+    return value
+
+
+def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
+    actual = assert_output_nonempty(payload, name)
+    if normalized(actual) != normalized(expected):
+        raise SystemExit(f"FAIL: output {name!r}: expected {expected!r}, got {actual!r}")
+
+
+def main() -> None:
+    # The flow must reach Slack through the real connector (or a connector-auth
+    # HTTP proxy), not a hand-rolled unauthenticated HTTP call.
+    assert_flow_uses_connector_target(SLACK_KEY)
+
+    seed_path = Path("seed.json")
+    if not seed_path.is_file():
+        raise SystemExit("FAIL: seed.json is missing; pre_run did not complete")
+    cases = json.loads(seed_path.read_text(encoding="utf-8")).get("cases")
+    if not isinstance(cases, list) or len(cases) != 1:
+        raise SystemExit("FAIL: seed.json must contain exactly one case")
+    case = cases[0]
+
+    payload = run_debug(inputs=case["inputs"], timeout=300)
+
+    # Classification outcomes.
+    for name, expected in case["expected"].items():
+        assert_named_equals(payload, name, expected)
+
+    # The Slack side effect: a posted-message identifier proves the alert was
+    # actually delivered to the channel.
+    assert_output_nonempty(payload, "slackMessageId")
+
+    print(
+        f"OK: {case['name']} completed — Sev1 + engineering classified, "
+        "correlationId preserved, and the Slack alert was posted (message id present)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -30,6 +30,7 @@ from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_slack_message_posted,
+    find_node_output_field,
     run_debug,
 )
 
@@ -64,15 +65,27 @@ def main() -> None:
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
+    # The prompt requires the alert to include severity, correlationId, AND the
+    # next steps. nextSteps is computed by the Script node (not a named End out),
+    # so read the flow's OWN nextSteps value from the debug payload and require that
+    # exact string in the posted message — a flow that omits it fails. Exact match
+    # is safe (it's the flow's own computed value tied to its own posted message).
+    next_steps = find_node_output_field(payload, "nextSteps")
+    if not next_steps:
+        raise SystemExit(
+            "FAIL: the flow's Script node did not produce a nextSteps value — the "
+            "prompt requires classifying a short next-steps string"
+        )
+
     # The Slack side effect, verified against the executed send's own response:
     # a real ts from an executed Slack SEND node, posted to the coding-agent-testing
-    # channel, whose message carries BOTH this run's correlationId and the severity
-    # (the alert must surface every required field, not just the id).
+    # channel, whose message carries every required field (correlationId, severity,
+    # next steps), not just the id.
     assert_slack_message_posted(
         payload,
         "slackMessageId",
         expected_channel=SLACK_CHANNEL,
-        must_contain=[case["inputs"]["correlationId"], case["expected"]["severity"]],
+        must_contain=[case["inputs"]["correlationId"], case["expected"]["severity"], next_steps],
     )
 
     print(

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -30,6 +30,7 @@ from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_slack_message_posted,
+    completed_node_ids_of_type,
     find_node_output_field,
     run_debug,
 )
@@ -67,10 +68,11 @@ def main() -> None:
 
     # The prompt requires the alert to include severity, correlationId, AND the
     # next steps. nextSteps is computed by the Script node (not a named End out),
-    # so read the flow's OWN nextSteps value from the debug payload and require that
-    # exact string in the posted message — a flow that omits it fails. Exact match
-    # is safe (it's the flow's own computed value tied to its own posted message).
-    next_steps = find_node_output_field(payload, "nextSteps")
+    # so read the flow's OWN nextSteps value from the EXECUTED Script node's output
+    # (scoped to completed Script nodes so a cosmetic/unrelated node can't supply
+    # it) and require that exact string in the posted message.
+    script_nodes = completed_node_ids_of_type(payload, "script")
+    next_steps = find_node_output_field(payload, "nextSteps", node_ids=script_nodes)
     if not next_steps:
         raise SystemExit(
             "FAIL: the flow's Script node did not produce a nextSteps value — the "

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -33,6 +33,7 @@ from _shared.flow_check import (  # noqa: E402
 )
 
 SLACK_KEY = "uipath-salesforce-slack"
+SLACK_CHANNEL = "C0B2FDZD1M3"  # coding-agent-testing
 
 
 def main() -> None:
@@ -54,11 +55,15 @@ def main() -> None:
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected)
 
-    # The Slack side effect: the flow must surface a real Slack message ts,
-    # which the Slack API returns only for a message it actually accepted.
-    # Paired with the real-connector assertion above, a hard-coded placeholder
-    # can't satisfy this.
-    assert_slack_message_posted(payload, "slackMessageId")
+    # The Slack side effect, verified against the executed send's own response:
+    # a real ts from an executed Slack node, posted to the coding-agent-testing
+    # channel, whose message carries this run's correlationId.
+    assert_slack_message_posted(
+        payload,
+        "slackMessageId",
+        expected_channel=SLACK_CHANNEL,
+        must_contain=case["inputs"]["correlationId"],
+    )
 
     print(
         f"OK: {case['name']} completed — Sev1 + engineering classified, "

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -15,7 +15,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any
 
 # Walk up to the directory that holds `_shared` so the import works regardless
 # of how deep this task lives under tests/tasks/uipath-maestro-flow/.
@@ -28,28 +27,12 @@ sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
-    assert_output_nonempty,
+    assert_named_equals,
+    assert_slack_message_posted,
     run_debug,
 )
 
 SLACK_KEY = "uipath-salesforce-slack"
-
-
-def normalized(value: Any) -> Any:
-    if isinstance(value, str):
-        lowered = value.strip().casefold()
-        if lowered == "true":
-            return True
-        if lowered == "false":
-            return False
-        return lowered
-    return value
-
-
-def assert_named_equals(payload: dict, name: str, expected: Any) -> None:
-    actual = assert_output_nonempty(payload, name)
-    if normalized(actual) != normalized(expected):
-        raise SystemExit(f"FAIL: output {name!r}: expected {expected!r}, got {actual!r}")
 
 
 def main() -> None:
@@ -71,13 +54,15 @@ def main() -> None:
     for name, expected in case["expected"].items():
         assert_named_equals(payload, name, expected)
 
-    # The Slack side effect: a posted-message identifier proves the alert was
-    # actually delivered to the channel.
-    assert_output_nonempty(payload, "slackMessageId")
+    # The Slack side effect: the flow must surface a real Slack message ts,
+    # which the Slack API returns only for a message it actually accepted.
+    # Paired with the real-connector assertion above, a hard-coded placeholder
+    # can't satisfy this.
+    assert_slack_message_posted(payload, "slackMessageId")
 
     print(
         f"OK: {case['name']} completed — Sev1 + engineering classified, "
-        "correlationId preserved, and the Slack alert was posted (message id present)"
+        "correlationId preserved, and the Slack alert was posted (real message ts)"
     )
 
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -32,6 +32,8 @@ from _shared.flow_check import (  # noqa: E402
     assert_slack_message_posted,
     completed_node_ids_of_type,
     find_node_output_field,
+    find_node_output_value,
+    normalized,
     run_debug,
 )
 
@@ -67,15 +69,25 @@ def main() -> None:
         assert_named_equals(payload, name, expected, case_sensitive=(name in CASE_SENSITIVE))
 
     # The prompt requires the alert to include severity, correlationId, AND the
-    # next steps. nextSteps is computed by the Script node (not a named End out),
-    # so read the flow's OWN nextSteps value from the EXECUTED Script node's output
-    # (scoped to completed Script nodes so a cosmetic/unrelated node can't supply
-    # it) and require that exact string in the posted message.
+    # next steps. nextSteps is computed by the Script (not a named End out), so read
+    # it from the ONE classification Script — the executed Script whose own output
+    # carries the expected severity — so an unrelated Script can't supply it. Require
+    # that exact string in the posted message.
     script_nodes = completed_node_ids_of_type(payload, "script")
-    next_steps = find_node_output_field(payload, "nextSteps", node_ids=script_nodes)
+    sev = case["expected"]["severity"]
+    classify_ids = {
+        nid for nid in script_nodes
+        if normalized(find_node_output_value(payload, "severity", node_ids={nid})) == normalized(sev)
+    }
+    if not classify_ids:
+        raise SystemExit(
+            f"FAIL: no executed Script node produced the expected severity {sev!r} — "
+            "cannot bind the nextSteps check to the classification Script"
+        )
+    next_steps = find_node_output_field(payload, "nextSteps", node_ids=classify_ids)
     if not next_steps:
         raise SystemExit(
-            "FAIL: the flow's Script node did not produce a nextSteps value — the "
+            "FAIL: the classification Script did not produce a nextSteps value — the "
             "prompt requires classifying a short next-steps string"
         )
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/check_escalation_slack_alert.py
@@ -26,6 +26,7 @@ while _directory != os.path.dirname(_directory) and not os.path.isdir(
 sys.path.insert(0, _directory)
 
 from _shared.flow_check import (  # noqa: E402
+    assert_connector_send_identity,
     assert_flow_uses_connector_target,
     assert_named_equals,
     assert_slack_message_posted,
@@ -41,6 +42,9 @@ def main() -> None:
     # The flow must reach Slack through the real connector (or a connector-auth
     # HTTP proxy), not a hand-rolled unauthenticated HTTP call.
     assert_flow_uses_connector_target(SLACK_KEY)
+
+    # Prompt requires sending as `user` (not the default bot).
+    assert_connector_send_identity(SLACK_KEY, expected="user", native_op_hint="send-message-to-channel")
 
     seed_path = Path("seed.json")
     if not seed_path.is_file():

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
@@ -11,17 +11,13 @@ description: >
   correlationId, and — the point of the test — the Slack Send Message activity
   actually posted (it returned a non-empty message id surfaced as a flow
   output). Grades the delivered Slack side effect, not "did it run".
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-salesforce-slack, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation]
 
 run_limits:
   expected_turns: 55
   max_turns: 120
   task_timeout: 2400
   turn_timeout: 1200
-
-sandbox:
-  driver: tempdir
-  python: {}
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/seed.py"
@@ -88,7 +84,7 @@ success_criteria:
   - type: run_command
     description: "Seeded Sev1 debug run completes, classifies Sev1 + engineering, preserves correlationId, and the Slack alert was actually posted (non-empty message id)"
     command: "python3 $TASK_DIR/check_escalation_slack_alert.py"
-    timeout: 660
+    timeout: 1000
     expected_exit_code: 0
-    weight: 8.0
+    weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
@@ -1,0 +1,94 @@
+task_id: skill-flow-e2e-escalation-slack-alert
+description: >
+  End-to-end, outcome-based slice of the customer-escalation orchestration.
+  The agent builds a manual-trigger escalation-triage Flow that classifies
+  severity and posts a Slack alert. A manual trigger is used deliberately —
+  the Outlook email-received trigger cannot be reliably debug-tested (seeding
+  a self-addressed email is flaky against the shared mailbox; see the
+  outlook_trigger_inbox and customer_escalation task notes). The grader seeds a
+  Sev1 case, runs `uip maestro flow debug --inputs`, and verifies the OUTCOME:
+  the flow completes, classifies Sev1 with engineering needed, preserves the
+  correlationId, and — the point of the test — the Slack Send Message activity
+  actually posted (it returned a non-empty message id surfaced as a flow
+  output). Grades the delivered Slack side effect, not "did it run".
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, uipath-salesforce-slack, feature:escalation]
+
+run_limits:
+  expected_turns: 55
+  max_turns: 120
+  task_timeout: 2400
+  turn_timeout: 1200
+
+sandbox:
+  driver: tempdir
+  python: {}
+
+pre_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/seed.py"
+    timeout: 30
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/cleanup_solutions.py"
+    timeout: 120
+
+initial_prompt: |
+  Build a UiPath Maestro Flow named "EscalationSlackAlert" (inside a solution of
+  the same name) with a MANUAL trigger.
+
+  The flow triages a customer escalation and posts a Slack alert with next steps.
+  Declare these flow inputs (in variables associated with the manual trigger):
+  senderEmail, subject, body, customerTier, productionDown (boolean),
+  workaroundAvailable (boolean), correlationId.
+
+  Steps:
+  1. A Script node classifies severity from the inputs:
+     - Sev1  = customerTier is "Enterprise" AND productionDown is true AND
+               workaroundAvailable is false.
+     - Sev2  = productionDown is true AND workaroundAvailable is true.
+     - Sev3  = everything else (informational / no production impact).
+     Also decide engineeringNeeded (true for Sev1 and Sev2, false for Sev3) and a
+     short nextSteps string.
+  2. Post a Slack alert to the channel "coding-agent-testing" using the Slack
+     "Send Message to channel" activity. Use the Slack connection named
+     "is-sandboxes" and send as `user`. The message must include the severity,
+     the correlationId, and the next steps.
+  3. End the flow, mapping these `out` variables:
+     - severity          (Sev1 / Sev2 / Sev3)
+     - engineeringNeeded (boolean)
+     - caseKey           = the incoming correlationId
+     - slackMessageId    = the identifier of the Slack message that was posted
+                           (from the Slack Send Message node's output)
+
+  Validate the flow. Do NOT run or debug the flow — the grader executes it with
+  seeded inputs. Do NOT ask for approval, confirmation, or feedback, and do NOT
+  pause between planning and implementation. Build the complete flow end-to-end
+  in a single pass. Before starting, load the uipath-maestro-flow skill and
+  follow its workflow.
+
+success_criteria:
+  # ── The agent validated the flow (convention adherence) ─────────────────
+  - type: command_executed
+    description: "Agent validated the generated Flow"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # ── The delivered flow validates ────────────────────────────────────────
+  - type: run_command
+    description: "Generated EscalationSlackAlert Flow validates without errors"
+    command: "uip maestro flow validate EscalationSlackAlert/EscalationSlackAlert/EscalationSlackAlert.flow --output json"
+    timeout: 180
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # ── OUTCOME: seeded Sev1 run posts to Slack and returns the right outputs ─
+  - type: run_command
+    description: "Seeded Sev1 debug run completes, classifies Sev1 + engineering, preserves correlationId, and the Slack alert was actually posted (non-empty message id)"
+    command: "python3 $TASK_DIR/check_escalation_slack_alert.py"
+    timeout: 660
+    expected_exit_code: 0
+    weight: 8.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/seed.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/seed.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Seed a Sev1 escalation case for the Slack-alert outcome eval.
+
+Writes seed.json with one Enterprise / production-down / no-workaround case.
+A fresh correlationId per run keeps the posted Slack message and the caseKey
+assertion isolated across runs. The grader (check_escalation_slack_alert.py)
+runs `flow debug --inputs <inputs>` and asserts both the classification outputs
+and that a Slack message was actually posted.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from uuid import uuid4
+
+
+def build_seed() -> dict:
+    run_id = uuid4().hex[:12]
+    return {
+        "run_id": run_id,
+        "cases": [
+            {
+                "name": "enterprise-production-down-sev1",
+                "inputs": {
+                    "senderEmail": "jane.doe@acmecorp.com",
+                    "subject": "Production down: checkout API returning 500s",
+                    "body": (
+                        "Critical outage since 09:15 UTC. All checkout requests "
+                        "are failing with HTTP 500 and orders are blocked."
+                    ),
+                    "customerTier": "Enterprise",
+                    "productionDown": True,
+                    "workaroundAvailable": False,
+                    "correlationId": f"E2E-{run_id}-SEV1",
+                },
+                "expected": {
+                    "severity": "Sev1",
+                    "engineeringNeeded": True,
+                    "caseKey": f"E2E-{run_id}-SEV1",
+                },
+            }
+        ],
+    }
+
+
+def main() -> None:
+    path = Path("seed.json")
+    path.write_text(json.dumps(build_seed(), indent=2) + "\n", encoding="utf-8")
+    print(f"seeded {path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds an **outcome-based** e2e coder-eval task at `tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/` (yaml + `seed.py` + `check_escalation_slack_alert.py`).

The agent builds a customer-escalation triage Flow that classifies severity and posts a **Slack alert**. The grader seeds a Sev1 case, runs `uip maestro flow debug --inputs`, and verifies the **outcome** — not just that the flow ran:

- run completes (`finalStatus == Completed`),
- classifies `Sev1` + `engineeringNeeded`, preserves `correlationId` → `caseKey`,
- **the Slack Send Message activity actually posted** — a non-empty `slackMessageId` is surfaced as a flow output (Slack only returns a message id when a message is really delivered).

## Why a manual trigger

The Outlook `email-received` trigger is **not reliably debug-testable** — seeding a self-addressed email is flaky against the shared mailbox (self-sends can route via inbox rules that bypass the connector's ~1h trigger lookback). The existing `multi_node/customer_escalation`, `interactive/customer_escalation_simulated`, and `single_node/outlook_trigger_inbox` tasks all document this and stop at validate. This task follows the proven `interactive/customer_escalation_triage` + `e2e/jira_*` pattern: manual trigger + `flow debug --inputs`, grader runs the debug.

## Validation

Ran end-to-end on **codereval / alpha**: a reference build's `flow debug` posted a real message to the `is-sandboxes` **`coding-agent-testing`** channel and the checker passed:

```
OK: enterprise-production-down-sev1 completed — Sev1 + engineering classified,
    correlationId preserved, and the Slack alert was posted (message id present)
```

No missing connections — the `is-sandboxes` Slack connection is Enabled and the channel is reachable.

## Lint

`/lint-task` verdict: OK (one Low — a minor "Script node" mention in the prompt; one Info — `check-cli-verbs.py` crashed under this box's Python 3.9, unrelated to the task).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
