### PR TITLE
feat(case): shared case-knowledge single-source layer

### DIFF
--- a/docs/case-knowledge-ledger.md
+++ b/docs/case-knowledge-ledger.md
@@ -203,5 +203,24 @@ Probe generator + 16 case variants archived in the PR description. Key rows:
 | p09/p10 | `required-stages-completed`, `isRequired` false / absent | Identical error — absent ≡ false |
 | p11 / p11b | Task-output xref, partial vs full bare-mint entry | Partial fails (`Variable…does not exist`); full **valid** |
 | p12 / p12b | Trigger output self-declared vs + root companion | Self-declared fails; companion **valid** |
+| p13 | Manual trigger with explicit `serviceType: "None"` | Valid (absent also valid — p00). Emit `"None"` per the build plugin; tolerate absent on read |
+| p14 | `wait-for-user` exit, no `user-selected-stage` anywhere | `Stage rule '<name>' has no possible stage options.` |
+| p15 | `user-selected-stage` entry, no `wait-for-user` anywhere | `Stage entry rule '<name>' will never be met.` |
+
+### Adversarial-review addendum (2026-08-17)
+
+An independent review of the shared layer surfaced 15 findings; all fixed in place. Rulings it forced:
+**R1** — manual-trigger emit shape: sources conflicted (planner guide: absent; maestro manual plugin:
+always `"None"`); probes p00+p13 show both validate → emit `"None"`, read-tolerate absent (K-TYP-4).
+**R2** — the wait-for-user↔user-selected-stage pairing IS validate-enforced (p14/p15, messages above) —
+kept in K-PAIR-4 with quotes. Scoping fixes: case-completion rows are `exit-only` only (K-PAIR-3);
+`stageType: "primary"` is never emitted (K-TYP-3); `<UNRESOLVED>` stays legal on identity/folder cells with
+a paired review item (K-SDD-3); only `selected-stage-exited` lanes need an origin diverting exit (K-STG-5);
+action-task SLA is not a `slaRules[]` entry (K-SLA-1); escalation-only SLA entries may omit count/unit
+(K-SLA-2); `=js:` namespaces are `vars, response, bindings, iterator, metadata` — the vars/metadata
+restriction is conditionExpression-only (K-EXPR-1/2; assignment ban sourced to FE
+`ValidateCaseManagementNoAssignmentsUtils.ts`); binding-form list completed (literals, `=datafabric.*`,
+`=orchestrator.JobAttachments`, `=response`/`=result`/`=Error`); `wait-for-timer` has no `tasks describe`
+flag (K-TYP-1); both whole-value xref spellings sanctioned (K-VAR-1).
 
 <!-- END: case-knowledge-ledger.md -->

--- a/skills/uipath-planner/references/case-knowledge/INDEX.md
+++ b/skills/uipath-planner/references/case-knowledge/INDEX.md
@@ -1,0 +1,36 @@
+# Case Knowledge — shared single-source layer
+
+Every cross-skill Case Management fact and rule lives here exactly once. `uipath-planner` owns this
+directory on disk; `uipath-maestro-case` reaches the same files via `references/case-knowledge` (symlink —
+identical content, no copy). Downstream references CITE rules by ID (e.g. `(K-STG-2)`), never restate them.
+Restating a `K-*` rule outside this directory is a defect the knowledge lint rejects.
+
+## Files
+
+| File | Owns | ID prefix |
+|---|---|---|
+| [facts/types.yaml](facts/types.yaml) | Task/node/trigger/variable type enums, name-mapping table | `K-TYP` |
+| [facts/pairing.yaml](facts/pairing.yaml) | Lifecycle gates: legal WHEN rules per slot, Marks-Complete pairing, exit types | `K-PAIR` |
+| [facts/naming.yaml](facts/naming.yaml) | Display-name character rules, uniqueness scopes | `K-NAME` |
+| [facts/sla.yaml](facts/sla.yaml) | SLA units/bounds, escalation fields, response model, breach/at-risk selector | `K-SLA` |
+| [semantics/stages.md](semantics/stages.md) | Stage lifecycle, secondary stages, global events, case completion | `K-STG` |
+| [semantics/sequencing.md](semantics/sequencing.md) | Task activation modes, sequential/parallel/adhoc grammar | `K-SEQ` |
+| [semantics/edges-retired.md](semantics/edges-retired.md) | Edges retired; condition-only reachability | `K-EDGE` |
+| [semantics/expressions.md](semantics/expressions.md) | Expression namespaces, conditionExpression scope | `K-EXPR` |
+| [semantics/variables-io.md](semantics/variables-io.md) | Variables doctrine: task xref default, declare-vs-xref, outputs grammar | `K-VAR` |
+| [contracts/sdd-contract.md](contracts/sdd-contract.md) | What a build-ready `sdd.md` contains; receipt check | `K-SDD` |
+| [contracts/handoff.md](contracts/handoff.md) | The design-handoff protocol between the two skills | `K-HOF` |
+| [contracts/resolution-ledger.md](contracts/resolution-ledger.md) | `registry-resolved.json` / resolution-ledger entry shape | `K-LEDG` |
+| [errors/validate-codes.md](errors/validate-codes.md) | Verified `uip maestro case validate` failures → cause → fix | `K-ERR` |
+
+## Conventions
+
+1. One rule = one ID = one definition. Definitions are marked `**[K-XXX-n]**` (YAML: the `id` key).
+2. Version- or behavior-sensitive claims carry `(as of <version/date>)` anchors. Expired anchor = re-verify,
+   not false. Probe evidence: `docs/case-knowledge-ledger.md` (repo root).
+3. Authority order for corrections: `uip maestro case validate` behavior (`@uipath/case-schema`) >
+   PO.Frontend source > CLI local types. The CLI's authoring subcommand allow-lists lag the v27 schema.
+4. Consumers: planner design files cite design-relevant IDs; maestro-case phase/plugin files cite
+   emit-relevant IDs. Both audit scripts (`audit_sdd.py`, `audit_plan.py`) read `facts/*.yaml` directly.
+
+<!-- END: INDEX.md -->

--- a/skills/uipath-planner/references/case-knowledge/INDEX.md
+++ b/skills/uipath-planner/references/case-knowledge/INDEX.md
@@ -1,9 +1,11 @@
 # Case Knowledge — shared single-source layer
 
 Every cross-skill Case Management fact and rule lives here exactly once. `uipath-planner` owns this
-directory on disk; `uipath-maestro-case` reaches the same files via `references/case-knowledge` (symlink —
-identical content, no copy). Downstream references CITE rules by ID (e.g. `(K-STG-2)`), never restate them.
-Restating a `K-*` rule outside this directory is a defect the knowledge lint rejects.
+directory on disk; `uipath-maestro-case` reaches the same files via a `references/case-knowledge` directory
+symlink (identical content, no copy — landed later in this PR series, together with the packaging
+dereference and the repo-rule amendment that sanctions it). Downstream references CITE rules by ID (e.g.
+`(K-STG-2)`), never restate them — enforced by `scripts/lint-case-knowledge.py` once the lint PR of this
+series lands.
 
 ## Files
 
@@ -31,6 +33,7 @@ Restating a `K-*` rule outside this directory is a defect the knowledge lint rej
 3. Authority order for corrections: `uip maestro case validate` behavior (`@uipath/case-schema`) >
    PO.Frontend source > CLI local types. The CLI's authoring subcommand allow-lists lag the v27 schema.
 4. Consumers: planner design files cite design-relevant IDs; maestro-case phase/plugin files cite
