### PR TITLE
docs(uipath-tasks): document --folder-path/--folder-key folder scoping [UV-15957]

### DIFF
--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -142,7 +142,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 
 11. **Labels replace the full set.** `tasks labels --labels` overwrites all labels on the task — include every label to keep, and pass `[]` to clear them all.
 
-12. **`data save` takes no type flag.** The command resolves the task type itself; pass the task ID, `--folder-id`, and `--data` (a JSON object).
+12. **`data save` takes no type flag.** The command resolves the task type itself; pass the task ID, a folder option (`--folder-id`/`--folder-path`/`--folder-key`), and `--data` (a JSON object).
 
 ---
 
@@ -152,7 +152,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 |------|----------------|
 | List all tasks | `tasks list` |
 | List tasks in a folder | `tasks list --folder-id <id>` |
-| List tasks in a folder by path/key | `tasks list --folder-path <path>` or `tasks list --folder-key <guid>` |
+| List tasks in a folder by path/key | `tasks list --folder-path "<path>"` or `tasks list --folder-key <guid>` |
 | List tasks as admin | `tasks list --as-admin` |
 | Get task details | `tasks get <task-id>` |
 | Get task with type hint | `tasks get <task-id> --task-type FormTask --folder-id <id>` |
@@ -162,7 +162,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 | Unassign a task | `tasks unassign <task-id>` |
 | Complete a task | `tasks complete <task-id> --type <type> --folder-id <id>` |
 | Complete with action | `tasks complete <task-id> --type FormTask --folder-id <id> --action "Approve" --data '{...}'` |
-| List assignable users | `tasks users <folder-id>` or `tasks users --folder-path <path>` |
+| List assignable users | `tasks users <folder-id>` or `tasks users --folder-path "<path>"` |
 | List task catalogs | `tasks catalogs list --folder-id <id>` |
 | Get a catalog | `tasks catalogs get <catalog-id> --folder-id <id>` |
 | Create a catalog | `tasks catalogs create --name <name> --folder-id <id>` |

--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -130,7 +130,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 
 5. **FormTask and AppTask require `--action` and `--data` for completion.** Other task types allow optional action and data.
 
-6. **Assign accepts `--user-id` or `--user` (email).** Use `tasks users <folder-id>` (or `tasks users --folder-path <path>`) to discover assignable users and their IDs.
+6. **Assign accepts `--user-id` or `--user` (email).** Use `tasks users <folder-id>` (or `tasks users --folder-path <path>` / `--folder-key <guid>`) to discover assignable users and their IDs.
 
 7. **Always discover before acting.** Use `tasks list` or `tasks get` to inspect task state before performing assign/complete operations.
 
@@ -162,7 +162,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 | Unassign a task | `tasks unassign <task-id>` |
 | Complete a task | `tasks complete <task-id> --type <type> --folder-id <id>` |
 | Complete with action | `tasks complete <task-id> --type FormTask --folder-id <id> --action "Approve" --data '{...}'` |
-| List assignable users | `tasks users <folder-id>` or `tasks users --folder-path "<path>"` |
+| List assignable users | `tasks users <folder-id>`, `tasks users --folder-path "<path>"`, or `tasks users --folder-key <guid>` |
 | List task catalogs | `tasks catalogs list --folder-id <id>` |
 | Get a catalog | `tasks catalogs get <catalog-id> --folder-id <id>` |
 | Create a catalog | `tasks catalogs create --name <name> --folder-id <id>` |
@@ -218,7 +218,9 @@ uip tasks get <task-id> --output json
 | Completion fails for FormTask | Missing `--action` or `--data` | FormTask and AppTask require both `--action` and `--data` |
 | Cannot assign | User lacks permissions in folder | Run `tasks users <folder-id>` to list eligible users |
 | `A folder is required` | Non-interactive run without a folder option | Pass `--folder-id`, `--folder-path`, or `--folder-key` |
-| `Folder not found for path/key ...` | The value doesn't match a folder this login can access | Run `uip or folders list` and use a listed `Path` or `Key` |
+| `Folder not found: '<value>'.` | The path/key doesn't match a folder this login can access | Run `uip or folders list` and use a listed `Path` or `Key` |
+| `Invalid --folder-key: <value>` | The key is not a UUID | Use the GUID from the `Key` column of `uip or folders list` |
+| `Error resolving folder path/key '<value>'` | The folder lookup itself failed (permissions or network) | Check the error detail in `Instructions`; verify access with `uip or folders list` |
 
 ---
 

