### PR TITLE
fix(uipath-maestro-case): null-guard task-output references in condition expressions

### DIFF
--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -72,6 +72,16 @@ In any `=js:` expression use **strict** `===` / `!==`, never loose `==` / `!=`. 
 
 SDD IF columns and `tasks.md` conditions use natural shorthand — `approved == true`, `status != "done"`. When rewriting into a `conditionExpression` (or any `=js:` sink) you MUST upgrade the operator: `approved == true` → `=js:vars.approved === true`. Do NOT transcribe `==` / `!=` verbatim.
 
+### Null-safe task-output references
+
+In a `conditionExpression` or SLA `expression`, null-guard every task-output dereference — guard the object, not the property:
+
+```
+=js:JSON.parse((vars.response4 || {}).RequestBody || '{}').outcome === 'Signed'
+```
+
+`(vars.X || {}).Y` — never `vars.X.Y || <default>`. Whole-value `=vars.<id>` needs no guard.
+
 ### Conservative rule for `=metadata.X`
 
 The lookup-path resolver has NO `=metadata.` branch — plain `=metadata.X` is NOT resolved at runtime. **Always wrap as `=js:metadata.X`** (or `=js:(metadata.X)` if the sink requires parens). The FE design-time picker may classify `=metadata.X` as "variable" type, but that's a UI hint, not a runtime contract.
@@ -145,6 +155,7 @@ vars.$xref('Stage Name','Task Name','output_name')
 - Three args = the same name-triple as whole-value `<-`: source stage `data.label`, source task `displayName`, source output `name`.
 - Single quotes ONLY — double quotes break the enclosing JSON string. Names containing a literal `'` are unsupported (re-author the name).
 - Drop it anywhere a bare `vars.X` is legal inside an `=js:` expression. It resolves to bare `vars.<outputReferenceId>` (NOT `=vars.` — it is already inside `=js:`).
+- In a `conditionExpression`, null-guard any dotted access off the resolved reference ([§ Null-safe task-output references](#null-safe-task-output-references)).
 
 **Example** — composite input payload, no middle variables:
 


### PR DESCRIPTION
## Problem

Rules evaluate at case start across **all** stages, so a task output is `null` until its task runs. Dereferencing one in a `conditionExpression` faults the whole instance:

```
[400300] Error evaluating expression in activity inputs
Cannot read property 'RequestBody' of null
```

`validate` stays green — it never evaluates expressions.

Hit while building a real case. This looks defensive but isn't:

```js
JSON.parse(vars.response4.RequestBody || '{}').outcome === 'Signed'
```

`|| '{}'` guards the *result* of `.RequestBody`; the throw lands on the access itself, before the fallback runs.

## Fix

`§ In-expression references` tells the author to drop a resolved output reference anywhere a bare `vars.X` is legal — naming `conditionExpression` explicitly — but never says it can be `null` there. Adds `§ Null-safe task-output references` beside `§ Equality operators`, same genre of gotcha validation can't catch.

Docs-only, +11/−0. No per-plugin pointers needed: all four condition plugins already link to this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)