### PR TITLE
fix(uipath-maestro-case): name sdd.md as the source of condition-expression

### DIFF
--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -60,7 +60,7 @@ Every `=`-prefixed value in `caseplan.json` is dispatched to one of two runtime 
 | **Connector trigger filter expression** (`body.filters.expression`) with variable refs | n/a | `` =js:`<JMESPath with ${vars.X} interpolations>` `` |
 | **Connector trigger filter expression** plain literal (no variables) | Unwrapped CEQL/JMESPath text | n/a |
 | **`conditionExpression`** (stage entry/exit, task entry, case exit, trigger rules) | (no plain branch) | `=js:<expr>` — no outer parens; sub-clauses get manual parens when combining via `&&` / `\|\|` |
-| **SLA rule `expression`** | (no plain branch) | `=js:<expr>` (default: `=js:true`) |
+| **SLA rule `expression`** | (no plain branch) | `=js:<expr>` (default rule: `=js:true` — SLA only) |
 | **Task output `source` / `target`** | `=vars.<varId>` / `=<rawFieldName>` | n/a (always plain) |
 | **Binding refs in `data.context`, `caseShape.context`** | `=bindings.<id>` | n/a |
 

--- a/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/case-exit-conditions/planning.md
@@ -21,7 +21,7 @@ Every case-exit condition declared in sdd.md gets its own T-task — **including
 | `rule-type` | From catalog below | See §Rule-type catalog |
 | `selected-stage-id` | Required for `selected-stage-*` rule-types | Resolved from stage capture map |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-planning.md § Planning Pipeline](../../../connector-trigger-planning.md#planning-pipeline) |
-| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `condition-expression` | sdd.md IF column (optional) | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
 | `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-planning.md § tasks.md fields (planning)](../../../connector-trigger-planning.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (case-exit scope)

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-entry-conditions/planning.md
@@ -26,7 +26,7 @@ Every stage with an **Entry Condition** declared in sdd.md gets its own stage-en
 | `sla-display-name` | `sla-status-change` arg 2 — the target's SDD `SLA Title` (or a Variable SLA Rules `Display Name`) | Target-unique SLA rule title; resolves to the SLA rule ID emitted from §4.8 during Phase 2. Required |
 | `escalation-display-name` | `sla-status-change` arg 3 — a `Display Name` from that target's SDD escalation table | Target-unique **at-risk** escalation title; resolves to its escalation ID. **At-risk only** — omit for a breach response. A breach rule references the SLA alone; supplying an escalation converts it into an at-risk rule ([sla-response-shapes.md § Status](../../../sla-response-shapes.md)) |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — resolved via [connector-trigger-planning.md § Planning Pipeline](../../../connector-trigger-planning.md#planning-pipeline) |
-| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `condition-expression` | sdd.md IF column (optional) | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
 | `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-planning.md § tasks.md fields (planning)](../../../connector-trigger-planning.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (stage-entry scope)

--- a/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/stage-exit-conditions/planning.md
@@ -24,7 +24,7 @@ Every stage with an **Exit Condition** declared in sdd.md gets its own stage-exi
 | `rule-type` | From catalog below | |
 | `selected-tasks-ids` | Required for `selected-tasks-completed` | Comma-separated task IDs. Selected tasks must be non-adhoc siblings in the same stage. |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-planning.md § Planning Pipeline](../../../connector-trigger-planning.md#planning-pipeline) |
-| `condition-expression` | Optional on any rule-type | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `condition-expression` | sdd.md IF column (optional) | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
 | `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-planning.md § tasks.md fields (planning)](../../../connector-trigger-planning.md#tasksmd-fields-planning). |
 
 ## Exit Type Catalog

--- a/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
+++ b/skills/uipath-maestro-case/references/plugins/conditions/task-entry-conditions/planning.md
@@ -25,7 +25,7 @@ Every task in sdd.md that declares an **Entry Condition** row gets its own task-
 | `sla-display-name` | `sla-status-change` arg 2 — the target's SDD `SLA Title` (or a Variable SLA Rules `Display Name`) | Target-unique SLA rule title; resolves to the SLA rule ID emitted from §4.8 during Phase 2. Required |
 | `escalation-display-name` | `sla-status-change` arg 3 — a `Display Name` from that target's SDD escalation table | Target-unique **at-risk** escalation title; resolves to its escalation ID. **At-risk only** — omit for a breach response, which references the SLA alone ([sla-response-shapes.md § Status](../../../sla-response-shapes.md)) |
 | `connector fields` | SDD **Connector Rule Detail** block | `type-id` (activity-type-id), `connector-key`, `connection-id`, `object-name`, `event-operation`, `event-mode`, `input-values`, optional `filter` — see [connector-trigger-planning.md § Planning Pipeline](../../../connector-trigger-planning.md#planning-pipeline) |
-| `condition-expression` | Optional | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
+| `condition-expression` | sdd.md IF column (optional) | Extra `=js:` gate on **case state** (`=js:vars.X ...`) — NOT the event payload (no `event` namespace) |
 | `outputs` | SDD **Connector Rule Outputs** block | Optional. `->` (extract field → case var) or `=` (assign expression → case var). See [connector-trigger-planning.md § tasks.md fields (planning)](../../../connector-trigger-planning.md#tasksmd-fields-planning). |
 
 ## Rule-Type Catalog (task-entry scope)


### PR DESCRIPTION
## Problem

Phase 1 wrote a `condition-expression` the SDD never stated:

```
## T83: Add stage-entry condition for "Wrap-up Dispute dropped" — global cardholder withdrawal
- rule-type: wait-for-connector
- condition-expression: =js:true          ← nothing in sdd.md asks for this
```

Phase 2/3 then propagated it into `caseplan.json` (`Rule_R083JJ`). Always truthy, so identical to omitting the key — verified on the shipped artifact, deleting it keeps both `uip maestro case validate` and `--skeleton-v2` at `Valid`. The defect is that the skill **invented content**, which Rule 2 (`SKILL.md:32`) forbids: *"trust `sdd.md` as written; the skill does not validate or gap-fill it."* It also masked the requirement that was genuinely unmet (correlation by case ID).

Of the 21 `condition-expression` values in that build, the other 20 trace to a real SDD value.

## Root cause

The field was **already marked optional**, so that was not the gap.

"Optional" answers *must this field be written?* — no. It says nothing about *where its value comes from*, and that unanswered question is what permits invention. Every neighbouring field in these tables names its sdd.md source. One row above, in the same table:

> `display-name` | **sdd.md Display Name column** (optional) | Carry the SDD value verbatim. Omit when the SDD cell is blank / `—` — do NOT invent one

`condition-expression` read only **"Optional on any rule-type"** — a free field, with no stated origin. A field sourced from a specific SDD value has nothing to transcribe when the SDD carries none.

Why `=js:true` specifically: it is the skill's default-rule idiom for SLA `slaRules[].expression` (~20 occurrences), and this build had 8 legitimate ones live in the same file. Adjacent field name, wrong sink.

## Change

5 lines, all pure replacements — nothing added, no restating "optional":

| File | Change |
|---|---|
| 4× `plugins/conditions/*/planning.md` | Source cell: `Optional on any rule-type` → `sdd.md IF value (optional)` |
| `bindings-and-expressions.md` | form-by-sink table: `=js:true` → `default rule: =js:true — SLA only` |

Scoped to Phase 1 (`sdd.md` → `tasks.md`), where the T-entry is authored. The Phase 2/3 write path is untouched: it propagated the T-entry correctly, so a guard there would not have fired.

## Validation

- `npm run skills:validate` → OK, 26 skills / 1715 files, `default` + `studioweb`
- No `skill-flavor` markers or `studioweb` overrides on these files, so both flavors get the edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)