### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@335134d

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ a065b21. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ b3c4498. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ b3c4498. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 335134d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-bpmn/references/api.md
+++ b/preview/uipath-maestro-bpmn/references/api.md
@@ -15,7 +15,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Option shapes** — [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [ConnectorOpts](#connectoropts-interface) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface)
 
-**Supporting types** — [BuiltBpmn](#builtbpmn-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [LoopSpec](#loopspec-interface) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface)
+**Supporting types** — [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [LoopSpec](#loopspec-interface) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface)
 
 ## bpmn (function)
 
@@ -27,6 +27,11 @@ export declare function bpmn(id: string): BpmnBuilder;
 ## BpmnBuilder (class)
 
 ````ts
+/**
+ * The top-level process builder `bpmn()` returns — every graph method of the
+ * shared scope (events, gateways, tasks, sub-processes, flows, variables) plus
+ * the process's `.name()` and the `.build()` that finishes it.
+ */
 export declare class BpmnBuilder extends ScopeBuilder {
     /** Set the process's display name. */
     name(n: string): this;
@@ -44,10 +49,6 @@ export declare class BpmnBuilder extends ScopeBuilder {
  * builder type (top-level or sub-process).
  */
 declare abstract class ScopeBuilder {
-    protected readonly _defs: DefinitionsRegistry;
-    protected readonly _nodes: BpmnNode[];
-    protected readonly _flows: BpmnFlow[];
-    protected readonly _vars: BpmnVarDecl[];
     /** A start event (authorable definitions: none / message / timer). */
     startEvent(id: string, opts?: StartOpts): this;
     /** An end event (authorable definitions: none / message / error / terminate). */
@@ -74,7 +75,11 @@ declare abstract class ScopeBuilder {
     scriptTask(id: string, opts: ScriptTaskOpts): this;
     /** A plain task that assigns variables (`BPMN.Variables`). */
     task(id: string, opts?: TaskOpts): this;
-    /** Typed form: a generated descriptor supplies the operation and its input types. */
+    /**
+     * An Integration Service **connector** service task (`bpmn:sendTask` +
+     * `uipath:activity` / `Intsvc.ActivityExecution`) — the typed form, where a
+     * generated descriptor supplies the operation and its input types.
+     */
     connector<I extends Record<string, unknown>, O>(id: string, descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: ConnectorOpts & {
             name?: string;
         }): this;
@@ -106,9 +111,16 @@ export declare class SubProcessBuilder extends ScopeBuilder {
 ## StartOpts (interface)
 
 ````ts
+/**
+ * Options for `.startEvent()`. At most one of `message` / `timer` picks the
+ * event definition (`timer` wins if both are set); neither means a plain start.
+ */
 export interface StartOpts {
+    /** Display name the designer shows on the event. */
     name?: string;
+    /** Start when this message arrives — declares/reuses a definitions-level `bpmn:message`. */
     message?: string;
+    /** Start on a timer — an ISO-8601 duration string, or a full `TimerSpec`. */
     timer?: TimerLike;
 }
 ````
@@ -116,10 +128,18 @@ export interface StartOpts {
 ## EndOpts (interface)
 
 ````ts
+/**
+ * Options for `.endEvent()`. `terminate`, `error`, or `message` picks the event
+ * definition, checked in that order; none of them means a plain end.
+ */
 export interface EndOpts {
+    /** Display name the designer shows on the event. */
     name?: string;
+    /** End as a TERMINATE event — abort the whole process instance, not just this path. */
     terminate?: boolean;
+    /** End by throwing this message — declares/reuses a definitions-level `bpmn:message`. */
     message?: string;
+    /** End by throwing this error (a name, or `{ name, code }`) — declares/reuses a definitions-level `bpmn:error`. */
     error?: string | {
             name: string;
             code?: string;
@@ -130,9 +150,16 @@ export interface EndOpts {
 ## CatchOpts (interface)
 
 ````ts
+/**
+ * Options for `.intermediateCatchEvent()`. `message` or `timer` picks what the
+ * event waits for (`timer` wins if both are set).
+ */
 export interface CatchOpts {
+    /** Display name the designer shows on the event. */
     name?: string;
+    /** Wait for this message — declares/reuses a definitions-level `bpmn:message`. */
     message?: string;
+    /** Wait for a timer — an ISO-8601 duration string, or a full `TimerSpec`. */
     timer?: TimerLike;
 }
 ````
@@ -140,8 +167,11 @@ export interface CatchOpts {
 ## ThrowOpts (interface)
 
 ````ts
+/** Options for `.intermediateThrowEvent()` — a `message` to throw, or none. */
 export interface ThrowOpts {
+    /** Display name the designer shows on the event. */
     name?: string;
+    /** The message to throw — declares/reuses a definitions-level `bpmn:message`. */
     message?: string;
 }
 ````
@@ -149,14 +179,24 @@ export interface ThrowOpts {
 ## BoundaryOpts (interface)
 
 ````ts
+/**
+ * Options for `.boundaryEvent()`: the activity it attaches to, whether it
+ * interrupts that activity, and the event definition — exactly one of
+ * `message` / `timer` / `error` (checked in the order error, timer, message;
+ * none at all is refused).
+ */
 export interface BoundaryOpts {
+    /** Display name the designer shows on the event. */
     name?: string;
     /** id of the activity this boundary event is attached to. */
     attachedTo: string;
     /** true (default) = interrupting; false = non-interrupting. */
     cancelActivity?: boolean;
+    /** Catch this message — declares/reuses a definitions-level `bpmn:message`. */
     message?: string;
+    /** Fire on a timer — an ISO-8601 duration string, or a full `TimerSpec`. */
     timer?: TimerLike;
+    /** Catch this error (a name, or `{ name, code }`) — declares/reuses a definitions-level `bpmn:error`. */
     error?: string | {
             name: string;
             code?: string;
@@ -167,7 +207,9 @@ export interface BoundaryOpts {
 ## GatewayOpts (interface)
 
 ````ts
+/** Options for `.exclusiveGateway()` / `.inclusiveGateway()`. */
 export interface GatewayOpts {
+    /** Display name the designer shows on the gateway. */
     name?: string;
     /** Outgoing flow id taken when no condition matches (exclusive/inclusive). */
     default?: string;
@@ -177,10 +219,13 @@ export interface GatewayOpts {
 ## ScriptTaskOpts (interface)
 
 ````ts
+/** Options for `.scriptTask()` — the Jint JavaScript body and its input/output mappings. */
 export interface ScriptTaskOpts {
+    /** Display name the designer shows on the task. */
     name?: string;
     /** The script body (Jint JavaScript). */
     script: string;
+    /** The script language marker. Defaults to `'JavaScript'` (Jint). */
     scriptFormat?: string;
     /** `uipath:input` rows: field name → `=`-expression read into the script. */
     inputs?: Record<string, string>;
@@ -192,7 +237,9 @@ export interface ScriptTaskOpts {
 ## TaskOpts (interface)
 
 ````ts
+/** Options for `.task()` — a display name and the variable assignments the task makes. */
 export interface TaskOpts {
+    /** Display name the designer shows on the task. */
     name?: string;
     /** Variable assignments (`BPMN.Variables`): variable id → `=`-expression/literal. */
     set?: Record<string, string>;
@@ -220,9 +267,13 @@ export interface ConnectorOpts {
 ## SubProcessOpts (interface)
 
 ````ts
+/** Options for `.subProcess()`. */
 export interface SubProcessOpts {
+    /** Display name the designer shows on the sub-process. */
     name?: string;
+    /** Mark an EVENT sub-process — started by an event inside it, not by an incoming flow. */
     triggeredByEvent?: boolean;
+    /** Run the body once per item of a collection — see `LoopSpec`. */
     loop?: LoopSpec;
 }
 ````
@@ -230,9 +281,13 @@ export interface SubProcessOpts {
 ## FlowOpts (interface)
 
 ````ts
+/** Options for `.sequenceFlow()`. */
 export interface FlowOpts {
+    /** The flow's element id. Defaults to `Flow_<source>_<target>`. */
     id?: string;
+    /** Edge label the designer shows. */
     name?: string;
+    /** `=`-expression gating this flow (exclusive/inclusive gateway outgoing). */
     condition?: string;
 }
 ````
@@ -240,9 +295,13 @@ export interface FlowOpts {
 ## VarOpts (interface)
 
 ````ts
+/** Options for `.var()` / `.input()` / `.output()`. */
 export interface VarOpts {
+    /** Display name; defaults to the variable's id. */
     name?: string;
+    /** Optional initial value. */
     default?: unknown;
+    /** When set, the variable is scoped to that element rather than root/global. */
     elementId?: string;
 }
 ````
@@ -258,17 +317,6 @@ export interface BuiltBpmn {
     errors: ErrorDecl[];
     nodes: BpmnNode[];
     flows: BpmnFlow[];
-}
-````
-
-## DefinitionsRegistry (class)
-
-````ts
-declare class DefinitionsRegistry {
-    readonly messages: MessageDecl[];
-    readonly errors: ErrorDecl[];
-    messageRef(name: string): string;
-    errorRef(name: string, code?: string): string;
 }
 ````
 
@@ -353,6 +401,17 @@ export interface BpmnVarDecl {
     direction: VarDirection;
     default?: unknown;
     elementId?: string;
+}
+````
+
+## DefinitionsRegistry (class)
+
+````ts
+declare class DefinitionsRegistry {
+    readonly messages: MessageDecl[];
+    readonly errors: ErrorDecl[];
+    messageRef(name: string): string;
+    errorRef(name: string, code?: string): string;
 }
 ````
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ a065b21. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ b3c4498. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ b3c4498. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 335134d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -131,6 +131,7 @@ export declare function casePlan(id: string): CaseBuilder;
 /**
      * Declare a read/write case variable.
      *
+     * @remarks
      * Readable from a `=js:vars.<name>` expression, like a trigger-bound In-arg.
      *
      * This comment used to say the opposite — that only `.input(shape, { from })`
@@ -158,6 +159,8 @@ export declare function casePlan(id: string): CaseBuilder;
      * projected into that trigger's `entry-points.json` input schema. A declared
      * In-arg is readable as `=vars.<name>` (its `inputOutputs` companion resolves it).
      *
+     * @example
+     * **Bind case In-args to a trigger's payload**
      * ```ts
      * const t = manualTrigger();
      * casePlan('x').trigger(t)
@@ -270,6 +273,8 @@ export interface CaseVarDecl {
  * vs array is `body.type`. Use in `.var()`/`.input()`/`.output()` where a
  * {@link TypeDesc} is expected.
  *
+ * @example
+ * **Declare an object variable and an array variable**
  * ```ts
  * .var('caseData', jsonSchema({ type: 'object', properties: { status: { type: 'string' } } }))
  * .var('attachments', jsonSchema({ type: 'array', items: { type: 'string' } }))
@@ -376,6 +381,7 @@ export interface ExitOpts {
      * `exitToStage` — including backward edges (returning to an earlier stage is just
      * an exit that routes there).
      *
+     * @remarks
      * The destination still evaluates its own `entryWhen(...)`, and only
      * STAGE-ENTRY rules are legal there: `selected-stage-completed` /
      * `selected-stage-exited` / `user-selected-stage` / `case-entered`. Do NOT try to
@@ -625,6 +631,7 @@ export interface ActionSpecData {
  * `InputOutput` row (`{ name, type, displayName? }`) under `data.inputs[]` /
  * `data.outputs[]`.
  *
+ * @remarks
  * Note: no `required` flag — on a task's io row `required` means "must hold a
  * value now", which `uip maestro case validate` rejects as an empty required
  * field at author time. Whether the assignee must fill a field is governed by the
@@ -777,6 +784,7 @@ export interface RuleOpts {
     /**
      * Symbolic stage label (for `selected-stage-completed` / `selected-stage-exited`).
      *
+     * @remarks
      * Both rules serialize identically — to `selectedStageId` — so this SDK draws no
      * distinction between them; the difference is interpreted at runtime. Use
      * `selected-stage-exited` for an interrupting exception-stage entry (what the
@@ -788,6 +796,7 @@ export interface RuleOpts {
      * Task references for `selected-tasks-completed`. Resolved **case-wide, not
      * per-stage** — a rule in one stage may reference a task in another.
      *
+     * @remarks
      * Two forms:
      * - bare `'Task Name'` — the normal form.
      * - qualified `'<Stage Label>/<Task Name>'` — also accepted, and clearer when a
@@ -1009,6 +1018,7 @@ export interface EventTriggerOpts {
      * (`=response.<field>`). Pass `{ source, type }` for a non-`string` type. Each
      * emits a trigger `outputs[]` row plus a readable root `inputOutputs` companion.
      *
+     * @remarks
      * With **no** outputs the event trigger is a **placeholder** (`data.uipath`
      * carries only `serviceType`) — the offline shape for an event on a connector
      * not yet registered; attach the real connection after registering it.

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -228,7 +228,11 @@ declare class TaskBuilder {
             inputs?: ActionField[];
             outputs?: ActionField[];
         }): this;
-    /** Typed form: a generated descriptor supplies the operation and its input types. */
+    /**
+     * An Integration Service connector task — runs a connector activity (e.g. Slack
+     * `send-message-to-channel`) — the typed form, where a generated descriptor
+     * supplies the operation and its input types.
+     */
     connector<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: ConnectorOpts): this;
     /** Stringly form, for a connector with no prepared module. */
     connector(key: string, action: string, inputs?: Record<string, unknown>, opts?: ConnectorOpts): this;

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ b3c4498. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 335134d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -154,6 +154,25 @@ Prefer self-contained variables because there may be no caller supplying inputs.
 
 **Reference: [`references/scheduled-trigger.md`](references/scheduled-trigger.md)**
 
+## Entry points (multiple triggers)
+
+A flow may have more than one root. `.trigger()` / `.input()` stay the DEFAULT
+root; `.entryPoint(id, trigger, { inputs?, version? }, prefixFn?)` adds another
+— its own trigger node, its own scoped inputs (read them with
+`entryInput('<id>', '<name>')`), and an optional prefix that runs before the
+root joins the first shared step. A prefix that ends terminally (or hands off
+with `.stepToRef(...)`) joins nothing.
+
+```ts
+flow('order-intake')
+  .input({ order: types.object })                       // default (manual) root
+  .entryPoint('nightly', scheduled({ every: 'R/P1D' }), {
+    inputs: { batchDate: types.string },
+  }, (b) => b.step('loadBatch', script({
+    code: 'return { note: $vars.nightly.output.batchDate };', returns: 'object' })))
+  .step('normalize', script({ code: 'return 1;' }))     // shared body
+```
+
 ## Connector events
 
 Start on, or pause for, an Integration Service event subscription.
@@ -298,7 +317,7 @@ Confirm identity and exact argument casing on the tenant; `.onError(...)` is sup
 
 Run a deployed Maestro agentic process synchronously.
 
-Signature: `agenticProcess({ key, name, folderPath, inputs?, returns? })`.
+Signature: `agenticProcess({ key, name, folderPath, inputs?, returns?, form?, completion? })`.
 
 ```ts
 .step('intake', agenticProcess({ key: processKey,
@@ -306,7 +325,9 @@ Signature: `agenticProcess({ key, name, folderPath, inputs?, returns? })`.
   inputs: { productId: 1 }, returns: { status: 'boolean' } }))
 ```
 
-Confirm identity and argument names live; declared outputs may still be null, and `.onError(...)` is supported.
+Confirm identity and argument names live; declared outputs may still be null;
+`.onError(...)` is supported. `form: 'bpmn' | 'flow' | 'case'` picks the published
+form; `completion: 'fire-and-forget'` waits for nothing — see the reference.
 
 **Reference: [`references/agentic-process.md`](references/agentic-process.md)**
 
@@ -542,7 +563,7 @@ Discover tenant-specific fields and ids rather than guessing; preserve every sce
 
 Run a body once for each value in a collection.
 
-Signature: `.loop(name, collection, bodyFn)`.
+Signature: `.loop(name, collection, bodyFn, options?)`.
 
 ```ts
 .loop('eachOrder', input('orders'), (body) => body
@@ -550,9 +571,32 @@ Signature: `.loop(name, collection, bodyFn)`.
     'return { id: $vars.eachOrder.currentItem.id };' })))
 ```
 
-The SDK has no per-iteration flow-variable mutation; keep per-item work in the body.
+Per-iteration flow-variable writes go through `{ updates }` on a body step.
+Options select the richer loop contract: `parallel: true`, `completionCondition`
+(checked after each iteration, stops early), and `body.break()` exits the whole
+loop from inside an arm. See the reference for the option details and examples.
 
 **Reference: [`references/loops.md`](references/loops.md)**
+
+## Do while
+
+Run a body, then repeat **while a condition is true** — checked AFTER each
+pass, so the body always runs at least once (`core.logic.dowhile`). The
+container publishes no data output: write results to a `.var()` from inside
+the body with `{ updates }`. `limit` caps iterations (1–10,000; blank means
+the platform default of 10,000), and `body.break()` works exactly as in
+`.loop()`.
+
+Signature: `.doWhile(name, condition, bodyFn, { limit?, breakEnabled? })`.
+
+```ts
+.var('page', types.number, 1)
+.doWhile('paginate', js`$vars.fetch.output.hasNextPage === true`, (body) => body
+  .step('fetch', http({ url: tmpl`https://api.example.test/items?page=${v('page')}`,
+    method: 'GET', managed: false, returns: { hasNextPage: 'boolean' } }),
+    { updates: { page: js`$vars.page + 1` } }),
+  { limit: 50 })
+```
 
 ## Return and end
 

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ a065b21. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ b3c4498. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/agent.md
+++ b/preview/uipath-maestro-flow/references/agent.md
@@ -1,6 +1,6 @@
 # Agent
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`agent()`](api.md#agent-function).*
+*Exact signatures, fields, and defaults: [`agent()`](api.md#agent-function).*
 
 Start a coded or low-code agent and wait for its output. The resource may be
 published in Orchestrator or registered as a sibling project in this solution.

--- a/preview/uipath-maestro-flow/references/agentic-process.md
+++ b/preview/uipath-maestro-flow/references/agentic-process.md
@@ -22,3 +22,20 @@ See [Orchestrator Processes](or-processes.md) and use the `ProcessOrchestration`
 ## General
 
 - Declared outputs can be returned as `null`
+
+## Forms and fire-and-forget completion
+
+One `agenticProcess()` covers all three published forms; `form` selects the
+wire identity: `'bpmn'` (default — Maestro BPMN process orchestration),
+`'flow'` (published Maestro Flow), `'case'` (Case Management process).
+
+`completion: 'fire-and-forget'` dispatches the process and continues
+immediately: `returns` is forbidden, the step publishes no output (reading
+`$vars.<step>.output` is a check error), and only dispatch failures route
+through `.onError(...)`. Local replay treats it as dispatch-only.
+
+```ts
+.step('launchReview', agenticProcess({ key: reviewKey, name: 'ClaimsReview',
+  folderPath: 'Shared', form: 'flow', completion: 'fire-and-forget',
+  inputs: { claimId: input('claimId') } }))
+```

--- a/preview/uipath-maestro-flow/references/agentic-process.md
+++ b/preview/uipath-maestro-flow/references/agentic-process.md
@@ -1,6 +1,6 @@
 # Agentic Process
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`agenticProcess()`](api.md#agenticprocess-function).*
+*Exact signatures, fields, and defaults: [`agenticProcess()`](api.md#agenticprocess-function).*
 
 Invoke a deployed Maestro agentic process.
 

--- a/preview/uipath-maestro-flow/references/api-workflow.md
+++ b/preview/uipath-maestro-flow/references/api-workflow.md
@@ -1,6 +1,6 @@
 # API Workflow
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`apiWorkflow()`](api.md#apiworkflow-function).*
+*Exact signatures, fields, and defaults: [`apiWorkflow()`](api.md#apiworkflow-function).*
 
 Run a deployed coded API workflow as a serverless Orchestrator job.
 

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -9,19 +9,19 @@ Exact `@uipath/flow-sdk` authoring signatures and option shapes, from the public
 declarations. Signatures, fields, optionality, and declaration comments are
 generated from the built types; longer tutorials stay in the node references.
 
-**Flow construction** — [SCHEDULE_PRESETS](#schedulepresets-const) · [onEvent](#onevent-function) · [scheduled](#scheduled-function) · [flow](#flow-function) · [subflow](#subflow-function)
+**Flow construction** — [SCHEDULE_PRESETS](#schedulepresets-const) · [manual](#manual-function) · [onEvent](#onevent-function) · [scheduled](#scheduled-function) · [flow](#flow-function) · [subflow](#subflow-function)
 
 **Actions** — [DELAY_PRESETS](#delaypresets-const) · [http](#http-function) · [script](#script-function) · [transform](#transform-function) · [hitl](#hitl-function) · [summarize](#summarize-function) · [batchTransform](#batchtransform-function) · [ixpExtract](#ixpextract-function) · [delay](#delay-function) · [mock](#mock-function) · [rpaWorkflow](#rpaworkflow-function) · [apiWorkflow](#apiworkflow-function) · [agenticProcess](#agenticprocess-function) · [agent](#agent-function) · [inlineAgent](#inlineagent-function) · [queueItem](#queueitem-function) · [connector](#connector-function) · [waitForEvent](#waitforevent-function)
 
-**Expressions and types** — [lit](#lit-function) · [v](#v-function) · [DEFAULT_TRIGGER_ID](#defaulttriggerid-const) · [input](#input-function) · [out](#out-function) · [ran](#ran-function) · [err](#err-function) · [js](#js-function) · [tmpl](#tmpl-function) · [types](#types-const)
+**Expressions and types** — [lit](#lit-function) · [v](#v-function) · [DEFAULT_TRIGGER_ID](#defaulttriggerid-const) · [input](#input-function) · [entryInput](#entryinput-function) · [out](#out-function) · [ran](#ran-function) · [err](#err-function) · [js](#js-function) · [tmpl](#tmpl-function) · [types](#types-const)
 
 **Generated descriptors** — [descriptor](#descriptor-function) · [triggerDescriptor](#triggerdescriptor-function)
 
 **Builders** — [FlowBuilder](#flowbuilder-class) · [StepList](#steplist-class) · [ArmBuilder](#armbuilder-class)
 
-**Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-interface) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-interface) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [HttpInputsBase](#httpinputsbase-interface)
+**Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-interface) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-type) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [NodeOptions](#nodeoptions-interface) · [HttpInputsBase](#httpinputsbase-interface) · [AgenticProcessInputsBase](#agenticprocessinputsbase-interface) · [LoopOptions](#loopoptions-interface) · [DoWhileOptions](#dowhileoptions-interface)
 
-**Supporting types** — [TriggerDescriptor](#triggerdescriptor-type) · [TriggerSpec](#triggerspec-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [TypeDesc](#typedesc-type) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [OutputColumn](#outputcolumn-interface) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [VarDecl](#vardecl-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type)
+**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [TriggerSpec](#triggerspec-type) · [TriggerDescriptor](#triggerdescriptor-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [OutputColumn](#outputcolumn-interface) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type)
 
 ## SCHEDULE_PRESETS (const)
 
@@ -34,6 +34,19 @@ generated from the built types; longer tutorials stay in the node references.
  * just the ones that round-trip as a named preset rather than as "custom".
  */
 export declare const SCHEDULE_PRESETS: readonly ["R/PT5M", "R/PT15M", "R/PT30M", "R/PT1H", "R/PT6H", "R/PT12H", "R/P1D", "R/P1W"];
+````
+
+## manual (function)
+
+````ts
+/**
+ * The manual trigger, explicitly. Omitting `.trigger(...)` means exactly this —
+ * the factory exists so decompiled source can carry the trigger's exact
+ * definition version (`.trigger(manual(), { version: '1.0.0' })`) instead of
+ * leaving the default implicit, and so hand-written flows can opt into the
+ * same explicitness.
+ */
+export declare function manual(): TriggerSpec;
 ````
 
 ## onEvent (function)
@@ -319,6 +332,18 @@ export declare const DEFAULT_TRIGGER_ID = "start";
 export declare function input(name: string): Expr;
 ````
 
+## entryInput (function)
+
+````ts
+/**
+ * Reference an ENTRY POINT's scoped input: `entryInput('nightly', 'batchDate')`
+ * reads `$vars.nightly.output.batchDate` — an input declared on
+ * `.entryPoint('nightly', …, { inputs: { batchDate: … } })`. `input(name)`
+ * remains the spelling for the DEFAULT root's inputs.
+ */
+export declare function entryInput(entryPointId: string, name: string): Expr;
+````
+
 ## out (function)
 
 ````ts
@@ -430,13 +455,37 @@ declare class FlowBuilder extends StepList {
      */
     name(n: string): this;
     /**
+     * Set the flow's description — persisted as the top-level `description`
+     * field of the emitted `.flow`, shown in the designer's flow header.
+     */
+    description(text: string): this;
+    /**
+     * Set designer layout — node positions/sizes and edge routes — keyed by the
+     * flow's own logical ids (step names, the trigger id, `end`). Optional pure
+     * metadata: nothing here changes what the flow does, and omitting it leaves
+     * the serializer's default arrangement. Unknown keys fail compilation rather
+     * than being dropped.
+     */
+    layout(layout: FlowLayout): this;
+    /**
      * Set what starts the flow. Omit this call for the **manual** trigger (a
      * caller starts the flow on demand) — that is the default and what most
      * flows want.
      *
      * @defaultValue the manual trigger
      */
-    trigger(spec: TriggerSpec): this;
+    trigger(spec: TriggerSpec | FlowTrigger, options?: NodeOptions): this;
+    /**
+     * Add an ADDITIONAL flow root (design §5.1): its own trigger node, its own
+     * scoped inputs (read them with `entryInput('<id>', '<name>')`), and an
+     * optional prefix that runs before the root joins the shared body. Without a
+     * prefix the root connects straight to the first shared step; a prefix that
+     * ends terminally (or hands off with `.stepToRef()`) joins nothing.
+     */
+    entryPoint(id: string, trigger: TriggerSpec | FlowTrigger, options?: {
+            version?: string;
+            inputs?: Record<string, TypeDesc | VarSpec>;
+        }, prefixFn?: (b: StepList) => void): this;
     /**
      * Rename the trigger node. The designer can rename it, so the SDK can too.
      *
@@ -446,11 +495,11 @@ declare class FlowBuilder extends StepList {
     /** Set the flow's version. */
     version(vsn: string): this;
     /** Declare the flow's inputs. Read them with `input('<name>')`. */
-    input(shape: Record<string, TypeDesc>): this;
+    input(shape: Record<string, TypeDesc | VarSpec>): this;
     /** Declare the flow's outputs — what `.return(...)` binds values to. */
-    output(shape: Record<string, TypeDesc>): this;
+    output(shape: Record<string, TypeDesc | VarSpec>): this;
     /** Declare a flow-level variable. Read it with `v('<name>')`. */
-    var(name: string, type: TypeDesc, defaultValue?: unknown): this;
+    var(name: string, type: TypeDesc | VarSpec, defaultValue?: unknown): this;
     /** Finish the flow and return the graph the compiler serializes. */
     build(): BuiltFlow;
 }
@@ -463,7 +512,7 @@ declare class FlowBuilder extends StepList {
 declare class StepList {
     steps: Step[];
     /** Add an action node (see `http` / `script` / `subflow`). */
-    step(name: string, spec: FlowActionSpec): this;
+    step(name: string, spec: FlowActionSpec | FlowAction, options?: NodeOptions): this;
     /**
      * Handle the PREVIOUS step's failure: if it fails, the flow runs `bodyFn`'s
      * steps instead of continuing.
@@ -478,7 +527,7 @@ declare class StepList {
      */
     stepToList(port: string, bodyFn: (b: StepList) => void): this;
     /** Branch on a condition. `thenFn`/`elseFn` receive a sub-builder for each arm. */
-    branch(name: string, cond: Expr, thenFn: (b: ArmBuilder) => void, elseFn?: (b: ArmBuilder) => void): this;
+    branch(name: string, cond: Expr, thenFn: (b: ArmBuilder) => void, elseFn?: (b: ArmBuilder) => void, options?: NodeOptions): this;
     /**
      * N-way branch on the value of `on` — one arm per case, plus an optional
      * default arm. Each arm gets its own sub-builder, exactly like `.branch`.
@@ -487,23 +536,39 @@ declare class StepList {
             value: CaseValue;
             body: (b: ArmBuilder) => void;
             label?: string;
-        }[], defaultFn?: (b: StepList) => void): this;
+        }[], defaultFn?: (b: StepList) => void, options?: NodeOptions): this;
     /**
      * Run two or more arms **in parallel** from this point and join them back
      * together on a Merge node — the one place the builder stops being a straight
      * chain.
      */
-    parallel(name: string, arms: ((b: StepList) => void)[]): this;
+    parallel(name: string, arms: ((b: StepList) => void)[], options?: NodeOptions): this;
     /** Iterate `collection`; `bodyFn` receives a sub-builder for the loop body. */
-    loop(name: string, collection: Expr, bodyFn: (b: StepList) => void): this;
+    loop(name: string, collection: Expr, bodyFn: (b: StepList) => void, options?: LoopOptions): this;
+    /**
+     * Run the body, then repeat **while `condition` is true** — the condition is
+     * checked AFTER each iteration, so the body always runs at least once
+     * (`core.logic.dowhile`). The container publishes no data output; write
+     * results to a `.var()` from inside the body (`{ updates }`), and read the
+     * loop's progress nowhere — unlike `.loop()` there is no `currentItem`.
+     */
+    doWhile(name: string, condition: Expr, bodyFn: (b: StepList) => void, options?: DoWhileOptions): this;
+    /**
+     * Exit the enclosing `.loop()` / `.doWhile()` through its **break handle**,
+     * ending the whole loop now — not just this iteration. Terminal on its path:
+     * nothing may follow it, exactly like `.terminate()`. Using it enables the
+     * container's break handle automatically. Compilation fails when there is no
+     * enclosing container.
+     */
+    break(): this;
     /** Stop the **whole run**, here and now — not just this path. */
-    terminate(name: string, label?: string): this;
+    terminate(name: string, label?: string, options?: NodeOptions): this;
     /** Go to another step, by name — an edge, not a node. */
     stepToRef(target: string): this;
     /** Go to another step from a NAMED PORT — a side exit. */
     stepToRef(port: string, target: string): this;
     /** Terminate this path, binding flow outputs to expressions. */
-    return(values?: Record<string, Expr | unknown>): this;
+    return(values?: Record<string, Expr | unknown>, options?: NodeOptions): this;
 }
 ````
 
@@ -843,42 +908,11 @@ export interface ApiWorkflowInputs {
 }
 ````
 
-## AgenticProcessInputs (interface)
+## AgenticProcessInputs (type)
 
 ````ts
-export interface AgenticProcessInputs {
-    /**
-     * The published agentic process's key (a GUID). It becomes part of the node's
-     * type, `uipath.core.agentic-process.<key>`. Find it with
-     * `uip or processes list --all-folders --process-type ProcessOrchestration` (an
-     * agentic process's `ProcessKey` reads `<name>.agentic.<name>`; the GUID you want
-     * is the row's `Key`) or `uip maestro flow registry search agentic`.
-     */
-    key: string;
-    /** The process's name in Orchestrator — e.g. `'ProcurementProcess'`. */
-    name: string;
-    /**
-     * The Orchestrator folder holding it — e.g.
-     * `'Shared/uipath-agents/ProcurementProcess'`.
-     */
-    folderPath: string;
-    /**
-     * The PROCESS's own input arguments, by its own argument names (e.g.
-     * `{ productId: 1 }`). Not a fixed schema — every agentic process declares its
-     * own, and only the deployed process knows them.
-     */
-    inputs?: Record<string, unknown>;
-    /**
-     * The process's OUTPUT arguments — the fields it returns, and their types (e.g.
-     * `{ status: 'boolean' }`). Required if anything reads the step's output, for the
-     * same reason as `rpaWorkflow`'s and `apiWorkflow`'s: the schema lives on the
-     * tenant and authoring happens offline, so an undeclared read is rejected.
-     *
-     * @enforcedBy AGENTIC_READ_WITHOUT_RETURNS Reading a field off the result requires
-     *   declaring it here.
-     */
-    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
-}
+/** What `agenticProcess()` takes: the shared fields plus the completion policy. */
+export type AgenticProcessInputs = AgenticProcessInputsBase & AgenticProcessCompletion;
 ````
 
 ## AgentInputs (interface)
@@ -1080,6 +1114,33 @@ export interface ConnectorOpts {
 }
 ````
 
+## NodeOptions (interface)
+
+````ts
+/**
+ * Options shared by every builder method that creates a definition-backed node
+ * (design §5.2). More fields (label overrides, variable updates) arrive in
+ * later phases; today this carries exact version selection.
+ */
+export interface NodeOptions {
+    /**
+     * The EXACT `definitions[].version` (and node `typeVersion`) this node must
+     * compile against — a request and a constraint, never a "latest" selector.
+     * Omit it and the SDK uses its pinned default for the node family; name a
+     * version the SDK cannot resolve exactly and compilation fails rather than
+     * substituting another version.
+     */
+    version?: string;
+    /**
+     * Flow-variable assignments applied when this node completes — the format's
+     * `variables.variableUpdates[nodeId]`, attached to the real node exactly as
+     * Flow JSON stores it. Keys name declared `.var()` variables (or flow
+     * outputs); values are `Expr`s or raw literals.
+     */
+    updates?: Record<string, Expr | unknown>;
+}
+````
+
 ## HttpInputsBase (interface)
 
 ````ts
@@ -1169,24 +1230,212 @@ interface HttpInputsBase {
 }
 ````
 
-## TriggerDescriptor (type)
+## AgenticProcessInputsBase (interface)
 
 ````ts
-export type TriggerDescriptor<W = Record<string, string>, O = Record<string, unknown>> = TriggerMeta & {
-    readonly __where?: W;
-    readonly __output?: O;
+interface AgenticProcessInputsBase {
+    /**
+     * The published agentic process's key (a GUID). It becomes part of the node's
+     * type, `uipath.core.agentic-process.<key>`. Find it with
+     * `uip or processes list --all-folders --process-type ProcessOrchestration` (an
+     * agentic process's `ProcessKey` reads `<name>.agentic.<name>`; the GUID you want
+     * is the row's `Key`) or `uip maestro flow registry search agentic`.
+     */
+    key: string;
+    /** The process's name in Orchestrator — e.g. `'ProcurementProcess'`. */
+    name: string;
+    /**
+     * The Orchestrator folder holding it — e.g.
+     * `'Shared/uipath-agents/ProcurementProcess'`.
+     */
+    folderPath: string;
+    /**
+     * The PROCESS's own input arguments, by its own argument names (e.g.
+     * `{ productId: 1 }`). Not a fixed schema — every agentic process declares its
+     * own, and only the deployed process knows them.
+     */
+    inputs?: Record<string, unknown>;
+    /**
+     * Which published form this Agentic Process is (design §2.1): the three forms
+     * share one public concept and differ only in wire identity. `'bpmn'` (the
+     * default, and what this factory always emitted) is a Maestro BPMN process
+     * orchestration; `'flow'` is a published Maestro Flow; `'case'` is a Case
+     * Management process.
+     */
+    form?: 'bpmn' | 'flow' | 'case';
+}
+````
+
+## LoopOptions (interface)
+
+````ts
+/**
+ * Loop-specific options (design §5.2). Any of these — or a `b.break()` in the
+ * body — selects the loop's v2.4 definition (the current Workbench contract,
+ * with inner `start`/`continue`/`break` handles); a plain `.loop()` keeps the
+ * SDK's long-pinned 1.0.0 emission unchanged. An explicit `{ version: '1.0.0' }`
+ * combined with any of these fails compilation: that definition cannot express
+ * them.
+ */
+export interface LoopOptions extends NodeOptions {
+    /** Run iterations in parallel instead of sequentially. */
+    parallel?: boolean;
+    /**
+     * Stop early when this condition (evaluated after each iteration) is true —
+     * e.g. `js`$vars.hits.output.length >= 10``.
+     */
+    completionCondition?: Expr;
+    /**
+     * Show the loop's break handle without wiring one — set automatically when
+     * the body calls `b.break()`.
+     */
+    breakEnabled?: boolean;
+}
+````
+
+## DoWhileOptions (interface)
+
+````ts
+/**
+ * Do-while options (design §3.1). `limit` caps iterations; the platform
+ * defaults a blank limit to 10,000 and rejects values outside 1–10,000.
+ */
+export interface DoWhileOptions extends NodeOptions {
+    /** Maximum iterations, 1–10,000. Blank means the platform default (10,000). */
+    limit?: number;
+    /** Show the break handle without wiring one — set automatically by `b.break()`. */
+    breakEnabled?: boolean;
+}
+````
+
+## ContributionDiagnostic (interface)
+
+````ts
+export interface ContributionDiagnostic {
+    code: string;
+    message: string;
+    severity: 'error' | 'warning';
+}
+````
+
+## DefinitionReference (type)
+
+````ts
+export type DefinitionReference = {
+    /** Resolve from the SDK's bundled core definitions. */
+    source: 'bundled';
+    /** The definition's `nodeType`, e.g. `'core.logic.delay'`. */
+    nodeType: string;
+    /** The exact definition version; also becomes the node's `typeVersion`. */
+    version: string;
+} | {
+    /** Resolve from the connector library supplied at compile time. */
+    source: 'library';
+    /** The definition's `nodeType`. */
+    nodeType: string;
+    /** The exact definition version; also becomes the node's `typeVersion`. */
+    version: string;
+} | {
+    /** Carry an exact registry/Workbench definition in memory. */
+    source: 'snapshot';
+    /** The definition's `nodeType`; must equal `manifest.nodeType`. */
+    nodeType: string;
+    /** The exact definition version; must equal `manifest.version`. */
+    version: string;
+    /** The complete node manifest, exactly as the platform serves it. */
+    manifest: unknown;
 };
+````
+
+## ContributionContext (interface)
+
+````ts
+export interface ContributionContext {
+    requestedVersion?: string;
+}
+````
+
+## BindingContribution (interface)
+
+````ts
+export interface BindingContribution {
+    id: string;
+    name: string;
+    type: string;
+    resource: string;
+    resourceKey: string;
+    default?: string;
+    propertyAttribute?: string;
+    resourceSubType?: string;
+}
+````
+
+## NodeContribution (interface)
+
+````ts
+export interface NodeContribution {
+    definition: DefinitionReference;
+    inputs?: Record<string, unknown>;
+    outputs?: Record<string, unknown>;
+    bindings?: BindingContribution[];
+}
+````
+
+## FlowNode (class)
+
+````ts
+export declare abstract class FlowNode<TOutputs = unknown> {
+    readonly __outputs?: TOutputs;
+    abstract readonly role: 'action' | 'trigger' | 'resource';
+    abstract contribute(context: ContributionContext): NodeContribution;
+    diagnostics(): ContributionDiagnostic[];
+}
+````
+
+## FlowAction (class)
+
+````ts
+export declare abstract class FlowAction<TOutputs = unknown> extends FlowNode<TOutputs> {
+    get role(): 'action';
+}
+````
+
+## FlowTrigger (class)
+
+````ts
+export declare abstract class FlowTrigger<TPayload = unknown> extends FlowNode<TPayload> {
+    get role(): 'trigger';
+}
+````
+
+## FlowResource (class)
+
+````ts
+export declare abstract class FlowResource extends FlowNode<never> {
+    get role(): 'resource';
+}
 ````
 
 ## TriggerSpec (type)
 
 ````ts
 export type TriggerSpec = {
+    kind: 'manual';
+} | {
     kind: 'scheduled';
     inputs: ScheduledInputs;
 } | {
     kind: 'event';
     subscription: EventSubscription;
+};
+````
+
+## TriggerDescriptor (type)
+
+````ts
+export type TriggerDescriptor<W = Record<string, string>, O = Record<string, unknown>> = TriggerMeta & {
+    readonly __where?: W;
+    readonly __output?: O;
 };
 ````
 
@@ -1330,10 +1579,31 @@ export interface EventFilter {
 export type ScheduleEvery = SchedulePreset | (string & {});
 ````
 
+## FlowLayout (interface)
+
+````ts
+export interface FlowLayout {
+    nodes?: Record<string, NodeLayout>;
+    edges?: Record<string, EdgeRoute>;
+}
+````
+
 ## TypeDesc (type)
 
 ````ts
 export type TypeDesc = (typeof types)[keyof typeof types];
+````
+
+## VarSpec (interface)
+
+````ts
+export interface VarSpec {
+    type: TypeDesc;
+    description?: string;
+    subType?: string;
+    schema?: Record<string, unknown>;
+    default?: unknown;
+}
 ````
 
 ## BuiltFlow (interface)
@@ -1342,12 +1612,16 @@ export type TypeDesc = (typeof types)[keyof typeof types];
 export interface BuiltFlow {
     id: string;
     name: string;
+    description?: string;
     version: string;
     inputs: VarDecl[];
     outputs: VarDecl[];
     vars: VarDecl[];
     steps: Step[];
     trigger?: TriggerSpec;
+    triggerOptions?: NodeOptions;
+    layout?: FlowLayout;
+    entryPoints?: BuiltEntryPoint[];
     triggerId?: string;
 }
 ````
@@ -1422,6 +1696,44 @@ export interface OutputColumn {
     name: string;
     description: string;
 }
+````
+
+## AgenticProcessCompletion (type)
+
+````ts
+export type AgenticProcessCompletion = {
+    /** Wait for the process and publish its outputs (the default). */
+    completion?: 'wait';
+    /**
+     * The process's OUTPUT arguments — the fields it returns, and their types (e.g.
+     * `{ status: 'boolean' }`). Required if anything reads the step's output, for the
+     * same reason as `rpaWorkflow`'s and `apiWorkflow`'s: the schema lives on the
+     * tenant and authoring happens offline, so an undeclared read is rejected.
+     *
+     * `uip maestro flow registry get uipath.core.agentic-process.<process>` shows what
+     * the platform synthesizes, under `outputDefinition.output.schema.properties`.
+     *
+     * Worth knowing before you assert on a value: a process can DECLARE a field and
+     * still leave it empty. `Shared/uipath-agents/ProcurementProcess` declares
+     * `{status: boolean}` and every job returns `{"status": null}` (measured
+     * 2026-07-29, four jobs) — the field arrives, the value does not.
+     *
+     * @enforcedBy AGENTIC_READ_WITHOUT_RETURNS Reading a field off the result requires
+     * declaring it here.
+     */
+    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+} | {
+    /**
+     * Dispatch the process and continue immediately — the platform's
+     * fire-and-forget switch. The node keeps only its `error` output (dispatch
+     * failures still route), and `check` rejects any read of the step's result.
+     * A local replay treats this as dispatch-only: it never fabricates the
+     * output a real run would not publish.
+     */
+    completion: 'fire-and-forget';
+    /** Impossible by design: an async dispatch publishes no output. */
+    returns?: never;
+};
 ````
 
 ## AgentLocation (type)
@@ -1509,6 +1821,7 @@ export type Step = {
     kind: 'action';
     name: string;
     spec: FlowActionSpec;
+    options?: NodeOptions;
 } | {
     kind: 'branch';
     name: string;
@@ -1518,6 +1831,7 @@ export type Step = {
     cond: Expr;
     then: Step[];
     otherwise: Step[];
+    options?: NodeOptions;
 } | {
     kind: 'switch';
     name: string;
@@ -1525,12 +1839,33 @@ export type Step = {
     on: Expr;
     cases: SwitchArm[];
     default?: Step[];
+    options?: NodeOptions;
 } | {
     kind: 'loop';
     name: string;
     label?: string;
     collection: Expr;
     body: Step[];
+    options?: LoopOptions;
+}
+/**
+ * A do-while container (`core.logic.dowhile`): run the body, then repeat
+ * while `condition` is true, up to `options.limit` iterations.
+ */
+ | {
+    kind: 'doWhile';
+    name: string;
+    label?: string;
+    condition: Expr;
+    body: Step[];
+    options?: DoWhileOptions;
+}
+/**
+ * Exit the enclosing loop/do-while through its break handle. Terminal on its
+ * path — nothing after it can run. Only valid inside a container body.
+ */
+ | {
+    kind: 'break';
 }
 /**
  * A fan-out and its join. `arms` is one step list per arm — an ARRAY, because
@@ -1543,6 +1878,7 @@ export type Step = {
     name: string;
     label?: string;
     arms: Step[][];
+    options?: NodeOptions;
 }
 /**
  * A hard stop: `core.logic.terminate`, a BPMN End event carrying a
@@ -1553,6 +1889,7 @@ export type Step = {
     kind: 'terminate';
     name: string;
     label?: string;
+    options?: NodeOptions;
 }
 /**
  * An edge to another step, by name. Creates no node of its own: it is ONE
@@ -1584,6 +1921,7 @@ export type Step = {
     kind: 'return';
     name: string;
     values: Record<string, Expr>;
+    options?: NodeOptions;
 };
 ````
 
@@ -1599,6 +1937,39 @@ export type FlowActionSpec = ActionSpec | SubflowSpec;
 export type CaseValue = string | number | boolean;
 ````
 
+## NodeLayout (interface)
+
+````ts
+export interface NodeLayout {
+    position: {
+            x: number;
+            y: number;
+        };
+    size?: {
+            width: number;
+            height: number;
+        };
+    collapsed?: boolean;
+}
+````
+
+## EdgeRoute (interface)
+
+````ts
+export interface EdgeRoute {
+    waypoints?: {
+            x: number;
+            y: number;
+            id?: string;
+        }[];
+    routedWaypoints?: {
+            x: number;
+            y: number;
+            id?: string;
+        }[];
+}
+````
+
 ## VarDecl (interface)
 
 ````ts
@@ -1606,6 +1977,21 @@ export interface VarDecl {
     name: string;
     type: TypeDesc;
     default?: unknown;
+    description?: string;
+    subType?: string;
+    schema?: Record<string, unknown>;
+}
+````
+
+## BuiltEntryPoint (interface)
+
+````ts
+export interface BuiltEntryPoint {
+    id: string;
+    trigger: TriggerSpec;
+    options?: NodeOptions;
+    inputs: VarDecl[];
+    steps: Step[];
 }
 ````
 

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -194,6 +194,7 @@ Behavior and worked examples: [delay.md](delay.md).
 ## mock (function)
 
 ````ts
+/** Declare a PLACEHOLDER step — "a real node goes here later". */
 export declare function mock(): ActionSpec;
 ````
 
@@ -275,8 +276,9 @@ Behavior and worked examples: [queue.md](queue.md).
 
 ````ts
 /**
- * Typed form: a generated descriptor supplies the nodeType and statically-checked
- * input types — `connector(CreateIssue, { fields: { summary: '…' } }, { connection })`.
+ * Declare an Integration Service connector action — the typed form, where a
+ * generated descriptor supplies the nodeType and statically-checked input types:
+ * `connector(CreateIssue, { fields: { summary: '…' } }, { connection })`.
  */
 export declare function connector<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: ConnectorOpts): ActionSpec;
 
@@ -293,7 +295,8 @@ Behavior and worked examples: [connector-params.md](connector-params.md).
 
 ````ts
 /**
- * Typed form: a generated trigger descriptor identifies the event —
+ * Wait mid-flow until a connector event fires, then continue with its payload —
+ * the typed form, where a generated trigger descriptor identifies the event:
  * `waitForEvent(EmailReceived, { where: { … } })`.
  */
 export declare function waitForEvent<W extends Record<string, string>>(descriptor: TriggerDescriptor<W, unknown>, opts?: TriggerOptions<W>): ActionSpec;

--- a/preview/uipath-maestro-flow/references/batch-transform.md
+++ b/preview/uipath-maestro-flow/references/batch-transform.md
@@ -1,6 +1,6 @@
 # Batch Transform
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`batchTransform()`](api.md#batchtransform-function).*
+*Exact signatures, fields, and defaults: [`batchTransform()`](api.md#batchtransform-function).*
 
 Adds AI-generated columns to a CSV and returns a new file attachment.
 

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -1,6 +1,6 @@
 # Integration Service Connectors
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`connector()`](api.md#connector-function).*
+*Exact signatures, fields, and defaults: [`connector()`](api.md#connector-function).*
 
 Call a curated or generic Integration Service operation.
 

--- a/preview/uipath-maestro-flow/references/delay.md
+++ b/preview/uipath-maestro-flow/references/delay.md
@@ -1,6 +1,6 @@
 # Delay
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`delay()`](api.md#delay-function).*
+*Exact signatures, fields, and defaults: [`delay()`](api.md#delay-function).*
 
 Delay pauses the current path for a duration.
 

--- a/preview/uipath-maestro-flow/references/event-trigger.md
+++ b/preview/uipath-maestro-flow/references/event-trigger.md
@@ -1,6 +1,6 @@
 # Connector Events
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`onEvent()`](api.md#onevent-function), [`waitForEvent()`](api.md#waitforevent-function).*
+*Exact signatures, fields, and defaults: [`onEvent()`](api.md#onevent-function), [`waitForEvent()`](api.md#waitforevent-function).*
 
 The same subscription can start a Flow or pause an already-running path.
 

--- a/preview/uipath-maestro-flow/references/hitl.md
+++ b/preview/uipath-maestro-flow/references/hitl.md
@@ -1,6 +1,6 @@
 # Human-in-the-Loop
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`hitl()`](api.md#hitl-function).*
+*Exact signatures, fields, and defaults: [`hitl()`](api.md#hitl-function).*
 
 Pause a Flow for a person using the default inline form, the quick-form node
 type, or a deployed Action App.

--- a/preview/uipath-maestro-flow/references/http.md
+++ b/preview/uipath-maestro-flow/references/http.md
@@ -1,6 +1,6 @@
 # HTTP
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`http()`](api.md#http-function).*
+*Exact signatures, fields, and defaults: [`http()`](api.md#http-function).*
 
 The one factory selects two distinct product nodes:
 

--- a/preview/uipath-maestro-flow/references/inline-agent.md
+++ b/preview/uipath-maestro-flow/references/inline-agent.md
@@ -1,6 +1,6 @@
 # Inline Agent
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`inlineAgent()`](api.md#inlineagent-function).*
+*Exact signatures, fields, and defaults: [`inlineAgent()`](api.md#inlineagent-function).*
 
 An inline agent is defined inside this Flow project and may be connected to
 tenant context, callable tools, and human escalation resources.

--- a/preview/uipath-maestro-flow/references/ixp.md
+++ b/preview/uipath-maestro-flow/references/ixp.md
@@ -1,6 +1,6 @@
 # IxP Extraction
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`ixpExtract()`](api.md#ixpextract-function).*
+*Exact signatures, fields, and defaults: [`ixpExtract()`](api.md#ixpextract-function).*
 
 IxP extraction runs a published Intelligent eXtraction Platform project on a
 Flow attachment.

--- a/preview/uipath-maestro-flow/references/loops.md
+++ b/preview/uipath-maestro-flow/references/loops.md
@@ -31,3 +31,28 @@ advances:
 The loop runs sequentially (`parallel: false`). Inside the body, read
 `$vars.<loop>.currentItem` and `$vars.<loop>.currentIndex` — or `v('eachOrder.currentItem')`
 from the builder.
+
+## Rich loop options (loop 2.4)
+
+Any of these — or a `body.break()` in the body — selects the loop's 2.4
+definition (inner `start`/`continue`/`break` handles); a plain `.loop()` keeps
+the long-standing 1.0.0 shape.
+
+- `parallel: true` — run iterations concurrently instead of sequentially.
+- `completionCondition` — an expression checked after each iteration; the loop
+  stops early when it is true.
+- `body.break()` — exit the whole loop from inside an arm. Terminal on its
+  path, like `.terminate()` but scoped to the loop; using it shows the loop's
+  break handle automatically (`breakEnabled`).
+
+```ts
+.var('found', types.string, '')
+.loop('scan', input('items'), (body) => body
+  .step('probe', script({ code: 'return $vars.scan.currentItem;', returns: 'object' }),
+    { updates: { found: js`$vars.probe.output.id` } })
+  .branch('hit', js`$vars.probe.output.score > 90`, (t) => t.break()),
+  { completionCondition: js`$vars.found !== ""` })
+```
+
+Per-iteration flow-variable writes go through `{ updates }` on a body step —
+`{ updates: { seen: js`$vars.seen + 1` } }` — never through a mutation node.

--- a/preview/uipath-maestro-flow/references/placeholder.md
+++ b/preview/uipath-maestro-flow/references/placeholder.md
@@ -1,6 +1,6 @@
 # Placeholder
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`mock()`](api.md#mock-function).*
+*Exact signatures, fields, and defaults: [`mock()`](api.md#mock-function).*
 
 A placeholder says that a real capability belongs at this point in the graph
 but does not exist yet.

--- a/preview/uipath-maestro-flow/references/queue.md
+++ b/preview/uipath-maestro-flow/references/queue.md
@@ -1,6 +1,6 @@
 # Queue Item
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`queueItem()`](api.md#queueitem-function).*
+*Exact signatures, fields, and defaults: [`queueItem()`](api.md#queueitem-function).*
 
 Create work on an Orchestrator queue, optionally waiting for another automation
 to process it.

--- a/preview/uipath-maestro-flow/references/rpa-workflow.md
+++ b/preview/uipath-maestro-flow/references/rpa-workflow.md
@@ -1,6 +1,6 @@
 # RPA Workflow
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`rpaWorkflow()`](api.md#rpaworkflow-function).*
+*Exact signatures, fields, and defaults: [`rpaWorkflow()`](api.md#rpaworkflow-function).*
 
 Run a published robotic process and wait for its output arguments.
 

--- a/preview/uipath-maestro-flow/references/scheduled-trigger.md
+++ b/preview/uipath-maestro-flow/references/scheduled-trigger.md
@@ -1,6 +1,6 @@
 # Scheduled Trigger
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`scheduled()`](api.md#scheduled-function).*
+*Exact signatures, fields, and defaults: [`scheduled()`](api.md#scheduled-function).*
 
 A scheduled trigger asks the platform scheduler to start a Flow repeatedly.
 

--- a/preview/uipath-maestro-flow/references/script.md
+++ b/preview/uipath-maestro-flow/references/script.md
@@ -1,6 +1,6 @@
 # Script
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`script()`](api.md#script-function).*
+*Exact signatures, fields, and defaults: [`script()`](api.md#script-function).*
 
 Script runs inline JavaScript for a computation that has no first-class Flow
 node. Upstream data is available through `$vars`; the result is read with

--- a/preview/uipath-maestro-flow/references/subflow.md
+++ b/preview/uipath-maestro-flow/references/subflow.md
@@ -1,6 +1,6 @@
 # Subflow
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`subflow()`](api.md#subflow-function).*
+*Exact signatures, fields, and defaults: [`subflow()`](api.md#subflow-function).*
 
 Subflow packages a child Flow authored in the same source file as one parent
 step.

--- a/preview/uipath-maestro-flow/references/summarize.md
+++ b/preview/uipath-maestro-flow/references/summarize.md
@@ -1,6 +1,6 @@
 # Summarize
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`summarize()`](api.md#summarize-function).*
+*Exact signatures, fields, and defaults: [`summarize()`](api.md#summarize-function).*
 
 Reads an attachment and produces a summary given a prompt.
 

--- a/preview/uipath-maestro-flow/references/transform.md
+++ b/preview/uipath-maestro-flow/references/transform.md
@@ -1,6 +1,6 @@
 # Transform
 
-*Behavior and worked examples. Exact signatures, fields, and defaults: [`transform()`](api.md#transform-function).*
+*Exact signatures, fields, and defaults: [`transform()`](api.md#transform-function).*
 
 Transform applies filter, map, or group-by operations to an array.
 


### PR DESCRIPTION
**Stacked on #2625** — this PR targets `sync/maestro-sdk-preview-drift` while that dmetzgar-owned PR remains open. After #2625 merges, retarget this PR to `main`.

## Summary

Re-sync the provenance-pinned Maestro Flow, Case, and BPMN preview snapshots from `flow-builder-sdk@a065b21` to execution-time upstream HEAD `flow-builder-sdk@335134d`.

The upstream drift includes the Flow JSON coverage series, the VitePress escaping fix, and the entry-point / richer loop / agentic-process / BPMN API documentation added through #426. It changes the generated and authored SDK skill surfaces while preserving the snapshot's established adaptations.

## Merge method

This is a sequence of three-way merges, not a copy:

- `a065b21` → `b3c4498`, merged against the adapted skills#2625 snapshot
- `b3c4498` → `335134d`, merged against the resulting snapshot after upstream advanced during execution

The existing frontmatter, provenance, self-containment, reference renames, and `example/` → `examples/` adaptations remain intact. Every non-adapted reference and example matches the new upstream pin.

## Residual tracked separately

flow-builder-sdk#420 fixes the generator so the API worked-example path becomes staged-workspace `example/GallerySubmission.flow.ts`. That PR is open and was not in upstream `main` at this sync pin, so this snapshot correctly still says `example-eval/GallerySubmission.flow.ts`. It will arrive through the automated next re-sync after #420 merges; there is no snapshot-only content patch here.

## Verification

- source/snapshot inventories match for all three skills
- byte-diff sweep passed; only the established adaptations differ
- relative Markdown links all resolve
- frontmatter names match folders and descriptions are under 1024 characters
- stale-path checks passed, with only the intentional provenance source-file references
- Flow router retains all 34 data rows; every referenced file and example exists
- preview verb gate: 0 blocking findings (Flow: 6 soft-stale, 3 uncertain; Case/BPMN: 0)
- no merge conflict markers; `git diff --check` passed

Part of UiPath/flow-builder-sdk#405.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)
