### PR TITLE
feat(uipath-insights): teach Insights RBAC reads and add an RBAC smoke eval [IN-13526]

### DIFF
--- a/skills/uipath-insights/SKILL.md
+++ b/skills/uipath-insights/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: uipath-insights
-description: "UiPath Insights job monitoring and read-only alert inspection via `uip insights` — job execution metrics, failure analysis, and process performance; filter discovery of Insights-active folders, processes, queues, and machines; real-time alert definition, history, delivery, and entitlement reads. Alert writes are not covered. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa."
-when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details', 'which folders can you see', 'what processes are active', 'find the folder key', 'discover queues', 'which machines reported', 'filter-folders', 'filter-processes', 'Insights alert', 'which alerts exist', 'alert history', 'did an alert fire', 'alert delivery', or 'alerting entitlement'. NOT for alert writes, starting/stopping jobs (uipath-platform), root-cause debugging of a specific job error (uipath-troubleshoot), or queue item metrics (queue discovery via filter-queues is supported; metrics are not). Also 'uip insights', 'insights jobs'."
+description: "UiPath Insights job monitoring and read-only inspection via `uip insights` — job execution metrics, failure analysis, and process performance; filter discovery of Insights-active folders, processes, queues, and machines; real-time alert definition, history, delivery, and entitlement reads; Insights user, role, and group reads. Alert and RBAC writes are not covered. For Orchestrator job start/stop/logs→uipath-platform, root-cause analysis of specific errors→uipath-troubleshoot, RPA workflow authoring→uipath-rpa, org-level users, groups, or roles→uipath-admin."
+when_to_use: "User says 'job failures', 'automation health', 'job success rate', 'processing time', 'which processes fail the most', 'failure reasons', 'job trends', 'how many jobs ran', 'insights dashboard', 'job metrics', 'job KPIs', 'job performance', 'uncompleted jobs', 'pending jobs', 'faulted jobs', 'job timeline', 'process details', 'which folders can you see', 'what processes are active', 'find the folder key', 'discover queues', 'which machines reported', 'filter-folders', 'filter-processes', 'Insights alert', 'which alerts exist', 'alert history', 'did an alert fire', 'alert delivery', 'alerting entitlement', 'who has Insights access', 'Insights roles', or 'Insights groups'. NOT for alert or RBAC writes, starting/stopping jobs (uipath-platform), root-cause debugging of a specific job error (uipath-troubleshoot), or queue item metrics (queue discovery via filter-queues is supported; metrics are not). Also 'uip insights', 'insights jobs'."
 allowed-tools: Bash, Read
 ---
 
 # UiPath Insights
 
-Use `uip insights` for job monitoring, monitoring-scope discovery, and read-only alert inspection. Read the guide for the task before running commands.
+Use `uip insights` for job monitoring, monitoring-scope discovery, read-only alert inspection, and Insights RBAC reads. Read the guide for the task before running commands.
 
 ## When to Use This Skill
 
@@ -17,10 +17,11 @@ Use `uip insights` for job monitoring, monitoring-scope discovery, and read-only
 - Whether jobs are stuck, pending, or still running
 - Finding the exact folder key, process name, queue name, or machine name to scope a query by
 - Which alerts exist, how one is configured, whether an alert fired, or how a triggered alert is delivered
+- Who has Insights access on a tenant, which roles exist and what they permit, and which groups hold them
 
 ## Critical Rules
 
