### PR TITLE
fix(traces): scope command_executed min_count per-item; clarify list vs list detailed docs

### DIFF
--- a/.claude/commands/lint-task.md
+++ b/.claude/commands/lint-task.md
@@ -91,6 +91,7 @@ Penalize:
 - `llm_judge` as the only or dominant criterion (graded by an LLM with no ground truth)
 - Criteria that would pass for any non-empty / well-formed input regardless of correctness
 - For `command_executed`, `min_count: 1` with a very loose regex — proves nothing about correctness
+- For `command_executed`, `min_count: 2` or higher with no structural (file/output-based) proof of multiplicity elsewhere in the task — `min_count` counts matching Bash tool calls, not occurrences within a call, so this false-fails any agent that batches commands into one Bash call. Flag `command_pattern`/task shape combinations where batching is plausible
 
 Reward:
 - `json_check` with assertions on actual output values

--- a/skills/uipath-platform/references/traces/feedback.md
+++ b/skills/uipath-platform/references/traces/feedback.md
@@ -66,9 +66,11 @@ uip traces feedback list \
 | `--offset` | Pagination offset, default 0 |
 | `--folder-key` | Optional |
 
+`--trace-id` is optional — omit it to filter and paginate across all traces (e.g. by `--agent-id`/`--agent-version`/`--negative`) without needing `list detailed`.
+
 ## list detailed
 
-Returns `spanAttributes` per record (`agentId`, `agentName`, `userPrompt`, `output`). No `--trace-id` needed — designed for cross-trace bulk review.
+Adds span context per record (`spanAttributes`: `agentId`, `agentName`, `userPrompt`, `output`) plus time-range/category/sort filters over `list`. Not required for cross-trace filtering — plain `list` already covers that by omitting `--trace-id`.
 
 ```bash
 # Last 24 hours

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -110,8 +110,8 @@ LLM execution trace observability and feedback annotation. See [traces/traces.md
 | `uip traces spans get <trace-id>` | Get spans by trace ID or `--job-key` |
 | `uip traces feedback create` | Add positive/negative feedback to a trace |
 | `uip traces feedback get <id>` | Fetch one feedback record |
-| `uip traces feedback list` | List feedback for a trace |
-| `uip traces feedback list detailed` | Cross-trace feedback with span context |
+| `uip traces feedback list` | List feedback, optionally filtered by trace/span/agent/sentiment |
+| `uip traces feedback list detailed` | Feedback with span context, plus time-range/category/sort filters |
 | `uip traces feedback update <id>` | Change sentiment, comment, or categories |
 | `uip traces feedback delete <id>` | Remove feedback |
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -394,10 +394,12 @@ Verify the agent ran a specific CLI command (matched by regex). From `init_valid
   description: "Agent created a solution with uip solution new"
   tool_name: "Bash"
   command_pattern: 'uip\s+solution\s+new'
