### PR TITLE
fix(traces): repair three failing traces eval tasks (grading, docs, fixture)

### DIFF
--- a/skills/uipath-platform/references/traces/feedback.md
+++ b/skills/uipath-platform/references/traces/feedback.md
@@ -66,9 +66,11 @@ uip traces feedback list \
 | `--offset` | Pagination offset, default 0 |
 | `--folder-key` | Optional |
 
+`--trace-id` is optional — omit it to filter and paginate across all traces (e.g. by `--agent-id`/`--agent-version`/`--negative`) without needing `list detailed`.
+
 ## list detailed
 
-Returns `spanAttributes` per record (`agentId`, `agentName`, `userPrompt`, `output`). No `--trace-id` needed — designed for cross-trace bulk review.
+Adds span context per record (`spanAttributes`: `agentId`, `agentName`, `userPrompt`, `output`) plus time-range/category/sort filters over `list`. Not required for cross-trace filtering — plain `list` already covers that by omitting `--trace-id`.
 
 ```bash
 # Last 24 hours

--- a/skills/uipath-platform/references/traces/feedback.md
+++ b/skills/uipath-platform/references/traces/feedback.md
@@ -10,7 +10,7 @@ Use for agent output quality review and building evaluation datasets.
 | `create` | Add feedback to a trace (or specific span) |
 | `get <id>` | Fetch one feedback record |
 | `list` | List feedback with filters |
-| `list detailed` | Cross-trace feedback with span context (max 200 items) |
+| `list detailed` | List feedback with span context, plus extra filters (max 200 items) |
 | `update <id>` | Change sentiment, comment, or categories |
 | `delete <id>` | Remove feedback |
 

--- a/skills/uipath-platform/references/uip-commands.md
+++ b/skills/uipath-platform/references/uip-commands.md
@@ -110,8 +110,8 @@ LLM execution trace observability and feedback annotation. See [traces/traces.md
 | `uip traces spans get <trace-id>` | Get spans by trace ID or `--job-key` |
 | `uip traces feedback create` | Add positive/negative feedback to a trace |
 | `uip traces feedback get <id>` | Fetch one feedback record |
-| `uip traces feedback list` | List feedback for a trace |
-| `uip traces feedback list detailed` | Cross-trace feedback with span context |
+| `uip traces feedback list` | List feedback, optionally filtered by trace/span/agent/sentiment |
+| `uip traces feedback list detailed` | Feedback with span context, plus time-range/category/sort filters |
 | `uip traces feedback update <id>` | Change sentiment, comment, or categories |
 | `uip traces feedback delete <id>` | Remove feedback |
 

--- a/tests/tasks/uipath-platform/traces/seed_faulted_incident.py
+++ b/tests/tasks/uipath-platform/traces/seed_faulted_incident.py
@@ -1,31 +1,56 @@
 #!/usr/bin/env python3
 """Write incident.json for the standalone-diagnose traces e2e task.
 
-Requires a job that has ALREADY faulted on the tenant — the point of the task is
-that the agent inspects a run it did not start. Provide it via
-E2E_FAULTED_JOB_KEY (optionally E2E_FAULTED_FOLDER_PATH, defaults to
-Shared/uipath-platform).
+Self-provisioning fixture: starts a fresh job against a dedicated,
+deliberately-faulting agent process (traces-diagnose-fault-fixture) and waits
+for it to fault, then hands the agent only the resulting job key + folder path
+via incident.json -- mirroring a real overnight handover, but generated fresh
+each run instead of depending on someone maintaining a live faulted job by hand.
 
-Exits non-zero with an explicit message when the fixture is absent, so an
-unprovisioned tenant reads as a missing fixture rather than a skill regression.
+FIXTURE_PROCESS_KEY is a plain resource identifier on the shared codereval/
+DefaultTenant (alpha.uipath.com) eval tenant, not a secret -- same reasoning
+already used to inline the traces-smoke-v3 process key in traces_e2e.yaml /
+traces_feedback_e2e.yaml.
 """
 import json
-import os
+import subprocess
 import sys
 from pathlib import Path
 
-job_key = os.environ.get("E2E_FAULTED_JOB_KEY", "").strip()
-if not job_key:
+FIXTURE_PROCESS_KEY = "328e7acc-1ab4-4bad-90a2-a6e74f21f681"  # traces-diagnose-fault-fixture
+FIXTURE_FOLDER_PATH = "Shared/uipath-platform"
+
+result = subprocess.run(
+    [
+        "uip", "or", "jobs", "start", FIXTURE_PROCESS_KEY,
+        "--folder-path", FIXTURE_FOLDER_PATH,
+        "--wait-for-completion", "--timeout", "90",
+        "--output", "json",
+    ],
+    capture_output=True, text=True, timeout=100,
+)
+
+try:
+    payload = json.loads(result.stdout)
+except json.JSONDecodeError:
+    sys.exit(f"FIXTURE START FAILED: could not parse `uip or jobs start` output:\n{result.stdout}\n{result.stderr}")
+
+job = payload.get("Data") or {}
+state = job.get("State")
+job_key = job.get("Key")
+
+if state != "Faulted" or not job_key:
     sys.exit(
-        "FIXTURE NOT PROVISIONED: E2E_FAULTED_JOB_KEY is unset. This task needs a "
-        "pre-faulted Agent-type job on the tenant (see the task description); export "
-        "its job key to the runner before enabling this task."
+        f"FIXTURE DID NOT FAULT AS EXPECTED: job ended in state {state!r} "
+        f"(expected 'Faulted'). traces-diagnose-fault-fixture "
+        f"({FIXTURE_PROCESS_KEY}) may no longer be reliably faulting -- check "
+        f"the published package on the tenant before re-running this task."
     )
 
 incident = {
     "job_key": job_key,
-    "folder_path": os.environ.get("E2E_FAULTED_FOLDER_PATH", "Shared/uipath-platform"),
+    "folder_path": FIXTURE_FOLDER_PATH,
     "reported_by": "overnight schedule handover",
 }
 Path("incident.json").write_text(json.dumps(incident, indent=2) + "\n")
-print(f"OK: incident.json written for job {job_key}")
+print(f"OK: incident.json written for freshly-faulted job {job_key}")

--- a/tests/tasks/uipath-platform/traces/traces_diagnose_faulted_job_e2e.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_diagnose_faulted_job_e2e.yaml
@@ -9,12 +9,12 @@ description: >
   raw `uip traces spans get` output: the span ID the agent reports must exist in
   that payload and carry fault evidence, so an invented ID cannot pass.
 
-  FIXTURE REQUIRED — not yet provisioned. Needs a pre-faulted Agent-type job on
-  the tenant, exported to the runner as E2E_FAULTED_JOB_KEY (plus
-  E2E_FAULTED_FOLDER_PATH when it is not in Shared/uipath-platform); pre_run
-  inherits the orchestrator environment, so no experiment passthrough entry is
-  needed. Without the variable, pre_run exits with FIXTURE NOT PROVISIONED rather
-  than scoring the agent.
+  Self-provisioning fixture: pre_run starts a fresh job against the dedicated
+  fault-fixture process `traces-diagnose-fault-fixture`
+  (328e7acc-1ab4-4bad-90a2-a6e74f21f681, in Shared/uipath-platform — a plain
+  resource identifier, not a secret) and waits for it to fault before the
+  agent's turn begins, so the "job is long finished" framing stays true without
+  anyone maintaining a static fixture by hand.
 tags: [uipath-platform, e2e, mode:diagnose, lifecycle:discover, traces]
 
 agent:
@@ -25,7 +25,7 @@ run_limits:
 
 pre_run:
   - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-platform/traces/seed_faulted_incident.py"
-    timeout: 60
+    timeout: 120
 
 initial_prompt: |
   A scheduled agent run failed overnight and nobody knows why. The on-call

--- a/tests/tasks/uipath-platform/traces/traces_feedback_comment_file_smoke.yaml
+++ b/tests/tasks/uipath-platform/traces/traces_feedback_comment_file_smoke.yaml
@@ -55,11 +55,25 @@ success_criteria:
     weight: 2.0
     pass_threshold: 1.0
 
+  # min_count: 1 (not 2) x2, scoped per trace-id. command_executed counts matching
+  # Bash events, not command occurrences within an event — an agent that chains both
+  # creates into ONE Bash call registers only 1 match, so a single min_count: 2
+  # criterion caps at 0.5 for correct behavior. Mirrors the min_count:1 convention
+  # in reconfigure_different_connection.yaml.
   - type: command_executed
-    description: "Both records were filed via --comment-file, never an inline --comment (mutual exclusion rule 2)"
+    description: "Trace 7d3a91e0f5c24b8ea0c6d219bb47f0a3 was filed via --comment-file, never inline --comment"
     tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--comment-file)'
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--trace-id[\s=]+["'']?7d3a91e0f5c24b8ea0c6d219bb47f0a3)(?=[\s\S]*--comment-file)'
     exclude_pattern: '--comment[\s=]'
-    min_count: 2
-    weight: 2.0
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Trace a18b4c7d2e934f60b5c81d3a6f9e2077 was filed via --comment-file, never inline --comment"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+traces\s+feedback\s+create(?=[\s\S]*--trace-id[\s=]+["'']?a18b4c7d2e934f60b5c81d3a6f9e2077)(?=[\s\S]*--comment-file)'
+    exclude_pattern: '--comment[\s=]'
+    min_count: 1
+    weight: 1.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Motivation

Three tasks in the `uipath-platform/traces` suite were failing in the [2026-08-13 coder-evalboard run](https://coder-evalboard.uipath-dev.com/runs/2026-08-13_04-49-42?q=traces). None was an agent regression — three different causes, none of them in the skill:

**1. `skill-platform-traces-feedback-comment-file` (0.88, 3/4) — a grading false-negative.** The agent's behavior was correct: it filed both feedback records via `--comment-file`, never an inline `--comment`. It just chained both `uip traces feedback create` invocations into one `set -o pipefail` Bash call instead of two — reasonable, efficient behavior.

The `command_executed` checker does **one boolean `pattern.search()` per Bash tool call**, not a count of pattern occurrences inside a call's text. So one bundled call can only ever contribute 1 to `match_count`, and the criterion's `min_count: 2` capped it at `min(1.0, 1/2) = 0.5` regardless of how many qualifying commands were actually in there. A task-authoring bug, not a CLI or agent bug.

**2. `skill-platform-traces-feedback-list-filters` (0.31, 1/3) — a doc framing gap.** Plain `uip traces feedback list` already supports every flag the grading needs (`--negative`, `--agent-id`, `--agent-version`, `--limit`, `--offset` — confirmed against `packages/traces-tool/src/commands/feedback/list.ts` in `UiPath/cli`). But for a cross-trace, paginated, filtered read the agent reached for `list detailed`, and the criteria explicitly require plain `list` (negative lookahead disallowing `list detailed`), so both the filter and pagination checks scored zero.

The `## list detailed` section was the only place in the skill docs using the phrase *"designed for cross-trace bulk review"*, and the task prompt says "across all traces" — a lexical pull toward the wrong subcommand. Plain `list` is equally capable of a cross-trace read (just omit `--trace-id`), but nothing in the docs said so.