-1. **Use `--output json`.** `jobs` commands return `{ Result, Code, Data }`. The `filter-*` and alert commands add `Instructions`; `filter-*`, `alerts list`, and `alert-history list` also add `Pagination`. Quote those `Instructions` in the explanation. A failure envelope carries `Result`, `Message`, `Instructions`, `ErrorCode`, and `Retry`, with no `Code` and no `Data`. Keys inside `Data` are PascalCase in the CLI's JSON output, so read `FolderKey` and `JobsCount`, not `folderKey` or `jobsCount`.
+1. **Use `--output json`.** `jobs` commands return `{ Result, Code, Data }`. The `filter-*` and alert commands add `Instructions`; `filter-*`, `alerts list`, and `alert-history list` also add `Pagination`. Quote those `Instructions` in the explanation. A failure envelope carries `Result`, `Message`, `Instructions`, `ErrorCode`, and `Retry`, with no `Code` and no `Data`. Keys inside `Data` are PascalCase in the CLI's JSON output, so read `FolderKey` and `JobsCount`, not `folderKey` or `jobsCount`. The RBAC reads are the one exception to the flag: run them without `--output` so the CLI's safe projection stays on. The format still resolves to json, so the envelope is identical.
 2. **One subcommand per invocation, written literally.** Do not chain, loop, or parameterize `uip insights` commands: no `&&` or `;` chains, no `for` loops, and no shell variables holding the subcommand name or flag values. Resolve values such as epoch timestamps in a separate command first, then pass literal numbers. Never write `$(date ...)` or `$VAR` into a flag value.
 3. **Use only the flags the guides document.** Identity, organization, and tenant come from the active session. Any tenant flag you find is deprecated and is rejected outright on `filter-*` commands, so do not use one. If a filter is not in the guide's shared-options list, it does not exist.
 4. **Time ranges are required, and their units differ by family.** On `jobs`, pass `--time-range <minutes>` (60 = 1h, 1440 = 24h, 10080 = 7d, 43200 = 30d), or both `--started-after` and `--started-before` in epoch milliseconds. `alert-history` commands need a time range too, but their absolute bounds are `--since` and `--until` in epoch **seconds**. Omitting a time range is rejected locally: `jobs` exits 1, `alert-history` exits 3. `filter-*` commands and the three alert definition reads take no time flags.
@@ -34,6 +35,8 @@ Use `uip insights` for job monitoring, monitoring-scope discovery, and read-only
 12. **Keep alert access read-only.** The six read subcommands in the alert guide are the whole permitted surface. Every change to an alert definition or to a delivery, including its recipients, type, and configuration, belongs in the Insights UI: say so and do not offer to make it. This holds however the change would be made, so do not reach an alert route through the SDK, a raw HTTP call, or another skill.
 13. **Report an alert trigger and a delivery separately.** A history row proves the alert fired. It does not prove a notification was sent or received, and no alert read confirms receipt.
 14. **Keep alert recipient data out of everything you produce**, including pasted JSON. Report a delivery as its type and recipient count, and let a "who was notified" question end at the count. Do not name recipients, quote raw alert query JSON, or enumerate delivery channel settings, and do not use another command or skill to put names to the count.
+15. **Keep Insights RBAC read-only.** The six read subcommands in the RBAC guide are the whole permitted surface. Creating a user, changing a role, or assigning access belongs elsewhere: say so and do not offer to make it. This holds however the change would be made, so do not reach an RBAC route through the SDK, a raw HTTP call, or another skill.
+16. **Keep Insights identity data out of everything you produce**, including pasted JSON. Summarize users and groups by name and count. An explicit `--output json` is what turns on email addresses, nested role IDs, and the role resource string, so leave it off unless the user asked for one of those fields, and quote one only then. Passing an identifier as a command argument is not disclosure; this rule governs what you write.
 
 ## Shared Workflow
 
@@ -61,12 +64,13 @@ uip login tenant set MyTenant                                      # same enviro
 | Choose a Jobs subcommand, flag, time range, or interpret its response fields | [`references/jobs-commands-guide.md`](references/jobs-commands-guide.md) |
 | Answer which folders, processes, queues, or machines are visible, or resolve an exact folder key, process name, or machine name to filter by | [`references/filter-discovery-guide.md`](references/filter-discovery-guide.md) |
 | Inspect alert definitions, alerting entitlement, trigger history, or delivery metadata | [`references/alerts-reads-guide.md`](references/alerts-reads-guide.md) |
+| Inspect Insights users, roles, or groups | [`references/rbac-reads-guide.md`](references/rbac-reads-guide.md) |
 
-Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence.
+Read only the guides the task needs. A job investigation that must first resolve a folder, process, or machine needs the filter guide, then the jobs guide. An alert question needs the alert guide alone; it owns the full definition, history, and delivery sequence. An Insights access question needs the RBAC guide alone.
 
 ## Scope Boundaries
 
