### PR TITLE
feat(ci): case-knowledge lint + facts-driven audit checks

### DIFF
--- a/.github/workflows/validate-case-knowledge.yml
+++ b/.github/workflows/validate-case-knowledge.yml
@@ -1,0 +1,23 @@
+name: Validate Case Knowledge
+
+on:
+  pull_request:
+    paths:
+      - 'skills/uipath-planner/references/case-knowledge/**'
+      - 'skills/uipath-planner/references/case-design/**'
+      - 'skills/uipath-planner/references/case-design-lane-guide.md'
+      - 'skills/uipath-planner/assets/templates/case-*.md'
+      - 'skills/uipath-planner/SKILL.md'
+      - 'skills/uipath-maestro-case/**'
+      - 'scripts/lint-case-knowledge.py'
+      - '.github/workflows/validate-case-knowledge.yml'
+
+jobs:
+  lint-case-knowledge:
+    runs-on: uipath-ubuntu-latest
+    name: Case knowledge single-definition lint
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - name: Lint case-knowledge layer (K-* single definition, citations, markers, budgets, symlink)
+        run: python3 scripts/lint-case-knowledge.py

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   ],
   "scripts": {
     "skills:test": "node --test tests/scripts/compose-skill-flavor.test.mjs tests/scripts/manage-skill-flavors-skill.test.mjs",
-    "skills:validate": "node scripts/compose-skill-flavor.mjs validate",
+    "skills:validate": "node scripts/compose-skill-flavor.mjs validate && python3 scripts/lint-case-knowledge.py",
     "skills:build": "node scripts/compose-skill-flavor.mjs build",
     "skills:pack": "node scripts/compose-skill-flavor.mjs pack",
     "skills:recover": "node scripts/npm-package-lifecycle.mjs recover",

--- a/scripts/lint-case-knowledge.py
+++ b/scripts/lint-case-knowledge.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Deterministic lint for the shared case-knowledge layer and its consumers.
+
+Checks (stdlib only, read-only, exit 0 clean / 1 findings):
+  1. K-* rule IDs are defined exactly once (md `**[K-XXX-n]**` markers + facts YAML top-level keys).
+  2. Every K-* citation across both skills' case surfaces resolves to a defined ID.
+  3. Every .md in case-knowledge/ and case-design/ ends with its exact `<!-- END: <basename> -->` marker.
+  4. Size budgets: case-knowledge .md <= 100 lines, facts .yaml <= 90, case-design .md <= 230.
+  5. The sanctioned maestro-case symlink exists, is a symlink, and resolves to the planner directory.
+  6. Relative links inside case-knowledge/ and case-design/ resolve to existing files.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+KN = REPO / "skills/uipath-planner/references/case-knowledge"
+CD = REPO / "skills/uipath-planner/references/case-design"
+SYMLINK = REPO / "skills/uipath-maestro-case/references/case-knowledge"
+
+# Where K-* citations are expected/allowed to appear.
+CITATION_ROOTS = [
+    REPO / "skills/uipath-planner/references",
+    REPO / "skills/uipath-planner/assets/templates",
+    REPO / "skills/uipath-planner/SKILL.md",
+    REPO / "skills/uipath-maestro-case/references",
+    REPO / "skills/uipath-maestro-case/SKILL.md",
+]
+
+K_ID = re.compile(r"\bK-[A-Z]+-\d+\b")
+MD_DEF = re.compile(r"\*\*\[(K-[A-Z]+-\d+)\]")
+YAML_DEF = re.compile(r"^(K-[A-Z]+-\d+):", re.M)
+MD_LINK = re.compile(r"\]\(([^)#\s]+)(?:#[^)\s]*)?\)")
+
+BUDGETS = [(KN, "*.md", 100), (KN, "*.yaml", 90), (CD, "*.md", 230)]
+
+
+def md_files(root: Path) -> list[Path]:
+    return sorted(p for p in root.rglob("*.md") if p.is_file())
+
+
+def main() -> None:
+    findings: list[str] = []
+    rel = lambda p: p.relative_to(REPO).as_posix()
+
+    if not KN.is_dir():
+        sys.exit(f"FATAL: {rel(KN)} missing")
+
+    # 5. Symlink integrity (repo checkout; built trees carry real copies instead).
+    if SYMLINK.exists() or SYMLINK.is_symlink():
+        if not SYMLINK.is_symlink():
+            findings.append(
+                f"{rel(SYMLINK)}: expected a symlink to the planner case-knowledge directory "
+                "(broken checkout? run: git config core.symlinks true, then re-checkout)"
+            )
+        elif SYMLINK.resolve() != KN.resolve():
+            findings.append(f"{rel(SYMLINK)}: must resolve to {rel(KN)}")
+    else:
+        findings.append(f"{rel(SYMLINK)}: sanctioned symlink missing")
+
+    # 1. Definitions.
+    defined: dict[str, str] = {}
+    for path in md_files(KN):
+        for match in MD_DEF.finditer(path.read_text(encoding="utf-8")):
+            rule_id = match.group(1)
+            if rule_id in defined:
+                findings.append(f"{rel(path)}: {rule_id} already defined in {defined[rule_id]}")
+            defined[rule_id] = rel(path)
+    for path in sorted(KN.glob("facts/*.yaml")):
+        for match in YAML_DEF.finditer(path.read_text(encoding="utf-8")):
+            rule_id = match.group(1)
+            if rule_id in defined:
+                findings.append(f"{rel(path)}: {rule_id} already defined in {defined[rule_id]}")
+            defined[rule_id] = rel(path)
+    if not defined:
+        findings.append(f"{rel(KN)}: no K-* definitions found")
+
+    # 2. Citations resolve. Skip the symlink (same content as KN).
+    def cite_files() -> list[Path]:
+        out: list[Path] = []
+        for root in CITATION_ROOTS:
+            if root.is_file():
+                out.append(root)
+                continue
+            for p in sorted(root.rglob("*")):
+                if not p.is_file() or p.suffix not in (".md", ".yaml"):
+                    continue
+                if SYMLINK in p.parents or p == SYMLINK:
+                    continue
+                out.append(p)
+        return out
+
+    for path in cite_files():
+        text = path.read_text(encoding="utf-8", errors="replace")
+        for cited in sorted(set(K_ID.findall(text))):
+            if cited not in defined:
+                findings.append(f"{rel(path)}: cites undefined {cited}")
+
+    # 3. END markers.
+    for root in (KN, CD):
+        if not root.is_dir():
+            continue
+        for path in md_files(root):
+            expected = f"<!-- END: {path.name} -->"
+            tail = path.read_text(encoding="utf-8").rstrip().splitlines()[-1].strip()
+            if tail != expected:
+                findings.append(f"{rel(path)}: last line must be {expected!r} (got {tail!r})")
+
+    # 4. Budgets.
+    for root, pattern, cap in BUDGETS:
+        if not root.is_dir():
+            continue
+        for path in sorted(root.rglob(pattern)):
+            lines = len(path.read_text(encoding="utf-8").splitlines())
+            if lines > cap:
+                findings.append(f"{rel(path)}: {lines} lines exceeds the {cap}-line budget — split or tighten")
+
+    # 6. Relative links resolve.
+    for root in (KN, CD):
+        if not root.is_dir():
+            continue
+        for path in md_files(root):
+            for match in MD_LINK.finditer(path.read_text(encoding="utf-8")):
+                target = match.group(1)
+                if target.startswith(("http://", "https://", "mailto:")):
+                    continue
+                if not (path.parent / target).resolve().exists():
+                    findings.append(f"{rel(path)}: broken relative link {target!r}")
+
+    if findings:
+        print("CASE-KNOWLEDGE LINT FAIL:", file=sys.stderr)
+        for n, finding in enumerate(findings, 1):
+            print(f"  {n}. {finding}", file=sys.stderr)
+        sys.exit(1)
+    print(f"CASE-KNOWLEDGE LINT OK: {len(defined)} K-* rules, single-definition holds")
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/uipath-maestro-case/scripts/audit_plan.py
+++ b/skills/uipath-maestro-case/scripts/audit_plan.py
@@ -63,9 +63,22 @@ def rule_token(value: str | None) -> str | None:
     return match.group(0) if match else None
 
 
+FACTS_DIR = Path(__file__).resolve().parent.parent / "references" / "case-knowledge" / "facts"
+
+
+def load_task_types() -> set[str]:
+    """K-TYP-1 enum from the shared facts (resolves through the case-knowledge symlink in the
+    repo, a real directory in shipped trees). Empty set = facts unavailable, check skipped."""
+    try:
+        return set(re.findall(r"sdd_type:\s*([a-z-]+)", (FACTS_DIR / "types.yaml").read_text(encoding="utf-8")))
+    except OSError:
+        return set()
+
+
 def audit(path: Path) -> list[str]:
     findings: list[str] = []
     sequential_lanes: dict[str, list[tuple[str, int]]] = {}
+    task_types = load_task_types()
     text = path.read_text(encoding="utf-8")
 
     headings = list(re.finditer(r"(?m)^## (T\d+)[^\n]*$", text))
@@ -105,6 +118,13 @@ def audit(path: Path) -> list[str]:
                 if re.search(rf"(?i)[;,]\s*{re.escape(field)}\s*:", section):
                     hint = " (present mid-line — each field goes on its own line)"
                 findings.append(f"{label}: missing `{field}:` line{hint}")
+
+        declared_type = rule_token(field_value(section, "type"))
+        if task_types and declared_type is not None and declared_type not in task_types:
+            findings.append(
+                f"{label}: `type: {declared_type}` outside the closed enum (K-TYP-1): "
+                + ", ".join(sorted(task_types))
+            )
 
         activation = (field_value(section, "activation-mode") or "").casefold()
         mode = rule_token(activation)

--- a/skills/uipath-planner/scripts/audit_sdd.py
+++ b/skills/uipath-planner/scripts/audit_sdd.py
@@ -220,6 +220,77 @@ def lineage_findings(text: str) -> list[str]:
     return findings
 
 
+FACTS_DIR = Path(__file__).resolve().parent.parent / "references" / "case-knowledge" / "facts"
+
+
+def load_facts() -> dict:
+    """Targeted extraction from the case-knowledge facts YAMLs (stdlib only).
+
+    Returns {} when the facts directory is absent so the shape audit still runs standalone.
+    """
+    facts: dict = {}
+    try:
+        types_text = (FACTS_DIR / "types.yaml").read_text(encoding="utf-8")
+        facts["task_types"] = set(re.findall(r"sdd_type:\s*([a-z-]+)", types_text))
+        pairing_text = (FACTS_DIR / "pairing.yaml").read_text(encoding="utf-8")
+        facts["yes_when"] = set(re.findall(r"[\w-]+", pairing_text.split("yes_when:", 1)[1].split("]", 1)[0]))
+        facts["no_when"] = set(re.findall(r"[\w-]+", pairing_text.split("no_when:", 1)[1].split("]", 1)[0]))
+        naming_text = (FACTS_DIR / "naming.yaml").read_text(encoding="utf-8")
+        pattern = re.search(r'allowed_pattern:\s*"([^"]+)"', naming_text)
+        facts["name_pattern"] = re.compile(pattern.group(1)) if pattern else None
+    except (OSError, IndexError):
+        return {}
+    return facts
+
+
+def facts_findings(text: str) -> list[str]:
+    """K-fact-driven legality checks: task type enum (K-TYP-1), Marks-Complete pairing
+    (K-PAIR-2), display-name charset (K-NAME-1)."""
+    facts = load_facts()
+    if not facts:
+        return []
+    findings: list[str] = []
+
+    for match in re.finditer(r"^\*\*Type:\*\*\s*`?([a-z][a-z-]+)`?\s*$", text, re.M):
+        if facts["task_types"] and match.group(1) not in facts["task_types"]:
+            findings.append(
+                f"task type {match.group(1)!r} outside the closed enum (K-TYP-1): "
+                + ", ".join(sorted(facts["task_types"]))
+            )
+
+    # Exit-condition rows: | WHEN | IF | Exit Type | Marks ... Complete | Display Name |
+    for line_no, line in enumerate(text.splitlines(), 1):
+        cells = [c.strip() for c in line.strip().strip("|").split("|")]
+        if len(cells) < 4 or not line.lstrip().startswith("|"):
+            continue
+        when = re.match(r"`?([a-z][a-z-]+)", cells[0])
+        if not when:
+            continue
+        rule = when.group(1)
+        marks = next((c for c in cells if c in ("Yes", "No")), None)
+        if marks is None or rule not in (facts["yes_when"] | facts["no_when"]):
+            continue
+        if marks == "Yes" and rule not in facts["yes_when"]:
+            findings.append(
+                f"line {line_no}: WHEN {rule!r} with Marks Complete 'Yes' is an illegal pair (K-PAIR-2)"
+            )
+        if marks == "No" and rule not in facts["no_when"]:
+            findings.append(
+                f"line {line_no}: WHEN {rule!r} with Marks Complete 'No' is an illegal pair (K-PAIR-2)"
+            )
+
+    name_pattern = facts.get("name_pattern")
+    if name_pattern:
+        for kind, name, _ in stage_blocks(text):
+            if not name_pattern.fullmatch(name.strip()):
+                findings.append(f"{kind.lower()} name {name!r} has characters outside K-NAME-1's safe set")
+        for match in re.finditer(r"^#{5} Task [S\d.]+: ([^\n]+)$", text, re.M):
+            candidate = strip_id_suffix(match.group(1)).strip()
+            if not name_pattern.fullmatch(candidate):
+                findings.append(f"task name {candidate!r} has characters outside K-NAME-1's safe set")
+    return findings
+
+
 def audit(sdd_path: Path, draft_path: Path | None) -> list[str]:
     findings: list[str] = []
     text = sdd_path.read_text(encoding="utf-8")
@@ -302,6 +373,7 @@ def audit(sdd_path: Path, draft_path: Path | None) -> list[str]:
                 )
 
     findings.extend(lineage_findings(text))
