### PR TITLE
fix(rpa): discovery agent writes its own context files; gate empty projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Every skill's maturity is tracked in [`assets/skill-status.json`](assets/skill-s
 
 | Agent | Description |
 |-------|-------------|
-| **Project Discovery** (`uipath-project-discovery-agent`) | Auto-discovers UiPath project structure, dependencies, conventions, and generates context files for Claude Code (`.claude/rules/project-context.md`) and UiPath Autopilot (`AGENTS.md`). Triggered automatically when a UiPath project is detected without existing context, or on explicit user request. |
+| **Project Discovery** (`uipath-project-discovery-agent`) | Auto-discovers UiPath project structure, dependencies, and conventions, then writes the context files itself for Claude Code (`.claude/rules/project-context.md`) and UiPath Autopilot (`AGENTS.md`). Triggered automatically when a UiPath project with authored workflows is detected without existing context, or on explicit user request. Skips empty and freshly-scaffolded projects. |
 
 ## Multi-Tool Support
 

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -84,10 +84,10 @@ Discovery on a project with no authored content returns a document of empty tabl
 | Condition | How to check |
 |-----------|--------------|
 | Greenfield — no `project.json` (you are about to create the project) | Step 0 found no `project.json` |
-| Empty project — 0 authored workflow files | Glob `**/*.xaml` and `**/*.cs`, excluding `.local/`, `.codedworkflows/`, `.objects/`, `.entities/`, `obj/`, `bin/` → combined count is 0 |
-| Freshly scaffolded — only the untouched entry point | Same count is 1, the file is `Main.xaml`, `Main.cs`, or `TestCase.xaml`, and its body holds no child activity inside the root `Sequence` (XAML) / no statement in the `Execute` body (coded) |
+| Empty project — 0 authored workflow files | Glob `**/*.xaml` and `**/*.cs`, excluding every dot-directory (any path segment starting with `.`) plus `obj/` and `bin/` → combined count is 0 |
+| Freshly scaffolded — only the untouched entry point | Same count is 1, the file is a scaffolded entry point (`Main.xaml` process/template, `NewActivity*.xaml` library, `TestCase.xaml` test automation, `Main.cs` coded), and it holds no authored logic — root `Sequence` empty or containing only `Comment` activities (XAML) / no statement in the `Execute` body (coded) |
 
-When the gate trips: proceed straight to the skill workflow and write no context files now. **After the build completes**, write both context files yourself (discovery-flow step 3 below) from what you just created: structure, dependencies, entry points.
+When the gate trips: proceed straight to the skill workflow and write no context files now. **After the build completes**, write both context files yourself from what you just created (structure, dependencies, entry points), using the same file paths and `AGENTS.md` marker logic as discovery-flow step 3 below.
 
 **Discovery flow** (used for both missing and stale context):
 1. Spawn the project discovery agent and wait for it to complete. Its definition lives inside this skill at [`agents/uipath-project-discovery-agent.md`](agents/uipath-project-discovery-agent.md). Use whichever spawn mechanism your host supports:

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -79,15 +79,15 @@ Before doing any work, check if `.claude/rules/project-context.md` exists in the
 
 ### Skip gate: nothing to discover yet
 
-Discovery on a project with no authored content returns a document of empty tables and costs a subagent round-trip. **Do NOT spawn the discovery agent** when any row matches:
+Discovery on a project with no authored content returns empty tables and costs a subagent round-trip. **Do NOT spawn the discovery agent** when any row matches:
 
 | Condition | How to check |
 |-----------|--------------|
 | Greenfield — no `project.json` (you are about to create the project) | Step 0 found no `project.json` |
