### PR TITLE
fix(uipath-maestro-case): route Phase 7 deploy handoff to uipath-solution

### DIFF
--- a/skills/uipath-maestro-case/references/case-commands.md
+++ b/skills/uipath-maestro-case/references/case-commands.md
@@ -176,7 +176,7 @@ uip solution publish <packagePath> --wait --output json
 
 > **On failure**, print the CLI error verbatim, log it in `build-issues.md`, and re-show the Phase 7 prompt. Full contract: [phased-execution.md § Phase 7](phased-execution.md#phase-7--publish-to-orchestrator).
 
-> Publish only lists the package on the feed. Installing it into an Orchestrator folder needs `uip solution deploy run` — out of Phase 7 scope.
+> Publish only lists the package on the feed. Installing it into an Orchestrator folder needs `uip solution deploy run` — out of Phase 7 scope; hand off to [`uipath-solution`](/uipath:uipath-solution).
 
 ---
 

--- a/skills/uipath-maestro-case/references/phased-execution.md
+++ b/skills/uipath-maestro-case/references/phased-execution.md
@@ -289,7 +289,7 @@ uip solution publish "<packagePath>" --wait --output json
 
 > `uip maestro case pack` is **not** the publish artifact. It emits a single project `.nupkg`, which `solution publish` does not accept — `solution pack` produces its own project `.nupkg` internally and wraps it in the `.zip`. Run `case pack` for the BPMN recompile only; always publish the `solution pack` `.zip`.
 
-Phase 7 stops at publish. `uip solution deploy run` (the step that installs the solution into an Orchestrator folder) is out of scope — report the published package and tell the user to deploy it from Orchestrator.
+Phase 7 stops at publish. Installing the package into an Orchestrator folder (`uip solution deploy run`) is out of scope — report the published package, then hand off to [`uipath-solution`](/uipath:uipath-solution). Not the Orchestrator UI: a cancelled upgrade wizard leaves the deployment in `Draft`, which blocks every later deploy with no CLI verb to clear it.
 
 ### On failure
 
@@ -297,7 +297,7 @@ If `case pack`, `solution pack`, or `publish` fails, print the CLI error verbati
 
 ### Suggested next steps
 
-Before the prompt: `Suggested next steps: publish to Orchestrator when you want the case on the tenant solution feed, or stop here if Studio Web and debug are enough.` After a successful publish: `Suggested next steps: verify the package with 'uip solution packages list', then deploy it to an Orchestrator folder.` On `Done`: `Suggested next steps: review caseplan.json/tasks.md locally or update sdd.md and re-run when you want changes.`
+Before the prompt: `Suggested next steps: publish to Orchestrator when you want the case on the tenant solution feed, or stop here if Studio Web and debug are enough.` After a successful publish: `Suggested next steps: verify the package with 'uip solution packages list', then load the uipath-solution skill to deploy it.` On `Done`: `Suggested next steps: review caseplan.json/tasks.md locally or update sdd.md and re-run when you want changes.`
 
 ### Publish-to-Orchestrator notes
 
@@ -305,7 +305,7 @@ Before the prompt: `Suggested next steps: publish to Orchestrator when you want 
 - A Phase 7 publish does **not** replace Phase 5 — Studio Web (`uip solution upload`) and the solution feed are separate destinations. A case can go to both, neither, or one.
 - If a Phase 6 fix changed the build after a Phase 7 publish, re-run Phase 7 with a bumped `--version`; the feed rejects duplicate `name+version` pairs.
 
-Deployment and activation are platform lifecycle concerns. Use the platform workflow for `uip solution deploy ...` commands and keep this case skill focused on the case project/package boundary.
+Deployment and activation belong to the solution lifecycle. Load [`uipath-solution`](/uipath:uipath-solution) for every `uip solution deploy ...` command; keep this skill at the case project/package boundary.
 
 For further authoring changes (add task, tweak condition, etc.), user updates `sdd.md` and re-runs skill from Phase 1 — skill does not offer in-place incremental edits.
 


### PR DESCRIPTION
## Problem

Phase 7 gave three answers for what happens after publish, none of them reachable:

| Line | Said | Problem |
|---|---|---|
| 292 | "tell the user to **deploy it from Orchestrator**" | the UI |
| 300 | "**deploy it to an Orchestrator folder**" | no command, no skill |
| 308 | "use **the platform workflow**" | wrong skill |

`uipath-platform`'s entire solution-deploy content is two glossary rows defining what a Solution folder is; its description redirects `uip solution` work to `uipath-solution`. So 308 dead-ends, and an agent falls back to the most concrete instruction — 292, the UI.

For an already-deployed case the UI's in-place path is the upgrade wizard. A cancelled wizard leaves a `VersionChange/Draft`, which rejects every package version except its own target and blocks `deploy run` — with no discard verb anywhere in the `uip solution deploy` tree (`run / activate / upgrade / list / status / uninstall / config`). That is the routing behind a customer escalation where a staging solution could not be upgraded for ~18h; the only exit was an undocumented `DELETE` against `automationsolutions_`.

## Fix

All three sites, plus the same dead end in `case-commands.md:179`, now point at [`uipath-solution`](/uipath:uipath-solution) — the skill that owns `uip solution deploy`. Line 292 also warns off the Orchestrator UI, with the reason.

Docs only, 4 lines, 2 files. Phase 7 still runs `resources refresh` → `case pack` → `solution pack` → `solution publish` and stops at the feed; installing into an Orchestrator folder remains out of scope.

## Verification

`npm run skills:validate` passes · no broken links · `check-skill-verbs.py` unchanged at 11 pre-existing findings · no flavor overrides or markers on the touched files.

## Follow-ups (not here)

- **`uipath-solution` corrections** (team-merlot / team-orange). `pack-and-deploy.md:318` says *"`deploy run` Always Creates a New Folder… there is no way to deploy into a pre-existing folder"*, which the escalation's logs appear to contradict — two in-place upgrades via `deploy run`, folders and release keys preserved. And `activate-and-manage.md` documents `deploy upgrade` as preview-build-only without covering stuck-`Draft` recovery. Both become load-bearing for case users once we point here.
- **Pre-pack parity gate.** Phase 7's `resources refresh` consumes `bindings_v2.json` rather than validating it, so a resource-less package packs, publishes and activates silently. Check 7 covers this but only fires at Phase 3 exit in greenfield. Related to #2605.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