-  min_count: 1          # minimum times the command must appear
+  min_count: 1          # minimum matching Bash tool calls required
   weight: 1.5           # scoring weight
   pass_threshold: 1.0   # fraction of min_count required to pass
 ```
+
+`min_count` counts **matching Bash tool calls**, not pattern occurrences within a call. If an agent legitimately bundles multiple qualifying commands into one shell invocation (e.g. `cmd-a && cmd-b`), that single tool call can only ever contribute 1 match — so `min_count: 2` or higher silently caps the score below 1.0 for a correct, efficient agent. Prefer `min_count: 1` scoped narrowly (e.g. one criterion per distinct argument or ID, splitting the weight between them) over a single `min_count: 2+`, and prove true multiplicity with a `run_command` / `file_contains` check on the resulting artifacts instead of counting tool calls. See `traces_feedback_comment_file_smoke.yaml` and `idempotent_reconfigure.yaml` for the pattern.
 
 ### `file_exists`
 

--- a/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
+++ b/tests/tasks/uipath-api-workflow/operate/run_execute/run_execute.yaml
@@ -31,12 +31,26 @@ initial_prompt: |
   Do NOT ask for approval or confirmation.
 
 success_criteria:
+  # min_count: 1 (not 2) x2, scoped per input. command_executed counts matching Bash
+  # events, not command occurrences within an event — the two dependency-free runs
+  # chain into one Bash call, which a single min_count: 2 criterion caps at 0.5.
+  # Kept as two per-input criteria rather than dropping to one: the prompt states the
+  # score >= 60 rule, so the run_85/run_40 file checks alone could be satisfied by one
+  # real run plus one hand-written file. This split is the anti-fabrication guard.
   - type: command_executed
-    description: "Agent executed the workflow with the local runner, once per input (the operate action)"
+    description: "Agent executed the workflow with the local runner for the score-85 input (the operate action)"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run'
-    min_count: 2
-    weight: 2.0
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run(?=[\s\S]*"score"\s*:\s*85)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent executed the workflow with the local runner for the score-40 input (the operate action)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+api-workflow\s+run(?=[\s\S]*"score"\s*:\s*40)'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: file_exists

--- a/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
+++ b/tests/tasks/uipath-insights/smoke_absolute_time_range.yaml
@@ -41,10 +41,23 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
+  # min_count: 1 (not 2) x2, scoped per subcommand. command_executed counts matching
+  # Bash events, not command occurrences within an event — the prompt's two queries
+  # chain into one Bash call, which a single min_count: 2 criterion caps at 0.5.
+  # Splitting also tightens the check: the old (summary|completed-timeline)
+  # alternation was satisfied by running `summary` twice.
   - type: command_executed
-    description: "Agent ran at least two different subcommands"
+    description: "Agent ran the summary subcommand"
     tool_name: "Bash"
-    command_pattern: 'uip\s+insights\s+jobs\s+(summary|completed-timeline)'
-    min_count: 2
-    weight: 1.5
+    command_pattern: 'uip\s+insights\s+jobs\s+summary'
+    min_count: 1
+    weight: 0.75
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran the completed-timeline subcommand"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+jobs\s+completed-timeline'
+    min_count: 1
+    weight: 0.75
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -29,11 +29,18 @@ initial_prompt: |
   Both snapshots go at the sandbox root.
 
 success_criteria:
+  # min_count: 1 (not 2). command_executed counts matching Bash events, not command
+  # occurrences within an event — a correct batched run (configure && cp && configure
+  # && cp in one call) registers only 1 match and this criterion would false-fail.
+  # Multiplicity is instead proven by the snapshot-diff checks below (count_equal /
+  # same_connection_id / no_empty_stubs across after_first_configure.flow and
+  # after_second_configure.flow) — a result a single configure cannot produce.
+  # Mirrors the min_count:1 convention in reconfigure_different_connection.yaml.
   - type: command_executed
-    description: "Agent called `node configure` at least twice"
+    description: "Agent called `node configure` at least once"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 2
+    min_count: 1
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-platform/traces/traces_feedback_comment_file_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_comment_file_smoke.yaml
@@ -55,11 +55,25 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # min_count: 1 (not 2) x2, scoped per trace-id. command_executed counts matching
+  # Bash events, not command occurrences within an event — an agent that chains both
+  # creates into ONE Bash call registers only 1 match, so a single min_count: 2
+  # criterion caps at 0.5 for correct behavior. Mirrors the min_count:1 convention
+  # in reconfigure_different_connection.yaml.
   - type: command_executed
-    description: "Both records were filed via --comment-file, never an inline --comment (mutual exclusion rule 2)"
+    description: "Trace 7d3a91e0f5c24b8ea0c6d219bb47f0a3 was filed via --comment-file, never inline --comment"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--comment-file)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--trace-id[\s=]+["'']?7d3a91e0f5c24b8ea0c6d219bb47f0a3)(?=[\s\S]*--comment-file)'
     exclude_pattern: '--comment[\s=]'
-    min_count: 2
-    weight: 2.0
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Trace a18b4c7d2e934f60b5c81d3a6f9e2077 was filed via --comment-file, never inline --comment"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--trace-id[\s=]+["'']?a18b4c7d2e934f60b5c81d3a6f9e2077)(?=[\s\S]*--comment-file)'
+    exclude_pattern: '--comment[\s=]'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-solution/project_remove_integration.yaml
+++ b/tests/tasks/uipath-solution/project_remove_integration.yaml
@@ -36,7 +36,11 @@ success_criteria:
     description: "Agent registered projects (set-up) via uip solution projects add (or import)"
     tool_name: "Bash"
     command_pattern: 'uip\s+solution\s+projects?\s+(add|import)\b(?!\s+(?:--help|-h)\b)'
-    min_count: 2
+    # min_count: 1 (not 2). command_executed counts matching Bash events, not command
+    # occurrences within an event — `projects add A && projects add B` in one call
+    # registers only 1 match. The outcome checks named below already prove both
+    # registrations happened.
+    min_count: 1
     weight: 1.0
     pass_threshold: 0.0  # advisory: `uip rpa init --location <solution-dir>` (and init inside a solution) auto-registers projects (CLI #2470), so explicit `projects add` is optional. Registration is outcome-checked by the json_check below plus the successful `projects remove` (which refuses to drop the last project — ending at 1 proves it started at 2). Mirrors uipath-agents/coded/coded_in_flow_e2e.yaml.
 

--- a/tests/tasks/uipath-tasks/smoke_completion.yaml
+++ b/tests/tasks/uipath-tasks/smoke_completion.yaml
@@ -62,19 +62,57 @@ success_criteria:
     weight: 2.5
     pass_threshold: 1.0
 
+  # min_count: 1 (not 3) x3, scoped per task id. command_executed counts matching Bash
+  # events, not command occurrences within an event — the three offline completes chain
+  # into one Bash call, which a single min_count: 3 criterion caps at 0.33. The
+  # (?:[^&;|\n]|\\\n)* class keeps each criterion pinned to its own command inside a batched
+  # call, so this also verifies the flag landed on the right task rather than anywhere
+  # in the call.
   - type: command_executed
-    description: "Every complete call includes --folder-id"
+    description: "The ExternalTask (3000001) complete call includes --folder-id"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--folder-id\s+\d+'
-    min_count: 3
-    weight: 2.0
+    command_pattern: 'uip\s+tasks\s+complete\s+3000001\s(?:[^&;|\n]|\\\n)*--folder-id\s+\d+'
+    min_count: 1
+    weight: 0.67
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Every complete call includes --type"
+    description: "The FormTask (3000002) complete call includes --folder-id"
     tool_name: "Bash"
-    command_pattern: 'uip\s+tasks\s+complete\s+\d+\s+.*--type\s+\w+'
-    min_count: 3
-    weight: 2.0
+    command_pattern: 'uip\s+tasks\s+complete\s+3000002\s(?:[^&;|\n]|\\\n)*--folder-id\s+\d+'
+    min_count: 1
+    weight: 0.67
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "The AppTask (3000003) complete call includes --folder-id"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+complete\s+3000003\s(?:[^&;|\n]|\\\n)*--folder-id\s+\d+'
+    min_count: 1
+    weight: 0.66
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "The ExternalTask (3000001) complete call includes --type"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+complete\s+3000001\s(?:[^&;|\n]|\\\n)*--type\s+\w+'
+    min_count: 1
+    weight: 0.67
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "The FormTask (3000002) complete call includes --type"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+complete\s+3000002\s(?:[^&;|\n]|\\\n)*--type\s+\w+'
+    min_count: 1
+    weight: 0.67
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "The AppTask (3000003) complete call includes --type"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tasks\s+complete\s+3000003\s(?:[^&;|\n]|\\\n)*--type\s+\w+'
+    min_count: 1
+    weight: 0.66
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-test/customfield_population_integration.yaml
+++ b/tests/tasks/uipath-test/customfield_population_integration.yaml
@@ -72,12 +72,27 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
+  # min_count: 1 (not 2) x2, scoped per field name. command_executed counts matching
+  # Bash events, not command occurrences within an event — the two creates chain into
+  # one Bash call, which a single min_count: 2 criterion caps at 0.5. The lookaheads
+  # now anchor after the `create` verb and scan with the batch-safe
+  # (?:[^&;|\n]|\\\n)* class, so each criterion is pinned to one command: this
+  # verifies the name/data-type pairing, which the old (Text|Label) alternation
+  # never checked.
   - type: command_executed
-    description: "Complete create commands defining fields scoped TestCase: `uip tm customfield create --project-key HEALTH --name <name> --data-type <Text|Label> --object-type TestCase` (x2)"
+    description: "Complete create command defining the Text field: `uip tm customfield create --project-key HEALTH --name 'Eval Reviewer' --data-type Text --object-type TestCase`"
     tool_name: "Bash"
-    command_pattern: '(?=.*--project-key\s+HEALTH)(?=.*--object-type\s+TestCase)(?=.*--data-type\s+(Text|Label))uip\s+tm\s+customfield\s+create'
-    min_count: 2
-    weight: 2.0
+    command_pattern: 'uip\s+tm\s+customfield\s+create\s(?=(?:[^&;|\n]|\\\n)*--project-key\s+HEALTH)(?=(?:[^&;|\n]|\\\n)*--object-type\s+TestCase)(?=(?:[^&;|\n]|\\\n)*--data-type\s+Text)(?=(?:[^&;|\n]|\\\n)*Eval\s+Reviewer)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Complete create command defining the Label field: `uip tm customfield create --project-key HEALTH --name 'Eval Risk' --data-type Label --object-type TestCase`"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+tm\s+customfield\s+create\s(?=(?:[^&;|\n]|\\\n)*--project-key\s+HEALTH)(?=(?:[^&;|\n]|\\\n)*--object-type\s+TestCase)(?=(?:[^&;|\n]|\\\n)*--data-type\s+Label)(?=(?:[^&;|\n]|\\\n)*Eval\s+Risk)'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed


### PR DESCRIPTION
## Motivation

Two tasks failed in the [2026-08-13 coder-evalboard run](https://coder-evalboard.uipath-dev.com/runs/2026-08-13_04-49-42?q=traces). Neither was an agent regression — both were false negatives, from two different causes:

**1. `skill-platform-traces-feedback-comment-file` (0.88, 3/4) — a grading bug.** The agent's behavior was correct: it filed both feedback records via `--comment-file`, never an inline `--comment`. It just chained both `uip traces feedback create` invocations into one `set -o pipefail` Bash call instead of two — reasonable, efficient behavior.

The `command_executed` checker does **one boolean `pattern.search()` per Bash tool call**, not a count of pattern occurrences inside a call's text. So one bundled call can only ever contribute 1 to `match_count`, and the criterion's `min_count: 2` capped it at `min(1.0, 1/2) = 0.5` regardless of how many qualifying commands were actually in there.

This exact shape was already hit and fixed two weeks ago in `reconfigure_different_connection.yaml` — but the convention was never written down anywhere a task author would see it, so this task re-introduced it. That's the real root cause, and why this PR also fixes the docs (Fix 3) rather than just the one criterion.

**2. `skill-platform-traces-feedback-list-filters` (0.31, 1/3) — a doc framing gap.** Plain `uip traces feedback list` already supports every flag the grading needs (`--negative`, `--agent-id`, `--agent-version`, `--limit`, `--offset` — confirmed against `packages/traces-tool/src/commands/feedback/list.ts` in `UiPath/cli`). But for a cross-trace, paginated, filtered read the agent reached for `list detailed`, and the criteria explicitly require plain `list` (negative lookahead disallowing `list detailed`), so both the filter and pagination checks scored zero.

The `## list detailed` section was the only place in the skill docs using the phrase *"designed for cross-trace bulk review"*, and the task prompt says "across all traces" — a lexical pull toward the wrong subcommand. Plain `list` is equally capable of a cross-trace read (just omit `--trace-id`), but nothing in the docs said so.

