### PR TITLE
fix(planner): state the non-adhoc selector rule for stage exit

### DIFF
--- a/skills/uipath-planner/references/case-design-lane-guide.md
+++ b/skills/uipath-planner/references/case-design-lane-guide.md
@@ -43,7 +43,7 @@ ENTRY, batched with the first document reads; every other mode starts it at the 
 
 ## Modes
 
-Three moves. **Listen** takes in everything offered; **Sketch** builds the complete case model by best assumption, recording every decision; **Confirm** shows the whole case once with the decisions taken and asks a single question. Listen and Sketch loop freely as new context lands; there is no separate Resolve or Approve pass — resolution rides the background chain and surfaces at Confirm.
+Three moves. **Listen** takes in everything offered; **Sketch** builds the complete case model by best assumption, recording every decision; **Confirm** shows the whole case once with the decisions taken and asks a single question. Listen and Sketch loop freely as new context lands; there is no separate Resolve or Approve pass — resolution rides the background chain and surfaces at Confirm. The §Adhoc-dependency audit is the one gate between Sketch and Confirm — it blocks the review, it is not a pass of its own.
 
 ### Listen
 
@@ -109,6 +109,22 @@ Paths Considered**; when the source has no signal at all, spend the one bounded 
 **The one clarifying call (rare).** Ask before the confirmation ONLY when: (a) no case is inferable at all (empty or contentless request), (b) the user's own inputs contradict each other on a shape-changing field, (c) the user asked to be asked, or (d) the mandatory other-path sweep found no source signal at all. Batch everything into ONE AskUserQuestion call (≤ 4 questions). An unclear answer → take the best assumption, disclose it, move on — never re-press. Everything else: assume and inform.
 
 **Red flags — you're about to over-ask.** "I should confirm the trigger type" / "review could be action or agent, better ask" / "the SLA wording is vague" — STOP: the playbook decides all of these; the decision line in the confirmation is the user's chance to correct. The bar for a question is *contradiction or emptiness*, not uncertainty. Equally, there is NO size gate, no "approval before creating files", no lightweight mode — the only stops in this lane are the one clarifying call (when earned), the confirmation itself (with its folded resolution gate), and the explicit-sign-off path.
