### PR TITLE
test(maestro-flow): scope the ixp routing node-add bound to the request's steps

### DIFF
--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -57,7 +57,7 @@ initial_prompt: |
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
   - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
   - Do NOT iterate on validation errors or rewrite the flow to fix them. A broken flow is acceptable.
-  - Exploration + an attempted node-add is enough — you do not need to build a working flow.
+  - You do not need a working flow — a skeleton whose nodes cover the steps of the request is enough. Leave a node unconfigured rather than leaving a step out.
 
 success_criteria:
   # What this checks: did the agent search the registry for IxP nodes?

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
@@ -62,7 +62,7 @@ initial_prompt: |
   - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
   - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
   - Do NOT iterate on validation errors or rewrite the flow to fix them. A broken flow is acceptable.
-  - Exploration + an attempted node-add is enough — you do not need to build a working flow.
+  - You do not need a working flow — a skeleton whose nodes cover the steps of the request is enough. Leave a node unconfigured rather than leaving a step out.
 
 success_criteria:
   # Inverted twin of the positive routing.yaml grep.


### PR DESCRIPTION
`skill-flow-ixp-routing/invoice-extraction` passed 12/20 over the last 20 Coder Eval runs, with failures concentrated on the GPT-5.6 arm (gpt-5.6-terra 2/7; everything else 9/10). The failing agents found the published IxP model every time, then built the fetch and post nodes *around* extraction and dropped the extraction node — quoting this prompt line back as their justification:

> Exploration + an attempted node-add is enough — you do not need to build a working flow.

It was meant to lower the bar (no *working* flow needed), but it also redefined the task downward: any single node-add satisfies "an attempted node-add". Replaced in `routing.yaml` and `routing_negative.yaml` with wording that keeps the cost-control intent while requiring the skeleton to cover the steps the user actually asked for.

**This tightens the prompt rather than relaxing an assertion** (which `routing.yaml:11` forbids): `success_criteria` is byte-identical in both files — criteria counts still 2 and 1, `dataset.rows` still 5 and 8. And it doesn't leak the answer — no node family, plugin, step name, or fallback is named, so a mis-routing agent still lands an HTTP or script node and still fails the grep.

Verified 5× on `codex`/`gpt-5.6-terra`: target row **5/5** (a docs-only attempt on `ixp/planning.md` + `ixp/impl.md` scored 0/5 and was dropped), `routing_negative` over-trigger guard **40/40**, **65/65** rows overall. Checked the artifacts too — all five landed a real `uipath.ixp.*` node, not the `core.logic.mock` the grep would also have accepted.

[RE-13177](https://uipath.atlassian.net/browse/RE-13177)


[RE-13177]: https://uipath.atlassian.net/browse/RE-13177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