### PR TITLE
fix(maestro-flow): decouple two flow criteria from the solution directory name

### DIFF
--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -67,9 +67,13 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
+  # Discover the flow file — the prompt names only the FLOW, never the enclosing
+  # solution, so a hardcoded `<Name>/<Name>/<Name>.flow` would grade the solution
+  # directory's name (an unstated requirement) and score 0.0 on a valid flow built
+  # at e.g. `EscalationJiraTicketSolution/EscalationJiraTicket/`.
   - type: run_command
     description: "Generated EscalationJiraTicket Flow validates without errors"
-    command: "uip maestro flow validate EscalationJiraTicket/EscalationJiraTicket/EscalationJiraTicket.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 180
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -27,12 +27,13 @@ from __future__ import annotations
 
 import glob
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, NoReturn
 
-
-FLOW_GLOB = "CustomerEscalation/CustomerEscalation/CustomerEscalation.flow"
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+from _shared.flow_check import find_project_dir  # noqa: E402
 
 
 def fail(msg: str) -> NoReturn:
@@ -40,9 +41,22 @@ def fail(msg: str) -> NoReturn:
 
 
 def load_flow() -> dict[str, Any]:
-    matches = glob.glob(FLOW_GLOB)
+    # Discover the Flow project rather than hardcoding
+    # `CustomerEscalation/CustomerEscalation/CustomerEscalation.flow`: the prompt
+    # names only the FLOW ('a Maestro Flow called "CustomerEscalation"'), never
+    # the enclosing solution, and the two names are independent — `uip solution
+    # init <S> && cd <S> && uip maestro flow init <F>` yields `<S>/<F>/<F>.flow`
+    # for any <S>, while a bare `uip maestro flow init <F>` auto-scaffolds
+    # `<F>Solution/<F>/<F>.flow`. A path-pinned glob graded the solution name,
+    # an unstated requirement: skill-flow-customer-escalation scored 0.0 on this
+    # criterion with a fully valid flow at
+    # `CustomerEscalationSolution/CustomerEscalation/CustomerEscalation.flow`.
+    # Mirrors the discovery in `_shared/validate_flow.py`, so this criterion and
+    # the validate criterion address the same file.
+    project_dir = find_project_dir()
+    matches = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
     if not matches:
-        fail(f"No flow file matching {FLOW_GLOB}")
+        fail(f"No .flow file found under {project_dir}")
     path = Path(matches[0])
     try:
         return json.loads(path.read_text())

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
@@ -11,6 +11,8 @@ These tests pin down the contract that:
 - Structural requirements (>=5 nodes, exactly one decision with >=2
   branches, >=2 scripts, Slack reference, non-trigger Outlook/Graph
   reference) are still enforced.