## Summary

**Fix 1 — `traces_feedback_comment_file_smoke.yaml`.** Split the failing 4th criterion into two `min_count: 1` criteria scoped per trace-id, so a single bundled Bash call registers a match for each. Total weight unchanged (2.0 → 1.0 + 1.0). Criteria 1-3 untouched.

**Fix 2 — `idempotent_reconfigure.yaml`.** Same bug, in the exact sibling task that was missed when `reconfigure_different_connection.yaml` was fixed. Dropped `min_count: 2` → `1` on the `node configure` criterion (and renamed its description from "at least twice" to "at least once", since that's now the literal check). The real "twice, idempotently" guarantee already lives in the `check_bindings.py` snapshot-diff checks below it — `count_equal` / `same_connection_id` / `no_empty_stubs` across `after_first_configure.flow` and `after_second_configure.flow` cannot be satisfied by a single configure.

**Fix 3 — documented the convention.** `tests/README.md`: corrected the misleading `# minimum times the command must appear` comment and added a paragraph explaining the real semantics. `.claude/commands/lint-task.md`: added a "Penalize" bullet so the linter flags this shape going forward.

**Fix 4 — audited the rest of the tree** (see below).

**Fix 5 — doc-only wording** in `references/traces/feedback.md` and `references/uip-commands.md`. No task YAML touched — the `list-filters` grading criteria are correct and achievable as written, verified against the real CLI.

## Fix 4 — audit scope: what changed, what didn't

Swept all of `tests/tasks/` for `command_executed` criteria with `min_count >= 2`: **24 criteria across 23 files**. Each was read together with its task's `initial_prompt` and full `success_criteria` list. Deliberately kept this a partial, reviewable audit rather than a 23-file rewrite.

**Changed (5 files)** — each had either a literal per-item scoping key from the prompt, or an existing structural check proving multiplicity. Total criterion weight is unchanged in every file:

| File | Change |
|---|---|
| `uipath-insights/smoke_absolute_time_range.yaml` | Split per subcommand (`summary`, `completed-timeline`). Also **tighter**: the old `(summary\|completed-timeline)` alternation with `min_count: 2` was satisfied by running `summary` twice, contradicting its own description. |
| `uipath-test/customfield_population_integration.yaml` | Split per field name (`Eval Reviewer`/Text, `Eval Risk`/Label). Also **tighter**: lookaheads now anchor after the `create` verb and use the repo's batch-safe `(?:[^&;\|\n]\|\\\n)*` class, so each criterion is pinned to one command — this verifies the name↔data-type pairing, which the old `(Text\|Label)` alternation never checked. |
| `uipath-tasks/smoke_completion.yaml` | Split both universal criteria per task id (`3000001`/`3000002`/`3000003`). Also **tighter**: the batch-safe class replaces `.*`, so each check confirms the flag landed on *that* task rather than anywhere in the call. |
| `uipath-api-workflow/operate/run_execute/run_execute.yaml` | Split per input (`"score":85` / `"score":40`). Kept as two criteria rather than dropping to one on purpose: the prompt states the `score >= 60` rule, so the `run_85`/`run_40` file checks alone could be satisfied by one real run plus one hand-written file. The split preserves that anti-fabrication guard. |
| `uipath-solution/project_remove_integration.yaml` | `min_count: 2` → `1`. The file's own inline comment already argued for this: registration is outcome-checked by the `json_check` on `length(Projects) == 1` plus the successful `projects remove`, which refuses to drop the last project — ending at 1 proves it started at 2. |

**Audited, left as-is (14 criteria)** — with reasons, so these are visible decisions rather than silent gaps:

- **`uipath-api-workflow/connector/testmanager_*` (7 tasks: attachments, crud_grounded, execution_results, generic_records, requirement_lifecycle, testcase_lifecycle, testset_lifecycle)**: `registry stub` takes a runtime-discovered activity-type GUID, not a literal name from the prompt, so there is no key to scope on; the only artifact check greps for the connector key rather than counting activities. All 7 are currently `skip: true`, so there is no live impact. *The right fix is a new `run_command` checker counting distinct `UiPathActivityTypeId` values in the produced `Workflow.json` — out of scope here.*
- **`uipath-review/review_multi_project_solution.yaml`**: splitting on `ProjectA`/`ProjectB` looked safe, but an agent that does `cd MySolution/ProjectA && uip rpa validate ...` puts the key *before* the command anchor and would newly false-fail. Not worth trading one false negative for another.
- **`uipath-insights/{envelope-contract/all_commands_envelope_e2e, job-health/job_health_investigation_e2e, smoke_job_health_investigation}.yaml`**: the three advisory `--output json` criteria. All have `pass_threshold: 0` per `.claude/rules/test-writing.md` ("never gate on `--output json`"), so the batching cap costs fractional weighted score but cannot fail the task. Deferred to keep this diff reviewable.
- **`uipath-coded-apps/integration_action_schema_validate_fix.yaml`** and **`uipath-maestro-case/diagnose/fix_broken_caseplan/fix_broken_caseplan.yaml`**: inherent validate → read-errors → fix → re-validate loops. The second invocation depends on reading the first's output, so the calls cannot collapse into one Bash event — batching is implausible, low risk.
- **`uipath-maestro-flow/connector_features/paginated_reference_lookup.yaml`**: the second `resources run list` needs the `nextPage` token printed by the first, so the two fetches are inherently separate events.
- **`uipath-platform/data-fabric/integration_entity_scope.yaml`**: `--folder-key` carries runtime-discovered GUIDs and folder B is only described as "one other visible folder" — no literal key exists.
- **`uipath-platform/data-fabric/integration_error_paths.yaml`**: the second probe targets an agent-invented nonexistent record id; the only sibling coverage is an `llm_judge`, not a structural check.
- **`uipath-admin/group_membership_management_e2e.yaml`**: both `groups members list` calls target the same group with identical arguments — no distinct key, and no artifact criterion proves the post-revoke listing happened. Genuine residual risk; the real remedy is a new membership check, not a criterion split.
- **`uipath-solution/operate/pack_determinism_integration.yaml`**: `check_pack_determinism.py` normalizes all GUIDs away, so it cannot distinguish two real packs from one package copied twice. Here `min_count: 2` *is* the anti-copy guard. *Worth a separate follow-up: assert the two zips' raw `packageVersionKey` GUIDs differ before normalization, which would make this a clean drop.*

## Tests performed

All grading claims below come from a **faithful re-implementation of the real checker**, not an approximation. I read `coder_eval/criteria/command_executed.py` from the installed package and mirrored `_matching_commands` + the scoring branch exactly, including the two details that change results: patterns compile with **`re.DOTALL`** (lines 141/202) and input is truncated to `_MAX_PATTERN_SEARCH_LEN = 2000`. The source also confirms the root cause verbatim — line 104 does one `pattern.search(cmd_text)` **per `CommandTelemetry` entry**, and line 241 scores `min(1.0, match_count / min_count)`.

- **Fix 1, end-to-end score.** Replayed the verbatim historical bundled command from the failing run as a single `CommandTelemetry.parameters["command"]` value. All 5 `command_executed` criteria now score 1.0, giving a **weighted task score of 1.000 — up from the 0.88 observed on the evalboard**. That reproduces the exact reported failure and shows this diff resolves it.
- **Negative cases.** The split does not weaken the test: inline `--comment` on both records → both criteria 0.0; only trace 1 filed → trace 2 criterion 0.0. Per-trace scoping also works for the two-separate-calls shape, not just the bundled one. Confirmed `--comment[\s=]` does **not** trip on `--comment-file` (followed by `-`, not whitespace/`=`) but **does** catch a genuine inline `--comment`.
- **Fix 4 behavior suite.** Every split was exercised against batched calls, separate calls, and backslash-continuation multi-line calls, plus a deliberately-wrong variant per file: customfield with swapped data-types → both 0.0; `smoke_completion` with `3000003` missing `--folder-id` → that criterion 0.0, others unaffected; `run_execute` with only the score-85 run → score-40 criterion 0.0. This caught a real defect mid-review: my first customfield patterns kept the file's existing unanchored `(?=.*...)` style, which passed the swapped-data-type case; re-anchoring after the verb with the batch-safe class fixed it.
- **Answering the review question on `exclude_pattern` and bundled calls.** Confirmed against source (line 108): `exclude_re.search(cmd_text)` is applied to the **whole tool-call text**, per call — so if an agent used `--comment-file` for one trace and inline `--comment` for the other *in a single Bash call*, both per-trace criteria score 0. Verified empirically. That is the conservative-correct outcome, since such a call violates mutual-exclusion rule 2.
- **Weight conservation.** Diffed total `success_criteria` weight per touched file against `origin/main`: unchanged in all 7 task files (8.5, 12.0, 8.0, 9.5, 6.0, 6.0, 11.0).
- **YAML + regex validity.** All 1182 task YAML files parse; every `command_pattern` in the tree compiles.
- **Repo tooling.** `scripts/check-cli-verbs.py` on the touched files: **0 High, 0 Medium**, 8 Info (all pre-existing "pattern too dynamic to verify" notes). `scripts/check-task-driver.py`: clean.

**Not claimed:** no live `coder-eval` re-run — no tenant creds in this sandbox, so I am not asserting a passing run. The advisory task-lint asks for one; I'd rather leave that box unchecked than claim a run I didn't perform. What the evidence above does establish is narrower but exact: replaying the real failing input through a faithful copy of the real checker takes the task from 0.88 to 1.000. Fixes 1, 2 and 4 are pure regex/config changes with no runtime behavior, so this reproduces the grading arithmetic that produced the original failure. Worth confirming on the next scheduled evalboard run.

**Fix 5 is a documentation-only nudge, not a deterministic guarantee.** Its outcome depends on stochastic model choice, so it cannot be verified by re-running the task, and I'm not claiming a re-run proved it. What was verified: the new wording is factually accurate against the CLI source (`--trace-id` really is optional on `list`), it doesn't contradict anything else in `feedback.md` or `uip-commands.md`, and both markdown tables still render.

## Test plan

- [x] All 1182 task YAML files parse; every `command_pattern` compiles
- [x] `scripts/check-cli-verbs.py` on touched files — 0 High, 0 Medium
- [x] `scripts/check-task-driver.py` — clean
- [x] Total criterion weight unchanged per touched file vs `origin/main`
- [x] Historical failing input replayed through a faithful copy of the real checker (incl. `re.DOTALL`) — task scores 1.000, up from 0.88
- [x] Negative cases still fail; Fix 4 splits verified on batched / separate / continuation calls + a wrong variant each
- [ ] Live `coder-eval` re-run of both traces tasks (needs tenant creds — worth confirming on the next scheduled evalboard run)

**Advisory lint findings, both acknowledged and intentionally not actioned:**
1. *"Evidence of passing run"* — see **Not claimed** above. I won't add a passing-run claim for a run I couldn't perform.
2. *Medium: prompt over-specification in `smoke_completion.yaml`* — the lint marks this **pre-existing**, and this PR does not touch that prompt (only the criteria structure). Rewriting the prompt would change what the task tests, which is outside this PR's scope; worth a separate change if the team agrees.

Out of scope: `skill-platform-traces-diagnose-faulted-job`, a separate fixture-provisioning problem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
