### PR TITLE
feat(uipath-feedback): Studio Web flavor — inline excerpts instead of attachments

### DIFF
--- a/skill-flavors/studioweb/uipath-feedback/SKILL.md
+++ b/skill-flavors/studioweb/uipath-feedback/SKILL.md
@@ -1,0 +1,53 @@
+<!--skill-flavor:feedback-description-budget:start-->
+Truncate the full description to 16000 characters max. Note if content was truncated. Studio Web feedback carries no attachments, so key file excerpts ride inline in the description — that is why the budget is larger here.
+<!--skill-flavor:feedback-description-budget:end-->
+
+<!--skill-flavor:feedback-prepare-attachments:start-->
+#### Inline key file excerpts (no attachments in Studio Web)
+
+`uip feedback send` does not support `--attachment` in Studio Web. Instead, inline the most relevant sanitized excerpts directly in the description under a final `## Key file excerpts` section, based on the detected area:
+
+- Flow: the `.flow` file
+- RPA: `project.json`, the failing workflow file (`.cs` or `.xaml`)
+- Agents: `pyproject.toml`, `bindings.json` (redacted)
+- CodedApps: `package.json`
+
+Put each excerpt in a fenced code block headed by its file path. Apply the Sanitization Rules and truncation limits (first 100 + last 30 lines per file) before inlining, and keep the whole description within the character budget — prefer the failing region of a file over its beginning when trimming.
+<!--skill-flavor:feedback-prepare-attachments:end-->
+
+<!--skill-flavor:feedback-preview:start-->
+```
+**Type:** bug
+**Priority:** normal
+**Title:** [Flow] [CLI] Expression error in nested loop currentItem
+**Description:** (first 3 lines...)
+**Inlined excerpts:** MyFlow.flow, project.json
+
+Send this to UiPath? (yes/no)
+```
+<!--skill-flavor:feedback-preview:end-->
+
+<!--skill-flavor:feedback-send-command:start-->
+```bash
+uip feedback send \
+  --type "<bug|improvement>" \
+  --title "<TITLE>" \
+  --description-file "/tmp/uip-feedback/description.md" \
+  --priority "<critical|normal|minor>" \
+  --output json
+```
+
+Do not pass `--attachment` — Studio Web rejects it before anything is sent.
+<!--skill-flavor:feedback-send-command:end-->
+
+<!--skill-flavor:feedback-cleanup-attachments:start-->
+Clean up the temp description file:
+
+```bash
+rm -rf /tmp/uip-feedback
+```
+<!--skill-flavor:feedback-cleanup-attachments:end-->
+
+<!--skill-flavor:feedback-cleanup-note:start-->
+Always clean up the temp description file regardless of success or failure.
+<!--skill-flavor:feedback-cleanup-note:end-->

--- a/skills/uipath-feedback/SKILL.md
+++ b/skills/uipath-feedback/SKILL.md
@@ -256,8 +256,11 @@ ExpressionError: Invalid expression at unknown location — currentItem is not d
 - **Top 3 Improvements**: (1) Include expression location (line/node) in validation errors. (2) Add a CLI command to list variables in scope at a given point. (3) Document loop variable naming conventions in the Flow skill.
 ```
 
+<!--skill-flavor:feedback-description-budget:start-->
 Truncate the full description to 4000 characters max. Note if content was truncated.
+<!--skill-flavor:feedback-description-budget:end-->
 
+<!--skill-flavor:feedback-prepare-attachments:start-->
 #### Prepare attachments
 
 Write sanitized copies of relevant project files to a temp directory:
@@ -273,11 +276,13 @@ Copy and sanitize files based on the detected area:
 - CodedApps: `package.json`
 
 Max 10 files, max 10MB each. Skip files that exceed limits.
+<!--skill-flavor:feedback-prepare-attachments:end-->
 
 #### Show preview and confirm
 
 Display to the user:
 
+<!--skill-flavor:feedback-preview:start-->
 ```
 **Type:** bug
 **Priority:** normal
