### PR TITLE
test(bpmn): align draft boundary eval with CLI scaffold

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
@@ -135,3 +135,65 @@ def assert_package_lifecycle(project_dir: Path, bpmn_name: str, start_id: str) -
         ep.get("filePath") == expected_file_path for ep in entry_points.get("entryPoints", [])
     ):
         fail(f"entry-points.json missing filePath {expected_file_path}")
+
+
+def assert_generated_project_scaffold(
+    project_dir: Path,
+    project_name: str,
+    bpmn_name: str,
+    start_id: str,
+    *,
+    entry_point_id: str | None = None,
+    expected_resource_count: int | None = None,
+) -> None:
+    """Assert the current CLI-owned Process Orchestration metadata contract."""
+
+    project = load_json(project_dir / "project.uiproj")
+    operate = load_json(project_dir / "operate.json")
+    entry_points = load_json(project_dir / "entry-points.json")
+    bindings = load_json(project_dir / "bindings_v2.json")
+    descriptor = load_json(project_dir / "package-descriptor.json")
+
+    if project.get("Name") != project_name:
+        fail(f"project.uiproj Name must be {project_name}")
+    if project.get("ProjectType") != "ProcessOrchestration":
+        fail("project.uiproj ProjectType must be ProcessOrchestration")
+    if "main" in project or "Main" in project:
+        fail("project.uiproj must not own the BPMN main path")
+
+    expected_main = f"/content/{bpmn_name}#{start_id}"
+    if operate.get("main") != expected_main:
+        fail(f"operate.json main must be {expected_main}")
+    if operate.get("contentType") != "ProcessOrchestration":
+        fail("operate.json contentType must be ProcessOrchestration")
+
+    entries = entry_points.get("entryPoints")
+    if not isinstance(entries, list) or len(entries) != 1:
+        fail("entry-points.json must contain exactly one manual entry point")
+    entry = entries[0]
+    if entry.get("filePath") != expected_main:
+        fail(f"entry-points.json filePath must be {expected_main}")
+    if entry.get("type") != "ProcessOrchestration":
+        fail("entry-points.json type must be ProcessOrchestration")
+    if entry_point_id is not None and entry.get("uniqueId") != entry_point_id:
+        fail("entry-points.json uniqueId must match uipath:entryPointId")
+
+    if bindings.get("version") != "2.0":
+        fail('bindings_v2.json version must be "2.0"')
+    resources = bindings.get("resources")
+    if not isinstance(resources, list):
+        fail("bindings_v2.json resources must be a list")
+    if expected_resource_count is not None and len(resources) != expected_resource_count:
+        fail(
+            "bindings_v2.json must contain "
+            f"{expected_resource_count} resources, found {len(resources)}"
+        )
+
+    expected_files = {
+        "operate.json": "operate.json",
+        "entry-points.json": "entry-points.json",
+        "bindings.json": "bindings_v2.json",
+        bpmn_name: bpmn_name,
+    }
+    if descriptor.get("files") != expected_files:
+        fail("package-descriptor.json must preserve the current CLI root files map")