--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -124,19 +124,19 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 
 2. **Task IDs are numeric.** Unlike other UiPath services that use GUIDs, Action Center uses numeric task IDs. Use `tasks list` to discover task IDs.
 
-3. **Folder ID is required for complete.** Tasks are scoped to folders. Use `--folder-id` when completing tasks.
+3. **Folder scope comes in three interchangeable forms.** Folder-scoped commands accept `--folder-id <numeric-id>`, `--folder-path <path>`, or `--folder-key <guid>` (mutually exclusive). Path and key are exactly what `uip or folders list` prints (it has no numeric ID column), so prefer them when the folder came from folder discovery; the numeric id still works when a task row gave you `folderId`.
 
 4. **Complete requires `--type`.** The API routes to different endpoints per task type. Always include `--type` when completing a task. Use `tasks get` to check the task type first.
 
 5. **FormTask and AppTask require `--action` and `--data` for completion.** Other task types allow optional action and data.
 
-6. **Assign accepts `--user-id` or `--user` (email).** Use `tasks users <folder-id>` to discover assignable users and their IDs.
+6. **Assign accepts `--user-id` or `--user` (email).** Use `tasks users <folder-id>` (or `tasks users --folder-path <path>`) to discover assignable users and their IDs.
 
 7. **Always discover before acting.** Use `tasks list` or `tasks get` to inspect task state before performing assign/complete operations.
 
 8. **Do not complete already-completed tasks.** Check the task `status` field — if it is `Completed`, inform the user.
 
-9. **Folder ID for catalogs/comments/labels/metadata/data.** These commands are folder-scoped. Pass `--folder-id`, or omit it on an interactive terminal to pick from a list. It is required in non-interactive runs (agents, CI) — always pass it explicitly there.
+9. **Folder scope for complete/catalogs/comments/labels/metadata/data.** These commands need a folder. Pass one of `--folder-id`/`--folder-path`/`--folder-key`, or omit all three on an interactive terminal to pick from a list. A folder option is required in non-interactive runs (agents, CI) — the command fails with `A folder is required` otherwise, so always pass one explicitly there.
 
 10. **Retention actions are `Delete` or `Archive`.** `Archive` also needs `--retention-bucket-id`. `--encrypted` is create-only and cannot be changed on update.
 
@@ -152,6 +152,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 |------|----------------|
 | List all tasks | `tasks list` |
 | List tasks in a folder | `tasks list --folder-id <id>` |
+| List tasks in a folder by path/key | `tasks list --folder-path <path>` or `tasks list --folder-key <guid>` |
 | List tasks as admin | `tasks list --as-admin` |
 | Get task details | `tasks get <task-id>` |
 | Get task with type hint | `tasks get <task-id> --task-type FormTask --folder-id <id>` |
@@ -161,7 +162,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 | Unassign a task | `tasks unassign <task-id>` |
 | Complete a task | `tasks complete <task-id> --type <type> --folder-id <id>` |
 | Complete with action | `tasks complete <task-id> --type FormTask --folder-id <id> --action "Approve" --data '{...}'` |
-| List assignable users | `tasks users <folder-id>` |
+| List assignable users | `tasks users <folder-id>` or `tasks users --folder-path <path>` |
 | List task catalogs | `tasks catalogs list --folder-id <id>` |
 | Get a catalog | `tasks catalogs get <catalog-id> --folder-id <id>` |
 | Create a catalog | `tasks catalogs create --name <name> --folder-id <id>` |
@@ -216,6 +217,8 @@ uip tasks get <task-id> --output json
 | Completion fails | Wrong `--type` | Use `tasks get` to check the actual task type |
 | Completion fails for FormTask | Missing `--action` or `--data` | FormTask and AppTask require both `--action` and `--data` |
 | Cannot assign | User lacks permissions in folder | Run `tasks users <folder-id>` to list eligible users |
+| `A folder is required` | Non-interactive run without a folder option | Pass `--folder-id`, `--folder-path`, or `--folder-key` |
+| `Folder not found for path/key ...` | The value doesn't match a folder this login can access | Run `uip or folders list` and use a listed `Path` or `Key` |
 
 ---
 

--- a/skills/uipath-tasks/SKILL.md
+++ b/skills/uipath-tasks/SKILL.md
@@ -169,7 +169,7 @@ uip tasks complete <task-id> --type ExternalTask --folder-id <folder-id> --outpu
 | Update a catalog | `tasks catalogs update <catalog-id> --folder-id <id>` |
 | List task comments | `tasks comments list <task-id> --folder-id <id>` |
 | Add a comment | `tasks comments add <task-id> --text <text> --folder-id <id>` |
