### PR TITLE
fix: ipe multiselect eval (#ENGCE-60626)

### DIFF
--- a/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py
@@ -5,26 +5,69 @@ Passes (exit 0) when any .flow file in the workspace has:
   1. a Slack connector node (type contains 'slack'), and
   2. a 'users' multiselect field on that node with exactly 3 entries.
 
+The 'users' value counts whether it is a native JSON array
+(["U1","U2","U3"]) or a flow expression string wrapping an array literal
+(e.g. "=js:(['U1','U2','U3'])") — both are valid ways to populate a
+multiselect field in a .flow.
+
 Name-agnostic: the prompt does not fix a project name, so every .flow file
 is checked ('**' glob skips dot-dirs, so .uipath/.skills flows are ignored).
 """
+import ast
 import glob
 import json
+import re
 import sys
 
 
-def find_users_list(obj):
-    """Recursively find a 'users' key holding a list."""
+def parse_users(value):
+    """Normalize a 'users' field value to a list of entries, else None.
+
+    Accepts a native list, or a string holding an array literal such as a
+    "=js:(['U1','U2','U3'])" expression.
+    """
+    if isinstance(value, list):
+        return value
+    if isinstance(value, str):
+        match = re.search(r"\[.*\]", value, re.DOTALL)
+        if not match:
+            return None
+        literal = match.group(0)
+        try:
+            parsed = ast.literal_eval(literal)
+        except (ValueError, SyntaxError):
+            parsed = None
+        if isinstance(parsed, (list, tuple)):
+            return list(parsed)
+        # Fallback: count quoted string entries inside the brackets.
+        entries = re.findall(r"""['"]([^'"]+)['"]""", literal)
+        return entries or None
+    return None
+
+
+def is_users_key(key):
+    """True for the 'users' multiselect key in any of its encodings.
+
+    Accepts the bare name and array-notation variants a .flow may emit:
+    'users', 'users[*]', 'users[]', 'users[0]'.
+    """
+    return isinstance(key, str) and re.fullmatch(r"users(\[.*\])?", key) is not None
+
+
+def find_users(obj):
+    """Recursively find a 'users' key holding a parseable multiselect value."""
     if isinstance(obj, dict):
         for key, value in obj.items():
-            if key == "users" and isinstance(value, list):
-                return value
-            found = find_users_list(value)
+            if is_users_key(key):
+                users = parse_users(value)
+                if users is not None:
+                    return users
+            found = find_users(value)
             if found is not None:
                 return found
     elif isinstance(obj, list):
         for item in obj:
-            found = find_users_list(item)
+            found = find_users(item)
             if found is not None:
                 return found
     return None
@@ -45,7 +88,7 @@ def check_flow(path):
         return "no Slack connector node"
 
     for node in slack_nodes:
-        users = find_users_list(node.get("inputs", {}))
+        users = find_users(node.get("inputs", {}))
         if users is None:
             continue
         if len(users) == 3:


### PR DESCRIPTION
## What

Fix the `skill-flow-ipe-multiselect` eval check (`check_multiselect_flow.py`) so it recognizes every valid way a `.flow` encodes the Slack group-DM `users` multiselect. The agent output was correct; the grader was too strict and failed correct flows.

## Why

The task asks the agent to build a Slack group-DM flow with 3 users in the `users` multiselect. The old checker only counted `users` when it was a **native JSON list** under an exactly-named `users` key. Agents legitimately emit the field in other shapes, so correct flows scored 0 on the multiselect criterion (overall run FAILURE at ~0.54).

Observed valid encodings the old checker rejected:

- Expression string wrapping an array literal: `"users": "=js:(['U0…','U0…','U0…'])"`
- Array-notation key with a native array: `"users[*]": ["U0…","U0…","U0…"]`

## Change

`tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py`:

- **Value parsing** — accept the `users` value as a native list **or** a string containing an array literal (e.g. `=js:([...])`), via `ast.literal_eval` with a quoted-token regex fallback.
- **Key matching** — match the multiselect key in any encoding: `users`, `users[*]`, `users[]`, `users[0]` (`re.fullmatch(r"users(\[.*\])?", key)`).
- Unchanged: Slack-node detection, name-agnostic `**/*.flow` globbing, the **exactly-3-entries** rule, messages, and exit codes.

## Verification

Ran `tasks/uipath-maestro-flow/connector_features/multiselect.yaml` under `experiments/default.yaml` (tempdir) — 3 parallel runs plus a confirmation run:

| Run | Score | Multiselect | Encoding emitted |
|-----|-------|-------------|------------------|
| 1 | 1.000 ✅ | PASS | `=js` string |
| 2 | 1.000 ✅ | PASS | `=js` string |
| 3 | surfaced the gap | — | `users[*]` array |
| confirm | 1.000 ✅ | PASS | `=js` string |

Run 3 is what surfaced the `users[*]` encoding; the checker was then extended to cover it. Re-running the finalized checker against **all four** saved artifacts passes (exit 0), and negative cases still fail correctly:

- 2-entry field → FAIL (`users field has 2 entries, expected 3`)
- missing `users` field → FAIL (`Slack node has no 'users' multiselect field`)

## Notes

Only `check_multiselect_flow.py` is in this change — this is a grader fix; the skill under test is unchanged.