-| Empty project — 0 authored workflow files | Glob `**/*.xaml` and `**/*.cs`, excluding every dot-directory (any path segment starting with `.`) plus `obj/` and `bin/` → combined count is 0 |
-| Freshly scaffolded — only the untouched entry point | Same count is 1, the file is a scaffolded entry point (`Main.xaml` process/template, `NewActivity*.xaml` library, `TestCase.xaml` test automation, `Main.cs` coded), and it holds no authored logic — root `Sequence` empty or containing only `Comment` activities (XAML) / no statement in the `Execute` body (coded) |
+| Empty project — 0 authored workflow files | Glob `**/*.xaml` + `**/*.cs`, excluding dot-directories and `obj/`, `bin/` → count 0 |
+| Freshly scaffolded — only the untouched entry point | Count 1; file is a scaffold entry point (`Main.xaml` process/template, `NewActivity*.xaml` library, `TestCase.xaml` test, `Main.cs` coded); no authored logic — root `Sequence` empty or only `Comment` activities (XAML) / empty `Execute` body (coded) |
 
-When the gate trips: proceed straight to the skill workflow and write no context files now. **After the build completes**, write both context files yourself from what you just created (structure, dependencies, entry points), using the same file paths and `AGENTS.md` marker logic as discovery-flow step 3 below.
+Gate tripped: write no context files now, proceed with the skill workflow. **After the build**, write both context files yourself from what you just created — same paths and `AGENTS.md` marker logic as discovery-flow step 3.
 
 **Discovery flow** (used for both missing and stale context):
 1. Spawn the project discovery agent and wait for it to complete. Its definition lives inside this skill at [`agents/uipath-project-discovery-agent.md`](agents/uipath-project-discovery-agent.md). Use whichever spawn mechanism your host supports:

--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -75,17 +75,30 @@ Before doing any work, check if `.claude/rules/project-context.md` exists in the
 6. If **any individual count differs by 60–70% or more** → run the discovery flow below
 7. If all counts are within the threshold → context is fresh, proceed with the skill workflow
 
-**If the file does NOT exist** → if a `project.json` exists, run the discovery flow below. **Greenfield (no `project.json`): skip the discovery agent** — nothing to discover. After the build completes, write both context files yourself (step 3 below) from what you just created: structure, dependencies, entry points.
+**If the file does NOT exist** → run the skip gate below; if it does not trip, run the discovery flow.
+
+### Skip gate: nothing to discover yet
+
+Discovery on a project with no authored content returns a document of empty tables and costs a subagent round-trip. **Do NOT spawn the discovery agent** when any row matches:
+
+| Condition | How to check |
+|-----------|--------------|
+| Greenfield — no `project.json` (you are about to create the project) | Step 0 found no `project.json` |
+| Empty project — 0 authored workflow files | Glob `**/*.xaml` and `**/*.cs`, excluding `.local/`, `.codedworkflows/`, `.objects/`, `.entities/`, `obj/`, `bin/` → combined count is 0 |
+| Freshly scaffolded — only the untouched entry point | Same count is 1, the file is `Main.xaml`, `Main.cs`, or `TestCase.xaml`, and its body holds no child activity inside the root `Sequence` (XAML) / no statement in the `Execute` body (coded) |
+
+When the gate trips: proceed straight to the skill workflow and write no context files now. **After the build completes**, write both context files yourself (discovery-flow step 3 below) from what you just created: structure, dependencies, entry points.
 
 **Discovery flow** (used for both missing and stale context):
 1. Spawn the project discovery agent and wait for it to complete. Its definition lives inside this skill at [`agents/uipath-project-discovery-agent.md`](agents/uipath-project-discovery-agent.md). Use whichever spawn mechanism your host supports:
    - **Host registers plugin agents by name** (e.g., Claude Code) → trigger the registered `uipath-project-discovery-agent` agent.
