### PR TITLE
test(maestro-flow): clarify IxP completion contract

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_01_invoice_extraction_greenfield.yaml
@@ -1,6 +1,9 @@
 # Same-ground campaign contract (Tao, 2026-08-10): loop-neutral v1-base
 # prompt; v1-weighted intersection criteria plus report-only offline advisories;
 # paired limit envelope. Cross-arm parity is enforced by the sync gate.
+# IxP completion RCA (Tao, 2026-08-13): removed the arm-specific registry
+# lookup per the neutral-prompt ruling; validation now gates completion in both
+# arms so the prompt has one explicit acceptance bar.
 task_id: skill-flow-ixp-e2e-invoice-extraction-greenfield
 description: |
   E2E (greenfield): SharePoint trigger → IxP extraction → HTTP POST. Tests end-to-end authoring of a real invoice-processing flow that monitors a SharePoint folder, extracts structured invoice fields, and forwards the result to a downstream system over HTTP.
@@ -22,11 +25,11 @@ initial_prompt: |
 
   - SharePoint connector: configured (use a connector trigger node against
     any document library the connection exposes)
-  - IxP model: pick the published model that matches vendor invoices from
-    `registry search "uipath.ixp"`
   - SAP: HTTP POST to https://sap.example.com/api/invoices, sending the
     extracted invoice fields as the request body
 
+  Validate the final flow file — the task is not complete until `uip maestro
+  flow validate` passes.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 success_criteria:
   - type: run_command


### PR DESCRIPTION
## Summary

- remove the arm-specific IxP registry-search hint from the greenfield task
- state that the task is complete when product validation passes
- record both corrections and their reasons in the task header

## Verification

- task YAML parses successfully
- prompt contains no registry-search hint and retains the unchanged run limits
- same-ground pair-8 contract check — all dimensions passed

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)