### PR TITLE
fix(uipath-agents): repair LlamaIndex RAG docs; accept both RAG primitives in llamaindex_rag checker

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/context-grounding.md
+++ b/skills/uipath-agents/references/coded/capabilities/context-grounding.md
@@ -21,13 +21,11 @@ To create, ingest, poll, search, or delete the index from the CLI instead of the
 
 ## Folder Targeting
 
-Context Grounding indexes live in Orchestrator folders. Pass a folder identifier whenever the index is not in the default folder resolved from your auth context — otherwise the service may return `400 FolderKey required`. `ContextGroundingRetriever` accepts `folder_path` or `folder_key`; `ContextGroundingVectorStore` accepts `folder_path`.
+Context Grounding indexes live in Orchestrator folders. Always pass a folder identifier, even when the index lives in the execution folder resolved from your auth context — omitting it can leave the `index` binding incorrectly applied, and the service may return `400 FolderKey required`. `ContextGroundingRetriever` accepts `folder_path` or `folder_key`; `ContextGroundingVectorStore` accepts `folder_path`.
 
 ```python
 retriever = ContextGroundingRetriever(index_name="my_index", folder_path="Shared/Knowledge")
 ```
-
-Add the supported folder argument for the component you use when cross-folder access is needed.
 
 ## Core Components
 

--- a/skills/uipath-agents/references/coded/capabilities/context-grounding.md
+++ b/skills/uipath-agents/references/coded/capabilities/context-grounding.md
@@ -31,6 +31,8 @@ Add the supported folder argument for the component you use when cross-folder ac
 
 ## Core Components
 
+Import paths below are LangChain/LangGraph (`uipath_langchain.*`). For LlamaIndex agents, use `uipath_llamaindex.retrievers.ContextGroundingRetriever` / `uipath_llamaindex.query_engines.ContextGroundingQueryEngine` — see [frameworks/llamaindex-integration.md](../frameworks/llamaindex-integration.md) § Context Grounding (RAG).
+
 ### ContextGroundingRetriever
 
 A document retrieval system using vector search to find relevant information based on natural language queries.

--- a/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
@@ -277,9 +277,9 @@ Two RAG primitives ship in `uipath-llamaindex`. Pick by workflow shape:
 
 The query engine wraps `ContextGroundingRetriever` + your synthesizer internally — use the retriever directly when the workflow already has its own synthesis step.
 
-> **Always use these primitives — not raw `sdk.context_grounding.search()` / `search_async()`.** They return LlamaIndex `NodeWithScore` objects that plug into synthesizers and tools, and declare `index_name` + `folder_path` at one call site — the exact shape of the `index` binding entry (see [../lifecycle/bindings-reference.md](../lifecycle/bindings-reference.md)). `index` bindings have no virtual fallback: the index must exist in Orchestrator before `uip codedagent push`.
+> **Prefer using these primitives — not raw `sdk.context_grounding.search()` / `search_async()`.** They return LlamaIndex `NodeWithScore` objects that plug into synthesizers and tools, and declare `index_name` + `folder_path` at one call site — the exact shape of the `index` binding entry (see [../lifecycle/bindings-reference.md](../lifecycle/bindings-reference.md)). `index` bindings have no virtual fallback: the index must exist in Orchestrator before `uip codedagent push`.
 
-Both accept `index_name`, `folder_path` (or `folder_key`), and `number_of_results` (default 10). Pass `folder_path` whenever the index is not in the default folder resolved from your auth context. Instantiate both inside a `@step` — never at module level (same lazy-client rule as LLMs, § UiPathOpenAI above).
+Both accept `index_name`, `folder_path` (or `folder_key`), and `number_of_results` (default 10). Always pass `folder_path`, even when the index lives in the execution folder resolved from your auth context — omitting it can leave the `index` binding incorrectly applied. Instantiate both inside a `@step` — never at module level (same lazy-client rule as LLMs, § UiPathOpenAI above).
 
 #### ContextGroundingQueryEngine
 

