### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@49520ad

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 41938ba. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 49520ad. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 41938ba. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 49520ad. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 41938ba. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 49520ad. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -141,7 +141,9 @@ Choose it when a caller, test, or another process should start each run.
 
 A platform timer starts the flow on a recurring interval.
 
-Signature: `.trigger(scheduled({ every: string }))`.
+Signature: `.trigger(scheduled({ every: string }))`. `every` takes an ISO-8601
+repeating interval, or a Quartz cron expression (e.g. `'0 0 2 * * ?'`), which
+selects the trigger's 1.2 definition automatically.
 
 ```ts
 export default flow('nightly')
@@ -153,6 +155,26 @@ export default flow('nightly')
 Prefer self-contained variables because there may be no caller supplying inputs.
 
 **Reference: [`references/scheduled-trigger.md`](references/scheduled-trigger.md)**
+
+## Form trigger
+
+A person starts the flow by submitting a form (`core.trigger.form`); the
+submitted values ARE the flow's inputs.
+
+Signature: `.trigger(formTrigger())` — no arguments; the form's fields are
+derived from `.input()` (one per input, required unless it has a default).
+
+```ts
+export default flow('expense')
+  .input({ amount: types.number, reason: types.string })
+  .trigger(formTrigger())
+  .step('log', script({ code: 'return $vars.start.output.amount;' }))
+  .build();
+```
+
+Locally `--input` supplies the values; no rung renders a form.
+
+**Reference: [`references/form-trigger.md`](references/form-trigger.md)**
 
 ## Entry points (multiple triggers)
 
@@ -197,16 +219,18 @@ payload can exercise downstream wiring, but it is not a subscription witness.
 Standalone HTTP keeps non-2xx responses on its success output. Managed HTTP routes
 them through its error port. Both expose JSON response bodies as parsed values.
 
-Signature: `http({ method?, url, managed, headers?, query?, body?, contentType?, timeout?, retryCount?, returns? })`.
+Signature: `http({ method?, url, managed, headers?, query?, body?, contentType?, timeout?, retryCount?, returns?, branches? })`.
 
 ```ts
 .step('getPolicy', http({ method: 'GET', url: policyUrl,
-  managed: true, returns: { limit: 'number' } }))
-.step('limit', script({
-  code: 'return $vars.getPolicy.output.body.limit;' }))
+  managed: true, returns: { limit: 'number' },
+  branches: [{ name: 'throttled', condition: js`$vars.getPolicy.output.statusCode === 429` }] }))
+.stepToList('branch-throttled', (b) => b.return({}))
+.step('limit', script({ code: 'return $vars.getPolicy.output.body.limit;' }))
 ```
 
-Match `managed` to the product node named by the scenario; set retry/timeouts only when requested.
+Match `managed` to the scenario's node. A branch is a `branch-<name>` side exit
+routed with `.stepToList`; the main path continues from the default port.
 
 **Reference: [`references/http.md`](references/http.md)**
 
@@ -262,14 +286,37 @@ Copy identity fields from a freshly pulled tenant registry; never construct them
 
 **Reference: [`references/ixp.md`](references/ixp.md)**
 
+## Document classify and Dynamic Extract
+
+Classify a document (`uipath.document.classify`), or extract fields against an
+INLINE schema (`uipath.ixp.extract-document-builder`) instead of a published
+IxP project's trained fields.
+
+Signatures: `documentClassify({ fileRef, pageRange?, splitPages?, modelConfig? })`;
+`dynamicExtract({ fileRef, schema, model: { modelName, folderKey, ... }, pageRange? })`.
+
+```ts
+.step('classify', documentClassify({ fileRef: input('file'), splitPages: true }))
+.step('extract', dynamicExtract({ fileRef: input('file'),
+  schema: { type: 'object', properties: { total: { type: 'string' } } },
+  model: { modelName: 'invoiceixp-cef0d447-ixp', folderKey: '<folder-guid>' } }))
+```
+
+Dynamic Extract still needs a model deployment identity — copy `modelName` and
+`folderKey` from the tenant; never construct them.
+
+**Reference: [`references/document-pipeline.md`](references/document-pipeline.md)**
+
 ## Delay
 
-Pause this path for a duration, then continue.
+Pause this path for a duration — or until an absolute date-time — then continue.
 
-Signature: `delay({ duration: string })`.
+Signature: `delay({ duration: string })` or `delay({ until: string })`
+(exactly one; `until` is an ISO-8601 date-time, e.g. `'2026-09-01T09:00:00Z'`).
 
 ```ts
 .step('cooldown', delay({ duration: 'PT30S' }))
+.step('embargo', delay({ until: '2026-09-01T09:00:00Z' }))
 .step('resumedAt', script({ code: 'return new Date().toISOString();' }))
 ```
 
@@ -312,6 +359,25 @@ Confirm identity and exact argument casing on the tenant; `.onError(...)` is sup
 **Reference: [`references/api-workflow.md`](references/api-workflow.md)**
 
 **Finding the key: [`references/or-processes.md`](references/or-processes.md)**
+
+## Published function
+
+Run a deployed Orchestrator **Function** — a small unit of code published as its
+own resource — as one step.
+
+Signature: `publishedFunction({ key, name, folderPath, inputs?, returns? })`.
+
+```ts
+.step('echo', publishedFunction({ key: functionKey,
+  name: 'acme-echo', folderPath: 'Shared/acme-echo',
+  inputs: { message: input('message') }, returns: { echoed: 'string' } }))
+```
+
+A function is usually deployed into a folder of its OWN name — read `folderPath`
+from the tenant rather than assuming `'Shared'`, since the binding's resourceKey
+is `<folderPath>.<name>`.
+
+**Reference: [`references/published-function.md`](references/published-function.md)**
 
 ## Agentic process
 
@@ -356,18 +422,20 @@ sibling before calling it. Verify resource identity and answer quality live.
 
 Define an autonomous agent inside this Flow project, with optional resources.
 
-Signature: `inlineAgent({ model, systemPrompt, userPrompt, inputs?, returns?, source?, context?, tools?, escalation?, ... })`.
+Signature: `inlineAgent({ model, systemPrompt, userPrompt, inputs?, returns?, source?, context?, tools?, escalation?, guardrails?, mode?, ... })`.
 
 ```ts