-`uip insights` ships three command families: `jobs`, the `filter-*` discovery commands, and the alert reads (`alerts`, `alert-history`, `alert-deliveries`). If a request needs anything else, say it is not available rather than guessing a subcommand.
+`uip insights` ships four command families: `jobs`, the `filter-*` discovery commands, the alert reads (`alerts`, `alert-history`, `alert-deliveries`), and the RBAC reads (`users`, `roles`, `groups`). If a request needs anything else, say it is not available rather than guessing a subcommand.
 
 | Request | Route |
 |---|---|
@@ -76,12 +80,15 @@ Read only the guides the task needs. A job investigation that must first resolve
 | Query queue item metrics | Not supported; `filter-queues` discovers queue scope only |
 | Any alert or delivery write (see Critical Rule 12) | Insights UI; not in the shipped `uip insights` surface |
 | Dashboards or robot utilization | Not in the shipped `uip insights` surface |
+| Any Insights RBAC write, such as assigning a role (see Critical Rule 15) | Insights UI; not in the shipped `uip insights` surface |
+| Manage org-level user accounts, groups, or roles outside Insights | `uipath-admin` |
 
 ## Anti-patterns
 
 - Do not add `--limit` or `--offset` to a `jobs` command. Each guide lists which of its commands page.
 - Do not reuse an identifier from an example. Folder keys, process names, and machine names come from a `filter-*` result or from the user.
 - Do not read an empty or `false` alert result as proof. Report what it rules out and what it leaves open.
+- Do not pass `--output json` to an RBAC read unless the user asked for a field the safe view withholds.
 
 ## Completion Output
 