+    findings.extend(facts_findings(text))
 
     draft_findings: list[str] = []
     if draft_path is not None:

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -56,7 +56,7 @@ TASK_ENTRY = {"current-stage-entered", "selected-tasks-completed",
               "wait-for-connector", "adhoc", "runs-sequentially",
               # the `start-task` SLA response; CLI-verified valid on task entry
               # (uip 1.198.0-preview.102). See skills/uipath-maestro-case/
-              # references/sla-response-shapes.md section 3.
+              # case-knowledge K-SLA-5 (where the rule lives).
               "sla-status-change"}
 CASE_COMPLETION = {"required-stages-completed", "wait-for-connector"}    # Marks: Yes
 CASE_EXIT = {"selected-stage-completed", "selected-stage-exited",

--- a/tests/tasks/uipath-maestro-case/_shared/test_sla_response_map_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sla_response_map_check.py
@@ -96,7 +96,7 @@ def test_start_task_via_stage_re_entry_is_rejected():
     """`No` implies the stage-re-entry shape, which re-runs the breached stage's tasks.
 
     A start-task response is the follow-up task's own task-entry rule, so `—` is the
-    only legal Interrupting value. See sla-response-shapes.md section 5, defect 4.
+    only legal Interrupting value. See case-knowledge K-SLA-5 / K-ERR-2 (start-task authored as stage re-entry).
     """
     text = sdd(
         "| stage: Assess | Assess SLA | Breached | start-task | Assess | No | manager check, assessor keeps working |\n",

--- a/tests/tasks/uipath-maestro-case/sla_response/start_task_same_stage/check_start_task_same_stage.py
+++ b/tests/tasks/uipath-maestro-case/sla_response/start_task_same_stage/check_start_task_same_stage.py
@@ -9,7 +9,7 @@ not re-entered and its other tasks do not re-run.
 accepts it (verified on uip 1.198.0-preview.102). Re-entering the stage restarts every task
 in it whose `shouldRunOnlyOnce` is `false` — the default for every task type — so a breach
 meant to add one manager check silently re-runs the whole stage. See
-`skills/uipath-maestro-case/references/sla-response-shapes.md` section 5, defect 4.
+case-knowledge K-SLA-5 / K-ERR-2 (start-task authored as stage re-entry re-runs the stage).
 
 The rule must reference **Review's own** SLA and be a breach rule (`slaId`, no
 `escalationId`), and the follow-up task must be an `action` task in Review with a working
@@ -69,7 +69,7 @@ def main() -> None:
             f"({cond.get('displayName')!r}). A start-task response belongs on the follow-up "
             "TASK's own entryConditions. validate accepts stage re-entry, but re-entering "
             "Review restarts every task whose shouldRunOnlyOnce is false (the default), not "
-            "just the manager check — see references/sla-response-shapes.md section 5, defect 4."
+            "just the manager check — see case-knowledge K-SLA-5 / K-ERR-2."
         )
 
     node, task, _cond, rule = task_hits[0]

