### PR TITLE
fix(process-mining): scope the raw-body negative to actual bare column names

### DIFF
--- a/tests/tasks/uipath-process-mining/query_group_by_sugar.yaml
+++ b/tests/tasks/uipath-process-mining/query_group_by_sugar.yaml
@@ -56,7 +56,7 @@ success_criteria:
   - type: command_not_executed
     description: "Agent must NOT hand-write a raw aggregate body with bare column names"
     tool_name: "Bash"
-    command_pattern: 'uip\s+pm\s+query\s+run\b.*--body-json\b.*"groupBy"'
+    command_pattern: 'uip\s+pm\s+query\s+run\b.*--body-json\b.*"groupBy"\s*:\s*\[\s*"(?!F__)'
     weight: 2.5
 
   - type: command_not_executed


### PR DESCRIPTION
Fourth and last piece of the process-mining eval-set work, after #2545, #2546 and
#2547. Independent of all three — merges in any order. One line.

## Why

`skill-pm-query-group-by-sugar` has a negative criterion whose description and
pattern disagree:

```yaml
- type: command_not_executed
  description: "Agent must NOT hand-write a raw aggregate body with bare column names"
  command_pattern: 'uip\s+pm\s+query\s+run\b.*--body-json\b.*"groupBy"'
```

The description says *bare column names*. The pattern fires on **any** raw
`--body-json` containing `"groupBy"`, whatever is inside it.

That gap showed up in a local run on `claude-sonnet-5` — **0.750 FAILURE** on a
task that scored 1.000 in both the 2026-08-05 and 2026-08-10 nightlies. The agent
did exactly what the task rewards, then improvised after the command errored:

```
1. uip pm query info 9c46289e --stage dev
2. uip pm query run ... --group-by Service_Component --metric Event_count:average
3. uip pm query run --help
4. uip pm query run ... --body-json '{"groupBy":["F__Cases__Service_Component"],...}'
```

Step 2 **is** the behaviour under test, and its criterion passed. Step 4 used an
id-shaped token — not a bare column name — but tripped the negative anyway and
cost 2.5 of the task's 10 weight.

So the criterion punishes "used the sugar *and then also* tried a raw body"
rather than "used a raw body with bare names *instead of* the sugar". The task
already has a positive criterion rewarding the sugar; this negative only needs to
catch the actual mistake.

## The change

Anchor to the first `groupBy` entry and require it not to be id-shaped. Real
field ids are `F__<Table>__<Col>__<hash>` (`references/querying.md`), so
`"(?!F__)` cleanly separates a bare column name from an id.

```diff
-    command_pattern: 'uip\s+pm\s+query\s+run\b.*--body-json\b.*"groupBy"'
+    command_pattern: 'uip\s+pm\s+query\s+run\b.*--body-json\b.*"groupBy"\s*:\s*\[\s*"(?!F__)'
```

| Command | Old | New |
|---|---|---|
| sugar only — `--group-by X --metric Y:average` | – | – |
| `{"groupBy":["Service_Component"]}` — the targeted mistake | fires | **fires** |
| `{ "groupBy" : [ "Open_year" ] }` — whitespaced bare name | fires | **fires** |
| `{"groupBy":["F__Cases__Service_Component"]}` — id-shaped | fires | – |
| `{"groupBy":["F__Cases__Service_Component__f0f7ab"]}` — real id | fires | – |

The grader evaluates patterns with Python `re`, so the negative lookahead is
supported.

## Verification

`coder-eval` (`experiments/default.yaml`, tempdir, `claude-sonnet-5`),
4 replicates of the task on this branch:

```
rep 00  SUCCESS  1.000  turns=15
rep 01  SUCCESS  1.000  turns=9
rep 03  SUCCESS  1.000  turns=13
```

(The fourth was still finishing when this was opened; I will post the final
tally as a comment.) Before the change the same task scored 0.750 on the same
model and CLI.

Also checked the pattern directly against all five cases in the table above —
each behaves as intended — and `coder-eval plan` still validates the task.

## What this does NOT fix

The underlying cause. These tasks run without a live tenant, so **every** command
errors, and what actually varies between runs is each model's appetite for
troubleshooting after a failure — despite the prompt saying "do NOT retry, do NOT
troubleshoot errors". This PR removes one criterion that punished a harmless
fallback; it does not stop an agent improvising in ways other criteria catch.

The two structural levers are still open, both noted in #2545:

- **One replicate per task**, so a single criterion flips a whole task between
  SUCCESS and FAILURE with nothing to average over.
- **The model changes between nightlies** (`gemini-3.5-flash` on 08-05,
  `gpt-5.6-terra` on 08-10), so consecutive runs are not comparable.

Worth deciding on those before reading any more nightly deltas as regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
