### PR TITLE
feat(planner): case knowledge as nine single-purpose reference files

### DIFF
--- a/skills/uipath-planner/references/case/authoring.md
+++ b/skills/uipath-planner/references/case/authoring.md
@@ -1,0 +1,158 @@
+# Authoring — from described process to case model
+
+How to turn the user's process into stages, tasks, and types. Reason the shape from the process —
+never reach for the template first. Build in order: **stages → tasks → types → sweep other paths**.
+Model semantics (gates, secondary stages, activation grammar): [model.md](model.md). Authority order and
+provenance: [principles.md](principles.md).
+
+## Derivation questions
+
+| Concept | Ask of the user's process |
+|---|---|
+| Stage | *What is the case working toward right now, and what makes that done?* One stage per named milestone. A stage that marks the case complete is main-flow (`Required: Yes`). |
+| Secondary stage | *Does this work belong at one fixed point (regular stage), or could it happen at several points / only on a condition?* "Handle rejected application", "escalate on breach", "rework loop" → secondary ([model.md § Secondary stages](model.md#secondary-stages)). An optional one-off inside the current stage stays an `adhoc` task, not a lane. |
+| Task | *Who or what performs this, and how?* One verb in the description ≈ one task. The "how" answer is the task type (below). |
+
+### Worked pass — vendor onboarding
+
+> "Vendors sign up through our portal. We screen them, run a compliance check, set them up in our finance
+> system, then activate. If compliance fails it goes back for remediation."
+
+- Milestones → stages: Intake → Screening → Compliance → Finance Setup → Activation (primary).
+- "goes back for remediation" → a returning secondary lane (condition-entered, `return-to-origin`) — never a sixth inline primary stage.
+- "sign up through portal" → event trigger, not Manual — assume and disclose.
+- Verbs → types: *screen* (AI over unstructured docs) → `agent`; *compliance check* (connector call vs human sign-off) → decide per the playbook, a "licensed officer signs off" phrase forces `action`; *set up in finance system* → `execute-connector-activity` (or `process` when a deployed process packages it); *activate* → confirm with the user.
+
+## Other-path sweep — mandatory before confirmation
+
+Look beyond the primary flow. Check the source for each scenario; pick the smallest faithful model:
+
+| Scenario | Candidate models |
+|---|---|
+| Rework / needs-info loop | Returning secondary lane (`return-to-origin`) |
+| Rejection, withdrawal, cancellation | Terminal secondary lane + non-completing case exit |
+| SLA escalation | Response per [slas.md](slas.md) — notification only unless the source creates work |
+| External-system failure | Secondary lane on the failure event, or an advisory review item |
+| Manual override / worker-launched side work | `adhoc` task (`Required: No`) or `user-selected-stage` lane |
+| Terminal outcomes different from success | Non-completing case-exit rows; XOR terminals (below) |
+
+Clear source signal → model it by best assumption and disclose in **Other Paths Considered**. No signal at
+all → spend the one bounded question before the confirmation; "primary flow only" is then a recorded
+decision, never an omission.
+
+## Execution patterns
+
+Classify before choosing entry rules (grammar: [model.md § Task activation](model.md#sequencing--activation)):
+
+| Pattern | Signal | Model |
+|---|---|---|
+| Strict sequence | "then", "after", "before", direct prerequisite | Consecutive single-task sets, every task `runs-sequentially` |
+| Parallel after predecessor | "after A, do B and C", both independent | B and C share one next task set, each `runs-sequentially` — never duplicate `selected-tasks-completed("A")` |
+| Race | Confirmation vs timeout/cancel/withdrawal | Listener + clock armed while the obligation is pending; downstream work gated on the winning fact |
+| Optional side work | "may", "can manually", no required downstream dependency | `adhoc`, `Required: No` |
+
+**Producer rule:** every non-start stage/task entry names its concrete producer before the confirmation —
+a source stage exit/completion, a task completion, a connector event, a paired `wait-for-user` exit, or a
+declared SLA reference. A schema-valid rule without a producer is a design defect.
+
+## Choosing the task type
+
+The `type` says **how the work gets done**, not what it is about. Read the verb + the actor, ask the
+matching question. The enum is closed ([model.md § Task types](model.md#task-types)).
+
+| Type | Pick when the work is… | The question that selects it |
+|---|---|---|
+| `action` | a **person** must do, decide, approve, review, or sign off — in a form | Does a human need to act or judge here? |
+| `agent` | an **AI agent** reasons over unstructured input: classify, extract, summarize, draft, score | Is this judgment over unstructured content an AI can do unattended? |
+| `rpa` | deterministic **UI / desktop** automation of a legacy app with no API | Is this clicking through a UI with no API? |
+| `process` | invoking a **deployed orchestration process** that already packages the automation | Is there a deployed process that already does this end-to-end? |
+| `api-workflow` | calling a **coded / API workflow** directly (HTTP, serverless logic) | Is this an API we call directly? |
+| `execute-connector-activity` | one **operation on an Integration Service connector** | Is this a single connector operation against a SaaS system? |
+| `wait-for-connector` | the case **pauses until an external system calls back** | Is the case waiting for an external system to respond? |
+| `wait-for-timer` | the case **pauses for a duration or until a datetime** | Is the case just waiting on time? |
+| `case-management` | the step **launches / coordinates a child case** | Does this spin up a sub-case? |
+
+**Tie-breakers:** SaaS integration with a tenant connector → `execute-connector-activity` over
+`api-workflow`. Ambiguous "approve / review / decide" verbs → `action` (human) vs `agent` (AI) per the
+assumption playbook ([case-design-lane-guide.md § Sketch](../case-design-lane-guide.md#sketch--best-assumption-every-field)),
+decided and disclosed. A compliance trigger phrase forces `action` regardless (below).
+
+## Task-type override priority
+
+Apply in order:
+
+1. **User decision pinned to a type** — honor unless schema-invalid or conflicting with tier 2.
+2. **Regulatory constraint requiring human sign-off** — the task MUST be `action`. Trigger phrases:
+   - "only a licensed X may decide / sign off / certify / approve"
+   - "regulation requires human review"
+   - "ECOA adverse-action notice" / "FCRA adverse action"
+   - "NCQA UM 3 adverse determination"
+   - "HIPAA-protected approval"
+   - "SOC 2 attestation"
+   - any `<role>-licensed` or `<role>-credentialed` gate ("licensed underwriter", "credentialed clinician")
+   - "fiduciary review", "legal sign-off", "auditor review"
+
+   If the user proposes a non-`action` type AND any phrase above appears anywhere in the conversation →
+   ask to confirm; never silently accept. Ask phrasing: name the regulation and propose `action` with the
+   LLM/agent work bound to the action's form and recipient.
+3. **Tenant evidence** — the registry cache resolves a deployed Action App / process / agent /
+   api-workflow / RPA that fits → prefer that resource's type and surface the match.
+4. **Connector availability** — an Integration Service connector matches the integration →
+   `execute-connector-activity` over `api-workflow`.
+5. **Verb signal** — fall through to the assumption playbook.
+6. **Fallback** — keep the user's stated value if any; otherwise a placeholder plus a `high` review item
+   ([principles.md § Review items](principles.md#review-items)).
+
+**Worked examples:**
+
+| Case context | User stated | Override fires | Final type |
+|---|---|---|---|
+| Adverse-action notice (lending) — "ECOA mandates licensed compliance officer signs off" | `agent` (LLM drafts the notice) | Yes — tier 2 | `action` (Compliance Officer recipient; LLM-drafted body bound to the action's form) |
+| Vendor scoring on intake | `agent` | No — no regulation, no licensed role | `agent` |
+| Underwriting decision on mortgage | `agent` | Jurisdiction-dependent; no tier-2 phrase in the transcript → keep `agent`, disclose the compliance caveat as a decision line | `agent` (disclosed) |
+| Inbound webhook from Salesforce | `api-workflow` | Tier 4 prefers the connector | `execute-connector-activity` when a Salesforce connector exists in the tenant; else `api-workflow` |
+| Process orchestration call | `process` | No | `process` |
+
+**Compliance-trigger scan.** Scan the whole conversation for the tier-2 phrases BEFORE recording any
+non-`action` type. A phrase surfacing after a non-`action` type was provisionally recorded → re-ask
+before continuing.
+
+**Activation is a separate axis.** How a task starts (sequential, event-triggered, manually triggered,
+stage-started) maps to entry rules ([model.md § Task activation](model.md#sequencing--activation)) and never
+changes the `type`: a manually triggered task can still be `action`, `agent`, `api-workflow`, or
+`process`. `sequential` requires an explicit order or dependency in the source.
+
+**Externally-hosted AI agents** (CrewAI, Salesforce Einstein, Databricks, LangChain, …) are not
+first-class: model as `api-workflow` (system-to-system) or `execute-connector-activity` when a connector
+exists.
+
+## Trigger derivation
+
+| Source says | Trigger |
+|---|---|
+| External system, portal, form, inbound event, or record-created start | Connector Event — a tenant object start stays an event trigger even when provisioning is missing (unresolved detail becomes a placeholder later; never downgrade to Manual) |
+| Schedule / recurring | Timer |
+| Otherwise | Manual |
+
+On-disk trigger values and enums: [model.md § Triggers](model.md#document-structure).
+
+## XOR terminal stages
+
+Mutually-exclusive happy-path terminals ("Funding on approve, Adverse Action Notice on decline"): case
+completion accepts only `required-stages-completed` ([model.md § Lifecycle gates](model.md#lifecycle-gates)),
+so the XOR lives at stage entry. Two sanctioned patterns — when detected at sketch time (multiple terminal
+candidates plus an earlier branching decision), surface both in one question before drafting rows:
+
+**Gated entry + required terminals (default — works on every tenant):**
+
+1. Both terminal stages `Required for case completion: Yes`.
+2. Each terminal's entry: `selected-stage-completed("<DecisionStage>")` + its lane guard `IF`
+   (`=js:vars.decision === "Approve"` / `!== "Approve"` — exact inverses).
+3. Each terminal completes normally: `required-tasks-completed`, `Marks Stage Complete: Yes`.
+4. Runtime stage-skip: entry `IF` is evaluated at activation; a terminal whose `IF` is false
+   auto-completes with status `Skipped` and still counts toward `required-stages-completed` closure.
+5. Case exit: ONE row, `required-stages-completed`, `Marks Case Complete: Yes`, `IF: —`.
+
+**Connector-event close** (only when both terminals genuinely emit a shared case-done event): terminals
+`Required: No`; entries as above; each terminal's last task emits the shared event; the case exit is ONE
+`wait-for-connector` row keyed on it.

--- a/skills/uipath-planner/references/case/grounding.md
+++ b/skills/uipath-planner/references/case/grounding.md
@@ -1,0 +1,87 @@
+# Design-Time Tenant Grounding
+
+Full identity resolution at design time — registry pull, per-resource cache lookups, connection
+checks, one batched gate — so a confirmed design carries resolved identities and the build's planning
+pass verifies instead of re-discovering.
+
+## Principles
+
+1. Tenant work never blocks entry — nothing about the tenant is a prerequisite for designing.
+2. Schema discovery is build work (`tasks describe` / `case spec`) — design resolves identities only.
+3. One pull per session; a pull that succeeded this session is reused by the build. Never delay the
+   confirmation waiting for a pull.
+4. Registry data is evidence, not requirements — never add or rename business work to match tenant
+   inventory; never dump catalogs into chat.
+
+## The contract
+
+1. **Intake batch.** Read every supplied document in parallel; extract named systems, resources,
+   likely tasks, roles. Named systems seed grounding.
+2. **Chain kickoff — background.** One background command: `uip login status --output json && uip
+   maestro case registry pull`. Build handoff mode: start it AT LANE ENTRY, batched with the first
+   document reads. Every other mode: start it at the first tenant-bound signal (a named
+   system/resource/connector, or an inferred runnable/connector/action task); a case with no
+   tenant-bound items never pulls. Best-effort — never block on it, never surface its output
+   unprompted.
+3. **Resolution pass — join, never wait.** When the sketch is complete and the pull succeeded,
+   resolve every named or inferred resource in ONE parallel batch of cache lookups; for each connector
+   also check enabled connections.
+
+   | Bucket | Definition | Action |
+   |---|---|---|
+   | Single confident match | 1 exact-name match across all folders, ≥ 1 shared name token; connectors: exactly 1 enabled connection | Adopt: identity + exact folder into SDD cells + a resolution record; disclose as a decision line. The only silent pick |
+   | Ambiguous | Multiple matches; cross-folder same name; no token overlap; > 1 enabled connection | Queue for the gate. A name deployed in ≥ 2 folders is always ambiguous — never pick a folder silently |
+   | Empty | 0 matches / 0 enabled connections AFTER a successful pull | Queue for the gate |
+
+   Cache files (`~/.uip/case-resources/`): agents `agent-index.json` · API workflows `api-index.json`
+   · RPA processes `process-index.json` · orchestration processes `processOrchestration-index.json`
+   · child cases `caseManagement-index.json` · Action Apps `action-apps-index.json` · connector
+   activities/triggers `typecache-activities-index.json` / `typecache-triggers-index.json`.
+
+4. **The ONE batched gate — at review time.** Queued items ride the Case Review turn
+   ([review.md](review.md)) as one AskUserQuestion (≤ 4 questions; overflow carries into the
+   confirmation's follow-up), grouped by `(name, type)` with usages listed. Options per group:
+   **Pick a match** (candidates with folder FQNs); **Resolve at build** (identity stays `<UNRESOLVED>`
+   + a paired review item; the build emits a placeholder); **Create during build** (ONLY for empty
+   `agent` / `api-workflow` lookups — records the decision, the build executes it; the lane never
+   scaffolds). Never pre-judge by name heuristics — the user's call. Pull unfinished when the review
+   is ready → present with resolve-at-build on pending items; never wait.
+5. **Visibility.** Every adopted identity, connection, gate decision, and deferral appears in the
+   Case Review (Resources and Integrations + Decisions I Made) and lands in SDD Section 2 cells and
+   the Section 4 roll-up. The resolution record below is machine-only — never user-facing.
+
+## The resolution record
+
+One record per resolved or attempted lookup, kept in memory by the lane; the build later persists the
+set verbatim as `tasks/registry-resolved.json`:
+
+```jsonc
+{
+  "stage": "<SDD stage name>",
+  "task": "<SDD task name>",
+  "taskType": "<task type>",
+  "cacheFile": "<index basename actually searched>",
+  "searchQuery": "<lookup string>",
+  "matches": [ /* FULL exact-name match set from the refreshed cache — never a summary */ ],
+  "selected": { /* adopted entry */ },        // null after a genuine empty lookup
+  "rationale": "<why>",
+  "gateDecision": "pick:<name>" | "resolve-at-build" | "create-during-build"  // only when the user answered
+}
+```
+
+1. `gateDecision` present = the user answered the gate for that item; the build executes it without
+   re-asking. A defaulted deferral (no session, failed or pending pull, non-interactive run) carries
+   NO `gateDecision` — the build's own gate re-asks it.
+2. Cache-state rule: before a successful pull this session, a missing cache file is a failed
+   precondition — never a zero-match result. Only after a successful pull may an empty match set enter
+   the empty-lookup flow.
+3. Deep runtime metadata (agent prompts, package versions, endpoints, release tags) stays out of the
+   SDD — the SDD carries name + folder + identity + sub-type; everything else rides this record.
+
+## No session / failures
+
+| Situation | Action |
+|---|---|
+| Not logged in, CLI absent, pull fails | One plain-language line the moment it happens: "I can't reach your UiPath tenant right now — I'll design with the names you give me and wire resources during the build." Keep concrete intended names; mark identities resolve-at-build (`<UNRESOLVED>` in the file) with paired review items; continue |
+| Design-only / draft / plan-only runs | Skip grounding entirely — intended names stay concrete, identities resolve-at-build, report that resource wiring defers to the build run |
+| Connector with zero enabled connections | A gate item — never a reason to change the task type |

--- a/skills/uipath-planner/references/case/model.md
+++ b/skills/uipath-planner/references/case/model.md
@@ -1,0 +1,197 @@
+# Case Model
+
+Everything a case design must respect about the Case Management platform model. Read once per session;
+the authoring method, render contracts, SLA model, and data-flow rules all build on this file.
+
+A case is a versioned JSON document of **stages**, **tasks**, and **conditions** that compiles into a
+deterministic rule plan evaluated on every case event. Identity is by **display name** at runtime — names
+are load-bearing, not labels. This skill designs the document (`sdd.md`); the build skill
+(`uipath-maestro-case`) emits and validates `caseplan.json` from it.
+
+## Document structure
+
+| Node kind | JSON `type` | Notes |
+|---|---|---|
+| Trigger | `uipath.case.trigger` | How a case instance is born. One primary trigger; more allowed. |
+| Stage | `case-management:Stage` | Primary or secondary. A secondary stage carries `data.stageType: "secondary"`; a primary stage OMITS the key — never emit `"primary"`. |
+| Sticky note | `case-management:StickyNote` | Canvas annotation only. |
+
+Trigger `serviceType` (under `data.inputs`):
+
+| Start | Emitted `serviceType` | SDD author token |
+|---|---|---|
+| Manual (user or API call) | `"None"` — never `"Manual"` | `Manual` |
+| Schedule | `"timer"` | `Intsvc.TimerTrigger` |
+| Connector event | `"Intsvc.EventTrigger"` | `Intsvc.EventTrigger` |
+
+### Task types
+
+The enum is closed — exactly these nine literals, used verbatim as the SDD `Type:` value and the JSON `type`:
+
+| Type | Work it performs |
+|---|---|
+| `process` | Invoke a deployed orchestration process |
+| `action` | Human-in-the-loop form: decide, approve, review, sign off |
+| `agent` | AI agent reasoning over unstructured input |
+| `rpa` | Deployed UI/desktop automation of a system with no API |
+| `api-workflow` | Direct call to a coded / API workflow |
+| `case-management` | Launch and coordinate a child case |
+| `execute-connector-activity` | One Integration Service connector operation (push) |
+| `wait-for-connector` | Pause until an external system calls back (pull) |
+| `wait-for-timer` | Pause for a duration or until a datetime |
+
+Never author: `external-agent`, `external-workflow`, `document-extraction`, `flow-process` (unsupported),
+and `wait-for-event` / `connector-activity` / `connector-trigger` (not schema literals). Externally-hosted
+AI agents (CrewAI, Einstein, Databricks, …) model as `api-workflow`, or `execute-connector-activity` when
+a tenant connector exists.
+
+## Lifecycle
+
+The case, each stage, and each task move through gates driven by **rules** in disjunctive normal form:
+the outer rule array is OR, each inner array is AND.
+
+### Lifecycle gates
+
+| Gate | Marks complete | Legal WHEN rules |
+|---|---|---|
+| Stage entry | — | `case-entered` (first stage only), `selected-stage-completed`, `selected-stage-exited`, `wait-for-connector`, `user-selected-stage`, `sla-status-change` |
+| Stage completion | Yes | `required-tasks-completed`, `wait-for-connector` |
+| Stage exit | No | `selected-tasks-completed`, `wait-for-connector` |
+| Task entry | — | `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, `sla-status-change`, `adhoc`, `runs-sequentially` |
+| Case completion | Yes | `required-stages-completed`, `wait-for-connector` |
+| Case exit | No | `selected-stage-completed`, `selected-stage-exited`, `wait-for-connector` |
+
+1. Tasks have NO exit or completion conditions — a task completes when its own work finishes; downstream
+   gates key off `required-tasks-completed` / `selected-tasks-completed`.
+2. `Marks Complete: Yes` pairs only with `required-*` rules (or `wait-for-connector`). A `Yes` +
+   `selected-*` pair is a schema error.
+3. `required-*` rules are vacuous without an explicit `isRequired: true` member. Required status is
+   explicit end-to-end — the SDD declares it per stage and task, and emission writes it verbatim. An
+   absent flag equals `false` at the validator: `Case rule '<name>' has no required stage(s) selected` /
+   `Stage exit rule '<name>' has no task(s) marked as required` (verified on uip 1.198.0-preview.102).
+4. **Case completion is a root rule.** At least one `metadata.caseExitRules[]` row carries
+   `marksCaseComplete: true` (normally `required-stages-completed`). A stage completing never closes the
+   case by itself; alternate outcomes (Rejected, Withdrawn, Cancelled) are case-exit rows with
+   `marksCaseComplete: false`.
+
+### Exit types
+
+| Row kind | Legal exit types |
+|---|---|
+| Stage completion (Yes) | `exit-only`, `return-to-origin`, `wait-for-user` |
+| Stage exit (No) | `exit-only`, `wait-for-user` |
+| Case completion (Yes) | `exit-only` |
+| Case exit (No) | `exit-only`, `wait-for-user` |
+
+- `wait-for-user` + `Marks Stage Complete: Yes` is legal and canonical for user-routed completion.
+- `return-to-origin` is completion-only, and its lane is always interrupting.
+
+**`wait-for-user` ↔ `user-selected-stage` pairing.** Validate enforces the pair both ways (verified on
+uip 1.198.0-preview.102): a `wait-for-user` exit with no `user-selected-stage` entry anywhere fails with
+`Stage rule '<name>' has no possible stage options.`; a `user-selected-stage` entry with no
+`wait-for-user` exit fails with `Stage entry rule '<name>' will never be met.`. `user-selected-stage` is
+picker exposure — a user choosing the next stage — never deterministic routing. Deterministic rejection,
+approval, send-back, and SLA routing use decision facts plus guarded entries instead.
+
+## Secondary stages
+
+A secondary stage is an **interrupting exception lane**: `data.stageType: "secondary"`,
+`isRequired: false`, excluded from `required-stages-completed`, with `Interrupting: Yes` on the stage AND
+on every entry row. Model errors, escalations, rejections, rework, and cancellations here — never as
+inline primary stages. Optional one-off work inside the current stage stays an `adhoc` task, not a lane.
+
+**One carve-out:** an `sla-status-change` entry whose response is parallel oversight — the breached work
+keeps running; nothing is paused, taken over, or rerouted — reads `Interrupting: No` on the stage and on
+that entry row. The lane stays secondary and `isRequired: false`, and it completes `exit-only` (never
+`return-to-origin`).
+
+**Exits by intent:**
+
+| Lane intent | Completion row |
+|---|---|
+| Returning / rework | `return-to-origin` + `Marks Stage Complete: Yes` + `required-tasks-completed` |
+| Terminal (Rejected / Withdrawn / Cancelled) | `exit-only` + `Yes`, plus a root case-exit row with `marksCaseComplete: false` |
+
+**Entry shape follows the lane's trigger source:**
+
+| Lane trigger | Entry shape |
+|---|---|
+| A person launches it | `user-selected-stage`, paired with an upstream `wait-for-user` exit |
+| External / global event | ONE `wait-for-connector` entry on the destination lane — never duplicated per origin stage |
+| SLA response | ONE `sla-status-change` entry ([slas.md](slas.md)) |
+| Decision / signal divert | The origin stage carries a gated diverting exit — `Marks Stage Complete: No`, WHEN `selected-tasks-completed("<decider task>")`, `IF` on the signal, `exitToStageId` → the lane — and the origin's completion exit carries the exact inverse `IF`. The lane enters via `selected-stage-exited("<origin>")` + the same `IF`. |
+
+Omitting the diverting exit makes a decision path dual-fire (ungated completion → the next stage AND the
+lane both enter) or deadlock (gated completion with no alternative exit). Only a `selected-stage-exited`
+lane entry needs a diverting exit; a `selected-stage-completed("<origin>")` + `IF` lane keys off the
+origin's normal completion — guard only.
+
+Two lanes with identical entry rules (same rule, selectors, and expression) are ambiguous routing — give
+each a distinct selector or guard. This is a design requirement; validate does not reject the duplicate
+(as of uip 1.198.0-preview.102).
+
+## Sequencing & activation
+
+Task-entry mode is exclusive — one mode, one rule, never combined:
+
+| Described timing | Activation Mode token | Entry rule |
+|---|---|---|
+| Ordered run (`then`, `after`, `before`, a dependency) | `sequential` | One `runs-sequentially` row — on EVERY task in the run, including the first |
+| Independent, starts with the stage | `parallel` | `current-stage-entered` |
+| Independent siblings after one predecessor | `parallel-after-predecessor` | `runs-sequentially`; the siblings share the next task set |
+| External callback | `event-triggered` | `wait-for-connector` (or `sla-status-change` for an SLA-started task) |
+| User launches it from the Case App | `adhoc` | One `adhoc` row + `Required: No` |
+| Fan-in, convergence, conditional gate | `fan-in` / `conditional-gate` | `selected-tasks-completed("<tasks>")` |
+
+- Structure mirrors the mode in the stage's 2D `data.tasks`: a strict chain is consecutive single-task
+  sets; parallel-after-predecessor siblings share one set. Never duplicate
+  `selected-tasks-completed("<previous>")` to express simple order.
+- `selected-tasks-completed` selects only non-`adhoc` tasks in the SAME stage.
+- A task with no entry condition never starts — validate accepts the omission silently.
+- Conditional-branch stages (mutually-exclusive tasks, one per outcome, all `Required: No`): add ONE
+  required convergence task whose entry is an OR over every branch — one
+  `selected-tasks-completed("<branch>")` row each — plus a `current-stage-entered` + inverse-guard row for
+  the no-branch path. `required-tasks-completed` then resolves on every path.
+- Re-entry (`return-to-origin` loops) — classify before setting `Run Only Once`:
+
+| Loop kind | Signal | Handling |
+|---|---|---|
+| New attempt | corrected, resubmitted, retry, appeal | Producers rerunnable (`Run Only Once: No`); reset or attempt-scope the live routing variables |
+| Re-evaluate an existing fact | the lane changes a fact and the origin re-reads it | `Run Only Once: Yes` on preserved producers; state which rule re-reads the fact |
+| Optional repeat | the user may repeat work nothing depends on | `adhoc`, not required |
+
+## Edges — retired
+
+`schema.edges` stays `[]`. Flow is condition-driven: each destination stage declares its own entries, and
+the case starts at the first stage's `case-entered` entry. Reachability is therefore condition-only — a
+missing or malformed entry condition is the only thing that can orphan a stage.
+
+### Naming rules
+
+Safe display characters for stage labels, task display names, and condition/SLA/escalation titles:
+
+```
+^[A-Za-z0-9 _-]+$
+```
+
+Never `:` — case-execution events are colon-delimited, so a colon in a name breaks routing. Repair an
+unsafe generated or carried name mechanically: replace runs of disallowed characters with one space,
+collapse spaces, trim; keep words and casing; on an empty result or a collision, add a safe qualifier or
+numeric suffix and disclose the change.
+
+| Name | Unique across |
+|---|---|
+| Task display name | The whole case — every stage, one pool |
+| Stage label | All node labels in the case; never the reserved Case Manager stage label |
+| SLA rule title | Its target (root or that stage) |
+| Escalation title | All SLAs on the element |
+
+Comparison is exact — case-sensitive, untrimmed. Never normalize external lookup names (Action App
+titles, process/connector names — they are matching keys); keep a separate safe display name instead.
+Never silently clamp a numeric violation (for example an out-of-range SLA duration) to pass validation —
+surface it and ask.
+
+## Related
+
+- Data flow, variables, expressions: [variables.md](variables.md)
+- SLA clocks, escalations, responses: [slas.md](slas.md)

--- a/skills/uipath-planner/references/case/model.md
+++ b/skills/uipath-planner/references/case/model.md
@@ -174,10 +174,13 @@ Safe display characters for stage labels, task display names, and condition/SLA/
 ^[A-Za-z0-9 _-]+$
 ```
 
-Never `:` — case-execution events are colon-delimited, so a colon in a name breaks routing. Repair an
-unsafe generated or carried name mechanically: replace runs of disallowed characters with one space,
-collapse spaces, trim; keep words and casing; on an empty result or a collision, add a safe qualifier or
-numeric suffix and disclose the change.
+Never `:` — case-execution events are colon-delimited, so a colon in a name breaks routing. The safe
+charset governs names being MINTED or first carried into a design: repair those mechanically — replace
+runs of disallowed characters with one space, collapse spaces, trim; keep words and casing; on an empty
+result or a collision, add a safe qualifier or numeric suffix and disclose the change. A name read from an
+existing draft or SDD during finalization is preserved verbatim, punctuation included — finalization
+normalizes structure, never names. The one exception is `:` (the structural ban): surface it and ask,
+never silently keep or repair it.
 
 | Name | Unique across |
 |---|---|

--- a/skills/uipath-planner/references/case/model.md
+++ b/skills/uipath-planner/references/case/model.md
@@ -73,6 +73,9 @@ the outer rule array is OR, each inner array is AND.
    `marksCaseComplete: true` (normally `required-stages-completed`). A stage completing never closes the
    case by itself; alternate outcomes (Rejected, Withdrawn, Cancelled) are case-exit rows with
    `marksCaseComplete: false`.
+5. **A gate sees case state as of its own event.** The extract of the task that fired the gate has not
+   run yet, so an `IF` that reads a case variable that task writes is stale — read the producing output
+   instead ([variables.md § Gate on the producer](variables.md#gate-on-the-producer-never-on-the-variable-it-writes)).
 
 ### Exit types
 

--- a/skills/uipath-planner/references/case/principles.md
+++ b/skills/uipath-planner/references/case/principles.md
@@ -1,0 +1,113 @@
+# Case Authoring Principles
+
+Cross-activity rules for authoring a Case Management SDD. Model semantics: [model.md](model.md).
+Data flow: [variables.md](variables.md). SLAs: [slas.md](slas.md). Confirmation + pre-render checks:
+[review.md](review.md). Conversation flow: [case-design-lane-guide.md](../case-design-lane-guide.md).
+
+## Inputs
+
+| Input | Purpose |
+|---|---|
+| User chat messages | Primary source — verbatim values, types, exits, SLAs |
+| User-supplied docs (paths, paste, attachments) | Secondary — read on Listen, parsed for case shape |
+| [case-sdd-template.md](../../assets/templates/case-sdd-template.md) | Structural mold for the rendered `sdd.md` |
+| Tenant registry cache (`~/.uip/case-resources/`) | Resolves deployed processes / agents / actions / connectors — [grounding.md](grounding.md) |
+| Tenant IS cache (`~/.uipath/cache/integrationservice/`) | Resolves connector identity, connections, activities, triggers |
+
+## Content authority hierarchy
+
+When signals conflict, the highest tier wins:
+
+1. **Platform schema constraints** — schema-invalid values never ship, regardless of source. Examples: a task `type` outside the closed enum, an illegal WHEN ↔ Marks-Complete pair ([model.md § Lifecycle gates](model.md#lifecycle-gates)).
+2. **Regulatory / compliance constraint** stated or implied (ECOA, NCQA, GDPR, HIPAA, SOC 2, FCRA, FINRA, …) — forces task types ([authoring.md § Task-type override priority](authoring.md#task-type-override-priority)).
+3. **Tenant evidence** — a deployed resource in the registry cache matching described work. Prefer its type and identity; never add stages/tasks or rename business work to match tenant inventory.
+4. **User-stated preference** in chat (verbatim "set the task to agent").
+5. **Doc-extracted values** from user-shared documents.
+6. **Inferred defaults** per the assumption playbook ([case-design-lane-guide.md § Sketch](../case-design-lane-guide.md#sketch--best-assumption-every-field)).
+7. **General-practice fallback.**
+
+Apply a higher-tier override AND surface it in the confirmation's `Decisions I Made` table with
+provenance `(source: <tier>-override)`.
+
+## Render policy
+
+**Template shape is part of the contract.** A valid in-memory model is not enough: the rendered `sdd.md`
+preserves the full template structure ([render-case-definition.md](render-case-definition.md),
+[render-stages-tasks.md](render-stages-tasks.md)). A prose summary is never an SDD; the compact
+confirmation is never an SDD substitute.
+
+- **Allowed `—`** (user left it untouched; the build defaults safely): case-level Description, variable defaults, persona scope notes, app-view detail, secondary-stage description, optional `IF` expressions, business calendars on timers.
+- **Allowed `<UNRESOLVED>`** (a later run resolves): registry identity ids (`taskTypeId`, `connectionId`, `actionAppId`, `agentId`, `processOrchestrationId`) when resolution was skipped, deferred at the gate, or returned zero matches. Pair every `<UNRESOLVED>` with a review item.
+- **Banned on required cells** (the render rules name them): populate concretely, keep only the identity `<UNRESOLVED>` (the build emits a placeholder), or ask the user.
+- **Forbidden SDD-body vocabulary.** Narrative cells (descriptions, rationales, notes) never carry skill-internal terms: `Pattern C`, `bridge`, `companion`, `inputOutputs[]`, `=jsonString:` (outside connector `Operation Configuration` cells), `groupOperator`, `essentialConfiguration` (as prose), `savedFilterTrees`, `dispatcher`, `io-binding`, `aliased into/from`, `reassign`, `originalVar`, `auto-mint`. These belong in skill references, never in `sdd.md`.
+
+## Domain fidelity
+
+The skill transcribes business terms; it never paraphrases them.
+
+**Preserve verbatim** (no synonym swaps):
+
+- Customer-named roles (`CFO`, `Underwriter II`, `Triage Nurse`) — never substitute `Approver`/`Reviewer`/`Manager`.
+- Customer-named domain nouns (`Vendor`, `Claim`, `Loan File`, `Member`) — never homogenize to `Record`/`Item`.
+- Customer-named stage labels (`Triage`, `Adverse Action Notice`) — user's casing and word choice.
+- Customer-named decision outcomes (`Approve` / `Decline` / `Needs Info` — not `Reject`/`Pending`).
+- Customer-named integration shortnames (`Workday`, never "the HR system").
+
+**Allowed mechanical normalization** (ledger reason `mechanical:<derivation>`): PascalCase Case Name from
+a spaced phrase, 2–4 char UPPER identifier prefix, camelCase variable names.
+
+**Anti-paraphrase rule:** when the user said `the senior underwriter signs off`, write exactly that —
+never `the manager approves the request`. Synonyms are a fidelity defect, not polish. A term the user
+wrote once is captured with provenance `verbatim:"<quote>"`; the confirmation's tables render it exactly,
+and that display is the spelling check.
+
+## Source ledger (provenance)
+
+Two surfaces: inline italic attribution in `sdd.md` (`Manual _(source: user-stated)_`; omit for
+`user-stated`) and the confirmation's `Decisions I Made` table.
+
+**Rationale is durable, not chat-only.** Provenance says where a value came from; rationale says why the
+choice fits. Persist rationale in each stage/task `Design Rationale` field and each SLA rationale field —
+the downstream build copies it into its plan entries so implementers can review choices without the
+original conversation.
+
+| Kind | When |
+|---|---|
+| `user-stated` | User wrote the value in chat (no annotation needed). Paraphrase acceptable. |
+| `verbatim:"<quote>"` | Rendered cell is exactly the user's phrase — strongest signal; preferred for customer-named entities. Truncate the quote at 40 chars in the ledger. |
+| `user-doc:<filename>` | Lifted from a user-shared document |
+| `mechanical:<derivation>` | One-step derivation (`mechanical:PascalCase→prefix`) |
+| `compliance-override:<rule>` | Regulatory constraint forced the value (`compliance-override:ECOA→action`) |
+| `tenant-registry:<resource-name>` | Resolved from the registry cache |
+| `connector-priority:<connector>` | Tier 3/tenant evidence selected `execute-connector-activity` over `api-workflow` |
+| `inferred-default:<reason>` | Defaulted with no matching source (use sparingly) |
+
+A non-`user-stated`, non-`verbatim` field without provenance blocks the confirmation until annotated.
+
+## Review items
+
+Structured gap escalations, emitted whenever a field could not be fully resolved but the downstream build
+needs the context. They live in the in-memory model and surface ONLY as `Review Flags` rows in the
+confirmation — never in the `sdd.md` body. The build persists them under the matching task's
+`review_items[]` in its resolution audit file.
+
+```jsonc
+{
+  "id": "rev_<short-slug>",
+  "target": "<sdd.md section path or task name>",
+  "issue": "<one-sentence problem>",
+  "severity": "high" | "medium" | "low",
+  "next_step": "<what the user must do to resolve>"
+}
+```
+
+| Level | Definition | Examples |
+|---|---|---|
+| **high** | Blocks the downstream build until resolved | Missing `connectionId` / `actionAppId` / deployed runnable; a resolved resource's required input unbound (`rev_unbound_input_<task>_<field>`); an extract naming a field the resource never emits (`rev_phantom_output_<task>_<field>`); open variable lineage; missing trigger config; unreconciled compliance override |
+| **medium** | Build defaults with a prompt | Missing escalation recipient (default = owner group); missing variable default; ambiguous recipient |
+| **low** | Cosmetic | Missing case description; missing secondary-stage description; stylistic placeholder |
+
+**Gate behavior:** any open `high` item relabels the confirmation's Build option
+`Build despite N flagged items` — the user must pick it; silently building past `high` is forbidden.
+`medium`/`low` surface as advisory rows, no acknowledgment needed. Never downgrade a severity to pass the
+gate — it moves only when the underlying issue actually resolves.

--- a/skills/uipath-planner/references/case/render-case-definition.md
+++ b/skills/uipath-planner/references/case/render-case-definition.md
@@ -1,0 +1,127 @@
+# Render — Section 1: Case Definition
+
+What each Section 1 cell of a case `sdd.md` must contain before the model may render. Semantics live in
+[model.md](model.md), [variables.md](variables.md), and [slas.md](slas.md) — this file defines cells, not
+rules. Render shape: [case-sdd-template.md](../../assets/templates/case-sdd-template.md).
+
+## 1.1 Case Metadata
+
+| Field | Required? | Value shape | If missing |
+|---|---|---|---|
+| Case Name | yes | PascalCase identifier (`MortgageLoanOrigination`) | Block approval. Ask. |
+| Description | optional | One sentence | `—` |
+| Identifier prefix | yes | UPPER, 2–4 chars | Default mechanically from the PascalCase name; record provenance |
+| Case SLA | conditional | `<count> <unit>`, unit ∈ `min h d w m` — bounds in [slas.md](slas.md) | `—` when the case has no SLA; otherwise block approval |
+| SLA Type | conditional | `time-based` / `condition-based`. The platform persists `condition-based` whenever ≥ 1 SLA rule carries a non-empty condition expression. `condition-based` requires the Variable SLA Rules table; `time-based` omits it | Default `time-based` when Case SLA is set with no overrides |
+| SLA Title | conditional | Non-empty root-unique title, no `:` | Omit the row when Case SLA is `—` (never render `—` here); else default `SLA Rule 1` + provenance. A title referenced by `sla-status-change` must be concrete |
+| Case App | optional | `Enabled` / `Disabled` | Default `Disabled`; record provenance |
+| Task-output passing | optional | `Direct` / `Shared` | Default `Direct` |
+
+**Pre-approval validation parity.** Before approval, apply the display-name and SLA-entry checks from
+[model.md § Naming rules](model.md#naming-rules) and [slas.md](slas.md) to every generated or carried
+display/title field. These are blocking authoring errors. Never normalize external lookup names; never
+silently clamp an out-of-range value — surface it and Ask, naming the original value.
+
+## 1.2 Case-Level SLA Escalation
+
+Required when Case SLA is set. Both rows always render with concrete cells — no `—`.
+
+| Threshold | Trigger | Recipient | Display Name |
+|---|---|---|---|
+| At-Risk | `<pct>%` of case SLA (defaults: [slas.md](slas.md)) | `UserGroup: <owner group>` / `User: <name>` | Non-empty root-unique title, no `:` |
+| Breached | 100% | One tier up — leadership; Compliance for regulation-driven cases | Non-empty root-unique title, no `:` |
+
+`Display Name` defaults to `Escalation Rule {N}` only when no `sla-status-change` row references it.
+Defaulted recipients get provenance `default applied — user did not name recipient`.
+
+## 1.2b SLA Response Map
+
+Required whenever ANY SLA is configured (case, stage, or `action` task). One row per
+`(Scope, SLA, Status)`. Response selection: [slas.md](slas.md).
+
+| Column | Cell rule |
+|---|---|
+| Scope | `case`, `stage: <StageName>`, or `task: <TaskName>` |
+| SLA | The target's SLA Title (or a Variable SLA Rules Display Name) |
+| Status | `At-Risk` or `Breached` — one row each |
+| Response | `notify-only` \| `start-task` \| `enter-stage` \| `exit-stage` \| `exit-case` |
+| Target | `—` for `notify-only`; the task name for `start-task` (the task lives in the breached stage); the stage name for `enter-stage`; the produced exit row for `exit-stage` / `exit-case` |
+| Interrupting | `—` for `notify-only` AND for every `start-task` — a task entry interrupts nothing, never `Yes`/`No`. Otherwise `Yes`/`No`, matching the produced stage-entry row |
+| Rationale | Why this response fits the source |
+
+**Closure both ways (blocking):** every non-`notify-only` row has its matching rule elsewhere in the SDD
+(an `sla-status-change` task-entry row for `start-task`, a stage-entry row for `enter-stage`, a stage-exit
+row, or a §1.4a row), and every `sla-status-change` row in the SDD has a row here. An Interrupting mismatch
+between the map cell and the produced row is blocking. **Default:** no stated response → both statuses
+`notify-only` with Target and Interrupting `—`; never invent a stage, task, or routing change for a
+notification.
+
+## 1.3 Triggers
+
+≥ 1 trigger. One row per triggering event, numbered from **T02** (T01 is the case file). The T-number keys
+§1.5 trigger-payload rows.
+
+| Field | Required? | Value |
+|---|---|---|
+| T# | yes | `T<N>`, sequential from `T02` |
+| Trigger Type | yes | `Manual` / `Intsvc.TimerTrigger` / `Intsvc.EventTrigger` — author tokens; on-disk mapping in [model.md](model.md) |
+| Source | conditional | Connector or system for event; schedule expression for timer; `Manual` literal |
+| Configuration | conditional | User intent in business terms. An event trigger MUST have a concrete operation phrase |
+
+**Configuration cell:** event → the operation in business terms (`Record created`, `Email received in
+Inbox; filter: subject contains "URGENT"`); tenant case-entity starts keep the object name in Source and
+the business event in Configuration; timer → cycle or duration (`daily at 09:00 UTC`); manual → `N/A`.
+**Forbidden in Configuration** (resolved at build time): CLI enum values (`CALENDAR_CREATED`), delivery
+modes (`polling` / `webhook`), meta notes (`No required event parameters`), activity slugs, HTTP methods.
+
+Payload-field → variable mapping lives ONLY in §1.5 ([variables.md](variables.md)) — never in this table.
+A case that starts when a tenant record is created is an `Intsvc.EventTrigger` row even when the object is
+not provisioned — unresolved detail becomes a placeholder later, never a downgrade to `Manual`. Unresolved
+event resolution (`connectionId` / `activityTypeId`) → high review item.
+
+## 1.3a Trigger Filter (conditional)
+
+Renders only when ≥ 1 trigger declares a filter. AND/OR tree; nested `{op, clauses}` groups flatten in the
+rendered table. Columns: `Field | Operator | Value | Literal?`. Operators (PascalCase, case-sensitive):
+`Equals`, `NotEquals`, `Contains`, `NotContains`, `StartsWith`, `EndsWith`, `GreaterThan`,
+`GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `In`, `NotIn`, `IsNull`, `IsNotNull`. Avoid
+`Literal: No` for unverified runtime expressions — it forces a lossy fallback; prefer literal values or a
+review item.
+
+## 1.4 Case Completion Conditions · 1.4a Case Exit Conditions
+
+Columns: `WHEN | IF | Marks Case Complete | Exit Type | Display Name`. §1.4 = `Yes` rows (≥ 1 required);
+§1.4a = `No` rows (alternate dispositions: Withdrawn / Rejected / Cancelled). Legal WHEN per
+[model.md § Lifecycle gates](model.md#lifecycle-gates); exit types per
+[model.md § Exit types](model.md#exit-types).
+
+**Display Name defaulting (every condition table):** carry the author's value verbatim; blank → default
+`Entry Rule {N}` (entry / task-entry) or `Complete Rule {N}` / `Exit Rule {N}` (exit tables, by
+Marks-Complete), `N` = 1-based within the same label kind. Never invent a label otherwise.
+
+When the case has ≥ 1 secondary stage AND §1.4a is empty → high review item (`Alt-disposition exits
+missing`) — the case cannot exit non-happy paths cleanly.
+
+## 1.5 Case Variables
+
+Declare a row ONLY per the declare-vs-direct-reference test in [variables.md](variables.md) — one task's
+output feeding one consumer is referenced directly, never declared. Authoring is declarative: `Category` +
+`sourceTriggers` + `sourceFields` drive build-time classification; nothing is inferred from prose.
+
+| Column | Required? | Cell rule |
+|---|---|---|
+| Name | yes | camelCase, no role suffix |
+| Category | yes | `In` / `Out` / `Variable` — never blank ([variables.md](variables.md)) |
+| Type | yes | `string` `integer` `float` `double` `boolean` `date` `datetime` `jsonSchema` `file` |
+| sourceTriggers | conditional | `Variable`: single `T<N>` or CSV. `In`: optional single `T<N>` (blank = primary trigger, never CSV). Empty for pure state and `Out` |
+| sourceFields | conditional | `Variable` only. One trigger → bare payload path (`response.subject`); CSV → keyed `T<N>: <path>; T<M>: <path>`, one entry per listed T-number. Always empty on `In`. Dot-paths only — no array indexing |
+| Default | optional | Concrete default or blank |
+| Description | yes | One line |
+
+- **Out-arg producer rule:** every `Out` row has a `Default` OR a task Outputs row targeting it
+  (`-> {name}` / `{name} = {expr}`) — pre-checked at the approval gate.
+- **Config-as-In:** runtime business rules (priority bands, thresholds, taxonomies) ride ONE `In` variable —
+  `string` with a JSON `Default` for opaque rule-sets; `jsonSchema` + `body` when the picker must navigate
+  sub-fields.
+- **File In-args** carry the caller pre-upload obligation — surfaced via the Caller-obligation block in
+  [review.md](review.md).

--- a/skills/uipath-planner/references/case/render-stages-tasks.md
+++ b/skills/uipath-planner/references/case/render-stages-tasks.md
@@ -1,0 +1,144 @@
+# Render — Section 2: Stages & Tasks
+
+What each Section 2 block of a case `sdd.md` must contain. Semantics live in [model.md](model.md),
+[variables.md](variables.md), and [slas.md](slas.md); this file defines cells and markers. Render shape:
+[case-sdd-template.md](../../assets/templates/case-sdd-template.md).
+
+## Stage headings
+
+- Primary: `### Stage {N}: {Stage Name} (\`{stage_id}\`)` — N is 1-based flow order.
+- Secondary: `### Secondary Stage: {Stage Name} (\`{stage_id}\`)`.
+- The trailing code-formatted `{stage_id}` MUST appear, and every cell that names a stage appends the id in
+  code-formatted parens — cross-references stay greppable.
+
+## Stage fields
+
+| Field | Required? | Cell rule |
+|---|---|---|
+| Type | yes | The literal `Stage` |
+| Stage Kind | conditional | Omitted for primary; `secondary` for exception lanes ([model.md § Secondary stages](model.md#secondary-stages)) |
+| Design Rationale | yes | One concrete sentence: why primary/secondary, why the entry/exit behavior fits. A global-event lane names the event and states that one interrupting entry replaces per-stage duplication; an SLA lane names the SLA, the response, and why it interrupts or not |
+| Description | yes (primary) / optional (secondary) | One sentence |
+| Required for Case Completion | yes | Explicit `Yes`/`No` — design default: primary `Yes`, secondary always `No`. Never leave it implicit |
+| Interrupting | secondary only | Per [model.md § Secondary stages](model.md#secondary-stages) |
+| Stage SLA | when the stage has an SLA | The `#### Stage SLA` block below |
+
+## Stage SLA block
+
+When the source gives every primary stage an SLA target, every named primary stage renders its own
+`#### Stage SLA` block. Deterministic titles when unnamed: `**SLA Title:** <Stage Name> SLA`, at-risk
+display name `<Stage Name> SLA at risk`, breach `<Stage Name> SLA breached`; every `sla-status-change`
+reference uses those exact strings. Render `**SLA Type:**` and `**SLA Title:**` as two separate lines — a
+collapsed single line hides the title from line-start tooling and `sla-status-change` references stop
+resolving. Duration, thresholds, recipients, and escalation cells: [slas.md](slas.md).
+
+## Stage condition tables
+
+- **Entry:** `WHEN | IF | Interrupting | Display Name`. ≥ 1 row per stage.
+- **Exit (completion `Yes` + exit `No` rows in ONE table):** `WHEN | IF | Exit Type | Marks Stage Complete
+  | Display Name`. ≥ 1 completion row per primary stage.
+- Legal WHEN per slot and exit-type legality: [model.md § Lifecycle gates](model.md#lifecycle-gates) and
+  [model.md § Exit types](model.md#exit-types).
+- Call forms with complete args appear ONLY in table rows; prose uses bare rule names.
+- `sla-status-change` arg forms: `sla-status-change("<target>","<SLA Title>")` for breach;
+  `sla-status-change("<target>","<SLA Title>","<At-Risk Escalation Display Name>")` for at-risk. Target is
+  the literal `root` (case scope) or the exact stage display name — never the case name or a synonym.
+
+## Stage Task Summary
+
+In plan order, ≥ 1 task per stage: `# | Task ID | Task | Type | Owner`. `Task ID` is code-formatted
+(`` `t11` ``); Required-Tasks cells elsewhere use those bare ids. Owner = persona name or `system`.
+
+## Task detail blocks
+
+Headings: `##### Task {N}.{M}: {Task Name}` (primary) / `##### Task S{K}.{M}: {Task Name}` (secondary,
+K = secondary-stage order) — never letter prefixes (`R.1`, `ESC.1`). Every block carries, in order:
+
+1. `**Type:**` — one of the nine values in [model.md § Task types](model.md#task-types)
+2. `**Activation Mode:**` — `sequential` \| `parallel` \| `parallel-after-predecessor` \| `event-triggered`
+   \| `adhoc` \| `fan-in` \| `conditional-gate`
+3. `**Design Rationale:**` — why the type fits the actor/work and why the mode fits the timing
+   (sequential names the ordering evidence; parallel states independence)
+4. `**Entry Condition:**` + its `WHEN | IF | Display Name` table (≥ 1 row; multiple rows = OR; render
+   `current-stage-entered` first when present)
+5. Exact marker `**Task envelope**` (no colon) + the `Required | Run Only Once | Skip Condition` table
+6. The type-specific detail block below
+
+`<UNRESOLVED>` renders as plain text, exactly `<UNRESOLVED>` — never backtick-wrapped, never annotated
+inside the cell.
+
+### Which WHEN to write (task entry)
+
+Grammar and exclusivity: [model.md § Task activation](model.md#sequencing--activation).
+
+| Rule | Write when |
+|---|---|
+| `current-stage-entered` | Ungated stage-started task. Never alongside event/adhoc/sequential rules |
+| `runs-sequentially` | The source states order (`then`, `after`, `before`, a dependency) — EVERY task in the ordered run, including the first |
+| `selected-tasks-completed("<Task>")` | True fan-in, branch convergence, condition-result routing, or a non-immediate dependency. Never for simple next-step order; never selects `adhoc` or cross-stage tasks |
+| `wait-for-connector` | Async connector callback; `IF` gates case state only ([variables.md](variables.md)) |
+| `sla-status-change(...)` | The `start-task` SLA response ([slas.md](slas.md)) — never alongside `current-stage-entered` |
+| `adhoc` | User-launched from the Case App; `Required: No` |
+
+## Per-type required cells
+
+### `action`
+
+| Cell | Rule |
+|---|---|
+| HITL Implementation | `Action App: <deploymentTitle>` — concrete intended name (registry-canonical when resolved, else user-requested). NEVER `<UNRESOLVED>`, never paraphrased |
+| Action App ID / Deployment Folder | Concrete when resolved; `<UNRESOLVED>` + high review item when not |
+| Recipient | Typed prefix only: `Email:` / `User:` / `UserGroup:` / `Role:` / `Expression:` — never a bare string. None known → drop the cell + high review item |
+| Priority · Task Title · Labels | `Low/Medium/High/Critical` · one-line user-visible instruction (required — Action Center displays it) · CSV or `—` |
+| Run Only Once · Required | Explicit `Yes`/`No` each |
+| Input / Output Schema | Tables `Field | Type | Binding (| Required)`. Declared fields MUST be a subset of the resolved app's schema; a field the app lacks → Ask (task-specific app / drop / placeholder), never silently author |
+| Buttons | Only when `is_decision: Yes` — then ≥ 2 rows, each `Maps To` referencing a declared §1.5 `Name` or `taskOutcome`, never an undeclared identifier |
+
+Reusing ONE deployed app across several `action` tasks is sanctioned when each task carries a distinct
+`actionType` dispatch value AND its declared fields ⊆ the app schema (the code-switched app); without a
+distinct `actionType`, or with non-bindable fields, it is the substitute-app defect ([review.md](review.md)).
+
+### `wait-for-connector` / `execute-connector-activity`
+
+Connector key · Connection (name + ID) · Activity Type ID · Service Type · Auth Method · Account/Endpoint ·
+Operation (and Trigger/Event for waits) · `Operation Configuration` carry-through · Inputs table (`Field`
+verbatim to the IS activity schema) · Outputs table. Missing `Connection ID` / `Activity Type ID` → high
+review item.
+
+### `wait-for-timer`
+
+Timer Type (`timeDuration` relative / `timeDate` absolute) · Duration/Until (ISO-8601 — NEVER
+`<UNRESOLVED>`: a timer cannot fire without it; block approval) · Business Calendar optional (`—`).
+
+### `case-management`
+
+Child Case (concrete intended name — NEVER `<UNRESOLVED>`, never the parent task's display name) · Folder
+Path / Resource Identity (`entityKey`; `<UNRESOLVED>` + high review item when unresolved) · Child Case
+Identifier prefix · Data Passed table (`Parent Variable | Child Variable`) · Wait for Completion `Yes`/`No`
+· Data Returned table only when waiting.
+
+### `process` / `agent` / `rpa` / `api-workflow` (shared block)
+
+| Cell | Rule |
+|---|---|
+| Resolved Resource | Concrete intended resource name — NEVER `<UNRESOLVED>` |
+| Folder Path | The exact resource folder (never a parent), or `<UNRESOLVED>` when identity is unresolved |
+| Resource Identity | `apiWorkflowId` / `agentId` (+version) / `processOrchestrationId`, or `<UNRESOLVED>` + high review item |
+| Binding Sub-Type | `Api` (api-workflow) / `Agent` (agent) / `ProcessOrchestration` (process) / `—` (rpa). Omitting it makes Studio Web report the resource as not found |
+| Dispatch / Operation | Selector + value for shared façades (`requestSource = "RegisterCaseShell"`), also an Inputs row; `—` for single-purpose resources |
+| Inputs / Outputs | Tables; `Field` verbatim to the declared In/Out argument names |
+
+No task-level SLA on any non-`action` type ([slas.md](slas.md)). Deep runtime metadata (agent prompts,
+package versions, endpoints) stays out of the SDD — it belongs to build-time discovery
+([grounding.md](grounding.md) records identities only).
+
+## I/O completeness (resolved resources)
+
+When a task resolves to a live resource: every REQUIRED declared input has a non-empty `Binding` (any form
+in [variables.md](variables.md), including a direct upstream-output reference — which needs no §1.5 row) OR
+`<UNRESOLVED>` + a high review item; every Outputs `->` row's `Field` exists verbatim in the resolved
+output contract (a phantom field → high review item). Optional inputs may be omitted. Tasks whose identity
+is `<UNRESOLVED>` have no contract and are skipped — their portable names stay concrete.
+
+**Bare field-name input lists are forbidden** (`**Inputs:** loanId, borrower`) — they force name-match
+guessing downstream; use the table form only.

--- a/skills/uipath-planner/references/case/review.md
+++ b/skills/uipath-planner/references/case/review.md
@@ -1,0 +1,217 @@
+# Case Review & Finalization
+
+The ONE confirmation checkpoint and the checks that gate it. Run §Finalization against the in-memory model
+FIRST — fix failures silently (they are authoring defects, not user decisions); anything unfixable becomes
+a Review Flags row. Severity levels and the review-item shape: [principles.md](principles.md).
+
+## The Case Review — eight sections, one question
+
+A decision-first business approval surface, complete enough to approve the case behavior without opening
+any SDD file — never a generic build plan and never a compressed SDD copy. The tenant resolution gate
+([grounding.md](grounding.md)), when it has items, rides this same turn.
+
+**Coverage map:** SDD §1 → Case Snapshot + SLA and Escalations + Rules and Outcomes; §2 → Primary Journey +
+Other Paths Considered + SLA and Escalations + Rules and Outcomes; §3 → Case Snapshot + human action labels
++ Resources and Integrations; §4 → Resources and Integrations. The review intentionally omits the data
+contract, variables, and task inputs/outputs — those stay complete in the SDD. Anything carrying a high
+review item also appears in Review Flags.
+
+Start with `## Case Review: <Case name>`, then exactly this order:
+
+1. **Case Snapshot** — `Item | Proposed design`. Rows: `Objective`, `Starts when`, `Primary personas`,
+   `Successful completion`, `Other terminal outcomes`, `SLA coverage`. Mark assumed values `(assumed)`.
+   No case ID prefix unless it affects a user decision.
+2. **Primary Journey** — `# | Stage | Purpose | Tasks | Starts when | Completes or exits when | Required? |
+   SLA`. Every primary stage once, in flow order. The `Tasks` cell names every task in execution order with
+   type, required/optional status, and activation/grouping — e.g. `Sequential: Capture request (Human
+   action, required) → Validate request (RPA workflow, required)`; `After both: Make decision (Human
+   action, required)`. Event-triggered and manually triggered tasks are shown explicitly.
+3. **Other Paths Considered** — `Scenario | Trigger or condition | Modeled as | Tasks | Interrupts active
+   work? | Return or case outcome | Rationale`. Every modeled exception, secondary stage, optional path,
+   and alternate terminal — AND standard paths intentionally left unmodeled when that omission is a
+   decision. Path tasks carry type, required/optional, activation/grouping.
+4. **SLA and Escalations** — `Scope | SLA | Time target or condition | Status or threshold | Response |
+   Response target | Interrupts active work? | Rationale`. One row per meaningful `(scope, SLA, status)`,
+   separate at-risk and breached rows when both exist. Responses from the closed set in
+   [slas.md](slas.md). Interrupting cell: `N/A` for `notify-only`; `—` for `start-task` (a task entry
+   interrupts nothing — never `Yes`/`No`); otherwise `Yes`/`No` matching the produced entry row. Never
+   assume every breach creates an escalation stage. `None` when the case has no SLA.
+5. **Rules and Outcomes** — `Scope | Element | Rule | When | If | Then`. Business-significant routing,
+   completion, and terminal rules only. Omit generated sequencing already visible in `Tasks`; do not
+   repeat SLA rows unless needed to understand routing. Business conditions in `If`; no data column.
+6. **Resources and Integrations** — `Task | Intended resource or system | Resolution`. Action apps,
+   agents, RPA/processes, API workflows, child cases, connectors, named external systems. `Resolution` =
+   the design-time outcome: `resolved (<folder>)`, a gate decision (`create during build`,
+   `resolve at build`), or a candidate pick. A missing row is not acceptable.
+7. **Decisions I Made** — `Decision | Why | Provenance`. Every assumption, override, resource decision,
+   task-type decision, activation/sequence decision, and intentionally omitted path, in plain language
+   (`you said "then"`, `compliance wording`, `no SLA mentioned`). Group only decisions sharing rationale
+   AND provenance. Flagged items carry ⚠.
+8. **Review Flags** — `Item to review | Why it matters | Default if accepted`. `None` when empty.
+   Unfixable findings, missing connections, unresolved high-impact choices.
+
+After Review Flags, when any §1.5 row is `Category: In` + `Type: file`, show this fixed block (omit
+otherwise — a conditional build obligation, not a ninth section):
+
+```
+Caller obligation (file In-arg detected):
+  File In-args:  <comma-separated names>
+  Programmatic callers must pre-create each JobAttachment via POST /odata/Attachments,
+  PUT bytes to the returned blob URI, then pass {ID,FullName,MimeType,Metadata} as the
+  In-arg value AND include the attachment ID in StartProcessDto.Attachments[].
+  Maestro Studio Web's "Start case" dialog does this automatically.
+```
+
+**Product vocabulary.** User-visible activation labels: `Sequential`, `Parallel`, `Parallel after
+predecessor`, `Event-triggered`, `Manually triggered`, `Fan-in`, `Conditional gate` (`adhoc` → `Manually
+triggered`). Prefer product task labels — `Human action`, `Agent`, `RPA workflow`, `API workflow`,
+`Child case` — over schema enum names.
+
+**No duplicated review surfaces.** Each business decision appears once. No Data Contract section, variable
+rows, task I/O rows, second stages list, or per-stage detail cards — technical detail stays in the SDD.
+
+**Completeness gate.** Incomplete unless: all eight sections shown, every stage and task named, every
+modeled and intentionally omitted path covered, every meaningful SLA response/status row present, Caller
+obligation when relevant. No approval question before every section has been shown — even sections reading
+`None`. Never substitute a list of build steps, artifacts, folders, or validation commands, or a summary
+that points at the SDD for a missing business decision.
+
+**Confirmation question (one AskUserQuestion)** — options by mode:
+
+| Mode | Options |
+|---|---|
+| Build handoff | `Build it — straight through` / `Build it — pause at the build preview` / `Change something`. The Build answer is the consent AND the build-review preference, captured once, never re-asked mid-build. With ⚠ flags: first option reads `Build despite N flagged items — straight through` |
+| Direct design-only | `Save the design` / `Change something` (⚠ → `Save despite N flagged items`) |
+| Draft request | `Save as draft` / `Change something`. A prompt that already says save-a-draft-and-stop counts as the answer: write immediately, no extra prompt |
+
+Corrections (`Change something` or free text) update the model, re-run the affected Finalization checks,
+and re-show ONLY the changed sections or rows, then one `Suggested next steps` line before the next
+prompt. A correction never restarts the walk. **Explicit sign-off requests** ("only after I approve") add
+exactly one approval prompt after acceptance, before any file is created — nothing else changes.
+
+## Logical integrity — the stage-graph walk
+
+Reachability is condition-only ([model.md](model.md) — the case has no edges), so this walk is the sole
+guard. Any failure is blocking; offer `Re-edit` / `Restart` / `Abort`.
+
+1. **Every stage reachable from a trigger** — walk entry conditions forward from each trigger and SLA
+   source. An unreachable primary stage is an orphan.
+2. **Every stage exits** — each primary stage has a completion consumed downstream, or another stage's
+   entry references it, or it feeds a secondary lane. A stage nothing keys off is a terminal loop.
+3. **Every case-exit row references a stage that exists** — no dangling selectors.
+4. **The §1.4 path can complete** — ≥ 1 primary stage is `Required: Yes`; otherwise the case can never
+   complete ([model.md § Lifecycle gates](model.md#lifecycle-gates)).
+5. **Secondary-lane entries: ≥ 1 interrupting entry each, DISTINCT, chosen by the lane's trigger source**
+   ([model.md § Secondary stages](model.md#secondary-stages)). Two lanes with identical entries (same rule
+   + selectors + expression) are ambiguous routing — a design requirement to differentiate, not
+   validate-enforced (as of uip 1.198.0-preview.102). A decision-reachable lane MUST carry a
+   `selected-stage-exited(origin)` + `IF` entry matching the origin's gated diverting exit, with the
+   origin's completion gated by the inverse `IF`; a missing divert dual-fires or deadlocks. A lane
+   described as decision-reachable but entered only via `wait-for-connector` is unreachable from its
+   stated source. `adhoc` is never a stage entry.
+6. **Every `sla-status-change` entry resolves** — the target is `root` or an existing stage, that target
+   declares the SLA, and every supplied title matches a row on THAT target; a two-arg breach row is
+   complete as written ([slas.md](slas.md)). Any real miss leaves the lane unreachable.
+7. **Every secondary stage is interrupting except a non-diverting SLA oversight row**
+   ([model.md § Secondary stages](model.md#secondary-stages)). Wrong classification is blocking; never
+   promote the lane to a regular stage.
+
+Worked example — a decision-routed return lane (AP Review → SLA Escalation on `requiresEscalation`):
+
+| Stage | Condition | WHEN | IF | Exit Type | Marks Complete |
+|---|---|---|---|---|---|
+| AP Review | exit (complete) | `required-tasks-completed` | `=js:(vars.requiresEscalation !== true)` | `exit-only` | Yes |
+| AP Review | exit (divert) | `selected-tasks-completed("AP ownership review")` | `=js:(vars.requiresEscalation === true)` | `exit-only` (`exitToStageId` → SLA Escalation) | No |
+| SLA Escalation | entry (`Interrupting: Yes`) | `selected-stage-exited("AP Review")` | `=js:(vars.requiresEscalation === true)` | — | — |
+| SLA Escalation | exit | `required-tasks-completed` | — | `return-to-origin` | Yes |
+
+On escalate the divert fires (completion's inverse `IF` is false), the lane runs, `return-to-origin`
+re-activates AP Review; on non-escalate the completion fires and the next stage enters via its own
+`selected-stage-completed("AP Review")`. The decision is read directly from the producing action's output
+([variables.md](variables.md)) — never relayed through a §1.5 variable.
+
+## Architect's lens — advisory pass
+
+Emit medium review items when these fire; the noted high variants gate like any high item.
+
+| Check | Trigger | Review item |
+|---|---|---|
+| Single-recipient bottleneck | An `action` recipient is one `User:`/`Email:` AND the stage runs on every case AND no documented volume limit | `rev_bottleneck_<task>`: confirm volume or use UserGroup/Role |
+| No escalation on SLA | Stage SLA set, escalation absent | `rev_escalation_<stage>`: no one is paged on breach |
+| Escalation loops to the breacher | Escalation recipient = the stage's primary recipient | `rev_escalation_loop_<stage>`: pick a tier-up recipient |
+| Sync child case in the critical path | `Wait for Completion: Yes` + parent SLA + no timeout cover | `rev_childcase_<task>`: consider async + completion event, or an exception path |
+| All-human stage | 100% `action` tasks, > 2 tasks | `rev_human_only_<stage>`: consider agent/process pre-screening |
+| No happy path on the first stage | Only `No` exits, no `required-tasks-completed` completion | `rev_no_happy_path_<stage>` |
+| Decision outcome unread | `is_decision: Yes` writes a variable no downstream rule reads | `rev_orphan_decision_<task>`: consume it or downgrade `is_decision` |
+| Connector failure uncovered | Connector task in a primary stage, no failure lane (HIGH when ≥ 2 connector tasks share a critical path with zero cover) | `rev_no_failure_path_<task>` |
+| Substitute app (HIGH) | One Action App on ≥ 2 tasks WITHOUT a distinct `actionType` each, or declared fields outside the app schema. Exempt: the code-switched app ([render-stages-tasks.md](render-stages-tasks.md)) | `rev_substitute_app_<app>`: code-switch or deploy task-specific apps |
+| Parallel bottleneck fan-in | ≥ 2 bottleneck stages fan into one downstream stage | `rev_multi_bottleneck_<stages>` |
+| Relay variable | A §1.5 `Variable` whose only producer is one task output and only consumer is one binding (exemptions in [variables.md](variables.md)) | `rev_relay_var_<name>`: reference the output directly, drop the row |
+| Aliased output | An Outputs `->` row whose `Field` leaf has no matching §1.5 row and lands in a differently-named variable | `rev_aliased_output_<task>`: declare a dedicated variable or confirm the reuse |
+
+## Finalization checklist
+
+Run ONCE against the in-memory model before presenting the review. Checks 16 and 19 need resolved I/O
+contracts, which design-time resolution does not pull — they are enforced at build; run them here only
+when a contract is already in memory.
+
+1. **Schema** — every task type is one of the nine in [model.md § Task types](model.md#task-types); every
+   WHEN ↔ Marks-Complete pair is legal per [model.md § Lifecycle gates](model.md#lifecycle-gates).
+2. **Render contract** — every required cell concrete ([render-case-definition.md](render-case-definition.md),
+   [render-stages-tasks.md](render-stages-tasks.md)); no banned `—`/`<UNRESOLVED>`
+   ([principles.md](principles.md)).
+   2a. **Template shape** — the rendered text passes the template conformance gate
+   ([case-design-lane-guide.md](../case-design-lane-guide.md)) on disk, before the `Status: ready` flip.
+   2b. **Safe display names** — the charset and repair procedure in
+   [model.md § Naming rules](model.md#naming-rules) on every generated or carried display field.
+3. **Decision buttons** — `is_decision: Yes` ⟹ ≥ 2 buttons; every `Maps To` LHS is a §1.5 `Name` or
+   `taskOutcome`.
+4. **Recipient encoding** — typed prefixes only ([render-stages-tasks.md](render-stages-tasks.md)).
+5. **Connector ids** — every connector task has `Connection ID` + `Activity Type ID`; every
+   `wait-for-connector` rule (any scope) resolves connector key + event operation (+ connection when not
+   tenant-default). Missing → paired high review item.
+6. **Variable lineage** — every consumer closes ([variables.md](variables.md)).
+7. **Override conflict** — no compliance trigger phrase paired with a non-`action` type without explicit
+   user reconciliation ([authoring.md](authoring.md)).
+8. **Alt-disposition coverage** — ≥ 1 secondary stage ⟹ §1.4a non-empty OR an open high item.
+9. **High-severity acknowledgment** — open high items force the `Build despite N flagged items` pick.
+10. **Provenance** — every non-user-stated, non-verbatim value carries a provenance kind
+    ([principles.md](principles.md)).
+    10a. **Design rationale** — every stage (kind + routing), task (type + activation), and configured SLA
+    (thresholds, recipients, response) carries durable rationale — blocking when missing.
+    10b. **SLA Response Map closure** — one row per `(Scope, SLA, Status)`, closure both ways, Interrupting
+    cells agree ([render-case-definition.md](render-case-definition.md)); a `notify-only` row that minted
+    a stage or task, or a bare SLA with no row, is blocking.
+11. **File-In-arg caller obligation** — the fixed block above whenever an `In` + `file` row exists.
+12. **Stage-graph connectivity** — the §Logical integrity walk, all seven checks.
+    12a. **Entry producer** — every non-start entry names a concrete producer (source stage, task,
+    connector event, paired `wait-for-user` exit, or a declared SLA reference); at-risk rows name the
+    escalation, breach rows the SLA alone ([slas.md](slas.md)).
+13. **Domain fidelity** — every verbatim-captured entity renders exactly ([principles.md](principles.md));
+    drift → `Re-edit` with the phrase pre-filled.
+14. **Architect's lens** — the advisory table above; medium rows are non-blocking, high variants gate.
+15. **Decision-routing closure** — every routing button's variable + value is consumed by a downstream
+    rule or declared terminal; a named destination lane with no keyed entry is a dead branch — blocking.
+    A fully-orphaned decision variable on an `is_decision: Yes` task is blocking.
+16. **Action-app schema fidelity** — declared Input/Output fields ⊆ the resolved app's schema; a
+    violation → high item `rev_action_schema_<task>`; code-switched reuse is sanctioned
+    ([render-stages-tasks.md](render-stages-tasks.md)).
+17. **Required-task presence** — a `required-tasks-completed` completion over a stage with zero
+    `Required: Yes` tasks is vacuous and fails validation with `Stage exit rule '<name>' has no task(s)
+    marked as required` (verified on uip 1.198.0-preview.102) — blocking; offer marking the stage's
+    terminal task required.
+18. **Resolved-resource presence** — concrete portable names everywhere (`Resolved Resource`, Action App
+    title, `Child Case` — never `<UNRESOLVED>`); identity + folder pairs concrete together, or unresolved
+    with a paired high item ([render-stages-tasks.md](render-stages-tasks.md)).
+19. **Resolved-resource I/O completeness** — required inputs bound, extract fields exist verbatim
+    ([render-stages-tasks.md](render-stages-tasks.md)); an unbound required input with no review item is
+    blocking.
+20. **Re-entry attempt check** — classify every `return-to-origin` / rework loop per
+    [model.md § Task activation](model.md#sequencing--activation); new-attempt loops keep producer tasks
+    rerunnable and reset or attempt-scope routing variables; re-evaluate loops document the re-read fact.
+
+**On pass:** present the Case Review (the Build/Save answer is the consent; explicit sign-off adds one
+prompt; design-only and draft requests save and stop). Corrections update the model and re-run only the
+affected checks. **On fail:** fix the model and re-run the failed checks plus any whose inputs changed —
+never the full suite; never present the review or render `sdd.md` while a fixable check is failing; only
+unfixable items surface, as ⚠ flags.

--- a/skills/uipath-planner/references/case/review.md
+++ b/skills/uipath-planner/references/case/review.md
@@ -115,6 +115,10 @@ guard. Any failure is blocking; offer `Re-edit` / `Restart` / `Abort`.
 7. **Every secondary stage is interrupting except a non-diverting SLA oversight row**
    ([model.md § Secondary stages](model.md#secondary-stages)). Wrong classification is blocking; never
    promote the lane to a regular stage.
+8. **No gate reads a variable its own trigger writes** — for every condition whose WHEN names a task,
+   the `IF` references that task's output, not a case variable the task's Outputs row feeds. The gate is
+   evaluated before the extract lands, so such a guard is dead on the first pass and the stage stalls with
+   no error ([variables.md § Gate on the producer](variables.md#gate-on-the-producer-never-on-the-variable-it-writes)).
 
 Worked example — a decision-routed return lane (AP Review → SLA Escalation on `requiresEscalation`):
 

--- a/skills/uipath-planner/references/case/slas.md
+++ b/skills/uipath-planner/references/case/slas.md
@@ -1,0 +1,76 @@
+# SLAs & Escalations
+
+Clocks, escalations, and what an at-risk or breached SLA does to the case. Stage semantics and the
+interrupting rules for SLA-entered lanes: [model.md](model.md). SDD rendering (SLA cells, the SLA
+Response Map): [render-case-definition.md](render-case-definition.md).
+
+## Where SLAs live
+
+| Surface | Location | Notes |
+|---|---|---|
+| Case | `metadata.slaRules` | |
+| Stage | stage `data.slaRules` | Secondary stages included |
+| `action` task | The task's own timer/SLA fields | NOT a `slaRules` entry. Add case behavior only when the missed task must change the case graph |
+
+No SLA cells on any other task type.
+
+## slaRules entries
+
+Conditional overrides first (priority order), then a trailing default entry with expression
+`=js:true`; the first truthy expression wins.
+
+1. Every entry requires `id` AND a non-empty target-unique `displayName` without `:` — validate
+   rejects a missing name (`SLA name is missing`) and a missing id (schema error) (verified on
+   uip 1.198.0-preview.102).
+2. `count`/`unit` may be omitted only as a pair, on a bare escalation-only entry. Units:
+   `min | h | d | w | m`; minute counts bounded 15–1000.
+3. Non-default entries require a non-empty expression.
+4. Escalations: `id` + non-empty element-unique `displayName` + ≥ 1 recipient (scope `User` /
+   `UserGroup`); `atRiskPercentage` required exactly when the trigger type is `at-risk`.
+
+## Breached vs at-risk — how status is selected
+
+| Status | The `sla-status-change` rule references | Requires |
+|---|---|---|
+| Breached | The SLA alone — an absent escalation reference IS the persisted breached shape | Nothing else. Never "complete" a breach rule with an escalation: that converts it to at-risk |
+| At-risk | The SLA + one concrete at-risk escalation declared on that same SLA | That escalation must exist on that SLA |
+
+Never the designer's `any` escalation sentinel. Borrowed and dangling references fail validate:
+`The escalation referenced by rule … no longer exists` / `The SLA referenced by rule … no longer
+exists`.
+
+## Choosing the response
+
+Pick from the source's words — WHERE the work lives, never whether it interrupts. A named task never
+justifies a new stage.
+
+| Response | Source says | What you author | Interrupting cell |
+|---|---|---|---|
+| `notify-only` | notify / alert / page someone, nothing more | An escalation on the target's `slaRules` — no stage, task, or condition | `n/a` |
+| `start-task` | Follow-up work inside the SAME breached stage ("as part of the review", a named task for a manager or peer) | One task in the breached stage carrying `sla-status-change` as its OWN task-entry row, against that stage's (or the case's) SLA | `—` — a task entry interrupts nothing; never `Yes`/`No` |
+| `enter-stage` | A separate lane owns it ("hand it to", "escalate into <Lane>") | A separate stage carrying the `sla-status-change` entry row | `Yes` when the response pauses, takes over, or reroutes active work; `No` for parallel oversight |
+| `exit-stage` | The breached stage should end or route away | A stage-exit row | Per exit semantics |
+| `exit-case` | The case should close, cancel, or reach an alternate terminal | A case-exit row | Per exit semantics |
+
+Never author `start-task` as a stage-entry row on the breached stage: it validates, but stage
+re-entry re-runs every task whose `shouldRunOnlyOnce` is `false` — a breach meant to add one manager
+check silently re-runs the whole stage.
+
+## Defaults when the source is silent
+
+- No stated response → both statuses `notify-only`. Never invent a stage, task, or routing change.
+- At-risk threshold: SLA ≤ 3 days → 75%; 3–10 days → 70%; > 10 days → 80%.
+- Recipients: at-risk → the owner persona's user group; breached → the leadership tier (Compliance
+  for regulation-driven cases). Record substituted defaults with provenance.
+
+## Verified behavior (uip 1.198.0-preview.102)
+
+| Shape | Result |
+|---|---|
+| Breach entry on a separate stage, either interrupting value | valid |
+| Breach / at-risk on a task's `entryConditions` (stage or case SLA) | valid |
+| At-risk with a same-SLA escalation | valid |
+| At-risk borrowing another SLA's escalation | invalid |
+| `escalationId: "any"` | invalid |
+| Dangling SLA reference | invalid |
+| Task with empty or absent `entryConditions` | valid — and the task never starts |

--- a/skills/uipath-planner/references/case/variables.md
+++ b/skills/uipath-planner/references/case/variables.md
@@ -29,6 +29,28 @@ Declare a Case Variables row ONLY when one of these holds:
 A row that relays one task's output to one consumer is the relay anti-pattern —
 [review.md](review.md) flags it (`rev_relay_var`).
 
+Declaring a row does not make the value readable earlier — see below.
+
+## Gate on the producer, never on the variable it writes
+
+A rule is evaluated **before** the extract of the task that triggered it. So a gate keyed on a task's
+completion that reads the case variable that task's Outputs row feeds sees the value from the previous
+pass — `null` on the first one. The branch silently never fires, the stage stalls, and nothing errors.
+
+| Gate | `IF` reads | At gate time |
+|---|---|---|
+| `selected-tasks-completed("Decide")` + `=js:vars.decision === "reject"`, where `Decide` declares `Action -> decision` | the case variable `Decide` writes | ✗ stale / `null` |
+| `selected-tasks-completed("Decide")` + `=js:vars.action === "reject"`, where `action` is `Decide`'s own output | the producing output | ✓ populated |
+
+**Rule:** when a condition's WHEN names a task, its `IF` MUST read that task's own output. Keep the `->`
+extract whenever the value must persist (Case App, audit, a later stage reads it) — the extract is not
+what the gate reads.
+
+Applies wherever the WHEN names the producer: stage-exit `selected-tasks-completed`, task-entry
+`selected-tasks-completed`, and the `selected-stage-exited` lane entry paired with a diverting exit —
+that entry repeats the origin exit's guard, so it repeats the producer reference too. Guard pairs stay
+exact inverses of each other. (Verified on uip 1.198.0-preview.102, 2026-08-18.)
+
 ## Trigger payloads
 
 Validation never reads trigger-node outputs (verified on uip 1.198.0-preview.102). A trigger payload

--- a/skills/uipath-planner/references/case/variables.md
+++ b/skills/uipath-planner/references/case/variables.md
@@ -1,0 +1,104 @@
+# Variables & Data Flow
+
+How data moves between triggers, tasks, conditions, and the caller. Lifecycle gates, naming, and stage
+semantics: [model.md](model.md). SDD cell rendering: [render-case-definition.md](render-case-definition.md)
+(Case Variables table) and [render-stages-tasks.md](render-stages-tasks.md) (task Inputs/Outputs).
+
+## Reference producers directly
+
+A downstream input or condition that consumes one upstream task's output references the output
+directly — the emitting task's output entry is its own declaration, and no Case Variables row exists:
+
+| Where the value is used | SDD spelling |
+|---|---|
+| The output IS the whole input value | `<- "Stage"."Task".out` — the bare `"<Stage>"."<Task>".<outputName>` cell form is equivalent |
+| One term inside a larger `=js:` expression | `vars.$xref('Stage','Task','out')` |
+
+The build resolves both spellings to the output's reference id. Direct references close lineage by
+ordering alone (producer task before consumer).
+
+## When to declare a Case Variables row
+
+Declare a Case Variables row ONLY when one of these holds:
+
+1. `In` / `Out` argument (the case boundary).
+2. Trigger-payload extraction (see below — the only way a trigger field becomes referenceable).
+3. Case-level state read by a condition (`IF`) or by ≥ 2 consumers.
+4. The value needs a rename or a custom `Default` / `Type` / `Description`.
+
+A row that relays one task's output to one consumer is the relay anti-pattern —
+[review.md](review.md) flags it (`rev_relay_var`).
+
+## Trigger payloads
+
+Validation never reads trigger-node outputs (verified on uip 1.198.0-preview.102). A trigger payload
+field is referenceable as `=vars.<name>` ONLY through a Case Variables `Variable` row carrying
+`sourceTriggers` (the trigger's T-number) + `sourceFields` (the payload path).
+
+## Category semantics
+
+| Category | Meaning | sourceTriggers | sourceFields | Closure |
+|---|---|---|---|---|
+| `In` | Caller-supplied at start; `Default`-initialized for event/timer triggers (no caller) | blank = primary trigger; a single `T<N>` selects another — never CSV | always empty (an In-arg selects a trigger, extracts nothing) | closed at case start |
+| `Out` | Returned to the caller | forbidden | empty | needs a producer Outputs row or a `Default` |
+| `Variable` | Internal state | single `T<N>`, or CSV for multi-trigger | bare path for one trigger; keyed `T<N>: <path>; T<M>: <path>` for CSV — one entry per listed T-number | producer or `Default` |
+
+**Types:** `string`, `integer`, `float`, `double`, `boolean`, `date`, `datetime`, `jsonSchema`,
+`file`. `json` is not a type. Use `jsonSchema` (with `body`) when downstream picks sub-fields;
+`string` for opaque JSON blobs nothing dereferences. `file` is a JobAttachment record — a file `In`
+argument carries the caller pre-upload obligation ([review.md](review.md) surfaces it).
+
+## Outputs rows
+
+| Operator | Cell form | `Field` cell | Purpose |
+|---|---|---|---|
+| Extract | `-> caseVar` | Non-empty runtime path (`response.status`, `Action`, `Error.code`) — emitted as the source verbatim | Capture a response field into a declared variable |
+| Set / compute / copy | `caseVar = <expr>` | `—` | Assign a literal, `=js:(...)`, or `=vars.X.Y` copy at task completion |
+
+1. The target variable is already declared per the rules above; a `->` to a new name is valid only as
+   the task's own self-declaring output.
+2. One row per target per task; never mix `->` and `=` on the same target in one task.
+3. Self-binding no-ops (`x = =vars.x`) are forbidden — they mask a missing producer. Computed
+   self-references (`x = =js:(vars.x + 1)`) are fine.
+4. Never alias a produced datum into an unrelated existing variable to close lineage — declare a
+   dedicated row or confirm the reuse.
+
+## Lineage closure
+
+Every consumer of `vars.X` needs a producer that fires earlier — stage order first, then task order
+within the stage: a trigger extraction, a task Outputs row, an action button's `Maps To`,
+`Category: In`, or a non-empty `Default`. [review.md](review.md) checks closure before the
+confirmation.
+
+## Expressions
+
+- `=js:`-prefixed JavaScript. Namespaces available to `=js:` evaluation: `vars`, `response`,
+  `bindings`, `iterator`, `metadata`. Assignment operators are forbidden in every case expression.
+- A rule's `conditionExpression` gates CASE STATE only (`vars.*`, `metadata.*`) — there is no `event`
+  namespace. In-rule extract-then-gate does not work at runtime (the gate evaluates before the
+  extract writes): extract `response.field -> caseVar` on the connector rule and gate a DOWNSTREAM
+  condition instead.
+- Use strict equality (`===` / `!==`); write mutually exclusive branch guards as exact inverses so
+  completion and divert rows cannot dual-fire.
+- Thresholded policy ("Credit Analyst only over $5M") lands in an executable cell — owner/recipient,
+  WHEN/IF, or a task input — with the numeral written out (`5000000`), actor and attribute on one
+  line. Prose or a persona-table mention alone is a render failure ([review.md](review.md)).
+
+## Binding-cell forms (task Inputs)
+
+| Form | Meaning |
+|---|---|
+| `<literal>` | Plain string / number / boolean |
+| `=vars.<id>` / `=vars.<id>.<sub>` | Declared variable or upstream output; dot-path into structured values |
+| `<- "Stage"."Task".out` / `vars.$xref('Stage','Task','out')` | Direct output references (above) |
+| `=bindings.<id>` | Registered resource (app, process, connection) |
+| `=metadata.<key>` | Case metadata |
+| `=metadata.ExternalId` | The platform-minted case identity — the canonical `caseId` binding; NOT a task output, never a `->` extraction |
+| `=trigger.<field>` | Trigger payload field |
+| `=js:<expr>` | Inline JavaScript (required when operators are involved) |
+| `=jsonString:<json>` | JSON-as-string — connector `essentialConfiguration` carry-through only |
+| `=datafabric.<path>` | Data Fabric reference |
+| `=orchestrator.JobAttachments` | File slot |
+| `=response` / `=result` / `=Error` | Conventional response handles |
+
+Bare field-name lists (`**Inputs:** a, b, c`) are forbidden — use the table with one form per cell.


### PR DESCRIPTION
## What

PR 1/2 of the planner case-knowledge restructure. Adds `skills/uipath-planner/references/case/` — nine files, ~1,220 lines, replacing the 1,040-line `case-authoring-rules-guide.md` monolith (retired in PR 2/2) whose content was interleaved across 7 concern types and restated key rules up to 7× internally.

| File | Lines | Owns |
|---|---|---|
| model.md | 197 | Node kinds, the closed 9-value task-type enum, lifecycle gates + Marks-Complete pairing, exit types, secondary-stage semantics, sequencing grammar, edges-retired, naming rules |
| variables.md | 104 | Direct output references (the default wiring), the Case Variables declaration test, categories, outputs grammar, lineage closure, expressions |
| slas.md | 76 | SLA surfaces, entry requirements, breached/at-risk selection, the five-response model, silence defaults, validate-verified behavior matrix |
| principles.md | 113 | Authority hierarchy, render policy (`—`/`<UNRESOLVED>`/banned), domain fidelity, provenance, review items |
| authoring.md | 158 | Process→model method, other-path sweep, execution patterns, task typing + compliance overrides, XOR terminal patterns |
| render-case-definition.md | 127 | SDD §1 cell contracts (metadata, SLA Response Map, triggers, exits, variables table) |
| render-stages-tasks.md | 144 | SDD §2 cell contracts per task type, binding-cell grammar, I/O completeness |
| grounding.md | 87 | Design-time tenant resolution, the ONE batched gate, the resolution record |
| review.md | 217 | The eight-section Case Review, the 7-check stage-graph walk, the 20-check finalization list, the architect's lens |

## Design

- **One fact, one home.** Every rule is stated once; other files link (all links + anchors verified programmatically with GitHub slug rules).
- **Flow-aligned loading.** A session reads `model.md` once at lane entry; every other file loads when its activity starts — sketching, wiring data, rendering a section, confirming.
- **Deterministic claims.** Behavior-sensitive rules carry `(verified on uip 1.198.0-preview.102)` anchors with the exact validate messages quoted (e.g. the `wait-for-user` ↔ `user-selected-stage` pairing errors, the required-flag vacuity errors).
- **Conflicts resolved at the source.** The old guide's internal contradictions (e.g. `wait-for-user` legality on completion rows; the `jsonSchema` type both banned and mandated) are ruled once here, per live validation behavior.
- `model.md`'s Task types / Lifecycle gates / Naming rules tables are stable, machine-parseable contracts — PR 2/2 wires `audit_sdd.py` to read them, so the enum/pairing/naming checks and the docs can never diverge.

Nothing references these files yet — PR 2/2 rewires the lane guide, template, examples, and SKILL.md, and deletes the monolith. `npm run skills:validate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)