--- a/skills/uipath-insights/references/rbac-reads-guide.md
+++ b/skills/uipath-insights/references/rbac-reads-guide.md
@@ -1,0 +1,151 @@
+# RBAC Read Commands
+
+Use this guide when the request concerns tenant-scoped Insights users, roles, and groups. These commands read Insights role assignments, not org identity: creating users or managing org-level groups and roles is outside this skill. All commands use the active CLI session.
+
+Tenant and organization context comes from the session. Never take it from the user and never invent a flag for it. User, role, and group GUIDs are different: accept one the user supplied or one a list returned, and pass it as the positional argument to the matching `get`. Never construct or guess one.
+
+## Safe Output
+
+These rows carry personal data that the other Insights commands do not: user and group email addresses, role IDs nested inside a principal, and a role `Resource` string that embeds the organization and tenant GUIDs.
+
+The CLI withholds all three unless the caller explicitly chooses a structured format (`--output json`, `--output yaml`, or the `--json` alias). Run these six commands without `--output`. The format still resolves to json, so the envelope parses exactly the same, and the safe view is what you get: no `Email` on a user or group, roles as names rather than `{Id, Name}`, and no `Resource` on a role. This is the one place in the skill where Critical Rule 1 does not apply.
+
+Add `--output json` only when the user asked for a field the safe view withholds. The whole workflow below runs without it, including the name-to-GUID join.
+
+Keep these values out of what you write even on a call that returns them. Summarize with names and counts. Quote an email, a nested role ID, or a `Resource` string only when the user asked for that specific field. The same restriction covers anything written outside the conversation: a file, a commit, a ticket, or a PR body.
+
+Some commands here are read-shaped rather than pure reads. See [Read-Shaped Side Effects](#read-shaped-side-effects) before reporting one as a plain lookup.
+
+## Commands
+
+### users list
+
+List tenant users visible to the current caller with their Insights role names.
+
+```bash
+uip insights users list
+```
+
+**Key Data fields:** `Id`, `Name`, `Roles` as names. `Email` and the role `Id`s need `--output json`; keep both out of prose.
+
+**Use when:** User asks which users have Insights access or needs a user ID for an exact lookup.
+
+### users get
+
+Get one Insights user by its GUID.
+
+```bash
+uip insights users get <user-id>
+```
+
+**Key Data fields:** `Id`, `Name`, `Roles` as names. `Email` and the role `Id`s need `--output json`; keep both out of prose.
+
+**Use when:** User asks which Insights roles are assigned to one known user.
+
+### roles list
+
+List Insights roles visible to the current caller and their actions.
+
+```bash
+uip insights roles list
+```
+
+**Key Data fields:** `Id`, `Name`, `Actions`. `Resource` needs `--output json`; keep it out of prose.
+
+**Use when:** User asks which Insights roles or actions are available. The list can be entitlement-filtered.
+
+### roles get
+
+Get one Insights role by its GUID.
+
+```bash
+uip insights roles get <role-id>
+```
+
+**Key Data fields:** `Id`, `Name`, `Actions`. `Resource` needs `--output json`; keep it out of prose.
+
+**Use when:** User asks what one role permits, including a role omitted from the entitlement-filtered list.
+
+### groups list
+
+List tenant groups visible to the current caller with their Insights role names.
+
+```bash
+uip insights groups list
+```
+
+**Key Data fields:** `Id`, `Name`, `Roles` as names. `Email` and the role `Id`s need `--output json`; keep both out of prose.
+
+**Use when:** User asks which groups have Insights roles or needs a group ID.
+
+### groups get
+
+Get one Insights group by its GUID.
+
+```bash
+uip insights groups get <group-id>
+```
+
+**Key Data fields:** `Id`, `Name`, `Roles` as names. `Email` and the role `Id`s need `--output json`; keep both out of prose.
+
+**Use when:** User asks which Insights roles are assigned to one known group.
+
+## Interpretation Rules
+
+`Data` keys are PascalCase in the CLI's JSON output in both views: `Id`, `Name`, `Roles`, `Actions`. Reading a lowercase key returns `undefined`.
+
+The three list commands take `--limit` and `--offset`. `--limit` defaults to 50, so a 50-row result is a full page rather than a complete list. Read `Pagination.Total` for the row count and `Pagination.HasMore` to tell whether rows remain. Keep going until `HasMore` is false before deciding a resource is absent, and say in the answer whether every page was retrieved. Raising `--limit` in one call is cheaper than walking `--offset`, because every offset page re-fetches the whole list from the backend. A `--limit` above 10000 is rejected locally.
+
+These lists take no subject filters. There is no `--name`, `--email`, `--role`, or `--group`, so match a person or group by scanning the retrieved rows. The global flags still apply, `--output` among them.
+
+The three `get` commands need a GUID. A value that is not a GUID is rejected locally as `ValidationError` with `ErrorCode: invalid_argument` and no request is sent, so that failure says nothing about whether the resource exists.
+
+`roles list` and `roles get` return the role definitions with GUIDs and actions. On `users list` and `groups list` in the safe view, each role on a row is a bare name string, so the way to its definition is to match that name in `roles list` and use that row's `Id` with `roles get`. That join is the reason the safe view costs nothing here. Under the full view the same role arrives as `{Id, Name}` and the `Id` is on the row already, which saves one call and is not worth turning on the email for.
+
+Passing an identifier as a command argument is not disclosure. Critical Rule 16 governs the answer you write, not the commands you run. Refer to the role by name in the answer.
+
+A role name absent from the entitlement-filtered `roles list` can still resolve through `roles get`, whether the GUID came from the user or from a nested role on a user or group row.
+
+The backend always sends the roles and actions arrays, and the CLI's projection emits `Roles` and `Actions` on every output row, so `[]` means the principal holds no Insights roles in this tenant or the role carries no actions. `Roles: []` is ordinary. `Actions: []` is not, because a role cannot be stored without at least one action, so name it as unexpected instead of summarizing it as an empty list.
+
+`Name` can be null on a principal, and so can `Email` and `Resource` on the calls that return them. `Id` is never null. A row with a null `Name` is still a principal holding the roles on that row, so refer to it by `Id` and say the display name is unset.
+
+A user whose directory lookup fails keeps its row with the name and email already stored, and nothing in the response marks that the lookup failed. So a display name on `users list` can be stale, and there is no way to tell from the output alone. Do not present a name as current identity evidence. Groups behave differently on the same failure: see Read-Shaped Side Effects.
+
+## Failure Branches
+
+Read the `Instructions` sentence the CLI returns with each of these. It carries the tenant-specific detail.
+
+- `Data: []` with `Pagination.Total` of 0. The tenant answered and nothing was visible to the caller. On `roles list` it can also be entitlement filtering. It does not prove the tenant has no users, roles, or groups.
+- `Data: []` with `Pagination.Total` above 0. `--offset` is past the last row. Lower it and run again.
+- HTTP 404 on a list. A list route cannot miss for data reasons, so this is most likely a tenant without the Insights Portal service. Confirm by running the other two lists. If all three answer the same way, report it once as a provisioning gap rather than as an empty tenant.
+- HTTP 404 on a `get`. The ID is not in the active tenant or is not visible to the caller. It is not proof the resource exists nowhere. On `groups get` this also covers a group that is in the tenant but whose directory entry does not resolve for this caller, which is the same condition that omits the row from `groups list`. A group missing from the list and 404ing on `get` is one cause, not two.
+- HTTP 403, `ErrorCode: permission_denied`. The caller lacks the Insights Management View permission in the active tenant.
+- HTTP 401 or no usable session. `Result: AuthenticationError`, exit 2. Correct the session and run again.
+- HTTP 429, `ErrorCode: rate_limited` with `Retry: RetryLater`. This is the one branch where a later retry is right.
+- HTTP 500 or 503, no `ErrorCode`, with the status in `Message`. The service or something it depends on failed. A directory outage surfaces here on the two groups commands, while `users list` and `users get` absorb the same outage and answer 200 with the stored name and email. Do not read a groups 5xx next to a users 200 as the two subjects disagreeing.
+- A malformed response. `ErrorCode: unknown_error`, so read `Message` for the shape violation.
+
+Outside the list 404 above, a failure on one list says nothing about the other two. When the request names users, groups, and roles, run all three and report each outcome separately.
+
+## Read-Shaped Side Effects
+
+Three of these commands do more than fetch:
+
+- `roles list` can make a cached entitlement call to Licensing.
+- `groups get` can persist refreshed directory name and email fields for the group.
+- `groups list` can omit a group whose directory entry does not resolve.
+
+The group omission is invisible in the response: `Pagination.Total` counts only the rows that survived, and no field marks the drop. So carry the caveat on every groups answer instead of waiting for a signal. Directory filtering can omit an unresolved group, which makes `groups list` a lower bound on the groups that hold Insights roles.
+
+`users list` keeps a row whose directory enrichment failed, so it needs no such caveat. It is still bounded by the caller's visibility and by the pages retrieved.
+
+Name the Licensing call only when the user asks what `roles list` costs or why a role is missing.
+
+## Investigation Workflow: Inspect Insights RBAC Configuration
+
+1. Run one list per subject the request names: `users list` for who has access, `groups list` for group assignments, `roles list` for what roles permit. A request naming more than one subject gets more than one list. Add a further list call only to resolve a name or ID an earlier one surfaced.
+2. Use a `get` command only for an ID the user supplied or a list returned.
+3. Page each list until `Pagination.HasMore` is false before summarizing.
+4. If a command is denied, run `uip login status --output json` and report its `Tenant` value with the boundary: reading Insights RBAC needs the Insights Management View permission in that tenant. Do not suggest changing access from this skill.
+5. If no row matches a name the user gave, report that no visible row in the active tenant matched and say which pages were retrieved. Do not report that the user or group does not exist, and do not fall back to org-level identity commands.

--- a/tests/tasks/activation/uipath-insights.jsonl
+++ b/tests/tasks/activation/uipath-insights.jsonl
@@ -31,3 +31,7 @@
 {"id": "uipath-insights-031", "prompt": "Is this tenant entitled to Insights real-time alerting?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-032", "prompt": "Did any Insights alert fire in the last 24 hours?", "expected_skill": "uipath-insights"}
 {"id": "uipath-insights-033", "prompt": "Which delivery is attached to my Insights alert?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-034", "prompt": "Who has access to Insights on this tenant?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-035", "prompt": "Which Insights roles exist and what do they permit?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-036", "prompt": "Which groups have been given Insights roles?", "expected_skill": "uipath-insights"}
+{"id": "uipath-insights-037", "prompt": "Which Insights roles is this user assigned?", "expected_skill": "uipath-insights"}

--- a/tests/tasks/uipath-insights/rbac/smoke.yaml
+++ b/tests/tasks/uipath-insights/rbac/smoke.yaml
@@ -1,0 +1,187 @@
+task_id: skill-insights-smoke-rbac-reads
+description: >
+  Smoke test: agent uses the uipath-insights skill to read tenant-scoped
+  Insights users, roles, and groups. Given a prompt asking who has Insights
+  access and what the roles permit, the agent should run the three RBAC list
+  reads, keep raw emails and nested role identifiers out of its summary, and
+  treat a denial or an empty result as a bounded answer rather than retrying
+  or falling back to org-level identity commands. The CLI is authenticated;
+  the tenant may or may not have the Insights Portal service provisioned, so
+  a permission or not-found result is a valid outcome.
+
+  Covers the 3 list reads of the 6 RBAC commands. `users get`, `roles get`,
+  and `groups get` are left out on purpose: each needs a GUID that does not
+  exist on an empty or unprovisioned tenant, so gating them would trade
+  tenant-agnosticism for surface coverage. They belong in an
+  integration-tier task against a seeded, Portal-provisioned tenant.
+tags: [uipath-insights, smoke, mode:diagnose, lifecycle:discover]
+
+run_limits:
+  expected_turns: 10
+
+initial_prompt: |
+  I need a read-only picture of who can use Insights on this tenant. List
+  the users with Insights access and the roles they hold, list the groups
+  with Insights roles, and tell me what those roles actually permit. Do not
+  change any access. Summarize with names and counts, not raw email
+  addresses or internal identifiers. If a command is denied or comes back
+  empty, say so plainly and say what it does and does not prove, then move
+  on. If the output says more rows exist, page through them before you
+  summarize. Run each command at most once per page; do not retry failures.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent activated the uipath-insights skill"
+    skill_name: "uipath-insights"
+    expected_skill: "uipath-insights"
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # exclude_pattern on all three: an agent that probes `<command> --help` to
+  # discover flags would otherwise be credited with the read itself. The
+  # exclusion is anchored to a help probe of that same command rather than the
+  # bare string --help, so a read that merely shares a call with the word
+  # (an echo, a comment) still counts. Same intent as the bare --help exclusion
+  # in tests/tasks/uipath-agents/lowcode/inline_solution_agent_tool.
+  - type: command_executed
+    description: "Agent ran users list to enumerate Insights users"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+users\s+list'
+    exclude_pattern: 'uip\s+insights\s+users\s+list(?:(?!uip\s)[^&;|])*--help'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran roles list to enumerate Insights roles"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+roles\s+list'
+    exclude_pattern: 'uip\s+insights\s+roles\s+list(?:(?!uip\s)[^&;|])*--help'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Agent ran groups list to enumerate Insights groups"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+groups\s+list'
+    exclude_pattern: 'uip\s+insights\s+groups\s+list(?:(?!uip\s)[^&;|])*--help'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  # command_executed only greps the command string, so the criteria above pass
+  # even when the verbs don't exist in the installed CLI. The alerts and filters
+  # smoke tasks close that hole by re-running a real read at grading time, but no
+  # RBAC read can serve as that gate: these routes need the Insights Portal
+  # service (insights_) provisioned, and a tenant without it answers every RBAC
+  # read with a permission or not-found result. --help is the tenant-agnostic
+  # substitute. It exits 0 only when the CLI actually registers the group and
+  # exits 3 on an unknown one, so this still fails against a CLI that has not
+  # shipped the RBAC reads. It proves the command surface exists, not that the
+  # backend answered.
+  - type: run_command
+    description: "CLI path is real: the users group is registered in the installed CLI"
+    command: "uip insights users list --help"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # One gate per group: a CLI that ships users but not roles or groups would
+  # otherwise pass on the users probe alone.
+  - type: run_command
+    description: "CLI path is real: the roles group is registered in the installed CLI"
+    command: "uip insights roles list --help"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "CLI path is real: the groups group is registered in the installed CLI"
+    command: "uip insights groups list --help"
+    timeout: 60
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # Critical Rule 13's "do not reach an RBAC route through the SDK or a raw
+  # HTTP call", enforced the way the alerts smoke enforces its Rule 12
+  # sibling. Route strings are the PermissionService paths the CLI calls
+  # (/api/User, /api/Role, /api/Group), both casings.
+  - type: command_not_executed
+    description: "Agent did not bypass the CLI to reach an RBAC route"
+    tool_name: "Bash"
+    command_pattern: '(curl|wget|axios|insights-sdk)(?:(?!uip\s)[^&;|])*api/(User|Role|Group|user|role|group)s?\b'
+    max_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # SKILL.md Critical Rule 2 forbids substitution and shell variables in a uip
+  # invocation. Same construction as the alerts smoke copy: the flag branch
+  # names only the flags these commands accept, because the (?!uip\s) barrier
+  # crosses newline-batched neighbours, so a generic --flag would match a
+  # neighbour's `curl --data $BODY`. The get branch catches a variable GUID.
+  - type: command_not_executed
+    description: "Agent did not use command substitution or a shell variable in a uip insights command"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+(users|roles|groups)(?:(?!uip\s)[^&;|])*--(limit|offset|output)[\s=]+"?(\$\(|`|\$[A-Za-z_])|uip\s+insights\s+(users|roles|groups)\s+get\s+"?(\$\(|`|\$[A-Za-z_])'
+    max_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not attempt an RBAC write"
+    tool_name: "Bash"
+    # The verbs are guesses either way, since no RBAC write exists in the CLI to
+    # copy a name from. Cover the whole non-read vocabulary rather than the six
+    # most obvious ones. The trailing \b keeps `add` off a future `adduser`-style
+    # read while still catching `add-role`.
+    command_pattern: 'uip\s+insights\s+(users|roles|groups)\s+(create|update|delete|assign|unassign|remove|add|set|grant|revoke|edit|patch|put|invite|enable|disable)\b'
+    max_count: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent did not invent identity flags on RBAC reads"
+    tool_name: "Bash"
+    # Not .* : the grader compiles patterns with re.DOTALL, so .* bleeds past
+    # the end of the command and false-fails a batched call that pairs an RBAC
+    # read with a legitimate login carrying --tenant. Excluding & ; | is not
+    # enough on its own either, because the grader also matches a
+    # shlex-normalized haystack where newlines collapse to spaces
+    # (coder_eval/criteria/command_executed.py, _normalize_shell), so a
+    # newline-separated batch survives that class. The `uip` lookahead stops
+    # the scan at the next invocation, which is what holds on the normalized
+    # haystack, and it is the construct the alerts and filters smoke tasks use.
+    # Residual gap: a non-uip follow-on command in the same call can
+    # still be scanned. Critical Rule 2 forbids that batching, so a compliant
+    # agent never reaches it.
+    #
+    # Flag list uses the -id spellings rather than bare --role / --group /
+    # --user: the guide's own prose names those three as flags that do not
+    # exist, and an agent echoing that sentence would otherwise fail its own
+    # criterion. --service is not named by any rule but is a plausible
+    # invention once the guide names the Insights Portal service.
+    command_pattern: 'uip\s+insights\s+(users|roles|groups)\s+\S+(?:(?!uip\s)[^&;|])*--(tenant|organization|user-id|role-id|group-id|action|resource|service)\b'
+    max_count: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  # Inverted on purpose. An explicit structured --output is what switches the
+  # CLI's RBAC projection to the full view, which adds Email, nested role IDs
+  # and the role Resource string. The skill tells the agent to leave it off on
+  # these six commands (Critical Rule 1's one exception), so the convention
+  # being measured is the ABSENCE of the flag. Covers --output json,
+  # --output=json, --output yaml and the --json alias, since all four set
+  # formatWasExplicit. Advisory: pass_threshold 0 keeps a full-view call out of
+  # the pass/fail gate, because asking for a withheld field is legitimate when
+  # the user asked for it.
+  - type: command_not_executed
+    description: "Advisory: agent kept RBAC reads in the safe view (no explicit --output)"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+insights\s+(users|roles|groups)\s+\S+(?:(?!uip\s)[^&;|])*(--output[\s=]+(json|yaml)|--json\b)'
+    max_count: 0
+    weight: 1.0
+    pass_threshold: 0

--- a/tests/tasks/uipath-insights/rbac/smoke.yaml
+++ b/tests/tasks/uipath-insights/rbac/smoke.yaml
@@ -106,7 +106,7 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  # Critical Rule 13's "do not reach an RBAC route through the SDK or a raw
+  # Critical Rule 15's "do not reach an RBAC route through the SDK or a raw
   # HTTP call", enforced the way the alerts smoke enforces its Rule 12
   # sibling. Route strings are the PermissionService paths the CLI calls
   # (/api/User, /api/Role, /api/Group), both casings.


### PR DESCRIPTION
https://uipath.atlassian.net/browse/IN-13526
Also related to https://uipath.atlassian.net/browse/IN-13527: the tagged eval tasks here are that ticket's skills-side test layer.

## What

Teaches the six Insights RBAC read commands: `users list`, `users get`, `roles list`, `roles get`, `groups list`, and `groups get`.

- New `references/rbac-reads-guide.md`: per-command usage and fields, the name-to-GUID join, a Safe Output section, a Failure Branches section, and the read-shaped side effects.
- `SKILL.md`: a routing row, RBAC in the frontmatter with a `→uipath-admin` redirect, two scope-boundary rows, one anti-pattern, and Critical Rules 15 and 16, the RBAC counterparts of the alert read-only rule.
- New `tests/tasks/uipath-insights/rbac/smoke.yaml` and four activation rows (034-037). The smoke task gates each of the three command groups with its own `--help` reality check, and carries the CLI-bypass and shell-variable negatives the alerts smoke uses, with the PermissionService route strings.

## Why

The six reads ship as five stacked cli PRs, and this is the companion to all of them: [#3860](https://github.com/UiPath/cli/pull/3860) shared refactor (merged), [#3660](https://github.com/UiPath/cli/pull/3660) users list (merged), [#3861](https://github.com/UiPath/cli/pull/3861) users get, [#3858](https://github.com/UiPath/cli/pull/3858) roles, and [#3859](https://github.com/UiPath/cli/pull/3859) groups. One guide covers the family, so the packet has one skills half rather than five. These reads share vocabulary with `uip admin` but read tenant-scoped Insights role assignments from the Insights Portal backend, not org identity. Without the boundary stated an agent picks the wrong skill, which is the confusion raised on #2552.

These six run without `--output`, the one exception to Critical Rule 1. The format still resolves to json so the envelope is unchanged, but the CLI's safe projection stays on and email addresses, nested role IDs, and the role resource string never reach the transcript. The name-to-GUID join works entirely in the safe view, so nothing is lost by leaving the flag off.

Three of the six are not pure reads: `roles list` can make a cached Licensing call, `groups get` persists refreshed directory fields, and `groups list` drops a group whose directory entry does not resolve. That last one also 404s `groups get`, so a group missing from the list and failing its `get` is one cause, not two.

## Testing

Ran on this branch: `npm run skills:validate`, `hooks/validate-skill-descriptions.sh`, `scripts/check-skill-status.py`, `check-task-driver.py`, `check-cli-verbs.py`, `check-skills-sh.py`, and link resolution. All pass. Frontmatter is 564 chars of description, which the repo hook checks, and 1510 combined against the 1536 characters Claude Code shows, read off both fields.

Every success criterion was tested against a local reimplementation of the grader's dual-haystack matcher (raw plus shlex-normalized), covering batched commands, `bash -lc` wrappers, and line continuations, then timed for backtracking. The eval patterns use the same non-bleeding construct as the alerts and filters smoke tasks.

Response shapes and side effects were derived from PermissionService source in `UiPath/Insights`, not from the CLI's defensive branches. That corrected two claims written the other way round: a nested role is always an object on the wire (`Dto/UserDto.cs`), and a directory failure keeps a user row with its stored name rather than nulling it (`Directory/DirectoryUserHelper.cs`).

## Limitations

**No RBAC route has run against a live backend.** The Insights Portal service (`insights_`) is unprovisioned on both tenants available to us, so every shape claim is source-derived. Anything depending on the hop between the CLI and PermissionService is unverified, including the 429 branch, which nothing in PermissionService itself produces.

**Smoke run passes.** CI run [33802397408](https://github.com/UiPath/skills/actions/runs/33802397408) attempt 3 on `f943d7d4` scores the RBAC task 12 of 12, weighted 1.000, against `@uipath/insights-tool@1.203.0-dev.8586`. Attempts 1 and 2 scored 0.750: the roles and groups reality gates exited 3 with `unknown command` because the published `dev` build predated [#3858](https://github.com/UiPath/cli/pull/3858) and [#3859](https://github.com/UiPath/cli/pull/3859), which landed on cli `main` on 2026-09-08 and reached the `dev` dist-tag on 2026-09-09.

The task gates the three list reads. The three `get` reads need a GUID that cannot exist on an unprovisioned tenant, so they belong in an integration-tier task against a seeded one.




