### PR TITLE
fix(uipath-agents,uipath-maestro-flow): fix six failing nightly agent tasks — skill-doc gaps, prompt redirect traps, checker/cleanup defects

### DIFF
--- a/skill-flavors/studioweb/uipath-agents/references/coded/quickstart.md
+++ b/skill-flavors/studioweb/uipath-agents/references/coded/quickstart.md
@@ -14,7 +14,7 @@ Use when the coded agent is tightly coupled to one flow and lives as a sibling f
 <!--skill-flavor:agent-solution-registration:end-->
 
 <!--skill-flavor:agent-scaffold-solution-root:start-->
-3. **Scaffold the coded agent as a sibling folder.** From the solution root (`/solution`) — `uip codedagent new` scaffolds into the **current directory**, it does NOT create a subfolder, so create the agent folder first and run everything inside it:
+3. **Scaffold the coded agent as a sibling folder.** From the solution root (`/solution`):
 <!--skill-flavor:agent-scaffold-solution-root:end-->
 
 <!--skill-flavor:agent-scaffold-result-paths:start-->

--- a/skill-flavors/studioweb/uipath-agents/references/coded/quickstart.md
+++ b/skill-flavors/studioweb/uipath-agents/references/coded/quickstart.md
@@ -14,7 +14,7 @@ Use when the coded agent is tightly coupled to one flow and lives as a sibling f
 <!--skill-flavor:agent-solution-registration:end-->
 
 <!--skill-flavor:agent-scaffold-solution-root:start-->
-3. **Scaffold the coded agent as a sibling folder.** From the solution root (`/solution`):
+3. **Scaffold the coded agent as a sibling folder.** From the solution root (`/solution`) — `uip codedagent new` scaffolds into the **current directory**, it does NOT create a subfolder, so create the agent folder first and run everything inside it:
 <!--skill-flavor:agent-scaffold-solution-root:end-->
 
 <!--skill-flavor:agent-scaffold-result-paths:start-->

--- a/skills/uipath-agents/references/coded/embedding-in-flows.md
+++ b/skills/uipath-agents/references/coded/embedding-in-flows.md
@@ -104,6 +104,22 @@ Without `--local`, `registry list`/`get` query the tenant registry (Orchestrator
 
 ## Wiring the Agent's Inputs
 
-For inputs that reference flow variables, use `{ "type": "literal", "expression": "{{ $vars.X }}", "fieldType": "string" }` — NOT `=js:...` expressions. `=js:` ships as a literal string to the agent activity and fails at runtime with `Cannot find name '<identifier>'`.
+One `inputs.<field>` entry per property in the agent's input schema (`entry-points.json`, mirrored in the definition's `inputDefinition.properties`). Two valid value shapes, same binding:
+
+```json
+"inputs": {
+  "<INPUT_FIELD>": {
+    "type": "jsExpression",
+    "expression": "$vars.<UPSTREAM_NODE_ID>.output.<FIELD>",
+    "fieldType": "<FIELD_TYPE>"
+  }
+}
+```
+
+- `jsExpression` — bare `$vars...` expression, no `=js:` prefix. Upstream values read as `$vars.<nodeId>.output.<field>`; flow globals as `$vars.<global>`.
+- `literal` — text template; static text mixable with `{{ }}` interpolations: `{ "type": "literal", "expression": "{{ $vars.<UPSTREAM_NODE_ID>.output.<FIELD> }}", "fieldType": "<FIELD_TYPE>" }`.
+- `<FIELD_TYPE>` is the property's JSON-schema type from the agent's input schema (e.g. `string`, `boolean`, `number`) — read it from there, do not invent it.
+
+NEVER a plain `"=js:..."` string value — it ships as a literal string to the agent activity and fails at runtime with `Cannot find name '<identifier>'`. Complete worked example (trigger → agent → end): uipath-maestro-flow skill, agent-plugin reference § Wiring Inputs.
 
 Input-only rule. Mapping the agent's output back to a flow-level global on an End node DOES use `=js:` — see [variables-and-expressions.md § Variable Updates](../../../uipath-maestro-flow/references/shared/variables-and-expressions.md#variable-updates-variableupdates).

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -255,27 +255,30 @@ Execute the following in order, end-to-end, in one pass — do not pause for con
 <!--skill-flavor:flow-project-creation:end-->
 
 <!--skill-flavor:agent-scaffold-solution-root:start-->
