### PR TITLE
test(maestro-flow): stop input echoes from satisfying assert_outputs_contain

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -61,6 +61,12 @@ _LAST_DEBUG_RAW: str | None = None
 # :func:`assert_outputs_contain`.
 _LAST_DEBUG_INPUT_IDS: set[str] = set()
 
+# Project dir :func:`run_debug` resolved for the most recent run. Stashed so the
+# source-declared `direction:"in"` signal works automatically instead of needing
+# every call site to opt in — and so the lookup is scoped to the project that
+# actually ran, never a bare glob from an arbitrary CWD.
+_LAST_DEBUG_PROJECT_DIR: str | None = None
+
 
 # A `uip maestro flow debug` run can die on a transient server-side error — a
 # gateway timeout / 5xx while polling the debug instance, which the CLI reports
@@ -121,11 +127,13 @@ def run_debug(
         cmd.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
-    global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS
-    # Record what we bound as input so output assertions can discount echoes.
+    global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS, _LAST_DEBUG_PROJECT_DIR
+    # Record what we bound as input, and where the project lives, so output
+    # assertions can discount echoes of our own inputs.
     _LAST_DEBUG_INPUT_IDS = {str(k) for k in (inputs or {})} | {
         str(k) for k in (attachments or {})
     }
+    _LAST_DEBUG_PROJECT_DIR = project_dir
     for attempt in range(retries):
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         _LAST_DEBUG_RAW = r.stdout
@@ -456,12 +464,13 @@ def _declared_input_global_keys(
        ids it passed via ``--inputs`` / ``--attachment``. Those are inputs by
        construction, and this is exact — no parsing, no guessing. It covers the
        plain (non-trigger) inputs that signal 1 cannot see.
-    3. **Source declaration** (only when ``project_dir`` is given). Reads that
-       project's first ``.flow`` and collects ``variables.globals[].id`` where
-       ``direction == "in"``. Catches inputs the checker never passed — an ``in``
-       global with a ``defaultValue`` still gets a runtime value and still
-       echoes. Opt-in because it needs a known project; parse failures degrade
-       to signals 1-2 rather than erroring.
+    3. **Source declaration.** Reads the project's first ``.flow`` and collects
+       ``variables.globals[].id`` where ``direction == "in"``. Catches inputs the
+       checker never passed — an ``in`` global with a ``defaultValue`` still gets
+       a runtime value and still echoes. The project defaults to the one
+       :func:`run_debug` resolved, so this needs no per-call-site opt-in;
+       ``project_dir`` overrides it for a caller holding a payload from
+       elsewhere. Parse failures degrade to signals 1-2 rather than erroring.
     """
     variables = _get_ci(payload, "variables", "Variables") or {}
     keys = list((_get_ci(variables, "globals", "Globals") or {}).keys())
@@ -476,6 +485,7 @@ def _declared_input_global_keys(
     # Signals 2 and 3 — ids known to be inputs, matched to keys by exact name or
     # by the leaf of a `<trigger>.output.<id>` key.
     declared = {str(i).lower() for i in _LAST_DEBUG_INPUT_IDS}
+    project_dir = project_dir or _LAST_DEBUG_PROJECT_DIR
     if project_dir:
         try:
             flows = sorted(
@@ -546,8 +556,9 @@ def assert_outputs_contain(
     previously passing vacuously and the task needs a real output assertion,
     usually :func:`assert_named_output_contains`.
 
-    ``project_dir`` widens the subtraction to inputs this checker never passed —
-    an ``in`` global with a ``defaultValue`` also echoes. ``allow_input_echo=True``
+    Inputs this checker never passed are covered too — an ``in`` global with a
+    ``defaultValue`` also echoes — by reading the project :func:`run_debug`
+    resolved; ``project_dir`` overrides that. ``allow_input_echo=True``
     restores the old whole-payload behavior for the rare check that legitimately
     grades a round-trip; prefer naming the output variable instead, so the
     subtraction is never a reason to weaken an assertion elsewhere.

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -471,6 +471,17 @@ def _declared_input_global_keys(
        :func:`run_debug` resolved, so this needs no per-call-site opt-in;
        ``project_dir`` overrides it for a caller holding a payload from
        elsewhere. Parse failures degrade to signals 1-2 rather than erroring.
+
+    Why not read direction from the payload? The runtime does return a
+    ``variables.globalDefinitions`` map, but it carries only ``name`` and
+    ``type`` — no direction — so it cannot separate an input from an output::
+
+        "globalDefinitions": {"start.output.inputDoc": {"name": "inputDoc", "type": "file"},
+                              "fileName": {"name": "fileName", "type": "string"}}
+
+    Verified against a live debug payload. It is useful only for mapping a
+    trigger-scoped key back to its declared id, which the leaf split below
+    already does.
     """
     variables = _get_ci(payload, "variables", "Variables") or {}
     keys = list((_get_ci(variables, "globals", "Globals") or {}).keys())
@@ -589,7 +600,7 @@ def assert_outputs_contain(
             )
         _fail_with_capture(
             f"Outputs missing {mode} {list(needles)}; present={present}; "
-            f"missing={missing}\nOutputs (inputs excluded): {haystack[:1000]}{detail}"
+            f"missing={missing}\nOutputs: {haystack[:1000]}{detail}"
         )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -53,6 +53,14 @@ from typing import Any, Iterable, Sequence
 # checker saw — which is otherwise ephemeral and unrecoverable post-run.
 _LAST_DEBUG_RAW: str | None = None
 
+# Variable ids the most recent :func:`run_debug` bound as INPUTS (via ``--inputs``
+# / ``--attachment``). Stashed because the runtime returns every global — `in` and
+# `out` alike — in one ``variables.globals`` dict with no direction marker, so
+# this is the only exact way to tell a result from an echo of what we just fed
+# in. Consumed by :func:`_declared_input_global_keys`; see the input-echo note on
+# :func:`assert_outputs_contain`.
+_LAST_DEBUG_INPUT_IDS: set[str] = set()
+
 
 # A `uip maestro flow debug` run can die on a transient server-side error — a
 # gateway timeout / 5xx while polling the debug instance, which the CLI reports
@@ -113,7 +121,11 @@ def run_debug(
         cmd.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
-    global _LAST_DEBUG_RAW
+    global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS
+    # Record what we bound as input so output assertions can discount echoes.
+    _LAST_DEBUG_INPUT_IDS = {str(k) for k in (inputs or {})} | {
+        str(k) for k in (attachments or {})
+    }
     for attempt in range(retries):
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
         _LAST_DEBUG_RAW = r.stdout
@@ -392,18 +404,102 @@ def collect_outputs(payload: dict) -> list[Any]:
     runtime (as a name→value dict). ``variables.globalVariables`` is the
     SDK-typed array shape; in practice the runtime populates the dict form.
     Both are walked to be safe.
+
+    NOTE: ``variables.globals`` holds every global — ``in`` as well as ``out``
+    — so this includes the flow's own INPUT values. That is deliberate for
+    callers doing a "did the run produce anything at all" check, but it makes
+    the set unsafe for grading a needle that is also an input. See
+    :func:`assert_outputs_contain`, which subtracts the declared inputs.
     """
+    return _global_leaves(payload)
+
+
+def _global_leaves(payload: dict, *, skip_keys: Iterable[str] = ()) -> list[Any]:
+    """Flattened global + element-output leaves, optionally skipping globals by
+    key. ``skip_keys`` is how :func:`assert_outputs_contain` drops declared
+    inputs; element outputs are never skipped (they are genuine node results)."""
+    skip = {str(k).lower() for k in skip_keys}
     out: list[Any] = []
     variables = _get_ci(payload, "variables", "Variables") or {}
-    for val in (_get_ci(variables, "globals", "Globals") or {}).values():
+    for key, val in (_get_ci(variables, "globals", "Globals") or {}).items():
+        if str(key).lower() in skip:
+            continue
         out.extend(_leaves(val))
     for v in _get_ci(variables, "globalVariables", "GlobalVariables") or []:
+        name = str(_get_ci(v, "id", "Id", "name", "Name") or "")
+        if name.lower() in skip:
+            continue
         value = _get_ci(v, "value", "Value")
         if value is not None:
             out.extend(_leaves(value))
     for e in _get_ci(variables, "elements", "Elements") or []:
         out.extend(_leaves(_get_ci(e, "outputs", "Outputs") or {}))
     return out
+
+
+def _declared_input_global_keys(
+    payload: dict, *, project_dir: str | None = None
+) -> set[str]:
+    """Return the ``variables.globals`` keys that hold INPUT values, not results.
+
+    Three signals, unioned, because no single one is complete. All are cheap:
+    none of them globs the filesystem, which matters because the module is
+    imported from an arbitrary CWD (at a repo root, ``**/*.flow`` matches
+    hundreds of unrelated flows through a ``plugins/`` symlink loop and would
+    read whichever one sorted first).
+
+    1. **Key shape.** A trigger-scoped input is keyed
+       ``<triggerNodeId>.output.<varId>`` at runtime — e.g.
+       ``start.output.inputDoc``. Outputs are keyed by bare id (``fileName``),
+       so this shape is unambiguously an input.
+    2. **What the checker itself bound.** :func:`run_debug` stashes the variable
+       ids it passed via ``--inputs`` / ``--attachment``. Those are inputs by
+       construction, and this is exact — no parsing, no guessing. It covers the
+       plain (non-trigger) inputs that signal 1 cannot see.
+    3. **Source declaration** (only when ``project_dir`` is given). Reads that
+       project's first ``.flow`` and collects ``variables.globals[].id`` where
+       ``direction == "in"``. Catches inputs the checker never passed — an ``in``
+       global with a ``defaultValue`` still gets a runtime value and still
+       echoes. Opt-in because it needs a known project; parse failures degrade
+       to signals 1-2 rather than erroring.
+    """
+    variables = _get_ci(payload, "variables", "Variables") or {}
+    keys = list((_get_ci(variables, "globals", "Globals") or {}).keys())
+    keys += [
+        str(_get_ci(v, "id", "Id", "name", "Name") or "")
+        for v in _get_ci(variables, "globalVariables", "GlobalVariables") or []
+    ]
+
+    # Signal 1 — trigger-scoped key shape.
+    inputs = {k for k in keys if re.match(r"^[^.]+\.output\.[^.]+$", str(k))}
+
+    # Signals 2 and 3 — ids known to be inputs, matched to keys by exact name or
+    # by the leaf of a `<trigger>.output.<id>` key.
+    declared = {str(i).lower() for i in _LAST_DEBUG_INPUT_IDS}
+    if project_dir:
+        try:
+            flows = sorted(
+                glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
+            )
+            if flows:
+                with open(flows[0]) as f:
+                    flow = json.load(f)
+                src = (
+                    flow.get("variables")
+                    or flow.get("workflow", {}).get("variables")
+                    or {}
+                )
+                declared |= {
+                    str(v["id"]).lower()
+                    for v in (src.get("globals") or [])
+                    if v.get("direction") == "in" and v.get("id")
+                }
+        except (OSError, ValueError, KeyError, TypeError):
+            pass
+    for k in keys:
+        if str(k).lower() in declared or str(k).rsplit(".", 1)[-1].lower() in declared:
+            inputs.add(k)
+    return inputs
 
 
 def _leaves(v: Any):
@@ -418,24 +514,71 @@ def _leaves(v: Any):
 
 
 def assert_outputs_contain(
-    payload: dict, needles: str | Sequence[str], *, require_all: bool = True
+    payload: dict,
+    needles: str | Sequence[str],
+    *,
+    require_all: bool = True,
+    allow_input_echo: bool = False,
+    project_dir: str | None = None,
 ) -> None:
-    """Assert the stringified outputs contain the given needle(s).
+    """Assert the stringified outputs contain the given needle(s), IGNORING the
+    flow's own input values.
 
     ``require_all=True`` (default): every needle must appear.
     ``require_all=False``: at least one needle must appear.
+
+    Input echoes do not count (MST — see below). ``variables.globals`` carries
+    every global, ``in`` included, and :func:`_leaves` flattens nested objects —
+    so a needle that is also an input is matched by the input's own value and
+    the assertion becomes a tautology, passing regardless of what the flow
+    computed. Observed live on the file-attachment task: binding
+    ``--attachment inputDoc=<random>.txt`` puts the whole attachment object in
+    ``globals``, so ``assert_outputs_contain(payload, "<random>.txt")`` passed a
+    flow whose End node mapped the output to a hardcoded ``"sample-report.txt"``::
+
+        {"start.output.inputDoc": {"ID": ..., "FullName": "evidence-<rand>.txt", ...},
+         "fileName": "sample-report.txt"}
+
+    Declared inputs are therefore subtracted before matching (see
+    :func:`_declared_input_global_keys`). When a needle is absent from the
+    outputs but WOULD have matched an input, the failure says so explicitly
+    rather than reporting a bare "missing" — that case means the check was
+    previously passing vacuously and the task needs a real output assertion,
+    usually :func:`assert_named_output_contains`.
+
+    ``project_dir`` widens the subtraction to inputs this checker never passed —
+    an ``in`` global with a ``defaultValue`` also echoes. ``allow_input_echo=True``
+    restores the old whole-payload behavior for the rare check that legitimately
+    grades a round-trip; prefer naming the output variable instead, so the
+    subtraction is never a reason to weaken an assertion elsewhere.
     """
     if isinstance(needles, str):
         needles = [needles]
-    haystack = _stringify(collect_outputs(payload))
+    all_leaves = _stringify(collect_outputs(payload))
+    if allow_input_echo:
+        haystack = all_leaves
+        input_keys: set[str] = set()
+    else:
+        input_keys = _declared_input_global_keys(payload, project_dir=project_dir)
+        haystack = _stringify(_global_leaves(payload, skip_keys=input_keys))
     present = [n for n in needles if n.lower() in haystack]
     missing = [n for n in needles if n.lower() not in haystack]
     ok = len(missing) == 0 if require_all else len(present) > 0
     if not ok:
         mode = "all of" if require_all else "any of"
+        echo_only = [n for n in missing if n.lower() in all_leaves]
+        detail = ""
+        if echo_only:
+            detail = (
+                f"\nINPUT ECHO: {echo_only} appear ONLY in the flow's input globals "
+                f"{sorted(input_keys)}, not in its outputs. Before this guard existed "
+                f"the match was satisfied by the input itself, so this check passed "
+                f"vacuously. Grade the real output instead — "
+                f"assert_named_output_contains(payload, '<outVarId>', ...)."
+            )
         _fail_with_capture(
             f"Outputs missing {mode} {list(needles)}; present={present}; "
-            f"missing={missing}\nOutputs: {haystack[:1000]}"
+            f"missing={missing}\nOutputs (inputs excluded): {haystack[:1000]}{detail}"
         )
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -402,6 +402,142 @@ def test_assert_outputs_contain_fails_when_missing():
         assert_outputs_contain(payload, ["world"])
 
 
+# ── assert_outputs_contain: input echoes must not satisfy the match ─────────
+#
+# `variables.globals` carries every global, `in` as well as `out`, and _leaves
+# flattens nested objects — so a needle that is also an input used to be matched
+# by the input's own value. Observed live on the file-attachment task: a flow
+# whose End node mapped the output to a hardcoded literal still "passed" because
+# the bound attachment object carried the random FullName the checker searched
+# for. These pin the guard that subtracts inputs before matching.
+
+
+@pytest.fixture
+def _no_bound_inputs():
+    """Isolate the run_debug input stash — it is process-global state."""
+    saved = flow_check._LAST_DEBUG_INPUT_IDS
+    flow_check._LAST_DEBUG_INPUT_IDS = set()
+    yield
+    flow_check._LAST_DEBUG_INPUT_IDS = saved
+
+
+def _globals_payload(mapping):
+    """Payload using the dict form the runtime actually returns."""
+    return {"variables": {"globals": dict(mapping)}}
+
+
+def test_trigger_scoped_input_echo_does_not_satisfy_match(_no_bound_inputs):
+    # The exact live shape: attachment object under `<trigger>.output.<varId>`,
+    # real output hardcoded to something else.
+    payload = _globals_payload(
+        {
+            "start.output.inputDoc": {
+                "ID": "1106735d-3076-4315-92ab-08defd736ffd",
+                "FullName": "evidence-2ba9f1a197d0.txt",
+                "MimeType": "application/octet-stream",
+                "Metadata": {"size": "8"},
+            },
+            "fileName": "sample-report.txt",
+        }
+    )
+    with pytest.raises(SystemExit, match="INPUT ECHO"):
+        assert_outputs_contain(payload, "evidence-2ba9f1a197d0.txt")
+
+
+def test_bound_input_id_echo_does_not_satisfy_match(_no_bound_inputs):
+    # Plain (non-trigger) input, keyed by bare id — indistinguishable from an
+    # output by shape alone, so the guard leans on what run_debug bound.
+    flow_check._LAST_DEBUG_INPUT_IDS = {"webhookPayload"}
+    payload = _globals_payload(
+        {
+            "webhookPayload": {"invoice": {"invoiceNumber": "MCS-2026-04872"}},
+            "resolution": "unable to process",
+        }
+    )
+    with pytest.raises(SystemExit, match="INPUT ECHO"):
+        assert_outputs_contain(payload, "MCS-2026-04872")
+
+
+def test_declared_input_echo_does_not_satisfy_match(tmp_path, _no_bound_inputs):
+    # An `in` global with a defaultValue echoes even though no checker bound it.
+    # Caught only with project_dir, since neither key shape nor the stash sees it.
+    import json as _json
+
+    proj = tmp_path / "MyFlow"
+    proj.mkdir()
+    (proj / "MyFlow.flow").write_text(
+        _json.dumps(
+            {
+                "variables": {
+                    "globals": [
+                        {"id": "cities", "direction": "in", "defaultValue": ["Seattle"]},
+                        {"id": "report", "direction": "out"},
+                    ]
+                }
+            }
+        )
+    )
+    payload = _globals_payload({"cities": ["Seattle"], "report": "no data"})
+
+    # Without the source signal the echo still slips through...
+    assert_outputs_contain(payload, "Seattle")
+    # ...with it, the vacuous match is reported.
+    with pytest.raises(SystemExit, match="INPUT ECHO"):
+        assert_outputs_contain(payload, "Seattle", project_dir=str(proj))
+
+
+def test_real_output_still_passes_when_it_also_appears_in_input(_no_bound_inputs):
+    # Subtracting inputs must not create false failures: when the flow genuinely
+    # produces the value, matching it is legitimate even though an input echoes it.
+    flow_check._LAST_DEBUG_INPUT_IDS = {"inputDoc"}
+    payload = _globals_payload(
+        {
+            "start.output.inputDoc": {"FullName": "evidence-abc.txt"},
+            "fileName": "evidence-abc.txt",
+        }
+    )
+    assert_outputs_contain(payload, "evidence-abc.txt")
+
+
+def test_element_outputs_are_never_subtracted(_no_bound_inputs):
+    # Node results are genuine outputs regardless of the input-key filter.
+    flow_check._LAST_DEBUG_INPUT_IDS = {"inputDoc"}
+    payload = {
+        "variables": {
+            "globals": {"start.output.inputDoc": {"FullName": "evidence-xyz.txt"}},
+            "elements": [{"outputs": {"echo": "evidence-xyz.txt"}}],
+        }
+    }
+    assert_outputs_contain(payload, "evidence-xyz.txt")
+
+
+def test_allow_input_echo_restores_whole_payload_match(_no_bound_inputs):
+    payload = _globals_payload(
+        {"start.output.inputDoc": {"FullName": "evidence-def.txt"}}
+    )
+    with pytest.raises(SystemExit):
+        assert_outputs_contain(payload, "evidence-def.txt")
+    assert_outputs_contain(payload, "evidence-def.txt", allow_input_echo=True)
+
+
+def test_collect_outputs_still_includes_inputs(_no_bound_inputs):
+    # collect_outputs is unchanged — billing_dispute_resolution uses it for a
+    # "did the run produce anything at all" check that must stay permissive.
+    payload = _globals_payload(
+        {"start.output.inputDoc": {"FullName": "evidence-ghi.txt"}}
+    )
+    assert "evidence-ghi.txt" in collect_outputs(payload)
+
+
+def test_input_echo_note_absent_for_an_ordinary_miss(_no_bound_inputs):
+    # A needle that appears nowhere is a plain miss, not an input echo — the
+    # remediation hint must not fire and misdirect the reader.
+    payload = _globals_payload({"fileName": "sample-report.txt"})
+    with pytest.raises(SystemExit) as exc:
+        assert_outputs_contain(payload, "nowhere-to-be-found")
+    assert "INPUT ECHO" not in str(exc.value)
+
+
 # ── _find_project (manifest-based Flow filtering, MST-9734) ─────────────────
 
 from flow_check import _find_project, _is_flow_project, find_project_dir  # noqa: E402

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -414,11 +414,14 @@ def test_assert_outputs_contain_fails_when_missing():
 
 @pytest.fixture
 def _no_bound_inputs():
-    """Isolate the run_debug input stash — it is process-global state."""
-    saved = flow_check._LAST_DEBUG_INPUT_IDS
+    """Isolate the run_debug stashes — they are process-global state."""
+    saved_ids = flow_check._LAST_DEBUG_INPUT_IDS
+    saved_dir = flow_check._LAST_DEBUG_PROJECT_DIR
     flow_check._LAST_DEBUG_INPUT_IDS = set()
+    flow_check._LAST_DEBUG_PROJECT_DIR = None
     yield
-    flow_check._LAST_DEBUG_INPUT_IDS = saved
+    flow_check._LAST_DEBUG_INPUT_IDS = saved_ids
+    flow_check._LAST_DEBUG_PROJECT_DIR = saved_dir
 
 
 def _globals_payload(mapping):
@@ -479,11 +482,16 @@ def test_declared_input_echo_does_not_satisfy_match(tmp_path, _no_bound_inputs):
     )
     payload = _globals_payload({"cities": ["Seattle"], "report": "no data"})
 
-    # Without the source signal the echo still slips through...
+    # With no project known at all, key shape and the bind-stash see nothing...
     assert_outputs_contain(payload, "Seattle")
-    # ...with it, the vacuous match is reported.
+    # ...an explicit project_dir reports the vacuous match...
     with pytest.raises(SystemExit, match="INPUT ECHO"):
         assert_outputs_contain(payload, "Seattle", project_dir=str(proj))
+    # ...and so does the project run_debug resolved, with no opt-in at the call
+    # site. This is what closes the defaultValue case suite-wide.
+    flow_check._LAST_DEBUG_PROJECT_DIR = str(proj)
+    with pytest.raises(SystemExit, match="INPUT ECHO"):
+        assert_outputs_contain(payload, "Seattle")
 
 
 def test_real_output_still_passes_when_it_also_appears_in_input(_no_bound_inputs):


### PR DESCRIPTION
Follow-up to #2670, which fixed one symptom of this. Independent branch off `main` — disjoint files, so it can land in either order.

## Problem

`variables.globals` carries **every** global — `in` as well as `out` — and `_leaves` flattens nested objects. So `assert_outputs_contain(payload, X)` never meant *"the flow output X"*. It meant *"X appears somewhere among all global values, inputs included."* Any needle that is also an input is matched by the input's own echo, and the assertion becomes a tautology.

Confirmed against a live tenant while fixing #2670. Binding `--attachment inputDoc=<random>.txt` puts the whole attachment object in globals, so searching for that random name **passed a flow whose End node mapped its output to a hardcoded literal**:

```json
{"start.output.inputDoc": {"ID": "...", "FullName": "evidence-<rand>.txt",
                           "MimeType": "application/octet-stream", "Metadata": {"size": "8"}},
 "fileName": "sample-report.txt"}
```

It's latent in **`multi_node/billing_dispute_resolution`** too — the heaviest flow task (840s). `INVOICE` lives inside the `WEBHOOK_PAYLOAD` the checker feeds in as the flow's object input, and 6 of the 11 follow-up verdict tokens (`credit`, `approv`, `duplicate`, `contract`, `290`, `300`) are in that payload as well. Both content assertions could pass without the flow reasoning about the dispute at all.

And in **`multi_node/multi_city_weather`**, which asserts `["Seattle", "Phoenix", "New York"]` to prove the loop iterated 3 times. If an agent declares those cities as an `in` array global — a normal reading of *"Loop over Seattle, Phoenix, and New York"* — the declaration alone satisfied the match, no loop required.

`flow_check` already ships the right per-variable helper — `assert_named_output_contains`, whose docstring names this exact trap ("matches trigger-input echoes… even when the agent never drafted it"). But relying on each author to remember it leaves the default matcher quietly wrong, so the guard belongs in the matcher.

## Fix

`assert_outputs_contain` subtracts the flow's inputs before matching, identifying them by three signals (`_declared_input_global_keys`), all active by default:

1. **Key shape** — a trigger-scoped input is keyed `<triggerId>.output.<varId>` at runtime; outputs are keyed by bare id.
2. **What the checker bound** — `run_debug` stashes the ids it passed via `--inputs` / `--attachment`. Exact, and covers plain inputs that signal 1 can't see.
3. **Source-declared `direction:"in"` ids** — catches an `in` global with a `defaultValue`, which echoes even though nothing bound it: invisible to signal 1 (bare id) and to signal 2 (never bound). Reads the project `run_debug` already resolved for its command line, so no call site has to opt in; an explicit `project_dir` overrides for a caller holding a payload from elsewhere.

**None of these globs the filesystem from CWD.** A first cut globbed `**/*.flow`; at a repo root that matches 428 flows through a `plugins/` symlink loop and reads whichever sorts first. It also tripled suite runtime — 20.55s to 2.90s once removed.

Failure reporting matters as much as the guard: when a needle is absent from the outputs but *would* have matched an input, the error says `INPUT ECHO`, names the culprit globals, and points at `assert_named_output_contains` — instead of a bare "missing". That case means the check was passing vacuously, so it needs a real output assertion, not a shrug. `allow_input_echo=True` restores the old behavior for a check that legitimately grades a round-trip. `collect_outputs` is unchanged, so callers using it for "did the run produce anything at all" stay permissive.

## No task migration needed

I simulated all 19 `assert_outputs_contain` call-site shapes against the guard rather than assuming:

| call site | result |
| --- | --- |
| `decision` (in `90` → needle `"warm"`) | passes |
| `switch` (in `2` → needle `"summer"`) | passes |
| `subflow` (in `"hello"` → needle `"olleh"`) | passes |
| no-input tasks (weather / slack / reading_list / jira / rpa / all 5 `edit/*`) | passes — nothing to echo |
| `multi_city_weather`, loop **emits** the cities | passes |
| `multi_city_weather`, loop emits **nothing** | **fails** `INPUT ECHO` (passed vacuously before) |
| `billing_dispute_resolution`, resolution **cites** the invoice | passes |
| `billing_dispute_resolution`, resolution **never** cites it | **fails** `INPUT ECHO` (ditto, incl. the verdict OR-set) |

The first three grade transformations absent from their inputs, so subtracting inputs cannot touch them. No checker file needs editing: the rows that flip to failing are flows that genuinely didn't produce the value, which is the grading these assertions were always meant to do.

Caveat: that's verified by unit tests and simulation, not by executing the e2e suite (needs a live tenant; `billing_dispute_resolution` alone is 840s). If a real run of either task fails after this, read it as a finding about the flow rather than a regression here.

## Tests

`197 passed` in `_shared/test_flow_check.py`, plus the `tests/scripts/test_runtime_payload_key_casing.py` guard. CI already runs this via `test-helpers.yml` → `pytest tests/tasks/uipath-maestro-flow/ -v`, so it's enforced on every PR — unlike the e2e criteria.

New cases cover: the live trigger-scoped attachment shape, a bound plain input (the billing shape), a `defaultValue` input via both an explicit `project_dir` and the auto-resolved one, a real output that *also* appears in an input (must still pass — no false failures), element outputs never being subtracted, `allow_input_echo` restoring old behavior, `collect_outputs` staying permissive, and an ordinary miss *not* emitting the `INPUT ECHO` hint so it can't misdirect.

That `allow_input_echo` test is the self-documenting proof of the delta: same payload, passes under the old behavior, raises under the new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)