### PR TITLE
fix(uipath-maestro-case): null-guard task-output dereferences in every =js: sink

### DIFF
--- a/skills/uipath-maestro-case/references/bindings-and-expressions.md
+++ b/skills/uipath-maestro-case/references/bindings-and-expressions.md
@@ -74,7 +74,7 @@ SDD IF columns and `tasks.md` conditions use natural shorthand — `approved == 
 
 ### Null-safe task-output references
 
-In a `conditionExpression` or SLA `expression`, null-guard every task-output dereference — guard the object, not the property:
+In any `=js:` sink (conditions, SLA, task inputs, connector bodies), null-guard every task-output dereference — guard the object, not the property:
 
 ```
 =js:JSON.parse((vars.response4 || {}).RequestBody || '{}').outcome === 'Signed'
@@ -155,7 +155,7 @@ vars.$xref('Stage Name','Task Name','output_name')
 - Three args = the same name-triple as whole-value `<-`: source stage `data.label`, source task `displayName`, source output `name`.
 - Single quotes ONLY — double quotes break the enclosing JSON string. Names containing a literal `'` are unsupported (re-author the name).
 - Drop it anywhere a bare `vars.X` is legal inside an `=js:` expression. It resolves to bare `vars.<outputReferenceId>` (NOT `=vars.` — it is already inside `=js:`).
-- In a `conditionExpression`, null-guard any dotted access off the resolved reference ([§ Null-safe task-output references](#null-safe-task-output-references)).
+- Null-guard any dotted access off the resolved reference ([§ Null-safe task-output references](#null-safe-task-output-references)).
 
 **Example** — composite input payload, no middle variables:
 


### PR DESCRIPTION
## Problem

`bindings-and-expressions.md § Null-safe task-output references` scoped the `(vars.X || {}).Y` guard to `conditionExpression` / SLA `expression` only. The same risk exists in any `=js:` sink — a task input value dereferencing an `adhoc`/optional task's output threw at runtime:

```
Failed to evaluate expression =js:vars.analysisResult2.DeviationFlags
Error: Cannot read property 'DeviationFlags' of null
```

Hit while building a real case: conditions got the guard (the doc says to), the equivalent task inputs didn't (the doc didn't say to).

## Change

Two one-line edits in `bindings-and-expressions.md`:
- `§ Null-safe task-output references` — scope widened from "conditionExpression or SLA expression" to "any `=js:` sink (conditions, SLA, task inputs, connector bodies)".
- `§ In-expression references` — dropped the leftover "In a `conditionExpression`," qualifier on the `$xref` guard bullet, which otherwise contradicts the rule it links to.

## Test plan
- [x] `npm run skills:validate` — clean (both `default` and `studioweb` flavors)
- [x] Verified against the real case build that surfaced this: adding the guard to the three affected expressions keeps `uip maestro case validate` at `Valid`