**3. `skill-platform-traces-diagnose-faulted-job` — an unprovisioned fixture.** The task was gated on an env var `E2E_FAULTED_JOB_KEY` that was never provisioned, so `pre_run` exited with `FIXTURE NOT PROVISIONED` on every run and the agent was never scored. It was merged written-blind, with an acknowledged "needs a human with live-tenant access" gap — meaning it had never actually been executed once since it landed.

## Summary

**Fix 1 — `traces_feedback_comment_file_smoke.yaml`.** Split the failing 4th criterion into two `min_count: 1` criteria scoped per trace-id, so a single bundled Bash call registers a match for each. Total weight unchanged (2.0 → 1.0 + 1.0). Criteria 1-3 untouched.

**Fix 2 — doc wording** in `references/traces/feedback.md` and the two traces feedback rows of `references/uip-commands.md`. `list` is now described as optionally filtered rather than trace-scoped, and `list detailed` as adding span context plus time-range/category/sort filters rather than owning "cross-trace". No task YAML touched — the `list-filters` grading criteria are correct and achievable as written, verified against the real CLI.

**Fix 3 — `seed_faulted_incident.py` + `traces_diagnose_faulted_job_e2e.yaml`.** The fixture is now self-provisioning: `pre_run` starts a job against a dedicated, deterministically-faulting two-node LangGraph process (`traces-diagnose-fault-fixture`, no LLM calls — one healthy node, then one that raises) and waits for it to fault, then writes only the resulting job key + folder path to `incident.json`. The "job is long finished" framing stays true, but nothing depends on a human maintaining a static faulted job. `pre_run` timeout raised 60 → 120 for headroom. `initial_prompt` and all `success_criteria` are untouched — neither referenced the env var, and both remain valid against a job key from the new source.

