### PR TITLE
test(maestro-flow): scope file-attachment output match to declared out vars

### DIFF
--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/check_file_attachment_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/check_file_attachment_flow.py
@@ -4,13 +4,37 @@
 uploaded it and the flow surfaced the file's name as output.
 
 The attachment filename is generated here at check time with a random token the
-agent never saw, so the only way it can appear in the flow output is if the
-attachment was actually uploaded, resolved to a Flow Attachment object, read by
-the Script node, and mapped to an output variable — i.e. the full
-``--attachment`` path works end to end. An agent that hardcodes a filename
-literal cannot pass.
+agent never saw, so it can only reach a declared OUTPUT variable if the
+attachment was actually uploaded, resolved to a Flow Attachment object, read via
+``.FullName``, and mapped out — i.e. the full ``--attachment`` path works end to
+end. An agent that hardcodes a filename literal cannot pass.
+
+Node-shape agnostic on purpose. The feature under test is the ``--attachment``
+binding and ``file``-variable hydration, not any particular node: the skill
+documents reading a hydrated ``file`` variable BOTH in a Script node body and
+directly in an End node's ``outputs.<varId>.source`` via ``=js:`` (see
+``references/shared/node-output-wiring.md`` — End nodes). Both surface
+``.FullName``, so pinning ``core.action.script`` rejected a correct two-node
+``trigger -> End`` flow that the skill itself steers agents toward.
+
+Scoping the match to the flow's ``out`` globals is what keeps the check honest,
+and it is NOT interchangeable with :func:`assert_outputs_contain`. That helper
+flattens every global — including the ``in`` file variable, whose runtime value
+IS the attachment object carrying ``FullName``. Matching the basename against
+that set is a tautology: it passes whenever a file uploads at all, even for a
+flow that outputs a hardcoded literal or nothing. Verified against a live
+tenant — a flow whose End node mapped ``fileName`` to the literal
+``"sample-report.txt"`` still "passed", because the runtime globals were::
+
+    {"start.output.inputDoc": {"ID": ..., "FullName": "evidence-<rand>.txt", ...},
+     "fileName": "sample-report.txt"}
+
+:func:`assert_named_output_contains` scopes to one declared output global — the
+value a downstream consumer actually receives — so the input echo cannot satisfy
+it. Do not "simplify" this back to a whole-payload match.
 """
 
+import json
 import os
 import sys
 import tempfile
@@ -18,24 +42,45 @@ import uuid
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
-    assert_flow_has_node_type,
-    assert_outputs_contain,
+    assert_named_output_contains,
     find_project_dir,
     read_flow_file_input_vars,
     run_debug,
 )
 
 
-def main():
-    # A Script node must read the attachment — prevents echoing a hardcoded literal.
-    assert_flow_has_node_type(["core.action.script"])
+def read_flow_out_vars(project_dir: str) -> list[str]:
+    """Return the ids of ``direction:"out"`` globals declared on the first
+    ``.flow`` file in ``project_dir`` — the variables a caller receives.
 
