### PR TITLE
fix(uipath-agents): correct grading blind spots behind two codex nightly task failures

### DIFF
--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/check_eval_mocking_mockito.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Eval-lifecycle check: both documented mocking patterns + JsonSimilarity.
+"""Eval-lifecycle check: declarative mockito mocking + JsonSimilarity.
 
-The agent must pin BOTH mocking patterns (the skill documents two of
-them, and a real agent will reach for one or the other depending on
-the call shape):
+The agent must wire the declarative mocking pattern the skill
+documents for deterministic offline evals:
 
-  - Declarative `mockingStrategy: mockito` on at least one test case,
-    mocking the UiPath SDK asset retrieval helper.
-  - In-code `@mockable(example_calls=[...])` on at least one function
-    in `main.py`, paired with the `ExampleCall` import from
-    `uipath.eval.mocks`. This is what makes the `requests.get`-style
-    helper substitutable at eval time without a real network call.
+  - Register external-call helpers in `main.py` with `@mockable`
+    from `uipath.eval.mocks` — mockito binds only to registered
+    functions. Bare `@mockable()` is correct here; `example_calls`
+    matter only for LLM-driven mocking, which is out of scope for
+    this task.
+  - Supply mock values via `mockingStrategy.type == "mockito"` on
+    at least one test case, with a non-empty return behavior.
 
 Output evaluator: `JsonSimilarityEvaluator`
 (`evaluatorTypeId == "uipath-json-similarity"`). The agent's output
@@ -19,8 +19,8 @@ exercises a separate evaluator type from `eval_exact_match`.
 
 Checks:
   1. `asset-retriever/pyproject.toml` exists with no `[build-system]`.
-  2. `asset-retriever/main.py` imports `mockable` and `ExampleCall` from
-     `uipath.eval.mocks` AND has at least one `@mockable(...)`
+  2. `asset-retriever/main.py` imports `mockable` from
+     `uipath.eval.mocks` AND has at least one `@mockable`
      decorator.
   3. `asset-retriever/evaluations/evaluators/*.json` contains an
      evaluator with `evaluatorTypeId == "uipath-json-similarity"`.
@@ -77,36 +77,31 @@ def check_pyproject() -> None:
     print("OK: pyproject.toml has no [build-system]")
 
 
-def check_in_code_mocking() -> None:
-    """Pattern 2: in-code `@mockable` paired with `ExampleCall`."""
+def check_mockable_registration() -> None:
+    """`@mockable` registration: mockito binds only to decorated functions."""
     main = _read_text(ROOT / "main.py")
     if "from uipath.eval.mocks" not in main:
         sys.exit(
-            "FAIL: main.py does not import from `uipath.eval.mocks`. The "
-            "`@mockable`/`ExampleCall` pair is documented as the in-code "
-            "mocking pattern; one of the two external calls should use it."
+            "FAIL: main.py does not import from `uipath.eval.mocks`. "
+            "External-call helpers must be registered with `@mockable` for "
+            "declarative mockito mocks to bind."
         )
     if "mockable" not in main:
         sys.exit(
             "FAIL: main.py imports from `uipath.eval.mocks` but never uses "
             "`mockable`. The decorator must wrap at least one helper."
         )
-    if "ExampleCall" not in main:
-        sys.exit(
-            "FAIL: main.py does not reference `ExampleCall`. `@mockable` "
-            "needs `example_calls=[ExampleCall(...)]` to supply mock outputs."
-        )
     if "@mockable" not in main:
         sys.exit(
             "FAIL: main.py imports `mockable` but no function is decorated "
-            "with `@mockable(...)`. The decoration is what makes the "
-            "function substitutable at eval time."
+            "with `@mockable`. The decoration is what makes the function "
+            "substitutable at eval time."
         )
-    print("OK: main.py wires the in-code @mockable pattern with ExampleCall")
+    print("OK: main.py registers external-call helpers with @mockable")
 
 
 def check_json_similarity_evaluator() -> str:
-    """Pattern 1 of two: structured-output evaluator."""
+    """Structured-output evaluator."""
     evals_dir = ROOT / "evaluations" / "evaluators"
     if not evals_dir.is_dir():
         sys.exit(f"FAIL: {evals_dir} does not exist")
@@ -139,7 +134,7 @@ def _has_mockito_with_return(case: dict) -> bool:
 
 
 def check_eval_set() -> int:
-    """Pattern 1 of mocking: declarative mockito for the asset call."""
+    """Declarative mockito mocks with return behaviors."""
     path = find_single_json(ROOT / "evaluations" / "eval-sets")
     doc = _load_json(path)
     if doc.get("version") != "1.0":
@@ -218,7 +213,7 @@ def main() -> None:
     if not ROOT.is_dir():
         sys.exit(f"FAIL: project directory {ROOT} does not exist")
     check_pyproject()
-    check_in_code_mocking()
+    check_mockable_registration()
     check_json_similarity_evaluator()
     case_count = check_eval_set()
     check_results(case_count)

--- a/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
+++ b/tests/tasks/uipath-agents/coded/eval_mocking_mockito/eval_mocking_mockito.yaml
@@ -1,11 +1,10 @@
 task_id: skill-agent-coded-eval-mocking-mockito
 description: >
-  Coded-agent (LangGraph) eval lifecycle with the **two documented mocking
-  patterns** (declarative `mockingStrategy: mockito` AND in-code
-  `@mockable`) plus a structured-output evaluator. The agent reads
-  an Orchestrator asset (mocked declaratively per test case) AND
-  looks up a remote label via a helper (mocked in-code via
-  `@mockable` so eval-time substitutes example outputs). Output is
+  Coded-agent (LangGraph) eval lifecycle with the declarative mocking
+  pattern (`mockingStrategy: mockito`) plus a structured-output
+  evaluator. The agent reads an Orchestrator asset AND looks up a
+  remote label via a helper; both external calls are registered with
+  `@mockable` and mocked declaratively per test case. Output is
   structured JSON, eval'd with `JsonSimilarityEvaluator`. The full
   pipeline runs offline. Project files are pre-seeded via `pre_run`
   (fixtures in `_fixtures/`) so the eval grades mocking + evaluator
@@ -36,9 +35,6 @@ initial_prompt: |
   about the shape of `{"masked_key": ..., "label": ...}`. Those
   should be as similar as possible to what we expect.
 
-  I also want to be able (in the future) to have an llm deciding
-  what mocking values should be substituted at runtime.
-  
   Do NOT publish, upload, or deploy. Complete it in a single pass.
 
 success_criteria:
@@ -60,7 +56,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Both mocking patterns wired + JsonSimilarity evaluator + offline eval results"
+    description: "Declarative mockito mocking wired + JsonSimilarity evaluator + offline eval results"
     command: "python3 $TASK_DIR/check_eval_mocking_mockito.py"
     timeout: 30
     expected_exit_code: 0

--- a/tests/tasks/uipath-agents/lowcode/solution_deploy_activate/check_deploy_activate.py
+++ b/tests/tasks/uipath-agents/lowcode/solution_deploy_activate/check_deploy_activate.py
@@ -5,10 +5,14 @@ The CLI-invocation criteria in the YAML prove the promotion *sequence* was
 typed. This grades what it left behind — locally and on the tenant — which is
 where the silent failure modes live:
 
-  1. **Package naming.** `uip solution pack` emits `<NAME>_<VERSION>.zip`
-     (underscore). It was `<NAME>.<VERSION>.zip` until 2026-08-06 (commit
-     6e585f64f). An agent working from stale guidance builds the right archive
-     but hands `publish` a path that does not exist.
+  1. **The packed archive never became a package.** `uip solution pack` emits
+     `<NAME>_<VERSION>.zip` (underscore) since 2026-08-06 (commit 6e585f64f);
+     an agent working from stale guidance builds the right archive but hands
+     `publish` a dot-separated path that does not exist, so nothing uploads.
+     Graded against the tenant, not the local filesystem: agents legitimately
+     stage the archive outside the workspace (e.g. /tmp), where artifact
+     collection never sees it — publish is the step that consumes the archive,
+     so the tenant-side package record is the proof the handoff worked.
   2. **The promoted agent is not the one that shipped.** The solution arrives
      pre-built; re-scaffolding or rewriting it promotes something the owner did
      not ask for.
@@ -62,35 +66,73 @@ def find_solution_dir(name: str) -> Path:
     fail(f"Could not locate the {name} solution directory under {CWD}")
 
 
-def check_package_naming(name: str, version: str) -> None:
-    """The packed archive exists and uses the underscore convention."""
+def _row_version(row: dict) -> str | None:
+    for key in ("PackageVersion", "Version", "packageVersion", "version"):
+        value = row.get(key)
+        if value:
+            return str(value)
+    return None
+
+
+def _local_zip_hint(name: str, version: str) -> str:
+    """Best-effort diagnostic from whatever archives artifact collection kept.
+
+    Never grades — the archive may legitimately live outside the workspace
+    (e.g. /tmp) and be invisible here. Only sharpens the failure message when a
+    local zip reveals what went wrong.
+    """
     zips = [
         p
         for p in CWD.rglob("*.zip")
         if ".venv" not in p.parts and "node_modules" not in p.parts
     ]
-    if not zips:
-        fail(
-            f"No .zip produced anywhere under {CWD} — `uip solution pack` did not "
-            f"emit an archive"
-        )
-
-    expected = f"{name}_{version}.zip"
-    if any(p.name == expected for p in zips):
-        print(f"OK: packaged archive {expected} uses the canonical <NAME>_<VERSION>.zip naming")
-        return
-
-    # Distinguish the stale dot-separated form from an unrelated archive so the
-    # diagnostic points at the actual mistake.
     dotted = f"{name}.{version}.zip"
+    expected = f"{name}_{version}.zip"
     names = sorted(p.name for p in zips)
     if dotted in names:
-        fail(
-            f"Archive is named {dotted!r} (dot-separated). `uip solution pack` emits "
-            f"{expected!r} since 2026-08-06 — publishing the dotted path fails with a "
-            f"missing-file error."
+        return (
+            f" A dot-separated {dotted!r} exists locally — `uip solution pack` emits "
+            f"{expected!r} since 2026-08-06, and publishing the dotted path fails "
+            f"with a missing-file error."
         )
-    fail(f"Expected a packaged archive named {expected!r}; found {names!r}")
+    if expected in names:
+        return f" The archive {expected!r} exists locally but was never published."
+    return ""
+
+
+def check_package_published(name: str, version: str, deployments: list | None) -> None:
+    """The packed archive was published: the tenant holds a package record.
+
+    Grades the uploaded artifact, not the local filesystem — agents legitimately
+    stage the packed .zip outside the workspace (e.g. /tmp), where artifact
+    collection never sees it. Publish is the step that consumes the archive, so
+    a deployment record referencing the package is proof the pack→publish
+    handoff worked (a stale dot-separated path makes publish fail with a
+    missing-file error and leaves no record). The agent may delete the package
+    after uninstall, so `packages list` is not reliable evidence; the deployment
+    tombstone survives and carries the package name.
+    """
+    if deployments is None:
+        print("SKIP: could not query deployments — published package unverified")
+        return
+
+    ours = [i for i in deployments if i.get("PackageName") == name]
+    if not ours:
+        fail(
+            f"No deployment on the tenant references package {name!r} — the packed "
+            f"archive was never published and deployed.{_local_zip_hint(name, version)}"
+        )
+
+    versions = {v for v in (_row_version(i) for i in ours) if v}
+    if versions and version not in versions:
+        fail(
+            f"Package {name!r} was deployed at version(s) {sorted(versions)!r}, "
+            f"expected {version!r} — the wrong cut was promoted"
+        )
+    if not versions:
+        print(f"NOTE: deployment records carry no version field — {version} unverified")
+
+    print(f"OK: package {name} {version} was published and referenced by a deployment")
 
 
 def check_solution_registers_agent(solution_dir: Path, name: str) -> None:
@@ -189,7 +231,7 @@ def _deploy_list() -> list | None:
     return [i for i in items if isinstance(i, dict)]
 
 
-def check_deployment_landed_and_removed(name: str) -> None:
+def check_deployment_landed_and_removed(name: str, items: list | None) -> None:
     """The package reached the tenant as a deployment, and that deployment is gone.
 
     Grades the *outcome*, not merely that the commands were invoked — `deploy run`
