### PR TITLE
fix(test): outcome-grade admin group-membership e2e instead of counting `members list`

### DIFF
--- a/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
+++ b/tests/tasks/uipath-admin/group_membership_management_e2e.yaml
@@ -54,13 +54,29 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # Outcome gate: read the group's final membership back from the tenant and
+  # require exactly one member — the task's stated goal ("confirm only one
+  # remains") after add-two / revoke-one. Replaces the old `members list` >=2
+  # command-count check, which graded how many times the agent TYPED the verify
+  # command rather than whether the end state was correct.
+  - type: run_command
+    description: "Group ends with exactly one member (first user retained, second revoked), read back from the tenant"
+    command: 'GROUP_NAME="Invoice Processing Team" EXPECT_MEMBERS=1 python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''verify_group_member.py''))"'
+    timeout: 90
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  # Advisory (pass_threshold 0): report that the agent self-verified via
+  # `members list`, without gating on how many times it was typed — the outcome
+  # gate above is the real verification.
   - type: command_executed
-    description: "Agent verified membership via members list (at least twice: after add and after revoke)"
+    description: "Agent self-verified membership via members list (advisory, non-gating)"
     tool_name: "Bash"
     command_pattern: 'uip\s+admin\s+groups\s+members\s+list'
-    min_count: 2
-    weight: 2.0
-    pass_threshold: 1.0
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0
 
 post_run:
   - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-admin'',''cleanup_group.py''))"'

--- a/tests/tasks/uipath-admin/verify_group_member.py
+++ b/tests/tasks/uipath-admin/verify_group_member.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Verify the marker group has at least one member after the agent added a user."""
+"""Verify a group's membership by reading it back from the live tenant.
+
+Outcome check shared by the identity group tests — grades the membership end
+state rather than trusting the agent's command string.
+
+Env:
+  GROUP_NAME      group to inspect (default: ce-identity-smoke-group, the smoke marker)
+  EXPECT_MEMBERS  if set, require EXACTLY this many members; if unset, require >=1
+"""
 
 import logging
 import os
@@ -10,36 +18,61 @@ from admin_helpers import run_cli, poll, fail, ok, first_list as _first_list
 
 logging.basicConfig(level=logging.INFO, format="verify_group_member: %(message)s")
 
-GROUP = "ce-identity-smoke-group"
+DEFAULT_GROUP = "ce-identity-smoke-group"
 
 
-def find_group():
+def find_group(name):
     data = run_cli(["admin", "groups", "list"])
     if not data or data.get("Result") != "Success":
         return None
     for g in data.get("Data", []):
-        if (g.get("Name") or g.get("name") or "") == GROUP:
+        if (g.get("Name") or g.get("name") or "") == name:
             return g
     return None
 
 
+def member_count(gid):
+    """Live member list for the group, or None when the read itself failed."""
+    data = run_cli(["admin", "groups", "members", "list", gid])
+    if not data or data.get("Result") != "Success":
+        return None
+    members = _first_list(data.get("Data"))
+    return members if members is not None else []
+
+
 def main():
-    g = poll(find_group)
+    group = os.environ.get("GROUP_NAME", DEFAULT_GROUP)
+    expect_raw = (os.environ.get("EXPECT_MEMBERS") or "").strip()
+    expect = int(expect_raw) if expect_raw else None
+
+    g = poll(lambda: find_group(group))
     if not g:
-        fail(f"group '{GROUP}' not found — setup may have failed")
+        fail(f"group '{group}' not found — setup or the agent's create step may have failed")
     gid = g.get("Id") or g.get("id")
 
-    def has_member():
-        data = run_cli(["admin", "groups", "members", "list", gid])
-        if not data or data.get("Result") != "Success":
-            return None
-        members = _first_list(data.get("Data"))
-        return members if (members and len(members) > 0) else None
+    # Poll until membership settles to the expected shape: group mutations are
+    # eventually consistent, so a just-revoked member can linger for a beat.
+    # Wrapped in a 1-tuple so a matched result is never mistaken for "not ready".
+    def settled():
+        members = member_count(gid)
+        if members is None:
+            return None  # read failed — retry
+        if expect is None:
+            return (members,) if len(members) > 0 else None
+        return (members,) if len(members) == expect else None
 
-    m = poll(has_member)
-    if not m:
-        fail(f"group '{GROUP}' has no members — agent did not add a user")
-    ok(f"group '{GROUP}' has {len(m)} member(s)")
+    result = poll(settled)
+    if result is None:
+        latest = member_count(gid)
+        actual = "unreadable" if latest is None else len(latest)
+        if expect is None:
+            fail(f"group '{group}' has no members — the add step did not take effect")
+        fail(f"group '{group}' has {actual} member(s) — expected exactly {expect} "
+             "after add-then-revoke; the membership end state is wrong")
+
+    members = result[0]
+    ok(f"group '{group}' has {len(members)} member(s), as expected"
+       + (f" (exactly {expect})" if expect is not None else " (>=1)"))
 
 
 main()


### PR DESCRIPTION
fix(test): outcome-grade admin group-membership e2e instead of counting `members list`

skill-admin-identity-group-membership failed at 0.89 because its final
criterion required `uip admin groups members list` to appear twice in the
transcript (min_count: 2). The agent produced the correct end state — created
the group, added two users, revoked the second — but listed once, so it scored
0.5 and the task FAILED. That criterion graded command typing, not the
membership outcome.

Replace it with the same outcome-grading pattern already used by the sibling
smoke: a run_command gate that reads the group's membership back from the live
tenant and asserts exactly one member remains (the task's stated goal). Keep a
members-list check as advisory (pass_threshold 0) so self-verification is still
reported without gating on how many times it was typed.

verify_group_member.py is parameterized via GROUP_NAME / EXPECT_MEMBERS env
vars; defaults preserve the smoke's existing behavior (ce-identity-smoke-group,
>=1 member) unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
