### PR TITLE
docs(uipath-platform): document bucket-files list's Data.Items[] envelope

### DIFF
--- a/skills/uipath-platform/references/orchestrator/work-with-storage.md
+++ b/skills/uipath-platform/references/orchestrator/work-with-storage.md
@@ -139,6 +139,22 @@ uip or bucket-files list <bucket-key> --folder-path "Finance" \
 
 Additional options: `--take-hint <n>` (items per page, default 500, max 1000), `--expiry-in-minutes` (presigned URL lifetime in the response).
 
+**Response shape: `Data.Items[]`, not a bare `Data[]`.** Unlike most `uip or` list commands, `bucket-files list` wraps its rows in a named `Items` field:
+
+```json
+{
+  "Result": "Success",
+  "Code": "BucketFileList",
+  "Data": {
+    "Items": [
+      { "FullPath": "/reports/summary.csv", "ContentType": "text/csv", "Size": 1234, "LastModified": "..." }
+    ]
+  }
+}
+```
+
+Reading `.Data` directly (as you would for `or triggers list`, `or machines list`, etc.) yields an object, not an array — indexing it as a list silently produces nothing rather than an error. Read `.Data.Items` instead.
+
 ### List Directories
 
 ```bash


### PR DESCRIPTION
## Summary

- `uip or bucket-files list` wraps its rows in `Data.Items[]`, unlike most `uip or` list commands (`triggers list`, `machines list`, `queues list`, ...) which return a bare `Data[]` array.
- Adds a short callout with a response sample to the "List Files" section of `work-with-storage.md`.

## Why

Reading `.Data` directly on this command yields an object, not an array. Indexing it as a list (e.g. piping straight into a table renderer, or `.Data[0]`) silently produces nothing rather than erroring — which reads as "the bucket is empty" when it may hold hundreds of files. Hit this against a populated bucket and reported it as empty on that basis before catching the shape mismatch.

## Test plan

- [x] Confirmed the shape against a live `bucket-files list` call
- [x] Checked whether this was already documented elsewhere in the skill (it wasn't — no JSON response sample exists for this command)
- [x] Kept the addition local to the existing "List Files" section rather than introducing a new envelope-shape reference doc