+- The verdict is independent of the enclosing SOLUTION directory's name,
+  which the prompt never specifies (see `test_any_solution_name_passes`).
 """
 
 from __future__ import annotations
@@ -21,21 +23,45 @@ import sys
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 
 CHECKER = Path(__file__).resolve().parent / "check_customer_escalation_flow.py"
 Node = dict[str, Any]
 Edge = dict[str, Any]
 
 
-def _flow_dir(tmp_path: Path) -> Path:
-    d = tmp_path / "CustomerEscalation" / "CustomerEscalation"
+def _flow_dir(tmp_path: Path, solution: str = "CustomerEscalationSolution") -> Path:
+    """Scaffold the real on-disk layout: `<Solution>/<Flow>/<Flow>.flow`.
+
+    The solution name defaults to something DIFFERENT from the flow name on
+    purpose. `uip maestro flow init` never produces a single-nested
+    `CustomerEscalation/CustomerEscalation/` tree — bare init auto-scaffolds
+    `CustomerEscalationSolution/`, and solution-first init lets the two names
+    diverge freely. A fixture pinned to `<Flow>/<Flow>/` kept these tests green
+    against a layout the CLI cannot emit, which is why the checker's
+    path-coupling survived to fail a real run.
+
+    `project.uiproj` is required: `find_project_dir` selects the project whose
+    manifest declares `ProjectType: "Flow"`.
+    """
+    d = tmp_path / solution / "CustomerEscalation"
     d.mkdir(parents=True)
+    (d / "project.uiproj").write_text(
+        json.dumps({"Name": "CustomerEscalation", "ProjectType": "Flow"})
+    )
     return d
 
 
-def _write_flow(tmp_path: Path, nodes: list[Node], edges: list[Edge]) -> None:
+def _write_flow(
+    tmp_path: Path,
+    nodes: list[Node],
+    edges: list[Edge],
+    solution: str = "CustomerEscalationSolution",
+) -> None:
     payload = {"version": "1.0.0", "nodes": nodes, "edges": edges}
-    (_flow_dir(tmp_path) / "CustomerEscalation.flow").write_text(json.dumps(payload))
+    flow_dir = _flow_dir(tmp_path, solution)
+    (flow_dir / "CustomerEscalation.flow").write_text(json.dumps(payload))
 
 
 def _run(cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -106,6 +132,24 @@ def test_outlook_connector_happy_path_passes(tmp_path: Path) -> None:
     """The original IS-connector shape (Tier 1) should still PASS."""
     nodes, edges = _outlook_connector_shape()
     _write_flow(tmp_path, nodes, edges)
+    result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "solution",
+    ["CustomerEscalationSolution", "CustomerEscalation", "AcmeEscalations", "Sol-9QX2"],
+)
+def test_any_solution_name_passes(tmp_path: Path, solution: str) -> None:
+    """The enclosing solution's name must not affect the verdict.
+
+    The prompt names only the flow, so grading the solution directory would
+    grade an unstated requirement. Covers bare-init auto-scaffold
+    (`<Flow>Solution`), the matching name, and two names the prompt never
+    implies.
+    """
+    nodes, edges = _outlook_connector_shape()
+    _write_flow(tmp_path, nodes, edges, solution=solution)
     result = _run(tmp_path)
     assert result.returncode == 0, result.stdout + result.stderr
 


### PR DESCRIPTION
## Problem

`skill-flow-customer-escalation` scored **0.333** on a flow that was completely correct.

The structural criterion hardcoded a path that pins the **solution** directory name:

```python
FLOW_GLOB = "CustomerEscalation/CustomerEscalation/CustomerEscalation.flow"
```

The agent built `CustomerEscalationSolution/CustomerEscalation/CustomerEscalation.flow`, so the glob missed and the criterion failed on the path alone:

```
FAIL: No flow file matching CustomerEscalation/CustomerEscalation/CustomerEscalation.flow
```

The prompt says only `Build a Maestro Flow called "CustomerEscalation"` — it never names a solution. The checker was grading an unstated requirement. Meanwhile the sibling validate criterion, already on `_shared/validate_flow.py`, found the same file and reported `Status: "Valid"`.

This is exactly the bug class `_shared/validate_flow.py` was written to kill in #2213 (after `skill-flow-loop-multiply` lost a criterion the same way). Its own docstring spells it out: `uip maestro flow init <F>` auto-scaffolds `<F>Solution/<F>/<F>.flow`, and solution-first init lets the two names diverge freely. That fix landed on the **validate** criteria only — the structural checkers were never migrated.

## Changes

**`check_customer_escalation_flow.py`** — drop `FLOW_GLOB` for `find_project_dir()`, mirroring `validate_flow.py` so both criteria address the same file. Also inherits husk/multi-project handling a raw glob can't do.

**`test_check_customer_escalation_flow.py`** — the reason CI never caught this. The fixture built `CustomerEscalation/CustomerEscalation/`, a layout the CLI **cannot emit**, so the suite stayed green against an impossible tree while the checker could never find a real agent's output. Now scaffolds the true `<Solution>/<Flow>/` shape with a deliberately *mismatched* solution name plus the `project.uiproj` discovery requires, and adds `test_any_solution_name_passes` across four solution names (bare-init `<Flow>Solution`, the matching name, and two the prompt never implies).

**`escalation_jira_ticket.yaml`** — same defect, still latent, weight 3.0. Its prompt names only the flow (the sole "solution" mention in the file is an unrelated cleanup command), yet the criterion ran `uip maestro flow validate EscalationJiraTicket/EscalationJiraTicket/EscalationJiraTicket.flow`. Swapped to `validate_flow.py`. Its structural sibling `check_escalation_jira_ticket.py` was already safe (`glob.glob("**/*.flow", recursive=True)`).

## Verification

- Fixed checker against the **preserved failing artifact**: `PASS: 10 nodes, 3 scripts, decision with 2 branches, Slack and Outlook reply references present`, exit 0. Every structural assertion was already satisfied — the path was the sole failure.
- New regression case confirmed to **fail against the pre-fix checker** (`git show origin/main:` copy run on the realistic layout → `FAIL: No flow file matching …`).
- `pytest tests/tasks/uipath-maestro-flow/` → **185 passed** (what CI runs).
- `scripts/check-task-driver.py tests/tasks` → clean.

## Scope note — what was deliberately left alone

I audited every hardcoded path under `tests/tasks/uipath-maestro-flow`. The rest are legitimate: their **own prompt pins the layout**, so there the path *is* the assertion and loosening it would weaken the test.

| Location | Why it stays |
|---|---|
| `e2e/check_devcon_expense_approval.py` | prompt: "in a solution of the same name" |
| `e2e/escalation_orchestrator_paths.yaml`, `escalation_slack_alert.yaml` | prompt: "(inside a solution of the same name)" |
| `evaluate/inline_agent_eval`, `local_crud.yaml`, `simulation/simulation_crud.yaml` | prompt: "MUST live at `<S>/<F>/<F>.flow`" |
| `smoke/init_validate.yaml`, `inline_agent_robust.yaml` | prompt states the exact path |
| `smoke/check_merge_parallel_sync_flow.py` | prompt pins it, and it already globs `**/` with the literal only as a tiebreak — the right defensive shape |
| `interactive/solution_select.yaml` | `WeatherSelection-7K4M` is dictated via simulated user turns; the unguessable suffix *is* the assertion |

All other flow checkers (delay, transform ×3, scheduled_trigger, connector_features, edit ×4, single_node ×7, billing ×3, calculator) already use `**/` globs or `find_project_dir`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