--- a/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
+++ b/skills/uipath-agents/references/coded/frameworks/llamaindex-integration.md
@@ -268,15 +268,41 @@ See `../capabilities/conversational-agents.md` § Running Locally for the `--kee
 
 ### Context Grounding (RAG)
 
-```python
-from uipath_llamaindex.query_engines import ContextGroundingQueryEngine
-from llama_index.core.tools import QueryEngineTool, ToolMetadata
+Two RAG primitives ship in `uipath-llamaindex`. Pick by workflow shape:
 
+| Primitive | Import | Use when |
+|-----------|--------|----------|
+| `ContextGroundingQueryEngine` | `uipath_llamaindex.query_engines` | Retrieval + LLM synthesis in one call, or exposing the index as a `QueryEngineTool` in an agentic workflow. Constructor REQUIRES `response_synthesizer` (no default). |
+| `ContextGroundingRetriever` | `uipath_llamaindex.retrievers` | Deterministic workflow RAG — retrieve raw passages in a `@step`, then synthesize the answer with your own prompt and LLM call. |
+
+The query engine wraps `ContextGroundingRetriever` + your synthesizer internally — use the retriever directly when the workflow already has its own synthesis step.
+
+> **Always use these primitives — not raw `sdk.context_grounding.search()` / `search_async()`.** They return LlamaIndex `NodeWithScore` objects that plug into synthesizers and tools, and declare `index_name` + `folder_path` at one call site — the exact shape of the `index` binding entry (see [../lifecycle/bindings-reference.md](../lifecycle/bindings-reference.md)). `index` bindings have no virtual fallback: the index must exist in Orchestrator before `uip codedagent push`.
+
+Both accept `index_name`, `folder_path` (or `folder_key`), and `number_of_results` (default 10). Pass `folder_path` whenever the index is not in the default folder resolved from your auth context. Instantiate both inside a `@step` — never at module level (same lazy-client rule as LLMs, § UiPathOpenAI above).
+
+#### ContextGroundingQueryEngine
+
+Build the required `response_synthesizer` with `get_response_synthesizer(llm=UiPathOpenAI())` — omitting it raises a constructor error:
+
+```python
+from llama_index.core.response_synthesizers import get_response_synthesizer
+from uipath_llamaindex.llms import UiPathOpenAI
+from uipath_llamaindex.query_engines import ContextGroundingQueryEngine
+
+# Inside a @step:
 query_engine = ContextGroundingQueryEngine(
     index_name="my_knowledge_base",
     folder_path="Shared",
-    response_synthesizer=response_synthesizer,
+    response_synthesizer=get_response_synthesizer(llm=UiPathOpenAI()),
 )
+response = await query_engine.aquery(ev.question)
+```
+
+As an agent tool:
+
+```python
+from llama_index.core.tools import QueryEngineTool, ToolMetadata
 
 tools = [
     QueryEngineTool(
@@ -287,6 +313,42 @@ tools = [
         ),
     )
 ]
+```
+
+#### Workflow RAG with ContextGroundingRetriever
+
+```python
+from llama_index.core.workflow import StartEvent, StopEvent, Workflow, step
+from uipath_llamaindex.llms import UiPathOpenAI
+from uipath_llamaindex.retrievers import ContextGroundingRetriever
+
+class QuestionEvent(StartEvent):
+    question: str
+
+class AnswerEvent(StopEvent):
+    answer: str
+
+class RagAgent(Workflow):
+    @step
+    async def answer(self, ev: QuestionEvent) -> AnswerEvent:
+        retriever = ContextGroundingRetriever(
+            index_name="my_knowledge_base",
+            folder_path="Shared",
+            number_of_results=5,
+        )
+        nodes = await retriever.aretrieve(ev.question)
+        if not nodes:
+            return AnswerEvent(answer="No relevant passages found in the knowledge base.")
+        passages = "\n\n".join(n.node.get_content() for n in nodes)
+        llm = UiPathOpenAI()
+        response = await llm.acomplete(
+            "Answer the question using ONLY the passages below. "
+            "If they do not answer it, say so.\n\n"
+            f"Passages:\n{passages}\n\nQuestion: {ev.question}"
+        )
+        return AnswerEvent(answer=str(response))
+
+workflow = RagAgent(timeout=60)
 ```
 
 ### Human-in-the-Loop