-   - **Host only spawns its own predefined subagents** (e.g., UiPath Autopilot) → spawn a read-only subagent and pass it that file (relative to this skill) as its instructions / custom skill.
-2. The agent returns the generated context document as its response
-3. Write the returned content to **both**:
+   - **Host only spawns its own predefined subagents** (e.g., UiPath Autopilot) → spawn a subagent and pass it that file (relative to this skill) as its instructions / custom skill. Grant it write access so it can produce the context files itself; a read-only subagent still works via step 3.
+2. The agent writes the context files itself and returns a `context-files:` status line followed by the context document. Use the returned document as this session's project context — do NOT re-read the files it just wrote, and do NOT rewrite them.
+3. **Only when the agent reports `context-files: not-written`** (read-only subagent host, or a write error) → write the returned content to **both**:
    - `.claude/rules/project-context.md` (create `.claude/rules/` directory if needed) — auto-loaded by Claude Code in future sessions
    - `AGENTS.md` at project root — the shared cross-agent context convention (read by UiPath Autopilot in Studio Desktop and other AGENTS.md-aware hosts). If `AGENTS.md` already exists, look for `<!-- PROJECT-CONTEXT:START -->` / `<!-- PROJECT-CONTEXT:END -->` markers and replace only between them; if no markers exist, append the fenced block at the end
-4. Then proceed with the skill workflow
+4. If the agent returns `SKIP: <reason>` instead of a document, treat it as a gate trip: no context files now, write them yourself after the build.
+5. Then proceed with the skill workflow
 
 ## Step 0: Resolve PROJECT_DIR
 

--- a/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
+++ b/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
@@ -36,7 +36,7 @@ You are a project discovery agent. Analyze a UiPath automation project, write th
 
 A project with no authored content yields a document of empty tables. Run this gate **before** any discovery work.
 
-Count authored files with Glob, excluding generated and metadata directories (`.local/`, `.codedworkflows/`, `.objects/`, `.entities/`, `.screenshots/`, `.settings/`, `obj/`, `bin/`):
+Count authored files with Glob, excluding every dot-directory (any path segment starting with `.` — `.local/`, `.codedworkflows/`, `.objects/`, `.settings/`, `.templates/`, …) plus `obj/` and `bin/`:
 
 ```
 **/*.xaml     → XAML workflow count
@@ -49,9 +49,9 @@ Write nothing and return the matching `SKIP:` line when **any** condition holds:
 |-----------|--------|
 | No `project.json` found | `SKIP: no project.json — nothing to discover` |
 | 0 authored `.xaml` + `.cs` files | `SKIP: empty project — no workflow files` |
-| Exactly 1 authored file, it is the scaffolded entry point (`Main.xaml`, `Main.cs`, or `TestCase.xaml`), and its body holds no child activity inside the root `Sequence` (XAML) / no statement in the `Execute` body (coded) | `SKIP: freshly-scaffolded project — no authored content` |
+| Exactly 1 authored file, it is a scaffolded entry point (`Main.xaml` process/template, `NewActivity*.xaml` library, `TestCase.xaml` test automation, `Main.cs` coded), and it holds no authored logic — root `Sequence` empty or containing only `Comment` activities (XAML) / no statement in the `Execute` body (coded) | `SKIP: freshly-scaffolded project — no authored content` |
 
-Read that single entry point to decide the third condition — an untouched scaffold has an empty root `Sequence`. Any authored activity or statement means the project is real: proceed to Step 3.
+Read that single entry point to decide the third condition. Scaffold noise is not authored content: ViewState metadata (`sap:WorkflowViewStateService.ViewState`) is a property element, not a child activity, and the blank test-case scaffold ships a `Comment` activity (`// Blank Test Case`) inside the root `Sequence`. Any other activity or statement means the project is real: proceed to Step 3.
 
 A user request to regenerate does NOT override the gate — a project with nothing in it has nothing to regenerate from. Return the `SKIP:` line either way.
 

--- a/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
+++ b/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
@@ -34,9 +34,9 @@ You are a project discovery agent. Analyze a UiPath automation project, write th
 
 ### Step 2: Gate — Skip Empty or Freshly-Scaffolded Projects
 
-A project with no authored content yields a document of empty tables. Run this gate **before** any discovery work.
+No authored content → document of empty tables. Run this gate **before** any discovery work.
 