-.step('triage', inlineAgent({ model: 'gpt-5.4',
-  systemPrompt: 'Return JSON with category.',
+.step('triage', inlineAgent({ model: 'gpt-5.4', systemPrompt: 'Return JSON with category.',
   userPrompt: 'Classify {{input.body}}', inputs: { body: input('body') },
-  returns: { category: 'string' } }))
+  returns: { category: 'string' },
+  guardrails: [{ id: 'no-pii', $guardrailType: 'custom', name: 'Block PII', selector: { scopes: ['Agent'] },
+    enabledForEvals: true, action: { $actionType: 'block', reason: 'PII detected' },
+    rules: [{ $ruleType: 'always', applyTo: 'inputAndOutput' }] }] }))
 ```
 
-Model/tool/escalation decisions and answer quality require live judgment.
+`tools` also takes `mcp`, `a2a`, `clientside`, `httpRequest` and `function` kinds; `memory: { name, id }` attaches an episodic memory; `escalation` takes `variant: 'quick-form'` for an inline form. `mode: 'advanced'` selects the Advanced harness.
 
-**Reference: [`references/inline-agent.md`](references/inline-agent.md)**
+**Reference: [`references/inline-agent.md`](references/inline-agent.md)** — resource families: [`references/agent-resources.md`](references/agent-resources.md)
 
 ## Queue item
 
@@ -384,6 +452,26 @@ Signature: `queueItem({ queue, folderPath, key, item, priority?, reference?, def
 Check tenant uniqueness/schema settings; wait only when a consumer exists and its result is needed.
 
 **Reference: [`references/queue.md`](references/queue.md)**
+
+## Data Fabric
+
+Read and update Data Fabric entity records (`core.datafabric.read` / `.update`).
+
+Signatures: `dataFabricRead({ entity, filters? })` and
+`dataFabricUpdate({ entity, record, set })` — `record` is exactly one of
+`{ byId }` or `{ fromRead: '<read step name>' }`.
+
+```ts
+.step('lookup', dataFabricRead({ entity: 'Invoices',
+  filters: [{ field: 'InvoiceId', value: input('invoiceId') }] }))
+.step('markPaid', dataFabricUpdate({ entity: 'Invoices',
+  record: { fromRead: 'lookup' }, set: { Status: 'Paid' } }))
+```
+
+Filters default to `operator: '='`; `or: true` joins a row with OR. No local
+rung reads a real entity — offline validate is the acceptance bar.
+
+**Reference: [`references/data-fabric.md`](references/data-fabric.md)**
 
 ## Error handling
 
@@ -506,22 +594,60 @@ Read a child's inputs with `input(...)`: its start node is named `<callerStepId>
 
 ## Human task
 
-Pause for a person using an inline form, quick form, or deployed Action App.
+Pause for a person: an inline form, quick form, deployed Action App, or a
+document-validation station.
 
-Signature: `hitl({ variant?, app?, title?, priority?, fields?, outcomes })`.
+Signature: `hitl({ variant?, app?, document?, title?, priority?, labels?, recipient?, fields?, outcomes, outcomePorts?, exposeError? })`.
 
 ```ts
 .step('review', hitl({ title: 'Review invoice',
-  fields: [{ id: 'comment', type: 'text', direction: 'output' }],
-  outcomes: ['Approve', 'Reject'] }))
-.switch('route', out('review', 'Action'), [
-  { value: 'Approve', body: (b) => b.return({ status: 'approved' }) },
-], (other) => other.return({ status: 'rejected' }))
+  recipient: { assignee: { type: 'user', value: 'reviewer@acme.test' } },
+  fields: [{ id: 'amount', type: 'number', direction: 'inOut', value: input('amount') }],
+  outcomes: ['Approve', 'Reject'], outcomePorts: true }))
+.stepToList('outcome-reject', (b) => b.return({ status: 'rejected' }))
+.step('proceed', script({ code: 'return "approved";' }))
 ```
 
-Choose the variant from the requested human experience and deployed app; offline runs script the human.
+`outcomePorts` routes per outcome (`outcome-<slug>` exits; the FIRST continues the main path); without it, route on `out('review', 'Action')`.
 
 **Reference: [`references/hitl.md`](references/hitl.md)**
+
+## Conversational
+
+Work a live CHAT: wait for the person's message, answer it, post a reply. Every
+step is keyed by a `conversationId` — the conversation trigger publishes it.
+
+Signatures: `.trigger(conversationTrigger())`; `waitForMessage({ conversationId, numExchanges? })`; `conversationalAgent({ model, systemPrompt, settings })`; `sendMessage({ conversationId, exchangeId, content, endExchange? })`; `conversationContext({ conversationId, exchangeLimit? })`.
+
+```ts
+.trigger(conversationTrigger())
+.step('listen', waitForMessage({ conversationId: out('start', 'conversationId') }))
+.step('reply', conversationalAgent({ model: 'gpt-5.4', systemPrompt: 'Answer briefly.',
+  settings: { context: out('listen', 'conversationContext') } }))
+```
+
+`waitForMessage` SUSPENDS the flow (a catch event), it does not poll. Use `sendMessage` when the flow decides what to say, an agent when the model does.
+
+**Reference: [`references/conversational.md`](references/conversational.md)**
+
+## Voice
+
+Talk to someone on a phone call. The call is identified by a `callContext`
+OBJECT — pass the whole thing, never a field inside it.
+
+Signatures: `.trigger(voiceTrigger())`; `createOutgoingCall({ from, to })`; `endCall({ callContext })`; `voiceAgent({ systemPrompt, callContext, voice?, maxIterations? })`.
+
+```ts
+.step('dial', createOutgoingCall({ from: '+15550001111', to: input('phone') }))
+.step('talk', voiceAgent({ systemPrompt: 'Confirm the delivery window.',
+  callContext: out('dial', 'callContext'),
+  voice: { model: 'gemini-3.1-flash-live-preview', persona: 'Kore' } }))
+.step('bye', endCall({ callContext: out('dial', 'callContext') }))
+```
+
+The incoming-call trigger publishes `out('start', 'callContext')`. A persona belongs to its voice model; `maxIterations` is capped at 8.
+
+**Reference: [`references/voice.md`](references/voice.md)**
 
 ## Transform
 

--- a/preview/uipath-maestro-flow/references/agent-resources.md
+++ b/preview/uipath-maestro-flow/references/agent-resources.md
@@ -1,0 +1,75 @@
+# Agent resource families
+
+*Exact signatures, fields, and defaults: [`inlineAgent()`](api.md#inlineagent-function). Prompting, inputs and the sidecar: [inline-agent.md](inline-agent.md).*
+
+An inline agent's capabilities are ARTIFACT nodes hanging off its own handles —
+tools on `tool`, an escalation on `escalation`, a memory on `memory` — not steps
+in the control flow. Each is authored as an entry on `inlineAgent`, and the
+compiler emits the node and the edge.
+
+```ts
+.step('triage', inlineAgent({
+  model: 'gpt-5.4', systemPrompt: '…', userPrompt: '…',
+  tools: [
+    { kind: 'mcp', name: 'Ticket MCP', key: '<guid>', slug: 'ticket-mcp', folderPath: 'Shared' },
+    { kind: 'a2a', name: 'Research Agent', key: '<guid>', slug: 'research-agent' },
+    { kind: 'clientside', name: 'pickFile', inputs: { prompt: 'string' }, returns: { path: 'string' } },
+    { kind: 'httpRequest', url: 'https://api.example.test/items', method: 'GET' },
+    { kind: 'function', key: '<guid>', name: 'acme-echo', folderPath: 'Shared/acme-echo' },
+  ],
+  memory: { name: 'Support History', id: '<guid>' },
+  escalation: [{ variant: 'quick-form', name: 'Confirm', outcomes: ['Approve', 'Reject'],
+    fields: [{ id: 'approved', type: 'boolean', direction: 'output' }] }],
+}))
+```
+
+## Tool kinds
+
+| Kind | What it is | Identity you must supply |
+| --- | --- | --- |
+| `builtin` | A platform tool (`summarize`, `analyzefiles`, `batchtransform`) | the tool name |
+| `connector` | An Integration Service operation | `connector` + `operation` (needs a library) |
+| `process` / `api` / `flow` / `maestro` / `agent` / `function` | A deployed resource | `key` (GUID) + `name` + `folderPath` |
+| `ixp` | A published IxP project | `projectId` + `name` |
+| `mcp` | An MCP server's tools | `name` + `key`; `slug` is what the runtime resolves |
+| `a2a` | A remote agent to delegate to | `name` + `key` + `slug` (required) |
+| `clientside` | The CALLING application runs it | `name`, plus the `inputs`/`returns` contract |
+| `httpRequest` | The built-in HTTP tool | nothing — see below |
+
+For `mcp`, `a2a`, `memory` and the per-instance resource kinds, the node TYPE is
+minted from the identity you give (`…tool.mcp.<name-slug>.<key-slug>`), so a
+wrong key emits a node the tenant cannot resolve. Read them from the tenant.
+
+**The HTTP tool's fields are three-way.** Each of `url`, `method`, `headers`,
+`params`, `body`, `timeout` is either FIXED (give it a value) or left for the
+MODEL to fill at call time (omit it, which keeps the definition's prompt-mode
+default and its field description). Fixing everything defeats the point of
+giving an agent a tool; fixing nothing gives the model no constraints. Fix what
+the scenario pins and leave the rest.
+
+**A client-side tool declares only a CONTRACT.** The flow says what the tool is
+called and what it takes and returns; the calling application owns the
+implementation and dispatches on the name. Nothing local runs it.
+
+## Escalation
+
+The default variant is app-backed: `app: { key, name, folderPath }` names a
+deployed Action Center app that owns the form. `variant: 'quick-form'` puts the
+form INLINE instead — `fields` (the same rows a human task takes) and no `app`.
+`check` refuses the two mixed, in either direction.
+
+## Memory
+
+`memory: { name, id }` attaches an episodic memory so the agent learns from past
+runs, with optional retrieval tuning (`dynamicFewShotLearning`,
+`semanticSimilarity`, `kValue`, `searchMode`). Naming one selects the agent's
+**1.4** definition — the version that declares the `memory` handle. Omitting it
+leaves the agent on 1.2 exactly as before.
+
+## Evidence boundary
+
+Every resource here is tenant data, runtime behaviour, or both: no local rung
+calls an MCP server, delegates to a remote agent, retrieves a memory, or asks a
+client application to run a tool. Offline `validate` proves the minted node
+types, the wiring to the right handle, and the declared contracts. Whether the
+resources exist and what they return is platform evidence.

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -9,9 +9,9 @@ Exact `@uipath/flow-sdk` authoring signatures and option shapes, from the public
 declarations. Signatures, fields, optionality, and declaration comments are
 generated from the built types; longer tutorials stay in the node references.
 
-**Flow construction** — [SCHEDULE_PRESETS](#schedulepresets-const) · [manual](#manual-function) · [onEvent](#onevent-function) · [scheduled](#scheduled-function) · [formTrigger](#formtrigger-function) · [flow](#flow-function) · [subflow](#subflow-function)
+**Flow construction** — [SCHEDULE_PRESETS](#schedulepresets-const) · [manual](#manual-function) · [onEvent](#onevent-function) · [scheduled](#scheduled-function) · [formTrigger](#formtrigger-function) · [conversationTrigger](#conversationtrigger-function) · [voiceTrigger](#voicetrigger-function) · [flow](#flow-function) · [subflow](#subflow-function)
 
-**Actions** — [DELAY_PRESETS](#delaypresets-const) · [http](#http-function) · [script](#script-function) · [transform](#transform-function) · [hitl](#hitl-function) · [summarize](#summarize-function) · [batchTransform](#batchtransform-function) · [ixpExtract](#ixpextract-function) · [delay](#delay-function) · [mock](#mock-function) · [rpaWorkflow](#rpaworkflow-function) · [apiWorkflow](#apiworkflow-function) · [agenticProcess](#agenticprocess-function) · [agent](#agent-function) · [inlineAgent](#inlineagent-function) · [documentClassify](#documentclassify-function) · [dynamicExtract](#dynamicextract-function) · [dataFabricRead](#datafabricread-function) · [dataFabricUpdate](#datafabricupdate-function) · [queueItem](#queueitem-function) · [connector](#connector-function) · [waitForEvent](#waitforevent-function)
+**Actions** — [DELAY_PRESETS](#delaypresets-const) · [http](#http-function) · [script](#script-function) · [transform](#transform-function) · [hitl](#hitl-function) · [summarize](#summarize-function) · [batchTransform](#batchtransform-function) · [ixpExtract](#ixpextract-function) · [delay](#delay-function) · [mock](#mock-function) · [rpaWorkflow](#rpaworkflow-function) · [apiWorkflow](#apiworkflow-function) · [publishedFunction](#publishedfunction-function) · [sendMessage](#sendmessage-function) · [waitForMessage](#waitformessage-function) · [conversationContext](#conversationcontext-function) · [createOutgoingCall](#createoutgoingcall-function) · [endCall](#endcall-function) · [voiceAgent](#voiceagent-function) · [conversationalAgent](#conversationalagent-function) · [agenticProcess](#agenticprocess-function) · [agent](#agent-function) · [inlineAgent](#inlineagent-function) · [documentClassify](#documentclassify-function) · [dynamicExtract](#dynamicextract-function) · [dataFabricRead](#datafabricread-function) · [dataFabricUpdate](#datafabricupdate-function) · [queueItem](#queueitem-function) · [connector](#connector-function) · [waitForEvent](#waitforevent-function)
 
 **Expressions and types** — [lit](#lit-function) · [v](#v-function) · [DEFAULT_TRIGGER_ID](#defaulttriggerid-const) · [input](#input-function) · [entryInput](#entryinput-function) · [out](#out-function) · [ran](#ran-function) · [err](#err-function) · [js](#js-function) · [tmpl](#tmpl-function) · [types](#types-const)
 
@@ -19,9 +19,9 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Builders** — [FlowBuilder](#flowbuilder-class) · [StepList](#steplist-class) · [ArmBuilder](#armbuilder-class)
 
-**Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-type) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-type) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [DocumentClassifyInputs](#documentclassifyinputs-interface) · [DynamicExtractInputs](#dynamicextractinputs-interface) · [DataFabricReadInputs](#datafabricreadinputs-interface) · [DataFabricUpdateInputs](#datafabricupdateinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [NodeOptions](#nodeoptions-interface) · [HttpInputsBase](#httpinputsbase-interface) · [DocValidationInputs](#docvalidationinputs-interface) · [AgenticProcessInputsBase](#agenticprocessinputsbase-interface) · [LoopOptions](#loopoptions-interface) · [DoWhileOptions](#dowhileoptions-interface)
+**Option shapes** — [TriggerOptions](#triggeroptions-interface) · [EventSubscription](#eventsubscription-interface) · [ScheduledInputs](#scheduledinputs-interface) · [HttpInputs](#httpinputs-type) · [ScriptInputs](#scriptinputs-interface) · [TransformInputs](#transforminputs-interface) · [HitlInputs](#hitlinputs-interface) · [SummarizeInputs](#summarizeinputs-interface) · [BatchTransformInputs](#batchtransforminputs-interface) · [IxpExtractInputs](#ixpextractinputs-interface) · [DelayInputs](#delayinputs-type) · [RpaWorkflowInputs](#rpaworkflowinputs-interface) · [ApiWorkflowInputs](#apiworkflowinputs-interface) · [PublishedFunctionInputs](#publishedfunctioninputs-interface) · [SendMessageInputs](#sendmessageinputs-interface) · [WaitForMessageInputs](#waitformessageinputs-interface) · [ConversationContextInputs](#conversationcontextinputs-interface) · [CreateOutgoingCallInputs](#createoutgoingcallinputs-interface) · [EndCallInputs](#endcallinputs-interface) · [VoiceAgentInputs](#voiceagentinputs-interface) · [ConversationalAgentInputs](#conversationalagentinputs-interface) · [AgenticProcessInputs](#agenticprocessinputs-type) · [AgentInputs](#agentinputs-interface) · [InlineAgentInputs](#inlineagentinputs-interface) · [DocumentClassifyInputs](#documentclassifyinputs-interface) · [DynamicExtractInputs](#dynamicextractinputs-interface) · [DataFabricReadInputs](#datafabricreadinputs-interface) · [DataFabricUpdateInputs](#datafabricupdateinputs-interface) · [QueueItemInputs](#queueiteminputs-interface) · [ConnectorOpts](#connectoropts-interface) · [NodeOptions](#nodeoptions-interface) · [HttpInputsBase](#httpinputsbase-interface) · [DocValidationInputs](#docvalidationinputs-interface) · [AgenticProcessInputsBase](#agenticprocessinputsbase-interface) · [LoopOptions](#loopoptions-interface) · [DoWhileOptions](#dowhileoptions-interface)
 
-**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [TriggerSpec](#triggerspec-type) · [TriggerDescriptor](#triggerdescriptor-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentGuardrail](#agentguardrail-type) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
+**Supporting types** — [ContributionDiagnostic](#contributiondiagnostic-interface) · [DefinitionReference](#definitionreference-type) · [ContributionContext](#contributioncontext-interface) · [BindingContribution](#bindingcontribution-interface) · [NodeContribution](#nodecontribution-interface) · [FlowNode](#flownode-class) · [FlowAction](#flowaction-class) · [FlowTrigger](#flowtrigger-class) · [FlowResource](#flowresource-class) · [TriggerSpec](#triggerspec-type) · [TriggerDescriptor](#triggerdescriptor-type) · [ChildFlow](#childflow-type) · [Expr](#expr-class) · [SubflowSpec](#subflowspec-interface) · [ActionSpec](#actionspec-type) · [ConnectorDescriptor](#connectordescriptor-type) · [ConnectorMeta](#connectormeta-interface) · [TriggerMeta](#triggermeta-interface) · [EventFilter](#eventfilter-interface) · [ScheduleEvery](#scheduleevery-type) · [FlowLayout](#flowlayout-interface) · [TypeDesc](#typedesc-type) · [VarSpec](#varspec-interface) · [BuiltFlow](#builtflow-interface) · [ScriptReturns](#scriptreturns-type) · [TransformVariant](#transformvariant-type) · [TransformOperation](#transformoperation-type) · [HitlVariant](#hitlvariant-type) · [AppRef](#appref-interface) · [FormField](#formfield-type) · [Outcome](#outcome-type) · [HitlRecipient](#hitlrecipient-interface) · [OutputColumn](#outputcolumn-interface) · [VoiceSettings](#voicesettings-interface) · [ConversationalAgentSettings](#conversationalagentsettings-interface) · [AgentGuardrail](#agentguardrail-type) · [AgenticProcessCompletion](#agenticprocesscompletion-type) · [AgentLocation](#agentlocation-type) · [AgentFlavour](#agentflavour-type) · [InlineAgentFieldType](#inlineagentfieldtype-type) · [AgentMemoryRef](#agentmemoryref-interface) · [ContextIndexRef](#contextindexref-interface) · [ToolRef](#toolref-type) · [EscalationRef](#escalationref-interface) · [DataFabricFilter](#datafabricfilter-interface) · [QueuePriority](#queuepriority-type) · [SchedulePreset](#schedulepreset-type) · [Step](#step-type) · [FlowActionSpec](#flowactionspec-type) · [CaseValue](#casevalue-type) · [NodeLayout](#nodelayout-interface) · [EdgeRoute](#edgeroute-interface) · [VarDecl](#vardecl-interface) · [BuiltEntryPoint](#builtentrypoint-interface) · [HttpBranch](#httpbranch-interface) · [ScriptReturnType](#scriptreturntype-type) · [FilterRule](#filterrule-interface) · [FilterMatch](#filtermatch-type) · [FieldMapping](#fieldmapping-interface) · [Aggregation](#aggregation-interface) · [ShownField](#shownfield-interface) · [AskedField](#askedfield-interface) · [InOutField](#inoutfield-interface) · [HitlChannel](#hitlchannel-type) · [HitlAssigneeType](#hitlassigneetype-type) · [HitlConnection](#hitlconnection-interface) · [CustomGuardrail](#customguardrail-interface) · [BuiltInValidatorGuardrail](#builtinvalidatorguardrail-interface) · [BuiltinToolRef](#builtintoolref-interface) · [ConnectorToolRef](#connectortoolref-interface) · [ProcessToolRef](#processtoolref-interface) · [IxpToolRef](#ixptoolref-interface) · [McpToolRef](#mcptoolref-interface) · [RemoteA2aToolRef](#remotea2atoolref-interface) · [ClientSideToolRef](#clientsidetoolref-interface) · [HttpRequestToolRef](#httprequesttoolref-interface) · [SwitchArm](#switcharm-interface) · [FilterCondition](#filtercondition-type) · [Transformation](#transformation-type) · [AggregationOperation](#aggregationoperation-type) · [FormFieldType](#formfieldtype-type) · [GuardrailSelector](#guardrailselector-interface) · [GuardrailAction](#guardrailaction-type) · [GuardrailRule](#guardrailrule-type) · [BuiltinToolName](#builtintoolname-type) · [ProcessToolKind](#processtoolkind-type) · [GuardrailScope](#guardrailscope-type) · [GuardrailFieldReference](#guardrailfieldreference-interface) · [GuardrailFieldSelector](#guardrailfieldselector-type)
 
 ## SCHEDULE_PRESETS (const)
 
@@ -82,6 +82,23 @@ Behavior and worked examples: [scheduled-trigger.md](scheduled-trigger.md).
  * flow's inputs.
  */
 export declare function formTrigger(): TriggerSpec;
+````
+
+## conversationTrigger (function)
+
+````ts
+/**
+ * Start the flow when a new CONVERSATION is created
+ * (`core.trigger.conversation`) — the entry point for a chat-driven process.
+ */
+export declare function conversationTrigger(): TriggerSpec;
+````
+
+## voiceTrigger (function)
+
+````ts
+/** Start the flow when a phone call comes IN (`core.trigger.voice`). */
+export declare function voiceTrigger(): TriggerSpec;
 ````
 
 ## flow (function)
@@ -234,6 +251,90 @@ export declare function apiWorkflow(inputs: ApiWorkflowInputs): ActionSpec;
 ````
 
 Behavior and worked examples: [api-workflow.md](api-workflow.md).
+
+## publishedFunction (function)
+
+````ts
+/**
+ * Invoke a published Orchestrator **Function** — a deployed unit of code run as
+ * one step (`uipath.core.function.<key>`, dispatched as
+ * `Orchestrator.ExecuteFunctionAsync`).
+ */
+export declare function publishedFunction(inputs: PublishedFunctionInputs): ActionSpec;
+````
+
+## sendMessage (function)
+
+````ts
+/**
+ * Post an assistant message into a live conversation
+ * (`uipath.conversational.send-message`).
+ */
+export declare function sendMessage(inputs: SendMessageInputs): ActionSpec;
+````
+
+## waitForMessage (function)
+
+````ts
+/**
+ * PAUSE until the person sends their next message
+ * (`uipath.conversational.wait-for-message`) — a catch event, like
+ * `waitForEvent`, so the flow suspends rather than polling.
+ */
+export declare function waitForMessage(inputs: WaitForMessageInputs): ActionSpec;
+````
+
+## conversationContext (function)
+
+````ts
+/**
+ * READ a conversation's transcript so far without waiting
+ * (`uipath.conversational.get-conversation-context`) — the shape a
+ * conversational agent takes as its turn context.
+ */
+export declare function conversationContext(inputs: ConversationContextInputs): ActionSpec;
+````
+
+## createOutgoingCall (function)
+
+````ts
+/**
+ * Place an outgoing phone call
+ * (`uipath.conversational.voice.create-outgoing-call`) and get back the
+ * `callContext` every other voice step is keyed by.
+ */
+export declare function createOutgoingCall(inputs: CreateOutgoingCallInputs): ActionSpec;
+````
+
+## endCall (function)
+
+````ts
+/**
+ * Hang up (`uipath.conversational.voice.end-call`). Reads
+ * `out('<step>', 'ended')`.
+ */
+export declare function endCall(inputs: EndCallInputs): ActionSpec;
+````
+
+## voiceAgent (function)
+
+````ts
+/**
+ * Put a VOICE agent on a live call (`uipath.agent.voice`) — it speaks and
+ * listens for one turn, then the flow continues.
+ */
+export declare function voiceAgent(inputs: VoiceAgentInputs): ActionSpec;
+````
+
+## conversationalAgent (function)
+
+````ts
+/**
+ * A CONVERSATIONAL agent (`uipath.agent.conversational`) — it answers one turn
+ * of a live chat, reading the transcript rather than flow arguments.
+ */
+export declare function conversationalAgent(inputs: ConversationalAgentInputs): ActionSpec;
+````
 
 ## agenticProcess (function)
 
@@ -996,6 +1097,199 @@ export interface ApiWorkflowInputs {
 }
 ````
 
+## PublishedFunctionInputs (interface)
+
+````ts
+/**
+ * A published Orchestrator **Function** — a small, single-purpose unit of code
+ * deployed as its own resource and invoked as one step
+ * (`Orchestrator.ExecuteFunctionAsync`). Same published-resource shape as
+ * `ApiWorkflowInputs`; what differs is the family and the folder.
+ */
+export interface PublishedFunctionInputs {
+    /**
+     * The function's key (a GUID) — it becomes part of the node's type,
+     * `uipath.core.function.<key>`. Find it with
+     * `uip maestro flow registry search "uipath.core.function"` (after
+     * `registry pull --force`) or the Orchestrator process listing.
+     */
+    key: string;
+    /** The function's name in Orchestrator, e.g. `'acme-echo'`. */
+    name: string;
+    /**
+     * The Orchestrator folder holding it. A function is usually deployed into a
+     * folder of its OWN name (e.g. `'Shared/acme-echo'`), and the binding's
+     * `resourceKey` is `<folderPath>.<name>` — copy the folder from the tenant
+     * rather than assuming `'Shared'`.
+     */
+    folderPath: string;
+    /** The function's own input arguments, by its own names. */
+    inputs?: Record<string, unknown>;
+    /**
+     * The function's OUTPUT arguments — the fields it returns, and their types.
+     * Required if anything reads the step's output: the schema lives on the
+     * tenant and authoring is offline, so an undeclared read is rejected.
+     *
+     * @enforcedBy FUNCTION_READ_WITHOUT_RETURNS Reading a field off the result requires
+     *   declaring it here.
+     */
+    returns?: Record<string, 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array'>;
+}
+````
+
+## SendMessageInputs (interface)
+
+````ts
+export interface SendMessageInputs {
+    /**
+     * The conversation to post into — from the conversation trigger
+     * (`out('start', 'conversationId')`) or a context read. Required.
+     */
+    conversationId: string | Expr;
+    /**
+     * The exchange (one user turn plus its answers) the message belongs to —
+     * `out('<waitStep>', 'conversationContext.latestExchangeId')`, or the
+     * trigger's exchange for the first answer. Required by the node's schema.
+     */
+    exchangeId: string | Expr;
+    /** What to say. Markdown — the node's only supported `mimeType`. Required. */
+    content: string | Expr;
+    /**
+     * Whether this message CLOSES the exchange. The platform's legacy default is
+     * to end it; pass `false` to keep the exchange open for another message.
+     */
+    endExchange?: boolean;
+}
+````
+
+## WaitForMessageInputs (interface)
+
+````ts
+export interface WaitForMessageInputs {
+    /** The conversation to wait on. Required. */
+    conversationId: string | Expr;
+    /**
+     * How many past exchanges the returned context carries. 1–40 in the
+     * designer; the platform default is 20.
+     */
+    numExchanges?: number;
+}
+````
+
+## ConversationContextInputs (interface)
+
+````ts
+export interface ConversationContextInputs {
+    /** The conversation to read. Required. */
+    conversationId: string | Expr;
+    /** How many exchanges to return, 1–40. The platform default is 20. */
+    exchangeLimit?: number;
+}
+````
+
+## CreateOutgoingCallInputs (interface)
+
+````ts
+export interface CreateOutgoingCallInputs {
+    /**
+     * The number to call FROM — a provisioned number on the tenant's telephony
+     * provider, in E.164 (`'+15551234567'`). Required.
+     */
+    from: string | Expr;
+    /** The number to call, in E.164. Required. */
+    to: string | Expr;
+}
+````
+
+## EndCallInputs (interface)
+
+````ts
+export interface EndCallInputs {
+    /**
+     * The call to hang up — bind the `callContext` published by the incoming-call
+     * trigger (`out('start', 'callContext')`) or by `createOutgoingCall`
+     * (`out('<step>', 'callContext')`). Required.
+     */
+    callContext: Expr | string;
+}
+````
+
+## VoiceAgentInputs (interface)
+
+````ts
+export interface VoiceAgentInputs {
+    /**
+     * The agent's standing instructions — who it is on the call and what it must
+     * do. Written as plain text; a voice agent has no `{{input.…}}` templating,
+     * because its turn comes from the live call rather than from flow arguments.
+     */
+    systemPrompt: string;
+    /**
+     * The call to attach the agent to — the `callContext` from the incoming-call
+     * trigger or `createOutgoingCall`. Required: without it the agent has no
+     * audio channel to join.
+     */
+    callContext: Expr | string;
+    /** How the agent sounds. Omit for the platform default voice. */
+    voice?: VoiceSettings;
+    /**
+     * How many tool-calling rounds the agent may take in one turn. The node's
+     * schema allows **1–8** — a tighter ceiling than a text agent's, because a
+     * caller is waiting.
+     */
+    maxIterations?: number;
+    /**
+     * The agent's own directory name (a UUID) — the node carries it as `source`
+     * and the compiler writes `<source>/agent.json` beside the flow. Omit and one
+     * is derived from the flow id + step name, so a recompile is not a diff.
+     */
+    source?: string;
+}
+````
+
+## ConversationalAgentInputs (interface)
+
+````ts
+export interface ConversationalAgentInputs {
+    /**
+     * The agent's standing instructions for the conversation. Plain text — a
+     * conversational agent's turn comes from the transcript, not from flow
+     * arguments, so there is no `{{input.…}}` templating.
+     */
+    systemPrompt: string;
+    /** The MODEL to run, e.g. `'gpt-5.4'`. Required by the node's definition. */
+    model: string;
+    /**
+     * How the agent gets its turn. The common case is
+     * `{ context: out('<waitStep>', 'conversationContext') }` — one binding the
+     * platform reads conversation id, exchange id, history and user settings out
+     * of. See `ConversationalAgentSettings`.
+     */
+    settings: ConversationalAgentSettings;
+    /**
+     * Whether the agent's reply CLOSES the exchange. The platform's legacy
+     * default is to end it; pass `false` to keep it open for another turn.
+     */
+    endExchange?: boolean;
+    /** Sampling temperature, 0–1. */
+    temperature?: number;
+    /** Max tokens in one response. */
+    maxTokenPerResponse?: number;
+    /** The model's own context ceiling — informational. */
+    modelMaxTokens?: number;
+    /** How many tool-calling rounds one turn may take, 1–100. */
+    maxIterations?: number;
+    /** Safety rails, the same array `inlineAgent` takes. */
+    guardrails?: AgentGuardrail[];
+    /**
+     * The agent's own directory name (a UUID) — the node carries it as `source`
+     * and the compiler writes `<source>/agent.json` beside the flow. Derived from
+     * the flow id + step name when omitted.
+     */
+    source?: string;
+}
+````
+
 ## AgenticProcessInputs (type)
 
 ````ts
@@ -1127,6 +1421,12 @@ export interface InlineAgentInputs {
      * (its 1.2 definition already declares the input) and in the `agent.json`.
      */
     guardrails?: AgentGuardrail[];
+    /**
+     * Attach an episodic memory so the agent learns from past runs — one
+     * `AgentMemoryRef`, wired to the agent's `memory` handle (its 1.4
+     * definition; naming one selects it).
+     */
+    memory?: AgentMemoryRef;
     /**
      * GROUND the agent on tenant knowledge — one or more Context Grounding
      * (semantic) indexes, wired to the agent's own `context` handle.
@@ -1660,6 +1960,10 @@ export type TriggerSpec = {
     subscription: EventSubscription;
 } | {
     kind: 'form';
+} | {
+    kind: 'conversation';
+} | {
+    kind: 'voice';
 };
 ````
 
@@ -1728,6 +2032,30 @@ export type ActionSpec = {
 } | {
     kind: 'apiWorkflow';
     inputs: ApiWorkflowInputs;
+} | {
+    kind: 'publishedFunction';
+    inputs: PublishedFunctionInputs;
+} | {
+    kind: 'sendMessage';
+    inputs: SendMessageInputs;
+} | {
+    kind: 'waitForMessage';
+    inputs: WaitForMessageInputs;
+} | {
+    kind: 'conversationContext';
+    inputs: ConversationContextInputs;
+} | {
+    kind: 'createOutgoingCall';
+    inputs: CreateOutgoingCallInputs;
+} | {
+    kind: 'endCall';
+    inputs: EndCallInputs;
+} | {
+    kind: 'voiceAgent';
+    inputs: VoiceAgentInputs;
+} | {
+    kind: 'conversationalAgent';
+    inputs: ConversationalAgentInputs;
 } | {
     kind: 'agenticProcess';
     inputs: AgenticProcessInputs;
@@ -1963,6 +2291,37 @@ export interface OutputColumn {
 }
 ````
 
+## VoiceSettings (interface)
+
+````ts
+export interface VoiceSettings {
+    model?: string;
+    persona?: string;
+    temperature?: number;
+    maxTokens?: number;
+    modelMaxTokens?: number;
+}
+````
+
+## ConversationalAgentSettings (interface)
+
+````ts
+export interface ConversationalAgentSettings {
+    mode?: 'simple' | 'custom';
+    context?: Expr | string;
+    conversationId?: Expr | string;
+    exchangeId?: Expr | string;
+    messages?: Expr | string;
+    userSettings?: Expr | string;
+}
+````
+
+## AgentGuardrail (type)
+
+````ts
+export type AgentGuardrail = CustomGuardrail | BuiltInValidatorGuardrail;
+````
+
 ## AgenticProcessCompletion (type)
 
 ````ts
@@ -2019,10 +2378,19 @@ export type AgentFlavour = 'coded' | 'lowcode';
 export type InlineAgentFieldType = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array';
 ````
 
-## AgentGuardrail (type)
+## AgentMemoryRef (interface)
 
 ````ts
-export type AgentGuardrail = CustomGuardrail | BuiltInValidatorGuardrail;
+export interface AgentMemoryRef {
+    name: string;
+    id: string;
+    description?: string;
+    folderKey?: string;
+    dynamicFewShotLearning?: boolean;
+    semanticSimilarity?: number;
+    kValue?: number;
+    searchMode?: 'hybrid' | 'semantic';
+}
 ````
 
 ## ContextIndexRef (interface)
@@ -2044,7 +2412,7 @@ export interface ContextIndexRef {
 ## ToolRef (type)
 
 ````ts
-export type ToolRef = BuiltinToolRef | ConnectorToolRef | ProcessToolRef | IxpToolRef;
+export type ToolRef = BuiltinToolRef | ConnectorToolRef | ProcessToolRef | IxpToolRef | McpToolRef | RemoteA2aToolRef | ClientSideToolRef | HttpRequestToolRef;
 ````
 
 ## EscalationRef (interface)
@@ -2053,7 +2421,9 @@ export type ToolRef = BuiltinToolRef | ConnectorToolRef | ProcessToolRef | IxpTo
 export interface EscalationRef {
     name: string;
     description?: string;
-    app: {
+    variant?: 'quick-form';
+    fields?: FormField[];
+    app?: {
             /** The app's key (a GUID) — from the app's URL or `uip` app listings. */
             key: string;
             /** The app's name, e.g. `'ContentReviewApp'`. */
@@ -2502,6 +2872,74 @@ export interface IxpToolRef {
 }
 ````
 
+## McpToolRef (interface)
+
+````ts
+export interface McpToolRef {
+    kind: 'mcp';
+    name: string;
+    key: string;
+    description?: string;
+    folderPath?: string;
+    folderKey?: string;
+    mcpType?: string;
+    serviceName?: string;
+    slug?: string;
+    selectedTools?: unknown[];
+}
+````
+
+## RemoteA2aToolRef (interface)
+
+````ts
+export interface RemoteA2aToolRef {
+    kind: 'a2a';
+    name: string;
+    key: string;
+    slug: string;
+    description?: string;
+    cachedAgentCard?: Record<string, unknown> | null;
+    resourceType?: string | null;
+    folderPath?: string;
+    folderKey?: string;
+    resourceFolderPath?: string;
+}
+````
+
+## ClientSideToolRef (interface)
+
+````ts
+export interface ClientSideToolRef {
+    kind: 'clientside';
+    name: string;
+    description?: string;
+    inputs?: Record<string, InlineAgentFieldType>;
+    returns?: Record<string, InlineAgentFieldType>;
+}
+````
+
+## HttpRequestToolRef (interface)
+
+````ts
+export interface HttpRequestToolRef {
+    kind: 'httpRequest';
+    name?: string;
+    description?: string;
+    url?: string;
+    method?: string;
+    headers?: Array<{
+            name: string;
+            value: string;
+        }>;
+    params?: Array<{
+            name: string;
+            value: string;
+        }>;
+    body?: string;
+    timeout?: number;
+}
+````
+
 ## SwitchArm (interface)
 
 ````ts
@@ -2593,7 +3031,7 @@ export type BuiltinToolName = 'analyzefiles' | 'summarize' | 'batchtransform';
 ## ProcessToolKind (type)
 
 ````ts
-export type ProcessToolKind = 'process' | 'agent' | 'api' | 'flow' | 'maestro';
+export type ProcessToolKind = 'process' | 'agent' | 'api' | 'flow' | 'maestro' | 'function';
 ````
 
 ## GuardrailScope (type)

--- a/preview/uipath-maestro-flow/references/brownfield.md
+++ b/preview/uipath-maestro-flow/references/brownfield.md
@@ -20,10 +20,39 @@ layout.
 
 Decompile reconstructs branch, switch, loop, parallel, error/ref, and
 subflow structure. It preserves original node ids so merge can reattach them.
-If it emits `mock() /* TODO: unsupported node type … */`, leave that node
-untouched unless the task specifically asks you to replace it; merge restores
-the original unsupported node.
+Every family the SDK can AUTHOR is reconstructed through its own factory —
+including human tasks, agents and their attached resources, the published
+resource families, queue items, the AI patterns, document steps, conversational
+and voice steps, and connector event subscriptions. A recovered agent keeps its
+`source` uuid, so its `agent.json` sidecar still resolves.
+
+A `mock() /* TODO: unsupported node type … */` therefore means the node is one
+the SDK does not author at all — a hand-written node, a newer platform family,
+or a UI-only one such as a sticky note. Leave it untouched unless the task
+specifically asks you to replace it; merge restores the original node.
 
 Validate `Deployed.merged.flow`, not the intermediate edited compile. The
 decompiler also emits `Deployed.pipeline.mjs`, which chains the same four
 steps when a single command is more convenient.
+
+## Split (`$ref`) artifacts
+
+A deployed `.flow` may be SPLIT across sibling files with JSON Reference —
+`"definitions": { "$ref": "./definitions.json" }`, or the same for layout or an
+extracted subflow. Decompile resolves those into one model as it reads the file:
+point it at the main file and nothing else is needed. Do NOT inline the sidecar
+by hand first, and do not edit either file to "prepare" it — the recovered source
+is identical either way.
+
+Only relative paths resolve. An absolute path, a Windows drive letter, a
+protocol URI (`https://…`, `file:///…`) or a traversal above the referencing
+file's root is refused by design: a `.flow` is untrusted input, and the
+alternative is a way to read arbitrary files. A same-document pointer
+(`{"$ref": "#/definitions/…"}`) is left alone — those are legitimate internal
+JSON-Schema pointers, not file references. A missing or unreadable target is an
+error naming the file, not a silent gap.
+
+Compile always writes ONE file. Write-through splitting is deliberately not
+supported: nothing in the designer or the skills splits files today, so there is
+no producer to round-trip against. Expect the recompiled artifact to carry the
+sidecar's content inline, and no `$ref` — that is correct, not drift.

--- a/preview/uipath-maestro-flow/references/conversational.md
+++ b/preview/uipath-maestro-flow/references/conversational.md
@@ -1,0 +1,77 @@
+# Conversational
+
+*Exact signatures, fields, and defaults: [`conversationTrigger()`](api.md#conversationtrigger-function), [`waitForMessage()`](api.md#waitformessage-function), [`sendMessage()`](api.md#sendmessage-function), [`conversationContext()`](api.md#conversationcontext-function), [`conversationalAgent()`](api.md#conversationalagent-function).*
+
+A chat-driven flow. A person opens a conversation; the flow waits for their
+message, answers it, and can post messages of its own. Every step is keyed by a
+`conversationId`, which the conversation TRIGGER publishes as
+`out('start', 'conversationId')`.
+
+```ts
+export default flow('support-chat')
+  .trigger(conversationTrigger())
+  .step('listen', waitForMessage({ conversationId: out('start', 'conversationId') }))
+  .step('reply', conversationalAgent({
+    model: 'gpt-5.4',
+    systemPrompt: 'You are a support agent. Be brief.',
+    settings: { context: out('listen', 'conversationContext') },
+  }))
+  .step('closing', sendMessage({
+    conversationId: out('start', 'conversationId'),
+    exchangeId: out('listen', 'conversationContext.latestExchangeId'),
+    content: 'Anything else I can help with?',
+  }))
+  .build();
+```
+
+## Conversations, exchanges, and messages
+
+Three nested things, and the field names follow them:
+
+- a **conversation** is the whole thread (`conversationId`);
+- an **exchange** is one user turn plus the answers to it (`exchangeId`);
+- a **message** is one utterance inside an exchange.
+
+`waitForMessage` returns the conversation CONTEXT, so the exchange to answer is
+a path inside it: `out('<waitStep>', 'conversationContext.latestExchangeId')`,
+and the transcript is `…conversationContext.messages`. (`out(step, path)`
+already inserts `.output` — do not write it again.)
+
+## Waiting versus reading
+
+`waitForMessage` **suspends** the flow — it is a `bpmn:IntermediateCatchEvent`
+on `Maestro.ReceiveMessageEvent`, the same mechanism as `waitForEvent`, so the
+run parks until the person speaks. `conversationContext` does NOT wait: it reads
+the transcript so far and continues. Reach for the first when the flow's next
+step depends on what the person says next, the second when it only needs
+history. Both cap how much history they return (`numExchanges` /
+`exchangeLimit`, 1–40, platform default 20).
+
+## Saying something: agent or flow
+
+`sendMessage` posts a message the FLOW composed — the role is always
+`assistant` and the content is Markdown (the node's only supported type), so
+neither is authored. `conversationalAgent` posts what a MODEL composed, reading
+the turn from `settings`:
+
+- `'simple'` mode (the default) takes ONE binding, `context`, and the platform
+  derives the conversation id, exchange id, transcript and user settings from
+  it. This is what you want almost always.
+- `'custom'` mode binds each field yourself, for a turn assembled from more
+  than one source; `conversationId` is then required.
+
+Either way the four derived fields are what the runtime reads — the platform's
+own editor calls them the source of truth and its validator rejects a node
+without `conversationId`, so the SDK emits them from your `context` binding
+rather than leaving them out. The agent's reply is
+`out('<step>', 'uipath__agent_response_messages')`, and compile writes a stable
+`<source>/agent.json` sidecar beside the `.flow` as it does for `inlineAgent`.
+
+## Evidence boundary
+
+The whole family is `AvailableOnTenant: false` today — the definitions are
+bundled from the workbench manifests, so a flow compiles and `validate`s
+offline, but nothing local starts a conversation or delivers a message. A green
+ladder proves the node types, the conversation/exchange wiring and the derived
+turn settings. A real thread, a real reply, and the agent's answer quality are
+platform evidence.

--- a/preview/uipath-maestro-flow/references/data-fabric.md
+++ b/preview/uipath-maestro-flow/references/data-fabric.md
@@ -1,0 +1,42 @@
+# Data Fabric
+
+*Exact signatures, fields, and defaults: [`dataFabricRead()`](api.md#datafabricread-function) and [`dataFabricUpdate()`](api.md#datafabricupdate-function).*
+
+Read entity records with filters (`core.datafabric.read`) and write fields back
+to one record (`core.datafabric.update`).
+
+Signatures: `dataFabricRead({ entity, filters? })`;
+`dataFabricUpdate({ entity, record, set })`.
+
+```ts
+.step('lookup', dataFabricRead({ entity: 'Invoices',
+  filters: [
+    { field: 'InvoiceId', value: input('invoiceId') },
+    { field: 'Status', operator: '!=', value: 'Paid', or: true },
+  ] }))
+.step('markPaid', dataFabricUpdate({ entity: 'Invoices',
+  record: { fromRead: 'lookup' },
+  set: { Status: 'Paid', PaidBy: js`$vars.lookup.output.Approver` } }))
+```
+
+## Filters and targeting
+
+A filter row is `{ field, operator?, value, or? }` — `operator` defaults to
+`'='`; `or: true` joins that row to the previous with OR instead of AND.
+Values may be literals or expressions.
+
+`record` names the target row and takes exactly ONE of:
+
+- `{ byId: '<record id>' }` — a known record id, literal or expression;
+- `{ fromRead: '<step name>' }` — the record a preceding `dataFabricRead`
+  step returned. `check` rejects a `fromRead` that names no read step.
+
+`set` maps field names to new values (literals or expressions); an empty `set`
+is rejected — the node would write nothing.
+
+## Evidence boundary
+
+The entity name and field names are tenant data — copy them from the scenario
+or the tenant, never invent them. No local rung reads a real entity: offline
+`validate` proves the emitted `entityConfig` shape (entity, filter rows,
+record targeting, field updates); actual reads and writes are platform-side.

--- a/preview/uipath-maestro-flow/references/delay.md
+++ b/preview/uipath-maestro-flow/references/delay.md
@@ -4,15 +4,19 @@
 
 Delay pauses the current path for a duration.
 
-Signature: `delay({ duration: string })`.
+Signature: `delay({ duration: string })` or `delay({ until: string })` —
+exactly one of the two arms.
 
 ```ts
 .step('cooldown', delay({ duration: 'PT30S' }))
+.step('embargo', delay({ until: '2026-09-01T09:00:00Z' }))
 .step('resumedAt', script({ code: 'return new Date().toISOString();' }))
 ```
 
 When the scenario needs a resume timestamp, compute it after the wait as shown.
-The surface exposes relative durations, not an absolute-date wait.
+`until` is an ISO-8601 date-time and emits the node's absolute-date arm
+(`timerType: 'timeDate'`); an `until` in the past resumes immediately at run
+time, so compute future dates from the scenario, not from authoring day.
 
 Normal replay may skip real elapsed time. When timing is itself part of the
 requirement, use the real-time wait rung with a deliberately short fixture

--- a/preview/uipath-maestro-flow/references/document-pipeline.md
+++ b/preview/uipath-maestro-flow/references/document-pipeline.md
@@ -1,0 +1,47 @@
+# Document classify and Dynamic Extract
+
+*Exact signatures, fields, and defaults: [`documentClassify()`](api.md#documentclassify-function) and [`dynamicExtract()`](api.md#dynamicextract-function).*
+
+Two document steps that need no published IxP project: classification
+(`uipath.document.classify`) labels a document, and Dynamic Extract
+(`uipath.ixp.extract-document-builder`) pulls fields against a schema you
+author INLINE. For a published project's trained fields, use `ixpExtract`
+([ixp.md](ixp.md)) instead.
+
+Signatures: `documentClassify({ fileRef, pageRange?, splitPages?, modelConfig? })`;
+`dynamicExtract({ fileRef, schema, model, pageRange?, modelConfig? })`.
+
+```ts
+.input({ file: types.file })
+.step('classify', documentClassify({ fileRef: input('file'), splitPages: true }))
+.step('extract', dynamicExtract({
+  fileRef: input('file'),
+  schema: { type: 'object', properties: {
+    invoiceTotal: { type: 'string', description: 'Grand total' } } },
+  model: { modelName: 'invoiceixp-cef0d447-ixp',
+    folderKey: 'c4359cde-55f0-4f0e-9322-c6cdce74ab4c' },
+}))
+.step('total', script({ code: 'return $vars.extract.output.ExtractionResult;' }))
+```
+
+## The model identity
+
+Dynamic Extract authors its SCHEMA inline, but execution still runs against a
+model deployment: `model.modelName` and `model.folderKey` are REQUIRED (the
+platform validator rejects the node without them), with optional `projectId`,
+`projectName`, `folderName`, and `versionTag`. Copy them from the tenant —
+never construct them.
+
+## Schema and outputs
+
+`schema` is a JSON-Schema object (`type: 'object'` with `properties`, each
+usually carrying a `description` the model reads). It is emitted as the node's
+`schemaDocument`. Classification lands at `out('classify', ...)`; extraction
+results at `out('extract', 'ExtractionResult')`.
+
+## Evidence boundary
+
+Both calls hit real document-understanding services — no local rung runs a
+model. Offline `validate` proves the emitted shape (fileRef wiring, schema,
+model identity, the classify `success` port); classification quality and
+extraction values are platform evidence.

--- a/preview/uipath-maestro-flow/references/form-trigger.md
+++ b/preview/uipath-maestro-flow/references/form-trigger.md
@@ -1,0 +1,41 @@
+# Form trigger
+
+*Exact signatures, fields, and defaults: [`formTrigger()`](api.md#formtrigger-function).*
+
+A person starts the flow by submitting a form (`core.trigger.form`). The
+submitted values ARE the flow's inputs — read them exactly like any other
+input (`input('name')` / `$vars.start.output.name`).
+
+Signature: `.trigger(formTrigger())` — the factory takes no arguments.
+
+```ts
+export default flow('expense-request')
+  .input({
+    invoiceAmount: types.number,
+    reason: types.string,
+    urgent: { type: types.boolean, default: false },
+  })
+  .trigger(formTrigger())
+  .step('assess', script({ code: 'return $vars.start.output.invoiceAmount > 500;' }))
+  .return({})
+  .build();
+```
+
+## The derived schema
+
+The form's fields are derived from `.input()` at compile time, the same rule
+the designer applies to a flow's arguments: one field per input, the field id
+IS the input's name (so submitted values line up by name), the label is the
+name sentence-cased (`invoiceAmount` → "Invoice amount"), the field type
+follows the input's type, and a field is **required exactly when its input
+declares no default**. There is nothing to author on the trigger itself —
+shape the form by shaping the inputs.
+
+`check` warns (`FORM_TRIGGER_NO_INPUTS`) when the flow declares no inputs: the
+person would get an empty form with only a submit button.
+
+## Evidence boundary
+
+No local rung renders a form — `--input` supplies the values locally, so a
+green ladder proves the trigger type, the derived schema, and that the graph
+runs. A person actually seeing and submitting the form is platform evidence.

--- a/preview/uipath-maestro-flow/references/hitl.md
+++ b/preview/uipath-maestro-flow/references/hitl.md
@@ -3,10 +3,12 @@
 *Exact signatures, fields, and defaults: [`hitl()`](api.md#hitl-function).*
 
 Pause a Flow for a person using the default inline form, the quick-form node
-type, or a deployed Action App.
+type, a deployed Action App, or a document-validation station.
 
 Signature:
-`hitl({ variant?: 'quick-form' | 'action-app', app?, title?, priority?, fields?, outcomes })`.
+`hitl({ variant?: 'quick-form' | 'action-app' | 'document-validation', app?,
+document?, title?, priority?, labels?, recipient?, fields?, outcomes,
+outcomePorts?, exposeError? })`.
 
 ```ts
 .step('review', hitl({ title: 'Review invoice',
@@ -16,6 +18,27 @@ Signature:
   { value: 'Approve', body: (b) => b.return({ status: 'approved' }) },
 ], (other) => other.return({ status: 'rejected' }))
 ```
+
+## Delivery, fields, and routing
+
+- `recipient` is `{ channels?, assignee: { type, value? }, connections? }` —
+  channels are `'Slack' | 'teams' | 'Email' | 'ActionCenter'` (Teams really is
+  the lowercase `'teams'`); assignee types are `user`, `group`, `staticEmail`,
+  `staticGroupName`, `workload`, `roundRobin`, `custom`. Omit the whole object
+  for the platform default (Email + Action Center, assigned to a group).
+- `labels` is one comma-separated string, shown in Action Center.
+- A field's `direction` is `'input'` (shown), `'output'` (asked), or `'inOut'`
+  (pre-filled AND editable — give it a `value`; the reviewed value comes back
+  at the field's own id).
+- `outcomePorts: true` gives each outcome its own exit, `outcome-<slug>` (the
+  name lowercased, non-alphanumerics to `-`). The FIRST outcome continues the
+  main path; route the others with `.stepToList('outcome-<slug>', …)`. Base
+  variant only. `exposeError: true` additionally exposes
+  `out('<step>', 'error')` and implies outcome-port routing.
+- `variant: 'document-validation'` takes `document: { extractionResult,
+  storageBucket?, documentId?, render?, taxonomy? }` and no `fields`; bind
+  `extractionResult` to the upstream extract step's `ExtractionResult`.
+  `render: 'custom'` requires `taxonomy` (and takes `app`).
 
 ## Variant judgment
 

--- a/preview/uipath-maestro-flow/references/http.md
+++ b/preview/uipath-maestro-flow/references/http.md
@@ -37,6 +37,16 @@ the task's named evidence mode and use live debug for product response shape.
 The definitions default `timeout` to `PT15M` and `retryCount` to `0`. Override
 them only when the scenario calls for different operational behavior.
 
+## Response branches
+
+`branches: [{ name, condition }]` declares extra exits evaluated against the
+response — each becomes a `branch-<name>` source port routed with
+`.stepToList('branch-<name>', …)`, while the main path continues from the
+default port. Conditions are expressions (e.g.
+``js`$vars.fetch.output.statusCode === 429` ``), typically reading the step's
+own declared `returns`. Names must be unique and constant conditions are
+rejected by `check`.
+
 ## Evidence
 
 An offline replay proves the graph and chosen response shape. A live request is

--- a/preview/uipath-maestro-flow/references/inline-agent.md
+++ b/preview/uipath-maestro-flow/references/inline-agent.md
@@ -6,7 +6,7 @@ An inline agent is defined inside this Flow project and may be connected to
 tenant context, callable tools, and human escalation resources.
 
 Signature:
-`inlineAgent({ model, systemPrompt, userPrompt, inputs?, returns?, source?, temperature?, maxTokenPerResponse?, modelMaxTokens?, maxIterations?, context?, tools?, escalation? })`.
+`inlineAgent({ model, systemPrompt, userPrompt, inputs?, returns?, source?, temperature?, maxTokenPerResponse?, modelMaxTokens?, maxIterations?, mode?, guardrails?, context?, tools?, escalation? })`.
 
 ```ts
 .step('triage', inlineAgent({ model: 'gpt-5.4',
@@ -83,3 +83,19 @@ the evidence for the actual configured model and cloud resources.
 Compile emits the node plus a stable `<source>/agent.json` sidecar. Prompt variables
 use `{{input.<name>}}`; `inputs` binds those names to flow references and `returns`
 declares what the agent hands back.
+
+## Guardrails and harness mode
+
+`guardrails` is Agent Builder's own array, carried on the node and in the
+sidecar. Each rail is `$guardrailType: 'custom'` (with `rules`) or
+`'builtInValidator'` (with `validatorType` + `validatorParameters`), plus
+`id`, `name`, `selector: { scopes: ['Agent'|'Llm'|'Tool'] }`, an `action`
+(`block` with a reason, `filter` over fields, or `log` with a severity), and
+`enabledForEvals`. Custom rules are `$ruleType: 'word' | 'number' | 'boolean'`
+over a field selector, or `'always'`. A rail with no scopes or an empty rules
+array can never fire — `check` rejects both.
+
+`mode: 'standard' | 'advanced'` picks the harness; naming it selects the
+node's 1.3 definition (omitting it keeps 1.2 byte-identically) and lands on
+the sidecar's `settings.mode`. Guardrail/harness behavior is runtime-side:
+offline rungs prove the emitted shape only.

--- a/preview/uipath-maestro-flow/references/published-function.md
+++ b/preview/uipath-maestro-flow/references/published-function.md
@@ -1,0 +1,66 @@
+# Published function
+
+*Exact signatures, fields, and defaults: [`publishedFunction()`](api.md#publishedfunction-function).*
+
+A **Function** is a small, single-purpose unit of code deployed to Orchestrator
+as its own resource. `publishedFunction()` invokes one as a single step
+(`uipath.core.function.<key>`, dispatched as
+`Orchestrator.ExecuteFunctionAsync`).
+
+Signature: `publishedFunction({ key, name, folderPath, inputs?, returns? })`.
+
+```ts
+.step('echo', publishedFunction({
+  key: '7059bdb5-fdd7-4e13-9d7b-1748aaeb129d',
+  name: 'acme-echo',
+  folderPath: 'Shared/acme-echo',
+  inputs: { message: input('message') },
+  returns: { echoed: 'string' },
+}))
+.step('relay', script({ code: 'return $vars.echo.output.echoed;' }))
+```
+
+## Identity
+
+Three fields, none of them derivable:
+
+- **`key`** — the function's GUID; it becomes the node type's suffix, so a wrong
+  one emits a node the tenant cannot resolve. Find it with
+  `uip maestro flow registry search "uipath.core.function"` (after
+  `registry pull --force`, since registry reads are cached).
+- **`name`** — the function's own name in Orchestrator.
+- **`folderPath`** — the folder it is deployed in. **A function is usually
+  deployed into a folder of its OWN name** (`'Shared/acme-echo'`, not
+  `'Shared'`). The binding's `resourceKey` is `<folderPath>.<name>`, so
+  assuming `'Shared'` points the dispatch at nothing while still validating.
+
+Two steps on the same function share ONE binding pair, exactly as the other
+published families do.
+
+## Declaring what it returns
+
+`returns` is required if anything reads the step's output. The function's real
+output arguments live on the tenant and authoring is offline, so an undeclared
+read is rejected (`FUNCTION_READ_WITHOUT_RETURNS`) — nothing here could tell a
+real field from a typo. `registry get uipath.core.function.<key>` shows what the
+platform synthesizes for a deployed one.
+
+## Which family to reach for
+
+| The deployed thing | Factory |
+| --- | --- |
+| A Function (a unit of code, its own resource) | `publishedFunction()` |
+| A coded API workflow | `apiWorkflow()` |
+| An RPA process | `rpaWorkflow()` |
+| A Maestro process orchestration | `agenticProcess()` |
+
+They share one emit path and differ only in service type and binding subtype, so
+picking the wrong one produces a flow that validates and dispatches nothing.
+Match the family the scenario names.
+
+## Evidence boundary
+
+Offline `validate` proves the node type, the binding pair and the declared
+output schema. That the function exists, accepts those arguments, and returns
+those fields is platform evidence — `.onError(...)` is supported for the
+dispatch failing.

--- a/preview/uipath-maestro-flow/references/scheduled-trigger.md
+++ b/preview/uipath-maestro-flow/references/scheduled-trigger.md
@@ -27,4 +27,8 @@ emitted with the authored interval and that the downstream graph runs; it does
 not prove the platform scheduler fired. The scheduling claim requires a
 deployed run observed at the requested cadence.
 
-`every` is an ISO-8601 repeating interval: `R/PT30M`, `R/PT1H`, `R/P1W`.
+`every` is an ISO-8601 repeating interval (`R/PT30M`, `R/PT1H`, `R/P1W`) or a
+Quartz cron expression (`0 0 2 * * ?`, `0 30 9 ? * MON-FRI`). A cron `every`
+selects the trigger's 1.2 definition automatically and emits `timerValue`; an
+ISO interval stays on 1.1 byte-identically. Pinning `{ version: '1.1' }` with a
+cron expression is a compile error.

--- a/preview/uipath-maestro-flow/references/voice.md
+++ b/preview/uipath-maestro-flow/references/voice.md
@@ -1,0 +1,63 @@
+# Voice
+
+*Exact signatures, fields, and defaults: [`voiceTrigger()`](api.md#voicetrigger-function), [`createOutgoingCall()`](api.md#createoutgoingcall-function), [`endCall()`](api.md#endcall-function), [`voiceAgent()`](api.md#voiceagent-function).*
+
+A voice call is a conversation with an audio front end. It is identified by a
+`callContext` OBJECT — not a bare conversation id — and that object is what
+every voice step is keyed by.
+
+```ts
+// Inbound: the platform hands you the call.
+export default flow('support-line')
+  .trigger(voiceTrigger())
+  .step('greet', voiceAgent({
+    systemPrompt: 'Greet the caller and find out why they called.',
+    callContext: out('start', 'callContext'),
+    voice: { model: 'gemini-3.1-flash-live-preview', persona: 'Kore' },
+  }))
+  .step('hangUp', endCall({ callContext: out('start', 'callContext') }))
+  .build();
+
+// Outbound: the flow places the call.
+.step('dial', createOutgoingCall({ from: '+15550001111', to: input('customerPhone') }))
+.step('talk', voiceAgent({ systemPrompt: '…', callContext: out('dial', 'callContext') }))
+```
+
+## The call context
+
+`out('start', 'callContext')` (inbound) or `out('<dialStep>', 'callContext')`
+(outbound) is the whole object — `{ type, id, conversationId, … }` — and that is
+what to pass. **Reaching inside it is the mistake this family invites**:
+`out('dial', 'callContext.conversationId')` is a string, the node's schema types
+the field as `object`, and a scalar there passes the file's schema and then
+fails at dispatch. `check` catches it (`VOICE_CALL_CONTEXT_NOT_OBJECT`).
+
+Both numbers on `createOutgoingCall` are E.164 — a leading `+` and 7–15 digits
+(`'+15551234567'`). `from` must be a number provisioned on the tenant's
+telephony provider; anything else is rejected when the call is placed, not when
+the flow is validated. `endCall` reads `out('<step>', 'ended')`.
+
+## How the agent sounds
+
+`voice` takes a VOICE model (a live/realtime one — not the text models
+`inlineAgent` takes) and one of THAT model's personas; the two travel together:
+
+| Model | Personas |
+| --- | --- |
+| `gemini-3.1-flash-live-preview` (default) | Aoede, Charon, Fenrir, Kore, Leda, Orus, Puck, Zephyr |
+| `gpt-realtime-2` | alloy, ash, ballad, coral, echo, sage, shimmer, verse |
+
+Omit `voice` entirely for the platform default. `maxIterations` is capped at
+**8**, tighter than a text agent's 100, because a caller is waiting on the turn.
+There is no prompt templating and no declared `returns`: the turn arrives as
+audio and the definition declares what comes back. Compile writes a
+voice-dialect `<source>/agent.json` sidecar (`settings.mode: 'voice'`) beside
+the `.flow`.
+
+## Evidence boundary
+
+`uipath.agent.voice` is served on this tenant; the trigger and the two call
+actions are `AvailableOnTenant: false` and ship bundled from the workbench
+manifests. Nothing local dials a phone: a green ladder proves the node types,
+the call-context threading and the voice settings. A real call, real audio, and
+what the caller heard are platform evidence.


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `41938ba` to current `UiPath/flow-builder-sdk@main` (`49520ad`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)