--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/check_llamaindex_rag.py
@@ -6,10 +6,15 @@ Asserts:
      `main.py` (LlamaIndex framework was correctly selected).
   2. `main.py` imports `Workflow` and `step` from `llama_index.core.workflow`
      and decorates at least one method with `@step`.
-  3. `main.py` imports `ContextGroundingQueryEngine` from
-     `uipath_llamaindex.query_engines` — the UiPath RAG primitive.
-  4. The query engine is instantiated with `index_name="hr-policy"`
-     (the index the user named in the prompt).
+  3. `main.py` imports a `uipath-llamaindex` Context Grounding RAG
+     primitive — `ContextGroundingQueryEngine` from
+     `uipath_llamaindex.query_engines` OR `ContextGroundingRetriever`
+     from `uipath_llamaindex.retrievers`. Both are documented, public
+     API (the query engine wraps the retriever); raw
+     `sdk.context_grounding.search()` / `search_async()` fails — the
+     skill's LlamaIndex guide says to use the framework primitives.
+  4. The primitive is instantiated with `index_name` resolving to
+     `"hr-policy"` (the index the user named in the prompt).
   5. `pyproject.toml` includes `uipath-llamaindex` as a dependency.
   6. No module-level UiPath* client construction (Critical Rule C4 —
      LLM clients must be lazy inside a `@step` body, never class- or
@@ -39,11 +44,26 @@ def fail(msg: str) -> None:
     sys.exit(f"FAIL: {msg}")
 
 
-def find_call(tree: ast.Module, func_name: str) -> ast.Call | None:
+def find_calls(tree: ast.Module, func_name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name
+    ]
+
+
+def uses_raw_sdk_search(tree: ast.Module) -> bool:
+    """True on any `<...>.context_grounding.search(...)` / `.search_async(...)` call."""
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == func_name:
-            return node
-    return None
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in ("search", "search_async", "unified_search", "unified_search_async")
+            and isinstance(node.func.value, ast.Attribute)
+            and node.func.value.attr == "context_grounding"
+        ):
+            return True
+    return False
 
 
 def module_str_constants(tree: ast.Module) -> dict[str, str]:
@@ -108,27 +128,59 @@ def main() -> None:
         fail("main.py has no `@step` decorator — the workflow nodes must be marked with @step")
     print("OK: LlamaIndex Workflow shape (Workflow import + @step decorator) present")
 
-    if not imports_from(tree, "uipath_llamaindex.query_engines", "ContextGroundingQueryEngine"):
+    # Either documented uipath-llamaindex RAG primitive passes. The query
+    # engine wraps the retriever internally; both bind the index the same
+    # way. Maps to (module, class, positional slot of `index_name`).
+    primitives = [
+        ("uipath_llamaindex.query_engines", "ContextGroundingQueryEngine", 1),
+        ("uipath_llamaindex.retrievers", "ContextGroundingRetriever", 0),
+    ]
+    imported = [(cls, pos) for mod, cls, pos in primitives if imports_from(tree, mod, cls)]
+    if not imported:
+        if uses_raw_sdk_search(tree):
+            fail(
+                "main.py grounds answers with raw `sdk.context_grounding.search()` / "
+                "`search_async()`. Use a `uipath-llamaindex` RAG primitive instead — "
+                "`ContextGroundingQueryEngine` (uipath_llamaindex.query_engines) or "
+                "`ContextGroundingRetriever` (uipath_llamaindex.retrievers) — per the "
+                "skill's LlamaIndex guide § Context Grounding (RAG)."
+            )
         fail(
-            "main.py does not import `ContextGroundingQueryEngine` from "
-            "`uipath_llamaindex.query_engines`. That is the UiPath RAG primitive "
-            "for LlamaIndex — use it to ground answers in the index."
+            "main.py imports neither `ContextGroundingQueryEngine` from "
+            "`uipath_llamaindex.query_engines` nor `ContextGroundingRetriever` from "
+            "`uipath_llamaindex.retrievers`. Those are the UiPath RAG primitives for "
+            "LlamaIndex — use one to ground answers in the index."
         )