-| Set task labels | `tasks labels <task-id> --labels '[{"name":"urgent"}]' --folder-id <id>` |
+| Set task labels | `tasks labels <task-id> --labels '[{"name":"region","displayName":"Region","displayValue":"EMEA"}]' --folder-id <id>` |
 | Edit task metadata | `tasks metadata <task-id> --folder-id <id> [--title --priority --catalog-id]` |
 | Get task data | `tasks data get <task-id> --folder-id <id>` |
 | Save task data | `tasks data save <task-id> --data '{...}' --folder-id <id>` |

--- a/skills/uipath-tasks/references/task-assignment.md
+++ b/skills/uipath-tasks/references/task-assignment.md
@@ -6,6 +6,10 @@ Before assigning a task, discover which users have task permissions in the folde
 
 ```bash
 uip tasks users <folder-id> --output json
+
+# Or by folder path/key — the values `uip or folders list` prints
+uip tasks users --folder-path <folder-path> --output json
+uip tasks users --folder-key <folder-key> --output json
 ```
 
 Response includes user details:

--- a/skills/uipath-tasks/references/task-assignment.md
+++ b/skills/uipath-tasks/references/task-assignment.md
@@ -7,8 +7,9 @@ Before assigning a task, discover which users have task permissions in the folde
 ```bash
 uip tasks users <folder-id> --output json
 
-# Or by folder path/key — the values `uip or folders list` prints
-uip tasks users --folder-path <folder-path> --output json
+# Or by folder path/key — the values `uip or folders list` prints.
+# Quote the path: folder paths may contain spaces.
+uip tasks users --folder-path "<folder-path>" --output json
 uip tasks users --folder-key <folder-key> --output json
 ```
 

--- a/skills/uipath-tasks/references/task-catalogs.md
+++ b/skills/uipath-tasks/references/task-catalogs.md
@@ -10,10 +10,13 @@ another, and catalog IDs are numeric. See the
 
 ## Folder scoping
 
-Every catalog command needs a folder. In an interactive terminal you can omit
-`--folder-id` and pick a folder from a list. In a non-interactive run (a coding
-agent or CI, where no picker can be shown) you must pass `--folder-id <id>`
-explicitly, otherwise the command fails.
+Every catalog command needs a folder, given one of three mutually exclusive
+ways: `--folder-id <numeric-id>`, `--folder-path <path>`, or
+`--folder-key <guid>` (path and key are what `uip or folders list` prints). In
+an interactive terminal you can omit all three and pick a folder from a list.
+In a non-interactive run (a coding agent or CI, where no picker can be shown)
+you must pass one explicitly, otherwise the command fails with
+`A folder is required`.
 
 ## List
 

--- a/skills/uipath-tasks/references/task-completion.md
+++ b/skills/uipath-tasks/references/task-completion.md
@@ -88,7 +88,9 @@ Before completing a task, always verify:
 
 3. **Folder ID matches:**
    ```bash
-   # The "folderId" field in the response gives you the --folder-id value
+   # The "folderId" field in the response gives you the --folder-id value.
+   # If you only know the folder from `uip or folders list`, pass its Path or
+   # Key instead: --folder-path <path> / --folder-key <guid>.
    ```
 
 ## SLA Tracking

--- a/skills/uipath-tasks/references/task-data.md
+++ b/skills/uipath-tasks/references/task-data.md
@@ -2,9 +2,9 @@
 
 Task data is the business/form field payload attached to a task: a JSON object of
 key/value pairs whose keys are the task's schema fields (the values an approver
-reviews). Folder-scoped: pass `--folder-id <id>`, or omit it in an interactive
-terminal to pick a folder (in a non-interactive run you must pass `--folder-id`).
-Task IDs are numeric.
+reviews). Folder-scoped: pass `--folder-id <id>` (or `--folder-path <path>` /
+`--folder-key <guid>`), or omit them in an interactive terminal to pick a folder
+(in a non-interactive run you must pass one). Task IDs are numeric.
 
 ## Get data
 

--- a/skills/uipath-tasks/references/task-lifecycle.md
+++ b/skills/uipath-tasks/references/task-lifecycle.md
@@ -9,8 +9,9 @@ uip tasks list --output json
 # List tasks in a specific folder
 uip tasks list --folder-id <folder-id> --output json
 