@@ -287,6 +292,7 @@ Display to the user:
 
 Send this to UiPath? (yes/no)
 ```
+<!--skill-flavor:feedback-preview:end-->
 
 The user can adjust type, priority, or title (the title carries the area / optional CLI-or-Skill tag) before confirming. **Never send without explicit "yes".**
 
@@ -297,6 +303,7 @@ The user can adjust type, priority, or title (the title carries the area / optio
 1. Write the sanitized description body to a temp file using the **Write tool** (not a shell heredoc — heredocs are bash-only and fail on PowerShell). Use an absolute path in the OS temp dir, e.g. `<temp>/uip-feedback/description.md`.
 2. Invoke the CLI with `--description-file` pointing at that file:
 
+<!--skill-flavor:feedback-send-command:start-->
 ```bash
 uip feedback send \
   --type "<bug|improvement>" \
@@ -306,6 +313,7 @@ uip feedback send \
   --attachment <FILE1> <FILE2> \
   --output json
 ```
+<!--skill-flavor:feedback-send-command:end-->
 
 `--description-file` reads the body from disk, so it is immune to shell quoting and works identically on PowerShell, cmd, and bash. (If the CLI predates this flag, pipe the body via stdin instead; do not inline it.)
 
@@ -319,11 +327,13 @@ Parse the JSON output. On success, show the user a confirmation with any referen
 
 **Fallback:** Only after `--description-file` genuinely fails (network, auth, real CLI error) save the full feedback to `./feedback-report.md` using the description body and tell the user: _"Could not send automatically. The report is saved to `feedback-report.md`."_
 
+<!--skill-flavor:feedback-cleanup-attachments:start-->
 Clean up temp attachments:
 
 ```bash
 rm -rf "${TMPDIR:-${TMP:-/tmp}}/uip-feedback-attachments"
 ```
+<!--skill-flavor:feedback-cleanup-attachments:end-->
 
 ### Step 5 -- Report result
 
@@ -342,7 +352,9 @@ Could not send feedback automatically.
 - You can submit it manually or retry with `/uipath-feedback` later.
 ```
 
+<!--skill-flavor:feedback-cleanup-note:start-->
 Always clean up temp attachments regardless of success or failure.
+<!--skill-flavor:feedback-cleanup-note:end-->
 
 ## Sanitization Rules
 


### PR DESCRIPTION
## Why

Studio Web's `uip feedback send` is served by a host interceptor (UiPath/Autopilot#4732) and is **description-only** — it rejects `--attachment` before anything is sent. The canonical skill still instructs agents to prepare temp attachment copies and pass `--attachment`, which in Studio Web only produces wasted preparation work followed by a ValidationError.

## What

Six `skill-flavor` marker blocks in `skills/uipath-feedback/SKILL.md` plus a `skill-flavors/studioweb/uipath-feedback/SKILL.md` override:

- **Prepare attachments** → **Inline key file excerpts**: same per-area file table, but excerpts go inside the description under a `## Key file excerpts` section, sanitized and truncated (first 100 + last 30 lines).
- **Description budget** raised 4000 → 16000 characters in Studio Web, since excerpts ride inline (the host interceptor caps the file at 32KB).
- **Send command** drops `--attachment` and pins the description path under `/tmp`, with an explicit "do not pass --attachment" note.
- **Preview / cleanup** wording adjusted accordingly.

Canonical (default-flavor) output is byte-identical — markers only.

## Verification

- `node scripts/compose-skill-flavor.mjs validate`: OK — default: 26 skills, 1715 files, 0 replacements; studioweb: 26 skills, 1715 files, 167 replacements.
- `compose-skill-flavor.mjs build`: composed studioweb SKILL.md carries the new guidance, composed default SKILL.md diffs empty against canonical, zero markers leak into either output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)