-    print("OK: imports ContextGroundingQueryEngine from uipath_llamaindex.query_engines")
+    print("OK: imports a uipath_llamaindex Context Grounding RAG primitive "
+          f"({', '.join(cls for cls, _ in imported)})")
 
-    call = find_call(tree, "ContextGroundingQueryEngine")
-    if call is None:
-        fail("no `ContextGroundingQueryEngine(...)` call site found")
-    kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
-    name_node = kwargs.get("index_name")
     consts = module_str_constants(tree)
-    if resolve_str(name_node, consts) != "hr-policy":
-        got = resolve_str(name_node, consts) or getattr(name_node, "value", name_node)
+    resolved: list[tuple[str, object]] = []
+    bound_cls = None
+    for cls, pos in imported:
+        for call in find_calls(tree, cls):
+            kwargs = {kw.arg: kw.value for kw in call.keywords if kw.arg is not None}
+            name_node = kwargs.get("index_name")
+            if name_node is None and len(call.args) > pos:
+                name_node = call.args[pos]
+            got = resolve_str(name_node, consts)
+            if got == "hr-policy":
+                bound_cls = cls
+                break
+            resolved.append((cls, got or getattr(name_node, "value", name_node)))
+        if bound_cls:
+            break
+    if bound_cls is None:
+        if not resolved:
+            fail(
+                "no `ContextGroundingQueryEngine(...)` / `ContextGroundingRetriever(...)` "
+                "call site found"
+            )
         fail(
-            f"`ContextGroundingQueryEngine(index_name=...)` resolves to {got!r}, "
-            "expected 'hr-policy' (the index the user named in the prompt)"
+            "no RAG primitive call binds `index_name` to 'hr-policy' (the index the "
+            f"user named in the prompt); found: {resolved!r}"
         )
-    print('OK: ContextGroundingQueryEngine bound to index_name="hr-policy"')
+    print(f'OK: {bound_cls} bound to index_name="hr-policy"')
 
     if not PYPROJECT.is_file():
         fail(f"missing {PYPROJECT}")

--- a/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
+++ b/tests/tasks/uipath-agents/coded/llamaindex_rag/llamaindex_rag.yaml
@@ -2,9 +2,12 @@ task_id: skill-agent-coded-llamaindex-rag
 description: >
   LlamaIndex Workflow + UiPath Context Grounding RAG. Verifies the
   skill picks LlamaIndex for a RAG scenario, scaffolds the project,
-  wires `ContextGroundingQueryEngine` from
-  `uipath_llamaindex.query_engines`, and binds it to the named
-  index in the prompt. The framework choice is a deliberate test of
+  wires a `uipath-llamaindex` Context Grounding primitive —
+  `ContextGroundingQueryEngine` (query_engines) or
+  `ContextGroundingRetriever` (retrievers) — and binds it to the
+  named index in the prompt. Raw `sdk.context_grounding.search()` /
+  `search_async()` fails: the skill's LlamaIndex guide requires the
+  framework primitives. The framework choice is a deliberate test of
   the skill's framework-selection logic — the prompt names neither
   the framework nor the RAG primitive.
 tags: [uipath-agents, e2e, mode:build, coded, lifecycle:generate, feature:framework-llamaindex, feature:rag-coded]