-Count authored files with Glob, excluding every dot-directory (any path segment starting with `.` — `.local/`, `.codedworkflows/`, `.objects/`, `.settings/`, `.templates/`, …) plus `obj/` and `bin/`:
+Count authored files with Glob, excluding dot-directories (`.local/`, `.settings/`, `.templates/`, …) and `obj/`, `bin/`:
 
 ```
 **/*.xaml     → XAML workflow count
@@ -47,13 +47,15 @@ Write nothing and return the matching `SKIP:` line when **any** condition holds:
 
 | Condition | Return |
 |-----------|--------|
-| No `project.json` found | `SKIP: no project.json — nothing to discover` |
+| No `project.json` | `SKIP: no project.json — nothing to discover` |
 | 0 authored `.xaml` + `.cs` files | `SKIP: empty project — no workflow files` |
-| Exactly 1 authored file, it is a scaffolded entry point (`Main.xaml` process/template, `NewActivity*.xaml` library, `TestCase.xaml` test automation, `Main.cs` coded), and it holds no authored logic — root `Sequence` empty or containing only `Comment` activities (XAML) / no statement in the `Execute` body (coded) | `SKIP: freshly-scaffolded project — no authored content` |
+| Exactly 1 authored file: an untouched scaffold entry point (below) | `SKIP: freshly-scaffolded project — no authored content` |
 
-Read that single entry point to decide the third condition. Scaffold noise is not authored content: ViewState metadata (`sap:WorkflowViewStateService.ViewState`) is a property element, not a child activity, and the blank test-case scaffold ships a `Comment` activity (`// Blank Test Case`) inside the root `Sequence`. Any other activity or statement means the project is real: proceed to Step 3.
+Scaffold entry points: `Main.xaml` (process/template), `NewActivity*.xaml` (library), `TestCase.xaml` (test automation), `Main.cs` (coded).
 
-A user request to regenerate does NOT override the gate — a project with nothing in it has nothing to regenerate from. Return the `SKIP:` line either way.
+Untouched = read the file, find no authored logic. XAML: root `Sequence` empty or holds only `Comment` activities (blank test scaffold ships one); ViewState metadata is not an activity. Coded: empty `Execute` body. Anything else → real project, proceed to Step 3.
+
+A regenerate request does NOT override the gate — nothing to regenerate from. Return the `SKIP:` line either way.
 
 ### Step 3: Discovery
 

--- a/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
+++ b/skills/uipath-rpa/agents/uipath-project-discovery-agent.md
@@ -1,24 +1,25 @@
 ---
 name: uipath-project-discovery-agent
-description: "Auto-discover UiPath project structure, dependencies, and conventions; returns context document for Claude Code/Autopilot. Spawn before workflow authoring or when user asks to refresh project context / regenerate AGENTS.md."
+description: "Auto-discover UiPath project structure, dependencies, and conventions; write `.claude/rules/project-context.md` + `AGENTS.md`, return the context document for Claude Code/Autopilot. Spawn before workflow authoring or when user asks to refresh project context / regenerate AGENTS.md. Skips empty and freshly-scaffolded projects."
 model: sonnet
-tools: Bash, Read, Glob, Grep
+tools: Bash, Read, Glob, Grep, Write, Edit
 ---
 
 # UiPath Project Discovery Agent
 
-You are a project discovery agent. Analyze a UiPath automation project and generate a structured context document consumed by Claude Code and UiPath Autopilot.
+You are a project discovery agent. Analyze a UiPath automation project, write the context files, and return the context document consumed by Claude Code and UiPath Autopilot.
 
 ## Task
 
-1. Check if `.claude/rules/project-context.md` already exists in the project directory
-   - **If yes and user did NOT ask to regenerate** → return the existing file content as your response. Do not re-discover.
+1. Locate the project (Step 1), then run the **empty-project gate** (Step 2). Gate trips → write nothing, return the single `SKIP: <reason>` line, stop.
+2. Check if `.claude/rules/project-context.md` already exists in the project directory
+   - **If yes and user did NOT ask to regenerate** → return the existing file content as your response. Do not re-discover, do not rewrite the files.
    - **If yes and user asked to regenerate** → proceed with discovery.
    - **If no** → proceed with discovery.
