### PR TITLE
fix(maestro-case): flush the issue log per section instead of once at the end

### DIFF
--- a/skills/uipath-maestro-case/SKILL.md
+++ b/skills/uipath-maestro-case/SKILL.md
@@ -148,7 +148,7 @@ No hard stop on Phase 3 exit — proceed directly to Phase 4.
 
 1. Run Step 12 once at the Phase 3 → Phase 4 boundary. It performs Checks 1–12, including bindings sidecar parity (Check 7), global output-ID uniqueness (Check 8), resolved-resource emission/preservation (Check 9), formal-arg slot ID format (Check 10), resourceKey self-consistency (Check 11), and connector node resolution completeness (Check 12).
 2. After all Step 12 checks pass, run full `uip maestro case validate`. Retry up to 3×; on 3rd failure **HARD STOP** AskUserQuestion: `Retry with fix` / `Pause for manual edit` / `Abort`
-3. Dump `build-issues.md` (Step 12.1)
+3. Summarize `build-issues.md` (Step 12.1) — the journal has been on disk since the first Phase 2 section boundary; this step fills the grouped summary from it
 
 ### Phase 5 — Publish
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -57,7 +57,7 @@ Before any build step, initialize an empty issue buffer **in the agent's reasoni
 issues = []
 ```
 
-> **Why incremental.** A list held in reasoning for the whole build is lost to context pressure before it is ever written, and no Step 12 check reads the log. Measured on two independent runs of the same task: `claude-sonnet-5` (52.4 min, 39 placeholder tasks, 120 `<UNRESOLVED>` markers) and `gpt-5.6-terra` (7.2 min, 23 placeholder tasks, 0 markers) — **neither wrote `build-issues.md` at all**, and both looked like builds a reviewer would accept. Flushing per section bounds worst-case loss to one section and rides the validate seam that already exists there.
+> **Why incremental.** A whole-build buffer held in reasoning is lost to context pressure before it is ever written, and no Step 12 check reads the log. Flushing per section bounds worst-case loss to one section and rides the validate seam already at that boundary.
 
 ---
 

--- a/skills/uipath-maestro-case/references/implementation.md
+++ b/skills/uipath-maestro-case/references/implementation.md
@@ -23,6 +23,7 @@ Every plugin uses direct JSON writes via its `impl-json.md`. Cross-cutting mecha
    - **<10 T-entries** — N Edits in sequence, one per T-entry. Skip the re-Read between sibling Edits.
    - **≥10 T-entries** — single whole-section Edit or Write replacing the section's container (e.g., `schema.nodes`, a stage's `data.tasks`). Compose the complete post-section state in reasoning from the section-entry Read, then emit one write. Untouched siblings (other sections, root fields, unrelated nodes) MUST be copied verbatim — drop nothing.
 3. **One validate** at section boundary.
+4. **One issue-log flush** at the same boundary — append the section's buffered issues to `tasks/build-issues.md` per [`plugins/logging/impl-json.md` § Flush](plugins/logging/impl-json.md), then clear the buffer. The first flush creates the file; later flushes append to its Journal table. **Flush even when the section produced zero issues** — after the first section the file must exist, and its existence is what proves the log survived the build.
 
 TaskUpdate items keyed by T-number are the audit trail — mark each `in_progress` before composing the entry's mutation, `completed` after the write returns success. The audit trail stays T-by-T even when the file diff collapses to one whole-section write.
 
@@ -49,12 +50,14 @@ Full contract — recovery, tool primitive selection (Edit default, whole-sectio
 
 ## Issue Log — Initialize Before Step 6
 
-Before any build step, initialize an empty issue list **in the agent's reasoning** (not as a file, not via subprocess). All plugins append to this shared list during execution. Dump to `tasks/build-issues.md` via the Write tool after Step 12. See [`plugins/logging/impl-json.md`](plugins/logging/impl-json.md) for the entry format, severity levels, and file schema.
+Before any build step, initialize an empty issue buffer **in the agent's reasoning** (not as a file, not via subprocess). All plugins append to it during the current section, and **the buffer is flushed to `tasks/build-issues.md` at every section boundary, then cleared** — it is NOT a whole-build accumulator. See [`plugins/logging/impl-json.md`](plugins/logging/impl-json.md) for the entry format, severity levels, flush mechanics, and file schema.
 
 ```text