The process key is inlined as a plain resource identifier, not a secret — the same reasoning already used for the `traces-smoke-v3` key in `traces_e2e.yaml` / `traces_feedback_e2e.yaml`.

## Tests performed

**Fix 3 was verified live against the real tenant** (`codereval` / `DefaultTenant` / `alpha.uipath.com`) — this task had never been executed since it was merged, so getting a real result was the whole point.

- **Full live `coder-eval` run — PASSED, 5/5 criteria, weighted score 1.000** (`status=SUCCESS duration=190.5s iterations=1`). Every criterion scored 1.00, including the structural one: `check_traces_diagnose_e2e.py` reported `OK: 052b2d7e5c04dde8 is one of 3 faulting span(s) across 5 span(s)` — non-vacuous, since it must find *some* but not *all* spans faulting.
- **Fixture determinism.** `pre_run` provisioned a freshly-faulted job in 24s inside the harness (comfortably within the new 120s timeout). Across every job started today the process faulted 3/3 times, with a real error: `Deliberate failure: forced fault for diagnostic testing`.
- **Standalone seed check.** Ran `seed_faulted_incident.py` directly first: printed `OK: incident.json written for freshly-faulted job <key>` and wrote a valid `incident.json`. The generated file is a run artifact and is not committed.

**One pre-existing platform issue worth flagging, found during this verification:** `uip traces spans get --job-key <key>` is broken tenant-wide — it returns `"Error retrieving trace ID for job"` with `Retry: RetryWillNotFix` for *every* process I tested (`traces-diagnose-fault-fixture`, `traces-smoke-v3`, `traces-smoke-agent`), including jobs that succeeded days ago. Fetching by trace ID works fine. This is unrelated to and predates this PR.

