### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@32331e4

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ ddf9da1. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ 32331e4. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ ddf9da1. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ 32331e4. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ ddf9da1. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ 32331e4. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
@@ -97,7 +97,7 @@ under `examples/` resolve inside this skill folder.
 | Filter | `core.action.transform.filter` | `transform({ variant: 'filter', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Map | `core.action.transform.map` | `transform({ variant: 'map', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
 | Group by | `core.action.transform.group-by` | `transform({ variant: 'group-by', ... })` | [Transform](#transform) | [transform.md](references/transform.md) | `examples/TrailLogSummary.flow.ts` |
-| Integration Service action | `uipath.connector.<key>.<action>` | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
+| Integration Service action | `uipath.connector.<key>.<action>` (Data Service: `uipath.connector.uipath-uipath-dataservice.*`) | `connector(...)` | [Integration Service connectors](#integration-service-connectors) | [connector-params.md](references/connector-params.md) | `examples/ClubDirectory.flow.ts` |
 | Subflow | `core.subflow` | `subflow(...)` | [Subflow](#subflow) | [subflow.md](references/subflow.md) | `examples/RecipeScaler.flow.ts` |
 | Human task | `uipath.human-in-the-loop` | `hitl(...)` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/GallerySubmission.flow.ts` |
 | Human quick form | `uipath.human-in-the-loop.quick-form` | `hitl({ variant: 'quick-form', ... })` | [Human task](#human-task) | [hitl.md](references/hitl.md) | `examples/FieldTripQuickForm.flow.ts` |
@@ -455,8 +455,9 @@ Check tenant uniqueness/schema settings; wait only when a consumer exists and it
 
 ## Data Fabric
 
-Read and update Data Fabric entity records (`core.datafabric.read` / `.update`).
-
+Use native Data Fabric nodes only when the scenario names Data Fabric
+(`core.datafabric.read` / `.update`). “Data Service” instead names the
+`uipath-uipath-dataservice` connector; route it to `connector(...)`.
 Signatures: `dataFabricRead({ entity, filters? })` and
 `dataFabricUpdate({ entity, record, set })` — `record` is exactly one of
 `{ byId }` or `{ fromRead: '<read step name>' }`.
@@ -698,7 +699,8 @@ Signatures: `connector(descriptor, inputs, opts?)`;
   { connection: 'jira', folder: 'shared' }))
 ```
 
-Discover tenant-specific fields and ids rather than guessing; preserve every scenario-named input.
+Data Service uses connector key `uipath-uipath-dataservice`; never substitute
+`dataFabricRead`. Discover tenant-specific fields and ids; preserve every scenario-named input.
 
 **Reference: [`references/connector-params.md`](references/connector-params.md)**
 

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -4,6 +4,11 @@
 
 Call a curated or generic Integration Service operation.
 
+**Data Service is an Integration Service connector, not Data Fabric.** For a
+task that names a Data Service entity, use connector key
+`uipath-uipath-dataservice` (for example, action `query-entity-records`) and
+never replace it with `dataFabricRead()` / `core.datafabric.read`.
+
 Signatures:
 
 - `connector(descriptor, inputs, opts?)`

--- a/preview/uipath-maestro-flow/references/data-fabric.md
+++ b/preview/uipath-maestro-flow/references/data-fabric.md
@@ -2,6 +2,13 @@
 
 *Exact signatures, fields, and defaults: [`dataFabricRead()`](api.md#datafabricread-function) and [`dataFabricUpdate()`](api.md#datafabricupdate-function).*
 
+Data Fabric and Data Service are different authoring surfaces. Use this native
+node family only when the scenario says **Data Fabric**. A **Data Service**
+entity is reached through the Integration Service connector key
+`uipath-uipath-dataservice`; follow
+[`connector-params.md`](connector-params.md) and do not substitute
+`dataFabricRead()` for that request.
+
 Read entity records with filters (`core.datafabric.read`) and write fields back
 to one record (`core.datafabric.update`).
 

--- a/scripts/sync-maestro-sdk-preview.mjs
+++ b/scripts/sync-maestro-sdk-preview.mjs
@@ -267,16 +267,23 @@ function mergeMapping({ skillsRoot, upstreamRoot, oldPin, newCommit, mapping }) 
   const base = gitShow(upstreamRoot, oldPin, mapping.source);
   const theirs = gitShow(upstreamRoot, newCommit, mapping.source);
   const ours = fs.existsSync(targetPath) ? fs.readFileSync(targetPath) : null;
+  const adapt = snapshotAdaptationFor(mapping.target);
+  const snapshotBase = base === null || !adapt
+    ? base
+    : Buffer.from(adapt(base.toString('utf8')));
+  const snapshotTheirs = theirs === null || !adapt
+    ? theirs
+    : Buffer.from(adapt(theirs.toString('utf8')));
 
   if (base === null && theirs === null) return false;
   if (base === null) {
-    if (ours === null) return writeIfChanged(targetPath, theirs);
-    if (ours.equals(theirs)) return false;
+    if (ours === null) return writeIfChanged(targetPath, snapshotTheirs);
+    if (ours.equals(snapshotTheirs)) return false;
     fail(`Add/add conflict for ${mapping.target} from ${mapping.source}`);
   }
   if (theirs === null) {
     if (ours === null) return false;
-    if (!ours.equals(base)) {
+    if (!ours.equals(snapshotBase)) {
       fail(`Modify/delete conflict for ${mapping.target} from ${mapping.source}`);
     }
     fs.unlinkSync(targetPath);
@@ -286,7 +293,7 @@ function mergeMapping({ skillsRoot, upstreamRoot, oldPin, newCommit, mapping }) 
     fail(`Snapshot deleted ${mapping.target} while upstream still contains ${mapping.source}`);
   }
 
-  const merged = mergeBuffers(ours, base, theirs, {
+  const merged = mergeBuffers(ours, snapshotBase, snapshotTheirs, {
     ours: `${mapping.target} (snapshot)`,
     base: `${mapping.source}@${oldPin}`,
     theirs: `${mapping.source}@${newCommit.slice(0, 7)}`,
@@ -345,6 +352,18 @@ export function adaptCaseExample(text) {
   return text.replaceAll('example/case-bindings.json', 'examples/bindings.json');
 }
 
+const snapshotAdaptations = new Map([
+  ['preview/uipath-maestro-flow/SKILL.md', adaptFlowSkill],
+  ['preview/uipath-maestro-case/SKILL.md', adaptCaseSkill],
+  ['preview/uipath-maestro-bpmn/SKILL.md', adaptBpmnSkill],
+  ['preview/uipath-maestro-flow/references/api.md', adaptFlowApi],
+  ['preview/uipath-maestro-case/examples/NotifyOnApproval.case.ts', adaptCaseExample],
+]);
+
+function snapshotAdaptationFor(target) {
+  return snapshotAdaptations.get(target);
+}
+
 function updateProvenance(text, source, newPin, target) {
   const escapedSource = source.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const pattern = new RegExp(`(\`${escapedSource}\` @ )[0-9a-f]{7,40}(\\. Canonical source)`, 'g');
@@ -365,14 +384,7 @@ function applyAdaptations(skillsRoot, newPin) {
     ) || changed;
   }
 
-  const adaptations = [
-    ['preview/uipath-maestro-flow/SKILL.md', adaptFlowSkill],
-    ['preview/uipath-maestro-case/SKILL.md', adaptCaseSkill],
-    ['preview/uipath-maestro-bpmn/SKILL.md', adaptBpmnSkill],
-    ['preview/uipath-maestro-flow/references/api.md', adaptFlowApi],
-    ['preview/uipath-maestro-case/examples/NotifyOnApproval.case.ts', adaptCaseExample],
-  ];
-  for (const [target, adapt] of adaptations) {
+  for (const [target, adapt] of snapshotAdaptations) {
     const targetPath = path.join(skillsRoot, target);
     if (!fs.existsSync(targetPath)) continue;
     changed = writeIfChanged(targetPath, adapt(readText(targetPath))) || changed;

--- a/tests/scripts/sync-maestro-sdk-preview.test.mjs
+++ b/tests/scripts/sync-maestro-sdk-preview.test.mjs
@@ -262,6 +262,14 @@ test('syncSnapshots three-way merges drift and reapplies only snapshot adaptatio
         'New upstream Case guidance.',
       ),
     );
+    write(
+      upstreamRoot,
+      'typescript/sdk/skill/SKILL.md',
+      read(upstreamRoot, 'typescript/sdk/skill/SKILL.md').replace(
+        '| Script | `core.action.script` |',
+        '| Script action | `core.action.script` |',
+      ),
+    );
     const newPin = commit(upstreamRoot, 'drift');
 
     const result = syncSnapshots({ skillsRoot, upstreamRoot });
@@ -287,7 +295,7 @@ test('syncSnapshots three-way merges drift and reapplies only snapshot adaptatio
     );
     assert.match(
       read(skillsRoot, 'preview/uipath-maestro-flow/SKILL.md'),
-      /`examples\/Foo\.flow\.ts`/,
+      /\| Script action \|.*`examples\/Foo\.flow\.ts`/,
     );
     assert.match(
       read(skillsRoot, 'preview/uipath-maestro-case/SKILL.md'),


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `ddf9da1` to merged `UiPath/flow-builder-sdk@32331e4` (#451).

The first dispatch ([32432767494](https://github.com/UiPath/skills/actions/runs/32432767494)) exposed a false three-way conflict where upstream changed a router row whose example path is adapted from `example/` to `examples/` in the snapshot. This PR carries a focused sync-engine correction: base and incoming content are normalized through the approved D1–D6 adaptations before merging. A regression fixture changes an adapted router row.

The snapshot commit was then generated by the same workflow from the repair commit. [Run 32433032443](https://github.com/UiPath/skills/actions/runs/32433032443) passed the merge, inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates and opened this PR.

Local verification:
- focused sync tests: 2/2 passed, including idempotence and the adapted-line regression;
- `npm run skills:validate`: passed for default and Studio Web;
- CLI verb gate: Flow 0 blocking / 6 soft-stale / 3 uncertain; Case and BPMN all zero;
- full `npm run skills:test`: 48/50 passed; the two failures are the existing npm registry-state dry-run fixtures (`--tag` required / published latest newer than fixture 1.2.3).

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)