-# pseudocode — kept in the agent's reasoning, not on disk
-issues = []  # shared across all steps
+# pseudocode — per-section buffer, flushed at each section boundary
+issues = []
 ```
+
+> **Why incremental.** A list held in reasoning for the whole build is lost to context pressure before it is ever written, and no Step 12 check reads the log. Measured on two independent runs of the same task: `claude-sonnet-5` (52.4 min, 39 placeholder tasks, 120 `<UNRESOLVED>` markers) and `gpt-5.6-terra` (7.2 min, 23 placeholder tasks, 0 markers) — **neither wrote `build-issues.md` at all**, and both looked like builds a reviewer would accept. Flushing per section bounds worst-case loss to one section and rides the validate seam that already exists there.
 
 ---
 
@@ -324,9 +327,13 @@ Authoritative validation. Full contract — command, retry policy, AskUserQuesti
 
 Run validate per [phased-execution.md § Phase 4](phased-execution.md#phase-4--validate). On success: proceed to Step 12.1. On 3rd failure: hard-stop prompt per the same section.
 
-## Step 12.1 — Dump issue log
+## Step 12.1 — Summarize the issue log
 
-Write issue list to `tasks/build-issues.md` per [`plugins/logging/impl-json.md`](plugins/logging/impl-json.md). On Phase 4 success → proceed to Phase 5.
+The journal has been on disk since the first section boundary; this step does **not** create it. Flush any buffered issues from the final section, then read the journal back and write the grouped counts into the summary block per [`plugins/logging/impl-json.md` § Summary](plugins/logging/impl-json.md). Counts come from the file, not from reasoning — that is the point of flushing incrementally.
+
+If `tasks/build-issues.md` is absent here, the incremental flush was skipped: reconstruct from on-disk artifacts and stamp the `NOTE:` line per [§ Recovery](plugins/logging/impl-json.md). A build carrying `<UNRESOLVED>` markers or placeholder tasks must not reach Phase 5 with no log.
+
+On Phase 4 success → proceed to Phase 5.
 
 ---
 

--- a/skills/uipath-maestro-case/references/phased-execution.md
+++ b/skills/uipath-maestro-case/references/phased-execution.md
@@ -32,7 +32,7 @@ Decisions are front-loaded so the build can run unattended; the gates that remai
 |---|---|---|---|
 | **2 — Prototyping** | Solution/project, structure, triggers, task shapes, conditions in all 4 scopes, SLA + escalation; connector-bound rules use canonical stubs | `caseplan.json` emitted; `--skeleton-v2` preview validate attempted, with unsupported-flag fallback to `--skeleton` | Pause-at-preview runs: `Publish for review` / `Skip publish and continue` / `Abort`. Straight-through runs: none — counts line, continue (Rule 11) |
 | **3 — Implementation** | Connector task schemas, task I/O value binding, resolved connector-rule stub upgrades | `caseplan.json` ready for authoritative validation | None — proceeds to Phase 4 |
-| **4 — Validate** | Run authoritative `uip maestro case validate`, dump `build-issues.md` | `caseplan.json` passes full validation | On 3rd validate failure: `Retry with fix` / `Pause for manual edit` / `Abort` |
+| **4 — Validate** | Run authoritative `uip maestro case validate`, summarize `build-issues.md` (journal already on disk) | `caseplan.json` passes full validation | On 3rd validate failure: `Retry with fix` / `Pause for manual edit` / `Abort` |
 | **5 — Publish** | Optional Studio Web upload | `DesignerUrl` printed | `Publish to Studio Web` / `Skip to Debug` |
 | **6 — Debug** | Optional CLI debug run (real execution — emails, API calls, etc.) | Debug output streamed | `Run debug session` / `Continue to publish` |
 | **7 — Publish to Orchestrator** | Optional `solution pack` + `solution publish` to the tenant solution feed | `.zip` packed; publish result printed | `Publish to Orchestrator` / `Done` |
@@ -197,9 +197,11 @@ Up to **3 validation retries** per session — each retry MUST be preceded by a 
 - `Pause for manual edit` — exit skill mid-flight; user edits `caseplan.json` directly and re-runs skill.
 - `Abort` — exit; dump `build-issues.md`; leave artifacts in place.
 
-### Dump issue log
+### Summarize the issue log
 
-After successful validate, write issue list to `tasks/build-issues.md` per [`plugins/logging/impl-json.md`](plugins/logging/impl-json.md), grouped by plugin with summary index. Source of truth for completion report. Write even if zero issues logged (confirms clean build).
+`tasks/build-issues.md` already exists — it is flushed at every section boundary from Phase 2 onward per [`plugins/logging/impl-json.md` § Flush](plugins/logging/impl-json.md). After successful validate, flush the final section's buffer, then read the journal back and fill the grouped summary block. Source of truth for the completion report; the counts come from the file, not from reasoning.
+
+If the file is absent here the incremental flush was skipped — reconstruct from on-disk artifacts and stamp the `NOTE:` line per [§ Recovery](plugins/logging/impl-json.md).
 
 On Phase 4 success → proceed to Phase 5.
 

--- a/skills/uipath-maestro-case/references/phased-execution.md
+++ b/skills/uipath-maestro-case/references/phased-execution.md
@@ -135,7 +135,7 @@ Proceed directly to Phase 3.
 
 #### On `Abort`
 
-1. Dump in-memory issue list to `tasks/build-issues.md` per [`plugins/logging/impl-json.md`](plugins/logging/impl-json.md).
+1. **Append** the current section's buffered issues to the existing `tasks/build-issues.md` journal, then fill the summary block, per [`plugins/logging/impl-json.md` § Flush](plugins/logging/impl-json.md). **Never whole-file dump here** — the journal already holds rows from every completed section and the per-section buffer has been cleared, so replacing the file would destroy that history. If the file does not exist (abort before the first section boundary), create it per § Flush.
 2. Print paths of `caseplan.json`, `tasks.md`, `registry-resolved.json`, and solution directory.
 3. Print `Suggested next steps: inspect tasks/build-issues.md and the generated artifacts, then rerun after editing the design or plan.`
 4. Exit skill.
@@ -181,7 +181,7 @@ End of detail mutations. Run full-mode validate (omit `--skeleton`; defaults to 
 uip maestro case validate "<caseplan.json path>" --output json
 ```
 