@@ -200,7 +242,6 @@ def check_deployment_landed_and_removed(name: str) -> None:
     `OperationStatus: Successful`), so a tombstone is the expected end state. A
     row in any other state is a deployment still standing on the tenant.
     """
-    items = _deploy_list()
     if items is None:
         return
 
@@ -234,10 +275,11 @@ def check_deployment_landed_and_removed(name: str) -> None:
 def main() -> None:
     name, version = load_seed()
     solution_dir = find_solution_dir(name)
-    check_package_naming(name, version)
+    deployments = _deploy_list()
+    check_package_published(name, version, deployments)
     check_solution_registers_agent(solution_dir, name)
     check_shipped_agent_intact(solution_dir)
-    check_deployment_landed_and_removed(name)
+    check_deployment_landed_and_removed(name, deployments)
     print("PASS: solution promotion outcome verified")
 
 

--- a/tests/tasks/uipath-agents/lowcode/solution_deploy_activate/solution_deploy_activate.yaml
+++ b/tests/tasks/uipath-agents/lowcode/solution_deploy_activate/solution_deploy_activate.yaml
@@ -8,7 +8,10 @@ description: >
   the suite runs `solution init` in 54 tasks but never packs, publishes or
   deploys, and `uipath-solution` carries no agent-flavoured deploy coverage
   either, so this path had no test owner anywhere in the repo. Also pins the
-  post-2026-08-06 package naming (`<NAME>_<VERSION>.zip`, underscore not dot).
+  post-2026-08-06 package naming (`<NAME>_<VERSION>.zip`, underscore not dot) —
+  graded tenant-side: a stale dotted path makes publish fail, so no package
+  record ever appears (the local .zip may be staged outside the workspace,
+  e.g. /tmp, where artifact collection never sees it).
   The two-stage branch (deploy inactive, activate separately) is reached through
   the owner's change process, not through test-shaped instructions: the prompt
   states the release rule, the skill has to know that `--skip-activate` is what
@@ -126,7 +129,7 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
-    description: "Promotion outcome: archive uses the canonical <NAME>_<VERSION>.zip naming, the shipped agent was promoted unchanged, and the deployment reached the tenant and was torn down again"
+    description: "Promotion outcome: the packed archive was published to the tenant as the seeded <NAME>/<VERSION> package, the shipped agent was promoted unchanged, and the deployment reached the tenant and was torn down again"
     command: "python3 $TASK_DIR/check_deploy_activate.py"
     timeout: 180
     expected_exit_code: 0


### PR DESCRIPTION
## Summary

Two coded-agent nightly tasks failed on grader defects rather than agent mistakes. Both fixes re-anchor grading on real outcomes the skill teaches, instead of incidental artifacts.

### 1. `deploy_activate` — grade publish outcome tenant-side, not via local .zip

The agent staged the packed archive in `/tmp` (a legitimate keep-the-worktree-clean choice), where artifact collection never sees it, so `check_deploy_activate.py`'s `CWD.rglob("*.zip")` found nothing despite a fully successful promotion. The deployment record on the tenant is the real proof the pack→publish handoff worked; the uninstall tombstone survives the agent's own cleanup and is the durable evidence. Local zips are now diagnostic hints only.

### 2. `eval_mocking_mockito` — scope the task to declarative mockito only

The checker required `ExampleCall`/`example_calls` in `main.py`, keyed to a soft "in the future… llm deciding mock values" prompt hint. The skill (`references/coded/lifecycle/evaluate.md`) teaches the opposite for this situation: bare `@mockable()` is correct when mockito supplies values, and `example_calls` belong only to LLM-driven mocking. The 2026-08-19 codex nightly built the doc-canonical solution and was failed by the grader for honoring the doc.

Dropped the future-LLM hint from the prompt and the `ExampleCall` checks from the grader; kept `@mockable` registration, mockito return-behavior, JsonSimilarity, and offline-results checks. LLM-mocking (`example_calls`) coverage now has no task — candidate for a dedicated follow-up task that asks for LLM-decided mock values explicitly.

## Validation

- **deploy_activate:** claude-code/claude-sonnet-5 run on 2026-08-19 scored 1.000; synthetic replay of the failed nightly's shape (zip only in `/tmp`, tombstone on tenant) now passes.
- **eval_mocking_mockito:** passing run `runs/2026-08-19_12-37-49`, claude-code/claude-sonnet-5, `experiments/default.yaml`, score 1.000 — the agent independently produced the bare-`@mockable()` + mockito-config solution and the updated checker passed it 5/5. The updated checker also verified against both preserved historical artifacts: the previously-failing codex 08-19 solution (now passes) and the previously-passing claude 07-27 solution (still passes). `/lint-task` verdict: Low (pre-existing, shared with sibling eval tasks); CLI-verb check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)