### PR TITLE
chore: scope token-optimization rule to markdown files via paths frontmatter

### DIFF
--- a/.claude/rules/token-optimization.md
+++ b/.claude/rules/token-optimization.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "**/*.md"
+---
+
 # Token Optimization — Terse Documentation Mode
 
 All skill documentation and agent-facing prose in this repo MUST follow these rules. Technical accuracy stays. Fluff dies.


### PR DESCRIPTION
Adds `paths` frontmatter to `.claude/rules/token-optimization.md` scoping the rule to `**/*.md`, so the terse-documentation rules only load when markdown files are in play instead of on every task.