### PR TITLE
fix(uipath-maestro-bpmn): forbid normalizing untouched nodes during edits

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -35,7 +35,10 @@ tags, imported Integration Service payloads, and stable element IDs. Do not
 regenerate the whole file or drop extension data the skill does not recognize —
 preserve-only structures (see the blocklist in
 [references/structural-bpmn.md](references/structural-bpmn.md)) round-trip
-untouched.
+untouched. Never normalize existing nodes to this skill's canonical templates:
+do not add missing attributes (e.g. `type="json" target="bodyField"` on an
+existing `uipath:input`) to elements the edit does not target — on untouched
+neighbors only wiring (`bpmn:incoming`/`bpmn:outgoing`) may change.
 
 For `.flow` JSON use `uipath-maestro-flow`; for XAML/coded workflows use
 `uipath-rpa`; for Python agents use `uipath-agents`; for Case plans use

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -164,7 +164,10 @@ template, but the runtime contract is fixed:
   with `type="json"` and `target="bodyField"`, and maps each field by variable
   id (`=vars.Var_Amount`). Include `<uipath:input name="args" type="json"
   target="bodyField"><![CDATA[{}]]></uipath:input>` even when there are no
-  inputs; this is part of the `BPMN.ScriptTask` registry template.
+  inputs; this is part of the `BPMN.ScriptTask` registry template. This rule
+  applies only to nodes you author: when editing, never retrofit these
+  attributes onto an existing node's mapping — a pre-existing
+  `<uipath:input name="args">` without them stays byte-identical.
 - Map the returned object's property back through `source="=result.response"`
   (the conventional scalar property) or `source="=result.response.<field>"`
   (another object field); `var` points at a declared variable id (do not put the

--- a/skills/uipath-maestro-bpmn/references/structural-bpmn.md
+++ b/skills/uipath-maestro-bpmn/references/structural-bpmn.md
@@ -165,9 +165,10 @@ template, but the runtime contract is fixed:
   id (`=vars.Var_Amount`). Include `<uipath:input name="args" type="json"
   target="bodyField"><![CDATA[{}]]></uipath:input>` even when there are no
   inputs; this is part of the `BPMN.ScriptTask` registry template. This rule
-  applies only to nodes you author: when editing, never retrofit these
-  attributes onto an existing node's mapping — a pre-existing
-  `<uipath:input name="args">` without them stays byte-identical.
+  applies to nodes you author and to mappings an edit explicitly targets;
+  never retrofit these attributes onto an untouched node's mapping — a
+  pre-existing `<uipath:input name="args">` outside the edit's target stays
+  byte-identical.
 - Map the returned object's property back through `source="=result.response"`
   (the conventional scalar property) or `source="=result.response.<field>"`
   (another object field); `var` points at a declared variable id (do not put the


### PR DESCRIPTION
## Why

The antigravity (gemini-3.6-flash) nightly `2026-08-19_04-15-02` failed all three BPMN edit tasks (`edit-add-node`, `edit-remove-node`, `edit-group-to-subflow`) with the identical checker error: `node 'Task_X' config/payload changed (only its wiring may change)`. Artifact diffs show the same single mutation in each: the agent stamped `type="json" target="bodyField"` onto the **protected** node's `<uipath:input>` mapping.

The bait is in the skill itself: `structural-bpmn.md` says to include those attributes "even when there are no inputs; this is part of the registry template" with no scoping — a literal reader treats it as a validity rule and retrofits it onto pre-existing nodes while editing. The editing section says "surgical edits" but never explicitly forbids normalizing untouched nodes to the documented canonical templates.

## What

Two sentences, no behavior change for authoring:

- `references/structural-bpmn.md` — scope the "include even when there are no inputs" rule to nodes the agent authors; a pre-existing `<uipath:input name="args">` without the attributes stays byte-identical.
- `SKILL.md` (editing section) — explicit no-normalization rule: never add missing attributes to elements the edit does not target; on untouched neighbors only wiring may change.

## Verification

Eval runs of the three edit tasks dispatched from this branch (results will be posted as comments):
- antigravity (the failing harness)
- claude (no-regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
