### PR TITLE
fix(is-scorecard): drop integration-service tag from Test Manager tasks

### DIFF
--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_attachments.yaml
@@ -4,7 +4,7 @@ description: >
   Test Manager connector attachment activity through the `uip is` surface —
   upload, get (list), download, and delete attachments. Offline (command-shape)
   grading; runs in CI without a live connection.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 run_limits:
   expected_turns: 20

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execute_terminal/testmanager_execute_terminal.yaml
@@ -12,7 +12,7 @@ description: >
   Graded on invoking Execute + Get AND on the execution actually reaching terminal
   (Finished/Passed/Failed/…), i.e. a real run happened — not just that Execute was
   called.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 sandbox:
   python: {}

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_execution_results.yaml
@@ -6,7 +6,7 @@ description: >
   read a test case log, robot logs, assertions, download an assertion, and read
   test steps and step logs. Offline (command-shape) grading; runs in CI without a
   live connection.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 run_limits:
   expected_turns: 40

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_generic_records.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 sandbox:
   python: {}

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_requirement_lifecycle.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 sandbox:
   python: {}

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_results_grounded/testmanager_results_grounded.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_results_grounded/testmanager_results_grounded.yaml
@@ -18,7 +18,7 @@ description: >
   the fixture's expected minimum — i.e. it fetched real results, not just called
   the activity. Reusable pattern for the read/results activities (assertions,
   robot logs, test steps, test case logs).
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 skip: true
 
 sandbox:

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testcase_lifecycle.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 sandbox:
   python: {}

--- a/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-platform/integration-service/testmanager/testmanager_testset_lifecycle.yaml
@@ -9,7 +9,7 @@ description: >
   operations through the uipath-uipath-testmanager connector ('uip is resources
   run'), creating a uniquely-seeded record and verifying the create->read
   round-trip — plus invoking every operation in the group for coverage.
-tags: [uipath-platform, integration, integration-service, test-manager, resources, execute]
+tags: [uipath-platform, integration, test-manager, resources, execute]
 
 sandbox:
   python: {}


### PR DESCRIPTION
## What

Removes the bare `integration-service` tag from the 8 Test Manager task YAMLs under `tests/tasks/uipath-platform/integration-service/testmanager/`. The `integration` tier tag and all other tags are preserved.

## Why

The org Coding-Agents Scorecard sources the **Integration Service** row's Tests Pass/Fail from a cross-cutting **tag selector** (tasks whose `tags` array contains `integration-service` OR `ipe`, across all host skills — see `.claude/commands/generate-confluence-scorecard.md`). These 8 Test Manager tasks carried the bare `integration-service` tag, so they were counted as IS even though they exercise **Test Manager** connector capabilities (test cases, sets, requirements, execution results, attachments) through the `uip is` surface.

Impact on the [2026-08-04 run](https://uipath.atlassian.net/wiki/spaces/CA/pages/90989724081): the IS row read **23/31 (74%)** and showed red. Reproducing the exact selector against that run's task data, **5 of the IS row's 8 failures were these Test Manager tasks**:

| task_id | 2026-08-04 | Owner |
|---|---|---|
| skill-platform-is-testmanager-execute-terminal | ❌ FAILURE | Test Manager |
| skill-platform-is-testmanager-execution-results | ❌ FAILURE | Test Manager |
| skill-platform-is-testmanager-generic-records | ❌ FAILURE | Test Manager |
| skill-platform-is-testmanager-testcase-lifecycle | ❌ FAILURE | Test Manager |
| skill-platform-is-testmanager-testset-lifecycle | ❌ FAILURE | Test Manager |
| skill-platform-is-testmanager-attachments | ✅ | Test Manager |
| skill-platform-is-testmanager-requirement-lifecycle | ✅ | Test Manager |
| skill-platform-is-testmanager-results-grounded | (not in run) | Test Manager |

These outcomes belong to the **Test Manager** row (`uipath-test`, already 11/16), not IS. Removing the tag reattributes them and drops the IS tag-selected set from **63 → 55**.

## Effect

- IS scorecard row stops absorbing Test Manager failures; the 3 remaining genuine IS failures (flow connector-authoring) are IS's to fix.
- Tasks **still run** — they remain selected under `uipath-platform` and `test-manager`; only the double-count as IS is removed.

## Note / reviewer call

These tasks reach Test Manager *via* the IS execution path (`uip is`), so tagging them IS was a defensible original choice. This PR treats them as Test Manager for scorecard attribution, matching their `test-manager` tag and capability. Fully reversible if the team prefers them counted under IS.

## Not included (follow-ups from the same audit)

- The 8 tasks still lack a `mode:*` tag (should be `mode:operate`).
- 13 genuinely-IS evals (agents-coded `feature:integration-service`, flow `bindings/`, etc.) are invisible to the selector because they lack the bare `integration-service` tag — the reverse hygiene gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)