-3. **Scaffold the coded agent as a sibling folder.** From the solution root (still inside `<SolutionName>/`):
+3. **Scaffold the coded agent as a sibling folder.** From the solution root (still inside `<SolutionName>/`) — `uip codedagent new` scaffolds into the **current directory**, it does NOT create a subfolder, so create the agent folder first and run everything inside it:
 <!--skill-flavor:agent-scaffold-solution-root:end-->
 
    ```bash
+   mkdir "<AgentName>"
+   cd "<AgentName>"
    uv venv --python 3.13
    source .venv/bin/activate        # .venv\Scripts\activate on Windows
-   uv add <framework-package>       # e.g. uipath-langchain for LangGraph
-   uv add uipath-dev --dev
-   uv sync
+   uv pip install <framework-package>   # e.g. uipath-langchain for LangGraph
    uip codedagent setup --force
    uip codedagent new "<AgentName>"
+   uv add uipath-dev --dev
+   uv sync
    ```
+
+   `uv add` requires the `pyproject.toml` that `codedagent new` generates — run it only after `new`, never at the solution root.
 
 <!--skill-flavor:agent-scaffold-result-paths:start-->
    Result: `<SolutionName>/<AgentName>/` sibling to `<SolutionName>/<FlowName>/`.
 <!--skill-flavor:agent-scaffold-result-paths:end-->
 
-4. **Implement the agent's `main.py`** with lazy LLM initialization (LLM clients inside graph nodes only — never at module top level), then regenerate entry-points / bindings:
+4. **Implement the agent's `main.py`** with lazy LLM initialization (LLM clients inside graph nodes only — never at module top level), then regenerate entry-points / bindings (still inside `<AgentName>/`):
 
    ```bash
-   cd "<AgentName>"
    uip codedagent init
    ```
 

--- a/skills/uipath-maestro-flow/references/author/references/plugins/agent/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/agent/impl.md
@@ -47,7 +47,7 @@ Confirm from `registry get`:
 - `model.serviceType` — `Orchestrator.StartAgentJob`
 - `model.bindings.resourceSubType` — `Agent`
 - `model.bindings.resourceKey` — the `<FolderPath>.<AgentName>` string used to scope binding resolution