@@ -58,7 +61,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "LlamaIndex Workflow shape + UiPath ContextGroundingQueryEngine wired to the `hr-policy` index"
+    description: "LlamaIndex Workflow shape + a uipath-llamaindex Context Grounding primitive (query engine or retriever) wired to the `hr-policy` index"
     command: "python3 $TASK_DIR/check_llamaindex_rag.py"
     timeout: 30
     expected_exit_code: 0


### PR DESCRIPTION
## Problem

All 4 nightly `skill-agent-coded-llamaindex-rag` runs (08-11 → 08-18) failed the same 6.0-weight criterion — `main.py` must import `ContextGroundingQueryEngine` — while every agent built functionally correct RAG bound to `hr-policy`/`Shared`.

Root cause: the skill's only LlamaIndex RAG example (`llamaindex-integration.md` § Context Grounding (RAG)) passed `response_synthesizer=response_synthesizer` with the variable **never defined** — and it's the constructor's first REQUIRED argument (no default). Every agent read the doc, inspected the installed package, saw the example can't work as written, and deviated to `ContextGroundingRetriever` (2 runs) or raw `sdk.context_grounding.search_async` (2 runs). `uipath_llamaindex.retrievers.ContextGroundingRetriever` was entirely undocumented in the skill.

## Docs fix

`references/coded/frameworks/llamaindex-integration.md` § Context Grounding (RAG):

- Primitive-selection table: `ContextGroundingQueryEngine` (one-call retrieve+synthesize / `QueryEngineTool`) vs `ContextGroundingRetriever` (deterministic workflow RAG, own synthesis step)
- Runnable query-engine example: `response_synthesizer=get_response_synthesizer(llm=UiPathOpenAI())`, flagged REQUIRED
- Complete `ContextGroundingRetriever` workflow example (lazy clients inside `@step` per C4, empty-results fallback)
- LlamaIndex counterpart of the LangGraph note: use the framework primitives, not raw `sdk.context_grounding.search()`/`search_async()`; `index` bindings have no virtual fallback

`references/coded/capabilities/context-grounding.md`: Core Components labeled as LangChain-path imports, with a pointer to the LlamaIndex guide.

Both primitives verified against upstream `UiPath/uipath-llamaindex-python` source, the official docs site (`uipath.github.io/uipath-python/llamaindex/context_grounding/`), and the `travel-helper-RAG-agent` sample.

## Checker relaxation

`tests/tasks/uipath-agents/coded/llamaindex_rag/`:

- Accepts **either** documented primitive with `index_name` resolving to `"hr-policy"` (kwarg or positional, module constants resolved)
- Raw `sdk.context_grounding.search()`/`search_async()`/`unified_search*` **fails explicitly** with a diagnostic pointing at the guide — a policy decision matching the new docs, recorded in the task description
- All other assertions unchanged (framework marker, `@step` shape, `pyproject`, C4 lazy-init)

Verified against all 4 nightly artifacts (2 retriever runs → pass; 2 raw-SDK runs → still fail, now with the targeted message) plus query-engine / wrong-index / no-RAG synthetics. `/lint-task`: OK, no findings; `check-cli-verbs.py`: clean; `npm run skills:validate`: OK (no flavor overrides touch these files).

## Passing run

Local run `llamaindex-rag-local-sonnet5` (2026-08-18, coder-eval 0.8.10, `claude-code` / `claude-sonnet-5`, `experiments/default.yaml`): **SUCCESS, weighted score 1.0** (4/4 criteria), 58 turns / 224 s — vs the 08-11 nightly's 0.43 at 97 turns / 329 s. The trajectory shows the agent following the new retriever example nearly line-for-line. Note: run used a local dev `uip` build rather than npm `@uipath/cli@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)