-On success: `{ Result: "Success", Code: "CaseValidate", Data: { File, Status: "Valid" } }` — proceed to Phase 4 dump step.
+On success: `{ Result: "Success", Code: "CaseValidate", Data: { File, Status: "Valid" } }` — proceed to the Phase 4 issue-log summary step.
 
 On failure: output lists `[error]` and `[warning]` entries with path and message. Fix reported issues (usually via targeted re-run of earlier step) and re-run `validate`.
 
@@ -195,7 +195,7 @@ Up to **3 validation retries** per session — each retry MUST be preceded by a 
 
 - `Retry with fix` — agent attempts fix, re-runs validate (counter does not reset).
 - `Pause for manual edit` — exit skill mid-flight; user edits `caseplan.json` directly and re-runs skill.
-- `Abort` — exit; dump `build-issues.md`; leave artifacts in place.
+- `Abort` — exit; append the current buffer to the `build-issues.md` journal and summarize (never replace it); leave artifacts in place.
 
 ### Summarize the issue log
 
@@ -319,7 +319,7 @@ Abort can occur at any hard stop:
 
 All follow same cleanup:
 
-1. Dump `build-issues.md`.
+1. Append the current buffer to the `build-issues.md` journal and fill the summary — append-only, never a whole-file replace.
 2. Print paths.
 3. Exit.
 

--- a/skills/uipath-maestro-case/references/plugins/logging/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/logging/impl-json.md
@@ -6,20 +6,7 @@ Unified issue log for the implementation phase. Initialized by `implementation.m
 
 > **Pseudocode only.** The snippets below are data-shape specifications, not runnable code. The agent accumulates issues in its own reasoning *within a section* and emits `tasks/build-issues.md` with the Write/Edit tools at each flush. Do NOT create a `.py` script or shell out to Python — per [`case-editing-operations.md § Tool usage`](../../case-editing-operations.md#tool-usage--mandatory), Read/Write/Edit are the only I/O primitives.
 
-## Why the log is incremental
-
-An issue list held in reasoning for the whole build is lost to context pressure before it is ever written, and nothing downstream notices — Step 12's checks read `caseplan.json` and its sidecars, never the log.
-
-Measured, two independent runs of the same task on different models:
-
-| Run | `<UNRESOLVED>` in `tasks.md` | Placeholder tasks | `build-issues.md` |
-|---|---|---|---|
-| `claude-sonnet-5`, 52.4 min | 120 | 39 | **never written** |
-| `gpt-5.6-terra` (codex), 7.2 min | 0 | 23 | **never written** |
-
-Both scored as builds a reviewer would accept. In the second, 23 placeholder tasks were recorded *nowhere* — not even as markers in `tasks.md`. The operator receives unwired resources with no record of which ones.
-
-**Flush grain is the section boundary, not the issue.** Per-issue writes would cost one Edit per finding and fight the [per-section batch write contract](../../case-editing-operations.md#per-section-batch-write-contract--canonical); per-build writes are the defect above. A section boundary already carries a validate, so the flush rides an existing seam and bounds worst-case loss to one section.
+**Flush grain: the section boundary.** Not per issue (one Edit per finding, fights the [per-section batch write contract](../../case-editing-operations.md#per-section-batch-write-contract--canonical)); not per build (a whole-build buffer is lost to context pressure before it is written, and no Step 12 check reads the log). A section boundary already carries a validate, so the flush rides an existing seam and bounds loss to one section.
 
 ## Setup — Step 6 entry
 

--- a/skills/uipath-maestro-case/references/plugins/logging/impl-json.md
+++ b/skills/uipath-maestro-case/references/plugins/logging/impl-json.md
@@ -1,17 +1,32 @@
 # Logging — Implementation
 
-Unified issue log for the implementation phase. Initialized by `implementation.md`, written to by any plugin, dumped to markdown after build.
+Unified issue log for the implementation phase. Initialized by `implementation.md`, written to by any plugin, **flushed to disk at every section boundary**, and summarized after build.
 
 > **No `planning.md`** — logging is an implementation-only utility (not a planned node type), so it has no planning doc. Intentional, not a gap.
 
-> **Pseudocode only.** The snippets below are data-shape specifications, not runnable code. The agent holds the issue list in its own reasoning during a run and emits `tasks/build-issues.md` with the Write tool at dump time. Do NOT create a `.py` script or shell out to Python — per [`case-editing-operations.md § Tool usage`](../../case-editing-operations.md#tool-usage--mandatory), Read/Write/Edit are the only I/O primitives.
+> **Pseudocode only.** The snippets below are data-shape specifications, not runnable code. The agent accumulates issues in its own reasoning *within a section* and emits `tasks/build-issues.md` with the Write/Edit tools at each flush. Do NOT create a `.py` script or shell out to Python — per [`case-editing-operations.md § Tool usage`](../../case-editing-operations.md#tool-usage--mandatory), Read/Write/Edit are the only I/O primitives.
 
-## Setup
+## Why the log is incremental
 
-Initialize the in-reasoning issue list before Step 6:
+An issue list held in reasoning for the whole build is lost to context pressure before it is ever written, and nothing downstream notices — Step 12's checks read `caseplan.json` and its sidecars, never the log.
+
+Measured, two independent runs of the same task on different models:
+
+| Run | `<UNRESOLVED>` in `tasks.md` | Placeholder tasks | `build-issues.md` |
+|---|---|---|---|
+| `claude-sonnet-5`, 52.4 min | 120 | 39 | **never written** |
+| `gpt-5.6-terra` (codex), 7.2 min | 0 | 23 | **never written** |
+
+Both scored as builds a reviewer would accept. In the second, 23 placeholder tasks were recorded *nowhere* — not even as markers in `tasks.md`. The operator receives unwired resources with no record of which ones.
+
+**Flush grain is the section boundary, not the issue.** Per-issue writes would cost one Edit per finding and fight the [per-section batch write contract](../../case-editing-operations.md#per-section-batch-write-contract--canonical); per-build writes are the defect above. A section boundary already carries a validate, so the flush rides an existing seam and bounds worst-case loss to one section.
+
+## Setup — Step 6 entry
+
+Accumulate issues in reasoning *within the current section only*:
 
 ```text