-2. Follow the Workflow below to discover the project and generate the context document
-3. **Return the full generated context document as your response** — the main agent will write the output files and use the content for the current session
+3. Follow the Workflow below to discover the project, generate the context document, and write it to both output files.
+4. **Return the full context document as your response**, prefixed with the Step 6 status line — the main agent uses the content for the current session.
 
-**IMPORTANT: Do NOT write any files.** You do not have write permissions. Your only job is to discover and return the context document. The main agent handles file writing.
+**You own the output files.** Write `.claude/rules/project-context.md` and `AGENTS.md` yourself (Step 5). Only when this host gives you no write tool: return the document with `context-files: not-written (no write tool)` and the main agent writes it.
 
 ---
 
@@ -31,7 +32,30 @@ You are a project discovery agent. Analyze a UiPath automation project and gener
 3. Fall back to current working directory
 4. Verify `project.json` exists and contains UiPath dependencies before proceeding
 
-### Step 2: Discovery
+### Step 2: Gate — Skip Empty or Freshly-Scaffolded Projects
+
+A project with no authored content yields a document of empty tables. Run this gate **before** any discovery work.
+
+Count authored files with Glob, excluding generated and metadata directories (`.local/`, `.codedworkflows/`, `.objects/`, `.entities/`, `.screenshots/`, `.settings/`, `obj/`, `bin/`):
+
+```
+**/*.xaml     → XAML workflow count
+**/*.cs       → coded workflow + source file count
+```
+
+Write nothing and return the matching `SKIP:` line when **any** condition holds:
+
+| Condition | Return |
+|-----------|--------|
+| No `project.json` found | `SKIP: no project.json — nothing to discover` |
+| 0 authored `.xaml` + `.cs` files | `SKIP: empty project — no workflow files` |
+| Exactly 1 authored file, it is the scaffolded entry point (`Main.xaml`, `Main.cs`, or `TestCase.xaml`), and its body holds no child activity inside the root `Sequence` (XAML) / no statement in the `Execute` body (coded) | `SKIP: freshly-scaffolded project — no authored content` |
+
+Read that single entry point to decide the third condition — an untouched scaffold has an empty root `Sequence`. Any authored activity or statement means the project is real: proceed to Step 3.
+
+A user request to regenerate does NOT override the gate — a project with nothing in it has nothing to regenerate from. Return the `SKIP:` line either way.
+
+### Step 3: Discovery
 
 Follow the Discovery Procedure below. Gather:
 
@@ -45,7 +69,7 @@ Follow the Discovery Procedure below. Gather:
 8. **Shared resources** — helper classes, models, Object Repository, connections
 9. **Code skeletons** — representative patterns for writing new code in this project
 
-### Step 3: Generate Context
+### Step 4: Generate Context
 
 Using the Output Template below, produce the context document:
 
@@ -53,9 +77,37 @@ Using the Output Template below, produce the context document:
 - Factual only — include only what was actually discovered, never assume
 - Omit any section where no relevant data was found
 
-### Step 4: Return the Context Document
+### Step 5: Write the Context Files
 
-Return the full generated context document as your response. Do NOT write any files — the main agent handles that.
+Write the generated document to **both** paths, relative to the project root. Both are required: one is auto-loaded by Claude Code in future sessions, the other is the cross-agent convention read by UiPath Autopilot in Studio Desktop.
+
+1. **`.claude/rules/project-context.md`** — create the directory first if missing (`mkdir -p .claude/rules`), then write the document verbatim with the metadata comment on line 1. Overwrite any existing file.
+2. **`AGENTS.md`** — wrap the document in context markers:
+
+   ```markdown
+   <!-- PROJECT-CONTEXT:START -->
+   {{DOCUMENT}}
+   <!-- PROJECT-CONTEXT:END -->
+   ```
+
+   | Existing `AGENTS.md` | Action |
+   |---------------------|--------|
+   | Missing | Write the marker-wrapped block as the whole file |
+   | Has both markers | Replace only the content between them — leave everything outside untouched |
+   | Exists, no markers | Append the marker-wrapped block at the end — never rewrite pre-existing content |
+
+Verify both files exist after writing. A failed write goes in the Step 6 status line — never drop a file silently.
+
+### Step 6: Return the Context Document
+
+Return one status line, then the full document:
+
+```
+context-files: written (.claude/rules/project-context.md, AGENTS.md)
+<full context document>
+```
+
+Use `context-files: not-written (<reason>)` when you could not write — no write tool in this host, or a write error naming the failed path. The main agent then writes the files from your response.
 
 ---
 
