### PR TITLE
fix(maestro-flow): correct the IxP get-taxonomy invocation and scaffold fixture [RE-13252]

### DIFF
--- a/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
+++ b/skills/uipath-maestro-flow/references/author/references/plugins/ixp/impl.md
@@ -301,10 +301,10 @@ Studio Web's variable picker renders `output.ExtractionResult` as opaque and doe
 The `FieldName` values present in `ResultsDocument.Fields[]` depend on the trained IxP model's taxonomy and are NOT exposed through `uip maestro flow registry get` (the registry's `outputDefinition.output.schema` describes the wrapper envelope shape, not the per-model trained fields). Get them from the deployment:
 
 ```bash
-uip ixp deployments get-taxonomy --folder-key <folderKey> "<modelName>" --output json
+uip ixp deployments get-taxonomy "<project-name>" --version <N> --output json
 ```
 
-Both args come from the `registry get` response you already fetched in [Build procedure](#build-procedure--copy-from-registry-get-do-not-construct-from-memory): `--folder-key` ← `Data.Node.inputDefaults.folderKey`; `<modelName>` (positional) ← `Data.Node.inputDefaults.modelName`. No additional discovery step. Requires `uip login`; the command uses the user Bearer to call the same DU-App route that Studio Web's "Schema definition" panel uses.
+The positional is a project name from `uip ixp projects list`, and `--version` is required — get it from `uip ixp projects list-models "<project-name>"`. `Data.Node.inputDefaults.modelName` is frequently NOT a project name; passing it returns 404 `ProjectNotFoundError`, which is an ordinary outcome, not a problem to debug. Requires `uip login`; the command uses the user Bearer to call the same DU-App route that Studio Web's "Schema definition" panel uses.
 
 Response shape:
 
@@ -335,14 +335,14 @@ Agent call sequence:
 
 1. `uip maestro flow registry search "uipath.ixp" --output json` — list IxP nodes.
 2. `uip maestro flow registry get "<node-type>" --output json` — read `Data.Node.inputDefaults.{folderKey, modelName}` (already done as part of [Build procedure](#build-procedure--copy-from-registry-get-do-not-construct-from-memory)).
-3. `uip ixp deployments get-taxonomy --folder-key <folderKey> "<modelName>" --output json` — read `documentTaxonomy.documentTypes[].fields[].fieldName`.
+3. `uip ixp deployments get-taxonomy "<project-name>" --version <N> --output json` — read `documentTaxonomy.documentTypes[].fields[].fieldName`.
 4. Author downstream consumers with `$vars.<id>.output.ExtractionResult.ResultsDocument.Fields.find(f => f.FieldName === '<fieldName from step 3>')?.Values?.[0]`.
 
-If the command fails (login expired, deployment not yet published, transient failure), fall back to defensive `find`-by-`FieldName` patterns with assumed field names and surface the assumptions to the user under **Open Questions**. Do NOT substitute a one-off extraction or IxP-product-UI inspection in the agent loop — `get-taxonomy` is the agent-loop path.
+If the command fails (no matching project, login expired, deployment not yet published, transient failure), fall back to defensive `find`-by-`FieldName` patterns with assumed field names and surface the assumptions to the user under **Open Questions**. **One attempt** — a 404 or validation error will not resolve by reissuing the lookup under another spelling of the name, so do not iterate on name variants. Do NOT substitute a one-off extraction or IxP-product-UI inspection in the agent loop — `get-taxonomy` is the agent-loop path.
 
 ## Landing the node when you cannot fully configure it
 
-**The extraction step must ALWAYS land a node — never drop it because configuration is incomplete.** A greenfield/exploration turn, an unwired upstream, a "you don't need a working flow" instruction, or an unconfirmed model are NOT reasons to skip it. The common failure is landing the steps around extraction while the extraction node itself goes missing.
+**The extraction step must ALWAYS land a node — never drop it because configuration is incomplete.** A greenfield/exploration turn, an unwired upstream, a "you don't need a working flow" instruction, or an unconfirmed model are NOT reasons to skip it. The common failure is landing the steps around extraction while the extraction node itself goes missing. Author it before the trigger and connector nodes — connector configuration branches open-endedly, and this is the node the request is about.
 
 - **Model published** (`registry search "uipath.ixp"` returns entries) → land the real `uipath.ixp.*` node. When you can't finish configuring it this turn, still build the instance from `registry get` (copy `inputs.model` and the fixed `outputs` literal — no user input needed), set `inputs.fileRef` to a placeholder expression, and defer the model choice, `fileRef` source, and taxonomy to **Open Questions**. Do NOT downgrade to `core.logic.mock` — a published model exists, so land the real node.
 - **No model published** (`Data: []`) → land a `core.logic.mock` placeholder per [If the Model Does Not Exist Yet](#if-the-model-does-not-exist-yet).

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -16,13 +16,16 @@ description: >
 
   Validate-only: no `uip maestro flow debug`.
 
+  The prompt names the document domain, not a model or bucket: resolving it is
+  the behaviour under test, so do not name either here.
+
 tags: [uipath-maestro-flow, integration, mode:build, lifecycle:generate, shape:multi-node, node:ixp]
 initial_prompt: |
   Create a flow called "ReceiptIntake" with a manual trigger, an extractor
   node, and add three script nodes named `postReceipt`, `sendToValidation`,
   and `logError`. Wire all three scripts to consume the extraction result —
-  two off the success output, one off the error output. Document is in the
-  storage bucket named: ReceiptBucket. Model used: Receipt Model. Each of
+  two off the success output, one off the error output. Document: a PDF receipt,
+  supplied to the extractor node as the flow's document input. Each of
   the three script nodes logs OK when it receives its respective extraction
   result.
 


### PR DESCRIPTION
The IxP plugin told agents to run a `get-taxonomy` command that cannot succeed. `impl.md` documented `--folder-key <folderKey> "<modelName>"`, but the CLI takes a project name as its only positional and requires `--version`, and has no `--folder-key` option at all. Agents followed the doc, hit a hard `ValidationError`, and escalated into name-variant probing instead of authoring the extraction node — on `integration_handle_routing`, 37 of 50 commands went on that hunt and the flow was killed carrying nothing but its scaffolded trigger.

Separately, `scaffold_multinode.yaml` named two resources that do not exist on the eval tenant: `registry search "Receipt Model"` returns `Data: []`, and no bucket matches `Receipt` among the 39 published. Agents spent the run looking for them.

Five IxP rows failed in `2026-08-18_04-17-21` (claude-sonnet-5), all as turn timeouts with zero criteria evaluated. The defect is model-independent — codex hits the identical error but recovers in 2-3 commands, which is why the codex-scheduled runs stayed green.

**What changed**

- Corrected the `get-taxonomy` invocation, and noted that a node's `inputDefaults.modelName` frequently is not a project name, so the resulting 404 is expected rather than something to debug.
- Capped the lookup at one attempt. Field names are only a refinement: the `find`-by-`FieldName` shape already returns `undefined` on a wrong guess, so it never gates authoring.
- Author the extraction node before the trigger and connector nodes — connector configuration branches open-endedly, and extraction is the node the request is about.
- `scaffold_multinode.yaml` now names the document domain instead of a model and bucket, matching `scaffold_minimal.yaml`. The resolved node type stays undisclosed, so domain-to-model resolution is still the behaviour under test. **Assertions are unchanged.**

**Verification** — three runs of the three affected rows on `claude-sonnet-5` via `Run Coder Eval`, 0/3 before, 6/9 after:

| Row | run 1 | run 2 | run 3 | before |
|---|---|---|---|---|
| `scaffold_multinode` | PASS 297s | PASS 500s | PASS 197s | ERROR 903s |
| `integration_handle_routing` | PASS 857s | PASS 644s | ERROR 904s | ERROR 903s |
| `e2e_01_invoice_extraction_greenfield` | PASS 1027s | ERROR 1204s | ERROR 1205s | ERROR 1204s |

The syntax fix is confirmed working in the runs: `get-taxonomy "<model-name>" --version N` returns 404 as the doc now predicts, and the same call against a real project name succeeds.

**Known-remaining, not fixed here.** `integration_handle_routing` and `e2e_01` are still flaky, and their passing attempts land at 857s and 1027s against 900s and 1200s caps — the agent is finishing the work, just not reliably inside the budget. That looks like a timeout adjustment rather than more guidance (cf. `test(bpmn): raise turn_timeout on three builds killed by the 900s default`), so I have left the yaml limits alone for a separate change.

Also unresolved and worth a look by someone with a live tenant: `impl.md` documents the taxonomy response as `documentTaxonomy.documentTypes[].fields[].fieldName`, but `skills/uipath-ixp/references/cli-reference.md` and the captured run output both show `Data.dataset.{entity_defs, label_groups}` in snake_case. That predates this PR and I could not verify it — my CLI login is expired — so I have not touched it.

RE-13252