+    Local rather than shared: the mirror-image ``read_flow_file_input_vars``
+    lives in ``_shared``, but only this task needs the out-side view, and
+    keeping it here avoids widening the shared surface for one caller.
+    """
+    import glob
+
+    flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+    if not flows:
+        sys.exit(f"FAIL: No .flow file found under {project_dir}")
+    with open(flows[0]) as f:
+        flow = json.load(f)
+    variables = flow.get("variables") or flow.get("workflow", {}).get("variables") or {}
+    return [v["id"] for v in (variables.get("globals") or []) if v.get("direction") == "out"]
+
+
+def main():
     project_dir = find_project_dir()
     file_vars = read_flow_file_input_vars(project_dir)
     if not file_vars:
         sys.exit(
             "FAIL: No file-typed input variable (direction:'in', type:'file') "
             "found in the flow — nothing to bind an --attachment to."
+        )
+    out_vars = read_flow_out_vars(project_dir)
+    if not out_vars:
+        sys.exit(
+            "FAIL: No output variable (direction:'out') found in the flow — "
+            "nothing for the attachment's file name to surface through."
         )
 
     # Unique basename the agent could not have hardcoded.
@@ -51,9 +96,26 @@ def main():
 
     # The runtime resolves a file attachment to {ID, FullName, MimeType, Metadata};
     # FullName is the uploaded file's basename. A passing flow reads it and surfaces
-    # it as an output variable.
-    assert_outputs_contain(payload, basename)
-    print(f"OK: Script node present; flow completed; output surfaced attachment FullName {basename!r}")
+    # it through a declared `out` variable — scoped per-variable so the `in`
+    # attachment object's own FullName cannot satisfy the match (see module docstring).
+    if len(out_vars) == 1:
+        assert_named_output_contains(payload, out_vars[0], basename)
+    else:
+        # Multiple declared outputs: the name must land in at least one of them.
+        for name in out_vars:
+            try:
+                assert_named_output_contains(payload, name, basename)
+                break
+            except SystemExit:
+                continue
+        else:
+            sys.exit(
+                f"FAIL: attachment FullName {basename!r} did not appear in any "
+                f"declared output variable {out_vars}."
+            )
+    print(
+        f"OK: flow completed; output variable surfaced attachment FullName {basename!r}"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -1,13 +1,15 @@
 task_id: skill-flow-file-attachment-debug
 description: >
   Build a Flow whose trigger exposes a file-typed input variable, read the
-  uploaded attachment in a Script node, and surface its file name as flow
-  output. Then verify the operate path: `uip maestro flow debug
-  --attachment <varId>=<localPath>` uploads the local file, the runtime
-  resolves it to a Flow Attachment object ({ID, FullName, MimeType, Metadata}),
-  and the flow completes. The checker binds a randomly-named local file the
-  agent never saw and asserts that name appears in the output — proving the
-  attachment actually flowed through, not a hardcoded literal.
+  uploaded attachment's name, and surface it as flow output. Any node shape the
+  skill sanctions is acceptable — a Script node body or the End node's
+  `outputs.<varId>.source` `=js:` binding both resolve `.FullName`. Then verify
+  the operate path: `uip maestro flow debug --attachment <varId>=<localPath>`
+  uploads the local file, the runtime resolves it to a Flow Attachment object
+  ({ID, FullName, MimeType, Metadata}), and the flow completes. The checker binds
+  a randomly-named local file the agent never saw and asserts that name appears
+  in the output — proving the attachment actually flowed through, not a
+  hardcoded literal.
 tags: [uipath-maestro-flow, e2e, mode:operate, lifecycle:generate, shape:single-node]
 
 agent:


### PR DESCRIPTION
## Problem

`skill-flow-file-attachment-debug` fails at `weighted_score: 0.500`:

```
FAIL: No node matches type hint 'core.action.script'.
Node types seen: ['core.control.end', 'core.trigger.manual']
```

Chasing that surfaced **two** bugs in `check_file_attachment_flow.py`, the first masking the second.

### 1. An off-target node-shape gate

The checker opened with `assert_flow_has_node_type(["core.action.script"])` — but nothing asks the agent for a Script node. `a62c33fd8` ("relax file-attachment prompt to goal-level") deleted the prompt bullet that required one:

```
- A Script node reads the attachment from the trigger output and returns the
  file name, e.g. `return { fileName: $vars.<triggerId>.output.inputDoc.FullName };`
```

Its message says *"Checker is unaffected (discovers the file-typed var dynamically, matches the random filename anywhere in output)"* — accounting for the two dynamic assertions but missing this static gate above them. The task passed on luck for three months until an agent took the shorter route.

The rejected flow is correct per the skill. Its End node carries:

```json
"outputs": { "fileName": { "source": "=js:$vars.start.output.inputDoc.FullName" } }
```

verbatim the pattern `references/shared/node-output-wiring.md` prescribes — **End nodes (`core.control.end`)** → `outputs.<varId>.source`, `=js:` **YES** — with the `.FullName` accessor from `variables-and-expressions.md`. That run reported `finalStatus: "Completed"` with `fileName = "sample-report.txt"`. `flow validate` passed and the `--attachment` criterion matched; only this gate failed.

### 2. A vacuous assertion the gate was hiding

`assert_outputs_contain` flattens **every** global — and the `in` file variable's runtime value *is* the attachment object carrying `FullName`. Matching the random basename against that set is a tautology: it passes whenever a file uploads at all, regardless of what the flow computes.

Confirmed against a live tenant. A flow whose End node maps `fileName` to the literal `"sample-report.txt"` **still passed**, because the runtime globals are:

```json
{"start.output.inputDoc": {"ID": "...", "FullName": "evidence-<rand>.txt",
                           "MimeType": "application/octet-stream", "Metadata": {"size": "8"}},
 "fileName": "sample-report.txt"}
```

So deleting the gate alone would have left a criterion that **cannot fail**. `flow_check.py` already ships the right helper — `assert_named_output_contains`, whose docstring calls out precisely this trigger-input-echo trap ("an `invoiceNumber` input global makes the invoice string 'present' even when the agent never drafted it"). `file_attachment` never migrated to it.

## Changes

- Drop the node-shape gate and its now-unused import.
- Scope the basename match to the flow's declared `direction:"out"` globals, discovered from source so the check stays goal-level rather than pinning the name `fileName`. Shape-agnostic, but no longer vacuous.
- Module docstring records the tautology with the observed payload, so the scoping doesn't get "simplified" back to a whole-payload match.
- `file_attachment.yaml` `description:` — name both sanctioned shapes rather than mandating a Script node. `initial_prompt` unchanged; it was already correct.

Siblings calling `assert_flow_has_node_type` (`decision`, `switch`, `rpa`, `api_workflow`, `subflow`, `terminate`, `coded_agent`, `lowcode_agent`) each pin a node their prompt makes inevitable, and are untouched. No skill-doc change: the skill steered the agent to a valid, working flow.

## Validation

Reproduced the rejected flow in a fresh org (`solution init` + `flow init` + the same `trigger -> End` binding) and ran the patched checker end to end against a live tenant:

| case | expected | result |
| --- | --- | --- |
| End node reads `.FullName` via `=js:` (the flow that was rejected) | pass | **exit 0** — `output variable surfaced attachment FullName 'evidence-0d80c20d9332.txt'` |
| End node maps `fileName` to a hardcoded literal | fail | **exit 1** — `Output 'fileName' missing all of ['evidence-38c9a6dea640.txt']; fileName=["sample-report.txt"]` |

The second row is the case the pre-patch checker passed. `flow validate` → `Status: "Valid"`; `py_compile` and `yaml.safe_load` clean with 3 criteria intact. Test solution deleted afterward via `cleanup_solutions.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)