### PR TITLE
fix(planner): state the Activation-Mode → entry-rule mapping at the SDD write site

### DIFF
--- a/skills/uipath-planner/assets/templates/case-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/case-sdd-template.md
@@ -226,7 +226,7 @@ Every row must have Category.
 
 | # | Task Name | Type | Activation Mode | Starts When | Required | Run Only Once | Persona | SLA |
 |---|-----------|------|-----------------|-------------|----------|---------------|---------|-----|
-| 1 | <TASK_NAME> | <action \| process \| agent \| rpa \| api-workflow \| wait-for-timer \| wait-for-connector \| execute-connector-activity \| case-management> | <sequential \| parallel \| parallel-after-predecessor \| event-triggered \| adhoc \| fan-in \| conditional-gate> | <stage enters, sequential group, after tasks, connector event, etc.> | <Yes \| No> | <Yes \| No> | <persona or —> | <count unit or —> |
+| 1 | <TASK_NAME> | <action \| process \| agent \| rpa \| api-workflow \| wait-for-timer \| wait-for-connector \| execute-connector-activity \| case-management> | <sequential \| parallel \| parallel-after-predecessor \| event-triggered \| adhoc \| fan-in \| conditional-gate> | <sequential group, stage enters, after tasks, connector event, etc.> | <Yes \| No> | <Yes \| No> | <persona or —> | <count unit or —> |
 
 ##### Task <N>.<M>: <TASK_NAME>
 
@@ -237,9 +237,21 @@ Every row must have Category.
 
 **Entry Condition:**
 
+> **`Activation Mode` decides `WHEN` — pick from the mode, not from the list order.**
+> `sequential` or `parallel-after-predecessor` → **`runs-sequentially`**, on *every* task in the
+> run **including the first one**. The rule already means "stage entered" on the first task set and
+> "previous task set completed" after it, so the first task does **not** take `current-stage-entered`
+> and a follower does **not** take `selected-tasks-completed("<previous task>")`.
+> `parallel` → `current-stage-entered`. `event-triggered` → its event rule.
+> `selected-tasks-completed(...)` is for **fan-in, branch convergence, condition-result routing, or a
+> non-immediate dependency** — never for "runs after the task above it".
+> Getting this wrong is not cosmetic: every task in the stage then renders as "Runs out of sequence",
+> and a non-sequential task's completion is **not** reset when its stage is re-entered, so a
+> re-entered stage cannot re-run it.
+
 | WHEN | IF | Display Name |
 |------|-----|--------------|
-| <current-stage-entered \| selected-tasks-completed("TaskA", "TaskB") \| wait-for-connector \| adhoc \| runs-sequentially> | <conditionExpression or —> | <label or —> |
+| <runs-sequentially \| current-stage-entered \| selected-tasks-completed("TaskA", "TaskB") \| wait-for-connector \| adhoc> | <conditionExpression or —> | <label or —> |
 
 **Task envelope**
 

