### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@d3e3a10

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 335134d. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ d3e3a10. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 335134d. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ d3e3a10. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 335134d. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ d3e3a10. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -144,7 +144,7 @@ export declare function hitl(inputs: HitlInputs): ActionSpec;
 
 Behavior and worked examples: [hitl.md](hitl.md).
 
-Worked example: `example-eval/GallerySubmission.flow.ts`.
+Worked example: `examples/GallerySubmission.flow.ts`.
 
 ## summarize (function)
 


### PR DESCRIPTION
**Stacked on #2625** — this PR targets `sync/maestro-sdk-preview-drift` while that dmetzgar-owned PR remains open. No commits were pushed directly to the owner's branch.

## Summary

Run the newly added provenance-aware sync pipeline from snapshot pin `flow-builder-sdk@335134d` to current upstream `flow-builder-sdk@d3e3a10`, the merge commit for flow-builder-sdk#420.

The upstream drift is exactly the staged-path generator fix:

- all three provenance headers advance to `d3e3a10`
- `flow/references/api.md` now points to the snapshot-local `examples/GallerySubmission.flow.ts`

This closes the real residual identified in flow-builder-sdk#405. The generator emits staged-workspace `example/`; the approved snapshot adaptation maps that to its self-contained `examples/` directory.

## Merge method

`scripts/sync-maestro-sdk-preview.mjs` performed a file-level three-way merge:

- base: `flow-builder-sdk@335134d`
- ours: the adapted #2625 snapshot
- theirs: `flow-builder-sdk@d3e3a10`

The script then applied only the ratified D1–D6 adaptations and verified the complete exception contract. This is a merge, not a copy.

## Verification

- sync rerun is idempotent at `d3e3a10`; all snapshot inventory, byte-exception, link, frontmatter, router, stale-path, and conflict-marker gates passed
- preview verb gate: 0 blocking findings (Flow: 6 soft-stale, 3 uncertain; Case/BPMN: 0)
- `npm run skills:validate` passed for default and Studio Web flavors
- `git diff --check` passed

Part of UiPath/flow-builder-sdk#405.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)