It did not block the task: the run shows the agent tried `--job-key` first, and when that failed recovered via `uip or jobs get <key>` (which exposes `traceId`) → `uip traces spans get <traceId>`. That path satisfies every criterion — criterion 2 explicitly accepts a trace-ID argument, and criterion 3 rewards exactly the `jobs get` step needed to discover it. Worth a separate CLI/platform issue; deliberately not papered over here, and the note in `uip-commands.md` that `spans get` accepts `--job-key` is left as-is rather than quietly edited, since the right fix is on the CLI side.

**Fix 1 grading proof.** Verified against a faithful re-implementation of the real checker — I read `coder_eval/criteria/command_executed.py` and mirrored `_matching_commands` plus the scoring branch exactly, including the two details that change results: patterns compile with `re.DOTALL` (lines 141/202) and input truncates at `_MAX_PATTERN_SEARCH_LEN = 2000`. The source confirms the root cause verbatim — line 104 does one `pattern.search(cmd_text)` per `CommandTelemetry` entry, line 241 scores `min(1.0, match_count / min_count)`.

- Replaying the verbatim historical bundled command from the failing run as a single tool call now scores all criteria 1.0, giving a **weighted task score of 1.000 — up from the 0.88 observed on the evalboard**.
- The split does not weaken the test: inline `--comment` on both records → both criteria 0.0; only trace 1 filed → trace 2 criterion 0.0. Per-trace scoping also works for the two-separate-calls shape, not just the bundled one. Confirmed `--comment[\s=]` does not trip on `--comment-file` (followed by `-`, not whitespace/`=`) but does catch a genuine inline `--comment`.
- Confirmed against source (line 108) that `exclude_pattern` applies to the whole tool-call text per call, so a call mixing `--comment-file` for one trace and inline `--comment` for the other scores 0 on both — the conservative-correct outcome, since such a call violates mutual-exclusion rule 2.

**Repo checks.** All 1182 task YAML files parse and every `command_pattern` compiles. `seed_faulted_incident.py` compiles. Total criterion weight is unchanged in both touched task files (8.5 and 12.5).

**Fix 2 is a documentation-only nudge, not a deterministic guarantee.** Its outcome depends on stochastic model choice, so it cannot be verified by re-running the task, and I'm not claiming a re-run proved it. What was verified: the wording is factually accurate against the CLI source (`--trace-id` really is optional on `list`), it doesn't contradict anything else in `feedback.md` or `uip-commands.md`, and both markdown tables still render.

## Test plan

- [x] Live `coder-eval` run of `skill-platform-traces-diagnose-faulted-job` — 5/5 criteria, score 1.000, first execution since the task was merged
- [x] Fixture faults deterministically (3/3 jobs) and provisions in ~24s
- [x] Fix 1: historical failing input replayed through a faithful copy of the real checker — 0.88 → 1.000
- [x] Fix 1: negative cases still fail (inline `--comment`, missing second trace)
- [x] All 1182 task YAMLs parse; every `command_pattern` compiles; weights unchanged
- [ ] Live re-run of `skill-platform-traces-feedback-comment-file` and `-list-filters` (worth confirming on the next scheduled evalboard run; Fix 1 is a pure regex change with no runtime behavior, and Fix 2's effect is stochastic by nature)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