--- a/tests/tasks/uipath-planner/_shared/check_sequential_activation.py
+++ b/tests/tasks/uipath-planner/_shared/check_sequential_activation.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Grade the SDD's `Activation Mode` → task-entry-rule mapping.
+
+`sdd_check.py` validates that a task-entry rule is a *legal* member of the enum, so
+`current-stage-entered`, `runs-sequentially`, and `selected-tasks-completed(...)` all pass
+it equally. Legality is not intent. A plain in-order run written as
+`current-stage-entered` on the first task plus `selected-tasks-completed("<previous>")` on
+its follower compiles to the same scheduler primitives, so nothing downstream complains —
+but it is wrong in two ways that only show up later:
+
+* Studio Web renders every task in the stage as "Runs out of sequence".
+* A non-sequential task's completion is **not** reset when its stage is re-entered, so a
+  re-entered stage cannot re-run it. A sequential task's is.
+
+This checker grades the choice. Exit 1 on any violation, 0 when every ordered run uses
+`runs-sequentially`.
+
+Usage:  python3 check_sequential_activation.py [path-to-sdd]
+"""
+from __future__ import annotations
+
+import glob
+import re
+import sys
+
+# Modes whose entry rule must be `runs-sequentially`.
+SEQUENTIAL_MODES = {"sequential", "parallel-after-predecessor"}
+
+STAGE_RE = re.compile(r"^###\s+(?:Stage\s+[^:]*|Secondary Stage):\s*(.+)$")
+TASK_RE = re.compile(r"^#{4,5}\s+Task\s+[\d.]+:\s*(.+)$")
+MODE_RE = re.compile(r"^\*\*Activation Mode:\*\*\s*(.+)$")
+
+
+def find_sdd(argv: list[str]) -> str | None:
+    if len(argv) > 1:
+        return argv[1]
+    for pat in ("sdd.md", "sdd.draft.md", "*sdd*.md", "**/sdd.md", "**/sdd.draft.md", "**/*sdd*.md"):
+        hits = sorted(glob.glob(pat, recursive=True))
+        if hits:
+            return hits[0]
+    return None
+
+
+def parse_tasks(text: str) -> list[dict]:
+    """Task records in document order, each with stage, name, mode, and entry rules."""
+    tasks: list[dict] = []
+    stage: str | None = None
+    cur: dict | None = None
+    in_entry = False
+
+    for raw in text.splitlines():
+        s = raw.strip()
+
+        m = STAGE_RE.match(s)
+        if m:
+            stage, cur, in_entry = m.group(1).strip(), None, False
+            continue
+
+        m = TASK_RE.match(s)
+        if m:
+            cur = {"stage": stage, "name": m.group(1).strip(), "mode": None, "when": []}
+            tasks.append(cur)
+            in_entry = False
+            continue
+
+        if cur is None:
+            continue
+
+        m = MODE_RE.match(s)
+        if m:
+            cur["mode"] = m.group(1).strip().strip("`").lower()
+            continue
+
+        if s.startswith("**Entry Condition"):
+            in_entry = True
+            continue
+        # Any other bold field, heading, or horizontal rule closes the entry table.
+        if s.startswith("**") or s.startswith("#") or s == "---":
+            in_entry = False
+            continue
+
+        if in_entry and s.startswith("|"):
+            cells = [c.strip() for c in s.strip().strip("|").split("|")]
+            if not cells or cells[0].upper() == "WHEN":
+                continue
+            if not cells[0] or set(cells[0]) <= set("-: "):
+                continue
+            cur["when"].append(cells[0].strip("`"))
+
+    return tasks
+
+
+def rule_token(cell: str) -> str:
+    m = re.match(r"^([a-z-]+)", cell.strip().strip("`").lower())
+    return m.group(1) if m else ""
+
+
+def selected_targets(cell: str) -> list[str]:
+    return [t.strip() for t in re.findall(r'"([^"]+)"', cell)]
+
+
+def violations(tasks: list[dict]) -> list[str]:
+    """One finding per offending task, most specific message first.
+
+    A task can trip several clauses for a single mistake: a sequential follower written as
+    `selected-tasks-completed("<previous>")` both lacks `runs-sequentially` and names its
+    predecessor. Reporting each clause separately inflates the count and makes one fix look
+    like several, so the unit here is the task, not the clause.
+    """
+    out: list[str] = []
+    by_stage: dict[str, list[dict]] = {}
+    for t in tasks:
+        by_stage.setdefault(t["stage"] or "?", []).append(t)
+
+    for stage, group in by_stage.items():
+        names = [t["name"] for t in group]
+        for i, t in enumerate(group):
+            mode = t["mode"] or ""
+            rules = [rule_token(c) for c in t["when"]]
+            label = f'{stage} / {t["name"]}'
+            finding = None
+
+            # Most specific: an immediate-predecessor selector IS a sequential run,
+            # whatever the declared mode says.
+            for cell in t["when"]:
+                if rule_token(cell) != "selected-tasks-completed":
+                    continue
+                targets = selected_targets(cell)
+                if len(targets) == 1 and i > 0 and targets[0] == names[i - 1]:
+                    finding = (
+                        f'{label}: selected-tasks-completed("{targets[0]}") selects the '
+                        f"immediately previous task - that is a sequential run. Use "
+                        f"runs-sequentially; selected-tasks-completed is for fan-in, branch "
+                        f"convergence, condition routing, or a non-immediate dependency."
+                    )
+                    break
+
+            if finding is None and mode in SEQUENTIAL_MODES:
+                if "runs-sequentially" not in rules:
+                    finding = (
+                        f'{label}: Activation Mode "{mode}" but entry rule is '
+                        f'{rules or ["(none)"]}. A sequential task carries runs-sequentially, '
+                        f"including the first task in the run."
+                    )
+                elif "current-stage-entered" in rules:
+                    finding = (
+                        f"{label}: sequential task must not also carry current-stage-entered - "
+                        f"runs-sequentially already means 'stage entered' on the first task set."
+                    )
+
+            if finding:
+                out.append(finding)
+    return out
+
+
+def main(argv: list[str]) -> int:
+    path = find_sdd(argv)
+    if not path:
+        print("FAIL: no sdd.md / sdd.draft.md found", file=sys.stderr)
+        return 1
+
+    try:
+        text = open(path, encoding="utf-8").read()
+    except OSError as exc:
+        print(f"FAIL: cannot read {path}: {exc}", file=sys.stderr)
+        return 1
+
+    tasks = parse_tasks(text)
+    if not tasks:
+        print(f"FAIL: parsed zero task detail blocks from {path}", file=sys.stderr)
+        return 1
+
+    # Unfilled template text is not a design; grading it would pass vacuously.
+    if any((t["mode"] or "").startswith("<") for t in tasks):
+        print(f"FAIL: {path} still carries unfilled Activation Mode placeholders", file=sys.stderr)
+        return 1
+
+    seq = [t for t in tasks if (t["mode"] or "") in SEQUENTIAL_MODES]
+    problems = violations(tasks)
+
+    print(f"{path}: {len(tasks)} tasks, {len(seq)} in a sequential mode")
+    if not problems:
+        print("PASS: every ordered run uses runs-sequentially")
+        return 0
+
+    print(f"\nFAIL: {len(problems)} sequential-activation violation(s):", file=sys.stderr)
+    for p in problems:
+        print(f"  - {p}", file=sys.stderr)
+    print(
+        "\n  See case-sdd-template.md § Entry Condition — Activation Mode decides WHEN.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/tasks/uipath-planner/_shared/test_check_sequential_activation.py
+++ b/tests/tasks/uipath-planner/_shared/test_check_sequential_activation.py
@@ -1,0 +1,194 @@
+"""Unit tests for check_sequential_activation.py."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+CHECKER = Path(__file__).parent / "check_sequential_activation.py"
+
+
+def run(tmp_path: Path, sdd: str):
+    p = tmp_path / "sdd.md"
+    p.write_text(sdd, encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(CHECKER), str(p)],
+        capture_output=True, text=True,
+    )
+
+
+def task(name: str, mode: str, when: str, num: str = "1.1") -> str:
+    return f"""
+##### Task {num}: {name}
+
+**Type:** action
+**Activation Mode:** {mode}
+**Description:** x
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| {when} | — | — |
+
+**Task envelope**
+"""
+
+
+def stage(name: str, *tasks: str) -> str:
+    return f"\n### Stage 1: {name}\n" + "".join(tasks)
+
+
+# ---------------------------------------------------------------- passing cases
+
+def test_sequential_with_runs_sequentially_passes(tmp_path):
+    sdd = stage("Intake",
+                task("A", "sequential", "runs-sequentially", "1.1"),
+                task("B", "sequential", "runs-sequentially", "1.2"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 0, r.stderr
+    assert "PASS" in r.stdout
+
+
+def test_parallel_with_stage_entered_passes(tmp_path):
+    sdd = stage("Intake",
+                task("A", "parallel", "current-stage-entered", "1.1"),
+                task("B", "parallel", "current-stage-entered", "1.2"))
+    assert run(tmp_path, sdd).returncode == 0
+
+
+def test_parallel_after_predecessor_with_runs_sequentially_passes(tmp_path):
+    sdd = stage("Intake",
+                task("A", "sequential", "runs-sequentially", "1.1"),
+                task("B", "parallel-after-predecessor", "runs-sequentially", "1.2"),
+                task("C", "parallel-after-predecessor", "runs-sequentially", "1.3"))
+    assert run(tmp_path, sdd).returncode == 0
+
+
+def test_fan_in_selecting_two_tasks_is_allowed(tmp_path):
+    sdd = stage("Intake",
+                task("A", "sequential", "runs-sequentially", "1.1"),
+                task("B", "sequential", "runs-sequentially", "1.2"),
+                task("C", "fan-in", 'selected-tasks-completed("A", "B")', "1.3"))
+    assert run(tmp_path, sdd).returncode == 0
+
+
+def test_non_immediate_dependency_is_allowed(tmp_path):
+    """Selecting a task that is NOT the immediate predecessor is a legitimate gate."""
+    sdd = stage("Intake",
+                task("A", "sequential", "runs-sequentially", "1.1"),
+                task("B", "sequential", "runs-sequentially", "1.2"),
+                task("C", "conditional-gate", 'selected-tasks-completed("A")', "1.3"))
+    assert run(tmp_path, sdd).returncode == 0
+
+
+def test_event_triggered_task_is_not_graded(tmp_path):
+    sdd = stage("Intake", task("A", "event-triggered", "wait-for-connector", "1.1"))
+    assert run(tmp_path, sdd).returncode == 0
+
+
+# ---------------------------------------------------------------- failing cases
+
+def test_first_sequential_task_with_stage_entered_fails(tmp_path):
+    """The observed defect: first task of a sequential run takes current-stage-entered."""
+    sdd = stage("Intake",
+                task("A", "sequential", "current-stage-entered", "1.1"),
+                task("B", "sequential", "runs-sequentially", "1.2"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "including the first task" in r.stderr
+
+
+def test_follower_selecting_immediate_predecessor_fails(tmp_path):
+    """The other observed defect: selected-tasks-completed on the task directly above."""
+    sdd = stage("Intake",
+                task("A", "sequential", "runs-sequentially", "1.1"),
+                task("B", "sequential", 'selected-tasks-completed("A")', "1.2"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "immediately previous task" in r.stderr
+
+
+def test_sequential_carrying_both_rules_fails(tmp_path):
+    sdd = f"""
+### Stage 1: Intake
+
+##### Task 1.1: A
+
+**Type:** action
+**Activation Mode:** sequential
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| runs-sequentially | — | — |
+| current-stage-entered | — | — |
+
+**Task envelope**
+"""
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "must not also carry current-stage-entered" in r.stderr
+
+
+def test_sequential_with_no_entry_rule_fails(tmp_path):
+    sdd = "\n### Stage 1: Intake\n" + """
+##### Task 1.1: A
+
+**Type:** action
+**Activation Mode:** sequential
+
+**Task envelope**
+"""
+    assert run(tmp_path, sdd).returncode == 1
+
+
+def test_counts_every_violation_not_just_the_first(tmp_path):
+    sdd = stage("Intake",
+                task("A", "sequential", "current-stage-entered", "1.1"),
+                task("B", "sequential", 'selected-tasks-completed("A")', "1.2"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "2 sequential-activation violation(s)" in r.stderr
+
+
+def test_violations_span_multiple_stages(tmp_path):
+    sdd = (stage("Intake", task("A", "sequential", "current-stage-entered", "1.1"))
+           + "\n### Stage 2: Closing\n"
+           + task("Z", "sequential", "current-stage-entered", "2.1"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "2 sequential-activation violation(s)" in r.stderr
+
+
+# ---------------------------------------------------------------- guard cases
+
+def test_unfilled_template_fails_rather_than_passing_vacuously(tmp_path):
+    sdd = stage("Intake", task("<TASK_NAME>", "<sequential \\| parallel>", "<current-stage-entered>", "1.1"))
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "placeholder" in r.stderr
+
+
+def test_no_tasks_fails(tmp_path):
+    r = run(tmp_path, "# Design\n\nNo stages here.\n")
+    assert r.returncode == 1
+    assert "zero task detail blocks" in r.stderr
+
+
+def test_missing_file_fails(tmp_path):
+    r = subprocess.run(
+        [sys.executable, str(CHECKER), str(tmp_path / "nope.md")],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 1
+
+
+def test_secondary_stage_heading_is_parsed(tmp_path):
+    sdd = "\n### Secondary Stage: Escalation\n" + task("A", "sequential", "current-stage-entered", "1.1")
+    r = run(tmp_path, sdd)
+    assert r.returncode == 1
+    assert "Escalation" in r.stderr

--- a/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
+++ b/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
@@ -65,6 +65,19 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
+    description: >
+      ordered work is authored as runs-sequentially — a plain in-order run must not be
+      written as current-stage-entered on the first task or
+      selected-tasks-completed("<previous>") on its follower. Both are legal enum values
+      and pass the shape check, so nothing else catches this; the result renders as
+      "Runs out of sequence" and its completion is not reset when the stage re-enters.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-planner/_shared/check_sequential_activation.py"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
     description: "design declares all 4 exception lanes"
     command: "cat *sdd*.md 2>/dev/null | grep -Eiq 'customer comms' && cat *sdd*.md 2>/dev/null | grep -Eiq 'escalation' && cat *sdd*.md 2>/dev/null | grep -Eiq 'withdrawn' && cat *sdd*.md 2>/dev/null | grep -Eiq 'rejected'"
     timeout: 10


### PR DESCRIPTION
Ordered work is still authored as out-of-sequence rules. This is the **fourth** change against that defect, and the first one with a measurement attached — which is the part worth reviewing.

> ### ⚠️ No `gpt-5.6-terra` data in this PR
>
> Everything below is `claude-sonnet-5` only. The codex workspace ran **out of credits** partway through (`CodexErrorInfoValue.usage_limit_exceeded`), and two attempts at the terra arm returned zero usable replicates.
>
> This matters for how you read the numbers. Terra reads ~3 files per run against sonnet's ~38, and the constraint being tested sits 62 lines from the write site — so terra should be **worse**, not better. **Sonnet is the ceiling model here and it still failed 7/10.** The fast-model rate is unmeasured and expected to be higher. I would rather state that than let a sonnet-only result imply full coverage.

## Prior art — please read this before the diff

@abhiram-vad has already merged three changes at this defect:

| | |
|---|---|
| #2178 | document sequential task entry normalization |
| #2215 | fixed sequential tasks and manual trigger tasks routing in phase 0 |
| #2392 | `parallel-after-predecessor` task-set placement and adhoc dependency guards |

The rule they produced is correct and is on main today, in `case-sdd-template.md` (via #2431) and three more times in `uipath-maestro-case`:

> Sequential work uses `runs-sequentially` on every task in the ordered task-set run, **including the first task**.

I am not proposing a different rule. The rule is right. **It is not being followed**, and until now nobody had measured how often.

## The measurement

`case_design_loan` / `loan_origination`, `claude-sonnet-5`, N=10 per arm, same base commit, same fixture, graded at artifact level:

| | before | after |
|---|---|---|
| designs with ≥1 violation | **7/10** | **2/10** |
| total violations | **21** | **3** |
| — first task → `current-stage-entered` | 10 | **0** |
| — follower → `selected-tasks-completed("<prev>")` | 11 | **3** |

Fisher exact, two-tailed: **tasks `p=0.00012`** · designs `p=0.070`.

Per-design counts, which show the dispersion better than any mean:

```
before  [6, 0, 1, 1, 3, 1, 2, 0, 0, 7]
after   [2, 0, 0, 0, 0, 0, 1, 0, 0, 0]
```

Instrument asserted per replicate before any artifact was read — `agent_config.plugins` populated (skill actually installed) and `total_assistant_turns > 2` (model actually ran). 20/20 valid.

## Why a correct rule was not being followed

Geometry, not comprehension. In the template the model is filling in:

| line | what the model writes | what is adjacent to it |
|---|---|---|
| 172 | — | **the rule** — in a section-level bullet list |
| 221 | `Starts When` free text | example led with **"stage enters"** |
| 226 | `Activation Mode:` | enum led with `sequential` ✅ |
| 234 | `WHEN` cell | enum led with **`current-stage-entered`**, `runs-sequentially` **last** |

The model got `Activation Mode` right in 31 of 35 tasks. It then filled the `WHEN` cell 62 lines away from the rule, where the first plausible token was the wrong answer and the nearby example pointed the same way.

That is consistent with a separate controlled experiment on this repo (same constraint, byte-identical, only its position varied, terra, N=10/arm): absent **1/10**, one section away **6/10**, in the write-site block **10/10**. A distant rule is partially effective, which is exactly what "correct rule, 7/10 compliance" looks like.

## The change

**Template** — the `Activation Mode → WHEN` mapping now sits *inside* the Entry Condition block, names both observed failure modes explicitly, and states the consequence: the stage renders as "Runs out of sequence", and a non-sequential task's completion is **not** reset when its stage is re-entered, so a re-entered stage cannot re-run it. The `WHEN` enum and the `Starts When` example are reordered to lead with the sequential form.

**The gate that did not exist.** `sdd_check.py:56` puts `current-stage-entered` and `runs-sequentially` in the same `TASK_ENTRY` legality set, so both pass and *intent* is never graded. `_shared/check_sequential_activation.py` grades the choice — 16 unit tests, wired into `loan_origination` at weight 2.0.

That absence is the through-line with the last three attempts: each added prose, none added a check, and the defect survived all three. This one adds the check.

## What this does NOT fix — please push back here

**Placement fixed only the half that was a placement problem.**

- **Mode 1** (first task → `current-stage-entered`): **10 → 0**. An ordering artifact, and reordering removed it.
- **Mode 2** (follower → `selected-tasks-completed("<previous>")`): **11 → 3**. These three survived an explicit prohibition *in the same table the model was filling*.

Mode 2 is not an attention failure. `selected-tasks-completed("Calculate Risk and Collateral LTV")` names its predecessor and **reads more rigorous** than an implicit positional rule. The model is choosing a wrong answer for a defensible reason, and proximity does not fix a reasoning preference. More prose probably will not either — the remaining lever is the checker as a hard gate, or letting `runs-sequentially` carry the predecessor name so the precise-looking option is also the correct one. I did not attempt that here.

## Other limits, stated rather than omitted

- **Design-level `p=0.070` is directional, not significant** at N=10. The task-level number is the finding. 7/10 → 2/10 looks more conclusive than it is.
- **The fixture never says "then"/"after"/"in order"** — ordering is implied by stage semantics, so a defender could call some of those tasks legitimately parallel. That makes the measured rate a **lower bound**.
- **Design-lane only.** This stops at `sdd.draft.md`. It does not demonstrate propagation into `tasks.md` / `caseplan.json` — though since Rule 6 makes an explicit SDD entry rule authoritative and Phase 1 is forbidden from rewriting it, the SDD is where the choice is decided.
- The ticket that prompted this cites `sdd-generation-rules.md` and a 7-column task table. Neither exists on main — the file is now `case-authoring-rules-guide.md` and the table has 9 columns including `Activation Mode` and `Starts When`. Two of its three stated root causes are stale; only the rule-selection bias reproduced.

## Checks

`pytest tests/tasks/uipath-planner/` → **71 passed** · `skills:validate` clean (26 skills, default + studioweb) · `check-cli-verbs` OK (catalog uip 1.201.0-dev.8272) · rebases onto current main with no conflict.

## Reviewers

@abhiram-vad @RaduAna-Maria — `skills/uipath-planner/` is yours per CODEOWNERS:77, and @abhiram-vad owns the three prior attempts, so I would particularly value your read on whether the mode-2 residual is worth a follow-up or whether the checker is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