@@ -324,10 +376,12 @@ Example: `<!-- discovery-metadata: cs=47 xaml=0 deps=3 -->`
 ## Critical Rules
 
 1. **NEVER fabricate project information.** Only include facts discovered by reading actual files.
-2. **Keep output under 200 lines.** Prefer tables and lists over prose.
-3. **Do NOT write any files.** Return the context document as your response only.
-4. **Sample intelligently.** Max 20 source files. Prioritize entry points and diversity.
-5. **Handle both project types.** Coded workflows (.cs), RPA workflows (.xaml), and mixed.
-6. **No placeholders in output.** Replace all with actual values or omit the section.
-7. **No commentary or recommendations.** Factual context document, not a code review.
-8. **Always return the full context document.** The main agent relies on this for current session context.
+2. **Run the Step 2 gate first.** Never discover, and never write files, for an empty or freshly-scaffolded project — return `SKIP: <reason>` instead.
+3. **Keep output under 200 lines.** Prefer tables and lists over prose.
+4. **Write both context files yourself** (Step 5). Hand file writing back to the main agent only when this host gives you no write tool.
+5. **Never destroy existing `AGENTS.md` content.** Replace only between the `PROJECT-CONTEXT` markers, or append.
+6. **Sample intelligently.** Max 20 source files. Prioritize entry points and diversity.
+7. **Handle both project types.** Coded workflows (.cs), RPA workflows (.xaml), and mixed.
+8. **No placeholders in output.** Replace all with actual values or omit the section.
+9. **No commentary or recommendations.** Factual context document, not a code review.
+10. **Always return the full context document** with its status line. The main agent relies on this for current session context.

--- a/skills/uipath-rpa/references/execution-maps-guide.md
+++ b/skills/uipath-rpa/references/execution-maps-guide.md
@@ -25,7 +25,7 @@ A clean `validate` + `build` does NOT prove runtime behavior. Known silent failu
 
 ## Journey: Greenfield XAML (no UIA)
 
-Skip the project-discovery subagent — no project exists (SKILL.md § Precondition). Write `project-context.md` + `AGENTS.md` yourself at T4.
+Skip the project-discovery subagent — nothing to discover yet (SKILL.md § Skip gate: no `project.json` before T1, only the untouched scaffold after it). Write `project-context.md` + `AGENTS.md` yourself at T4.
 
 | Turn | Emit in ONE assistant message |
 |---|---|