+
+### Adhoc-dependency audit — before the Case Review
+
+Run over the in-memory model after resolution, before the confirmation. Blocking: never a Review Flags row,
+never a question.
+
+1. List every `selected-tasks-completed` rule in the model — stage-exit rows AND task-entry rows.
+2. Resolve each selected name to a task. It MUST be a task in the SAME stage as the rule's owner, spelled
+   exactly as that task's display name.
+3. Reject any selector that resolves to an `adhoc` task. Required routing cannot depend on optional
+   user-launched work — the picker omits `adhoc` tasks, so the gate never fires
+   ([case/model.md § Lifecycle gates](case/model.md#lifecycle-gates)).
+4. Repair in the model, then re-run the audit: remodel the human work as an `action` task
+   (`Required: Yes`) and keep the guard, or re-key the gate to the non-`adhoc` sibling that actually gates
+   the route. Deleting the guard to clear the audit is forbidden.
+5. Never present the Case Review while any selector is unresolved or names an `adhoc` task.
 
 ### Confirm — the single checkpoint
 

--- a/skills/uipath-planner/references/case/model.md
+++ b/skills/uipath-planner/references/case/model.md
@@ -56,8 +56,8 @@ the outer rule array is OR, each inner array is AND.
 |---|---|---|
 | Stage entry | — | `case-entered` (first stage only), `selected-stage-completed`, `selected-stage-exited`, `wait-for-connector`, `user-selected-stage`, `sla-status-change` |
 | Stage completion | Yes | `required-tasks-completed`, `wait-for-connector` |
-| Stage exit | No | `selected-tasks-completed`, `wait-for-connector` |
-| Task entry | — | `current-stage-entered`, `selected-tasks-completed`, `wait-for-connector`, `sla-status-change`, `adhoc`, `runs-sequentially` |
+| Stage exit | No | `selected-tasks-completed` (note 6), `wait-for-connector` |
+| Task entry | — | `current-stage-entered`, `selected-tasks-completed` (note 6), `wait-for-connector`, `sla-status-change`, `adhoc`, `runs-sequentially` |
 | Case completion | Yes | `required-stages-completed`, `wait-for-connector` |
 | Case exit | No | `selected-stage-completed`, `selected-stage-exited`, `wait-for-connector` |
 
@@ -76,6 +76,11 @@ the outer rule array is OR, each inner array is AND.
 5. **A gate sees case state as of its own event.** The extract of the task that fired the gate has not
    run yet, so an `IF` that reads a case variable that task writes is stale — read the producing output
    instead ([variables.md § Gate on the producer](variables.md#gate-on-the-producer-never-on-the-variable-it-writes)).
+6. **`selected-tasks-completed` selects non-`adhoc` tasks in the SAME stage — at EVERY gate that accepts
+   it, stage exit as well as task entry.** The Case App omits `adhoc` tasks from the selected-task picker,
+   so a gate keyed to optional user-launched work never fires: the stage stalls with no error. When
+   required routing depends on human work, model that work as an `action` task (`Required: Yes`), never as
+   `adhoc`. Validate does not enforce the restriction; a clean `uip maestro case validate` is not evidence.
 
 ### Exit types
 

--- a/skills/uipath-planner/references/case/review.md
+++ b/skills/uipath-planner/references/case/review.md
@@ -119,6 +119,12 @@ guard. Any failure is blocking; offer `Re-edit` / `Restart` / `Abort`.
    the `IF` references that task's output, not a case variable the task's Outputs row feeds. The gate is
    evaluated before the extract lands, so such a guard is dead on the first pass and the stage stalls with
    no error ([variables.md § Gate on the producer](variables.md#gate-on-the-producer-never-on-the-variable-it-writes)).
+9. **Every `selected-tasks-completed` selector names a non-`adhoc` task in the rule's own stage** —
+   stage-exit rows AND task-entry rows. An `adhoc` selector is a dead gate: the picker never offers the
+   task, so the gate never fires and the stage stalls with no error
+   ([model.md § Lifecycle gates](model.md#lifecycle-gates)). Repair by remodeling the required human work
+   as an `action` task (`Required: Yes`) and keeping the guard — never by deleting the guard or
+   re-pointing it at an unrelated task. Validate does not catch this.
 
 Worked example — a decision-routed return lane (AP Review → SLA Escalation on `requiresEscalation`):
 
@@ -187,7 +193,7 @@ when a contract is already in memory.
     cells agree ([render-case-definition.md](render-case-definition.md)); a `notify-only` row that minted
     a stage or task, or a bare SLA with no row, is blocking.
 11. **File-In-arg caller obligation** — the fixed block above whenever an `In` + `file` row exists.
-12. **Stage-graph connectivity** — the §Logical integrity walk, all seven checks.
+12. **Stage-graph connectivity** — the §Logical integrity walk, all nine checks.
     12a. **Entry producer** — every non-start entry names a concrete producer (source stage, task,
     connector event, paired `wait-for-user` exit, or a declared SLA reference); at-risk rows name the
     escalation, breach rows the SLA alone ([slas.md](slas.md)).

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -31,6 +31,8 @@ Checks (domain-agnostic):
      interrupted).
   7. PO.Frontend name/SLA parity — stage/task/SLA/escalation names, uniqueness,
      duration bounds, conditional expressions, recipients, and at-risk fields.
+  8. Selected-task selector integrity — no ``selected-tasks-completed`` rule
+     (stage exit or task entry) names an ``adhoc`` task.
 
 Finds ``sdd.md`` under the current working directory.
 """
@@ -316,6 +318,67 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
     return issues
 
 
+def _task_label(raw: str) -> str:
+    """Normalize a task display name for selector matching."""
+    label = re.sub(r"\s*\([^)]*\)\s*$", "", raw.strip().strip("`"))
+    return label.strip().strip("\"'").strip()
+
+
+def _selected_task_selector_issues(text: str, source: str = "sdd.md") -> list[str]:
+    """Reject ``selected-tasks-completed`` selectors that name an ``adhoc`` task.
+
+    The Case App omits adhoc tasks from the selected-task picker, so a stage-exit
+    or task-entry gate keyed to optional user-launched work never fires and the
+    stage stalls with no error. ``uip maestro case validate`` does not enforce the
+    restriction, so it is graded here.
+    """
+    issues: list[str] = []
+    adhoc_tasks: dict[str, str] = {}            # normalized task label -> owning stage
+    selectors: list[tuple[str, str, int]] = []  # (selected label, owning stage, line)
+    cur_stage = "case"
+    cur_task: str | None = None
+
+    for line_no, line in enumerate(text.splitlines(), 1):
+        s = line.strip()
+        stage = re.match(r"###\s+(?:Stage \d+|Exception Stage|Secondary Stage):\s*(.*)", s)
+        if stage:
+            cur_stage = _task_label(stage.group(1)) or "case"
+            cur_task = None
+            continue
+        task = re.match(r"#####\s+Task\s+S?[\d.]+:\s*(.+)", s)
+        if task:
+            cur_task = _task_label(task.group(1))
+            continue
+        if s.startswith("#"):
+            cur_task = None
+            continue
+        if cur_task and re.match(r"\*\*Activation Mode:\*\*\s*`?adhoc\b", s, re.I):
+            adhoc_tasks.setdefault(cur_task, cur_stage)
+            continue
+        if not s.startswith("|"):
+            continue
+        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        if not cells:
+            continue
+        if cur_task and _rule_token(cells[0]) == "adhoc":
+            adhoc_tasks.setdefault(cur_task, cur_stage)
+        if "selected-tasks-completed" in cells[0]:
+            for name in re.findall(r"[\"\u201c]([^\"\u201c\u201d]+)[\"\u201d]", cells[0]):
+                selectors.append((_task_label(name), cur_stage, line_no))
+
+    for name, stage, line_no in selectors:
+        owner = adhoc_tasks.get(name)
+        if owner is None:
+            continue
+        issues.append(
+            f"selector: selected-tasks-completed names adhoc task {name!r} at "
+            f"{source}:{line_no} ({stage} rule, task declared in {owner}) — adhoc tasks are "
+            "excluded from the selected-task picker, so the gate never fires; model required "
+            "human work as an action task"
+        )
+    return issues
+
+
 def _colon_issues(text: str, source: str = "sdd.md") -> list[str]:
     """Backward-compatible focused helper used by older checker unit tests."""
     return [issue for issue in _sdd_frontend_issues(text, source) if "contains ':'" in issue]
@@ -389,6 +452,7 @@ def main() -> None:
     issues: list[str] = []
     issues.extend(_sdd_template_shape_issues(text, path))
     issues.extend(_sdd_frontend_issues(text, path))
+    issues.extend(_selected_task_selector_issues(text, path))
 
     # When Phase 1 has already generated tasks.md next to the SDD, validate its
     # SLA and escalation T-entries before JSON emission.

--- a/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py
@@ -13,6 +13,7 @@ from sdd_check import (  # noqa: E402
     _return_to_origin_pairing_issue,
     _sdd_frontend_issues,
     _sdd_template_shape_issues,
+    _selected_task_selector_issues,
     _tasks_frontend_issues,
 )
 
@@ -307,3 +308,91 @@ def test_tasks_sla_validation_ignores_non_sla_stage_headers():
 - stage-kind: secondary
 '''
     assert _tasks_frontend_issues(tasks, "tasks.md") == []
+
+
+# --------------------------------------------------------------------------
+# selected-tasks-completed selector integrity (adhoc tasks are never selectable)
+# --------------------------------------------------------------------------
+
+def _stage_with_adhoc(exit_when: str, adhoc_mode: str = "adhoc") -> str:
+    """One stage: a required action task, an adhoc task, and a stage-exit rule."""
+    return f"""
+### Stage 1: Review
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|---|---|---|---|---|
+| {exit_when} | — | exit-only | No | Divert |
+
+##### Task 1.1: Approve invoice
+
+**Type:** action
+**Activation Mode:** parallel
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| current-stage-entered | — | Entry |
+
+##### Task 1.2: Request more info
+
+**Type:** action
+**Activation Mode:** {adhoc_mode}
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| {adhoc_mode} | — | Manual |
+"""
+
+
+def test_stage_exit_selecting_an_adhoc_task_is_rejected():
+    issues = _selected_task_selector_issues(
+        _stage_with_adhoc('selected-tasks-completed("Request more info")')
+    )
+    assert len(issues) == 1
+    assert "adhoc task 'Request more info'" in issues[0]
+
+
+def test_stage_exit_selecting_a_non_adhoc_task_is_allowed():
+    assert _selected_task_selector_issues(
+        _stage_with_adhoc('selected-tasks-completed("Approve invoice")')
+    ) == []
+
+
+def test_multi_task_selector_flags_only_the_adhoc_member():
+    issues = _selected_task_selector_issues(
+        _stage_with_adhoc('selected-tasks-completed("Approve invoice", "Request more info")')
+    )
+    assert len(issues) == 1
+    assert "Request more info" in issues[0]
+
+
+def test_adhoc_declared_only_by_its_entry_rule_is_still_rejected():
+    text = _stage_with_adhoc(
+        'selected-tasks-completed("Request more info")', adhoc_mode="adhoc"
+    ).replace("**Activation Mode:** adhoc", "**Activation Mode:** manually triggered")
+    issues = _selected_task_selector_issues(text)
+    assert len(issues) == 1
+    assert "adhoc task 'Request more info'" in issues[0]
+
+
+def test_task_entry_selector_naming_an_adhoc_task_is_rejected():
+    text = _stage_with_adhoc("required-tasks-completed") + """
+##### Task 1.3: Close review
+
+**Type:** action
+**Activation Mode:** fan-in
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|---|---|---|
+| selected-tasks-completed("Request more info") | — | After info |
+"""
+    issues = _selected_task_selector_issues(text)
+    assert len(issues) == 1
+    assert "adhoc task 'Request more info'" in issues[0]

--- a/tests/tasks/uipath-planner/_shared/sdd_check.py
+++ b/tests/tasks/uipath-planner/_shared/sdd_check.py
@@ -31,6 +31,8 @@ Checks (domain-agnostic):
      interrupted).
   7. PO.Frontend name/SLA parity — stage/task/SLA/escalation names, uniqueness,
      duration bounds, conditional expressions, recipients, and at-risk fields.
+  8. Selected-task selector integrity — no ``selected-tasks-completed`` rule
+     (stage exit or task entry) names an ``adhoc`` task.
 
 Finds ``sdd.md`` under the current working directory.
 """
@@ -316,6 +318,67 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
     return issues
 
 
+def _task_label(raw: str) -> str:
+    """Normalize a task display name for selector matching."""
+    label = re.sub(r"\s*\([^)]*\)\s*$", "", raw.strip().strip("`"))
+    return label.strip().strip("\"'").strip()
+
+
+def _selected_task_selector_issues(text: str, source: str = "sdd.md") -> list[str]:
+    """Reject ``selected-tasks-completed`` selectors that name an ``adhoc`` task.
+
+    The Case App omits adhoc tasks from the selected-task picker, so a stage-exit
+    or task-entry gate keyed to optional user-launched work never fires and the
+    stage stalls with no error. ``uip maestro case validate`` does not enforce the
+    restriction, so it is graded here.
+    """
+    issues: list[str] = []
+    adhoc_tasks: dict[str, str] = {}            # normalized task label -> owning stage
+    selectors: list[tuple[str, str, int]] = []  # (selected label, owning stage, line)
+    cur_stage = "case"
+    cur_task: str | None = None
+
+    for line_no, line in enumerate(text.splitlines(), 1):
+        s = line.strip()
+        stage = re.match(r"###\s+(?:Stage \d+|Exception Stage|Secondary Stage):\s*(.*)", s)
+        if stage:
+            cur_stage = _task_label(stage.group(1)) or "case"
+            cur_task = None
+            continue
+        task = re.match(r"#####\s+Task\s+S?[\d.]+:\s*(.+)", s)
+        if task:
+            cur_task = _task_label(task.group(1))
+            continue
+        if s.startswith("#"):
+            cur_task = None
+            continue
+        if cur_task and re.match(r"\*\*Activation Mode:\*\*\s*`?adhoc\b", s, re.I):
+            adhoc_tasks.setdefault(cur_task, cur_stage)
+            continue
+        if not s.startswith("|"):
+            continue
+        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        if not cells:
+            continue
+        if cur_task and _rule_token(cells[0]) == "adhoc":
+            adhoc_tasks.setdefault(cur_task, cur_stage)
+        if "selected-tasks-completed" in cells[0]:
+            for name in re.findall(r"[\"\u201c]([^\"\u201c\u201d]+)[\"\u201d]", cells[0]):
+                selectors.append((_task_label(name), cur_stage, line_no))
+
+    for name, stage, line_no in selectors:
+        owner = adhoc_tasks.get(name)
+        if owner is None:
+            continue
+        issues.append(
+            f"selector: selected-tasks-completed names adhoc task {name!r} at "
+            f"{source}:{line_no} ({stage} rule, task declared in {owner}) — adhoc tasks are "
+            "excluded from the selected-task picker, so the gate never fires; model required "
+            "human work as an action task"
+        )
+    return issues
+
+
 def _colon_issues(text: str, source: str = "sdd.md") -> list[str]:
     """Backward-compatible focused helper used by older checker unit tests."""
     return [issue for issue in _sdd_frontend_issues(text, source) if "contains ':'" in issue]
@@ -389,6 +452,7 @@ def main() -> None:
     issues: list[str] = []
     issues.extend(_sdd_template_shape_issues(text, path))
     issues.extend(_sdd_frontend_issues(text, path))
+    issues.extend(_selected_task_selector_issues(text, path))
 
     # When Phase 1 has already generated tasks.md next to the SDD, validate its
     # SLA and escalation T-entries before JSON emission.


### PR DESCRIPTION
## Problem

`uipath-planner` documents the `selected-tasks-completed` non-adhoc restriction **only in task-entry framing**:

- `references/case/model.md:152` — bullet under §Sequencing & activation (task-entry mode table)
- `references/case/render-stages-tasks.md:78` — inside the table headed *"Which WHEN to write (task entry)"*

Nothing on the **stage-exit** path says it: the Lifecycle gates table lists `selected-tasks-completed` for Stage exit with no caveat, the stage condition tables defer to that table, the §Logical integrity walk had no selector check, and the SDD template's stage-exit row is bare vocabulary. A designer authoring a stage exit never encounters the rule, so a stage exit can be gated on an optional user-launched task. That gate never fires — the Case App omits `adhoc` tasks from the selected-task picker — and `uip maestro case validate` does not enforce the restriction, so the design reaches build looking clean.

Second gap: `uipath-maestro-case`'s handoff contract expects this lane to run a **"pre-approval adhoc-dependency audit"** that blocks the Case Review on an adhoc selector. No such step existed in the lane guide. The closest text was buildability must #7 (required human work → `action`, optional → `adhoc`), which never mentions selectors or gates.

## Change

| File | Change |
|---|---|
| `references/case/model.md` | Canonical, gate-agnostic **note 6** under §Lifecycle gates — the restriction holds at every gate that accepts the rule, plus the "validate does not enforce it" fact. Stage exit and Task entry rows now point at note 6. |
| `references/case/review.md` | New §Logical integrity **check 9** (selector integrity at both gates, with the repair: remodel the human work as an `action` task, never delete the guard). Also corrects Finalization check 12's stale count — the walk already had 8 checks while the text said "all seven". |
| `references/case-design-lane-guide.md` | Defines the **Adhoc-dependency audit** (list → resolve → reject → repair → re-run, blocking, never a Review Flags row) as the gate between Sketch and Confirm, and names it in §Modes. |

## Tests

`sdd_check.py` gains **check 8 — selected-task selector integrity**: any `selected-tasks-completed` selector (stage exit or task entry) naming an `adhoc` task fails the mechanical SDD check. Applied to **both eval-suite twins** (`tests/tasks/uipath-planner/_shared/`, `tests/tasks/uipath-maestro-case/_shared/`) so `test_shared_twins.py` stays green.

Five unit tests in `tests/tasks/uipath-maestro-case/_shared/test_sdd_check.py`: adhoc selector rejected, non-adhoc selector allowed, mixed multi-task selector flags only the adhoc member, adhoc declared only by its entry rule still caught, task-entry selector caught.

```
pytest tests/tasks/uipath-maestro-case/_shared tests/tasks/uipath-planner/_shared -q
122 passed, 14 skipped
npm run skills:validate
OK - default: 26 skills, 1725 files, 0 replacements; studioweb: 26 skills, 1725 files, 161 replacements.
```

Also smoke-run end to end: `sdd_check.py` against a fixture SDD whose stage exit selects an adhoc task exits non-zero with the selector issue.

**Heads-up for reviewers:** check 8 is a new failure mode for the eval tasks that already run `sdd_check.py` (`case_finalize_draft`, `case_finalize_draft_loan`, `case_finalize_draft_picker`, `aged_invoice_structural`). A run that previously passed while producing an adhoc-gated stage exit will now fail — intended, and the point of the guardrail.

## Scope notes

- Deliberately narrow: the checker flags **adhoc selection only**. Cross-stage and unknown-name selectors are documented in the same rule but not graded, to avoid fuzzy display-name matching false positives.
- `references/case/render-stages-tasks.md` §Stage condition tables was left alone — it defers to model.md for legal WHEN, which now carries the caveat. Happy to add an inline pointer there if reviewers prefer.