### PR TITLE
fix(rpa): make rpa vs rpa-legacy tool choice explicit at the routing point

### DIFF
--- a/skills/uipath-rpa/SKILL.md
+++ b/skills/uipath-rpa/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: uipath-rpa
-description: "Always invoke for `.xaml` or `.cs` workflow files. UiPath RPA — create, edit, build, run, debug `.cs` coded workflows and `.xaml` workflows. UI automation with Object Repository selectors, test case authoring, Integration Service connector calls. Live desktop/browser UI exploration and control. Deploy via `.uipx`→uipath-solution. Non-solution Orchestrator ops→uipath-platform. Test reports→uipath-test. Agents→uipath-agents."
-when_to_use: "User wants to create, edit, debug, or run a UiPath automation — '.cs' coded workflows or '.xaml' files. Triggers: 'build a workflow', 'automate Excel/email/web/PDF/queue items', 'add a try-catch', 'fix this XAML error', 'scrape this site', 'process invoices', 'create a test case', or project.json shows UiPath dependencies. NOT for '.flow' files (→uipath-maestro-flow), Python agents (→uipath-agents)."
+description: "Always invoke for `.xaml` or `.cs` workflow files. UiPath RPA — create, edit, build, **pack to `.nupkg`**, run, debug `.cs` coded workflows and `.xaml` workflows. UI automation with Object Repository selectors, test case authoring, Integration Service connector calls. Live desktop/browser UI exploration and control. Packing an RPA project stays here (`uip rpa pack` vs `uip rpa-legacy pack` is decided by `targetFramework` — see Project Type Detection); only solution-level `.uipx` deployment→uipath-solution. Non-solution Orchestrator ops→uipath-platform. Test reports→uipath-test. Agents→uipath-agents."
+when_to_use: "User wants to create, edit, debug, run, or **pack/package** a UiPath automation — '.cs' coded workflows or '.xaml' files. Triggers: 'build a workflow', 'pack this project', 'build a .nupkg', 'package and upload this process', 'automate Excel/email/web/PDF/queue items', 'add a try-catch', 'fix this XAML error', 'scrape this site', 'process invoices', 'create a test case', or project.json shows UiPath dependencies. Invoke BEFORE running any `uip rpa` or `uip rpa-legacy` command — the two are not interchangeable. NOT for '.flow' files (→uipath-maestro-flow), Python agents (→uipath-agents)."
 ---
 
 # UiPath RPA Assistant
@@ -46,7 +46,9 @@ Before creating or modifying anything, determine which project to work with. See
 After establishing `PROJECT_DIR`, **first check `project.json` for `targetFramework`**:
 
 - **`targetFramework: "Legacy"` (or field absent in an older project) → Legacy mode.** Stop here and switch to the Legacy-mode workflow: [references/legacy/legacy-mode-guide.md](references/legacy/legacy-mode-guide.md). Legacy projects use the standalone `uip rpa-legacy` CLI, .NET Framework 4.6.1, classic activities (no "X" suffix), and `mscorlib` assembly references. The rest of this SKILL.md (modern mode) does NOT apply to Legacy projects.
-- **`targetFramework: "Windows"` or `"Portable"` (Cross-platform) → Modern mode**, continue below.
+- **`targetFramework: "Windows"` or `"Portable"` (Cross-platform) → Modern mode**, continue below. Both use the `uip rpa` CLI — `"Windows"` here means Modern Windows-only, **not** Windows-Legacy.
+
+> **`uip rpa-legacy` is for `targetFramework: "Legacy"` ONLY — never as a fallback when `uip rpa` is unavailable.** "legacy" names the legacy *uipcli*, not legacy *projects*. It packs a Modern (`Windows`/`Portable`) project successfully and exits 0, so a passing pack is not evidence you picked the right tool. Fix `uip rpa` instead.
 
 For modern projects, determine whether this is a **coded** or **XAML** project:
 


### PR DESCRIPTION
## Problem

Found while packing a `targetFramework: "Windows"` RPA project: I reached for `uip rpa-legacy pack` when `uip rpa` was unavailable, and nothing in the skill or the tooling corrected it.

Three compounding factors, all in `Project Type Detection`:

1. **The Modern branch named no tool.** The Legacy bullet says *"Legacy projects use the standalone `uip rpa-legacy` CLI"*; the Modern bullet said only *"→ Modern mode, continue below"*. So `rpa-legacy` was the **only concrete tool named** at the moment of choosing.
2. **"legacy" is ambiguous — and the wrong reading is technically true.** It names the legacy *uipcli*, not legacy *projects*. `uipcli` does pack Modern projects (that is the premise of the uipcli→uip parity work), so "old CLI, works on RPA projects" is a reasonable inference.
3. **`"Windows"` invites conflation with "Windows-Legacy".** `targetFramework: "Windows"` is Modern; nothing said so in one place.

There is also no failure signal: `uip rpa-legacy pack` on a Modern project compiles, signs, produces a valid `.nupkg`, and Orchestrator accepts it with the correct `TargetFramework`. A passing pack looks like a correct pack.

Separately, the frontmatter never mentioned **pack / package / .nupkg**, while `description` routed deployment away (`Deploy via .uipx→uipath-solution`). A request phrased as *"pack this rpa process and upload it"* therefore did not read as a `uipath-rpa` task at all — so the routing rule was never reached.

## Changes

- **Name `uip rpa` on the Modern branch**, and state that `"Windows"` means Modern Windows-only, **not** Windows-Legacy. This is the substantive fix — it makes the routing bullets symmetric, so a reader gets the right answer without needing to reach any warning.
- **Add a guard** that `rpa-legacy` is `Legacy`-only and never a fallback, with the two non-obvious points: "legacy" refers to the CLI, and a passing pack is not evidence of the right tool.
- **Add pack triggers to the frontmatter** (`'pack this project'`, `'build a .nupkg'`, `'package and upload this process'`), qualify the deployment redirect so packing stays in scope, and note that `uip rpa` and `uip rpa-legacy` are not interchangeable.

Five insertions, three deletions, one file.

## Notes for review

- Deliberately kept short. An earlier draft listed the concrete costs (missing `--package-author`; a 0-byte `.local/generated/Triggers.Generated.xaml` that breaks the *next* `uip rpa pack` with `Root element is missing`). Those were cut as version-specific detail that will rot, in a section that is otherwise one-line bullets. The `Triggers.Generated.xaml` symptom→fix pair may deserve a line in `references/xaml/common-pitfalls.md` — happy to add it here or separately.
- The "not interchangeable" phrasing matches existing house style in `references/cli-reference.md`, which uses it for `solution upload` vs `solution publish`.
- A skill change makes the mistake *discouraged*, not impossible. The complete fix is a `targetFramework` check inside `rpa-legacy` itself, which has none today — that belongs in `UiPath/cli` (`packages/rpa-legacy-tool`) and is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