-issues = []   # pseudocode — kept in the agent's reasoning, not on disk
+issues = []   # pseudocode — per-section buffer, NOT a whole-build accumulator
 ```
 
 ## Entry Format
@@ -20,7 +35,7 @@ issues = []   # pseudocode — kept in the agent's reasoning, not on disk
 issues.append({                 # pseudocode — not executed
     "severity": "ERROR",        # "ERROR" | "WARNING" | "SKIPPED"
     "step": "9",                # implementation step number
-    "plugin": "io-binding",     # plugin name — used for grouping in the output file
+    "plugin": "io-binding",     # plugin name — used for grouping in the summary
     "message": "human-readable description"
 })
 ```
@@ -31,49 +46,65 @@ issues.append({                 # pseudocode — not executed
 | `WARNING` | Possible problem — operation proceeded | May cause runtime issues |
 | `SKIPPED` | Intentionally deferred — placeholder/unresolved | User must complete manually |
 
-## Dump
+## Flush — at every section boundary (MANDATORY)
 
-After Step 12 (validate), group issues by `plugin` and write to `tasks/build-issues.md`:
+Flush alongside the section's validate, then clear the buffer. Sections are the ones named in [`implementation.md` § Per-section batched writes](../../implementation.md): Phase 2 §4.2.1 vars, §4.3 triggers, §4.4 stages, §4.6 task shapes, §4.8 SLA, §4.7 conditions; Phase 3 §9.7 connector schema, §9.8 I/O binding, §10.5 connector-rule upgrades.
+
+**Flush even when the section produced zero issues** — the file's existence after the first section is what proves the log survived.
+
+### First flush — create the file (Write)
 
 ```markdown
 # Build Issues — <CaseName>
 
-**Case file:** caseplan.json | **Timestamp:** <ISO>
+**Case file:** caseplan.json | **Build started:** <ISO>
 
+<!--build-issues:summary:start-->
+_Summary written at Step 12.1._
+<!--build-issues:summary:end-->
+
+## Journal
+
+Appended at each section boundary as the build proceeds. Chronological, not grouped —
+grouping happens in the summary above at Step 12.1.
+
+| Sev | Step | Plugin | Message |
+|---|---|---|---|
+| SKIPPED | 9 | connector-activity | Task "Confirm Payment Settlement" — connector unresolved, placeholder emitted |
+```
+
+### Later flushes — append rows (Edit)
+
+One `Edit` per section, appending the section's rows to the end of the Journal table. Never rewrite earlier rows — the journal is append-only, so a later context loss cannot erase what an earlier section recorded.
+
+A section with no issues appends nothing; the file already exists, which is the signal that matters.
+
+## Summary — Step 12.1
+
+Read the journal back, group by `plugin`, and replace **only** the block between
+`<!--build-issues:summary:start-->` and `<!--build-issues:summary:end-->`:
+
+```markdown
 | Category | Errors | Warnings | Skipped |
 |---|---|---|---|
 | [io-binding](#io-binding) | 3 | 1 | 2 |
 | [global-vars](#global-vars) | 1 | 0 | 0 |
 | **Total** | **4** | **1** | **2** |
-
----
-
-## io-binding
-
-### Errors
-
-| Step | Issue |
-|---|---|
-| 9 | Input `amount` not found on task "Validate Expense Data" |
-
-### Skipped
-
-| Step | Task | Reason |
-|---|---|---|
-| 9 | Run Compliance Check | No inputs — placeholder task |
-
-## global-vars
-
-### Errors
-
-| Step | Issue |
-|---|---|
-| 6 | Variable `caseStatus` declared twice |
 ```
 
-- Omit severity subsections with zero entries
-- Plugins with zero issues: write `No issues.` under the heading
-- Write the file even if zero total issues — confirms a clean build
-- The completion report (Step 13) reads this file directly
+- Group counts come from the journal on disk, **not** from reasoning — that is the point of the journal.
+- Omit severity subsections with zero entries; plugins with zero issues need no heading.
+- Leave the Journal section intact. It is the audit trail; the summary is a view over it.
+- The completion report (Step 13) reads this file directly.
+
+## Recovery — journal missing at Step 12.1
+
+If `tasks/build-issues.md` does not exist when Step 12.1 runs, the incremental flush was skipped. Reconstruct what the artifacts prove — `<UNRESOLVED>` markers in `tasks.md`, placeholder tasks (`data: {}`) in `caseplan.json`, `selected: null` entries in `tasks/registry-resolved.json`, and any surviving connector stub — and stamp the file:
+
+```
+NOTE: reconstructed at Step 12.1 from on-disk artifacts — the incremental journal was not written. Severity and step attribution are approximate.
+```
+
+A reconstructed log records what the artifacts prove, not what the build observed. It is a fallback, not the contract.
 
 <!-- END: impl-json.md -->

--- a/tests/tasks/uipath-maestro-case/_shared/check_issue_journal.py
+++ b/tests/tasks/uipath-maestro-case/_shared/check_issue_journal.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Grade the incremental issue journal — `tasks/build-issues.md`.
+
+Regression guarded
+------------------
+The issue log used to be accumulated in the agent's reasoning for the whole
+build and written once at Step 12.1. On a long build that list is lost to
+context pressure before it is ever written, and no Step 12 check reads the log.
+
+Measured on two independent runs of the same task, different models, both of
+which produced a caseplan a reviewer would accept:
+
+    claude-sonnet-5   52.4 min   39 placeholder tasks   120 <UNRESOLVED>   NO log
+    gpt-5.6-terra      7.2 min   23 placeholder tasks     0 <UNRESOLVED>   NO log
+
+The fix flushes the buffer at every section boundary, so the journal is on disk
+from the first section onward. This checker verifies the *incremental* contract,
+not merely that some file exists:
+
+  1. When the build carries unresolved work, build-issues.md must exist.
+  2. It must carry the `## Journal` section — the append-only audit trail.
+  3. The Step 12.1 summary block must be filled, not left at its placeholder.
+  4. The journal must carry >= 1 row when there is unresolved work to record.
+
+A reconstructed log (stamped with the NOTE: line) passes 1-3 but is reported,
+because it records what the artifacts prove rather than what the build observed.
+
+Exit 0 = pass, 1 = fail. Run from the sandbox root.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+SKIP = {".venv", "node_modules", ".npm-prefix", "dist"}
+
+SUMMARY_START = "<!--build-issues:summary:start-->"
+SUMMARY_END = "<!--build-issues:summary:end-->"
+PLACEHOLDER_SUMMARY = "_Summary written at Step 12.1._"
+RECONSTRUCTED = "reconstructed at Step 12.1"
+
+
+def find_one(root: Path, name: str) -> Path | None:
+    for p in root.rglob(name):
+        if SKIP.isdisjoint(p.parts):
+            return p
+    return None
+
+
+def carries_unresolved(root: Path) -> tuple[bool, str]:
+    """Does this build have anything the operator must be told about?"""
+    reasons = []
+
+    tasks_md = find_one(root, "tasks.md")
+    if tasks_md is not None:
+        try:
+            n = len(re.findall(r"<UNRESOLVED", tasks_md.read_text()))
+            if n:
+                reasons.append(f"{n} <UNRESOLVED> marker(s)")
+        except OSError:
+            pass
+
+    caseplan = find_one(root, "caseplan.json")
+    if caseplan is not None:
+        try:
+            case = json.loads(caseplan.read_text())
+        except (OSError, json.JSONDecodeError):
+            case = None
+        if case:
+            ph = 0
+            for node in case.get("nodes") or []:
+                if node.get("type") != "case-management:Stage":
+                    continue
+                for lane in (node.get("data") or {}).get("tasks") or []:
+                    for task in lane:
+                        if not (task.get("data") or {}):
+                            ph += 1
+            if ph:
+                reasons.append(f"{ph} placeholder task(s)")
+
+    return bool(reasons), ", ".join(reasons)
+
+
+def journal_rows(text: str) -> int:
+    """Count data rows in the ## Journal table."""
+    m = re.search(r"^##\s+Journal\s*$", text, re.MULTILINE)
+    if not m:
+        return -1  # section absent
+    body = text[m.end():]
+    nxt = re.search(r"^##\s+", body, re.MULTILINE)
+    if nxt:
+        body = body[: nxt.start()]
+    rows = 0
+    for raw in body.splitlines():
+        line = raw.strip()
+        if not line.startswith("|"):
+            continue
+        if set(line) <= set("|-: "):
+            continue
+        cells = [c.strip().lower() for c in line.strip("|").split("|")]
+        if cells[:1] == ["sev"] or (cells and cells[0] in {"sev", "severity"}):
+            continue
+        rows += 1
+    return rows
+
+
+def main() -> int:
+    root = Path.cwd()
+    unresolved, why = carries_unresolved(root)
+    print(f"unresolved work: {why or 'none'}")
+
+    issues = find_one(root, "build-issues.md")
+    reached_phase2 = find_one(root, "caseplan.json") is not None
+
+    if issues is None:
+        if not reached_phase2:
+            print("\nPASS: build never reached Phase 2 — no journal expected.")
+            return 0
+        detail = f" ({why})" if unresolved else " (no unresolved work, but the flush is unconditional)"
+        print(
+            f"\nFAIL: the build reached Phase 2 but there is NO tasks/build-issues.md{detail}.\n"
+            "  The journal is flushed at EVERY section boundary — including sections that\n"
+            "  produced zero issues — so the file must exist from the first Phase 2 section\n"
+            "  onward, long before Step 12.1. Its absence means the flush never happened.\n"
+            "  See plugins/logging/impl-json.md § Flush."
+        )
+        return 1
+
+    rel = issues.relative_to(root)
+    try:
+        text = issues.read_text()
+    except OSError as exc:
+        print(f"\nFAIL: {rel} unreadable: {exc}")
+        return 1
+
+    rows = journal_rows(text)
+    if rows < 0:
+        print(
+            f"\nFAIL: {rel} has no '## Journal' section.\n"
+            "  The incremental contract requires an append-only journal written at each\n"
+            "  section boundary; a single end-of-build dump does not satisfy it."
+        )
+        return 1
+
+    if rows == 0 and unresolved:
+        print(
+            f"\nFAIL: {rel} has a Journal section but no rows, while the build carries\n"
+            f"  unresolved work ({why}). Every placeholder or unresolved marker is a\n"
+            "  SKIPPED entry the operator needs."
+        )
+        return 1
+
+    if SUMMARY_START in text:
+        block = text.split(SUMMARY_START, 1)[1].split(SUMMARY_END, 1)[0]
+        if PLACEHOLDER_SUMMARY in block or not block.strip():
+            print(
+                f"\nFAIL: {rel} still carries the placeholder summary — Step 12.1 did not\n"
+                "  fill it from the journal."
+            )
+            return 1
+
+    print(f"\njournal rows: {rows}")
+    if RECONSTRUCTED in text:
+        print(
+            f"PASS (degraded): {rel} is a RECONSTRUCTED log — the incremental flush was\n"
+            "  skipped and the log was rebuilt from artifacts at Step 12.1. Severity and\n"
+            "  step attribution are approximate."
+        )
+        return 0
+
+    print(f"PASS: {rel} carries an incremental journal with {rows} row(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-case/_shared/test_check_issue_journal.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_check_issue_journal.py
@@ -1,0 +1,178 @@
+"""Unit tests for check_issue_journal.py — the incremental issue-log grader.
+
+Fixtures are minimal synthetic stubs; no tenant, no captured artifact.
+CI runs these via ``pytest tests/tasks/uipath-maestro-case/``.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHECKER = Path(__file__).with_name("check_issue_journal.py")
+
+GOOD = """# Build Issues — Stub
+
+**Case file:** caseplan.json | **Build started:** 2026-08-13T00:00:00Z
+
+<!--build-issues:summary:start-->
+| Category | Errors | Warnings | Skipped |
+|---|---|---|---|
+| **Total** | **0** | **0** | **1** |
+<!--build-issues:summary:end-->
+
+## Journal
+
+| Sev | Step | Plugin | Message |
+|---|---|---|---|
+| SKIPPED | 9 | connector-activity | Task "X" unresolved — placeholder emitted |
+"""
+
+NO_JOURNAL = """# Build Issues — Stub
+
+<!--build-issues:summary:start-->
+| Category | Errors |
+|---|---|
+| **Total** | **1** |
+<!--build-issues:summary:end-->
+
+## io-binding
+
+| Step | Issue |
+|---|---|
+| 9 | something |
+"""
+
+EMPTY_JOURNAL = GOOD.split("## Journal")[0] + """## Journal
+
+| Sev | Step | Plugin | Message |
+|---|---|---|---|
+"""
+
+PLACEHOLDER_SUMMARY = GOOD.replace(
+    "| Category | Errors | Warnings | Skipped |\n|---|---|---|---|\n| **Total** | **0** | **0** | **1** |",
+    "_Summary written at Step 12.1._",
+)
+
+RECONSTRUCTED = GOOD.replace(
+    "**Build started:**",
+    "NOTE: reconstructed at Step 12.1 from on-disk artifacts — the incremental journal was not written.\n\n**Build started:**",
+)
+
+
+def caseplan(placeholder=True):
+    task = {"id": "tA", "type": "wait-for-timer", "displayName": "Hold",
+            "data": {} if placeholder else {"serviceType": "X"}}
+    return {"id": "case-Stub000001", "version": "27.0.0", "name": "Stub", "metadata": {},
+            "nodes": [{"id": "Stage_a", "type": "case-management:Stage",
+                       "data": {"label": "S", "tasks": [[task]]}}], "edges": []}
+
+
+def run(tmp_path, *, case=None, log=None, tasks_md=None):
+    if case is not None:
+        d = tmp_path / "Sol" / "Proj"; d.mkdir(parents=True, exist_ok=True)
+        (d / "caseplan.json").write_text(json.dumps(case))
+    for name, content in (("build-issues.md", log), ("tasks.md", tasks_md)):
+        if content is not None:
+            d = tmp_path / "tasks"; d.mkdir(parents=True, exist_ok=True)
+            (d / name).write_text(content)
+    return subprocess.run([sys.executable, str(CHECKER)], cwd=tmp_path,
+                          capture_output=True, text=True)
+
+
+# --- the regression ------------------------------------------------------------------
+
+def test_unresolved_work_with_no_log_fails(tmp_path):
+    """Both measured runs: placeholders present, no build-issues.md at all."""
+    res = run(tmp_path, case=caseplan())
+    assert res.returncode == 1, res.stdout
+    assert "NO tasks/build-issues.md" in res.stdout
+
+
+def test_incremental_journal_passes(tmp_path):
+    res = run(tmp_path, case=caseplan(), log=GOOD)
+    assert res.returncode == 0, res.stdout
+    assert "incremental journal" in res.stdout
+
+
+# --- the incremental contract, not just existence ------------------------------------
+
+def test_end_of_build_dump_without_journal_fails(tmp_path):
+    """The OLD format — grouped sections, no journal — must not satisfy the new contract."""
+    res = run(tmp_path, case=caseplan(), log=NO_JOURNAL)
+    assert res.returncode == 1, res.stdout
+    assert "no '## Journal' section" in res.stdout
+
+
+def test_empty_journal_with_unresolved_work_fails(tmp_path):
+    res = run(tmp_path, case=caseplan(), log=EMPTY_JOURNAL)
+    assert res.returncode == 1, res.stdout
+    assert "no rows" in res.stdout
+
+
+def test_unfilled_summary_fails(tmp_path):
+    res = run(tmp_path, case=caseplan(), log=PLACEHOLDER_SUMMARY)
+    assert res.returncode == 1, res.stdout
+    assert "placeholder summary" in res.stdout
+
+
+# --- degraded but honest --------------------------------------------------------------
+
+def test_reconstructed_log_passes_but_is_reported(tmp_path):
+    res = run(tmp_path, case=caseplan(), log=RECONSTRUCTED)
+    assert res.returncode == 0, res.stdout
+    assert "PASS (degraded)" in res.stdout
+    assert "RECONSTRUCTED" in res.stdout
+
+
+# --- clean builds ---------------------------------------------------------------------
+
+def test_clean_build_still_requires_the_journal(tmp_path):
+    """The flush is unconditional — a zero-issue section still creates the file."""
+    res = run(tmp_path, case=caseplan(placeholder=False), tasks_md="## T01\n- id: real\n")
+    assert res.returncode == 1, res.stdout
+    assert "no unresolved work, but the flush is unconditional" in res.stdout
+
+
+def test_clean_build_with_empty_journal_passes(tmp_path):
+    """Zero issues and zero rows is fine — the file's existence is the signal."""
+    res = run(tmp_path, case=caseplan(placeholder=False),
+              tasks_md="## T01\n- id: real\n", log=EMPTY_JOURNAL)
+    assert res.returncode == 0, res.stdout
+
+
+def test_build_that_never_reached_phase2_is_exempt(tmp_path):
+    """Halted in Phase 1 — no caseplan, so no journal expected."""
+    res = run(tmp_path, tasks_md="## T01\n- id: <UNRESOLVED: process>\n")
+    assert res.returncode == 0, res.stdout
+    assert "never reached Phase 2" in res.stdout
+
+
+def test_unresolved_markers_alone_require_a_journal(tmp_path):
+    res = run(tmp_path, case=caseplan(placeholder=False),
+              tasks_md="## T01\n- id: <UNRESOLVED: process>\n")
+    assert res.returncode == 1, res.stdout
+    assert "<UNRESOLVED> marker" in res.stdout
+
+
+# --- guards ----------------------------------------------------------------------------
+
+def test_venv_copies_ignored(tmp_path):
+    """A placeholder-laden caseplan inside .venv must not drive the verdict."""
+    v = tmp_path / ".venv" / "s"; v.mkdir(parents=True)
+    (v / "caseplan.json").write_text(json.dumps(caseplan()))
+    res = run(tmp_path, case=caseplan(placeholder=False),
+              tasks_md="## T01\n- id: real\n", log=EMPTY_JOURNAL)
+    assert res.returncode == 0, res.stdout
+    assert "none" in res.stdout.splitlines()[0]
+
+
+@pytest.mark.parametrize("header", ["| Sev | Step | Plugin | Message |",
+                                    "| Severity | Step | Plugin | Message |"])
+def test_header_row_is_not_counted(tmp_path, header):
+    log = GOOD.replace("| Sev | Step | Plugin | Message |", header)
+    res = run(tmp_path, case=caseplan(), log=log)
+    assert res.returncode == 0, res.stdout
+    assert "1 row(s)" in res.stdout

--- a/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
+++ b/tests/tasks/uipath-maestro-case/logging/logging_issue_log.yaml
@@ -129,10 +129,10 @@ initial_prompt: |
     to `exit-only` or any other valid value.
 
   Run `uip maestro case validate TimerLogCase/TimerLogCase/caseplan.json
-  --output json`. Validation is expected to fail due to the invalid exitType.
-  After validate completes (regardless of exit code), write the issue log to
-  `tasks/build-issues.md`. The task is NOT complete until validate has run and
-  `tasks/build-issues.md` exists.
+  --output json`. Validation is expected to fail due to the invalid exitType;
+  that is not a reason to stop. The task is NOT complete until validate has run
+  and the build's issue log is on disk. Follow the skill's own logging contract
+  for when and how that log is written.
 
 success_criteria:
   - type: run_command
@@ -156,6 +156,18 @@ success_criteria:
       - "Build"
       - "TimerLogCase"
     weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: >
+      The log is an incremental journal, not a single end-of-build dump — it carries the
+      append-only Journal section flushed at each section boundary, and a summary filled
+      from it at Step 12.1. An end-of-build dump held in reasoning is lost to context
+      pressure before it is ever written.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-case/_shared/check_issue_journal.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
     pass_threshold: 1.0
 
 post_run:


### PR DESCRIPTION
## The bug

The issue list was accumulated **in the agent's reasoning** for the whole build and written once at Step 12.1. On a long build that list is lost to context pressure before it is ever written — and nothing downstream reads it, because Step 12's checks inspect `caseplan.json` and its sidecars, never the log.

Measured on two independent runs of the same task, different models, both producing a caseplan a reviewer would accept:

| Run | `<UNRESOLVED>` in `tasks.md` | Placeholder tasks | `build-issues.md` |
|---|---|---|---|
| `claude-sonnet-5`, 52.4 min | 120 | 39 | **never written** |
| `gpt-5.6-terra` (codex), 7.2 min | 0 | 23 | **never written** |

The codex run is the worse of the two: 23 placeholder tasks recorded **nowhere at all**, not even as markers in `tasks.md`. The operator receives unwired resources with no record of which ones.

## The fix

**Flush grain is the section boundary, not the issue.** Per-issue writes would cost one `Edit` per finding and fight the per-section batch write contract; per-build writes are the defect itself. A section boundary already carries a validate, so the flush rides an existing seam and bounds worst-case loss to one section.

- `tasks/build-issues.md` becomes an append-only **Journal**, on disk from the first Phase 2 section onward.
- **Step 12.1 stops being the only write** and becomes a summary pass that reads the journal back *off disk* — counts come from the file, not from reasoning. That is the whole point.
- Flush happens **even when a section produced zero issues** — the file's existence after the first section is what proves the log survived.
- A **Recovery** path covers a missing journal, stamped with a literal `NOTE:` so a reconstructed log is never mistaken for an observed one.

## Verification

**13 unit tests** on synthetic stubs (`_shared/check_issue_journal.py`), wired into the existing `logging_issue_log` task. The checker verifies the *incremental contract*, not mere existence — an old-style end-of-build dump **fails** for having no Journal section, which is what makes it a regression test rather than a file-exists check.

Mutation-tested: `always-clean` → 9 fail · `journal-not-required` → 1 fail · `empty-journal-ok` → 1 fail. `pytest tests/tasks/uipath-maestro-case/` → **93 passed**.

### End-to-end: N=3 per model, 6/6 clean

`logging_issue_log`, run locally against this branch:

| Model | Runs | Result | Duration | Journal | Summary filled | Rows |
|---|---|---|---|---|---|---|
| `gpt-5.6-terra` (codex) | 3 | **3/3 SUCCESS 1.000** | 3.7 / 5.5 / 3.9 min | ✅✅✅ | ✅✅✅ | 1 / 2 / 1 |
| `claude-sonnet-5` | 3 | **3/3 SUCCESS 1.000** | 8.2 / 8.2 / 11.1 min | ✅✅✅ | ✅✅✅ | 2 / 1 / 2 |

Every run was verified **at the artifact level, not by score**:

- `caseplan.json` present — so none passed via the checker's never-reached-Phase-2 exemption, which is how an auth failure would otherwise manufacture a false green
- `## Journal` section present
- summary block filled, not left at its `_Summary written at Step 12.1._` placeholder
- **zero** runs took the `reconstructed` fallback path — all six wrote the journal as they went

The `claude-sonnet-5` arm matters most: that is the model whose 52-minute, 39-placeholder build shipped no log at all and started this.

### The controlled pair that isolated the mechanism

Before the N=3, one variable was changed on its own:

| `logging_issue_log` on codex/terra | Result |
|---|---|
| prompt restating *"after validate, write the issue log"* | old format — **FAILURE 0.684** |
| that competing instruction removed | Journal + filled summary — **SUCCESS 1.000** |

The produced artifact is exactly the new contract:

```markdown
<!--build-issues:summary:start-->
| Category | Errors | Warnings | Skipped |
| [stage-exit-conditions](#stage-exit-conditions) | 1 | 0 | 0 |
<!--build-issues:summary:end-->

## Journal
| Sev | Step | Plugin | Message |
| ERROR | 12 | stage-exit-conditions | Validation reports `...exitConditions.0.type` is `invalid-exit-type`... |
```

**Worth generalising:** a task prompt that restates skill procedure silently overrides the skill, so tests written that way cannot detect skill regressions. That is why the prompt edit here *removes* an instruction rather than adding one — it deletes over-specification, it does not teach the answer.

## This PR stands alone

**No dependency on any other PR, in either direction, and no required merge order.**

- It introduces no reference to Check 15, Step 12.2, or anything outside this branch — verified: `grep -rn "Check 15\|Step 12\.2" skills/ tests/` returns nothing.
- Its own regression coverage is self-contained: `_shared/check_issue_journal.py` plus the criterion wired into `logging_issue_log`. Nothing external enforces the contract for it.
- The 6/6 end-to-end result above was produced against **this branch alone**, off `main`.

If #2590 also lands, the two compose — that PR's Check 15 is a Phase 4 exit guard that detects a missing log, while this one removes the cause so there is far less to detect. But neither needs the other, and either can merge first.

**One trivial textual overlap**, if both land: both edit the Phase 4 numbered list in `SKILL.md`. This PR rewrites item 3 (`Dump` → `Summarize`); #2590 edits item 1 and appends an item 4. Git will flag it because the lines are adjacent; the resolution is to keep both edits, which are not in tension.

## Caveats

- The two arms ran **concurrently**, so durations are not comparable across models — the 3.7–5.5 min vs 8.2–11.1 min split is under contention and should not be read as a speed result. Compliance, which is what is being measured, is unaffected.
- The controlled pair is still **N=1 per arm**. The N=3 establishes that the fix holds; the pair explains *why* the first attempt did not, and that explanation is a single observation.
- `logging_issue_log` builds a small timer-only case. It exercises the flush contract, not the 39-placeholder scale at which the defect was originally found — that fixture (`context_scale`) is untracked in main and not part of this PR.
- Local harness is `coder-eval 0.9.2`; CI pins `0.9.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