-# Same, by folder path or key — the values `uip or folders list` prints
-uip tasks list --folder-path <folder-path> --output json
+# Same, by folder path or key — the values `uip or folders list` prints.
+# Quote the path: folder paths may contain spaces.
+uip tasks list --folder-path "<folder-path>" --output json
 uip tasks list --folder-key <folder-key> --output json
 
 # List tasks as admin (elevated access)
@@ -47,7 +48,7 @@ Type-specific endpoints are faster because they avoid the generic OData lookup:
 uip tasks list --output json
 uip tasks users <folder-id> --output json
 # (or by path/key when the folder came from `uip or folders list`:
-#  uip tasks users --folder-path <folder-path> --output json)
+#  uip tasks users --folder-path "<folder-path>" --output json)
 
 # 2. Assign to a user
 uip tasks assign <task-id> --user alice@company.com --output json

--- a/skills/uipath-tasks/references/task-lifecycle.md
+++ b/skills/uipath-tasks/references/task-lifecycle.md
@@ -9,9 +9,17 @@ uip tasks list --output json
 # List tasks in a specific folder
 uip tasks list --folder-id <folder-id> --output json
 
+# Same, by folder path or key — the values `uip or folders list` prints
+uip tasks list --folder-path <folder-path> --output json
+uip tasks list --folder-key <folder-key> --output json
+
 # List tasks as admin (elevated access)
 uip tasks list --as-admin --output json
 ```
+
+`--folder-id`, `--folder-path`, and `--folder-key` are mutually exclusive. Path
+and key are resolved to the numeric folder id before the task query runs, so
+all three scope the same way.
 
 ## Getting Task Details
 
@@ -38,6 +46,8 @@ Type-specific endpoints are faster because they avoid the generic OData lookup:
 # 1. List tasks and discover folder users
 uip tasks list --output json
 uip tasks users <folder-id> --output json
+# (or by path/key when the folder came from `uip or folders list`:
+#  uip tasks users --folder-path <folder-path> --output json)
 
 # 2. Assign to a user
 uip tasks assign <task-id> --user alice@company.com --output json

--- a/skills/uipath-tasks/references/task-metadata.md
+++ b/skills/uipath-tasks/references/task-metadata.md
@@ -61,7 +61,7 @@ keep. Use `[]` to clear all labels.
 
 ```bash
 # Set labels
-uip tasks labels <task-id> --folder-id <folder-id> --labels '[{"name":"urgent"}]' --output json
+uip tasks labels <task-id> --folder-id <folder-id> --labels '[{"name":"region","displayName":"Region","displayValue":"EMEA"}]' --output json
 
 # Clear all labels
 uip tasks labels <task-id> --folder-id <folder-id> --labels '[]' --output json

--- a/skills/uipath-tasks/references/task-metadata.md
+++ b/skills/uipath-tasks/references/task-metadata.md
@@ -1,8 +1,9 @@
 # Task Metadata, Comments & Labels Reference
 
 Operations that annotate or reorganize an existing task. All are folder-scoped:
-pass `--folder-id <id>`, or omit it on an interactive terminal to pick a folder
-(required when stdout is not a TTY). Task IDs are numeric.
+pass `--folder-id <id>` (or `--folder-path <path>` / `--folder-key <guid>`), or
+omit them on an interactive terminal to pick a folder (a folder option is
+required when stdout is not a TTY). Task IDs are numeric.
 
 ## Edit metadata
 


### PR DESCRIPTION
Companion to UiPath/cli#3688 (UV-15957): folder-scoped `uip tasks` commands now accept `--folder-path` / `--folder-key` besides `--folder-id`, resolved to the numeric folder id — path and key are exactly what `uip or folders list` prints (it has no numeric ID column).

Documents in the uipath-tasks skill:

- the three-way, mutually exclusive folder scope (Critical Rules 3 and 9, navigation table, task-lifecycle/catalogs/data/metadata references)
- `tasks users --folder-path/--folder-key` as the discovery form (assignment reference, workflow snippets)
- the non-interactive fail-loud message (`A folder is required`) and the `Folder not found for path/key` troubleshooting rows

**Merge ordering:** hold until UiPath/cli#3688 reaches `@alpha` (cli/main) — the flags don't exist in the published CLI before that. Verbs referenced (`uip tasks list/users`, `uip or folders list`) already exist, so the verb gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)