### PR TITLE
test(planner): grade generated SDDs on shape, fix the grader, gate runs as evidence

### DIFF
--- a/scripts/check-eval-run.py
+++ b/scripts/check-eval-run.py
@@ -22,7 +22,7 @@ number from it.
 Usage
 -----
     python3 scripts/check-eval-run.py RUN_DIR [--expect-experiment NAME]
-                                              [--min-turns N] [--json]
+                                              [--min-output-tokens N] [--json]
 
     # typical: the repo's own experiment must have been used
     python3 scripts/check-eval-run.py tests/runs/my-run --expect-experiment skill-tests-default
@@ -40,7 +40,7 @@ import sys
 JUDGE_UNCONFIGURED = "judge transport unconfigured"
 
 
-def replicate_findings(task_json: pathlib.Path, min_turns: int, regrade: bool = False) -> list[str]:
+def replicate_findings(task_json: pathlib.Path, min_output_tokens: int, regrade: bool = False) -> list[str]:
     """Reasons this replicate is not evidence. Empty list == trustworthy."""
     out: list[str] = []
     try:
@@ -84,7 +84,7 @@ def replicate_findings(task_json: pathlib.Path, min_turns: int, regrade: bool = 
             f"(turns={turns}, agent={t.get('agent_type')}). Usually a provider error "
             "(expired credit, auth); check conversation.log"
         )
-    elif min_turns > 0 and produced < min_turns:
+    elif min_output_tokens > 0 and produced < min_output_tokens:
         out.append(f"only {produced} output token(s) — suspiciously little work")
 
     for crit in t.get("success_criteria_results") or []:
@@ -104,7 +104,7 @@ def main() -> int:
     ap.add_argument("run_dir", type=pathlib.Path)
     ap.add_argument("--expect-experiment", default=None,
                     help="fail unless the run's experiment report names this experiment")