@@ -44,7 +44,7 @@ Skip the project-discovery subagent — no project exists (SKILL.md § Precondit
 
 | Turn | Emit in ONE assistant message |
 |---|---|
-| **T1 — Context** | § Precondition context check ∥ `Read` `project.json` + target `.xaml` + cards ∥ ONE `Bash`: `analyzer-rules list --project-dir "<PROJECT_DIR>" --output json` ∥ memory recall ∥ off-card `activities find` fan-out |
+| **T1 — Context** | § Precondition context check — § Skip gate first, then the discovery subagent, which writes `project-context.md` + `AGENTS.md` itself ∥ `Read` `project.json` + target `.xaml` + cards ∥ ONE `Bash`: `analyzer-rules list --project-dir "<PROJECT_DIR>" --output json` ∥ memory recall ∥ off-card `activities find` fan-out |
 | **T2 — Edit** | Batched `Edit`s (anchor each on its own target block — same-file Edits serialize; overlapping anchors fail) ∥ `packages install` `Bash` if new dependencies |
 | **T3 — Gate** | ONE `Bash`: per-file `validate` (relative `--file-path`) `&&` `build` `&&` optional `run` per § Gate ≠ runtime proof |
 | **T4 — Report** | Output check (if T3 ran) + § Completion Output + memory save |


### PR DESCRIPTION
## Problem

Two defects in the `uipath-project-discovery-agent` flow:

1. **The subagent could not write its own output.** It had no write tools, so it returned the context document and the *main* agent wrote `.claude/rules/project-context.md` + `AGENTS.md`. That was a limitation at the time subagents had no write access. It costs a round-trip and the write silently gets dropped whenever the main agent moves on to the actual task.
2. **It was spawned for new and empty projects.** The only guard was "no `project.json` → skip", so a scaffolded-but-empty project (just `Main.xaml`, nothing authored) paid for a full discovery pass that can only produce a document of empty tables.

## Changes

**`skills/uipath-rpa/agents/uipath-project-discovery-agent.md`**

- `tools:` gains `Write, Edit`. The "**Do NOT write any files**" block becomes "**You own the output files**".
- New **Step 5 — Write the Context Files**: writes `.claude/rules/project-context.md` (verbatim, metadata comment on line 1) and `AGENTS.md`. The `PROJECT-CONTEXT` marker merge logic (missing → write / markers present → replace between them / no markers → append) moved out of SKILL.md into the agent that now performs it.
- New **Step 6 — Return**: emits a `context-files: written (...)` status line followed by the document, so the main agent still gets session context without re-reading what was just written. Hosts that only spawn read-only subagents (UiPath Autopilot) return `context-files: not-written (<reason>)` and the old main-agent write path still applies — the flow degrades gracefully.
- New **Step 2 — Gate**: returns a single `SKIP: <reason>` line, writing nothing, for no `project.json`, zero authored `.xaml`/`.cs`, or a lone untouched scaffolded entry point. A regenerate request does not override it.
- Critical Rules renumbered: rule 3 flipped from "do NOT write any files" to "write both context files yourself"; added the gate rule and an `AGENTS.md` non-destruction rule.

**`skills/uipath-rpa/SKILL.md`** — new `### Skip gate: nothing to discover yet` under § Precondition, applying the same three conditions before spawning (Glob counts exclude `.local/`, `.codedworkflows/`, `.objects/`, `.entities/`, `obj/`, `bin/`). Discovery-flow step 3 now fires **only** on `context-files: not-written`; step 4 treats a `SKIP:` return as a gate trip (write the files yourself after the build, same as greenfield).

The gate is checked in both places on purpose: SKILL.md keeps the main agent from spawning at all, the agent's Step 2 is the backstop for when it is spawned anyway or invoked directly.

**`references/execution-maps-guide.md`, `README.md`** — greenfield/brownfield T1 rows and the agents table follow the reworked flow.

## Validation

- `npm run skills:validate` → `OK - default: 26 skills, 1718 files, 0 replacements; studioweb: 26 skills, 1718 files, 95 replacements.`
- `PYTHONUTF8=1 python scripts/check-skill-status.py` → `OK — 26 skills, manifest valid.` (without `PYTHONUTF8=1` it hits a pre-existing cp1252 decode error on Windows, reproduced on a clean tree)
- Agent frontmatter parses as YAML; description is 327 chars.
- `hooks/validate-skill-descriptions.sh` → clean.

## Notes for the reviewer

- No test task added: `tests/` has no success-criteria type that can assert "a subagent was not spawned" or "this file is absent", so the gate is not gradable with the current vocabulary. Happy to add one if you'd rather approximate it.
- No `plugin.json` change — the agent registration path is unchanged.
- `uipath-rpa` has no flavor markers and no `skill-flavors/studioweb/uipath-rpa/` overrides, so no flavor override review was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
