### PR TITLE
test(bpmn): align script lifecycle eval with generated metadata

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/authoring/check_script_jint_lifecycle.py
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/check_script_jint_lifecycle.py
@@ -11,8 +11,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from _shared.bpmn_assertions import (  # noqa: E402
     BPMN_NS,
     UIPATH_NS,
+    assert_generated_project_scaffold,
     assert_has_shape,
-    assert_package_lifecycle,
     fail,
     load_bpmn,
     mapping_inputs,
@@ -61,7 +61,19 @@ def main() -> None:
 
     assert_has_shape(root, task.attrib["id"])
     start = one_element(root, "startEvent")
-    assert_package_lifecycle(PROJECT, BPMN_NAME, start.attrib["id"])
+    entry_point = start.find(
+        f"./{{{BPMN_NS}}}extensionElements/{{{UIPATH_NS}}}entryPointId"
+    )
+    if entry_point is None or not entry_point.attrib.get("value"):
+        fail("manual start must declare uipath:entryPointId")
+    assert_generated_project_scaffold(
+        PROJECT,
+        "ScriptNormalizer",
+        BPMN_NAME,
+        start.attrib["id"],
+        entry_point_id=entry_point.attrib["value"],
+        expected_resource_count=0,
+    )
     print("OK: scriptTask uses JavaScript/v3 Jint-safe source and package lifecycle files")
 
 


### PR DESCRIPTION
## Summary

- replace the obsolete script lifecycle assertion with the current generated-project scaffold contract
- require `project.uiproj` to carry `Name` and `ProjectType`, while `operate.json.main` owns the full BPMN/start-event path
- cross-check the BPMN entry-point ID, generated entry point, empty bindings, and package descriptor

## Root cause

The checker required `project.uiproj.main` and legacy package metadata shapes. The current CLI scaffold intentionally omits that field and stores `/content/<bpmn>#<start>` in `operate.json.main`, so a correct generated project failed the lifecycle criterion.

## Validation

- original failing Script/Jint artifact replay: passed unchanged
- shared assertion regression tests: 3/3 passed
- fresh `claude-sonnet-5` run on the latest #2387 head: 2/2 criteria, score 1.000
- combined run: `2026-08-18_10-57-34`

## Stack

- depends on #2672
