### PR TITLE
feat(planner): case-design activity files (rules-guide dissolution, part 1)

### DIFF
--- a/skills/uipath-planner/references/case-design/authoring-core.md
+++ b/skills/uipath-planner/references/case-design/authoring-core.md
@@ -1,0 +1,131 @@
+# Case authoring core — inputs, authority, provenance, review items
+
+Cross-activity rules for authoring a case SDD. Shared facts/semantics live in
+[case-knowledge/](../case-knowledge/INDEX.md) — cited by `K-*` ID, never restated here.
+
+> **Phase legend.** Phase 0 = this design lane. Phase 1 = the build skill's planning pass (verify-only
+> when this lane already resolved resources). Phase 2/3 = its prototyping/implementation passes. Checks
+> marked "enforced at build" run in `uipath-maestro-case`.
+
+## Inputs
+
+| Input | Purpose |
+|---|---|
+| User chat messages | Primary source — verbatim values, types, exits, SLAs |
+| User-supplied docs (paths, paste, attachments) | Secondary — read on Listen, parsed for case shape |
+| [`case-sdd-template.md`](../../assets/templates/case-sdd-template.md) | Structural mold for the rendered `sdd.md` |
+| Platform case schema constraints | The design-relevant subset lives in [case-knowledge/facts/](../case-knowledge/INDEX.md) |
+| Tenant registry cache map ([case-design-lane-guide.md § Tenant grounding](../case-design-lane-guide.md#tenant-grounding--full-resolution-at-design-time)) | Which `~/.uip/case-resources/` index answers each resource type |
+| Tenant registry (`~/.uip/case-resources/`) | Resolves deployed processes / agents / actions / connectors |
+| Tenant IS cache (`~/.uipath/cache/integrationservice/`) | Resolves connector identity, connections, activities, triggers |
+
+Platform schema is truth: choices conflicting with it are schema-invalid regardless of source.
+
+## Content authority hierarchy
+
+When signals conflict, top wins:
+
+1. **Platform schema constraints** — schema-invalid values never ship. Examples: task `type` outside the enum (K-TYP-1); `Marks Stage Complete: Yes` + `selected-tasks-completed` (K-PAIR-2).
+2. **Regulatory / compliance constraint** stated or implied (ECOA, NCQA, GDPR, HIPAA, SOC 2, FCRA, FINRA, …). Forces types — [task-typing.md § Override priority](task-typing.md#task-type-override-priority).
+3. **Tenant evidence** from the registry cache — a deployed resource matching described work. Prefer its type/identity; never add stages/tasks or rename business work to match tenant inventory.
+4. **User-stated preference** in chat (verbatim "set the task to agent").
+5. **Doc-extracted values** from user-shared docs.
+6. **Inferred defaults** per the assumption playbook ([case-design-lane-guide.md § Sketch](../case-design-lane-guide.md#sketch--best-assumption-every-field)).
+7. **General-practice fallback.**
+
+A higher tier overriding a lower one is applied AND surfaced in the confirmation's `Decisions I Made`
+table with provenance `(source: <higher-tier>-override)`.
+
+## Render policy — `—`, `<UNRESOLVED>`, banned
+
+- **Template shape is part of the render contract.** A valid model is not enough if the file collapses
+  into a prose summary — the rendered `sdd.md` preserves the full template structure (K-SDD-1, K-SDD-2);
+  the compact Phase 0 confirmation is never an SDD substitute.
+- **Allowed `—`** (untouched by the user, Phase 1 defaults safely): case-level Description, variable
+  defaults, persona scope notes, app-view detail, secondary-stage description, optional `IF`
+  conditionExpressions, business calendars on timers.
+- **Allowed `<UNRESOLVED>`** (gaps Phase 1 / post-build resolves): registry IDs (`taskTypeId`,
+  `connectionId`, `actionAppId`, `agentId`, `processOrchestrationId`) when resolution was skipped,
+  deferred at the gate, or returned 0 matches. Pair EVERY `<UNRESOLVED>` with a review item.
+- **Banned** on every required cell named in the render rules: populate concretely, keep the identity
+  `<UNRESOLVED>` (build emits a placeholder), or Ask.
+- **Forbidden SDD-body vocabulary.** No narrative cell may contain skill-internal terms: `Pattern C`,
+  `bridge`, `companion`, `inputOutputs[]`, `=jsonString:` (outside connector `Operation Configuration`
+  cells), `groupOperator`, `essentialConfiguration` (as prose), `savedFilterTrees`, `dispatcher`,
+  `Phase 2 validator`, `Phase 3 dispatcher`, `Finding #N`, `io-binding`, `aliased into/from`, `reassign`,
+  `originalVar`, `auto-mint`. These live in skill references, never in `sdd.md`.
+
+## Domain fidelity
+
+Narrative cells (descriptions, persona/stage/task names, button labels, §3/§4 prose) preserve the user's
+domain vocabulary verbatim — this skill transcribes business terms, never paraphrases.
+
+**Preserve verbatim** (no synonym swaps, ever):
+
+- Customer-named roles (`CFO`, `Underwriter II`, `Triage Nurse`) — never `Approver`/`Reviewer`/`Manager` substitutes.
+- Customer-named domain nouns (`Vendor`, `Claim`, `Loan File`, `Member`) — never homogenized to `Record`/`Item`.
+- Customer-named stage labels (`Triage`, `Adverse Action Notice`) — user's casing and word choice.
+- Customer-named decision outcomes (`Approve` / `Decline` / `Needs Info` — not `Reject`/`Pending`).
+- Customer-named integration shortnames (`Workday`, never "the HR system").
+
+**Allowed normalization** (mechanical, ledger reason `mechanical:<derivation>`): PascalCase Case Name,
+2–4 char identifier prefix, camelCase variable names (K-NAME-4).
+
+**Detection:** a term the user wrote once surfaces in the ledger as `verbatim:"<quote>"`; the
+confirmation's tables render it verbatim — that display is the spelling check. **Anti-paraphrase rule:**
+when the urge strikes to write `the manager approves the request` and the user said `the senior
+underwriter signs off`, use the user's phrase. Synonyms are a fidelity bug, not polish.
+
+## Source ledger (provenance)
+
+Two surfaces: inline in `sdd.md` (italic attribution — `Manual _(source: user-stated)_`; omit for
+`user-stated`) and the confirmation's `Decisions I Made` table.
+
+**Rationale is durable, not chat-only.** Provenance says where a value came from; rationale says why the
+choice fits. Persist rationale in each stage/task `Design Rationale` field and each SLA rationale field —
+Phase 1 copies it to the matching `tasks.md` T-entries so implementers can review without the original
+conversation.
+
+| Kind | When |
+|---|---|
+| `user-stated` | User wrote the value in chat (no annotation). Paraphrase acceptable. |
+| `verbatim:"<quote>"` | Rendered cell is exactly the user's phrase — strongest signal; preferred for customer-named entities. Quote truncated at 40 chars in the ledger. |
+| `user-doc:<filename>` | Lifted from a user-shared doc |
+| `mechanical:<derivation>` | One-step derivation (`mechanical:PascalCase→prefix`) |
+| `compliance-override:<rule>` | Regulatory constraint forced the value (`compliance-override:ECOA→action`) |
+| `tenant-registry:<resource-name>` | Resolved from the registry cache |
+| `connector-priority:<connector>` | Tier 4 selected `execute-connector-activity` over `api-workflow` |
+| `inferred-default:<reason>` | Defaulted with no matching source (sparingly) |
+
+A non-`user-stated`, non-`verbatim` field without provenance is a validation error — Approve blocks until
+annotated.
+
+## Review items
+
+Structured gap escalations: emitted whenever a field could not be fully resolved but the build's planning
+pass needs the context. They live in the in-memory model and surface ONLY as confirmation `Review Flags`
+rows — never in the `sdd.md` body; the build's Phase 1 persists them into `tasks/registry-resolved.json`
+under the task's `review_items[]` (K-LEDG-4).
+
+```jsonc
+{
+  "id": "rev_<short-slug>",
+  "target": "<sdd.md section path or task name>",
+  "issue": "<one-sentence problem>",
+  "severity": "high" | "medium" | "low",
+  "next_step": "<what the user must do to resolve>"
+}
+```
+
+| Level | Definition | Examples |
+|---|---|---|
+| **high** | Blocks Phase 1 / `caseplan.json` build until resolved | Missing `connectionId` / `actionAppId` / deployed runnable; a resolved resource's required input unbound (`rev_unbound_input_<task>_<field>`); an extract naming a field the resource never emits (`rev_phantom_output_<task>_<field>`); unresolved lineage; missing trigger config; unreconciled compliance override |
+| **medium** | Phase 1 defaults with a prompt | Missing escalation recipient (default = owner group); missing variable default; ambiguous recipient |
+| **low** | Cosmetic | Missing case description; missing secondary-stage description; stylistic placeholder |
+
+**Confirmation gate behavior:** any `high` items relabel the Build option `Build despite N flagged items`
+— the user must pick it; silently building past `high` is forbidden. `medium`/`low` surface as advisory
+rows, no acknowledgment. Never downgrade a `high` to pass the gate — severity moves only when the issue
+actually resolves.
+
+<!-- END: authoring-core.md -->

--- a/skills/uipath-planner/references/case-design/case-render.md
+++ b/skills/uipath-planner/references/case-design/case-render.md
@@ -1,0 +1,134 @@
+# Case Render — SDD Section 1 content rules
+
+What Section 1 (Case Definition) must contain before the model may render. Shared facts: cite, don't
+restate — [K-TYP](../case-knowledge/facts/types.yaml), [K-PAIR](../case-knowledge/facts/pairing.yaml),
+[K-NAME](../case-knowledge/facts/naming.yaml), [K-SLA](../case-knowledge/facts/sla.yaml),
+[K-VAR](../case-knowledge/semantics/variables-io.md).
+
+## 1.1 Case Metadata
+
+| Field | Required? | Value shape | If missing |
+|---|---|---|---|
+| Case Name | yes | PascalCase identifier (`MortgageLoanOrigination`) | Block Approve. Ask. |
+| Description | optional | One sentence | `—` |
+| Identifier prefix | yes | UPPER, 2–4 chars (K-NAME-4) | Default mechanically; record in ledger |
+| Case SLA | conditional | Duration (`5 business days`) | `—` when no SLA; else block Approve |
+| SLA Type | conditional | `time-based` / `condition-based` | Default `time-based` when Case SLA set with no overrides. FE persists `condition-based` whenever ≥ 1 `slaRules[]` entry carries a non-empty `conditionExpression` (PO.Frontend `CaseManagementSlaProperties.tsx:27-30`). `condition-based` requires the Variable SLA Rules table; `time-based` omits it |
+| SLA Title | conditional | Non-empty root-unique title (K-SLA-2, K-NAME-3) | Omit the row when Case SLA is `—` (never `—` here); else default `SLA Rule 1` + ledger. A title referenced by `sla-status-change` must be concrete |
+| Case App | optional | `Enabled` / `Disabled` (`metadata.caseAppEnabled`) | Default `Disabled`; ledger |
+| Task-output passing | optional | `Direct` / `Shared` (`metadata.caseDirectlyPassTaskOutputs`) | Default `Direct` |
+
+**Pre-Approve validation parity.** Before Approve, apply the platform's own name/SLA checks — safe display
+characters, mechanical repair, uniqueness scopes (K-NAME-1/2/3), SLA entry requirements and bounds
+(K-SLA-2) — to everything the skill generates or carries into display/title fields. These are blocking
+authoring errors, not style warnings. Never normalize external lookup names (K-NAME-2); never silently
+clamp numeric violations (K-NAME-5) — surface and Ask.
+
+## 1.2 Case-level SLA escalation
+
+Required when Case SLA is set. Both rows always render; no `—` in any cell.
+
+| Threshold | Trigger | Recipient | Display Name |
+|---|---|---|---|
+| At-risk | `<pct>%` of case SLA (defaults: K-SLA-6) | `UserGroup: <owner-group>` / `User: <name>` | Non-empty root-unique title (K-NAME-3) |
+| Breached | 100% | One tier up — leadership; Compliance for regulation-driven cases (K-SLA-6) | Non-empty root-unique title |
+
+`Display Name` defaults to `Escalation Rule {N}` only when no `sla-status-change` row references it.
+Default substitutions → ledger (`default applied — user did not name recipient`).
+
+## 1.2b SLA Response Map
+
+Required whenever ANY SLA is configured (case, stage, or `action` task). One row per `(Scope, SLA,
+Status)`. Columns: `Scope | SLA | Status | Response | Target | Interrupting | Rationale`.
+
+| Field | Value |
+|---|---|
+| Scope | `case`, `stage: <StageName>`, or `task: <TaskName>` |
+| SLA | the target's SLA Title (or a Variable SLA Rules Display Name) |
+| Status | `At-Risk` / `Breached` — one row each |
+| Response | closed set + selection test: K-SLA-4/5 |
+| Target | `—` for `notify-only`; task name for `start-task` (task lives in the breached stage); stage name for `enter-stage`; the produced exit row for `exit-stage`/`exit-case` |
+| Interrupting | `—` for `notify-only` AND for every `start-task` (a task entry interrupts nothing — never `Yes`/`No`); otherwise `Yes`/`No` matching the produced stage-entry row (K-STG-3) |
+| Rationale | why this response fits the source |
+
+**Closure both ways (blocking):** every non-`notify-only` row has its matching rule elsewhere in the SDD
+(an `sla-status-change` task-entry row for `start-task`, stage-entry row for `enter-stage`, a stage-exit
+row, or a §1.4a row), and every `sla-status-change` row in the SDD has a row here. An Interrupting mismatch
+between map cell and produced row is blocking. **Default:** no stated response → both statuses
+`notify-only`, Target and Interrupting `—`; never invent a stage/task/routing for a notification (K-SLA-4).
+
+## 1.3 Triggers
+
+≥ 1 trigger. One row per triggering event, numbered sequentially from **T02** (T01 = the case file). The
+T-number keys §1.5 trigger-payload rows (K-VAR-3).
+
+| Field | Required? | Value |
+|---|---|---|
+| T# | yes | `T<N>`, starts at `T02` |
+| Trigger Type | yes | `Manual` / `Intsvc.TimerTrigger` / `Intsvc.EventTrigger` — author tokens; on-disk mapping K-TYP-4 (`Manual` is shorthand: serviceType is ABSENT on disk) |
+| Source | conditional | Connector/system for event; schedule expression for timer; `Manual` literal |
+| Configuration | conditional | User intent only, business terms. `Intsvc.EventTrigger` MUST have a concrete operation phrase |
+
+**Configuration cell — write:** event → the operation in business terms (`Record created`, `Email received
+in Inbox; filter: subject contains "URGENT"`); tenant case-entity starts keep the object name in Source and
+the business event in Configuration; timer → cycle/duration (`daily at 09:00 UTC`); manual → `N/A`.
+**Forbidden in Configuration** (resolved at planning time): CLI enum values (`CALENDAR_CREATED`), default
+modes (`polling`/`webhook`), meta notes (`No required event parameters`), activity slugs/HTTP
+methods/spec-discovered detail.
+
+Payload-field → variable mapping lives ONLY in §1.5 (`sourceTriggers`/`sourceFields`) — never in this
+table. **Tenant object starts are not Manual:** a record-created start is an `Intsvc.EventTrigger` row even
+when tenant provisioning is missing — unresolved detail becomes a placeholder later, never a trigger-type
+downgrade. Unresolved event resolution (`connectionId`/`activityTypeId`) → `high` review item.
+
+## 1.3a Trigger Filter (conditional)
+
+Renders only when ≥ 1 trigger declares a filter. AND/OR tree; nested `{op, clauses}` groups flatten in the
+rendered table. Operators (PascalCase, case-sensitive): `Equals`, `NotEquals`, `Contains`, `NotContains`,
+`StartsWith`, `EndsWith`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `In`,
+`NotIn`, `IsNull`, `IsNotNull`. Columns: `Field | Operator | Value | Literal?`. Avoid `Literal: No` for
+unverified runtime expressions — it forces lossy JMESPath fallback; prefer literals or a review item.
+
+## 1.4 Case Completion Conditions
+
+≥ 1 row, `Marks Case Complete: Yes`. Columns `WHEN | IF | Marks Case Complete | Exit Type | Display Name`.
+Legal WHEN: K-PAIR-1 case-completion set; `Yes` + `selected-stage-*` blocks Approve (K-PAIR-2). Exit type
+`exit-only`. **Display Name defaulting (all condition tables):** carry the author's value verbatim; blank →
+skill defaults (`Entry Rule {N}` for entry/task-entry; `Complete Rule {N}` / `Exit Rule {N}` for
+exit tables by Marks-Complete), `N` = 1-based within the same label kind; never invent a label otherwise.
+
+## 1.4a Case Exit Conditions (alternate disposition)
+
+Optional, `Marks Case Complete: No` — secondary-stage terminals (Withdrawn / Rejected / Cancelled)
+(K-PAIR-6, K-STG-4). Legal WHEN: K-PAIR-1 case-exit set; exit type `exit-only` / `wait-for-user`. When the
+case has ≥ 1 secondary stage AND §1.4a is empty → `high` review item (`Alt-disposition exits missing`).
+
+## 1.5 Case Variables
+
+**Declare-vs-xref decision per candidate value: K-VAR-1/2/3.** Only `In`/`Out` args, trigger-payload
+`Variable`s, and case-level state read by a condition or ≥ 2 places get a row; one task's output feeding
+one consumer is referenced directly — the case-var relay is the anti-pattern (K-VAR-2). Authoring is
+declarative: `Category` + `sourceTriggers` + `sourceFields` drive build-time classification — no inference
+from prose.
+
+| Column | Required? | Notes |
+|---|---|---|
+| Name | yes | camelCase, no role suffix (K-NAME-4) |
+| Category | yes | `In` / `Out` / `Variable` — never `—` (K-TYP-6, semantics K-VAR-8) |
+| Type | yes | K-TYP-5 enum; `jsonSchema` vs `string` per K-TYP-5; `file` = JobAttachment |
+| sourceTriggers | conditional | `Variable`: single `T<N>` or CSV; `In`: optional single `T<N>` (blank = primary T02, never CSV); empty for pure state and `Out` (K-VAR-8) |
+| sourceFields | conditional | `Variable` only. Single trigger → bare path (`response.subject`); CSV → keyed `T<N>: <path>; T<M>: <path>`, one entry per T-number, strict. Always empty on `In`. Dot-paths only — no array indexing |
+| Default | optional | Concrete default or empty |
+| Description | yes | One line |
+
+- **Out-arg producer rule:** every `Out` row has a `Default` OR a task Outputs row targeting it
+  (`-> {name}` / `{name} = {expr}`) — pre-checked at the Approve gate (K-VAR-7).
+- **Config-as-In:** runtime business rules (priority bands, thresholds, taxonomies) ride ONE `In` variable
+  — `Type: string` with a JSON `Default` for opaque blobs, `Type: jsonSchema` + `body` when the FE picker
+  must navigate sub-fields (K-TYP-5). Overridable at case start, consumed by agents.
+- **File In-args** carry the caller pre-upload obligation (K-VAR-8) — surfaced via the Caller-obligation
+  block at review.
+- **Outputs operators** (`->` extract with verbatim runtime path; `caseVar = expr` set/compute/copy;
+  one writer per target per task): K-VAR-5/6. Worked patterns: [case-sdd-examples.md](../../assets/templates/case-sdd-examples.md).
+
+<!-- END: case-render.md -->

--- a/skills/uipath-planner/references/case-design/grounding.md
+++ b/skills/uipath-planner/references/case-design/grounding.md
@@ -1,0 +1,78 @@
+# Design-time tenant grounding & connector checks
+
+The single home for design-time resolution. The lane does **full identity resolution** — registry pull,
+per-resource cache lookups, connection checks, one batched gate — so a confirmed design carries resolved
+identities and the build's planning pass becomes verify-only. Ledger shape + gateDecision semantics:
+K-LEDG-1..4.
+
+## Principles
+
+1. **Tenant work never blocks Entry.** Nothing about the tenant is a prerequisite for designing.
+2. **Schema discovery is NOT design work.** `tasks describe` / `case spec` stay in the build phases;
+   design resolves identities only.
+3. **Never pull twice per session.** A pull that succeeded this session is reused by the build
+   (same-session fast path). Never delay the confirmation waiting for a pull.
+4. **Registry data is evidence, not requirements** — never add/rename business work to match tenant
+   inventory; never dump catalogs into chat.
+
+## The 5-step contract
+
+1. **Intake batch.** Read every supplied document in parallel; extract named systems, resources, likely
+   tasks, roles. Named systems seed grounding.
+2. **Chain kickoff — background.** ONE background command: `uip login status --output json && uip maestro
+   case registry pull`. **Build handoff mode:** start it AT LANE ENTRY, batched with the first document
+   reads (the build needs a fresh registry unconditionally; entry-time start lets resolution land before
+   the Case Review). **Every other mode:** start it the FIRST moment the sketch identifies tenant-bound
+   work (named system/resource/connector, or an inferred runnable/connector/action task); a case with no
+   tenant-bound items never pulls. Best-effort: never block on it, never surface its output unprompted.
+3. **Resolution pass — join, never wait.** When the sketch is complete and the pull succeeded, resolve
+   every named or inferred resource in ONE parallel batch of cache lookups; for each connector also check
+   enabled connections. Bucket each result:
+
+   | Bucket | Definition | Action |
+   |---|---|---|
+   | Single confident match | 1 exact-name match across all folders, ≥ 1 shared name token; connectors: exactly 1 enabled connection | **Adopt**: identity + exact folder into SDD cells + ledger entry; disclose as a decision line. The only silent pick. |
+   | Ambiguous | Multiple matches, cross-folder same-name, no token overlap; > 1 enabled connection | Queue for the gate. A name deployed in ≥ 2 folders is ALWAYS ambiguous — never pick a folder silently. |
+   | Empty | 0 matches / 0 enabled connections AFTER a successful pull | Queue for the gate. A missing cache file BEFORE a successful pull is a failed precondition, never a zero-match result (K-LEDG-3). |
+
+   Cache-file map (`~/.uip/case-resources/`):
+
+   | Resource | Index |
+   |---|---|
+   | Agents | `agent-index.json` |
+   | API workflows | `api-index.json` |
+   | RPA processes | `process-index.json` |
+   | Orchestration processes | `processOrchestration-index.json` |
+   | Child cases | `caseManagement-index.json` |
+   | Action Apps (HITL) | `action-apps-index.json` |
+   | Connector activities / triggers | `typecache-activities-index.json` / `typecache-triggers-index.json` |
+
+4. **Resolution gate — the ONE batched ask, at review time.** Present queued items WITH the Case Review —
+   one AskUserQuestion (≤ 4 questions; overflow carries into the confirmation's follow-up), grouped by
+   `(name, type)` with usages listed. Options per group:
+   - **Pick a match** — candidates listed with folder FQNs; user picks one or `resolve at build`.
+   - **Resolve at build** — identity stays `<UNRESOLVED>` + paired review item; the build emits a
+     placeholder the user upgrades later.
+   - **Create during build** — ONLY for empty `agent` / `api-workflow` lookups; records the decision, the
+     BUILD executes inline-create (the lane never scaffolds or spawns build subagents). Non-creatable
+     kinds (RPA process, action, case-management, connectors, agentic process) show `resolve at build`
+     only.
+
+   Never pre-judge by name heuristics — the user's call. Pull not finished when the review is ready → do
+   not wait; present with `resolve at build` on pending items. `gateDecision` is recorded ONLY for items
+   the user actually answered (K-LEDG-2); every defaulted deferral records `resolve at build` WITHOUT one,
+   so the build's own gate re-asks it. The gate runs ONCE for what the user ruled on — the build must not
+   re-ask those and MUST still ask about everything defaulted.
+5. **Visibility.** Every adopted identity, connection, gate decision, and deferral appears in the Case
+   Review (Resources and Integrations + Decisions I Made) and lands in SDD Section 2 cells + the Section 4
+   roll-up. The ledger itself is machine-only — never user-facing.
+
+## No-session / failure behavior
+
+| Situation | Action |
+|---|---|
+| Not logged in, CLI absent, pull fails | One plain-language line the moment it happens (`I can't reach your UiPath tenant right now — I'll design with the names you give me and wire resources during the build.`). Keep concrete intended names; mark every identity `resolve at build` (`<UNRESOLVED>` in the file) + paired review items; continue — the design stays complete. Never let `resolve at build` rows be the first signal. |
+| Design-only / draft / plan-only runs | Skip grounding entirely — preserve intended names, mark identities `resolve at build`, report that resource wiring defers to the build run. |
+| Connector with zero enabled connections | A gate item — never a reason to change the task type. |
+
+<!-- END: grounding.md -->

--- a/skills/uipath-planner/references/case-design/review-finalize.md
+++ b/skills/uipath-planner/references/case-design/review-finalize.md
@@ -1,0 +1,218 @@
+# Case Review & Finalization
+
+Planner-owned contract for the ONE confirmation checkpoint and the pre-confirmation checks that gate it.
+Shared semantics are cited by ID from `../case-knowledge/` — never restated here.
+
+## Case Review — the single checkpoint
+
+One structured review, one question. Run §Finalization against the in-memory model FIRST — fix failures
+silently (agent defects, not user decisions); unfixable → Review Flags rows. Decision-first business
+approval surface, complete enough to approve case behavior without opening any SDD file — never a generic
+build plan or a compressed SDD copy. The tenant-grounding resolution gate rides this same turn.
+
+**Coverage map:** SDD §1 → Case Snapshot + SLA and Escalations + Rules and Outcomes; §2 → Primary Journey +
+Other Paths Considered + SLA and Escalations + Rules and Outcomes; §3 → Case Snapshot + human action labels
++ action apps in Resources and Integrations; §4 → Resources and Integrations. The review intentionally
+omits the data contract, variables, and task inputs/outputs — those stay complete in the SDD. Anything with
+a `high` review item also appears in Review Flags.
+
+Start with `## Case Review: <Case name>`, then exactly this section order:
+
+1. **Case Snapshot** — `Item | Proposed design`. Rows: `Objective`, `Starts when`, `Primary personas`,
+   `Successful completion`, `Other terminal outcomes`, `SLA coverage`. Mark assumed values `(assumed)`.
+   No case ID prefix unless it affects a user decision.
+2. **Primary Journey** — `# | Stage | Purpose | Tasks | Starts when | Completes or exits when | Required? |
+   SLA`. Every primary stage once, flow order. `Tasks` names every task in execution order with type,
+   required/optional status, activation/grouping — e.g. `Sequential: Capture request (Human action,
+   required) → Validate request (RPA workflow, required)`; `After both: Make decision (Human action,
+   required)`. Event-triggered and manually triggered tasks shown explicitly.
+3. **Other Paths Considered** — `Scenario | Trigger or condition | Modeled as | Tasks | Interrupts active
+   work? | Return or case outcome | Rationale`. Every modeled exception, secondary stage, optional path,
+   alternate terminal — AND standard paths intentionally left unmodeled when that omission is a decision.
+   Path tasks carry type, required/optional, activation/grouping.
+4. **SLA and Escalations** — `Scope | SLA | Time target or condition | Status or threshold | Response |
+   Response target | Interrupts active work? | Rationale`. One row per meaningful `(scope, SLA, status)`,
+   separate at-risk and breached rows when both exist. Response from the closed set (K-SLA-4). Interrupting
+   cell: `N/A` for `notify-only`; `—` for `start-task` (a task entry interrupts nothing — K-SLA-4, never
+   `Yes`/`No`); otherwise `Yes`/`No` matching the produced entry row. Never assume every breach creates an
+   escalation stage. `None` when the case has no SLA.
+5. **Rules and Outcomes** — `Scope | Element | Rule | When | If | Then`. Business-significant routing,
+   completion, and terminal rules only. Omit generated sequencing already visible in `Tasks`; do not repeat
+   SLA rows unless needed to understand routing. Business conditions in `If`; no data/variable column.
+6. **Resources and Integrations** — `Task | Intended resource or system | Resolution`. Action apps, agents,
+   RPA/processes, API workflows, child cases, connectors, named external systems. `Resolution` = the
+   design-time outcome: `resolved (<folder>)`, gate decision (`create during build`, `resolve at build`),
+   or a candidate pick. A missing row is not acceptable.
+7. **Decisions I Made** — `Decision | Why | Provenance`. Every assumption, override, resource decision,
+   task-type decision, activation/sequence decision, intentionally omitted path. Plain-language provenance
+   (`you said "then"`, `compliance wording`, `no SLA mentioned`). Group only decisions sharing rationale AND
+   provenance. Don't repeat facts clear in another section unless the choice itself needs approval.
+   Flagged items carry ⚠.
+8. **Review Flags** — `Item to review | Why it matters | Default if accepted`. `None` when empty. Unfixable
+   Finalization findings, missing connections, unresolved high-impact choices, anything to inspect before
+   approving.
+
+After Review Flags, show the fixed **Caller obligation** text (checklist item 11) when any §1.5 row is
+`Category: In` + `Type: file`; omit otherwise — a conditional build obligation, not a ninth section.
+
+**Product vocabulary.** User-visible activation labels: `Sequential`, `Parallel`, `Parallel after
+predecessor`, `Event-triggered`, `Manually triggered`, `Fan-in`, `Conditional gate` (`adhoc` → `Manually
+triggered`, `parallel-after-predecessor` → `Parallel after predecessor`). Prefer product task labels —
+`Human action`, `Agent`, `RPA workflow`, `API workflow`, `Child case` — over schema enum names.
+
+**No duplicated review surfaces.** Each business decision appears once. No Data Contract section, variable
+rows, task I/O rows, second stages list, or per-stage/per-task detail cards — technical detail stays in
+the SDD.
+
+**Completeness gate.** Incomplete unless: all eight sections shown, every stage and task named, every
+modeled and intentionally omitted path covered, every meaningful SLA response/status row present, Caller
+obligation when relevant. No approval question before every section has been shown — even sections reading
+`None`. Never substitute a list of build steps, artifacts, folders, or validation commands, or a summary
+pointing at the SDD for a missing business decision.
+
+**Confirmation question (AskUserQuestion)** — options by mode:
+
+| Mode | Options |
+|---|---|
+| Build handoff | `Build it — straight through` / `Build it — pause at the build preview` / `Change something`. The Build answer is the consent AND the build-review preference, captured once, never re-asked mid-build. With ⚠ flags: first option reads `Build despite N flagged items — straight through`. |
+| Direct design-only | `Save the design` / `Change something` (⚠ → `Save despite N flagged items`) |
+| Draft request | `Save as draft` / `Change something`. A prompt that already says save-a-draft-and-stop counts as the answer: write immediately, no extra prompt. |
+
+Corrections (`Change something` or free text) update the model, re-run affected Finalization checks, and
+re-show ONLY the changed sections/rows, then a short `Suggested next steps` line before the next prompt.
+A correction never restarts the walk. **Explicit sign-off requests** ("only after I approve") add exactly
+one approval prompt after acceptance, before any file is created — nothing else changes.
+
+## Review items
+
+Shape: `{id: rev_<slug>, target, issue, severity: high|medium|low, next_step}` — kept in the model,
+surfaced only in Review Flags (never the SDD body); the build persists them into
+`tasks/registry-resolved.json` `review_items[]` (K-LEDG-4). Severity: `high` blocks the build until
+resolved (missing connector/app/runnable identity, unbound required input `rev_unbound_input_<task>_<field>`,
+phantom output `rev_phantom_output_<task>_<field>`, open lineage, missing trigger config, unreconciled
+compliance override); `medium` = build can default with a prompt; `low` = cosmetic. With any `high` open,
+the Build option is relabeled `Build despite N flagged items` — silently building past `high` is forbidden.
+Never downgrade severity to pass the gate.
+
+## Logical integrity — stage graph
+
+Condition-only reachability is the sole guard (K-EDGE-2). Any failure → blocking error; offer `Re-edit` /
+`Restart` / `Abort`.
+
+1. **Every stage reachable from a trigger** — walk entry conditions forward from each trigger/SLA source
+   (K-STG-7). Unreachable primary stage = orphan → blocking.
+2. **Every stage exits** — each primary stage has a completion consumed downstream, or another stage's
+   entry references it, or it feeds a secondary lane. A stage nothing keys off → blocking (terminal-loop).
+3. **Every case-exit row references a stage that exists** — no dangling selectors.
+4. **Every §1.4 Required-Stages path can complete** — ≥ 1 primary stage `Required: Yes` (K-PAIR-5), else
+   the case can never complete.
+5. **Secondary-lane entries: ≥ 1 interrupting entry each, DISTINCT, chosen by trigger source** (K-STG-5
+   shapes; K-STG-6 global events — never repeat per origin). Two lanes with identical entries (rule +
+   selectors + expression) are ambiguous routing — a design requirement to differentiate, NOT
+   validate-enforced (as of uip 1.198.0-preview.102). Decision-reachable lanes MUST carry a
+   `selected-stage-completed`/`-exited` + `IF` entry matching the origin's gated diverting exit, with the
+   origin's completion gated by the inverse `IF` (K-STG-5) — missing divert dual-fires or deadlocks →
+   blocking. A lane described as decision-reachable but entered only via `wait-for-connector` is unreachable
+   from its stated source → blocking. `adhoc` is never a stage entry (K-SEQ-4).
+6. **Every `sla-status-change` entry resolves** — target is `root` or an existing stage, that target
+   declares the SLA, every supplied title matches a row on THAT target; a two-arg breach row is complete as
+   written (K-SLA-3). Any real miss leaves the lane unreachable → blocking.
+7. **Every secondary stage interrupting except a non-diverting SLA oversight row** (K-STG-3). Wrong
+   classification → blocking; never promote the lane to a regular stage.
+
+Worked example — decision-routed return lane (AP Review → SLA Escalation on `requiresEscalation`):
+
+| Stage | Condition | WHEN | IF | Exit Type | Marks Complete |
+|---|---|---|---|---|---|
+| AP Review | exit (complete) | `required-tasks-completed` | `=js:(vars.requiresEscalation !== true)` | `exit-only` | Yes |
+| AP Review | exit (divert) | `selected-tasks-completed("AP ownership review")` | `=js:(vars.requiresEscalation === true)` | `exit-only` (`exitToStageId` → SLA Escalation) | No |
+| SLA Escalation | entry (`Interrupting: Yes`) | `selected-stage-exited("AP Review")` | `=js:(vars.requiresEscalation === true)` | — | — |
+| SLA Escalation | exit | `required-tasks-completed` | — | `return-to-origin` | Yes |
+
+On escalate the divert fires (completion's inverse `IF` false), the lane runs, `return-to-origin`
+re-activates AP Review; on non-escalate the completion fires and the next stage enters via its own
+`selected-stage-completed("AP Review")`. The decision is read directly from the producing action's output
+(K-VAR-1) — never relayed through a §1.5 variable.
+
+## Architect's lens — advisory pass
+
+Emit `medium` review items when these fire (the noted `high` variants gate like any `high`):
+
+| Check | Trigger | Review item |
+|---|---|---|
+| Single-recipient bottleneck | `action` recipient is one `User:`/`Email:` AND stage runs on every case AND no documented volume limit | `rev_bottleneck_<task>`: confirm volume or use UserGroup/Role |
+| No escalation on SLA | Stage SLA set, escalation absent | `rev_escalation_<stage>`: no one paged on breach |
+| Escalation loops to breacher | Escalation recipient = stage's primary recipient | `rev_escalation_loop_<stage>`: pick a tier-up recipient |
+| Sync child case in critical path | `Wait for Completion: Yes` + parent SLA + no timeout cover | `rev_childcase_<task>`: consider async + completion connector or exception path |
+| All-`action` stage | 100% `action`, > 2 tasks | `rev_human_only_<stage>`: consider agent/process pre-screen |
+| No happy path on first stage | Only `No` exits, no `required-tasks-completed` row | `rev_no_happy_path_<stage>` |
+| Decision outcome unread | `is_decision: Yes` writes a var no downstream rule reads | `rev_orphan_decision_<task>`: consume it or downgrade `is_decision` |
+| Connector failure uncovered | Connector task in primary stage, no failure lane (`high` when ≥ 2 connector tasks share a critical path with zero cover) | `rev_no_failure_path_<task>` |
+| Generic app substitute (`high`) | One Action App on ≥ 2 tasks WITHOUT distinct `actionType` each, or declared fields outside the app schema. Exempt: code-switched app (distinct `actionType` per task, fields ⊆ schema) — sanctioned pattern | `rev_substitute_app_<app>`: code-switch or deploy task-specific apps |
+| Parallel bottleneck fan-in | ≥ 2 bottleneck stages fan into one downstream stage | `rev_multi_bottleneck_<stages>` |
+| Case-var relay | §1.5 `Variable` whose only producer is one task output and only consumer is one binding (K-VAR-2 exemptions apply) | `rev_relay_var_<name>`: reference the output directly, drop the row |
+| Aliased output | An Outputs `-> caseVar` row whose `Field` leaf has no matching §1.5 row and lands in a differently-named variable (K-VAR-7 forbids aliasing to CLOSE lineage; this catches the intentional-looking rest) | `rev_aliased_output_<task>`: declare a dedicated variable for the datum or confirm the reuse |
+
+## Finalization checklist
+
+Run ONCE against the in-memory model before presenting the review. Checks 16/19 need resolved I/O
+contracts (`tasks describe` / `case spec`) the lane does not pull — they are enforced at build; run here
+only when a contract is already in memory.
+
+1. **Schema check** — every task type ∈ K-TYP-1; every WHEN ↔ Marks-Complete pair legal (K-PAIR-2).
+2. **Render contract** — every required cell concrete (no banned `—`/`<UNRESOLVED>`).
+   2a. **Template shape** — the rendered text passes the lane guide's template conformance gate, on-disk,
+   before the `Status: ready` flip.
+   2b. **Safe display names** — K-NAME-1 charset on every generated/carried display field; repair per
+   K-NAME-2, disclose changes.
+3. **Decision buttons** — `is_decision: Yes` ⟹ ≥ 2 buttons; every `Maps To` LHS is a §1.5 `Name` or `taskOutcome`.
+4. **Recipient encoding** — typed prefixes only (K-TYP-7).
+5. **Connector ids** — every connector task has `Connection ID` + `Activity Type ID`; every
+   `wait-for-connector` rule (any scope) resolves `Connector Key` + `Event Operation` (+ `Connection ID`
+   when not tenant-default). Missing → paired `high` item.
+6. **Variable lineage** — every consumer closes (K-VAR-7).
+7. **Override conflict** — no compliance trigger phrase paired with a non-`action` type without explicit
+   user reconciliation.
+8. **Alt-disposition coverage** — ≥ 1 secondary stage ⟹ §1.4a non-empty OR an open `high` item.
+9. **High-severity acknowledgment** — `high` items force the `Build despite N flagged items` pick.
+10. **Source ledger** — every non-`user-stated`/non-`verbatim` value has provenance.
+    10a. **Design rationale** — every stage (kind + routing), task (type + activation/sequencing), and
+    configured SLA (thresholds, recipients, response) carries durable rationale — blocking when missing.
+    10b. **SLA Response Map closure** — one row per `(Scope, SLA, Status)`, responses ∈ K-SLA-4, every
+    non-`notify-only` row has its matching rule and vice versa, Interrupting cells agree; a `notify-only`
+    row that minted a stage/task, or a bare SLA with no row, is blocking.
+11. **File-In-arg caller obligation** — when any `In` + `file` row exists, the review includes:
+    `Caller obligation (file In-arg detected): File In-args: <names>. Programmatic callers must pre-create
+    each JobAttachment via POST /odata/Attachments, PUT bytes, then pass {ID,FullName,MimeType,Metadata} as
+    the In-arg value AND include the attachment ID in StartProcessDto.Attachments[]. Maestro Studio Web's
+    "Start case" dialog does this automatically.` Informational, not blocking.
+12. **Stage-graph connectivity** — the §Logical integrity walk, all seven checks.
+    12a. **Entry producer/reference** — every non-start entry names a concrete producer (K-STG-7); at-risk
+    rows name the escalation, breach rows the SLA alone (K-SLA-3).
+13. **Domain fidelity** — every `verbatim:"…"` entity renders exactly; drift → `Re-edit` with the phrase pre-filled.
+14. **Architect's lens** — run the advisory table; `medium` non-blocking, `high` variants gate.
+15. **Decision-routing closure** — every routing button's variable+value consumed by a downstream rule or
+    declared terminal; a named destination lane with no keyed entry = dead branch → blocking. Fully-orphaned
+    decision var on `is_decision: Yes` → blocking.
+16. **Action-app schema fidelity** — declared Input/Output fields ⊆ the resolved app's schema; violation →
+    `high` `rev_action_schema_<task>`; code-switched reuse sanctioned (lens row).
+17. **Required-task presence** — a `required-tasks-completed` completion over a stage with zero
+    `Required: Yes` tasks is vacuous and fails validate (`Stage exit rule '…' has no task(s) marked as
+    required` — K-PAIR-5) → blocking; offer marking the terminal task required.
+18. **Resolved-resource presence** — concrete portable names everywhere (`Resolved Resource`, Action App
+    title, `Child Case` — never `<UNRESOLVED>`); identity+folder pairs concrete together, or unresolved
+    with a paired `high` item.
+19. **Resolved-resource I/O completeness** — every required input bound (xref forms count, no §1.5 row
+    needed — K-VAR-1) or `<UNRESOLVED>` + `high` item; every `->` Field exists verbatim in the resolved
+    contract. Skip tasks with unresolved identity.
+20. **Re-entry attempt check** — classify every `return-to-origin`/rework loop per K-SEQ-7; new-attempt
+    loops keep producers rerunnable and reset/attempt-scope routing vars; re-evaluate loops document the
+    re-read fact.
+
+**On pass:** present the Case Review (the Build/Save answer is the consent; explicit sign-off adds one
+prompt; design-only/draft requests save and stop). Corrections update the model and re-run only affected
+checks. **On fail:** fix the model and re-run the failed checks (plus any whose inputs changed) — never the
+full suite, never present the review or render `sdd.md` while a fixable check fails; only unfixable items
+surface, as ⚠ flags.
+
+<!-- END: review-finalize.md -->

--- a/skills/uipath-planner/references/case-design/stage-shaping.md
+++ b/skills/uipath-planner/references/case-design/stage-shaping.md
@@ -1,0 +1,140 @@
+# Stage Shaping — derive the case shape, then render it
+
+Reason the shape from the process the user describes — never reach for the template first. Build the model
+in order: **stages → tasks → types → sweep other paths**. Reason first; render second. Shared semantics:
+cite, don't restate — stages/lanes ([K-STG](../case-knowledge/semantics/stages.md)), activation
+([K-SEQ](../case-knowledge/semantics/sequencing.md)), gates
+([K-PAIR](../case-knowledge/facts/pairing.yaml)).
+
+## Deriving stages
+
+**Stage** — a bounded milestone with an entry, tasks, and a completion/exit (K-STG-1). Derive one stage per
+milestone the user names. Ask: *what is the case working toward right now, and what makes that done?* A
+stage that marks the case complete is main-flow (`Required: Yes`, K-PAIR-5).
+
+**Secondary stage** — semantics in K-STG-2..6. Ask: *does this work belong at one fixed point (regular
+stage), or could it happen at several points / only on a condition (secondary)?* "Handle rejected
+application", "escalate on SLA breach", "rework loop" → secondary. Returning work exits `return-to-origin`;
+terminal rejection/withdrawal/cancel exits `exit-only` + a §1.4a case-exit row (K-STG-4). An optional
+one-off inside the current stage stays an `adhoc` task (K-SEQ-4), not a lane. Global events are modeled
+once on the destination lane (K-STG-6). Entry shape follows the lane's trigger (K-STG-5).
+
+**Task** — one unit of work, owned by a persona or the system. One verb in the user's description ≈ one
+task. Type selection: [task-typing.md](task-typing.md).
+
+### Worked pass (vendor onboarding)
+
+> "Vendors sign up through our portal. We screen them, run a compliance check, set them up in our finance
+> system, then activate. If compliance fails it goes back for remediation."
+
+- Milestones → stages: Intake → Screening → Compliance → Finance Setup → Activation (primary).
+- "goes back for remediation" → secondary stage, condition-entered, `return-to-origin` — never a sixth
+  inline primary.
+- "sign up through portal" → event trigger, not Manual — assume and disclose.
+- Verbs → task types per [task-typing.md](task-typing.md); ambiguous verbs decided by playbook, disclosed.
+
+## Other-path sweep — mandatory before confirmation
+
+Actively look beyond the primary flow: rework / needs-info loops; rejection, withdrawal, cancellation; SLA
+escalation; external-system failure; manual override / worker-selected side work; optional side work;
+terminal outcomes differing from success. Choose the smallest faithful model per path: secondary stage,
+terminal case-exit, non-completing case-exit, task-level branch, `adhoc` task, or SLA notification-only
+row. Clear source signal → model by best assumption + disclose in **Other Paths Considered**. No signal at
+all → spend the one bounded question before confirmation; "primary-flow-only" is then a recorded decision,
+not an omission.
+
+## Case execution patterns
+
+Classify before choosing rule types (grammar: K-SEQ-2/3/4):
+
+| Pattern | Signal | Model |
+|---|---|---|
+| Strict sequence | "then", "after", "before", direct prerequisite | consecutive single-task sets; every task `runs-sequentially` (K-SEQ-2) |
+| Parallel after predecessor | "after A, do B and C", independent | B and C share one next task set, each `runs-sequentially`; never duplicate `selected-tasks-completed("A")` (K-SEQ-2) |
+| Race | confirmation vs timeout/cancel/withdrawal | listener + clock armed while the obligation is pending; downstream gated on the winning fact (K-SEQ-3) |
+| Optional side work | "may", "can manually", no required downstream dependency | `adhoc`, `Required: No` (K-SEQ-4) |
+
+**Producer rule:** every non-start stage/task entry names its concrete producer before the Case Review —
+source stage exit/completion, task completion, connector event detail, paired `wait-for-user`, or declared
+SLA reference. A schema-valid rule without a producer is a design defect (K-STG-7).
+
+## Stage render contract
+
+### Headings
+
+- Primary: `### Stage {N}: {Stage Name} (\`{stage_id}\`)` — N is 1-based flow order.
+- Secondary: `### Secondary Stage: {Stage Name} (\`{stage_id}\`)`.
+- The trailing code-formatted `{stage_id}` MUST appear; every by-name stage reference in any cell appends
+  the id in code-formatted parens (greppable cross-references).
+
+### Stage fields
+
+| Field | Required? | Value |
+|---|---|---|
+| Type | yes | `Stage` (literal) |
+| Stage Kind | optional | `primary` (default — omit) / `secondary` (K-STG-2) |
+| Design Rationale | yes | One concrete sentence: why primary/secondary, why the entry/exit behavior fits. Global-event lanes name the event + state that one interrupting entry replaces per-stage duplication (K-STG-6); SLA lanes name SLA, response, and why it interrupts or not (K-SLA-4) |
+| Description | yes (primary) / optional (secondary) | One sentence |
+| Required for case completion | yes | Explicit `Yes`/`No` — design default: primary `Yes`, secondary always `No` (K-PAIR-5) |
+| Interrupting | secondary only | `Yes`; `No` only on the SLA parallel-oversight carve-out (K-STG-3) |
+| Stage SLA | when stage has SLA | Duration + `time-based`/`condition-based` + `SLA Title` (K-SLA-2) + conditional-rule and escalation tables ([case-render.md §1.2](case-render.md)) |
+
+**Stage SLA rendering:** when the source says every primary stage has an SLA target, every named primary
+stage renders its own `#### Stage SLA` block. Deterministic titles when unnamed: `**SLA Title:** <Stage
+Name> SLA`, at-risk `<Stage Name> SLA at risk`, breach `<Stage Name> SLA breached`; every
+`sla-status-change` reference uses those exact strings. Render `**SLA Type:**` and `**SLA Title:**` as two
+separate lines — a collapsed single line hides the title from line-start tooling and the reference never
+resolves.
+
+### Stage Entry Conditions table
+
+≥ 1 row. Columns `WHEN | IF | Interrupting | Display Name`. Legal WHEN: K-PAIR-1 stage-entry set;
+`sla-status-change` arg forms per [case-knowledge/contracts/sdd-contract.md](../case-knowledge/contracts/sdd-contract.md)
+(K-SDD-3). Interrupting cell per K-STG-2/3. Write call forms ONLY in condition rows, always with complete
+args; prose uses bare rule names. `user-selected-stage` requires the upstream `wait-for-user` pair
+(K-PAIR-4) and is never the rule for deterministic rejection/approval/send-back/SLA routing — use decision
+facts + guarded entries.
+
+### Stage Completion + Exit Conditions — one rendered table
+
+Completion (`Yes`) and exit (`No`) rows render together: `WHEN | IF | Exit Type | Marks Stage Complete |
+Display Name`. ≥ 1 completion row per primary stage. Legal/forbidden WHEN and exit types: K-PAIR-1/2/3 —
+a `Yes` + `selected-*` pair blocks Approve. `return-to-origin` is completion-only (K-PAIR-3). Regular
+stage-to-stage routing is NOT carried here — destination stages declare it via their own entry conditions
+(K-STG-1). **One carve-out:** routing INTO a decision/signal-routed lane IS carried here — the gated
+diverting exit + inverse-`IF` completion pair (K-STG-5); omitting it dual-fires or deadlocks the decision
+path.
+
+### Stage Task Summary table
+
+In plan order, ≥ 1 task per stage: `# | Task ID | Task | Type | Owner`. `Task ID` code-formatted
+(`` `t11` ``); Required-Tasks cells elsewhere use those bare ids. Owner = persona or `system`.
+
+### Deterministic stage completion
+
+- **Conditional-branch stages:** mutually-exclusive conditional tasks are all `Required: No`; add ONE
+  required convergence task with the DNF OR entry covering every branch + the no-branch guard (K-SEQ-6).
+- **Re-entry safety** (`return-to-origin` loops): classify each loop and set `Run Only Once` + variable
+  reset per K-SEQ-7. New-attempt loops keep producer/review/decision tasks rerunnable.
+
+### XOR terminal stages
+
+Mutually-exclusive happy-path terminals ("Funding on approve, AAN on decline"): K-PAIR-2 forbids
+`selected-stage-*` on case-completion rows, so the XOR lives at stage entry. Two sanctioned patterns —
+narrate the choice and surface BOTH via AskUserQuestion when detected at Sketch time (multiple terminal
+candidates + an earlier branching decision):
+
+**X1 — gated entry + required terminals (default; no connector needed):**
+1. Both terminals `Required for case completion: Yes`.
+2. Each terminal's entry: `selected-stage-completed("<DecisionStage>")` + lane guard `IF`
+   (`=js:vars.decision === "Approve"` / `"Decline"` — exact inverses, K-EXPR-3).
+3. Each terminal completes normally: `required-tasks-completed`, `Marks Stage Complete: Yes`.
+4. Stage-skip rule: the runtime evaluates entry `IF` at activation; a terminal whose `IF` is false
+   auto-completes (`Skipped`) and still counts toward `required-stages-completed` closure.
+5. Case exit §1.4: ONE row, `required-stages-completed`, `Marks Case Complete: Yes`, `IF: —`.
+
+**X2 — connector-event close** (only when both terminals genuinely emit a shared case-done event):
+terminals `Required: No`; entries as X1; each terminal's last task emits the shared event; case exit = ONE
+`wait-for-connector` row keyed on it.
+
+<!-- END: stage-shaping.md -->

--- a/skills/uipath-planner/references/case-design/task-render.md
+++ b/skills/uipath-planner/references/case-design/task-render.md
@@ -1,0 +1,143 @@
+# Task render contracts
+
+Per-task-type render rules for SDD Section 2 task detail blocks. Rule semantics live in
+[case-knowledge](../case-knowledge/INDEX.md) — cite, never restate. Slot legality: K-PAIR-1.
+
+## Every task
+
+1. **Entry Condition block** (≥ 1 row; multiple rows = DNF outer-OR; render `current-stage-entered` first when present):
+
+```
+**Entry Condition**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| {rule} | {conditionExpression or "—"} | optional |
+```
+
+2. **Design Rationale** — one concrete sentence: why the type fits the actor/work, why the activation mode fits the timing (sequential: name the ordering evidence; parallel: state independence). Persisted into the matching `tasks.md` T-entries.
+
+## Which WHEN to write (task entry)
+
+| Rule | Write when the source says |
+|---|---|
+| `current-stage-entered` | Ungated stage-started task. Never alongside event/adhoc/sequential rules (K-SEQ-1). |
+| `runs-sequentially` | Ordered run — `then` / `after` / `before` / dependency; EVERY task in the run incl. the first (K-SEQ-2). |
+| `selected-tasks-completed("<Task>")` | True fan-in, branch convergence, condition-result routing, non-immediate dependency (K-SEQ-3). Never for simple next-step order; never select `adhoc` or cross-stage tasks. |
+| `wait-for-connector` | Async connector callback. `IF` gates case state only (K-EXPR-2). |
+| `sla-status-change(...)` | The `start-task` SLA response — task fires on the SLA event, referencing the containing stage's own SLA or `root` (K-SLA-5). Never also `current-stage-entered`. |
+| `adhoc` | Manual fire from the Case App; `Required: No` (K-SEQ-4). |
+
+**Activation Mode cell** (per task): `sequential` \| `parallel` \| `parallel-after-predecessor` \| `event-triggered` \| `adhoc`. Sequential runs and parallel-after-predecessor siblings per K-SEQ-2; downstream plans preserve the confirmed mode and rule exactly.
+
+## `action` task — required cells
+
+| Cell | Value |
+|---|---|
+| HITL Implementation | `Action App: <deploymentTitle>` — concrete intended app name (registry-canonical when resolved, else user-requested). NEVER `<UNRESOLVED>`, never paraphrased. |
+| Action App ID | Concrete id from `action-apps-index.json`, or `<UNRESOLVED>` |
+| Deployment Folder | `deploymentFolder.fullyQualifiedName`, or `<UNRESOLVED>` when App ID unresolved |
+| Recipient | Typed prefix only (K-TYP-7): `Email:` / `User:` / `UserGroup:` / `Role:` / `Expression:` — never bare strings |
+| Priority | `Low` / `Medium` / `High` / `Critical` |
+| Task Title | One-line user-visible instruction (REQUIRED — Action Center displays it) |
+| Labels | CSV or `—` |
+| Run Only Once | `Yes` / `No` (re-entry classification: K-SEQ-7) |
+| Required | `Yes` / `No` |
+| Input Schema | Table `Field \| Type \| Binding \| Required` |
+| Output Schema | Table `Field \| Type \| Binding` (arrow form `-> =vars.<id>`) |
+| Buttons | Only when `is_decision: Yes`: `Button \| Maps To \| Behavior` |
+
+- **Portable name:** the Action App title is the Phase 0 → Phase 1 lookup key — establish before registry lookup, preserve when unresolved (+ `high` review item + placeholder fallback). Action Apps are never created inline.
+- **Schema fidelity:** Input/Output `Field` cells MUST be a subset of the resolved app's schema (`tasks describe --type action`). A user-described field the app lacks → Ask (deploy task-specific app / drop / placeholder), never silently author.
+- **Code-switched app (sanctioned):** ONE deployed app across many `action` tasks is correct when each task carries a distinct `actionType` dispatch value AND declared fields ⊆ app schema. Flag `rev_substitute_app` (high) only without distinct `actionType` or with non-bindable fields.
+- **Decision flag:** `is_decision: Yes` only when the task forks the case path; requires ≥ 2 buttons. `Maps To` LHS references a declared §1.5 variable Name or `taskOutcome` — never an undeclared identifier. Non-decision actions render no Buttons table.
+- No recipient and no role/email known → drop the cell + `high` review item.
+
+## `wait-for-connector` / `execute-connector-activity` task — required cells
+
+| Cell | Source |
+|---|---|
+| Connector (key), Connection (display name), Connection ID | IS catalog / connection cache |
+| Activity Type ID, Service Type, Auth Method, Account / Endpoint | IS typecache / catalog / connection cache |
+| Operation / Trigger, Operation Configuration (`=jsonString:<json>` carry-through) | IS catalog / typecache |
+| Inputs | `Field \| Type \| Binding` — `Field` matches IS activity schema verbatim |
+| Outputs | `Field \| Binding / Value` (K-VAR-5) |
+
+Stage-started connector tasks declare `current-stage-entered` as the first entry row like any other task — no task-type auto-injection. Missing `connectionId` / `activityTypeId` → `high` review item (Phase 1 cannot resolve without them).
+
+## `wait-for-timer` task — required cells
+
+| Cell | Value |
+|---|---|
+| Timer Type | `timeDuration` (relative) / `dateTime` (absolute) |
+| Duration / Until | ISO-8601 duration (`P30D`) or date-time — NEVER `<UNRESOLVED>` (timer cannot fire; block Approve) |
+| Business Calendar | Optional; `—` |
+
+## `case-management` task — required cells
+
+| Cell | Value |
+|---|---|
+| Child Case | Concrete intended child-case `name` — portable lookup key; NEVER `<UNRESOLVED>`, never the parent task's display name |
+| Folder Path | Exact `folders[0].fullyQualifiedName`, or `<UNRESOLVED>` when identity unresolved |
+| Resource Identity | Selected `entityKey` from `caseManagement-index.json`, or `<UNRESOLVED>` (+ `high` review item, placeholder-only) |
+| Child Case Identifier | Child's identifier prefix |
+| Data Passed | Table `Parent Variable \| Child Variable` |
+| Wait for Completion | `Yes` / `No` |
+| Data Returned | Table `Child Variable \| Parent Variable` — only when `Wait for Completion: Yes` |
+
+## `process` / `agent` / `rpa` / `api-workflow` — shared block
+
+| Cell | Required? | Value |
+|---|---|---|
+| Resolved Resource | yes | Concrete intended resource `name` (registry-canonical when resolved, else user-requested). NEVER `<UNRESOLVED>`. |
+| Folder Path | yes | Resolved `folders[0].fullyQualifiedName` (exact resource folder, never a parent), or `<UNRESOLVED>` when identity unresolved |
+| Resource Identity | yes | `apiWorkflowId` / `agentId` (+version) / `processOrchestrationId`, or `<UNRESOLVED>` |
+| Binding Sub-Type | yes | `Api` (api-workflow) / `Agent` (agent) / `ProcessOrchestration` (process) / `—` (rpa). Omitting it → Studio Web "resource not found". |
+| Dispatch / Operation | conditional | Façade selector + value (`requestSource = "RegisterCaseShell"`); `—` for single-purpose. Also an Inputs row (literal binding). |
+| Inputs | yes | `Field \| Type \| Binding` — `Field` matches the runnable's In-argument name verbatim |
+| Outputs | yes | `Field \| Binding / Value` — `Field` matches the Out-argument name verbatim for `->` rows (K-VAR-5) |
+
+**Deep metadata stays out of the SDD** (K-LEDG-4). Identity source per type:
+
+| Task type | Registry source | Identity field |
+|---|---|---|
+| `process` | `processOrchestration-index.json` | `processOrchestrationId` |
+| `agent` | `agent-index.json` | `agentId` (+ version) |
+| `rpa` | `process-index.json` | `processOrchestrationId` |
+| `api-workflow` | `api-index.json` | `apiWorkflowId` (+ endpoint) |
+
+Unresolved identity → `high` review item. **No SLA cells on these types** — SLA is case / stage / `action` only (K-SLA-1). Externally-hosted AI agents (CrewAI, Einstein, Databricks…) model as `api-workflow` or `execute-connector-activity` — never `external-agent` (K-TYP-2).
+
+## Binding cell — allowed forms (Inputs)
+
+Semantics: K-EXPR-1; xref doctrine: K-VAR-1.
+
+| Form | Meaning |
+|---|---|
+| `<literal>` | Plain string / number / boolean |
+| `=vars.<id>` / `=vars.<id>.<sub>` | §1.5 variable, or an upstream task output referenced directly (K-VAR-1) |
+| `=bindings.<id>` | Registered resource |
+| `=metadata.<key>` / `=metadata.ExternalId` | Case metadata / the platform case identity — canonical `caseId` binding, never a `->` extraction |
+| `=trigger.<field>` | Trigger payload field |
+| `=js:<expr>` | Inline JS (required when operators are involved) |
+| `=jsonString:<json>` | JSON-as-string (connector `essentialConfiguration` only) |
+| `=datafabric.<path>` / `=orchestrator.JobAttachments` | Data Fabric / file slot |
+| `=response` / `=result` / `=Error` | Conventional response handles |
+| `"<Stage>"."<Task>".<outputName>` (whole-value `<-`) / `vars.$xref('Stage','Task','out')` | Cross-task output reference → `=vars.<outputId>` at build (K-VAR-1) |
+
+**Bare field-name lists are FORBIDDEN** (`**Inputs:** loanId, borrower`) — they force name-match inference; use the table.
+
+## Outputs rows
+
+Operators, one-writer-per-target, self-binding ban: K-VAR-5 / K-VAR-6. Targets pre-declared per K-VAR-2 (declare-vs-xref).
+
+## Resolved-resource I/O completeness
+
+When a task resolves to a live resource (contract in `tasks/registry-resolved.json`), coverage is two-directional — enforced at build (Phase 1 discovery + Phase 3 io-binding); apply at design only when a contract is already in memory:
+
+1. **Inputs — required coverage:** every required declared input has a non-empty `Binding` row (any form above, incl. an upstream-output xref — which needs NO §1.5 row, K-VAR-1) OR `<UNRESOLVED>` + `high` review item (`rev_unbound_input_<task>_<field>`). Optional inputs may be omitted (user-described but unmapped → `medium`). Never invent a `Default` to suppress an unmapped required input.
+2. **Outputs — field fidelity:** every `-> caseVar` row's `Field` (top-level leaf) exists verbatim in the resolved output contract; a phantom field → `high` (`rev_phantom_output_<task>_<field>`). Selective consumption is fine — only referenced outputs need rows.
+
+Tasks with `<UNRESOLVED>` type-specific identity have no contract and are skipped; their portable names stay concrete.
+
+<!-- END: task-render.md -->

--- a/skills/uipath-planner/references/case-design/task-typing.md
+++ b/skills/uipath-planner/references/case-design/task-typing.md
@@ -1,0 +1,77 @@
+# Choosing the task type
+
+The `type` says **how the work gets done**, not what it's about. Read the verb + actor, ask the matching
+question, pick the type. The enum is closed (K-TYP-1); never-author list in K-TYP-2. Pick the baseline
+here; [§ Override priority](#task-type-override-priority) resolves conflicts on top.
+
+| Type | Pick when the work is… | The question that selects it |
+|---|---|---|
+| `action` | a **person** must do, decide, approve, review, or sign off — in a form (human-in-the-loop) | Does a human need to act or judge here? |
+| `agent` | an **AI agent** reasons over unstructured input: classify, extract, summarize, draft, score | Is this judgment over unstructured content an AI can do unattended? |
+| `rpa` | deterministic **UI / desktop** automation of a legacy app with no API (an existing RPA process) | Is this clicking through a UI / legacy system with no API? |
+| `process` | invoking a **deployed orchestration process** that already packages this automation | Is there a deployed process that already does this end-to-end? |
+| `api-workflow` | calling a **coded / API workflow** directly (HTTP, serverless business logic) | Is this an API / coded workflow we call directly? |
+| `execute-connector-activity` | one **operation on an Integration Service connector** (Salesforce create record, send email) | Is this a single connector operation against a SaaS system? |
+| `wait-for-connector` | the case **pauses until an external system calls back** (webhook, inbound event) | Is the case waiting for an external system to respond? |
+| `wait-for-timer` | the case **pauses for a duration or until a datetime** | Is the case just waiting on time? |
+| `case-management` | the step **launches / coordinates a child case** | Does this spin up a sub-case? |
+
+**Tie-breakers:** SaaS integration with a tenant connector → `execute-connector-activity` over
+`api-workflow`. "Approve / review / decide" verbs are ambiguous between `action` (human) and `agent` (AI)
+— decide per the assumption playbook ([case-design-lane-guide.md § Sketch](../case-design-lane-guide.md#sketch--best-assumption-every-field))
+and disclose. A compliance trigger phrase forces `action` regardless (below).
+
+## Task-type override priority
+
+Apply in order when picking `type`:
+
+1. **User decision pinned to a type** — honor unless schema-invalid (K-TYP-1) or conflicting with (2).
+2. **Regulatory constraint requiring human sign-off** — task MUST be `action`. Trigger phrases that force
+   `action` regardless of user preference:
+   - "only a licensed X may decide / sign off / certify / approve"
+   - "regulation requires human review"
+   - "ECOA adverse-action notice" / "FCRA adverse action"
+   - "NCQA UM 3 adverse determination"
+   - "HIPAA-protected approval"
+   - "SOC 2 attestation"
+   - any `<role>-licensed` or `<role>-credentialed` gate ("licensed underwriter", "credentialed clinician")
+   - "fiduciary review", "legal sign-off", "auditor review"
+
+   If the user proposes any non-`action` type AND any phrase above appears in the conversation → Ask to
+   confirm; never silently accept. Ask phrasing: name the regulation and propose `action` with the
+   LLM/agent work bound to the action's form/recipient.
+3. **Tenant evidence** — the registry cache resolves a deployed Action App / process / agent /
+   api-workflow / RPA that fits → prefer that resource's type and surface the match.
+4. **Connector availability** — an IS connector matches the integration → `execute-connector-activity`
+   over `api-workflow`.
+5. **Verb signal** — fall through to the assumption playbook.
+6. **Fallback** — keep the user's stated value if any; otherwise emit a placeholder per the build skill's
+   placeholder contract + a `high` review item ([authoring-core.md § Review items](authoring-core.md#review-items)).
+
+**Worked examples:**
+
+| Case context | User stated | Override fires | Final type |
+|---|---|---|---|
+| Adverse-action notice (lending) — "ECOA mandates licensed compliance officer signs off" | `agent` (LLM drafts notice) | Yes — tier 2 | `action` (Compliance Officer recipient; LLM-drafted body bound to the action's form context) |
+| Vendor scoring on intake | `agent` (LLM scores docs) | No — no regulation, no licensed role | `agent` |
+| Underwriting decision on mortgage | `agent` (LLM applies criteria) | Maybe — jurisdiction-dependent; no tier-2 phrase in transcript → keep `agent`, disclose the compliance caveat as a decision line | `agent` (disclosed) |
+| Inbound webhook from Salesforce | `api-workflow` | No — but tier 4 prefers the connector | `execute-connector-activity` if a Salesforce connector exists in tenant; else `api-workflow` |
+| Process orchestration call | `process` | No | `process` |
+
+**Compliance trigger detection.** Scan the entire Listen + Ask transcript for the tier-2 phrases BEFORE
+recording any non-`action` type. If a phrase surfaces after a non-`action` type was provisionally
+recorded, re-Ask before continuing to resolution.
+
+## Activation is a separate axis
+
+Task activation modes (`sequential`, `event-triggered`, `manually-triggered`, stage-started) map to entry
+rules per K-SEQ-1 — they never change the `type`. `adhoc` decides how a task STARTS, not what it is: a
+manually triggered task may still be `action`, `agent`, `api-workflow`, `process`, etc. Downstream plans
+preserve the confirmed SDD mode and rule exactly; `sequential` requires an explicit order or dependency in
+the source (K-SEQ-2).
+
+**Externally-hosted AI agents** (CrewAI, Salesforce Einstein, Databricks, LangChain, …) are NOT
+first-class: model as `api-workflow` (system-to-system) or `execute-connector-activity` when a connector
+exists. Never invent `external-agent` (K-TYP-2).
+
+<!-- END: task-typing.md -->


### PR DESCRIPTION
## What

PR 3/8 of the case-knowledge restructure (stacked on #2629). Pure addition: `skills/uipath-planner/references/case-design/` — the planner-private design layer that dissolves the 1040-line `case-authoring-rules-guide.md` into seven activity-scoped files, each ≤220 lines, loaded only when its activity starts:

| File | Lines | Carries |
|---|---|---|
| authoring-core.md | 131 | Authority hierarchy, domain fidelity, provenance ledger, review items, render policy incl. forbidden SDD-body vocabulary |
| stage-shaping.md | 140 | Stage derivation method, other-path sweep, execution patterns, stage render contract, XOR terminal patterns |
| task-typing.md | 77 | 9-type decision table, override priority + compliance triggers, worked examples |
| case-render.md | 134 | SDD §1 contracts: metadata, SLA map, triggers, exits, variables (declare-vs-xref applied) |
| task-render.md | 143 | Per-type task blocks, binding cell grammar, I/O completeness |
| grounding.md | 78 | Design-time tenant resolution: 5-step contract, bucketing, the ONE batched gate |
| review-finalize.md | 219 | The 8-section Case Review, logical-integrity walk, 20-check finalization, architect's lens |

Every shared rule is a `K-*` citation into `case-knowledge/` — zero restatement (mechanically checked: all cited IDs resolve, all relative links resolve, END markers present). Ledger rulings C4 and C12 are applied here.

**Not in this PR:** nothing references these files yet. PR 4 rewires the lane guide/template/SKILL.md and deletes the old rules guide — reviewable as one atomic flip.

## Stack

1. #2628 ledger → 2. #2629 shared layer → **3. this PR** → 4. rewire+delete → 5. maestro symlink+router → 6. maestro dedupe → 7. infra guards → 8. lint+CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)