-- `inputDefinition` — typically empty (agents accept free-form input via the flow's wiring)
+- `inputDefinition` — the agent's typed input schema, one property per input field (mirrors the agent's `entry-points.json`). Each property gets one `inputs.<field>` entry on the node instance — see [Wiring Inputs](#wiring-inputs). Empty only when the agent declares no typed inputs (free-form)
 
 ## Adding / Editing
 
@@ -65,7 +65,13 @@ The instance carries only per-instance data (`inputs`, `outputs`, `display`). BP
   "type": "uipath.core.agent.ffa33d88-8a85-4570-933c-9a69aa2dfbb5",
   "typeVersion": "<DEFINITION_VERSION>",
   "display": { "label": "Classify Intent" },
-  "inputs": {},
+  "inputs": {
+    "<INPUT_FIELD>": {
+      "type": "jsExpression",
+      "expression": "$vars.<UPSTREAM_NODE_ID>.output.<FIELD>",
+      "fieldType": "<FIELD_TYPE>"
+    }
+  },
   "outputs": {
     "error": {
       "type": "object",
@@ -101,7 +107,7 @@ Confirm all three from `registry get` before wiring.
 }
 ```
 
-**Declare `error` only — `output` is derived.** Authoring it makes the converter copy your `source` verbatim; `"=result.response"` then resolves to null at runtime while `flow validate` passes. See [file-format.md § Node outputs](../../../../shared/file-format.md#node-outputs).
+**Declare `error` only — `output` is derived.** Authoring it makes the converter copy your `source` verbatim; `"=result.response"` then resolves to null at runtime while `flow validate` passes. Exception: `output` MAY be declared with exactly `source: "=this"` plus the agent's output schema — that form is safe; the hazard is any other hand-authored `source`. See [file-format.md § Node outputs](../../../../shared/file-format.md#node-outputs).
 
 `<AGENT_ICON>` depends on the agent's implementation type: `"coded-agent"` for Python-coded agents, `"autonomous-agent"` for low-code (`agent.json`) agents. Detect the type by inspecting the sibling agent project directory: if `agent.json` exists at its root, use `"autonomous-agent"`; otherwise use `"coded-agent"`. Do NOT copy `.display.icon` from `uip maestro flow registry get --local` — that manifest returns `"coded-agent"` for every in-solution agent regardless of implementation type, and the value must be corrected here.
 
@@ -144,6 +150,45 @@ Same shape as the published variant — no `model` on the instance.
 
 > For the resolution mechanics and why these entries are required, see [file-format.md — Bindings](../../../../shared/file-format.md#bindings--orchestrator-resource-bindings-top-level-bindings).
 
+## Wiring Inputs
+
+One `inputs.<field>` entry per property in the definition's `inputDefinition.properties`. Two valid value shapes, same binding:
+
+1. **`jsExpression`** — bare `$vars...` expression, NO `=js:` prefix:
+
+   ```json
+   "inputs": {
+     "<INPUT_FIELD>": {
+       "type": "jsExpression",
+       "expression": "$vars.<UPSTREAM_NODE_ID>.output.<FIELD>",
+       "fieldType": "<FIELD_TYPE>"
+     }
+   }
+   ```
+
+2. **`literal`** — text template; static text mixable with `{{ }}` interpolations: `{ "type": "literal", "expression": "{{ $vars.<UPSTREAM_NODE_ID>.output.<FIELD> }}", "fieldType": "<FIELD_TYPE>" }`.
+
+NEVER a plain `"=js:..."` string value — it ships verbatim to the agent activity and fails at runtime with `Cannot find name '<identifier>'`. `<FIELD_TYPE>` is the property's JSON-schema type from the definition's `inputDefinition.properties` (e.g. `string`, `boolean`, `number`) — read it from there, do not invent it.
+
+Worked example: trigger → agent → end, flow input surfaced through the trigger. The flow declares the input as a global bound to the trigger, and the agent reads it from the trigger's output:
+
+```json
+"variables": {
+  "globals": [
+    { "id": "<INPUT_FIELD>", "direction": "in", "type": "string", "defaultValue": "", "triggerNodeId": "trigger1" }
+  ]
+}
+```
+
+```json
+"edges": [
+  { "id": "e1", "sourceNodeId": "trigger1", "sourcePort": "output", "targetNodeId": "agent1", "targetPort": "input" },
+  { "id": "e2", "sourceNodeId": "agent1", "sourcePort": "output", "targetNodeId": "end1", "targetPort": "input" }
+]
+```
+
+The agent node's `inputs.<INPUT_FIELD>` then references `$vars.trigger1.output.<INPUT_FIELD>` (shape 1 above). Upstream values always read as `$vars.<nodeId>.output.<field>`; flow-level globals read as `$vars.<global>`.
+
 ## Accessing Output
 
 The agent's response is available downstream:
@@ -181,4 +226,4 @@ For the resource file format and wiring details, see the `uipath-agents` skill:
 | In-solution node doesn't resolve | `resourceKey` was hand-invented rather than read from the resource file, or `uip solution projects add` was never run for the agent project | Run `uip maestro flow registry list --local` and use the returned `resourceKey` (same value as `resource.key` in `resources/solution_folder/process/agent/<CodedAgentProject>.json`) |
 | Agent execution failed | Underlying agent errored | Check `$vars.{nodeId}.error` for details. For coded agents, test locally first with `uip codedagent run` |
 | Empty `output.content` | Agent returned no response | Verify the agent is configured correctly (published: in Orchestrator; in-solution: in Studio Web) |
-| `inputDefinition` is empty | Expected — agents accept input via flow wiring, not typed fields | Wire upstream data to the agent via `$vars` expressions |
+| `inputDefinition` is empty | Agent declares no typed input schema (free-form) | Wire upstream data via `jsExpression` inputs — see [Wiring Inputs](#wiring-inputs) |

--- a/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
+++ b/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/check_deploy_folder_and_rebump.py
@@ -9,7 +9,8 @@ Asserts:
   1. `acme-echo/pyproject.toml` is valid TOML with a `[project]` table.
   2. The `version` follows semver `MAJOR.MINOR.PATCH`.
   3. The `version` is strictly greater than `0.0.1` (the pre-seeded
-     version), with `0.0.2` being the expected patch bump.
+     version). Any bump counts — leftover versions on the tenant feed
+     from earlier runs legitimately force the agent past `0.0.2`.
   4. No `[build-system]` section (Critical Rule C1).
 """
 
@@ -69,14 +70,13 @@ def main() -> None:
 
     version = parse_version(text)
     print(f"OK: pyproject.toml [project].version parses as {version}")
-    EXPECTED_VERSION = (0, 0, 2)
-    if version != EXPECTED_VERSION:
+    if version <= SCAFFOLD_VERSION:
         fail(
-            f"version {version} is not the expected patch bump {EXPECTED_VERSION}. "
-            "The agent should read pyproject.toml, see version 0.0.1, and bump "
-            "the patch to 0.0.2 before redeploying."
+            f"version {version} was not bumped past the pre-seeded "
+            f"{SCAFFOLD_VERSION}. The agent should read pyproject.toml, see "
+            "version 0.0.1, and bump it before redeploying."
         )
-    print(f"OK: version bumped to {version} — correct patch bump before redeploy")
+    print(f"OK: version bumped to {version} — bumped past pre-seeded 0.0.1 before redeploy")
 
     print("OK: deploy-to-folder + patch-bump roundtrip verified")
 

--- a/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/cleanup_deploy_folder_and_rebump.py
+++ b/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/cleanup_deploy_folder_and_rebump.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""post_run: sweep uploaded `acme-echo` versions off the tenant package feed.
+
+Deletes every version of the `acme-echo` package except the pre-seeded
+`0.0.1` baseline, so the next run's patch bump never collides with
+`Version already exists`. Sweeping (rather than deleting only this run's
+version) also heals debris left by runs whose cleanup never fired.
+
+The uip CLI has no package-delete verb, so deletion calls the
+Orchestrator OData API directly (`DELETE /odata/Processes('Id:Version')`)
+with the token from the same `.auth` file the CLI reads.
+
+Best-effort, idempotent (NotFound = OK), exits 0 always.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+
+PACKAGE_ID = "acme-echo"
+BASELINE_VERSION = "0.0.1"
+
+AUTH_CANDIDATES = (
+    os.path.expanduser("~/.uipath/.auth"),
+    "/.uipath/.auth",
+)
+
+
+def read_auth() -> tuple[str, str] | None:
+    """Return (bearer_token, orchestrator_base_url) or None."""
+    for path in AUTH_CANDIDATES:
+        try:
+            with open(path, encoding="utf-8") as f:
+                pairs = dict(
+                    line.strip().split("=", 1) for line in f if "=" in line
+                )
+        except OSError:
+            continue
+        token = pairs.get("UIPATH_ACCESS_TOKEN")
+        url = (pairs.get("UIPATH_URL") or "").rstrip("/")
+        org = pairs.get("UIPATH_ORGANIZATION_NAME")
+        tenant = pairs.get("UIPATH_TENANT_NAME")
+        if token and url and org and tenant:
+            return token, f"{url}/{org}/{tenant}/orchestrator_"
+    return None
+
+
+def feed_versions() -> list[str]:
+    r = subprocess.run(
+        ["uip", "or", "packages", "versions", PACKAGE_ID, "--output", "json"],
+        capture_output=True, text=True, timeout=120,
+    )
+    try:
+        env = json.loads(r.stdout) if r.stdout.strip() else {}
+    except json.JSONDecodeError:
+        return []
+    data = env.get("Data") or []
+    if isinstance(data, dict):
+        data = data.get("Value") or data.get("Items") or data.get("Results") or []
+    versions = []
+    for item in data:
+        if isinstance(item, dict) and item.get("Version"):
+            versions.append(str(item["Version"]))
+    return versions
+
+
+def main() -> None:
+    auth = read_auth()
+    if auth is None:
+        print("cleanup: no usable .auth file found — skipping feed sweep")
+        return
+    token, orchestrator = auth
+
+    for version in feed_versions():
+        if version == BASELINE_VERSION:
+            continue
+        url = f"{orchestrator}/odata/Processes('{PACKAGE_ID}:{version}')"
+        req = urllib.request.Request(
+            url, method="DELETE",
+            headers={
+                "Authorization": f"Bearer {token}",
+                # Cloudflare rejects urllib's default Python-urllib UA (error 1010)
+                "User-Agent": "uipath-skills-tests-cleanup/1.0",
+            },
+        )
+        try:
+            urllib.request.urlopen(req, timeout=30)
+            print(f"cleanup: deleted {PACKAGE_ID}:{version}")
+        except urllib.error.HTTPError as e:
+            print(f"cleanup: skipped {PACKAGE_ID}:{version} — HTTP {e.code}")
+        except Exception as e:  # noqa: BLE001 — best-effort sweep
+            print(f"cleanup: skipped {PACKAGE_ID}:{version} — {e}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        sys.exit(0)

--- a/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/deploy_folder_and_rebump.yaml
@@ -1,8 +1,11 @@
 task_id: skill-agent-coded-deploy-folder-and-rebump
 description: >
-  Verifies the agent knows to bump the patch version in pyproject.toml
+  Verifies the agent knows to bump the version in pyproject.toml
   before redeploying to the tenant package feed. Project is pre-seeded at
   version 0.0.1 (already deployed once); agent must bump and redeploy.
+  Any bump past 0.0.1 passes — leftover feed versions from earlier runs
+  legitimately force the agent higher than 0.0.2. post_run sweeps the
+  uploaded versions back off the tenant feed.
   Targets --tenant, not --folder: `codedagent deploy --folder` matches
   folder-scoped package feeds by name, and the run tenant's Shared folder
   has no dedicated feed, so a folder deploy always fails at feed lookup.
@@ -44,3 +47,7 @@ success_criteria:
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0
+
+post_run:
+  - command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-agents/coded/deploy_folder_and_rebump/cleanup_deploy_folder_and_rebump.py"
+    timeout: 120

--- a/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
+++ b/tests/tasks/uipath-agents/coded/deploy_my_workspace/deploy_my_workspace.yaml
@@ -7,6 +7,12 @@ description: >
   the package was built — a "version already exists" publish conflict
   does not fail the task. Exercises the production packaging path the
   rest of the suite never reaches.
+  The summarizer is deliberately LLM-backed (free-form paraphrase per
+  run): deterministic no-LLM logic is a Coded Function and the skill
+  redirects it to uipath-functions, whose lifecycle has no
+  `uip codedagent deploy`. Do not reword the prompt back to a
+  deterministic echo, and keep it free of implementation hints (no
+  framework or node mechanics).
 tags: [uipath-agents, e2e, coded, lifecycle:deploy, feature:deploy]
 
 run_limits:
@@ -16,14 +22,18 @@ run_limits:
   max_turns: 40
 
 initial_prompt: |
-  Build a minimal no-LLM UiPath coded agent named `deploy-smoke`
-  that echoes the input message. Input: `message` (string). Output:
-  `echoed` (string). Then deploy it to the personal workspace.
+  I want a small UiPath coded agent called `deploy-smoke`. Given a
+  short text `message`, it should reply with a one-sentence summary
+  in its own words — the wording should adapt to whatever the message
+  says, not follow a fixed template. Input: `message` (string).
+  Output: `summary` (string).
 
-  The test harness has UiPath auth pre-configured. The workspace may
-  already hold this package from an earlier run — if the deploy
-  reports the version already exists, that is expected; consider the
-  deploy step done and do not re-deploy.
+  Build it, then deploy it to my personal workspace. No local test
+  run needed — packaging and deploying are the goal. The test harness
+  has UiPath auth pre-configured. The workspace may already hold this
+  package from an earlier run — if the deploy reports the version
+  already exists, that is expected; consider the deploy step done and
+  do not re-deploy.
 
   Do NOT pause between planning and implementation. Complete
   end-to-end in a single pass.

--- a/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_custom_evaluator/eval_custom_evaluator.yaml
@@ -4,6 +4,12 @@ description: >
   a custom evaluator with `uip codedagent add evaluator`, implement it, and
   register it with `uip codedagent register evaluator` to generate the JSON
   spec. The evaluator must be wired into an eval set and run successfully.
+  The greeter is deliberately non-deterministic (varied greeting phrasing per
+  run): deterministic no-LLM logic is a Coded Function and the skill redirects
+  it to uipath-functions, which has no eval lifecycle. Non-determinism is what
+  makes this an agent workload that needs evals — do not reword the prompt
+  back to "pure deterministic Python", and keep the prompt free of
+  implementation hints (no framework, node, or randomness mechanics).
 tags: [uipath-agents, smoke, coded, lifecycle:validate, feature:eval]
 
 run_limits:
@@ -13,14 +19,15 @@ run_limits:
   max_turns: 90
 
 initial_prompt: |
-  I want a small UiPath coded agent called `greeter` — give it a name
-  and it returns "Hello, <name>!". Pure deterministic Python, no LLM.
+  I want a small UiPath coded agent called `greeter` — given a name
+  it should politely greet that person back. Mix up the phrasing a
+  bit so it doesn't sound canned.
 
-  Once it's running locally, I want a custom evaluator for it that flags
-  whether the agent responds quickly enough — say, under about half a
-  second. Hook that evaluator up to an eval set with a couple of test
-  cases and run it locally — no cloud reporting — and write the results
-  out so I can review them.
+  Once it's running locally, I want a custom evaluator for it that
+  flags whether the agent responds quickly enough — say, under about
+  half a second. Hook that evaluator up to an eval set with a couple
+  of test cases and run it locally — no cloud reporting — and write
+  the results out so I can review them.
 
   Build it here. It's all local — no sign-in, nothing to publish or
   deploy. Work straight through in one pass.

--- a/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
+++ b/tests/tasks/uipath-agents/coded/hitl_create_task_with_app/hitl_create_task_with_app.yaml
@@ -7,23 +7,32 @@ description: >
   agent imports `CreateTask` from `uipath.platform.common`, wires
   `interrupt(CreateTask(app_name=..., app_folder_path=..., title=...,
   data={...}, assignee=...))` into a graph node, and emits the
-  matching `app` resource binding. 
+  matching `app` resource binding.
+  Prompt is deliberately outcome-independent: a plain CreateTask
+  resume delivers ONLY the task's `data` (the app's inOut fields —
+  for RefundReviewApp, just `Comment`), never `task.action`. The
+  scenario therefore treats the review as a sign-off gate that
+  carries the reviewer's comment forward. Do NOT reword it to require
+  acting on the approve/reject outcome — that would need
+  CreateEscalation semantics and push agents to the wrong pattern.
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-langgraph, feature:hitl-coded]
 max_iterations: 1
 
 initial_prompt: |
   Can you build me a uipath coded agent in LangGraph for handling refunds?
+
   Call it refund-gate, put it in a refund-gate folder. The idea: anything
-  over $500 has to be reviewed by a person before it goes through. Open a
+  over $500 has to be signed off by a person before it goes through. Open a
   review task for the Compliance team (compliance@example.com) in their
   RefundReviewApp app, deployed to the Orchestrator folder
   Shared/uipath-agents/RefundReviewSol - it's a normal Action Center review
   task, not an escalation - show them the customer, the amount, and why the
   refund's being asked for.
-  Once they submit, carry on with the call they made and whatever note they
-  left. Anything $500 or under just goes through. And please make sure the
-  RefundReviewApp app is actually hooked up, otherwise it can't send them
-  the request.
+
+  The submitted task itself is the sign-off: once they submit, the refund
+  is cleared to proceed - just pick up whatever comment they left and carry
+  it into the agent's output for the audit trail. Anything $500 or under
+  just goes through without a sign-off.
 
   No need to run or deploy it, just build it. Run it all the way through
   and only stop if you hit something you genuinely can't get past.

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/check_openai_agents_handoff.py
@@ -147,10 +147,11 @@ def check_main_py(factory_symbol: str) -> None:
             "instead of UiPath's gateway."
         )
     # Three named agents: triage, billing, technical. Normalize "BillingAgent" /
-    # "billing_agent" / "billing" all to "billing" so role-equivalent names pass.
-    name_pattern = re.compile(r'name\s*=\s*"([^"]+)"')
+    # "billing_agent" / "billing-agent" / "Billing Agent" / "billing" all to
+    # "billing" so role-equivalent names pass.
+    name_pattern = re.compile(r'''name\s*=\s*['"]([^'"]+)['"]''')
     declared_names = {
-        n.lower().removesuffix("_agent").removesuffix("agent")
+        re.sub(r"[\s_-]*agents?$", "", n.lower())
         for n in name_pattern.findall(text)
     }
     expected = {"triage", "billing", "technical"}

--- a/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
+++ b/tests/tasks/uipath-agents/coded/openai_agents_handoff/openai_agents_handoff.yaml
@@ -18,15 +18,17 @@ run_limits:
 initial_prompt: |
   I want an OpenAI Agents UiPath coded agent called `triage-agent` that
   sits in front of two specialists. A triage agent reads the customer's
-  message and hands off to a billing agent for invoice and payment
-  questions, or to a technical agent for product and feature questions.
+  message and hands off to a `billing-agent` for invoice and payment
+  questions, or to a `technical-agent` for product and feature questions.
   All three should run on the UiPath LLM gateway, not the public OpenAI
   API.
 
   Register the triage agent's factory as the entry point under the key
   `agent`. It should also take the customer's ID as typed context
-  alongside their message — model that context as a `CustomerInput` — so
-  the specialists know who they're helping.
+  alongside their message — model that context as a `CustomerInput`
+  with a single `customer_id` field (the message itself travels as the
+  standard `messages` input, not inside the context) — so the
+  specialists know who they're helping.
 
   Build it end-to-end, and before you call it done, run it locally on a
   sample billing question to confirm the handoff actually fires.


### PR DESCRIPTION
Fixes six failing nightly `uipath-agents` coder-eval tasks. Each fix is grounded in transcript analysis of the failing runs and verified with a local passing run on `claude-sonnet-5` (`experiments/default.yaml`, same model as nightly).

## 1–2. Coded-in-flow tasks: skill-doc gaps (`245cf5aef`)

`skill-agent-coded-in-flow-e2e` and `skill-agent-coded-in-flow-published` both ended `MAX_TURNS_EXHAUSTED` (80 turns, scores 0.690 / 0.483) with the same root cause: the agent completed the coded-agent stage, then spent its final 30+ tool calls grepping both skills for the agent node's `inputs` contract — documented only as a one-sentence fragment — and never edited the `.flow` file. A secondary defect cost the e2e run ~20 turns: `quickstart.md` Scenario 2 told the agent to run `uip codedagent new` from the solution root and claimed it creates a subfolder; it scaffolds into CWD.

- **`uipath-maestro-flow` `plugins/agent/impl.md`** — new **§ Wiring Inputs**: one `inputs.<field>` entry per `inputDefinition.properties` property; both value shapes (`jsExpression` bare `$vars` expression, `literal` `{{ }}` text template — both product-canonical); `=js:`-string anti-pattern; `<FIELD_TYPE>` read from the schema, never invented; generic trigger→agent→end worked example. Populated the node-instance example's `inputs`; corrected the "`inputDefinition` typically empty" claim; outputs rule now allows `output` declared with exactly `source: "=this"` + the agent's output schema.
- **`uipath-agents` `embedding-in-flows.md`** — § Wiring the Agent's Inputs expanded from one sentence to the same contract.
- **`uipath-agents` `quickstart.md`** — Scenario 2 step 3: `mkdir`/`cd` before scaffolding, `codedagent new` scaffolds-into-CWD note, `uv add` moved after `new` (requires the generated `pyproject.toml`), redundant step-4 `cd` dropped.

Grounded in two Studio Web solution exports of the same flow, identical except the input value shape — proving both shapes canonical. Examples use generic `<PLACEHOLDER>` values only.

**Passing runs:**

| Task | Nightly | This branch |
|---|---|---|
| coded-in-flow e2e | MAX_TURNS_EXHAUSTED, 0.690 | **1.000, 12/12, 60/80 turns** |
| coded-in-flow published | MAX_TURNS_EXHAUSTED, 0.483 | **1.000, 7/7, 57/80 turns** |

Published run's doc-consultation phase dropped from ~35 tool calls to 8; both runs wired the node in the documented `jsExpression` shape and passed `uip maestro flow validate`. `npm run skills:validate` passes (default + studioweb).

## 3. `deploy_folder_and_rebump`: checker + tenant-state defects (`fed0156f7`)

Checker demanded exactly version `0.0.2`, but versions left on the tenant feed by earlier runs forced the agent past it (a run legitimately reached 0.0.8) — failing correct behavior. Now accepts any bump strictly greater than the pre-seeded `0.0.1`, and a best-effort idempotent `post_run` sweep restores the acme-echo feed to the `0.0.1` baseline via the Orchestrator OData API (the CLI has no package-delete verb). Verified: SUCCESS 1.0; feed restored after the run.

## 4. `eval_custom_evaluator`: prompt triggered the functions redirect (`ff8d107e5`)

The prompt's "pure deterministic Python, no LLM" is the exact trigger for the skill's Coded Function redirect, so agents correctly rerouted to `uipath-functions` (no eval lifecycle) and never ran the graded `uip codedagent` evaluator commands. Reworded as a non-deterministic greeter (an agent workload that needs evals); hermeticity preserved via the latency bar and no-sign-in constraint. Verified: SUCCESS 1.0, all 4 criteria.

## 5. `hitl_create_task_with_app`: prompt demanded an unobservable outcome (`ca37fdbb4`)

A plain CreateTask resume delivers only the task's data dict (the app's inOut fields), never `task.action` — verified via live suspend/resume. The old prompt's "carry on with the call they made" demanded the approve/reject outcome, pushing agents to CreateEscalation (graded wrong) or into SDK-source research spirals that blew the 1200s budget. Reframed as a sign-off gate carrying the reviewer's comment forward; bindings hint dropped so the criterion tests the skill, not the prompt. Verified: 1.000 twice (261s/64 turns, 397s/95 turns).

## 6. `deploy_my_workspace`: prompt triggered the functions redirect (`bb1d8d89b`)

"Minimal no-LLM coded agent that echoes the input" hit the same Coded Function redirect, so agents shipped via `uip function pack/publish` and never matched the graded `uip codedagent deploy --my-workspace` pattern. Reworded as an LLM-backed one-line summarizer with no plausible deterministic implementation; ungraded local-run step dropped. Verified: SUCCESS 1.0, all 3 criteria, no `uip function` commands.

## 7. `openai_agents_handoff`: checker rejected kebab-case agent names (`ade3b8c93`)

Grader bug: the checker normalized agent names with `removesuffix("agent")`, so kebab-case names (`billing-agent` — the naming style the prompt itself models with `triage-agent`) normalized to `billing-` and failed the triage/billing/technical check on an otherwise perfect solution (nightly scored 0.524 with the three command criteria green). Normalization is now separator-aware (`[\s_-]*agents?$`) and accepts single-quoted `name=` kwargs. Local reruns surfaced a second latent trap: agents that model the customer's message inside `CustomerInput` make `message` a required input field, so the checker's fixed re-run payload fails context validation and the runtime silently passes `context=None`, crashing instructions callables. The prompt now pins the shape (single `customer_id` field; the message travels as the standard `messages` input) and names the `billing-agent`/`technical-agent` specialists explicitly, making the graded names ground-truth anchors. Verified: SUCCESS 1.0, 4/4 criteria, 229s — all nine checker assertions including the live `uip codedagent run agent` gateway re-run; generated entry-point schema requires exactly `['messages', 'customer_id']`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
