### PR TITLE
fix(maestro-bpmn): project.uiproj main wiring + IS metadata default

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -122,7 +122,9 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    expression/error mappings, retry attributes), then generate one
    `BPMNShape`/`BPMNEdge` per node and flow. For local authoring prompts, use the
    plain project layout `<ProjectName>/<ProjectName>.bpmn` with
-   `<ProjectName>/project.uiproj`; do not create `*Solution/`, package files, or
+   `<ProjectName>/project.uiproj` whose lowercase `"main"` references the BPMN
+   filename (a `project.uiproj` that does not reference the BPMN file breaks
+   packing and validation); do not create `*Solution/`, package files, or
    `.uipx` artifacts unless the user explicitly asks to package or operate the
    project.
    When adding draft or preserve-only case-management variants, include a real
@@ -150,9 +152,11 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    generated outputs, `bindings_v2.json`, and package metadata. Avoid softer
    wording such as "connection and process binding" because it hides the concrete
    artifact the CLI must supply.
-   If a local-only prompt asks for `operate.json`, `entry-points.json`,
-   `bindings_v2.json`, or `package-descriptor.json`, follow the minimal local
-   metadata shape in
+   In an Integration Service draft handoff, never hand-author `operate.json`,
+   `entry-points.json`, `bindings_v2.json`, or `package-descriptor.json` —
+   they are CLI-owned enrichment: leave them absent and name them as blockers.
+   Only when a local-only prompt explicitly asks for them (or packing requires
+   them), follow the minimal local metadata shape in
    [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
    Do not copy CLI scaffold metadata shapes into a synthetic local project.
 4. **Validate.** Run the CLI validator — it runs the full PO.Frontend canvas


### PR DESCRIPTION
## Problem

Two BPMN authoring failures in the claude 08-18 nightly ([run](https://coder-evalboard.uipath-dev.com/runs/2026-08-18_04-17-21)), both guidance gaps rather than model gaps:

1. **`skill-bpmn-script-jint-lifecycle` (0.2)** — `project.uiproj` `"main"` did not reference the .bpmn file. The wiring contract exists only in `references/shared/local-metadata-regeneration-guide.md`; the SKILL.md scaffold step names the file but not the contract. Antigravity made the identical miss in July (`operate.json main does not reference the BPMN file`, `bpmn-business-rule-task`) — multi-model evidence the top-level guidance is insufficient.
2. **`skill-bpmn-integration-service-boundary` (0.167)** — agent hand-authored `bindings_v2.json`, `entry-points.json`, `operate.json`, `package-descriptor.json`. The existing SKILL.md rule states only the conditional ("If a local-only prompt asks for … follow the minimal local metadata shape") without the default, so a local-only IS-draft prompt reads as permission.

## Fix — 2 sentences in SKILL.md, nothing else

- Scaffold step: `project.uiproj` **whose lowercase `"main"` references the BPMN filename** (breaks packing/validation otherwise).
- Metadata rule now leads with the default: **in an IS draft handoff never hand-author the four package files — leave absent, name as blockers**; the minimal-local-shape path applies only when explicitly asked or packing requires it.

No frontmatter change (no activation-gate impact), no reference or task changes.

## Verification

`run-coder-eval.yml` from this branch, `agent=claude`, on the two failing tasks — results to follow in a comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