--- a/tests/tasks/uipath-planner/_shared/sdd_check.py
+++ b/tests/tasks/uipath-planner/_shared/sdd_check.py
@@ -56,7 +56,7 @@ TASK_ENTRY = {"current-stage-entered", "selected-tasks-completed",
               "wait-for-connector", "adhoc", "runs-sequentially",
               # the `start-task` SLA response; CLI-verified valid on task entry
               # (uip 1.198.0-preview.102). See skills/uipath-maestro-case/
-              # references/sla-response-shapes.md section 3.
+              # case-knowledge K-SLA-5 (where the rule lives).
               "sla-status-change"}
 CASE_COMPLETION = {"required-stages-completed", "wait-for-connector"}    # Marks: Yes
 CASE_EXIT = {"selected-stage-completed", "selected-stage-exited",


### PR DESCRIPTION
## What

PR 8/8 of the restructure stack (stacked on #2634). The enforcement layer that keeps the dedupe from silently regrowing:

**`scripts/lint-case-knowledge.py`** (stdlib-only; wired into `npm run skills:validate` and a path-scoped workflow):
1. Every `K-*` rule ID defined exactly once (md markers + facts YAML keys) — restatement becomes structurally impossible to reintroduce unnoticed
2. Every `K-*` citation across both skills' case surfaces resolves
3. Exact `<!-- END: <file> -->` markers on every case-knowledge/case-design file (the Rule-24 contract, now enforced)
4. Size budgets (case-knowledge ≤100, facts ≤90, case-design ≤230 lines)
5. Sanctioned-symlink integrity with the `core.symlinks` remediation message
6. Relative-link resolution

Current state: **72 K-* rules, green.**

**Facts-driven audit checks** — `audit_sdd.py` (planner) and `audit_plan.py` (maestro-case) now read `case-knowledge/facts/*.yaml` (targeted stdlib extraction, graceful skip when absent): task-type enum (K-TYP-1), WHEN↔Marks-Complete pairing legality (K-PAIR-2), and display-name charset (K-NAME-1) are now deterministic script checks at design and plan time — the enum/pairing/naming facts exist once and every checker reads the same source, so the C7-class bug (a template dropping `min` from an enum copy) cannot recur.

## Remaining follow-up (tracked, not in this PR)

Eval verification evidence (coder-eval suites + a loan-origination e2e build) is being produced and will be posted to this PR before the stack merges.

## Stack

1. #2628 → 2. #2629 → 3. #2630 → 4. #2631 → 5. #2632 → 6. #2633 → 7. #2634 → **8. this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)