-   emit-relevant IDs. Both audit scripts (`audit_sdd.py`, `audit_plan.py`) read `facts/*.yaml` directly.
+   emit-relevant IDs. Both audit scripts (`audit_sdd.py`, `audit_plan.py`) read `facts/*.yaml` directly
+   (wired in this series' lint/CI PR).
 
 <!-- END: INDEX.md -->

--- a/skills/uipath-planner/references/case-knowledge/contracts/handoff.md
+++ b/skills/uipath-planner/references/case-knowledge/contracts/handoff.md
@@ -1,0 +1,44 @@
+# Design handoff — the one protocol
+
+THE definition of how a case build request without an `sdd.md` becomes a design and returns to the build.
+Both skills point here; neither restates it. (`uipath-planner` = "the lane"; `uipath-maestro-case` = "the
+build".)
+
+**[K-HOF-1] Trigger.** The build detects no `sdd.md` at the resolved path (or a case `sdd.draft.md`
+finalization request). It hands off IMMEDIATELY — before reading its own references, hunting the
+filesystem, or running tenant commands — by loading `uipath-planner` and entering its Case Design Lane in
+**Build handoff** mode, in THIS conversation, never a subagent. The in-memory model, resolution ledger, and
+the session's registry pull cross the skill boundary for free. The build never designs: no improvised
+interview, no design subagents, no generic "Build Plan" checkpoint. If `uipath-planner` is unavailable:
+one line saying so, ask the user for an `sdd.md` (or a pasted design to build from), stop.
+
+**[K-HOF-2] The lane owns everything through the SDD write:** best-assumption design with the user,
+mandatory other-path sweep, design-time tenant grounding with ONE batched resolution gate, and ONE
+confirmation — the decision-first, eight-section **Case Review** (Case Snapshot, Primary Journey, Other
+Paths Considered, SLA and Escalations, Rules and Outcomes, Resources and Integrations, Decisions I Made,
+Review Flags; + the conditional Caller-obligation block). It names every stage and task with type,
+activation/grouping, required status, routing, and SLA context; it deliberately omits the data contract,
+variables, and task I/O (complete in `sdd.md`). It is the ONLY approval surface — a user "Yes" to any
+generic plan must not create files. The Build options fold in the build-review preference
+(`straight through` / `pause at the build preview`; relabeled `Build despite N flagged items` when ⚠ flags
+exist). Corrections re-show only changed sections.
+
+**[K-HOF-3] The Build answer IS the consent.** On it the lane writes `sdd.md` at the working root
+(write-early cadence; never overwriting an existing one — presence = trust-as-written, abort and surface),
+`Status: ready`, and the build resumes immediately in the same conversation — `uip solution init` + its
+Phase 1 — with no extra approval prompt (an explicit sign-off request adds exactly one). User-facing
+language never mentions the handoff: one continuous flow.
+
+**[K-HOF-4] What crosses the boundary.** (a) `sdd.md` — the contract, trusted as written; (b) the
+in-memory model; (c) the resolution ledger entries ([resolution-ledger.md](resolution-ledger.md)) — the
+build's Phase 1 persists them verbatim to `tasks/registry-resolved.json` and verifies instead of
+re-resolving; (d) the session's registry pull (build reuses the cache when the lane's pull succeeded this
+session). Gate decisions the user actually answered are executed without re-asking; defaulted deferrals
+(no `gateDecision`) get the build's own gate.
+
+**[K-HOF-5] Scope of the handoff.** Design, standalone-draft, and draft-finalization requests invoked
+directly belong to the planner (the build builds only). Cross-product planning beyond the case stays a
+plain-text suggestion of `uipath-planner` — no handoff. The build's receipt check for SDDs it did not watch
+being written: [sdd-contract.md § Receipt check](sdd-contract.md).
+
+<!-- END: handoff.md -->

--- a/skills/uipath-planner/references/case-knowledge/contracts/resolution-ledger.md
+++ b/skills/uipath-planner/references/case-knowledge/contracts/resolution-ledger.md
@@ -1,0 +1,38 @@
+# Resolution ledger — the one entry shape
+
+THE definition of the resolution record that crosses the design→build boundary. The planner's lane keeps
+it in memory; the build persists it verbatim as `tasks/registry-resolved.json` and extends it.
+
+**[K-LEDG-1] Entry shape — exact keys, one object per resolved/attempted lookup:**
+
+```jsonc
+{
+  "stage": "<SDD stage name>",          // associates the entry to one SDD declaration
+  "task": "<SDD task name>",
+  "taskType": "<K-TYP-1 value>",
+  "cacheFile": "<basename actually searched, e.g. agent-index.json>",
+  "searchQuery": "<the lookup string>",
+  "matches": [ /* FULL exact-name match set from the refreshed cache — never a summary */ ],
+  "selected": { /* adopted entry */ },  // or null after a genuine empty lookup
+  "rationale": "<why>",
+  "gateDecision": "pick:<name>" | "resolve-at-build" | "create-during-build"  // ONLY if the user answered
+}
+```
+
+**[K-LEDG-2] `gateDecision` presence = user consent.** It exists ONLY for items the user actually answered
+at the design-time resolution gate; the build executes it without re-asking (`resolve-at-build` →
+placeholder; `create-during-build` → inline-create flow; `pick:` → bind that entry). A defaulted deferral
+— no session, failed/pending pull, non-interactive run — carries NO `gateDecision` and gets the build's own
+gate in full. Never treat a defaulted `resolve at build` as a user decision.
+
+**[K-LEDG-3] Cache-state rule.** Before a successful `registry pull` this session, a missing cache
+directory/file is a failed refresh precondition — never a zero-match result. Only after a successful pull
+may an empty exact-name match set enter the empty-lookup flow. `matches` always reflects the cache
+refreshed this session.
+
+**[K-LEDG-4] Deep metadata stays out of the SDD.** Runtime metadata that does not affect plan replication
+(agent prompts, package versions, endpoints, release tags) lives in this file under the task's entry, plus
+each resolved contract's I/O (from `tasks describe` / `case spec`) and `review_items[]`. The SDD carries
+name + folder + identity + sub-type only.
+
+<!-- END: resolution-ledger.md -->

--- a/skills/uipath-planner/references/case-knowledge/contracts/sdd-contract.md
+++ b/skills/uipath-planner/references/case-knowledge/contracts/sdd-contract.md
@@ -25,10 +25,12 @@ backtick-wrapped (build checkers match the plain marker).
 args (`selected-stage-completed("<Stage>")`, `sla-status-change("<root|Stage>","<SLA Title>"[,"<At-Risk
 Escalation>"])` — target literal `root` for case scope); prose uses bare rule names, never partial call
 forms. Inputs `Binding` cells use the K-EXPR-1 forms plus the xref forms (K-VAR-1); Outputs rows use the
-K-VAR-5 operators. Bare field-name lists are forbidden. Every `process`/`agent`/`rpa`/`api-workflow` task
-carries a concrete `Resolved Resource` (never `<UNRESOLVED>`), `Folder Path`, `Resource Identity`, and
-`Binding Sub-Type`; actions carry a concrete Action App title; case-management tasks a concrete
-`Child Case`.
+K-VAR-5 operators. Bare field-name lists are forbidden. Portable names are ALWAYS concrete — `Resolved
+Resource` on every `process`/`agent`/`rpa`/`api-workflow` task, the Action App title on every action, the
+`Child Case` name on every case-management task — never `<UNRESOLVED>`. Identity and folder cells
+(`Resource Identity`, `Folder Path`, `Action App ID`, `Deployment Folder`, `Binding Sub-Type`) are concrete
+when resolved, or `<UNRESOLVED>` paired with a review item when deferred (K-LEDG-2's `resolve-at-build`
+flow depends on this).
 
 **[K-SDD-4] Companion artifacts.** The build derives `tasks/tasks.md` and
 `tasks/registry-resolved.json` in a `tasks/` directory at the working root, ADJACENT to `sdd.md` — never

--- a/skills/uipath-planner/references/case-knowledge/contracts/sdd-contract.md
+++ b/skills/uipath-planner/references/case-knowledge/contracts/sdd-contract.md
@@ -1,0 +1,43 @@
+# Build-ready SDD — the contract
+
+What a case `sdd.md` must contain for the build to consume it trust-as-written. The full render shape is
+the planner's template (`assets/templates/case-sdd-template.md`); this contract is the structural subset
+both skills depend on.
+
+**[K-SDD-1] Required skeleton.** First heading `# SDD — {Case Name}`; `## Document History`;
+`## Planner Handoff` header + `<!-- planner-handoff:v1 -->` marker with `Status: ready`;
+`## Table of Contents`; exact section headings `## Section 1: Case Definition` (containing
+`### Case Metadata`, `### Case Triggers`, `### Case Exit Conditions`, `### Case Variables`),
+`## Section 2: Stages & Tasks`, `## Section 3: Personas & App Views` (`### Personas`,
+`### Process App Views`), `## Section 4: Integrations` (resource families or explicit `> None.`).
+
+**[K-SDD-2] Per-stage / per-task blocks.** Every primary stage: `### Stage {N}: {Name}`; every secondary
+stage: `### Secondary Stage: {Name}` with an explicit `**Interrupting:**` line. Every stage block:
+`**Type:**`, `**Design Rationale:**`, `#### Stage Entry Conditions`, `#### Stage Exit Conditions`
+(completion `Yes` and exit `No` rows in one table: `WHEN | IF | Exit Type | Marks Stage Complete |
+Display Name`), `#### Tasks`. Every task: `##### Task {N}.{M}: {Name}` (secondary: `##### Task S{K}.{M}:`,
+never letter prefixes) with `**Type:**` (K-TYP-1 value), `**Activation Mode:**`, `**Design Rationale:**`,
+`**Entry Condition:**` + its `| WHEN | IF | Display Name |` table, exact marker `**Task envelope**`
+(no colon), and the type-specific detail block. `<UNRESOLVED>` renders as plain text — never
+backtick-wrapped (build checkers match the plain marker).
+
+**[K-SDD-3] Cell grammar the build parses mechanically.** Condition cells use the call forms with complete
+args (`selected-stage-completed("<Stage>")`, `sla-status-change("<root|Stage>","<SLA Title>"[,"<At-Risk
+Escalation>"])` — target literal `root` for case scope); prose uses bare rule names, never partial call
+forms. Inputs `Binding` cells use the K-EXPR-1 forms plus the xref forms (K-VAR-1); Outputs rows use the
+K-VAR-5 operators. Bare field-name lists are forbidden. Every `process`/`agent`/`rpa`/`api-workflow` task
+carries a concrete `Resolved Resource` (never `<UNRESOLVED>`), `Folder Path`, `Resource Identity`, and
+`Binding Sub-Type`; actions carry a concrete Action App title; case-management tasks a concrete
+`Child Case`.
+
+**[K-SDD-4] Companion artifacts.** The build derives `tasks/tasks.md` and
+`tasks/registry-resolved.json` in a `tasks/` directory at the working root, ADJACENT to `sdd.md` — never
+inside the solution/project directory. Any SDD header naming a tasks file points at `tasks/tasks.md`.
+
+**[K-SDD-5] Receipt check** (the build runs this on any `sdd.md` it did not watch being written — one
+Grep): the four `## Section {1..4}:` headings AND ≥ 1 `##### Task` detail block must be present. A
+freeform/summary SDD (top-level `## Source`, `## Case Objective`, `## Task Plan`, `## Acceptance
+Scenarios`, build-mode/path narration) is not buildable — route it back through the planner's template
+conformance gate. A valid `caseplan.json` never proves the SDD followed the template.
+
+<!-- END: sdd-contract.md -->

--- a/skills/uipath-planner/references/case-knowledge/errors/validate-codes.md
+++ b/skills/uipath-planner/references/case-knowledge/errors/validate-codes.md
@@ -18,6 +18,8 @@ behavior. All rows verified on uip 1.198.0-preview.102 (2026-07-31 / 2026-08-17 
 | `The escalation referenced by rule … no longer exists` | At-risk rule borrowing another SLA's escalation, or the `any` sentinel | K-SLA-3 — same-SLA at-risk escalation, or drop `escalationId` for breach |
 | `The SLA referenced by rule … no longer exists` | Dangling `slaId` | Reference an SLA declared on the row's target |
 | `Case has no completion rules` | No `caseExitRules[]` entry with `marksCaseComplete: true` | K-PAIR-6 |
+| `Stage rule '<name>' has no possible stage options.` | `wait-for-user` exit with no `user-selected-stage` entry anywhere | K-PAIR-4 — add the paired entry |
+| `Stage entry rule '<name>' will never be met.` | `user-selected-stage` entry with no `wait-for-user` exit anywhere | K-PAIR-4 — add the paired exit |
 | `connector activity missing` | Bare `wait-for-connector` rule without `uipath` + `context` | Splice the `case spec` scaffold; stub placeholders keep an empty-outputs `uipath` block |
 
 **[K-ERR-2] Defects validate CANNOT see** — green run, broken case; all on the author:

--- a/skills/uipath-planner/references/case-knowledge/errors/validate-codes.md
+++ b/skills/uipath-planner/references/case-knowledge/errors/validate-codes.md
@@ -1,0 +1,38 @@
+# `uip maestro case validate` — verified failures and invisible defects
+
+Single source for validate behavior claims. Message-quoted, version-anchored — the SDK path
+(`@uipath/case-schema`) surfaces MESSAGES, not `CASE_MGMT_*` codes; never cite bare codes as validate
+behavior. All rows verified on uip 1.198.0-preview.102 (2026-07-31 / 2026-08-17 probes;
+`docs/case-knowledge-ledger.md`).
+
+**[K-ERR-1] Verified failure messages → cause → fix**
+
+| Message (as emitted) | Cause | Fix |
+|---|---|---|
+| `Variable 'vars.X' does not exist` | Reference to an undeclared name: partial output entry (K-VAR-4), trigger output without root companion (K-VAR-3), or typo | Emit the full bare-mint output shape; add the §1.5/root companion for trigger fields; fix the reference |
+| `SLA name is missing` | SlaRuleEntry without `displayName` | K-SLA-2 — id + displayName on every entry |
+| `Invalid input: expected string, received undefined` at `…slaRules.N.id` | SlaRuleEntry without `id` | Same |
+| `One of your stage SLAs has a validation error` | Out-of-range duration (e.g. `min` < 15 or > 1000), or other entry-level violation | K-SLA-2 bounds; never silently clamp (K-NAME-5) |
+| `Stage exit rule '<name>' has no task(s) marked as required` | `required-tasks-completed` over a stage with zero `isRequired: true` tasks | K-PAIR-5 — mark the real completer required |
+| `Case rule '<name>' has no required stage(s) selected` | `required-stages-completed` with no `isRequired: true` primary stage (absent ≡ false) | K-PAIR-5 — explicit `isRequired: true` on required stages |
+| `The escalation referenced by rule … no longer exists` | At-risk rule borrowing another SLA's escalation, or the `any` sentinel | K-SLA-3 — same-SLA at-risk escalation, or drop `escalationId` for breach |
+| `The SLA referenced by rule … no longer exists` | Dangling `slaId` | Reference an SLA declared on the row's target |
+| `Case has no completion rules` | No `caseExitRules[]` entry with `marksCaseComplete: true` | K-PAIR-6 |
+| `connector activity missing` | Bare `wait-for-connector` rule without `uipath` + `context` | Splice the `case spec` scaffold; stub placeholders keep an empty-outputs `uipath` block |
+
+**[K-ERR-2] Defects validate CANNOT see** — green run, broken case; all on the author:
+
+1. A task with no entry condition never starts (`entryConditions: []` and absent key both pass — K-SEQ-5).
+2. `start-task` authored as a stage-entry row re-runs every `shouldRunOnlyOnce: false` task on re-entry (K-SLA-5).
+3. A breach rule "completed" with an escalation becomes an at-risk rule — behavior change, still green (K-SLA-3).
+4. A non-interrupting lane promoted to a regular stage silently joins the completion contract (K-STG-3).
+5. An envelope field nested inside `data` (e.g. `skipCondition`) passes and is dead config.
+6. Two secondary stages with identical entry rules pass (probe p07b) — ambiguous routing stays a design defect (K-STG-6).
+7. A connector rule's `context` internals are unchecked beyond `connectorKey` + `operation` presence — a wrong `serviceType` passes; Studio Web is the real connector judge.
+
+**[K-ERR-3] Validate cadence.** Intermediate authoring states are expected-invalid: run validate once at
+the end of prototyping (informational) and once at the validation phase (authoritative); every retry must
+be preceded by a fix edit — validate → validate with no intervening edit is a defect. `--skeleton` runs
+structural checks only (`--skeleton-v2` does not exist as of 1.198.0-preview.102).
+
+<!-- END: validate-codes.md -->

--- a/skills/uipath-planner/references/case-knowledge/facts/naming.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/naming.yaml
@@ -1,0 +1,21 @@
+# K-NAME — Display-name and identifier rules. Single source. Machine-read by audit scripts.
+# Authority: FE validation (colon-delimited case-execution events make `:` structural, not cosmetic)
+# + `uip maestro case validate` (as of 1.198.0-preview.102).
+
+K-NAME-1:
+  rule: "Safe display characters for every generated/carried Case Designer display or title field (stage label, task displayName, condition display names, SLA titles, escalation titles): letters, numbers, spaces, hyphen, underscore ONLY. Never `:` (case-execution events are colon-delimited — breaks routing), periods, slashes, quotes, parens, ampersands, commas, semicolons, emoji."
+  allowed_pattern: "^[A-Za-z0-9 _-]+$"
+
+K-NAME-2:
+  rule: "Mechanical repair for unsafe generated/user-carried display names: replace runs of disallowed chars with one space, collapse spaces, trim; keep words and casing; on empty/collision add a safe qualifier or numeric suffix and disclose. NEVER normalize external lookup names (Action App titles, process/connector/queue names) — those are matching keys; keep a separate safe display name."
+
+K-NAME-3:
+  rule: "Uniqueness scopes: task displayName unique across the WHOLE case (all stages — one pool; critical). Stage label unique across all node labels in the case, and must not reuse the reserved Case Manager stage label. SLA rule displayName unique within its target (root or that stage). Escalation displayName unique across ALL SLAs on the element (scope is the element, not one SLA). Names settle at design time — the planner authors every name, so global task-name uniqueness binds in the SDD, not just at build."
+
+K-NAME-4:
+  rule: "Mechanical derivations allowed without asking (record provenance): PascalCase Case Name from spaced phrase; 2–4 char UPPER identifier prefix from the PascalCase name; camelCase variable names from spaced phrases. Everything customer-named renders verbatim — no synonym substitution."
+
+K-NAME-5:
+  rule: "Numeric violations are surfaced, never silently repaired: an out-of-range value (e.g. SLA minutes < 15) is not clamped/rounded to pass validation — name the original value and ask for a replacement. Silent clamping is a requirements change."
+
+# END: naming.yaml

--- a/skills/uipath-planner/references/case-knowledge/facts/pairing.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/pairing.yaml
@@ -24,12 +24,14 @@ K-PAIR-2:
   no_when:   [selected-tasks-completed, selected-stage-completed, selected-stage-exited, wait-for-connector]
 
 K-PAIR-3:
-  rule: "Exit `type` legality per row kind: completion rows (Yes) = exit-only | return-to-origin | wait-for-user; exit rows (No) = exit-only | wait-for-user. wait-for-user + marksStageComplete:true is LEGAL and canonical for user-routed completion (probes p01/p02, as of 1.198.0-preview.102). return-to-origin is completion-only — never on a No row — and requires Interrupting: Yes on its lane (K-STG-4)."
-  completion_exit_types: [exit-only, return-to-origin, wait-for-user]
-  exit_exit_types: [exit-only, wait-for-user]
+  rule: "Exit `type` legality per row kind. STAGE rows: completion (Yes) = exit-only | return-to-origin | wait-for-user; exit (No) = exit-only | wait-for-user. wait-for-user + marksStageComplete:true is LEGAL and canonical for user-routed completion (probes p01/p02, as of 1.198.0-preview.102). return-to-origin is completion-only — never on a No row — and requires Interrupting: Yes on its lane (K-STG-4). CASE rows (metadata.caseExitRules): completion (Yes) = exit-only only; exit (No) = exit-only | wait-for-user."
+  stage_completion_exit_types: [exit-only, return-to-origin, wait-for-user]
+  stage_exit_exit_types: [exit-only, wait-for-user]
+  case_completion_exit_types: [exit-only]
+  case_exit_exit_types: [exit-only, wait-for-user]
 
 K-PAIR-4:
-  rule: "wait-for-user ↔ user-selected-stage pair across stages: a wait-for-user exit requires ≥1 other stage carrying a user-selected-stage entry, and vice versa — an unpaired half fails validate. user-selected-stage is picker exposure for user-chosen routing; deterministic rejection/approval/SLA routing uses decision facts + guarded entries instead."
+  rule: "wait-for-user ↔ user-selected-stage pair across stages — validate-enforced both ways (as of 1.198.0-preview.102): an unpaired wait-for-user exit fails with `Stage rule '<name>' has no possible stage options.` (probe p14); an unpaired user-selected-stage entry fails with `Stage entry rule '<name>' will never be met.` (probe p15). user-selected-stage is picker exposure for user-chosen routing; deterministic rejection/approval/SLA routing uses decision facts + guarded entries instead."
 
 K-PAIR-5:
   rule: "required-* rules are vacuous without explicit isRequired: required-stages-completed needs ≥1 primary stage isRequired:true; required-tasks-completed needs ≥1 task isRequired:true in that stage. Validate errors: 'Case rule <name> has no required stage(s) selected' / 'Stage exit rule <name> has no task(s) marked as required' (probes p08–p10, as of 1.198.0-preview.102). isRequired ABSENT ≡ false at the validator — required status is always explicit end-to-end: SDD declares it per stage/task (design default: primary stage Yes, task Yes, secondary stage No, adhoc task No); tasks.md carries it; emission writes it verbatim. No silent defaults at any layer."

--- a/skills/uipath-planner/references/case-knowledge/facts/pairing.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/pairing.yaml
@@ -1,0 +1,40 @@
+# K-PAIR — Lifecycle gates: which WHEN rule is legal in which slot; Marks-Complete pairing; exit types.
+# Single source (replaces restatements in rules guide, template, condition plugins). Machine-read by audit scripts.
+# Authority: v27 @uipath/case-schema behavior via `uip maestro case validate` + shipped-case evidence.
+# The CLI's authoring-command allow-lists (schema-helpers VALID_*_RULE_TYPES) lag this matrix (no
+# sla-status-change) — they gate `uip maestro case *-conditions add` only, not the schema.
+
+K-PAIR-1:
+  rule: "Legal WHEN rules per slot. Anything outside the slot's set is a design defect even when schema-valid."
+  slots:
+    stage-entry:        [case-entered, selected-stage-completed, selected-stage-exited, wait-for-connector, user-selected-stage, sla-status-change]
+    stage-completion:   [required-tasks-completed, wait-for-connector]     # Marks Stage Complete: Yes
+    stage-exit:         [selected-tasks-completed, wait-for-connector]     # Marks Stage Complete: No
+    task-entry:         [current-stage-entered, selected-tasks-completed, wait-for-connector, sla-status-change, adhoc, runs-sequentially]
+    case-completion:    [required-stages-completed, wait-for-connector]    # Marks Case Complete: Yes
+    case-exit:          [selected-stage-completed, selected-stage-exited, wait-for-connector]  # Marks Case Complete: No
+  notes:
+    - "case-entered: first/root stage only."
+    - "Tasks have NO exit/completion conditions — a task completes when its work finishes (downstream keys off required-/selected-tasks-completed)."
+    - "sla-status-change scope: enter-stage (stage-entry) and start-task (task-entry) — see K-SLA-4/5."
+
+K-PAIR-2:
+  rule: "Marks-Complete pairing: Yes pairs only with required-* (or wait-for-connector); selected-* is for No (routing/early exit/alternate disposition). Yes + selected-* is a schema-pairing error — block at design."
+  yes_when:  [required-tasks-completed, required-stages-completed, wait-for-connector]
+  no_when:   [selected-tasks-completed, selected-stage-completed, selected-stage-exited, wait-for-connector]
+
+K-PAIR-3:
+  rule: "Exit `type` legality per row kind: completion rows (Yes) = exit-only | return-to-origin | wait-for-user; exit rows (No) = exit-only | wait-for-user. wait-for-user + marksStageComplete:true is LEGAL and canonical for user-routed completion (probes p01/p02, as of 1.198.0-preview.102). return-to-origin is completion-only — never on a No row — and requires Interrupting: Yes on its lane (K-STG-4)."
+  completion_exit_types: [exit-only, return-to-origin, wait-for-user]
+  exit_exit_types: [exit-only, wait-for-user]
+
+K-PAIR-4:
+  rule: "wait-for-user ↔ user-selected-stage pair across stages: a wait-for-user exit requires ≥1 other stage carrying a user-selected-stage entry, and vice versa — an unpaired half fails validate. user-selected-stage is picker exposure for user-chosen routing; deterministic rejection/approval/SLA routing uses decision facts + guarded entries instead."
+
+K-PAIR-5:
+  rule: "required-* rules are vacuous without explicit isRequired: required-stages-completed needs ≥1 primary stage isRequired:true; required-tasks-completed needs ≥1 task isRequired:true in that stage. Validate errors: 'Case rule <name> has no required stage(s) selected' / 'Stage exit rule <name> has no task(s) marked as required' (probes p08–p10, as of 1.198.0-preview.102). isRequired ABSENT ≡ false at the validator — required status is always explicit end-to-end: SDD declares it per stage/task (design default: primary stage Yes, task Yes, secondary stage No, adhoc task No); tasks.md carries it; emission writes it verbatim. No silent defaults at any layer."
+
+K-PAIR-6:
+  rule: "Case completion is a root rule, separate from stage completion: ≥1 metadata.caseExitRules[] entry with marksCaseComplete:true (normally required-stages-completed). A stage exit with marksStageComplete:true completes only that stage. Rejection/withdrawal/cancel outcomes are separate case-exit rows with marksCaseComplete:false."
+
+# END: pairing.yaml

--- a/skills/uipath-planner/references/case-knowledge/facts/sla.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/sla.yaml
@@ -4,10 +4,10 @@
 # (probe dates 2026-07-31 and 2026-08-17); emit JSON shapes live in the SLA/condition plugins.
 
 K-SLA-1:
-  rule: "SLA surfaces: case (metadata.slaRules), stage (data.slaRules — secondary stages included), and `action` tasks (the task's own timer/SLA fields). NEVER SLA cells on process/agent/rpa/api-workflow/timer/connector/case-management tasks. All SLA data on a target lives in one slaRules[] array: conditional overrides first (priority order), trailing default entry with expression '=js:true'; first truthy expression wins."
+  rule: "SLA surfaces: case (metadata.slaRules), stage (data.slaRules — secondary stages included), and `action` tasks. NEVER SLA cells on process/agent/rpa/api-workflow/timer/connector/case-management tasks. Case/stage SLA data lives in the target's one slaRules[] array: conditional overrides first (priority order), trailing default entry with expression '=js:true'; first truthy expression wins. An action-task SLA is NOT a slaRules[] entry — it is the action task's own timer/SLA fields; add sla-status-change case behavior only when the missed task must change the case graph."
 
 K-SLA-2:
-  rule: "SlaRuleEntry requires `id` AND non-empty target-unique `displayName` (no ':') on EVERY entry — both validate-enforced ('SLA name is missing' / zod expected-string; probes p03/p04, as of 1.198.0-preview.102). Units: min|h|d|w|m. count > 0; unit min ⟹ 15 ≤ count ≤ 1000. Non-default entries require a non-empty expression. Escalations: id + non-empty element-unique displayName + ≥1 recipient; atRiskPercentage required iff trigger type at-risk."
+  rule: "SlaRuleEntry requires `id` AND non-empty target-unique `displayName` (no ':') on EVERY entry — both validate-enforced ('SLA name is missing' / zod expected-string; probes p03/p04, as of 1.198.0-preview.102). Units: min|h|d|w|m. count/unit optional as a PAIR only on a bare escalation-only entry; when present, count > 0 and unit min ⟹ 15 ≤ count ≤ 1000. Non-default entries require a non-empty expression. Escalations: id + non-empty element-unique displayName + ≥1 recipient; atRiskPercentage required iff trigger type at-risk."
   units: [min, h, d, w, m]
   min_bounds: { lower: 15, upper: 1000 }
 

--- a/skills/uipath-planner/references/case-knowledge/facts/sla.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/sla.yaml
@@ -1,0 +1,36 @@
+# K-SLA — SLA clocks, escalations, and the response model. Single source (supersedes the retired
+# maestro-case references/sla-response-shapes.md and every restatement in the rules guide/plugins).
+# Machine-read by audit scripts. Verified against `uip maestro case validate` 1.198.0-preview.102
+# (probe dates 2026-07-31 and 2026-08-17); emit JSON shapes live in the SLA/condition plugins.
+
+K-SLA-1:
+  rule: "SLA surfaces: case (metadata.slaRules), stage (data.slaRules — secondary stages included), and `action` tasks (the task's own timer/SLA fields). NEVER SLA cells on process/agent/rpa/api-workflow/timer/connector/case-management tasks. All SLA data on a target lives in one slaRules[] array: conditional overrides first (priority order), trailing default entry with expression '=js:true'; first truthy expression wins."
+
+K-SLA-2:
+  rule: "SlaRuleEntry requires `id` AND non-empty target-unique `displayName` (no ':') on EVERY entry — both validate-enforced ('SLA name is missing' / zod expected-string; probes p03/p04, as of 1.198.0-preview.102). Units: min|h|d|w|m. count > 0; unit min ⟹ 15 ≤ count ≤ 1000. Non-default entries require a non-empty expression. Escalations: id + non-empty element-unique displayName + ≥1 recipient; atRiskPercentage required iff trigger type at-risk."
+  units: [min, h, d, w, m]
+  min_bounds: { lower: 15, upper: 1000 }
+
+K-SLA-3:
+  rule: "Status rides on the escalation reference (sla-status-change rule fields): Breached = slaId ALONE — an absent escalationId IS the persisted Breached shape; never 'complete' it by adding an escalation (that silently converts it to at-risk). At-risk = slaId + a concrete escalationId declared ON THAT SAME SLA with triggerInfo.type at-risk. Never the Case Designer 'any' sentinel (validate: 'The escalation referenced by rule … no longer exists'); dangling slaId likewise invalid."
+
+K-SLA-4:
+  rule: "Response model — pick from the source's words, never from the SLA's scope. Closed set:"
+  responses:
+    notify-only:  { author: "escalation on the target's slaRules[].escalationRule — no stage, no task, no condition", interrupting: "n/a" }
+    start-task:   { author: "one task in the BREACHED stage carrying sla-status-change as its OWN task-entry row against that stage's (or root's) SLA — no new stage, no stage-entry row", interrupting: "— (task entry interrupts nothing; never Yes/No)" }
+    enter-stage:  { author: "a separate stage carrying the sla-status-change entry row", interrupting: "Yes when the response pauses/takes over/reroutes active work; No for parallel oversight" }
+    exit-stage:   { author: "a stage-exit row", interrupting: "per exit semantics" }
+    exit-case:    { author: "a metadata.caseExitRules[] row", interrupting: "per exit semantics" }
+  default: "No stated response → both statuses notify-only (at-risk → owning persona/group; breached → next tier). Never invent a stage, task, or routing change for a notify-only requirement."
+
+K-SLA-5:
+  rule: "start-task vs enter-stage turns on WHERE the work lives, not on interruption: work inside the breached stage's own review ('as part of the assessment', a named TASK for a manager/peer) → start-task; a separate lane owns it ('hand it to', 'escalate into <Lane>', a named STAGE) → enter-stage. A named task never justifies minting a stage. NEVER author start-task as a stage-entry row on the breached stage: validate accepts it but stage re-entry re-runs every shouldRunOnlyOnce:false task — the canonical invisible defect."
+
+K-SLA-6:
+  rule: "Default at-risk thresholds when unstated: SLA ≤ 3d → 75%; 3–10d → 70%; > 10d → 80%. Default recipients: at-risk → owner persona's user group; breached → leadership tier (Compliance for regulation-driven cases). Record substitutions with provenance."
+
+K-SLA-7:
+  rule: "Validate-verified matrix (uip 1.198.0-preview.102): breach on separate stage (slaId only, either isInterrupting) valid; breach/at-risk on a task's entryConditions (stage or root SLA) valid; at-risk with same-SLA escalation valid; at-risk borrowing another SLA's escalation INVALID; escalationId 'any' INVALID; dangling slaId INVALID; task with empty/absent entryConditions valid (defect invisible — such a task never starts)."
+
+# END: sla.yaml

--- a/skills/uipath-planner/references/case-knowledge/facts/types.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/types.yaml
@@ -15,20 +15,20 @@ K-TYP-1:
     - { sdd_type: case-management,             plugin: case-management,    cli_flag: case-management }
     - { sdd_type: execute-connector-activity,  plugin: connector-activity, cli_flag: connector-activity }
     - { sdd_type: wait-for-connector,          plugin: connector-trigger,  cli_flag: connector-trigger }
-    - { sdd_type: wait-for-timer,              plugin: wait-for-timer,     cli_flag: wait-for-timer }
+    - { sdd_type: wait-for-timer,              plugin: wait-for-timer,     cli_flag: null }  # no `tasks describe` — timer needs no schema discovery
 
 K-TYP-2:
   rule: "Never author these as task types. Schema-valid-but-unsupported: external-agent, external-workflow, document-extraction, flow-process (not supported yet). Not types at all: connector-activity, connector-trigger, wait-for-event (folder/flag names, not schema literals). Externally-hosted AI agents model as api-workflow or execute-connector-activity."
   never_author: [external-agent, external-workflow, document-extraction, flow-process, connector-activity, connector-trigger, wait-for-event]
 
 K-TYP-3:
-  rule: "Node `type` discriminators (v27): trigger = uipath.case.trigger; stage = case-management:Stage (stageType: primary|secondary in data — ExceptionStage node type removed at v22); sticky note = case-management:StickyNote."
+  rule: "Node `type` discriminators (v27): trigger = uipath.case.trigger; stage = case-management:Stage (secondary stages carry data.stageType: 'secondary'; primary = the key OMITTED — never emit 'primary'; ExceptionStage node type removed at v22); sticky note = case-management:StickyNote."
   node_types: ["uipath.case.trigger", "case-management:Stage", "case-management:StickyNote"]
-  stage_types: [primary, secondary]
+  stage_type_emitted: { primary: null, secondary: secondary }
 
 K-TYP-4:
-  rule: "Trigger serviceType on disk (data.inputs.serviceType): manual = key ABSENT (never 'Manual'); timer = 'timer' (SDD author token: Intsvc.TimerTrigger); connector event = 'Intsvc.EventTrigger'."
-  service_types: { manual: null, timer: timer, event: Intsvc.EventTrigger }
+  rule: "Trigger serviceType (data.inputs.serviceType): manual = EMIT 'None' (absent also validates — read-tolerance for older files; probes p00/p13, as of 1.198.0-preview.102 — never 'Manual'); timer = 'timer' (SDD author token: Intsvc.TimerTrigger); connector event = 'Intsvc.EventTrigger'."
+  service_types: { manual: None, timer: timer, event: Intsvc.EventTrigger }
 
 K-TYP-5:
   rule: "Variable Type enum: string, integer, float, double, boolean, date, datetime, jsonSchema, file. `json` is NOT a type. jsonSchema (with `body`) for structured payloads whose sub-fields are picked/referenced downstream; string for opaque JSON blobs nothing dereferences. file = JobAttachment record. jsonSchema validates (probe p06, as of 1.198.0-preview.102)."

--- a/skills/uipath-planner/references/case-knowledge/facts/types.yaml
+++ b/skills/uipath-planner/references/case-knowledge/facts/types.yaml
@@ -1,0 +1,51 @@
+# K-TYP — Case type enums + name mappings. Single source; consumers cite, never restate.
+# Machine-read by scripts/audit_sdd.py and scripts/audit_plan.py.
+# Authority: v27 schema (@uipath/case-schema via `uip maestro case validate`); verified 2026-08-17,
+# uip 1.198.0-preview.102. Naming-asymmetry mapping: sdd_type IS the caseplan.json `type` literal
+# (schema-kebab); plugin = maestro-case plugin folder; cli_flag = `tasks describe --type` value.
+
+K-TYP-1:
+  rule: "Task `type` enum is closed — exactly these 9 authorable values. sdd.md `Type:` and caseplan.json `type` use sdd_type verbatim."
+  task_types:
+    - { sdd_type: process,                     plugin: process,            cli_flag: process }
+    - { sdd_type: action,                      plugin: action,             cli_flag: action }
+    - { sdd_type: agent,                       plugin: agent,              cli_flag: agent }
+    - { sdd_type: rpa,                         plugin: rpa,                cli_flag: rpa }
+    - { sdd_type: api-workflow,                plugin: api-workflow,       cli_flag: api-workflow }
+    - { sdd_type: case-management,             plugin: case-management,    cli_flag: case-management }
+    - { sdd_type: execute-connector-activity,  plugin: connector-activity, cli_flag: connector-activity }
+    - { sdd_type: wait-for-connector,          plugin: connector-trigger,  cli_flag: connector-trigger }
+    - { sdd_type: wait-for-timer,              plugin: wait-for-timer,     cli_flag: wait-for-timer }
+
+K-TYP-2:
+  rule: "Never author these as task types. Schema-valid-but-unsupported: external-agent, external-workflow, document-extraction, flow-process (not supported yet). Not types at all: connector-activity, connector-trigger, wait-for-event (folder/flag names, not schema literals). Externally-hosted AI agents model as api-workflow or execute-connector-activity."
+  never_author: [external-agent, external-workflow, document-extraction, flow-process, connector-activity, connector-trigger, wait-for-event]
+
+K-TYP-3:
+  rule: "Node `type` discriminators (v27): trigger = uipath.case.trigger; stage = case-management:Stage (stageType: primary|secondary in data — ExceptionStage node type removed at v22); sticky note = case-management:StickyNote."
+  node_types: ["uipath.case.trigger", "case-management:Stage", "case-management:StickyNote"]
+  stage_types: [primary, secondary]
+
+K-TYP-4:
+  rule: "Trigger serviceType on disk (data.inputs.serviceType): manual = key ABSENT (never 'Manual'); timer = 'timer' (SDD author token: Intsvc.TimerTrigger); connector event = 'Intsvc.EventTrigger'."
+  service_types: { manual: null, timer: timer, event: Intsvc.EventTrigger }
+
+K-TYP-5:
+  rule: "Variable Type enum: string, integer, float, double, boolean, date, datetime, jsonSchema, file. `json` is NOT a type. jsonSchema (with `body`) for structured payloads whose sub-fields are picked/referenced downstream; string for opaque JSON blobs nothing dereferences. file = JobAttachment record. jsonSchema validates (probe p06, as of 1.198.0-preview.102)."
+  variable_types: [string, integer, float, double, boolean, date, datetime, jsonSchema, file]
+
+K-TYP-6:
+  rule: "Variable Category enum (SDD §1.5): In (caller/trigger-bound argument), Out (returned to caller), Variable (internal state incl. trigger-payload extraction). Never blank."
+  variable_categories: [In, Out, Variable]
+
+K-TYP-7:
+  rule: "Escalation enums: triggerInfo.type = at-risk | sla-breached (atRiskPercentage required iff at-risk); action.type = notification; recipient scope = User | UserGroup. Action-task recipient prefixes in SDD: Email:, User:, UserGroup:, Role:, Expression: — never bare strings."
+  escalation_trigger: [at-risk, sla-breached]
+  recipient_scope: [User, UserGroup]
+  sdd_recipient_prefixes: ["Email:", "User:", "UserGroup:", "Role:", "Expression:"]
+
+K-TYP-8:
+  rule: "Exit condition `type` enum: exit-only | wait-for-user | return-to-origin. Slot legality in K-PAIR."
+  exit_types: [exit-only, wait-for-user, return-to-origin]
+
+# END: types.yaml

--- a/skills/uipath-planner/references/case-knowledge/semantics/edges-retired.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/edges-retired.md
@@ -1,0 +1,15 @@
+# Edges — retired
+
+**[K-EDGE-1] Never author edges.** `schema.edges` stays `[]` (the key remains for FE compatibility).
+Stage transitions derive entirely from entry/exit conditions; the case start derives from the first
+stage's `case-entered` entry, not a TriggerEdge. The FE auto-derives canvas connectors from conditions.
+
+**[K-EDGE-2] Condition-only reachability is therefore load-bearing.** With no edge graph to fall back on,
+a malformed or missing entry condition is the only thing that can orphan a stage — the reachability walk
+(K-STG-7) is the sole guard.
+
+**[K-EDGE-3] Round-tripped files may contain FE-materialized edge objects.** Treat them as read-only:
+never copy, adapt, or author one; model flow with conditions. Defensive stray-edge removal is a build-side
+edit operation, not authoring.
+
+<!-- END: edges-retired.md -->

--- a/skills/uipath-planner/references/case-knowledge/semantics/expressions.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/expressions.md
@@ -1,11 +1,16 @@
 # Expressions — namespaces and gates
 
-**[K-EXPR-1] Expression forms.** Case expressions are `=js:`-prefixed JavaScript over case state
-(`vars.<id>`, `metadata.<key>`). Assignment operators are forbidden in every case expression. Reference
-forms in bindings: `=vars.<id>` (variable / upstream output — K-VAR), `=vars.<id>.<sub>` (dot-path into a
-structured value), `=metadata.<key>`, `=metadata.ExternalId` (the platform-minted case identity — the
-canonical `caseId` binding; it is NOT a task output), `=bindings.<id>` (registered resources),
-`=trigger.<field>`, `=jsonString:<json>` (connector essentialConfiguration carry-through only).
+**[K-EXPR-1] Expression forms.** Case expressions are `=js:`-prefixed JavaScript; predefined namespaces
+available to `=js:` evaluation are `vars`, `response`, `bindings`, `iterator`, `metadata` (the narrower
+conditionExpression scope is K-EXPR-2). Assignment operators are forbidden in every case expression
+(FE `ValidateCaseManagementNoAssignmentsUtils.ts`, PO.Frontend @ e8c176e4d). Binding-cell reference forms:
+plain literals (`"50"`, `0`, `true`), `=vars.<id>` (variable / upstream output — K-VAR),
+`=vars.<id>.<sub>` (dot-path into a structured value), `=metadata.<key>`, `=metadata.ExternalId` (the
+platform-minted case identity — the canonical `caseId` binding; NOT a task output), `=bindings.<id>`
+(registered resources), `=trigger.<field>`, `=js:<expr>` (required when operators are involved),
+`=jsonString:<json>` (connector essentialConfiguration carry-through only), `=datafabric.<path>`,
+`=orchestrator.JobAttachments` (file slot), and the conventional response handles `=response` / `=result`
+/ `=Error`.
 
 **[K-EXPR-2] `conditionExpression` gates CASE STATE only.** No `event` namespace exists — a rule's
 expression cannot read the incoming event payload. In-rule extract-then-gate (extract `response.X ->

--- a/skills/uipath-planner/references/case-knowledge/semantics/expressions.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/expressions.md
@@ -1,0 +1,25 @@
+# Expressions — namespaces and gates
+
+**[K-EXPR-1] Expression forms.** Case expressions are `=js:`-prefixed JavaScript over case state
+(`vars.<id>`, `metadata.<key>`). Assignment operators are forbidden in every case expression. Reference
+forms in bindings: `=vars.<id>` (variable / upstream output — K-VAR), `=vars.<id>.<sub>` (dot-path into a
+structured value), `=metadata.<key>`, `=metadata.ExternalId` (the platform-minted case identity — the
+canonical `caseId` binding; it is NOT a task output), `=bindings.<id>` (registered resources),
+`=trigger.<field>`, `=jsonString:<json>` (connector essentialConfiguration carry-through only).
+
+**[K-EXPR-2] `conditionExpression` gates CASE STATE only.** No `event` namespace exists — a rule's
+expression cannot read the incoming event payload. In-rule extract-then-gate (extract `response.X ->
+caseVar` and gate `=js:vars.caseVar` on the SAME rule) does NOT work at runtime: the gate evaluates before
+the extract writes. To condition on payload content, extract on the connector rule and place the gate on a
+DOWNSTREAM stage-entry / task-entry condition.
+
+**[K-EXPR-3] Use strict equality** (`===` / `!==`) in `=js:` guards, and write mutually-exclusive branch
+guards as exact inverses (`=== v` / `!== v`) so completion and divert rows cannot dual-fire (K-STG-5).
+
+**[K-EXPR-4] Thresholded policy is executable, not prose.** A source rule tying an actor or step to a
+comparator ("Credit Analyst only over $5M") must appear in an executable cell — a guarded WHEN/IF, a
+computed owner/recipient (`=js:vars.loanAmount > 5000000 ? "Role:CreditAnalyst" : "Role:Underwriter"`), or
+a task-entry gate — with the numeral written out, actor and attribute on one line. Prose or persona-table
+mention alone is a render failure.
+
+<!-- END: expressions.md -->

--- a/skills/uipath-planner/references/case-knowledge/semantics/sequencing.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/sequencing.md
@@ -1,0 +1,48 @@
+# Task activation — sequential, parallel, event, adhoc
+
+Single source for task activation-mode grammar. Slot legality: [facts/pairing.yaml](../facts/pairing.yaml).
+
+**[K-SEQ-1] Task-entry mode is exclusive.** Map the product's task modes exactly: *sequential* → one
+`runs-sequentially` entry rule (only rule on the task); *event-triggered* → the explicit event rule
+(`wait-for-connector` with connector config, or `sla-status-change` for a start-task SLA response);
+*manually-triggered* → one `adhoc` rule + `isRequired: false`; *stage-started* → `current-stage-entered`.
+Never add `current-stage-entered` alongside any of the others, and never infer a mode from `data.tasks`
+lane layout.
+
+**[K-SEQ-2] Sequential normalization.** When the source states order (`then`, `after`, `before`,
+`in order`, an upstream-output prerequisite) for contiguous tasks in one stage, EVERY task in the ordered
+run — including the first — carries exactly one `runs-sequentially` row. The first task set's rule means
+"stage entered"; each later set's rule means "previous task set completed". Structure mirrors it in
+`data.tasks` (2D): strict chain = consecutive single-task sets `[[A],[B],[C]]`; independent siblings after
+one predecessor share the next set `[[A],[B,C]]`, each sibling still `runs-sequentially`
+(*parallel-after-predecessor*). Never author duplicate `selected-tasks-completed("<prev>")` rows for
+simple next-step ordering; a missing data binding does not erase stated ordering. Break an ordered run only
+at tasks that are `adhoc`, condition-gated, dependent on non-immediate siblings, or whose ENTRY rule is
+`wait-for-connector` (a task merely TYPED `wait-for-connector` stays in the run).
+
+**[K-SEQ-3] `selected-tasks-completed` is for true fan-in,** branch convergence, condition-result routing,
+non-immediate dependencies, or explicit gates. It must select only non-`adhoc` tasks in the SAME stage.
+For race patterns (confirmation vs timeout/cancel), arm the listener and clock while the obligation is
+pending and gate downstream work on the winning fact, not on the whole parallel set completing.
+
+**[K-SEQ-4] `adhoc` is an activation mode, not a task type.** Task-entry only — never a stage-entry rule.
+An adhoc task is `isRequired: false`, user-launched from the Case App, any task type, and never selected by
+`required-tasks-completed` / `selected-tasks-completed` / any required flow.
+
+**[K-SEQ-5] A task with no entry condition never starts.** `validate` accepts `entryConditions: []` and a
+missing key; the task silently emits no plan entry. Every task carries ≥ 1 entry condition.
+
+**[K-SEQ-6] Conditional-branch stages need a required convergence task.** Mutually-exclusive conditional
+tasks (one per reason code, each `current-stage-entered` + `IF`) are all `Required: No` — only one runs, so
+none can be the required completer. Add ONE required convergence task whose entry is a DNF OR covering
+every branch (each `selected-tasks-completed("<branch>")` row, plus a `current-stage-entered` +
+inverse-guard row for the no-branch path); `required-tasks-completed` then resolves deterministically.
+
+**[K-SEQ-7] Re-entry safety (`return-to-origin` loops).** Classify before setting `Run Only Once`:
+*new attempt/resubmission* (corrected, retry, appeal) → producer/review/decision tasks stay rerunnable
+(`Run Only Once: No`) and live routing variables reset or attempt-scope; *re-evaluate existing fact* →
+`Run Only Once: Yes` only on producers whose prior output must persist, documenting which rule re-reads it;
+*optional repeat* → `adhoc`/non-required. A stale terminal value (`SendBack`, `Rejected`) must not remain
+live at re-entry unless deliberately re-evaluated.
+
+<!-- END: sequencing.md -->

--- a/skills/uipath-planner/references/case-knowledge/semantics/sequencing.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/sequencing.md
@@ -5,7 +5,8 @@ Single source for task activation-mode grammar. Slot legality: [facts/pairing.ya
 **[K-SEQ-1] Task-entry mode is exclusive.** Map the product's task modes exactly: *sequential* → one
 `runs-sequentially` entry rule (only rule on the task); *event-triggered* → the explicit event rule
 (`wait-for-connector` with connector config, or `sla-status-change` for a start-task SLA response);
-*manually-triggered* → one `adhoc` rule + `isRequired: false`; *stage-started* → `current-stage-entered`.
+*manually-triggered* → one `adhoc` rule + `isRequired: false`; *stage-started* (SDD Activation Mode token:
+`parallel`) → `current-stage-entered`.
 Never add `current-stage-entered` alongside any of the others, and never infer a mode from `data.tasks`
 lane layout.
 

--- a/skills/uipath-planner/references/case-knowledge/semantics/stages.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/stages.md
@@ -1,0 +1,56 @@
+# Stages — lifecycle, secondary lanes, global events, case completion
+
+Single source for cross-skill stage semantics. Slot/pairing facts: [facts/pairing.yaml](../facts/pairing.yaml).
+
+**[K-STG-1] Stage lifecycle.** A stage has entry conditions (when it activates), tasks (work inside),
+and exit conditions split by `marksStageComplete`: `Yes` = completion (the stage is DONE — satisfies a
+downstream `selected-stage-completed`), `No` = early exit/routing (satisfies `selected-stage-exited`).
+Only completion counts toward `required-stages-completed`. Destination routing lives on the DESTINATION
+stage's entry condition (`selected-stage-completed("Origin")` / `selected-stage-exited("Origin")`) — one
+stage fans out to N stages via their entries, not via its own exit rows (exception: K-STG-5 diverting exit).
+
+**[K-STG-2] Secondary stage = interrupting exception lane.** A `case-management:Stage` with
+`data.stageType: "secondary"` (the `ExceptionStage` node type died at v22). Use it for work that is not a
+fixed step on the line — errors, escalations, rejections, rework, cancellations — reached only by
+condition. Always `isRequired: false`, never counted in `required-stages-completed`, never entered by an
+edge. Stage-level `Interrupting: Yes` and every entry row `Interrupting: Yes` — ONE carve-out (K-STG-3).
+If the work is an optional one-off inside the current stage, keep it an `adhoc` task (K-SEQ-4), not a lane.
+
+**[K-STG-3] The parallel-oversight carve-out.** When an `sla-status-change` entry's response is parallel
+oversight — breached work keeps running, nothing paused/taken over/rerouted — the stage-level
+`Interrupting` field AND that entry row both read `No`. The lane stays `secondary` + `isRequired: false`;
+promoting it to a regular stage would make it required for completion. Scoped to `sla-status-change` rows
+only: `wait-for-connector`, `user-selected-stage`, and diverting `selected-stage-exited` entries are always
+`Yes`. `Yes` on the stage with `No` on its only entry row is a contradiction — blocking.
+
+**[K-STG-4] Secondary exits by intent.** Returning/rework lanes complete with `return-to-origin`
+(re-activates the origin; ALWAYS requires `Interrupting: Yes` — `return-to-origin` + `No` is illegal, so a
+parallel-oversight lane must complete `exit-only`). Terminal lanes (Rejected/Withdrawn/Cancelled) complete
+`exit-only` PLUS a root case-exit row with `marksCaseComplete: false` (K-PAIR-6). Canonical returning
+shape: `return-to-origin` + `Marks Stage Complete: Yes` + `required-tasks-completed`.
+
+**[K-STG-5] Entry shape follows the lane's trigger.**
+- Person launches it → `user-selected-stage`, paired with an upstream `wait-for-user` exit (K-PAIR-4).
+- External/global event → ONE `wait-for-connector` entry on the destination lane.
+- SLA response entering the lane → ONE scoped `sla-status-change` entry (K-SLA-4).
+- Decision/signal divert → the ORIGIN stage carries a **gated diverting exit** (`Marks Stage Complete: No`,
+  WHEN `selected-tasks-completed("<decider task>")`, `IF` on the signal, `exitToStageId` → the lane) and its
+  completion exit carries the INVERSE `IF` so the two are mutually exclusive; the lane's entry is
+  `selected-stage-exited(origin)` + the same `IF`. Without the diverting exit the decision path dual-fires
+  or deadlocks. This is divert-and-return, not a true mid-stage interrupt — a variable-driven mid-stage
+  interrupt is not expressible without a connector. Only `selected-stage-*` lane entries need a matching
+  origin diverting exit; connector/SLA/user entries need nothing on origins.
+
+**[K-STG-6] Global-event normalization.** An event that can fire at any point and requires case work
+(withdrawal from a portal, an SLA status change) is modeled ONCE on the destination secondary stage's
+entry — never duplicated as tasks/exit rules on every primary stage. A true interrupting entry exits
+whichever stage is active. Two lanes with identical entry rules (same rule + selectors + expression) are
+ambiguous routing — give each a distinct selector or guard. (Design rule; not validate-enforced as of
+1.198.0-preview.102 — probe p07b.)
+
+**[K-STG-7] Reachability is condition-only** ([edges retired](edges-retired.md)): every primary stage
+reachable from a trigger through entry conditions; every primary stage has a completion consumed
+downstream (or feeds a lane / case-exit); every non-start entry names a concrete producer (source stage,
+task, connector event, paired wait-for-user, or declared SLA). A stage with no entry condition is orphaned.
+
+<!-- END: stages.md -->

--- a/skills/uipath-planner/references/case-knowledge/semantics/stages.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/stages.md
@@ -38,8 +38,9 @@ shape: `return-to-origin` + `Marks Stage Complete: Yes` + `required-tasks-comple
   completion exit carries the INVERSE `IF` so the two are mutually exclusive; the lane's entry is
   `selected-stage-exited(origin)` + the same `IF`. Without the diverting exit the decision path dual-fires
   or deadlocks. This is divert-and-return, not a true mid-stage interrupt — a variable-driven mid-stage
-  interrupt is not expressible without a connector. Only `selected-stage-*` lane entries need a matching
-  origin diverting exit; connector/SLA/user entries need nothing on origins.
+  interrupt is not expressible without a connector. Only a `selected-stage-exited` lane entry needs the
+  matching origin diverting exit; a `selected-stage-completed(origin)` + `IF` lane keys off the origin's
+  normal completion (guard only), and connector/SLA/user entries need nothing on origins.
 
 **[K-STG-6] Global-event normalization.** An event that can fire at any point and requires case work
 (withdrawal from a portal, an SLA status change) is modeled ONCE on the destination secondary stage's

--- a/skills/uipath-planner/references/case-knowledge/semantics/variables-io.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/variables-io.md
@@ -6,8 +6,9 @@ variables plugins; SDD cell grammar stays in the planner render rules — both c
 ## The doctrine: reference producers directly; declare only what has no producer
 
 **[K-VAR-1] Task-output xref is the DEFAULT wiring.** A downstream input or condition that consumes one
-upstream task's output references it directly — SDD forms: whole-value `<- "Stage"."Task".out` or
-in-expression `vars.$xref('Stage','Task','out')`; emitted form `=vars.<outputId>`. The emitting task
+upstream task's output references it directly — SDD forms: whole-value `<- "Stage"."Task".out` (the bare
+`"<Stage>"."<Task>".<outputName>` cell spelling is equivalent) or in-expression
+`vars.$xref('Stage','Task','out')`; emitted form `=vars.<outputId>`. The emitting task
 self-declares the output (its `data.outputs[]` entry IS the declaration — no root companion, no case
 variable). Validate-verified: a full bare-mint output entry resolves from downstream inputs, conditions,
 and interrupting stage entries with zero root declarations (probes p11b/p07c, as of 1.198.0-preview.102).

--- a/skills/uipath-planner/references/case-knowledge/semantics/variables-io.md
+++ b/skills/uipath-planner/references/case-knowledge/semantics/variables-io.md
@@ -1,0 +1,58 @@
+# Variables & I/O — the doctrine
+
+Single source for how data flows through a case. Emit-side entry shapes stay in the maestro-case
+variables plugins; SDD cell grammar stays in the planner render rules — both cite these IDs.
+
+## The doctrine: reference producers directly; declare only what has no producer
+
+**[K-VAR-1] Task-output xref is the DEFAULT wiring.** A downstream input or condition that consumes one
+upstream task's output references it directly — SDD forms: whole-value `<- "Stage"."Task".out` or
+in-expression `vars.$xref('Stage','Task','out')`; emitted form `=vars.<outputId>`. The emitting task
+self-declares the output (its `data.outputs[]` entry IS the declaration — no root companion, no case
+variable). Validate-verified: a full bare-mint output entry resolves from downstream inputs, conditions,
+and interrupting stage entries with zero root declarations (probes p11b/p07c, as of 1.198.0-preview.102).
+
+**[K-VAR-2] Declare a case variable (§1.5 row / root `inputOutputs[]`) ONLY for:** (a) `In`/`Out`
+arguments; (b) trigger-payload extraction (K-VAR-3); (c) case-level state read by a condition or ≥ 2
+consumers; (d) renaming or custom `Default`/`Type`/`Description` on an output. Minting a row to relay one
+task's output to one consumer is the **case-var relay anti-pattern** — reference it directly and drop the
+row.
+
+**[K-VAR-3] Trigger outputs REQUIRE a root companion.** Validation never scans trigger-node outputs
+(FE `ValidateCaseManagementFlowVariableUtils.ts` collects task/rule/root arrays only; probes p12/p12b): a
+trigger payload field is referenceable as `=vars.<name>` only through a root `inputOutputs[]` entry. In the
+SDD this is exactly a §1.5 `Variable` row with `sourceTriggers` (T-number) + `sourceFields` (payload path)
+— the sanctioned "case variable" use, not a relay.
+
+**[K-VAR-4] Full-shape output entries or nothing.** An emitted task output carries the complete bare-mint
+shape — `name, type, id, var, value, source, target, elementId` — a partial entry (missing
+source/target/elementId) is invisible to the resolver: `Variable 'vars.X' does not exist` (probe p11).
+`type` is required on every output entry. The resolver matches on `id` alone, case-sensitive.
+
+## Outputs grammar (every task's Outputs rows)
+
+**[K-VAR-5] Two operators.** Extract `-> caseVar`: `Field` = non-empty runtime path (`response.status`,
+`Action`, `Error.code`), emitted `source` is `=<Field>` verbatim. Set/compute/copy `caseVar = <expr>`:
+`Field` = `—`; expr is a literal, `=js:(...)`, or `=vars.X.Y` copy. The target case variable must already
+be declared (K-VAR-2 rows only — a `->` to a brand-new name is a declaration bug, unless it is the
+self-declaring bare output of K-VAR-1).
+
+**[K-VAR-6] One writer per target per task.** Each target variable appears in at most one Outputs row per
+task; mixing `->` and `=` on the same target in one task is rejected. Self-binding no-ops
+(`caseVar = =vars.caseVar`) are forbidden — they mask a missing producer; computed self-references
+(`=js:(vars.x + 1)`) are fine.
+
+**[K-VAR-7] Lineage closure.** Every consumer of `vars.X` needs a producer that fires earlier (stage
+order, then task order) — a trigger extraction (K-VAR-3), a task Outputs row, an action button's
+`Maps To`, an `In` category, or a non-empty `Default`. Direct xrefs (K-VAR-1) close by ordering alone.
+Never close lineage by aliasing a produced datum into an unrelated existing variable, guessing producers,
+or silently retagging `Category`/inventing a `Default`.
+
+**[K-VAR-8] Category semantics.** `In` = caller-supplied at start (or `Default`-initialized for
+event/timer triggers); `sourceFields` always empty; single optional `T<N>` selects a non-primary trigger.
+`Out` = returned to caller; needs a producer row or `Default`; `sourceTriggers` forbidden. `Variable` =
+internal state; trigger-fed rows per K-VAR-3 (CSV `sourceTriggers` requires keyed
+`T<N>: <path>; T<M>: <path>` — one entry per T-number). A `file` variable is a JobAttachment record; a
+file-typed `In` carries the caller pre-upload obligation.
+
+<!-- END: variables-io.md -->


### PR DESCRIPTION
## What

PR 2/7 of the case-knowledge restructure (stacked on #2628). Adds `skills/uipath-planner/references/case-knowledge/` — the single-source layer for every fact and rule BOTH skills need:

| Group | Files | Content |
|---|---|---|
| `facts/` | types, pairing, naming, sla (YAML) | Closed enums, SDD↔JSON name mapping, rule×slot legality, Marks-Complete pairing, SLA response model — machine-read by `audit_sdd.py`/`audit_plan.py` (wired later in the stack) |
| `semantics/` | stages, sequencing, edges-retired, expressions, variables-io | The cross-skill concept prose that was restated 6–20× per rule (audit D1–D16), now written once with `K-*` IDs |
| `contracts/` | handoff, sdd-contract, resolution-ledger | The design↔build boundary: handoff protocol (previously two ~500-word prose twins), build-ready SDD shape + receipt check, ledger entry shape |
| `errors/` | validate-codes | Verified validate failures (message-quoted, version-anchored) + the 7 defects validate cannot see |

Every conflict ruling (C1–C13) from the ledger is applied here — e.g. `wait-for-user`+`Yes` legal (K-PAIR-3), SLA `id`+`displayName` both required (K-SLA-2), explicit `isRequired` end-to-end (K-PAIR-5), task-xref-first variables doctrine with trigger-companion requirement (K-VAR-1..4).

## Why in planner

The user-approved architecture: planner owns the case-knowledge directory; maestro-case reaches the identical files via one committed directory symlink (next PR), with packaging dereferencing at pack time so shipped skills stay self-contained.

## Stack

1. #2628 — Phase 0 ledger
2. **→ this PR** — shared layer
3. planner design-file dissolution + template fixes
4. maestro-case symlink + SKILL.md router
5. maestro-case dedupe-in-place
6. packaging/infra guards
7. knowledge lint + CI

`npm run skills:validate` passes (26 skills / 1732 files per flavor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)