-    ap.add_argument("--min-output-tokens", dest="min_turns", type=int, default=1,
+    ap.add_argument("--min-output-tokens", type=int, default=1,
                     help="minimum model output tokens for a replicate to count (default 1)")
     ap.add_argument("--regrade", action="store_true",
                     help="the run came from `coder-eval evaluate` (no agent executed): "
@@ -123,7 +123,8 @@ def main() -> int:
     if args.regrade:
         report["experiment"] = "(re-grade — no experiment)"
     elif exp_md.is_file():
-        first = exp_md.read_text(encoding="utf-8").splitlines()[0] if exp_md.read_text(encoding="utf-8") else ""
+        content = exp_md.read_text(encoding="utf-8")
+        first = content.splitlines()[0] if content else ""
         name = first.split(":", 1)[-1].strip() if ":" in first else first.strip()
         report["experiment"] = name
         if args.expect_experiment and name != args.expect_experiment:
@@ -143,7 +144,7 @@ def main() -> int:
 
     bad = 0
     for tj in task_jsons:
-        findings = replicate_findings(tj, args.min_turns, regrade=args.regrade)
+        findings = replicate_findings(tj, args.min_output_tokens, regrade=args.regrade)
         rel = tj.relative_to(run_dir).parent
         report["replicates"].append({"replicate": str(rel), "findings": findings})
         bad += bool(findings)

--- a/scripts/check-eval-run.py
+++ b/scripts/check-eval-run.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Assert a coder-eval run measured what it claims, BEFORE anyone reads its scores.
+
+Why this exists
+---------------
+A coder-eval run can complete, report per-task scores, and mean nothing. Observed
+failures, all of which produced plausible numbers:
+
+  * the skill under test was never installed — the run silently fell back to
+    coder-eval's built-in default experiment, which has no `plugins:` block, so the
+    agent ran with no skill at all and every skill-contract criterion failed
+  * the model never executed — a provider error (expired credit, auth) ends the
+    dialog after ~2 turns while the orchestrator still writes a finished task.json
+    with a score
+  * the judge had no transport — `llm_judge` scores 0.0 with
+    "(judge transport unconfigured)", so every task is FAILURE regardless of merit
+
+Each of those is indistinguishable from a real regression if you read only the
+score. This gate makes them loud. Run it on a run directory before quoting any
+number from it.
+
+Usage
+-----
+    python3 scripts/check-eval-run.py RUN_DIR [--expect-experiment NAME]
+                                              [--min-turns N] [--json]
+
+    # typical: the repo's own experiment must have been used
+    python3 scripts/check-eval-run.py tests/runs/my-run --expect-experiment skill-tests-default
+
+Exit 0 when every replicate is trustworthy, 1 otherwise. Says nothing about whether
+the skill is correct — only whether the run is evidence.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+JUDGE_UNCONFIGURED = "judge transport unconfigured"
+
+
+def replicate_findings(task_json: pathlib.Path, min_turns: int, regrade: bool = False) -> list[str]:
+    """Reasons this replicate is not evidence. Empty list == trustworthy."""
+    out: list[str] = []
+    try:
+        t = json.loads(task_json.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [f"unreadable task.json: {exc}"]
+
+    # A `coder-eval evaluate` re-grade runs NO agent: there is no plugin install,
+    # no token usage and no experiment report, so asserting those here would fail
+    # every re-grade — the cheapest and most useful path. Only judge reachability
+    # and the criteria themselves are meaningful in that mode.
+    if regrade:
+        for crit in t.get("success_criteria_results") or []:
+            if JUDGE_UNCONFIGURED in str(crit.get("details", "")):
+                out.append(
+                    "llm_judge scored 0.0 with no judge transport — this re-grade's "
+                    "pass/fail is not about the skill. Configure ANTHROPIC_API_KEY or Bedrock, "
+                    "or use an agent_judge criterion, which runs on the local CLI login."
+                )
+                break
+        return out
+
+    agent_cfg = t.get("agent_config") or {}
+    if not agent_cfg.get("plugins"):
+        out.append(
+            "no plugin loaded — agent_config.plugins is empty, so the skill under "
+            "test was never installed (usually the built-in default experiment)"
+        )
+
+    # "Did the model execute?" is measured by output tokens, NOT by turn count.
+    # Turn count is agent-dependent and misleading: codex reports
+    # total_assistant_turns == 1 on fully successful runs and 2 on runs that died
+    # on a provider error, so any turn threshold is near-inverted for it. Token
+    # usage is absent entirely when the provider refused.
+    usage = t.get("total_token_usage") or {}
+    produced = usage.get("output_tokens")
+    if not produced:
+        turns = t.get("total_assistant_turns")
+        out.append(
+            "the model produced no output — total_token_usage is empty "
+            f"(turns={turns}, agent={t.get('agent_type')}). Usually a provider error "
+            "(expired credit, auth); check conversation.log"
+        )
+    elif min_turns > 0 and produced < min_turns:
+        out.append(f"only {produced} output token(s) — suspiciously little work")
+
+    for crit in t.get("success_criteria_results") or []:
+        if JUDGE_UNCONFIGURED in str(crit.get("details", "")):
+            out.append(
+                "llm_judge scored 0.0 with no judge transport — this run's pass/fail "
+                "is not about the skill. Configure ANTHROPIC_API_KEY or Bedrock, or use an "
+                "agent_judge criterion, which runs on the local CLI login."
+            )
+            break
+
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("run_dir", type=pathlib.Path)
+    ap.add_argument("--expect-experiment", default=None,
+                    help="fail unless the run's experiment report names this experiment")
+    ap.add_argument("--min-output-tokens", dest="min_turns", type=int, default=1,
+                    help="minimum model output tokens for a replicate to count (default 1)")
+    ap.add_argument("--regrade", action="store_true",
+                    help="the run came from `coder-eval evaluate` (no agent executed): "
+                         "skip plugin/token/experiment assertions")
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    run_dir: pathlib.Path = args.run_dir
+    if not run_dir.is_dir():
+        print(f"FAIL: no such run directory: {run_dir}", file=sys.stderr)
+        return 1
+
+    report: dict = {"run_dir": str(run_dir), "experiment": None, "replicates": [], "run_level": []}
+
+    exp_md = run_dir / "experiment.md"
+    if args.regrade:
+        report["experiment"] = "(re-grade — no experiment)"
+    elif exp_md.is_file():
+        first = exp_md.read_text(encoding="utf-8").splitlines()[0] if exp_md.read_text(encoding="utf-8") else ""
+        name = first.split(":", 1)[-1].strip() if ":" in first else first.strip()
+        report["experiment"] = name
+        if args.expect_experiment and name != args.expect_experiment:
+            report["run_level"].append(
+                f"experiment is {name!r}, expected {args.expect_experiment!r} — a "
+                "silent fallback to a different experiment changes what was measured"
+            )
+    else:
+        report["run_level"].append(
+            "no experiment.md — cannot confirm which experiment ran "
+            "(pass --regrade if this came from `coder-eval evaluate`)"
+        )
+
+    task_jsons = sorted(run_dir.rglob("task.json"))
+    if not task_jsons:
+        report["run_level"].append("no task.json found — the run produced no replicates")
+
+    bad = 0
+    for tj in task_jsons:
+        findings = replicate_findings(tj, args.min_turns, regrade=args.regrade)
+        rel = tj.relative_to(run_dir).parent
+        report["replicates"].append({"replicate": str(rel), "findings": findings})
+        bad += bool(findings)
+
+    total = len(task_jsons)
+    ok = total - bad
+    report["summary"] = {"replicates": total, "trustworthy": ok, "invalid": bad}
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+        return 1 if (bad or report["run_level"]) else 0
+
+    print(f"run: {run_dir}")
+    print(f"experiment: {report['experiment']}")
+    print(f"replicates: {total}  trustworthy: {ok}  invalid: {bad}")
+
+    for msg in report["run_level"]:
+        print(f"\n  RUN-LEVEL: {msg}", file=sys.stderr)
+    for rep in report["replicates"]:
+        if rep["findings"]:
+            print(f"\n  {rep['replicate']}:", file=sys.stderr)
+            for f in rep["findings"]:
+                print(f"      - {f}", file=sys.stderr)
+
+    if bad or report["run_level"]:
+        print(
+            f"\nFAIL: this run is not evidence for {bad}/{total} replicate(s). "
+            "Fix the instrument and re-run before quoting its numbers.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if args.regrade:
+        print("OK: re-grade graded every replicate without a judge-transport gap")
+    else:
+        print("OK: every replicate loaded the skill, executed, and graded without a transport gap")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
+++ b/tests/tasks/uipath-maestro-case/_shared/sdd_check.py
@@ -86,11 +86,40 @@ TASK_DETAIL_MARKERS = {
 
 
 def _find_sdd() -> str:
-    matches = sorted(p for p in glob.glob("**/sdd.md", recursive=True) if "/.venv/" not in p)
-    if not matches:
-        sys.exit("FAIL: no sdd.md found under the current directory")
-    return matches[0]
+    """Locate the SDD whatever basename the lane's mode chose.
 
+    Build handoff writes `sdd.md`; direct design writes `<case-name-kebab>-sdd.md`;
+    a draft request writes `sdd.draft.md`. Globbing only `sdd.md` made this checker
+    unusable on the two design paths — it exited FAIL before reading anything, so
+    wiring it into a design task would have produced a criterion that can never pass.
+    Prefer the finalized basenames over a draft when both exist.
+    """
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    patterns = ("**/sdd.md", "**/*-sdd.md", "**/sdd.draft.md", "**/*-sdd.draft.md")
+    for pat in patterns:
+        matches = sorted(
+            p for p in glob.glob(pat, recursive=True)
+            if "/.venv/" not in p and "/node_modules/" not in p
+        )
+        if matches:
+            return matches[0]
+    sys.exit(
+        "FAIL: no SDD found under the current directory "
+        "(looked for sdd.md, *-sdd.md, sdd.draft.md, *-sdd.draft.md)"
+    )
+
+
+def _split_row(line: str) -> list[str]:
+    """Split a markdown table row on UNESCAPED pipes only.
+
+    A JS guard containing `||` must be written `\\|\\|` inside a table, so splitting
+    on every `|` invents phantom cells and shifts every column to its right. That
+    made rule-legality and exit-type checks fail on correct input whenever an IF
+    expression used a logical OR — common in mutually-exclusive completion guards.
+    """
+    parts = re.split(r"(?<!\\)\|", line.strip().strip("|"))
+    return [c.replace("\\|", "|").strip() for c in parts]
 
 def _rule_token(cell: str) -> str | None:
     """Leading rule keyword from a WHEN cell (``case-entered``, ``adhoc``, …)."""
@@ -252,7 +281,7 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
         if case_sla:
             check_duration(case_sla.group(1), case_sla.group(2), line_no)
 
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        cells = _split_row(line)
         if in_stage_sla and len(cells) >= 2 and re.fullmatch(r"\d+(?:\.\d+)?", cells[0]):
             check_duration(cells[0], cells[1], line_no)
         if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
@@ -505,7 +534,7 @@ def main() -> None:
             gate = None; continue
         if not (gate and s.startswith("|")):
             continue
-        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        cells = _split_row(s)
         if not cells:
             continue
         # Header row: capture Marks-Complete / Exit-Type column positions by name

--- a/tests/tasks/uipath-planner/_shared/sdd_check.py
+++ b/tests/tasks/uipath-planner/_shared/sdd_check.py
@@ -86,11 +86,40 @@ TASK_DETAIL_MARKERS = {
 
 
 def _find_sdd() -> str:
-    matches = sorted(p for p in glob.glob("**/sdd.md", recursive=True) if "/.venv/" not in p)
-    if not matches:
-        sys.exit("FAIL: no sdd.md found under the current directory")
-    return matches[0]
+    """Locate the SDD whatever basename the lane's mode chose.
 
+    Build handoff writes `sdd.md`; direct design writes `<case-name-kebab>-sdd.md`;
+    a draft request writes `sdd.draft.md`. Globbing only `sdd.md` made this checker
+    unusable on the two design paths — it exited FAIL before reading anything, so
+    wiring it into a design task would have produced a criterion that can never pass.
+    Prefer the finalized basenames over a draft when both exist.
+    """
+    if len(sys.argv) > 1:
+        return sys.argv[1]
+    patterns = ("**/sdd.md", "**/*-sdd.md", "**/sdd.draft.md", "**/*-sdd.draft.md")
+    for pat in patterns:
+        matches = sorted(
+            p for p in glob.glob(pat, recursive=True)
+            if "/.venv/" not in p and "/node_modules/" not in p
+        )
+        if matches:
+            return matches[0]
+    sys.exit(
+        "FAIL: no SDD found under the current directory "
+        "(looked for sdd.md, *-sdd.md, sdd.draft.md, *-sdd.draft.md)"
+    )
+
+
+def _split_row(line: str) -> list[str]:
+    """Split a markdown table row on UNESCAPED pipes only.
+
+    A JS guard containing `||` must be written `\\|\\|` inside a table, so splitting
+    on every `|` invents phantom cells and shifts every column to its right. That
+    made rule-legality and exit-type checks fail on correct input whenever an IF
+    expression used a logical OR — common in mutually-exclusive completion guards.
+    """
+    parts = re.split(r"(?<!\\)\|", line.strip().strip("|"))
+    return [c.replace("\\|", "|").strip() for c in parts]
 
 def _rule_token(cell: str) -> str | None:
     """Leading rule keyword from a WHEN cell (``case-entered``, ``adhoc``, …)."""
@@ -252,7 +281,7 @@ def _sdd_frontend_issues(text: str, source: str = "sdd.md") -> list[str]:
         if case_sla:
             check_duration(case_sla.group(1), case_sla.group(2), line_no)
 
-        cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        cells = _split_row(line)
         if in_stage_sla and len(cells) >= 2 and re.fullmatch(r"\d+(?:\.\d+)?", cells[0]):
             check_duration(cells[0], cells[1], line_no)
         if in_variable_sla and len(cells) >= 3 and re.fullmatch(r"\d+(?:\.\d+)?", cells[1]):
@@ -505,7 +534,7 @@ def main() -> None:
             gate = None; continue
         if not (gate and s.startswith("|")):
             continue
-        cells = [c.strip() for c in s.strip().strip("|").split("|")]
+        cells = _split_row(s)
         if not cells:
             continue
         # Header row: capture Marks-Complete / Exit-Type column positions by name

--- a/tests/tasks/uipath-planner/_shared/test_check_eval_run.py
+++ b/tests/tasks/uipath-planner/_shared/test_check_eval_run.py
@@ -1,0 +1,134 @@
+"""Guards for scripts/check-eval-run.py — the run-is-evidence gate.
+
+The gate exists because a coder-eval run can finish with plausible scores while
+measuring nothing. These tests build synthetic run directories for each failure
+mode, so the gate is verified in both directions without needing a real run.
+
+The signal choices encoded here were learned the hard way:
+
+* Execution is measured by **output tokens**, not turn count. `codex` reports
+  `total_assistant_turns == 1` on fully successful runs and `2` on runs that died
+  on a provider error, so a turn threshold is near-inverted for it.
+* `--regrade` drops the agent assertions, because `coder-eval evaluate` runs no
+  agent — asserting plugins/tokens there would fail every re-grade, which is the
+  cheapest and most useful path.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+GATE = REPO / "scripts" / "check-eval-run.py"
+
+GOOD_USAGE = {"output_tokens": 12882, "input_tokens": 2010930}
+
+
+def write_run(root: Path, *, task: dict, experiment: str | None = "skill-tests-default") -> Path:
+    run = root / "run"
+    rep = run / "default" / "some-task" / "00"
+    rep.mkdir(parents=True)
+    (rep / "task.json").write_text(json.dumps(task), encoding="utf-8")
+    if experiment is not None:
+        (run / "experiment.md").write_text(
+            f"# Experiment Report: {experiment}\n", encoding="utf-8"
+        )
+    return run
+
+
+def gate(run: Path, *extra: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(GATE), str(run), *extra], capture_output=True, text=True
+    )
+
+
+def base_task(**over) -> dict:
+    task = {
+        "agent_type": "codex",
+        "final_status": "SUCCESS",
+        "total_assistant_turns": 1,  # healthy for codex — deliberately low
+        "agent_config": {"plugins": [{"type": "local", "path": "$SKILLS_REPO_PATH"}]},
+        "total_token_usage": dict(GOOD_USAGE),
+        "success_criteria_results": [{"score": 1.0, "details": "ok"}],
+    }
+    task.update(over)
+    return task
+
+
+def test_gate_exists():
+    assert GATE.is_file(), f"missing {GATE}"
+
+
+def test_healthy_run_passes_even_with_one_turn(tmp_path: Path):
+    """A codex run with a single assistant turn is normal, not broken."""
+    run = write_run(tmp_path, task=base_task())
+    r = gate(run, "--expect-experiment", "skill-tests-default")
+    assert r.returncode == 0, f"healthy run rejected:\n{r.stdout}\n{r.stderr}"
+
+
+def test_missing_plugin_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(agent_config={"plugins": None}))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "no plugin loaded" in (r.stdout + r.stderr)
+
+
+def test_no_output_tokens_fails(tmp_path: Path):
+    """The provider-error shape: task.json exists, usage is empty."""
+    run = write_run(tmp_path, task=base_task(total_token_usage={}, total_assistant_turns=2))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "produced no output" in (r.stdout + r.stderr)
+
+
+def test_wrong_experiment_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(), experiment="default")
+    r = gate(run, "--expect-experiment", "skill-tests-default")
+    assert r.returncode != 0
+    assert "expected" in (r.stdout + r.stderr)
+
+
+def test_unconfigured_judge_fails(tmp_path: Path):
+    run = write_run(tmp_path, task=base_task(
+        success_criteria_results=[{"score": 0.0, "details": "(judge transport unconfigured)"}]
+    ))
+    r = gate(run)
+    assert r.returncode != 0
+    assert "judge transport" in (r.stdout + r.stderr)
+
+
+def test_regrade_mode_ignores_agent_assertions(tmp_path: Path):
+    """`coder-eval evaluate` produces no plugin, no tokens and no experiment.md.
+    Those are expected in that mode, so --regrade must not flag them."""
+    run = write_run(
+        tmp_path,
+        task={"success_criteria_results": [{"score": 1.0, "details": "ok"}]},
+        experiment=None,
+    )
+    r = gate(run, "--regrade")
+    assert r.returncode == 0, f"--regrade flagged a normal re-grade:\n{r.stdout}\n{r.stderr}"
+
+
+def test_regrade_mode_still_catches_the_judge(tmp_path: Path):
+    """--regrade relaxes the agent checks but must keep the judge check, or the
+    cheap path becomes the one where a transport gap hides."""
+    run = write_run(
+        tmp_path,
+        task={"success_criteria_results": [
+            {"score": 0.0, "details": "(judge transport unconfigured)"}
+        ]},
+        experiment=None,
+    )
+    r = gate(run, "--regrade")
+    assert r.returncode != 0
+    assert "judge transport" in (r.stdout + r.stderr)
+
+
+def test_empty_run_dir_fails(tmp_path: Path):
+    run = tmp_path / "empty"
+    run.mkdir()
+    r = gate(run)
+    assert r.returncode != 0
+    assert "no task.json" in (r.stdout + r.stderr)

--- a/tests/tasks/uipath-planner/_shared/test_sdd_check_row_parsing.py
+++ b/tests/tasks/uipath-planner/_shared/test_sdd_check_row_parsing.py
@@ -1,0 +1,167 @@
+"""Regression guards for sdd_check.py's row parsing and SDD discovery.
+
+Both bugs below made the checker report failures on CORRECT input, which is worse
+than not running it: the first person to hit a false positive stops trusting the
+grader. Found while grading a real 2,220-line SDD from the 08/18 bug bash.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parent
+CHECK = SHARED / "sdd_check.py"
+
+MINIMAL = """# SDD — RowParse
+
+## Document History
+
+<!-- planner-handoff:v1 -->
+## Planner Handoff
+
+| Field | Value |
+|---|---|
+| **Status** | ready |
+
+## Section 1: Case Definition
+
+### Case Metadata
+
+| Property | Value |
+|----------|-------|
+| Case Name | RowParse |
+
+### Case Triggers
+
+| T# | Trigger Type | Source | Configuration |
+|----|-------------|--------|---------------|
+| T02 | Manual | Manual | N/A |
+
+### Case Exit Conditions
+
+| WHEN | IF | THEN | Exit Type | Marks Case Complete | Display Name |
+|------|-----|------|-----------|---------------------|--------------|
+| required-stages-completed | — | Case exited | exit-only | Yes | — |
+
+### Case Variables
+
+| Name | Category | Type | sourceTriggers | sourceFields | Default | Description |
+|---|---|---|---|---|---|---|
+| cost | Variable | double | | | 0 | Cost |
+
+## Section 2: Stages & Tasks
+
+### Stage 1: Only
+
+**Type:** Stage
+**Design Rationale:** Single stage.
+**Description:** Single stage.
+**Required for case completion:** Yes
+
+#### Stage Entry Conditions
+
+| WHEN | IF | Interrupting | Display Name |
+|------|-----|--------------|--------------|
+| case-entered | — | No | Start |
+
+#### Stage Exit Conditions
+
+| WHEN | IF | Exit Type | Marks Stage Complete | Display Name |
+|------|-----|-----------|---------------------|--------------|
+| required-tasks-completed | {guard} | exit-only | Yes | Done |
+
+#### Tasks
+
+| # | Task Name | Type | Activation Mode | Starts When | Required | Run Only Once | Persona | SLA |
+|---|-----------|------|-----------------|-------------|----------|---------------|---------|-----|
+| 1 | Do it | action | parallel | stage enters | Yes | No | Owner | — |
+
+##### Task 1.1: Do it
+
+**Type:** action
+**Activation Mode:** parallel
+**Design Rationale:** Human decides.
+**Description:** Human decides.
+
+**Entry Condition:**
+
+| WHEN | IF | Display Name |
+|------|-----|--------------|
+| current-stage-entered | — | — |
+
+**Task envelope**
+
+| Required | Run Only Once | Skip Condition |
+|----------|---------------|----------------|
+| Yes | No | — |
+
+## Section 3: Personas & App Views
+
+### Personas
+
+### Process App Views
+
+## Section 4: Integrations
+
+> None.
+"""
+
+
+def run(tmp_path: Path, name: str, guard: str):
+    (tmp_path / name).write_text(MINIMAL.replace("{guard}", guard), encoding="utf-8")
+    return subprocess.run(
+        [sys.executable, str(CHECK)], cwd=tmp_path, capture_output=True, text=True
+    )
+
+
+# Symptoms of the column-shift bug. The fixture is deliberately not a fully
+# conformant SDD — these tests isolate ROW PARSING, so they assert the specific
+# false positives are gone rather than demanding an overall clean bill.
+SHIFT_SYMPTOMS = ("invalid exit-type", "not legal for stage-exit")
+
+
+def test_escaped_pipe_in_guard_does_not_shift_columns(tmp_path: Path):
+    """A JS `||` must be written `\\|\\|` inside a markdown table.
+
+    Splitting the row on every `|` invented phantom cells and shifted every column
+    right, so `Exit Type` landed on a lone backslash and rule legality was graded
+    against the wrong Marks-Complete value — on a legal table.
+    """
+    r = run(tmp_path, "sdd.md", r"=js:(vars.cost < 5000 \|\| vars.cost > 9000)")
+    out = r.stdout + r.stderr
+    hits = [s for s in SHIFT_SYMPTOMS if s in out]
+    assert not hits, f"escaped pipes still shift columns ({hits}):\n{out}"
+
+
+def test_plain_guard_is_symptom_free_too(tmp_path: Path):
+    """Control: without an escaped pipe the same symptoms must be absent, so the
+    test above measures escape handling rather than a fixture defect."""
+    r = run(tmp_path, "sdd.md", "=js:(vars.cost < 5000)")
+    out = r.stdout + r.stderr
+    hits = [s for s in SHIFT_SYMPTOMS if s in out]
+    assert not hits, f"baseline fixture already trips the symptoms ({hits}):\n{out}"
+
+
+def test_finds_direct_design_basename(tmp_path: Path):
+    """Direct design writes `<case-name-kebab>-sdd.md`, not `sdd.md`. Globbing only
+    `sdd.md` made the checker exit before reading anything, so wiring it into a
+    design-lane eval produced a criterion that could never pass."""
+    r = run(tmp_path, "row-parse-sdd.md", "=js:(vars.cost < 5000)")
+    out = r.stdout + r.stderr
+    # Assert it actually READ the file, not merely that one error string is absent —
+    # the pre-fix message was "no sdd.md found", so asserting on "no SDD found"
+    # passed vacuously against the broken finder.
+    assert "row-parse-sdd.md" in out, (
+        "checker never opened the `*-sdd.md` design-lane artifact — its output does "
+        f"not name the file:\n{out}"
+    )
+
+
+def test_missing_sdd_still_fails_loudly(tmp_path: Path):
+    """The finder must stay strict — an empty directory is a failure, not a pass."""
+    r = subprocess.run(
+        [sys.executable, str(CHECK)], cwd=tmp_path, capture_output=True, text=True
+    )
+    assert r.returncode != 0
+    assert "no SDD found" in (r.stdout + r.stderr)

--- a/tests/tasks/uipath-planner/case_design_interview/candidate_interview.yaml
+++ b/tests/tasks/uipath-planner/case_design_interview/candidate_interview.yaml
@@ -142,6 +142,17 @@ success_criteria:
     weight: 3.0
     pass_threshold: 0.7
 
+  - type: run_command
+    description: >
+      generated SDD is mechanically sound — variable lineage closes, every =vars reference
+      resolves, per-gate rule legality holds, task types are in the closed enum, and every
+      stage has legal entry/exit conditions. Substring checks cannot see any of this.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-planner/_shared/sdd_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
 simulation:
   enabled: true
   persona: |

--- a/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
+++ b/tests/tasks/uipath-planner/case_design_loan/loan_origination.yaml
@@ -65,6 +65,17 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: run_command
+    description: >
+      generated SDD is mechanically sound — variable lineage closes, every =vars reference
+      resolves, per-gate rule legality holds, task types are in the closed enum, and every
+      stage has legal entry/exit conditions. Substring checks cannot see any of this.
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-planner/_shared/sdd_check.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: run_command
     description: "design declares all 4 exception lanes"
     command: "cat *sdd*.md 2>/dev/null | grep -Eiq 'customer comms' && cat *sdd*.md 2>/dev/null | grep -Eiq 'escalation' && cat *sdd*.md 2>/dev/null | grep -Eiq 'withdrawn' && cat *sdd*.md 2>/dev/null | grep -Eiq 'rejected'"
     timeout: 10


### PR DESCRIPTION
Grades generated SDDs on shape instead of substring presence, fixes two bugs in the grader that made it fail on correct input, and adds a gate that verifies a coder-eval run actually measured something.

Scoped to the eval harness — no skill content.

---

## Generated SDDs were graded by substring

The two design-lane evals checked a generated SDD like this:

```
ls *sdd*.md | grep -q .                    a file exists
grep -Eiq 'withdrawn' 'rejected' ...       these words appear
grep -cE '^#+ +Stage [0-9]' >= 6           there are >= 6 stage headings
```

Presence, not correctness. A 2,220-line SDD that invents its own table format passes all four.

`sdd_check.py` — lineage closure, per-gate rule legality, task-type enum, entry/exit legality — already existed, but was wired only into the three `case_finalize_*` tasks and never into the two that exercise the design lane. Now wired into both.

**First contact found real defects: 4 of 6 generated SDDs are mechanically unsound.** None of it visible to the substring checks.

## The grader had two bugs, both failing on CORRECT input

These had to be fixed before wiring it in. A grader that cries wolf is worse than no grader — the first false positive is the one that ends its credibility.

**1. Rows were split on escaped pipes.** A JS `||` must be written `\|\|` inside a markdown table, so splitting on every `|` invented phantom cells and shifted every column right. Against a real SDD it produced two confident, wrong findings on a **legal** table:

```
invalid exit-type '\'                             <- landed on a lone backslash
'required-tasks-completed' is not legal for
  stage-exit exit (Marks=No)                      <- graded the wrong column
```

Any SDD using a logical OR in an `IF` guard hit this — common in the mutually-exclusive completion/divert pairs the case model prescribes.

**2. The finder globbed only `sdd.md`.** Build handoff writes `sdd.md`, but direct design writes `<case-name-kebab>-sdd.md` and a draft writes `sdd.draft.md`. So it exited *"no sdd.md found"* before reading anything — wiring it into a design task unfixed would have produced a criterion that **could never pass**.

With both fixed it grades a real SDD clean: 39 variables, 33 `=vars` references resolve, lineage closes, 8 stages with legal conditions.

`sdd_check.py` is a deliberate per-suite twin, and `test_shared_twins.py` caught that only one copy had been edited. Both updated.

## `scripts/check-eval-run.py` — is this run evidence?

A coder-eval run can complete, report per-task scores, and mean nothing. Three shapes observed in a single day, each initially read as a regression:

| failure | what it looks like |
|---|---|
| skill never installed | silent fallback to the built-in default experiment (no `plugins:` block) — the agent ran with no skill |
| model never executed | expired provider credit ends the dialog; a finished `task.json` with a score is still written |
| judge unreachable | `llm_judge` scores 0.0 with `(judge transport unconfigured)` — every task FAILURE regardless of merit |

The gate names each and exits 1, so a run is validated before anyone quotes it. It says nothing about whether the skill is correct — only whether the run is **evidence**.

**Execution is measured by output tokens, not turn count.** This matters: `codex` reports `total_assistant_turns == 1` on fully successful runs and `2` on runs that died on a provider error, so a turn threshold is near-inverted for it. A first draft used `turns >= 3` and **rejected a known-good N=10 terra run 10/10** — caught by running the gate against real archived runs rather than only synthetic fixtures.

`--regrade` drops the agent assertions for `coder-eval evaluate` runs, which execute no agent; asserting plugins/tokens/experiment there would fail every re-grade, and re-grading saved artifacts is the cheapest useful path. It keeps the judge check, so the cheap path is not where a transport gap hides.

## Guards are mutation-tested, not decorative

| guard | reverted-fix result |
|---|---|
| `test_sdd_check_row_parsing` (4) | 3 of 4 fail; the control still passes |
| `test_check_eval_run` (9) | verified against 6 real archived runs (3 good, 3 bad) — correct 6/6, each failing for the right reason |

One of those assertions **started out vacuous** — it checked for a message string the broken code never emitted, so it passed against the bug. It now requires evidence the file was actually read.

## Checks

```
tests/tasks/uipath-planner/       68 passed
tests/tasks/uipath-maestro-case/ 109 passed
skills:validate                   OK (26 skills, default + studioweb)
check-skill-status                OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
