### PR TITLE
test(maestro-flow): tag escalation e2e tasks path-to-ga + new outcome-graded marker

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -107,6 +107,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 | **connector** | flat, present iff applicable | Marks tasks that use any IS connector. The specific connector is in the YAML body / file path. |
 | **windows** | flat, present iff applicable | Marks tasks that require a Windows host (e.g. RPA `.xaml`/`.cs` projects that need Studio Helm). Used by `smoke-rpa-skills.yml` to route the task to a `windows-latest` runner; Linux/macOS smoke runs skip it. |
 | **path-to-ga** | flat, optional | Marks exhaustive, difficult, currently blocked, or historically fragile tasks that represent must-pass scenarios on the path to GA. | `path-to-ga` |
+| **outcome-graded** | flat, optional | Marks tasks whose primary criteria grade the live outcome of an executed run rather than authored file contents. | `outcome-graded` |
 | **feature** | `feature:X`, repeatable | Cross-cutting capability orthogonal to node/resource/connector. Closed vocabulary: `http`, `trigger`, `registry`, `transform`, `eval`, `approval-gate`, `write-back`, `escalation`, `connections`, `activities`, `records`, `entities`, `api-workflow`, `compliance`, `test-case`, `hooks`, `conversational`. Do not invent leaf names like `feature:ceql-where` or directory-name markers like `feature:connector-feature` — those duplicate the file path. |
 
 ### Rules
@@ -114,7 +115,7 @@ Tags drive `make` targets, coverage reports, and evalboard drilldown. The `tags:
 1. **Required on every task: `skill` + `tier` + `mode:*` + `lifecycle:*`.** These drive `make` targets, coverage, and evalboard dashboards.
 2. **One value per singular dimension** (`tier`, `mode`, `shape`). A task doesn't have two tiers.
 3. **`node:` and `feature:` are repeatable.** A flow exercising decision and switch nodes gets both `node:decision` and `node:switch`.
-4. **`connector`, `resource`, `windows`, and `path-to-ga` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
+4. **`connector`, `resource`, `windows`, `path-to-ga`, and `outcome-graded` are flat boolean markers**, not enumerations. Use them once per task; the specific connector/resource is identifiable from the file path, `task_id`, or YAML body. Adding `connector:slack` etc. is no longer the convention.
 5. **Use only the vocabularies above.** Propose new values in the PR — do not invent tags inline. New values should apply to at least two tasks in practice.
 6. **Don't repeat the skill name as a feature tag.** Don't tag a flow task with `rpa` (bare) or `uipath-rpa` as a feature.
 

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -13,7 +13,7 @@ description: >
   Tenant prerequisite: a `uipath-atlassian-jira` connection in folder
   `Shared/uipath-maestro-flow` reaching the `CE` / "Coder Eval" project (issue
   type Task). Targets live in the task's `jira_is.py`.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation, path-to-ga, outcome-graded]
 
 run_limits:
   expected_turns: 55

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml
@@ -14,7 +14,7 @@ description: >
   by its timestamp. Salesforce is not called (match status is an input), so no
   Salesforce connection is required; the Slack node is a real connector with an error
   port so a Slack hiccup cannot fault the run.
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:decision, connector, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, node:decision, connector, feature:escalation, path-to-ga, outcome-graded]
 
 run_limits:
   expected_turns: 80

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_slack_alert/escalation_slack_alert.yaml
@@ -11,7 +11,7 @@ description: >
   correlationId, and — the point of the test — the Slack Send Message activity
   actually posted (it returned a non-empty message id surfaced as a flow
   output). Grades the delivered Slack side effect, not "did it run".
-tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation]
+tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector, feature:escalation, path-to-ga, outcome-graded]
 
 run_limits:
   expected_turns: 55


### PR DESCRIPTION
## What

Minimal, owner-scoped change (4 files, +5/−4):

1. Tags the three outcome-based escalation e2e tasks from #2601 (`escalation_jira_ticket`, `escalation_orchestrator_paths`, `escalation_slack_alert`) with `path-to-ga` and the new `outcome-graded` marker.
2. Defines `outcome-graded` in the tag taxonomy (tests/README.md table row + rule 4) as required for any new closed-vocabulary value.

## Out of scope (deliberate)

Backfilling other qualifying tasks (admin smokes, billing/jira e2e, etc.) was explored in earlier revisions of this PR and **removed at the owner's direction** — it belongs in a dedicated follow-up sweep. The taxonomy definition here is the enabler; the cohort grows incrementally.

## Evidence

First nightly exposure (antigravity, `2026-08-19_04-15-02`): all three tasks SUCCESS at 1.00. Tag-only change — no new eval dispatch needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