--- a/tests/tasks/uipath-maestro-bpmn/_shared/test_bpmn_assertions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/test_bpmn_assertions.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Regression tests for shared Maestro BPMN eval assertions."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from bpmn_assertions import assert_generated_project_scaffold
+
+
+class GeneratedProjectScaffoldTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project = Path(self.temp_dir.name)
+        self._write(
+            "project.uiproj",
+            {"Name": "Sample", "ProjectType": "ProcessOrchestration"},
+        )
+        self._write(
+            "operate.json",
+            {
+                "main": "/content/Sample.bpmn#Event_start",
+                "contentType": "ProcessOrchestration",
+            },
+        )
+        self._write(
+            "entry-points.json",
+            {
+                "entryPoints": [
+                    {
+                        "filePath": "/content/Sample.bpmn#Event_start",
+                        "uniqueId": "11111111-1111-4111-8111-111111111111",
+                        "type": "ProcessOrchestration",
+                    }
+                ]
+            },
+        )
+        self._write("bindings_v2.json", {"version": "2.0", "resources": []})
+        self._write(
+            "package-descriptor.json",
+            {
+                "files": {
+                    "operate.json": "operate.json",
+                    "entry-points.json": "entry-points.json",
+                    "bindings.json": "bindings_v2.json",
+                    "Sample.bpmn": "Sample.bpmn",
+                }
+            },
+        )
+
+    def tearDown(self) -> None:
+        self.temp_dir.cleanup()
+
+    def _write(self, name: str, content: dict) -> None:
+        (self.project / name).write_text(json.dumps(content), encoding="utf-8")
+
+    def assert_scaffold(self) -> None:
+        assert_generated_project_scaffold(
+            self.project,
+            "Sample",
+            "Sample.bpmn",
+            "Event_start",
+            entry_point_id="11111111-1111-4111-8111-111111111111",
+            expected_resource_count=0,
+        )
+
+    def test_accepts_current_cli_metadata_shape(self) -> None:
+        self.assert_scaffold()
+
+    def test_rejects_legacy_project_main_field(self) -> None:
+        self._write(
+            "project.uiproj",
+            {
+                "Name": "Sample",
+                "ProjectType": "ProcessOrchestration",
+                "main": "Sample.bpmn",
+            },
+        )
+        with self.assertRaisesRegex(SystemExit, "must not own the BPMN main path"):
+            self.assert_scaffold()
+
+    def test_rejects_legacy_package_content_list(self) -> None:
+        self._write(
+            "package-descriptor.json",
+            {
+                "content": [
+                    "content/Sample.bpmn",
+                    "content/bindings_v2.json",
+                    "content/entry-points.json",
+                    "content/operate.json",
+                ]
+            },
+        )
+        with self.assertRaisesRegex(SystemExit, "current CLI root files map"):
+            self.assert_scaffold()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
+++ b/tests/tasks/uipath-maestro-bpmn/connector/check_integration_service_boundary.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 
-import glob
 import os
 import re
 import sys
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from _shared.bpmn_assertions import assert_generated_project_scaffold  # noqa: E402
 from _shared.bpmn_check import (  # noqa: E402
+    NS,
     elements,
     fail,
     has_uipath_extension,
@@ -17,28 +18,34 @@ from _shared.bpmn_check import (  # noqa: E402
     require_sequence_integrity,
 )
 
+PROJECT = Path("SlackDigestBoundaryBpmnSolution/SlackDigestBoundaryBpmn")
+BPMN_NAME = "SlackDigestBoundaryBpmn.bpmn"
+
 
 def main() -> None:
     path, root = parse_bpmn("SlackDigestBoundaryBpmn")
+    if Path(path) != PROJECT / BPMN_NAME:
+        fail(f"BPMN source must be created at {PROJECT / BPMN_NAME}")
     wrappers = [*elements(root, "sendTask"), *elements(root, "serviceTask")]
     if not any(has_uipath_extension(task, "Intsvc.") for task in wrappers):
         fail("missing draft Integration Service uipath:activity shell")
     require_no_private_connector_values(root)
-    generated = [
-        name
-        for name in (
-            "bindings_v2.json",
-            "entry-points.json",
-            "operate.json",
-            "package-descriptor.json",
-        )
-        if glob.glob(f"**/{name}", recursive=True)
-    ]
-    if generated:
-        fail(f"draft boundary should not hand-author generated package files: {generated}")
+    starts = elements(root, "startEvent")
+    if len(starts) != 1:
+        fail(f"expected exactly one manual start event, found {len(starts)}")
+    entry_point = starts[0].find("bpmn:extensionElements/uipath:entryPointId", NS)
+    if entry_point is None or not entry_point.attrib.get("value"):
+        fail("manual start must declare uipath:entryPointId")
+    assert_generated_project_scaffold(
+        PROJECT,
+        "SlackDigestBoundaryBpmn",
+        BPMN_NAME,
+        starts[0].attrib["id"],
+        entry_point_id=entry_point.attrib["value"],
+        expected_resource_count=0,
+    )
     notes = "\n".join(
-        Path(p).read_text(encoding="utf-8")
-        for p in glob.glob("SlackDigestBoundaryBpmn/**/*.md", recursive=True)
+        p.read_text(encoding="utf-8") for p in PROJECT.rglob("*.md")
     )
     low = notes.lower()
     # Each blocker is satisfied by any reasonable phrasing of the concept, not a

--- a/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/connector/integration_service_boundary.yaml
@@ -1,8 +1,8 @@
 task_id: skill-bpmn-integration-service-boundary
 description: >
-  Integration Service boundary eval: agent creates BPMN source shape and an
-  explicit CLI-enrichment handoff without hand-authoring connector-owned
-  connection metadata or running cloud-side commands.
+  Integration Service boundary eval: agent creates a local BPMN scaffold and
+  an explicit CLI-enrichment handoff without inventing connector-owned values
+  or running cloud-side commands.
 tags: [uipath-maestro-bpmn, integration, mode:build, lifecycle:generate, connector, feature:connections]
 
 run_limits:
@@ -30,7 +30,7 @@ initial_prompt: |
 success_criteria:
   - type: file_exists
     description: "BPMN source was created"
-    path: "SlackDigestBoundaryBpmn/SlackDigestBoundaryBpmn.bpmn"
+    path: "SlackDigestBoundaryBpmnSolution/SlackDigestBoundaryBpmn/SlackDigestBoundaryBpmn.bpmn"
     weight: 1.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Summary

- align the Integration Service boundary eval with the solution/project path returned by `uip maestro bpmn init`
- validate the canonical CLI-generated metadata set instead of rejecting its presence
- keep the draft boundary strict: no connector resources, invented tenant values, or missing enrichment blockers
- add regression coverage for current metadata and the obsolete project-main/package-content shapes

## Root cause

The eval still expected a flat source-only project and treated all four generated package files as hand-authored. The supported initializer creates a solution, nests the BPMN project, and generates those files. This made a correct scaffold fail both criteria.

## Validation

- shared assertion regression tests: 3/3 passed
- original failing Integration Service artifact replay: passed unchanged
- fresh `claude-sonnet-5` run on the latest #2387 head: 2/2 criteria, score 1.000
- combined run: `2026-08-18_10-57-34`

## Stack

- based on #2387 (`codex/bpmn-metadata-refresh`)
- followed by #2673
- #2658 owns the orthogonal 1800-second timeout adjustment
