### PR TITLE
fix(ci): give the preview sync workflow a token that can read flow-builder-sdk

### DIFF
--- a/.github/workflows/sync-maestro-sdk-preview.yml
+++ b/.github/workflows/sync-maestro-sdk-preview.yml
@@ -43,12 +43,17 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # flow-builder-sdk is private, so the default github.token cannot read it
+      # ("Repository not found"). GH_PAT is this repo's repo-read credential for
+      # private cross-repo checkouts (same pattern as run-coder-eval.yml);
+      # persist-credentials: false keeps the PAT out of .git/config.
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
         if: steps.check.outputs.exists != 'true'
         with:
           repository: UiPath/flow-builder-sdk
           ref: main
           fetch-depth: 0
+          token: ${{ secrets.GH_PAT }}
           persist-credentials: false
           path: flow-builder-sdk
 


### PR DESCRIPTION
## What broke

The first manual dispatch of **Re-sync Maestro SDK preview** after #2625 merged — [run 32412162692](https://github.com/UiPath/skills/actions/runs/32412162692) — failed at the `UiPath/flow-builder-sdk` checkout with `Repository not found`.

## Why

That repo is private, and the checkout step passes no `token:`, so `actions/checkout` falls back to the workflow's default `github.token` — which has no cross-repo read access. `Repository not found` is GitHub's private-repo-unauthorized answer. The workflow merged unexecuted (its `schedule`/`workflow_dispatch` triggers only fire from the default branch), so this could not have been caught before the first real dispatch — which is exactly what the post-merge smoke dispatch was for.

## Fix

One input on the checkout: `token: ${{ secrets.GH_PAT }}` — this repo's established repo-read credential for private cross-repo checkouts, with the same `persist-credentials: false` hygiene as run-coder-eval.yml's `coder_eval_uipath` checkout (see its comment: "GH_PACKAGES_TOKEN is packages-only, so this is the one step that requires GH_PAT").

## Verified locally, end to end

With a readable upstream checkout, the rest of the pipeline is proven healthy against the *real* pending drift:

- `scripts/sync-maestro-sdk-preview.mjs --upstream <flow-builder-sdk@main>` merges `41938ba → 49520ad` clean: 10 files, +693/−43 under `preview/` (the Phase 4/5 surfaces — new references incl. `voice.md`, `data-fabric.md`, `conversational.md`, …).
- All snapshot gates pass: `git diff --check` clean; verb gate flow **0 blocking** / 6 soft-stale (the known positional-arg false positives), case 0/0, bpmn 0/0.

After this merges, re-dispatch the workflow once — it should open exactly that sync PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018EfF7VpRmQH65W9xgcMars