### PR TITLE
fix(planner): reconcile the case render contracts with the template, and gate the checks that were missing

### DIFF
--- a/scripts/check-case-render-authority.py
+++ b/scripts/check-case-render-authority.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Fail when the case render contracts and the SDD template disagree about SHAPE.
+
+Authority split (declared in `references/case/principles.md`):
+
+    the TEMPLATE is the shape      — headings, column lists, section numbering
+    the references are SEMANTICS   — what belongs in a cell, and why
+
+Both currently describe shape, with no tiebreaker, so an agent that satisfies one
+must violate the other. The existing gates cannot see this: the template conformance
+gate checks that headings EXIST, never that two documents AGREE, so contradictions
+pass every check and ship.
+
+What this catches:
+
+  1. A stage/task heading format asserted in a reference that the template does not use.
+  2. A pipe-delimited column list asserted in a reference with no matching table
+     header in the template.
+
+Read-only. Exit 0 clean, 1 on findings.
+
+    python3 scripts/check-case-render-authority.py [--json]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+REPO = pathlib.Path(__file__).resolve().parent.parent
+TEMPLATE = REPO / "skills/uipath-planner/assets/templates/case-sdd-template.md"
+RENDER_DOCS = [
+    REPO / "skills/uipath-planner/references/case/render-stages-tasks.md",
+    REPO / "skills/uipath-planner/references/case/render-case-definition.md",
+]
+
+# A heading shape claim: a backticked `### Stage {N}: {Stage Name}`-ish string.
+HEADING_CLAIM = re.compile(r"`(#{3,5}\s+[^`]+)`")
+# A column-list claim: a backticked run containing at least two pipes.
+COLUMN_CLAIM = re.compile(r"`([^`\n]*\|[^`\n]*\|[^`\n]*)`")
+# A rendered markdown table header row in the template.
+TABLE_HEADER = re.compile(r"^\|(.+)\|\s*$", re.M)
+
+# Placeholder syntaxes differ between the docs ({N} / <N>) without being a conflict.
+PLACEHOLDER = re.compile(r"[<{][^<>{}]*[>}]")
+
+
+def normalize_heading(s: str) -> str:
+    s = s.strip().rstrip(".")
+    s = PLACEHOLDER.sub("*", s)
+    s = re.sub(r"\\`|`", "", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+OPTIONAL_COL = re.compile(r"\(\s*\|[^)]*\)")
+
+
+def normalize_columns(s: str) -> tuple[str, ...]:
+    # `Field | Type | Binding (| Required)` documents an OPTIONAL column; the
+    # parenthetical is notation, not a cell. Treating it as one produced a false
+    # conflict against a template that defines both variants.
+    s = OPTIONAL_COL.sub("", s)
+    cells = [c.strip().strip("`").strip() for c in s.strip().strip("|").split("|")]
+    cells = [PLACEHOLDER.sub("*", c) for c in cells if c]
+    return tuple(c.lower() for c in cells)
+
+
+def template_facts(text: str) -> tuple[set[str], set[tuple[str, ...]]]:
+    headings = {
+        normalize_heading(line)
+        for line in text.splitlines()
+        if re.match(r"^#{3,5}\s+\S", line)
+    }
+    # The template also pins some heading shapes in HTML comments / inline backticks
+    # (secondary-stage task numbering, for one). Those are definitions too — not
+    # counting them made the checker report a conflict that does not exist.
+    headings |= {normalize_heading(m) for m in HEADING_CLAIM.findall(text)}
+    columns: set[tuple[str, ...]] = set()
+    for m in TABLE_HEADER.finditer(text):
+        row = m.group(1)
+        if set(row.replace("|", "").strip()) <= set("-: "):
+            continue  # separator row
+        cols = normalize_columns(row)
+        if len(cols) >= 2:
+            columns.add(cols)
+    return headings, columns
+
+
+def scan(doc: pathlib.Path, headings: set[str], columns: set[tuple[str, ...]]) -> list[dict]:
+    findings: list[dict] = []
+    if not doc.is_file():
+        return [{"file": str(doc), "line": 0, "kind": "missing", "claim": "", "detail": "file not found"}]
+    text = doc.read_text(encoding="utf-8")
+
+    for m in HEADING_CLAIM.finditer(text):
+        claim = normalize_heading(m.group(1))
+        if not claim.startswith("#"):
+            continue
+        if claim in headings:
+            continue
+        # Only flag stage/task headings — those are the shape the template owns.
+        if not re.search(r"\b(Stage|Task)\b", claim):
+            continue
+        findings.append({
+            "file": str(doc.relative_to(REPO)),
+            "line": text[: m.start()].count("\n") + 1,
+            "kind": "heading",
+            "claim": m.group(1).strip(),
+            "detail": "asserted in a render contract but not used by the template",
+        })
+
+    for m in COLUMN_CLAIM.finditer(text):
+        cols = normalize_columns(m.group(1))
+        if len(cols) < 3:
+            continue
+        if cols in columns:
+            continue
+        findings.append({
+            "file": str(doc.relative_to(REPO)),
+            "line": text[: m.start()].count("\n") + 1,
+            "kind": "columns",
+            "claim": m.group(1).strip(),
+            "detail": "column list has no matching table header in the template",
+        })
+    return findings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    if not TEMPLATE.is_file():
+        print(f"FAIL: template not found at {TEMPLATE}", file=sys.stderr)
+        return 1
+
+    headings, columns = template_facts(TEMPLATE.read_text(encoding="utf-8"))
+    findings: list[dict] = []
+    for doc in RENDER_DOCS:
+        findings.extend(scan(doc, headings, columns))
+
+    if args.json:
+        print(json.dumps({"findings": findings}, indent=2))
+        return 1 if findings else 0
+
+    print(f"template: {TEMPLATE.relative_to(REPO)} — {len(headings)} headings, {len(columns)} table shapes")
+    if not findings:
+        print("OK: render contracts assert no shape the template does not define")
+        return 0
+
+    print(f"\nFAIL: {len(findings)} shape conflict(s) between the render contracts and the template:\n",
+          file=sys.stderr)
+    for f in findings:
+        print(f"  {f['file']}:{f['line']}  [{f['kind']}]", file=sys.stderr)
+        print(f"      {f['claim']}", file=sys.stderr)
+        print(f"      {f['detail']}", file=sys.stderr)
+    print(
+        "\n  The template is the shape; the references are the semantics.\n"
+        "  Move the heading/column definition into the template, or replace the\n"
+        "  claim with a pointer to it. See references/case/principles.md.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-eval-run.py
+++ b/scripts/check-eval-run.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Assert a coder-eval run measured what it claims, BEFORE anyone reads its scores.
+
+Why this exists
+---------------
+A coder-eval run can complete, report per-task scores, and mean nothing. Observed
+failures, all of which produced plausible numbers:
+
+  * the skill under test was never installed — the run silently fell back to
+    coder-eval's built-in default experiment, which has no `plugins:` block, so the
+    agent ran with no skill at all and every skill-contract criterion failed
+  * the model never executed — a provider error (expired credit, auth) ends the
+    dialog after ~2 turns while the orchestrator still writes a finished task.json
+    with a score
+  * the judge had no transport — `llm_judge` scores 0.0 with
+    "(judge transport unconfigured)", so every task is FAILURE regardless of merit
+
+Each of those is indistinguishable from a real regression if you read only the
+score. This gate makes them loud. Run it on a run directory before quoting any
+number from it.
+
+Usage
+-----
+    python3 scripts/check-eval-run.py RUN_DIR [--expect-experiment NAME]
+                                              [--min-turns N] [--json]
+
+    # typical: the repo's own experiment must have been used
+    python3 scripts/check-eval-run.py tests/runs/my-run --expect-experiment skill-tests-default
+
+Exit 0 when every replicate is trustworthy, 1 otherwise. Says nothing about whether
+the skill is correct — only whether the run is evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+JUDGE_UNCONFIGURED = "judge transport unconfigured"
+
+
+def replicate_findings(task_json: pathlib.Path, min_turns: int, regrade: bool = False) -> list[str]:
+    """Reasons this replicate is not evidence. Empty list == trustworthy."""
+    out: list[str] = []
+    try:
+        t = json.loads(task_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"unreadable task.json: {exc}"]
+
+    # A `coder-eval evaluate` re-grade runs NO agent: there is no plugin install,
+    # no token usage and no experiment report, so asserting those here would fail
+    # every re-grade — the cheapest and most useful path. Only judge reachability
+    # and the criteria themselves are meaningful in that mode.
+    if regrade:
+        for crit in t.get("success_criteria_results") or []:
+            if JUDGE_UNCONFIGURED in str(crit.get("details", "")):
+                out.append(
+                    "llm_judge scored 0.0 with no judge transport — this re-grade's "
+                    "pass/fail is not about the skill. Configure ANTHROPIC_API_KEY or Bedrock, "
+                    "or use an agent_judge criterion, which runs on the local CLI login."
+                )
+                break
+        return out
+
+    agent_cfg = t.get("agent_config") or {}
+    if not agent_cfg.get("plugins"):
+        out.append(
+            "no plugin loaded — agent_config.plugins is empty, so the skill under "
+            "test was never installed (usually the built-in default experiment)"
+        )
+
+    # "Did the model execute?" is measured by output tokens, NOT by turn count.
+    # Turn count is agent-dependent and misleading: codex reports
+    # total_assistant_turns == 1 on fully successful runs and 2 on runs that died
+    # on a provider error, so any turn threshold is near-inverted for it. Token
+    # usage is absent entirely when the provider refused.
+    usage = t.get("total_token_usage") or {}
+    produced = usage.get("output_tokens")
+    if not produced:
+        turns = t.get("total_assistant_turns")
+        out.append(
+            "the model produced no output — total_token_usage is empty "
+            f"(turns={turns}, agent={t.get('agent_type')}). Usually a provider error "
+            "(expired credit, auth); check conversation.log"
+        )
+    elif min_turns > 0 and produced < min_turns:
+        out.append(f"only {produced} output token(s) — suspiciously little work")
+
+    for crit in t.get("success_criteria_results") or []:
+        if JUDGE_UNCONFIGURED in str(crit.get("details", "")):
+            out.append(
+                "llm_judge scored 0.0 with no judge transport — this run's pass/fail "
+                "is not about the skill. Configure ANTHROPIC_API_KEY or Bedrock, or use an "
+                "agent_judge criterion, which runs on the local CLI login."
+            )
+            break
+
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_dir", type=pathlib.Path)
+    ap.add_argument("--expect-experiment", default=None,
+                    help="fail unless the run's experiment report names this experiment")
+    ap.add_argument("--min-output-tokens", dest="min_turns", type=int, default=1,
+                    help="minimum model output tokens for a replicate to count (default 1)")
+    ap.add_argument("--regrade", action="store_true",
+                    help="the run came from `coder-eval evaluate` (no agent executed): "
+                         "skip plugin/token/experiment assertions")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    run_dir: pathlib.Path = args.run_dir
+    if not run_dir.is_dir():
+        print(f"FAIL: no such run directory: {run_dir}", file=sys.stderr)
+        return 1
+
+    report: dict = {"run_dir": str(run_dir), "experiment": None, "replicates": [], "run_level": []}
+
+    exp_md = run_dir / "experiment.md"
+    if args.regrade:
+        report["experiment"] = "(re-grade — no experiment)"
+    elif exp_md.is_file():
+        first = exp_md.read_text(encoding="utf-8").splitlines()[0] if exp_md.read_text(encoding="utf-8") else ""
+        name = first.split(":", 1)[-1].strip() if ":" in first else first.strip()
+        report["experiment"] = name
+        if args.expect_experiment and name != args.expect_experiment:
+            report["run_level"].append(
+                f"experiment is {name!r}, expected {args.expect_experiment!r} — a "
+                "silent fallback to a different experiment changes what was measured"
+            )
+    else:
+        report["run_level"].append(
+            "no experiment.md — cannot confirm which experiment ran "
+            "(pass --regrade if this came from `coder-eval evaluate`)"
+        )
+
+    task_jsons = sorted(run_dir.rglob("task.json"))
+    if not task_jsons:
+        report["run_level"].append("no task.json found — the run produced no replicates")
+
+    bad = 0
+    for tj in task_jsons:
+        findings = replicate_findings(tj, args.min_turns, regrade=args.regrade)
+        rel = tj.relative_to(run_dir).parent
+        report["replicates"].append({"replicate": str(rel), "findings": findings})
+        bad += bool(findings)
+
+    total = len(task_jsons)
+    ok = total - bad
+    report["summary"] = {"replicates": total, "trustworthy": ok, "invalid": bad}
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 1 if (bad or report["run_level"]) else 0
+
+    print(f"run: {run_dir}")
+    print(f"experiment: {report['experiment']}")
+    print(f"replicates: {total}  trustworthy: {ok}  invalid: {bad}")
+
+    for msg in report["run_level"]:
+        print(f"\n  RUN-LEVEL: {msg}", file=sys.stderr)
+    for rep in report["replicates"]:
+        if rep["findings"]:
+            print(f"\n  {rep['replicate']}:", file=sys.stderr)
+            for f in rep["findings"]:
+                print(f"      - {f}", file=sys.stderr)
+
+    if bad or report["run_level"]:
+        print(
+            f"\nFAIL: this run is not evidence for {bad}/{total} replicate(s). "
+            "Fix the instrument and re-run before quoting its numbers.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.regrade:
+        print("OK: re-grade graded every replicate without a judge-transport gap")
+    else:
+        print("OK: every replicate loaded the skill, executed, and graded without a transport gap")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/uipath-planner/assets/templates/case-sdd-template.md
+++ b/skills/uipath-planner/assets/templates/case-sdd-template.md
@@ -136,13 +136,23 @@ Tenant object starts are still event triggers: a case that starts when a tenant 
 |----|-------------|--------|---------------|
 | T02 | <Manual \| Intsvc.EventTrigger \| Intsvc.TimerTrigger> | <source system, connector, object, or Manual> | <business event, timer cadence, filter intent, or N/A> |
 
+### Trigger Filter
+
+<!-- Render only when >= 1 trigger declares a filter. Nested {op, clauses} groups flatten into this table.
+Operator vocabulary and the Literal guidance live in references/case/render-case-definition.md § 1.3a. -->
+
+| Field | Operator | Value | Literal? |
+|-------|----------|-------|----------|
+| <payload field> | <Equals \| Contains \| GreaterThan \| ...> | <value> | <Yes \| No> |
+
 ### Case Exit Conditions
 
 <!-- WHEN + Marks Case Complete pairing is schema-constrained: Marks Case Complete = Yes normally uses `required-stages-completed`; selected-stage rules are for non-completing exits. -->
 
-| WHEN | IF | THEN | Marks Case Complete | Display Name |
-|------|-----|------|---------------------|--------------|
-| required-stages-completed | — | Case exited | Yes | — |
+| WHEN | IF | THEN | Exit Type | Marks Case Complete | Display Name |
+|------|-----|------|-----------|---------------------|--------------|
+| required-stages-completed | — | Case exited | exit-only | Yes | — |
+| selected-stage-completed("<SECONDARY_STAGE_NAME>") | — | Case closed, not completed | exit-only | No | — |
 
 ### Case Variables
 

--- a/skills/uipath-planner/references/case/grounding.md
+++ b/skills/uipath-planner/references/case/grounding.md
@@ -27,6 +27,15 @@ pass verifies instead of re-discovering.
    resolve every named or inferred resource in ONE parallel batch of cache lookups; for each connector
    also check enabled connections.
 
+   > **Connections need `--all-folders`.** `uip is connections list --output json` searches only the
+   > default Integration Service scope and returns `Data: []` with *"No connections found for any
+   > connector"* on tenants holding hundreds of connections (measured: 0 vs 251 on one tenant). Always
+   > pass `--all-folders`. Without it every connector buckets **Empty** instead of **Ambiguous**, and
+   > the two offer the user different options — `Empty` offers "create during build", `Ambiguous`
+   > offers "pick a match" — so the default scope silently changes what the gate asks. The two scopes
+   > are not schema-compatible either: `--all-folders` returns PascalCase keys (`Id`, `Name`,
+   > `ConnectorKey`, `ConnectorName`, `State`, `Owner`). Parse for those, not camelCase.
+
    | Bucket | Definition | Action |
    |---|---|---|
    | Single confident match | 1 exact-name match across all folders, ≥ 1 shared name token; connectors: exactly 1 enabled connection | Adopt: identity + exact folder into SDD cells + a resolution record; disclose as a decision line. The only silent pick |

--- a/skills/uipath-planner/references/case/render-case-definition.md
+++ b/skills/uipath-planner/references/case/render-case-definition.md
@@ -82,7 +82,7 @@ event resolution (`connectionId` / `activityTypeId`) → high review item.
 ## 1.3a Trigger Filter (conditional)
 
 Renders only when ≥ 1 trigger declares a filter. AND/OR tree; nested `{op, clauses}` groups flatten in the
-rendered table. Columns: `Field | Operator | Value | Literal?`. Operators (PascalCase, case-sensitive):
+rendered table. Columns are the template's § 1.3a. Operators (PascalCase, case-sensitive):
 `Equals`, `NotEquals`, `Contains`, `NotContains`, `StartsWith`, `EndsWith`, `GreaterThan`,
 `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`, `In`, `NotIn`, `IsNull`, `IsNotNull`. Avoid
 `Literal: No` for unverified runtime expressions — it forces a lossy fallback; prefer literal values or a
@@ -90,7 +90,7 @@ review item.
 
 ## 1.4 Case Completion Conditions · 1.4a Case Exit Conditions
 
-Columns: `WHEN | IF | Marks Case Complete | Exit Type | Display Name`. §1.4 = `Yes` rows (≥ 1 required);
+Columns are the template's § Case Exit Conditions. §1.4 = `Yes` rows (≥ 1 required);
 §1.4a = `No` rows (alternate dispositions: Withdrawn / Rejected / Cancelled). Legal WHEN per
 [model.md § Lifecycle gates](model.md#lifecycle-gates); exit types per
 [model.md § Exit types](model.md#exit-types).

--- a/skills/uipath-planner/references/case/render-stages-tasks.md
+++ b/skills/uipath-planner/references/case/render-stages-tasks.md
@@ -6,10 +6,10 @@ What each Section 2 block of a case `sdd.md` must contain. Semantics live in [mo
 
 ## Stage headings
 
-- Primary: `### Stage {N}: {Stage Name} (\`{stage_id}\`)` — N is 1-based flow order.
-- Secondary: `### Secondary Stage: {Stage Name} (\`{stage_id}\`)`.
-- The trailing code-formatted `{stage_id}` MUST appear, and every cell that names a stage appends the id in
-  code-formatted parens — cross-references stay greppable.
+Heading format is the template's — see
+[`case-sdd-template.md`](../../assets/templates/case-sdd-template.md) § Section 2. N is 1-based flow
+order; secondary stages use the `Secondary Stage` form. Reference a stage from another cell by its exact
+display name, which is unique per case ([model.md § Naming](model.md)).
 
 ## Stage fields
 
@@ -46,8 +46,9 @@ resolving. Duration, thresholds, recipients, and escalation cells: [slas.md](sla
 
 ## Stage Task Summary
 
-In plan order, ≥ 1 task per stage: `# | Task ID | Task | Type | Owner`. `Task ID` is code-formatted
-(`` `t11` ``); Required-Tasks cells elsewhere use those bare ids. Owner = persona name or `system`.
+In plan order, ≥ 1 task per stage. Columns are the template's — see
+[`case-sdd-template.md`](../../assets/templates/case-sdd-template.md) § Section 2 `#### Tasks`. Owner is a
+persona name or `system`; Required-Tasks cells elsewhere name tasks by their exact display name.
 
 ## Task detail blocks
 

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -86,11 +86,40 @@ TASK_DETAIL_MARKERS = {
 
 
 def _find_sdd() -> str:
-    matches = sorted(p for p in glob.glob("**/sdd.md", recursive=True) if "/.venv/" not in p)
-    if not matches:
-        sys.exit("FAIL: no sdd.md found under the current directory")
-    return matches[0]
+    """Locate the SDD whatever basename the lane's mode chose.
 
+    Build handoff writes `sdd.md`; direct design writes `<case-name-kebab>-sdd.md`;
+    a draft request writes `sdd.draft.md`. Globbing only `sdd.md` made this checker
+    unusable on the two design paths — it exited FAIL before reading anything, so
+    wiring it into a design task would have produced a criterion that can never pass.
+    Prefer the finalized basenames over a draft when both exist.
+    """
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    patterns = ("**/sdd.md", "**/*-sdd.md", "**/sdd.draft.md", "**/*-sdd.draft.md")
+    for pat in patterns:
+        matches = sorted(
+            p for p in glob.glob(pat, recursive=True)
+            if "/.venv/" not in p and "/node_modules/" not in p
+        )
+        if matches:
+            return matches[0]
+    sys.exit(
+        "FAIL: no SDD found under the current directory "
+        "(looked for sdd.md, *-sdd.md, sdd.draft.md, *-sdd.draft.md)"
+    )
+
+
+def _split_row(line: str) -> list[str]:
+    """Split a markdown table row on UNESCAPED pipes only.
+
+    A JS guard containing `||` must be written `\\|\\|` inside a table, so splitting
+    on every `|` invents phantom cells and shifts every column to its right. That
+    made rule-legality and exit-type checks fail on correct input whenever an IF
+    expression used a logical OR — common in mutually-exclusive completion guards.
+    """
+    parts = re.split(r"(?<!\\)\|", line.strip().strip("|"))
+    return [c.replace("\\|", "|").strip() for c in parts]
 
 def _rule_token(cell: str) -> str | None:
     """Leading rule keyword from a WHEN cell (``case-entered``, ``adhoc``, …)."""
@@ -252,7 +281,7 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
         if case_sla:
             check_duration(case_sla.group(1), case_sla.group(2), line_no)
 
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        cells = _split_row(line)
         if in_stage_sla and len(cells) >= 2 and re.fullmatch(r"\d+(?:\.\d+)?", cells[0]):
             check_duration(cells[0], cells[1], line_no)
         if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
@@ -505,7 +534,7 @@ def main() -> None:
             gate = None; continue
         if not (gate and s.startswith("|")):
             continue
-        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        cells = _split_row(s)
         if not cells:
             continue
         # Header row: capture Marks-Complete / Exit-Type column positions by name

--- a/tests/tasks/uipath-planner/_shared/sdd_check.py
+++ b/tests/tasks/uipath-planner/_shared/sdd_check.py
@@ -86,11 +86,40 @@ TASK_DETAIL_MARKERS = {
 
 
 def _find_sdd() -> str:
-    matches = sorted(p for p in glob.glob("**/sdd.md", recursive=True) if "/.venv/" not in p)
-    if not matches:
-        sys.exit("FAIL: no sdd.md found under the current directory")
-    return matches[0]
+    """Locate the SDD whatever basename the lane's mode chose.
 
+    Build handoff writes `sdd.md`; direct design writes `<case-name-kebab>-sdd.md`;
+    a draft request writes `sdd.draft.md`. Globbing only `sdd.md` made this checker
+    unusable on the two design paths — it exited FAIL before reading anything, so
+    wiring it into a design task would have produced a criterion that can never pass.
+    Prefer the finalized basenames over a draft when both exist.
+    """
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    patterns = ("**/sdd.md", "**/*-sdd.md", "**/sdd.draft.md", "**/*-sdd.draft.md")
+    for pat in patterns:
+        matches = sorted(
+            p for p in glob.glob(pat, recursive=True)
+            if "/.venv/" not in p and "/node_modules/" not in p
+        )
+        if matches:
+            return matches[0]
+    sys.exit(
+        "FAIL: no SDD found under the current directory "
+        "(looked for sdd.md, *-sdd.md, sdd.draft.md, *-sdd.draft.md)"
+    )
+
+
+def _split_row(line: str) -> list[str]:
+    """Split a markdown table row on UNESCAPED pipes only.
+
+    A JS guard containing `||` must be written `\\|\\|` inside a table, so splitting
+    on every `|` invents phantom cells and shifts every column to its right. That
+    made rule-legality and exit-type checks fail on correct input whenever an IF
+    expression used a logical OR — common in mutually-exclusive completion guards.
+    """
+    parts = re.split(r"(?<!\\)\|", line.strip().strip("|"))
+    return [c.replace("\\|", "|").strip() for c in parts]
 
 def _rule_token(cell: str) -> str | None:
     """Leading rule keyword from a WHEN cell (``case-entered``, ``adhoc``, …)."""
@@ -252,7 +281,7 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
         if case_sla:
             check_duration(case_sla.group(1), case_sla.group(2), line_no)
 
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        cells = _split_row(line)
         if in_stage_sla and len(cells) >= 2 and re.fullmatch(r"\d+(?:\.\d+)?", cells[0]):
             check_duration(cells[0], cells[1], line_no)
         if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
@@ -505,7 +534,7 @@ def main() -> None:
             gate = None; continue
         if not (gate and s.startswith("|")):
             continue
-        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        cells = _split_row(s)
         if not cells:
             continue
         # Header row: capture Marks-Complete / Exit-Type column positions by name

--- a/tests/tasks/uipath-planner/_shared/test_case_render_authority.py
+++ b/tests/tasks/uipath-planner/_shared/test_case_render_authority.py
@@ -1,0 +1,65 @@
+"""CI wrapper: the case render contracts must not contradict the SDD template.
+
+`scripts/check-case-render-authority.py` is the real check. It lived as a standalone
+script with no runner, which meant it could not gate a PR — the claim that it "would
+have failed the #2640 merge" was only true of a human choosing to run it. Wrapping it
+as a pytest gets it collected by the existing `test-helpers.yml` job (which already
+runs pytest over `tests/tasks/uipath-planner/**`), so it gates on every PR touching
+the planner surface, with no workflow change.
+
+Keep the logic in the script: it is also the thing a human runs when reconciling, and
+its --json mode is machine-readable.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+CHECKER = REPO / "scripts" / "check-case-render-authority.py"
+TEMPLATE = REPO / "skills/uipath-planner/assets/templates/case-sdd-template.md"
+
+
+def test_checker_and_template_are_present():
+    """Fail loudly rather than vacuously if the paths move."""
+    assert CHECKER.is_file(), f"missing {CHECKER}"
+    assert TEMPLATE.is_file(), f"missing {TEMPLATE}"
+
+
+def test_render_contracts_assert_no_shape_the_template_lacks():
+    r = subprocess.run(
+        [sys.executable, str(CHECKER)], capture_output=True, text=True, cwd=REPO
+    )
+    assert r.returncode == 0, (
+        "case render contracts and the SDD template disagree about shape.\n"
+        "The template is the shape; references/case/*.md are the semantics.\n\n"
+        f"{r.stdout}\n{r.stderr}"
+    )
+
+
+def test_checker_detects_an_injected_conflict(tmp_path: Path):
+    """Mutation guard: prove the check can fail.
+
+    A checker that only ever passes is decoration. This copies the render contract,
+    injects a column list the template does not define, and asserts the checker
+    notices — run against a temp copy so the real tree is untouched.
+    """
+    doc = REPO / "skills/uipath-planner/references/case/render-stages-tasks.md"
+    original = doc.read_text(encoding="utf-8")
+    injected = original + "\n\nColumns: `Bogus | Columns | ThatDoNotExist | Anywhere`.\n"
+    try:
+        doc.write_text(injected, encoding="utf-8")
+        r = subprocess.run(
+            [sys.executable, str(CHECKER)], capture_output=True, text=True, cwd=REPO
+        )
+        assert r.returncode != 0, (
+            "checker passed despite an injected column list the template does not "
+            f"define — it is not actually comparing shapes:\n{r.stdout}\n{r.stderr}"
+        )
+        assert "ThatDoNotExist" in (r.stdout + r.stderr), (
+            "checker failed but did not name the offending claim, so a developer "
+            f"cannot act on it:\n{r.stdout}\n{r.stderr}"
+        )
+    finally:
+        doc.write_text(original, encoding="utf-8")

--- a/tests/tasks/uipath-planner/_shared/test_check_eval_run.py
+++ b/tests/tasks/uipath-planner/_shared/test_check_eval_run.py
@@ -1,0 +1,134 @@
+"""Guards for scripts/check-eval-run.py — the run-is-evidence gate.
+
+The gate exists because a coder-eval run can finish with plausible scores while
+measuring nothing. These tests build synthetic run directories for each failure
+mode, so the gate is verified in both directions without needing a real run.
+
+The signal choices encoded here were learned the hard way:
+
+* Execution is measured by **output tokens**, not turn count. `codex` reports
+  `total_assistant_turns == 1` on fully successful runs and `2` on runs that died
+  on a provider error, so a turn threshold is near-inverted for it.
+* `--regrade` drops the agent assertions, because `coder-eval evaluate` runs no
+  agent — asserting plugins/tokens there would fail every re-grade, which is the
+  cheapest and most useful path.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+GATE = REPO / "scripts" / "check-eval-run.py"
+
+GOOD_USAGE = {"output_tokens": 12882, "input_tokens": 2010930}
+
+
+def write_run(root: Path, *, task: dict, experiment: str | None = "skill-tests-default") -> Path:
+    run = root / "run"
+    rep = run / "default" / "some-task" / "00"
+    rep.mkdir(parents=True)
+    (rep / "task.json").write_text(json.dumps(task), encoding="utf-8")
+    if experiment is not None:
+        (run / "experiment.md").write_text(
+            f"# Experiment Report: {experiment}\n", encoding="utf-8"
+        )
+    return run
+
+
+def gate(run: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GATE), str(run), *extra], capture_output=True, text=True
+    )
+
+
+def base_task(**over) -> dict:
+    task = {
+        "agent_type": "codex",
+        "final_status": "SUCCESS",
+        "total_assistant_turns": 1,  # healthy for codex — deliberately low
+        "agent_config": {"plugins": [{"type": "local", "path": "$SKILLS_REPO_PATH"}]},
+        "total_token_usage": dict(GOOD_USAGE),
+        "success_criteria_results": [{"score": 1.0, "details": "ok"}],
+    }
+    task.update(over)
+    return task
+
+
+def test_gate_exists():
+    assert GATE.is_file(), f"missing {GATE}"
+
+
+def test_healthy_run_passes_even_with_one_turn(tmp_path: Path):
+    """A codex run with a single assistant turn is normal, not broken."""
+    run = write_run(tmp_path, task=base_task())
+    r = gate(run, "--expect-experiment", "skill-tests-default")
+    assert r.returncode == 0, f"healthy run rejected:\n{r.stdout}\n{r.stderr}"
+
+
+def test_missing_plugin_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(agent_config={"plugins": None}))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "no plugin loaded" in (r.stdout + r.stderr)
+
+
+def test_no_output_tokens_fails(tmp_path: Path):
+    """The provider-error shape: task.json exists, usage is empty."""
+    run = write_run(tmp_path, task=base_task(total_token_usage={}, total_assistant_turns=2))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "produced no output" in (r.stdout + r.stderr)
+
+
+def test_wrong_experiment_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(), experiment="default")
+    r = gate(run, "--expect-experiment", "skill-tests-default")
+    assert r.returncode != 0
+    assert "expected" in (r.stdout + r.stderr)
+
+
+def test_unconfigured_judge_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(
+        success_criteria_results=[{"score": 0.0, "details": "(judge transport unconfigured)"}]
+    ))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "judge transport" in (r.stdout + r.stderr)
+
+
+def test_regrade_mode_ignores_agent_assertions(tmp_path: Path):
+    """`coder-eval evaluate` produces no plugin, no tokens and no experiment.md.
+    Those are expected in that mode, so --regrade must not flag them."""
+    run = write_run(
+        tmp_path,
+        task={"success_criteria_results": [{"score": 1.0, "details": "ok"}]},
+        experiment=None,
+    )
+    r = gate(run, "--regrade")
+    assert r.returncode == 0, f"--regrade flagged a normal re-grade:\n{r.stdout}\n{r.stderr}"
+
+
+def test_regrade_mode_still_catches_the_judge(tmp_path: Path):
+    """--regrade relaxes the agent checks but must keep the judge check, or the
+    cheap path becomes the one where a transport gap hides."""
+    run = write_run(
+        tmp_path,
+        task={"success_criteria_results": [
+            {"score": 0.0, "details": "(judge transport unconfigured)"}
+        ]},
+        experiment=None,
+    )
+    r = gate(run, "--regrade")
+    assert r.returncode != 0
+    assert "judge transport" in (r.stdout + r.stderr)
+
+
+def test_empty_run_dir_fails(tmp_path: Path):
+    run = tmp_path / "empty"
+    run.mkdir()
+    r = gate(run)
+    assert r.returncode != 0
+    assert "no task.json" in (r.stdout + r.stderr)

--- a/tests/tasks/uipath-planner/_shared/test_connection_scope_documented.py
+++ b/tests/tasks/uipath-planner/_shared/test_connection_scope_documented.py
@@ -1,0 +1,85 @@
+"""Guard: the case lane's documented `uip is connections list` carries `--all-folders`.
+
+The default Integration Service scope returns an EMPTY list on tenants that hold
+hundreds of connections — measured 0 vs 251 on one tenant — so an agent following a
+reference that omits the flag buckets every connector as `Empty` instead of
+`Ambiguous`. Those two buckets offer the user different options at the resolution
+gate ("create during build" vs "pick a match"), so the omission silently changes
+what the user is asked.
+
+Scope note: the same un-scoped invocation is documented in several other skills
+(`uipath-rpa`, `uipath-api-workflow`, `uipath-platform/agent-workflow.md`, and parts
+of `uipath-troubleshoot`). Those are owned by other teams and are NOT enforced here;
+they are a known follow-up. This guard covers the case design lane and the case build
+skill, where the mis-bucketing changes a user-facing gate.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+REPO = pathlib.Path(__file__).resolve().parents[4]
+SKILLS = REPO / "skills"
+
+# Surfaces this guard enforces.
+ENFORCED = (
+    "uipath-planner/references/case",
+    "uipath-maestro-case",
+)
+
+# An invocation is correctly scoped if it names all folders OR targets one
+# connection / folder explicitly.
+EXPLICIT_SCOPE = ("--all-folders", "--connection-id", "--folder-key", "--folder ")
+
+INVOCATION = re.compile(r"uip\s+is\s+connections\s+list([^\n`]*)")
+
+
+def enforced_markdown() -> list[pathlib.Path]:
+    out: list[pathlib.Path] = []
+    for rel in ENFORCED:
+        out.extend(sorted((SKILLS / rel).rglob("*.md")))
+    return out
+
+
+def test_repo_layout_is_what_this_test_assumes():
+    """Fail loudly if the path math is wrong rather than passing vacuously."""
+    assert SKILLS.is_dir(), f"expected skills/ under {REPO}"
+    assert enforced_markdown(), f"no markdown under {ENFORCED} — the glob is wrong"
+
+
+def test_case_lane_connection_list_is_scoped():
+    offenders: list[str] = []
+    for md in enforced_markdown():
+        text = md.read_text(encoding="utf-8", errors="replace")
+        for m in INVOCATION.finditer(text):
+            tail = m.group(1)
+            if any(flag in tail for flag in EXPLICIT_SCOPE):
+                continue
+            # Prose that names the flag as the fix nearby is documentation, not a recipe.
+            start = text.rfind("\n\n", 0, m.start())
+            para = text[start if start != -1 else 0 : m.end() + 400]
+            if "--all-folders" in para:
+                continue
+            line = text[: m.start()].count("\n") + 1
+            offenders.append(f"{md.relative_to(REPO)}:{line}: {m.group(0).strip()}")
+
+    assert not offenders, (
+        "`uip is connections list` documented without an explicit scope:\n  "
+        + "\n  ".join(offenders)
+        + "\n\nThe default scope returns [] on tenants that have connections. Pass "
+        "--all-folders (or target --connection-id / --folder-key). See "
+        "skills/uipath-planner/references/case/grounding.md."
+    )
+
+
+def test_all_folders_response_shape_is_documented():
+    """The two scopes are not schema-compatible: `--all-folders` returns PascalCase.
+    A reference that tells the agent to read connections must say so."""
+    grounding = SKILLS / "uipath-planner/references/case/grounding.md"
+    assert grounding.is_file(), f"missing {grounding}"
+    text = grounding.read_text(encoding="utf-8")
+    missing = [k for k in ("Id", "Name", "ConnectorKey", "State") if f"`{k}`" not in text]
+    assert not missing, (
+        f"grounding.md documents the connection lookup but not these response keys: {missing}. "
+        "An agent parsing camelCase against a PascalCase payload reads every field as absent."
+    )

--- a/tests/tasks/uipath-planner/_shared/test_sdd_check_row_parsing.py
+++ b/tests/tasks/uipath-planner/_shared/test_sdd_check_row_parsing.py
@@ -1,0 +1,167 @@
+"""Regression guards for sdd_check.py's row parsing and SDD discovery.
+
+Both bugs below made the checker report failures on CORRECT input, which is worse
+than not running it: the first person to hit a false positive stops trusting the
+grader. Found while grading a real 2,220-line SDD from the 08/18 bug bash.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parent
+CHECK = SHARED / "sdd_check.py"
+
+MINIMAL = """# SDD — RowParse
+
+## Document History
+
+<!-- planner-handoff:v1 -->
+## Planner Handoff
+
+| Field | Value |
+|---|---|
+| **Status** | ready |
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|----------|-------|
+| Case Name | RowParse |
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|----|-------------|--------|---------------|
+| T02 | Manual | Manual | N/A |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Exit Type | Marks Case Complete | Display Name |
+|------|-----|------|-----------|---------------------|--------------|
+| required-stages-completed | — | Case exited | exit-only | Yes | — |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|---|---|---|---|---|---|---|
+| cost | Variable | double | | | 0 | Cost |
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Only
+
+**Type:** Stage
+**Design Rationale:** Single stage.
+**Description:** Single stage.
+**Required for case completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|--------------|--------------|
+| case-entered | — | No | Start |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| required-tasks-completed | {guard} | exit-only | Yes | Done |
+
+#### Tasks
+
+| # | Task Name | Type | Activation Mode | Starts When | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|-----------------|-------------|----------|---------------|---------|-----|
+| 1 | Do it | action | parallel | stage enters | Yes | No | Owner | — |
+
+##### Task 1.1: Do it
+
+**Type:** action
+**Activation Mode:** parallel
+**Design Rationale:** Human decides.
+**Description:** Human decides.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| current-stage-entered | — | — |
+
+**Task envelope**
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+## Section 3: Personas & App Views
+
+### Personas
+
+### Process App Views
+
+## Section 4: Integrations
+
+> None.
+"""
+
+
+def run(tmp_path: Path, name: str, guard: str):
+    (tmp_path / name).write_text(MINIMAL.replace("{guard}", guard), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(CHECK)], cwd=tmp_path, capture_output=True, text=True
+    )
+
+
+# Symptoms of the column-shift bug. The fixture is deliberately not a fully
+# conformant SDD — these tests isolate ROW PARSING, so they assert the specific
+# false positives are gone rather than demanding an overall clean bill.
+SHIFT_SYMPTOMS = ("invalid exit-type", "not legal for stage-exit")
+
+
+def test_escaped_pipe_in_guard_does_not_shift_columns(tmp_path: Path):
+    """A JS `||` must be written `\\|\\|` inside a markdown table.
+
+    Splitting the row on every `|` invented phantom cells and shifted every column
+    right, so `Exit Type` landed on a lone backslash and rule legality was graded
+    against the wrong Marks-Complete value — on a legal table.
+    """
+    r = run(tmp_path, "sdd.md", r"=js:(vars.cost < 5000 \|\| vars.cost > 9000)")
+    out = r.stdout + r.stderr
+    hits = [s for s in SHIFT_SYMPTOMS if s in out]
+    assert not hits, f"escaped pipes still shift columns ({hits}):\n{out}"
+
+
+def test_plain_guard_is_symptom_free_too(tmp_path: Path):
+    """Control: without an escaped pipe the same symptoms must be absent, so the
+    test above measures escape handling rather than a fixture defect."""
+    r = run(tmp_path, "sdd.md", "=js:(vars.cost < 5000)")
+    out = r.stdout + r.stderr
+    hits = [s for s in SHIFT_SYMPTOMS if s in out]
+    assert not hits, f"baseline fixture already trips the symptoms ({hits}):\n{out}"
+
+
+def test_finds_direct_design_basename(tmp_path: Path):
+    """Direct design writes `<case-name-kebab>-sdd.md`, not `sdd.md`. Globbing only
+    `sdd.md` made the checker exit before reading anything, so wiring it into a
+    design-lane eval produced a criterion that could never pass."""
+    r = run(tmp_path, "row-parse-sdd.md", "=js:(vars.cost < 5000)")
+    out = r.stdout + r.stderr
+    # Assert it actually READ the file, not merely that one error string is absent —
+    # the pre-fix message was "no sdd.md found", so asserting on "no SDD found"
+    # passed vacuously against the broken finder.
+    assert "row-parse-sdd.md" in out, (
+        "checker never opened the `*-sdd.md` design-lane artifact — its output does "
+        f"not name the file:\n{out}"
+    )
+
+
+def test_missing_sdd_still_fails_loudly(tmp_path: Path):
+    """The finder must stay strict — an empty directory is a failure, not a pass."""
+    r = subprocess.run(
+        [sys.executable, str(CHECK)], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert r.returncode != 0
+    assert "no SDD found" in (r.stdout + r.stderr)

--- a/tests/tasks/uipath-planner/case_design_interview/candidate_interview.yaml
+++ b/tests/tasks/uipath-planner/case_design_interview/candidate_interview.yaml
@@ -142,6 +142,17 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
 
+  - type: run_command
+    description: >
+      generated SDD is mechanically sound — variable lineage closes, every =vars reference
+      resolves, per-gate rule legality holds, task types are in the closed enum, and every
+      stage has legal entry/exit conditions. Substring checks cannot see any of this.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-planner/_shared/sdd_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
 simulation:
   enabled: true
   persona: |

--- a/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
+++ b/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
@@ -65,6 +65,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
+    description: >
+      generated SDD is mechanically sound — variable lineage closes, every =vars reference
+      resolves, per-gate rule legality holds, task types are in the closed enum, and every
+      stage has legal entry/exit conditions. Substring checks cannot see any of this.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-planner/_shared/sdd_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
     description: "design declares all 4 exception lanes"
     command: "cat *sdd*.md 2>/dev/null | grep -Eiq 'customer comms' && cat *sdd*.md 2>/dev/null | grep -Eiq 'escalation' && cat *sdd*.md 2>/dev/null | grep -Eiq 'withdrawn' && cat *sdd*.md 2>/dev/null | grep -Eiq 'rejected'"
     timeout: 10


### PR DESCRIPTION
Four commits from the 08/18 bug bash, one per root cause, each with a mechanical guard so the fix cannot silently regress. Fixes **D1, D2, D5, D6, D9** of the twelve findings, plus three defects found in the verification code while fixing them.

The through-line: **every one of the twelve bug-bash defects passed every existing gate.** The template conformance gate passed. The Finalization checklist passed. Structural counts came out clean. All twelve were found by a human noticing that two documents contradicted each other. That is the thing these commits try to make impossible rather than merely detectable.

---

## `706c4bbde` — connection lookup needs `--all-folders` (D5)

`uip is connections list --output json` searches only the default Integration Service scope. On a tenant that holds connections it returns:

```json
"Data": [],
"Instructions": "No connections found for any connector. Scope: default
                 Integration Service scope. Use --all-folders ..."
```

Measured on `popoc/DefaultTenant`: **0 with the default scope, 251 with `--all-folders`.** Outlook 365 alone has 59.

`grounding.md` said "check enabled connections" without naming the flag, so an agent following it sees zero and buckets every connector **Empty** instead of **Ambiguous**. Not a cosmetic mislabel — the two buckets offer the user *different options* at the resolution gate (`Empty` → "create during build"; `Ambiguous` → "pick a match"), so the missing flag silently changes the question the user is asked, and can offer to create a connector that already exists 59 times.

The scopes are also **not schema-compatible**: `--all-folders` returns PascalCase (`Id`, `Name`, `ConnectorKey`, `State`). Code parsing camelCase reads every field as absent. Both facts now in the reference.

> **The postmortem asked whether D5 was case-specific. It is not.** The guard caught the same un-scoped invocation in `uipath-rpa`, `uipath-api-workflow`, `uipath-platform/agent-workflow.md`, and `uipath-troubleshoot`. Those have different CODEOWNERS and are **deliberately not fixed here** — widening this commit into their references would make it unreviewable. The guard names them as follow-up.

## `41d3d2cd7` — the template is the shape, the references are the semantics (D1, D2, D6, D9)

**This is the systemic one.** #2639/#2640 split case knowledge into nine `references/case/*.md` files. Three of them describe the rendered SDD's shape — but so does `case-sdd-template.md`, and so does the conformance gate. Nobody said which wins, and `review.md` check 2 cites *both*, which forwards the conflict instead of resolving it.

An agent following the docs faithfully then **must** violate one of them. Five collisions, measured:

| where | claim | reality |
|---|---|---|
| `render-stages-tasks.md:9,10` | `` ### Stage {N}: {Name} (`{stage_id}`) `` — "MUST appear" | template and gate have no id |
| `render-stages-tasks.md:49` | `# \| Task ID \| Task \| Type \| Owner` | template has 9 columns |
| `render-case-definition.md:85` | `Field \| Operator \| Value \| Literal?` | "Literal" appears **nowhere** in the template |
| `render-case-definition.md:93` | `... \| Exit Type \| ...` | template has `THEN`, no Exit Type |

**Resolution — one authority per concern.** The template owns shape; the references own semantics. Shape assertions removed from both render contracts, replaced with pointers.

Two shapes existed only in a reference, so the **template gains them** rather than losing the capability:

- **`Exit Type` on Case Exit Conditions.** The template was the wrong one here, with independent evidence: `_shared/sdd_check.py` already parses that header for an `exit type` column. The template never offered it, so exit semantics (`exit-only` / `wait-for-user`) had nowhere to be authored.
- **`### Trigger Filter`.** Shape lived only in the reference; the template had no such section, so a filtered trigger could not be rendered conformantly.

**`stage_id` suffix: dropped.** Template and gate already agreed without it, so dropping is a one-file change where keeping it means editing the template, the gate, and every stage-naming cell. Stage display names are unique per case so cross-references still resolve; they are no longer greppable *by id*, which is the cost. **Reversible in `render-stages-tasks.md` alone — say the word if that trade is wrong.**

**Guard:** `scripts/check-case-render-authority.py`, wired as a pytest so it gates PRs.

## `3ddc9307a` — grade generated SDDs on shape, and fix the grader's own two bugs

The design-lane evals graded a generated SDD with substring checks: does a file exist, do these words appear, are there ≥6 stage headings. That is presence, not correctness — a 2,220-line SDD that invented its own Section 4 table format passes all four. `sdd_check.py` existed but was wired only into the three `case_finalize_*` tasks, never the two that exercise the design lane.

Wiring it in required fixing two grader bugs first, **both of which made it fail on correct input** — worse than not running it, because the first false positive is the one that ends a grader's credibility:

1. **Rows were split on escaped pipes.** A JS `||` must be written `\|\|` in a markdown table, so splitting on every `|` invented phantom cells and shifted every column right. On a real SDD it produced two confident, wrong findings (`invalid exit-type '\'`, and a legality error from reading the wrong column) on a **legal** table. Any SDD using a logical OR in an IF guard hit this — common in the mutually-exclusive completion/divert pairs the model itself prescribes.
2. **The finder globbed only `sdd.md`.** Direct design writes `<case-name>-sdd.md`; a draft writes `sdd.draft.md`. So it exited "no sdd.md found" before reading anything, and wiring it in unfixed would have produced a criterion that could never pass.

With both fixed it grades the bug-bash SDD clean: 39 variables, 33 `=vars` references resolve, lineage closes, 8 stages with legal conditions.

**First contact found real defects: 4 of 6 generated SDDs are mechanically unsound** — invisible to the substring checks.

## `c2b2c9b13` — gate a run as evidence, and make the authority check gate PRs

**`scripts/check-eval-run.py`.** A coder-eval run can finish with plausible scores and mean nothing. Three shapes observed in one day, each read as a regression:

- the skill was never installed (silent fallback to the built-in experiment, no `plugins:` block)
- the model never executed (expired credit ends the dialog; a finished `task.json` is still written)
- the judge had no transport (`llm_judge` scores 0.0, so every task is FAILURE regardless of merit)

Execution is measured by **output tokens, not turn count**. `codex` reports `total_assistant_turns == 1` on fully successful runs and `2` on runs that died on a provider error, so a turn threshold is near-inverted for it — a first draft used `turns >= 3` and rejected a known-good N=10 terra run 10/10. Verified against **six real archived runs** (3 good, 3 bad): correct 6/6, each failing for the right reason. `--regrade` relaxes the agent assertions for `coder-eval evaluate` (which runs no agent) while keeping the judge check.

**Authority check now gates PRs.** It shipped in `41d3d2cd7` as a script with no runner — the claim that it "would have failed the #2640 merge" was an overclaim, since nothing invoked it. A pytest wrapper gets it collected by the existing `test-helpers.yml` job, no workflow change, with a mutation guard that injects a bogus column list and asserts the checker names it.

---

## Guards are mutation-tested, not decorative

Every guard here was verified to **fail without its fix**:

| guard | reverted-fix result |
|---|---|
| `test_connection_scope_documented` | fails |
| `test_sdd_check_row_parsing` (4) | 3 of 4 fail; control still passes |
| `test_case_render_authority` | injected conflict detected and named |
| `test_check_eval_run` (9) | verified against 6 real runs, both directions |

One of those assertions **started out vacuous** — it checked for a message string the broken code never emitted, so it passed against the bug. Now requires evidence the file was actually read.

## Checks

```
tests/tasks/uipath-maestro-case/   109 passed
tests/tasks/uipath-planner/         74 passed
tests/tasks/uipath-maestro-flow/   181 passed
tests/tasks/uipath-agents/          17 passed
tests/scripts/ (4 guard jobs)       89 passed
                                   470 passed
skills:validate · check-skill-status · check-skills-sh · check-case-render-authority — all OK
```

Pre-existing and **not from this branch**: `pytest tests/` run wholesale hits 2 collection errors (`ModuleNotFoundError: _shared.case_check` in `e2e_expense_runnable` and `sla_with_escalation`). `git diff origin/main..HEAD` touches none of those files, and CI runs each suite separately, which is why the per-suite runs are clean. Worth a separate fix.

## Not in this PR

- **Cause 2** (D3, D7, D8, D11) — platform gaps the docs neither solve nor flag: an `adhoc` task cannot be waited on; one SLA status maps to one Response Map row; a condition-based SLA duplicates its responses per override; SLA units are calendar, not business days. These need product decisions, not a doc pass. The cheap half — an explicit "cannot be modelled" section — is worth doing next.
- **Cause 3** (D4, D10, D12) — under-specified references: the `=js:` evaluation sandbox, resolution-gate overflow past 4 questions, mid-run mode change.
- **`audit_sdd.py:280`** — a live guardrail bug found while testing: it picks Marks-Complete as *"the first cell containing Yes or No"*, which on a Stage Entry table is the `Interrupting` cell. It reported three illegal rule pairings in a correct SDD. It is also wired into only 1 of 4 design entry modes. A gate nobody runs, wrong when run. Wants its own commit.

## Reviewers

@abhiram-vad @RaduAna-Maria — `skills/uipath-planner/` is yours per CODEOWNERS:77. @abhiram-vad, this reconciles the render contracts from #2639/#2640; the `stage_id` question is the one real design call and I would value your view, since the greppable-cross-reference benefit was presumably deliberate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
