### PR TITLE
Fix: ixp mode and lifecycle tags from tests

### DIFF
--- a/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
+++ b/tests/tasks/uipath-ixp/integration/labelling_correctness.yaml
@@ -6,7 +6,7 @@ description: >
   under `--group`, unconfirm rollback, and mark-missing — each checked by
   re-reading `get-predictions`. These are CLI payload-construction behaviors, not
   backend semantics.
-tags: [uipath-ixp, integration, mode:operate]
+tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
 run_limits:
   max_turns: 68

--- a/tests/tasks/uipath-ixp/integration/name_resolution.yaml
+++ b/tests/tasks/uipath-ixp/integration/name_resolution.yaml
@@ -5,7 +5,7 @@ description: >
   DocumentId via `documents list`, and a project by its TITLE → Name via
   `projects list` — rather than passing the human label straight through. The
   resolution step is the integration part; smokes pass the id in the prompt.
-tags: [uipath-ixp, integration, mode:operate]
+tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
 run_limits:
   max_turns: 48

--- a/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
+++ b/tests/tasks/uipath-ixp/integration/publish_lifecycle.yaml
@@ -14,7 +14,7 @@ description: >
   version left and could not complete the sequence.
 
   Version numbers also come from `list-models`, never from training order.
-tags: [uipath-ixp, integration, mode:operate]
+tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
 run_limits:
   max_turns: 68

--- a/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
+++ b/tests/tasks/uipath-ixp/integration/versions_and_metrics.yaml
@@ -7,7 +7,7 @@ description: >
   Verifies a real second version was produced (ModelVersion advanced) and that
   per-version metrics carry real per-field scores: outcomes a command-shape smoke
   cannot reach.
-tags: [uipath-ixp, integration, mode:operate]
+tags: [uipath-ixp, integration, mode:operate, lifecycle:setup]
 
 run_limits:
   max_turns: 72

--- a/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/conditional_unconfirm.yaml
@@ -12,7 +12,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:operate, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_all_predictions.yaml
@@ -5,7 +5,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_normalized_values.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
+++ b/tests/tasks/uipath-ixp/smoke/confirm_predictions.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
+++ b/tests/tasks/uipath-ixp/smoke/delete_document_by_id.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
+++ b/tests/tasks/uipath-ixp/smoke/get_metrics.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:discover]
+tags: [uipath-ixp, smoke, mode:diagnose, lifecycle:discover]
 
 run_limits:
   expected_turns: 4

--- a/tests/tasks/uipath-ixp/smoke/list_projects.yaml
+++ b/tests/tasks/uipath-ixp/smoke/list_projects.yaml
@@ -5,7 +5,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:discover]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:discover]
 
 run_limits:
   expected_turns: 4

--- a/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
+++ b/tests/tasks/uipath-ixp/smoke/mark_missing.yaml
@@ -4,7 +4,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
+++ b/tests/tasks/uipath-ixp/smoke/metrics_for_version.yaml
@@ -5,7 +5,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:diagnose, lifecycle:discover]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/move_field_between_groups.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_field_between_groups.yaml
@@ -15,7 +15,7 @@ description: >
   a failing `get-taxonomy` leaves nothing to carry into `fields add`, and a
   failing `fields add` makes withholding the `fields delete` the correct call
   (add-before-delete). Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/move_tag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/move_tag.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
+++ b/tests/tasks/uipath-ixp/smoke/negative_guards.yaml
@@ -7,7 +7,7 @@ description: >
   (Rule 8); marking-missing a field IXP predicted (Rule 12); passing
   the project Title instead of its Name (Rule 7). Agent ignores the
   hints. Criteria grade actual CLI invocations, not a self-report.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 11

--- a/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
+++ b/tests/tasks/uipath-ixp/smoke/no_blind_confirm_all.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_confirm.yaml
@@ -10,7 +10,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 6

--- a/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
+++ b/tests/tasks/uipath-ixp/smoke/per_occurrence_unconfirm.yaml
@@ -11,7 +11,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_live.yaml
@@ -5,7 +5,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
+++ b/tests/tasks/uipath-ixp/smoke/publish_tag_staging.yaml
@@ -5,7 +5,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
+++ b/tests/tasks/uipath-ixp/smoke/taxonomy_edit_chain.yaml
@@ -12,7 +12,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 
 agent:
   type: claude-code

--- a/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unconfirm_rollback.yaml
@@ -8,7 +8,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:execute]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 sandbox:
   python: {}

--- a/tests/tasks/uipath-ixp/smoke/unpublish.yaml
+++ b/tests/tasks/uipath-ixp/smoke/unpublish.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/untag.yaml
+++ b/tests/tasks/uipath-ixp/smoke/untag.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
+tags: [uipath-ixp, smoke, mode:operate, lifecycle:setup]
 
 run_limits:
   expected_turns: 5

--- a/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
+++ b/tests/tasks/uipath-ixp/smoke/update_prompts_heredoc.yaml
@@ -7,7 +7,7 @@ description: >
 
   Harness is unauthenticated; CLI calls fail with auth errors.
   Grades command shape, not wire effect.
-tags: [uipath-ixp, smoke, lifecycle:edit]
+tags: [uipath-ixp, smoke, mode:build, lifecycle:setup]
 
 run_limits:
   expected_turns: 8


### PR DESCRIPTION
**26 of the 51** `uipath-ixp` task files had a **wrong or missing** `mode:` / `lifecycle:` tag.
This fixes the `tags:` line in each.
For `mode` and `lifecycle`, check the values in this table: https://github.com/UiPath/skills/blob/ff379f8bf266baa9952ad377c814f13a35359eac/tests/README.md?plain=1#L94

## Why it matters

**These two tags aren't cosmetic.** The scorecard generator groups tasks by `mode:` to fill the
**Build / Operate / Troubleshoot** columns, and `tests/README.md` marks both tags as **required**.

Three problems were in there:

1. **11 tasks had no `mode:` at all.** They still counted toward the overall mean and the
   pass/fail total, but **landed in no mode column**.
2. **`mode:build` was copy-pasted onto operate work.** `publish`, `unpublish`, `untag`,
   `move-tag`, `confirm`, `mark-missing`, `delete-document` all act on an **already-deployed
   live model** — that's operate. *(This exact drift is called out by name for `uipath-ixp` in
   `.claude/commands/test-coverage.md`.)*
3. **`lifecycle:` used values outside the allowed set.** `execute` (10 files) and `edit` (1)
   aren't in the vocabulary — it's **`discover` / `generate` / `setup`**. Four integration files
   had **no `lifecycle:` at all**.

## Result

| | before | after |
|---|:---:|:---:|
| `mode:build` | 31 | 25 |
| `mode:operate` | 9 | **24** |
| `mode:diagnose` | **0** | **2** |
| missing `mode:` | 11 | **0** |
| invalid or missing `lifecycle:` | 15 | **0** |

Every one of the 51 tasks now carries **exactly one** valid `mode:` and **exactly one** valid
`lifecycle:`.