### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@fd0070d

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ 32331e4. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ fd0070d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 
@@ -124,18 +124,34 @@ uip maestro bpmn validate <Name>.bpmn --output json
 | `.parallelGateway(id, { name? })` | `bpmn:parallelGateway` |
 | `.inclusiveGateway(id, { name?, default? })` | `bpmn:inclusiveGateway` |
 | `.eventBasedGateway(id, { name? })` | `bpmn:eventBasedGateway` |
-| `.scriptTask(id, { script, inputs?, outputs?, name? })` | `bpmn:scriptTask` (Jint JS + `BPMN.ScriptTask` mapping) |
-| `.task(id, { set?, name? })` | `bpmn:task` (`BPMN.Variables` variable assignment) |
-| `.connector(id, key, action, inputs, { connection?, folder?, name? })` | `bpmn:sendTask` (`uipath:activity` / `Intsvc.ActivityExecution`) — an IS connector op. See **Connector service task** below. |
-| `.subProcess(id, sp => …, { name?, triggeredByEvent?, loop? })` | `bpmn:subProcess` (nested graph) |
+| `.scriptTask(id, { script, inputs?, outputs?, name?, retry?, loop? })` | `bpmn:scriptTask` (Jint JS + `BPMN.ScriptTask` mapping) |
+| `.task(id, { set?, name?, retry?, loop? })` | `bpmn:task` (`BPMN.Variables` variable assignment) |
+| `.connector(id, key, action, inputs, { connection?, folder?, name?, outputVar?, skipCondition?, retry?, loop? })` | `bpmn:sendTask` (`uipath:activity` / `Intsvc.ActivityExecution`) — an IS connector op. See **Connector service task** below. |
+| `.subProcess(id, sp => …, { name?, triggeredByEvent?, loop?, retry? })` | `bpmn:subProcess` (nested graph) |
+| `.binding(id, { name?, value?, resource?, propertyAttribute? })` | `uipath:binding` (top level only) — an identifier supplied per environment, read as `=bindings.<id>` |
 | `.sequenceFlow(source, target, { id?, name?, condition? })` | `bpmn:sequenceFlow` |
 
 - **Timers** accept an ISO-8601 string shorthand (`timer: 'PT15M'`) or a full
   `{ duration | date | cycle }`.
 - **Errors** accept a name string or `{ name, code }`. A boundary error event
   needs a `code`.
-- **Multi-instance** loops: `loop: { collection: '=vars.X', itemVar: 'item', sequential?, completion? }`;
-  read the current item in the body as `iterator.item`.
+- **Multi-instance** loops: `loop: { collection: '=vars.X', itemVar: 'item', sequential?, completion? }`
+  on **any activity**, not just a sub-process; read the current item as
+  `iterator.item` (or `iterator.<itemVar>`). `completion` is emitted for the
+  platform but is not evaluated by the local engine, so a local run always
+  iterates the whole collection.
+- **Retry**: `retry: { maxRetries, backoff?: 'PT30S', backoffType?: 'static'|'exponential', exponentialBase?, allErrors?, maxDuration? }`
+  on any activity. `maxRetries` counts retries AFTER the first attempt (`3` = four
+  runs). Add **`allErrors: true`** unless you mean only platform-retryable
+  failures — without it an ordinary activity failure is not retried at all.
+  Durations are days/hours/minutes/seconds only: `PT30S`, `P1DT12H`. Not `P1W`.
+- **Skip**: `skipCondition: '=js:vars.X'` skips an activity when it is truthy (the
+  step records as not executed; the rest of the path still runs). Available on
+  `.connector()` only — a script or variable task emits a `uipath:mapping`, which
+  cannot carry it.
+- **Bindings**: `.binding('apiBase', { value: 'https://api.example.com' })` declares
+  an identifier configured per environment; read it as `=bindings.apiBase`. A
+  connector's `connection`/`folder` already declare their own.
 
 ## Connector service task
 
@@ -175,13 +191,23 @@ export default bpmn('notify')
 
 ## Rules the static check enforces (mirrors `uip maestro bpmn validate`)
 
-- Every non-default outgoing flow of an exclusive/inclusive gateway needs a
-  `condition`; the `default` flow has none.
-- No **fake joins** — an activity/event must not have more than one incoming
-  flow; merge with a gateway.
-- No **superfluous gateway** (exactly one in and one out).
-- Sequence-flow endpoints and gateway `default`/boundary `attachedTo` must
-  resolve; ids are unique; each scope has a start event; timers have a value.
+- An exclusive gateway with **more than one** outgoing flow needs a `condition`
+  on each non-`default` one. A gateway with a single outgoing flow is a JOIN and
+  needs none. (An unconditioned inclusive-gateway branch is a warning — the
+  platform's rule does not cover it.)
+- **Every id in the document must be unique** — across elements, flows, variables,
+  bindings, and message/error declarations. Not a style rule: the XML parser drops
+  the second element that reuses an id, so it vanishes from the process while both
+  validators still report the file valid.
+- A boundary event attaches to an **activity** (including a connector), and its
+  `attachedTo` must resolve; so must a gateway `default` and every sequence-flow
+  endpoint. Each scope has a start event; timers have a value; a variable's
+  `elementId` names a real element.
+- `retry.maxRetries` is a positive integer, and `backoff`/`maxDuration` are
+  durations the runtime can parse.
+- Warnings, not errors: a **superfluous gateway** (one in, one out) and an
+  **implicit join** (an activity/event with more than one incoming flow) — the
+  platform accepts both, but a gateway is clearer.
 
 ## Notes
 

--- a/preview/uipath-maestro-bpmn/references/api.md
+++ b/preview/uipath-maestro-bpmn/references/api.md
@@ -13,9 +13,9 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Builders** — [BpmnBuilder](#bpmnbuilder-class) · [ScopeBuilder](#scopebuilder-class) · [SubProcessBuilder](#subprocessbuilder-class)
 
-**Option shapes** — [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [ConnectorOpts](#connectoropts-interface) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface)
+**Option shapes** — [BindingOpts](#bindingopts-interface) · [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [BpmnConnectorOpts](#bpmnconnectoropts-type) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface) · [ActivityOpts](#activityopts-interface) · [ConnectorOpts](#connectoropts-interface)
 
-**Supporting types** — [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [LoopSpec](#loopspec-interface) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface)
+**Supporting types** — [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [BindingDecl](#bindingdecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [ActivityNodeFields](#activitynodefields-interface) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface) · [RetrySpec](#retryspec-interface) · [LoopSpec](#loopspec-interface)
 
 ## bpmn (function)
 
@@ -35,6 +35,12 @@ export declare function bpmn(id: string): BpmnBuilder;
 export declare class BpmnBuilder extends ScopeBuilder {
     /** Set the process's display name. */
     name(n: string): this;
+    /**
+     * Declare an external identifier the process needs supplied — a base URL, a
+     * folder path, a process name (`uipath:binding`). Expressions read it as
+     * `=bindings.<id>`, and an offline run resolves it to `value`.
+     */
+    binding(id: string, opts?: BindingOpts): this;
     /** Finish the process and return the graph the serializer turns into XML. */
     build(): BuiltBpmn;
 }
@@ -80,13 +86,9 @@ declare abstract class ScopeBuilder {
      * `uipath:activity` / `Intsvc.ActivityExecution`) — the typed form, where a
      * generated descriptor supplies the operation and its input types.
      */
-    connector<I extends Record<string, unknown>, O>(id: string, descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: ConnectorOpts & {
-            name?: string;
-        }): this;
+    connector<I extends Record<string, unknown>, O>(id: string, descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: BpmnConnectorOpts): this;
     /** Stringly form, for a connector with no prepared module. */
-    connector(id: string, key: string, action: string, inputs?: Record<string, unknown>, opts?: ConnectorOpts & {
-            name?: string;
-        }): this;
+    connector(id: string, key: string, action: string, inputs?: Record<string, unknown>, opts?: BpmnConnectorOpts): this;
     /** A sub-process — a scope of its own, with its own elements and flows (`bpmn:subProcess`). */
     subProcess(id: string, fn: (sp: SubProcessBuilder) => void, opts?: SubProcessOpts): this;
     /** A sequence flow from `source` to `target` (1-1 with `bpmn:sequenceFlow`). */
@@ -105,6 +107,32 @@ declare abstract class ScopeBuilder {
 ````ts
 /** A sub-process body: the same graph methods, plus an internal node builder. */
 export declare class SubProcessBuilder extends ScopeBuilder {
+}
+````
+
+## BindingOpts (interface)
+
+````ts
+/** Options for `.binding()`. */
+export interface BindingOpts {
+    /** Display name the designer shows. Defaults to the binding's id. */
+    name?: string;
+    /**
+     * The value the binding resolves to when nothing overrides it — which is what
+     * an offline run reads, so it is the one field a local run needs.
+     */
+    value?: string;
+    /**
+     * The kind of resource this identifies. Defaults to `'custom'`, which is the
+     * right answer for a plain configurable value; use the registry's resource name
+     * (`'Connection'`, `'process'`, `'queue'`, `'businessRule'`) when the binding
+     * addresses one of those.
+     */
+    resource?: string;
+    /** Which property of that resource is wanted. Defaults to `'value'`. */
+    propertyAttribute?: string;
+    /** The resource's key, when it differs from `BindingOpts.value`. */
+    resourceKey?: string;
 }
 ````
 
@@ -220,7 +248,7 @@ export interface GatewayOpts {
 
 ````ts
 /** Options for `.scriptTask()` — the Jint JavaScript body and its input/output mappings. */
-export interface ScriptTaskOpts {
+export interface ScriptTaskOpts extends ActivityOpts {
     /** Display name the designer shows on the task. */
     name?: string;
     /** The script body (Jint JavaScript). */
@@ -238,43 +266,53 @@ export interface ScriptTaskOpts {
 
 ````ts
 /** Options for `.task()` — a display name and the variable assignments the task makes. */
-export interface TaskOpts {
+export interface TaskOpts extends ActivityOpts {
     /** Display name the designer shows on the task. */
     name?: string;
-    /** Variable assignments (`BPMN.Variables`): variable id → `=`-expression/literal. */
+    /** Variable assignments (`BPMN.Variables`): variable id → the value to assign. */
     set?: Record<string, string>;
 }
 ````
 
-## ConnectorOpts (interface)
+## BpmnConnectorOpts (type)
 
 ````ts
-export interface ConnectorOpts {
-    /** Connector action version (defaults to the library's newest match). */
-    version?: string;
-    /** Symbolic connection name declared in bindings.json (→ ConnectionId). */
-    connection?: string;
-    /** Symbolic folder name declared in bindings.json (→ connectionFolderKey). */
-    folder?: string;
+/**
+ * `.connector()` options: the shared connector options, plus the BPMN-only
+ * display `name` and output-variable override.
+ */
+export type BpmnConnectorOpts = ConnectorOpts & ActivityOpts & {
+    /** Display name the designer shows on the task. */
+    name?: string;
     /**
-     * Which OBJECT a **generic** operation addresses — e.g. ServiceNow's "List All
-     * Records" on `'acr_user'`, NetSuite's "Get Record" on `'AccountingPeriod'`.
+     * `=`-expression that skips this activity when it evaluates truthy — the step
+     * is recorded as not executed and the flow carries on
+     * (`uipath:activity/@skipCondition`).
+     *
+     * Only connectors (and other `uipath:activity` nodes) can carry it: a script or
+     * variable task serializes a `uipath:mapping`, which has no such attribute, so
+     * a skip authored there would be dropped and the step would run regardless.
      */
-    object?: string;
-}
+    skipCondition?: string;
+    /**
+     * Variable the connector's response lands in. Defaults to `<id>_response`,
+     * which is what makes two connectors in one process independent — a shared
+     * name would have the second clobber the first. The standard error payload
+     * always lands in `<id>_Error`.
+     */
+    outputVar?: string;
+};
 ````
 
 ## SubProcessOpts (interface)
 
 ````ts
 /** Options for `.subProcess()`. */
-export interface SubProcessOpts {
+export interface SubProcessOpts extends ActivityOpts {
     /** Display name the designer shows on the sub-process. */
     name?: string;
     /** Mark an EVENT sub-process — started by an event inside it, not by an incoming flow. */
     triggeredByEvent?: boolean;
-    /** Run the body once per item of a collection — see `LoopSpec`. */
-    loop?: LoopSpec;
 }
 ````
 
@@ -306,6 +344,39 @@ export interface VarOpts {
 }
 ````
 
+## ActivityOpts (interface)
+
+````ts
+/**
+ * What every ACTIVITY accepts, on top of its own options — a script task, a
+ * variable task, a connector task, a sub-process.
+ */
+export interface ActivityOpts {
+    /** Retry the activity when it fails — see `RetrySpec`. */
+    retry?: RetrySpec;
+    /** Run it once per item of a collection — see `LoopSpec`. */
+    loop?: LoopSpec;
+}
+````
+
+## ConnectorOpts (interface)
+
+````ts
+export interface ConnectorOpts {
+    /** Connector action version (defaults to the library's newest match). */
+    version?: string;
+    /** Symbolic connection name declared in bindings.json (→ ConnectionId). */
+    connection?: string;
+    /** Symbolic folder name declared in bindings.json (→ connectionFolderKey). */
+    folder?: string;
+    /**
+     * Which OBJECT a **generic** operation addresses — e.g. ServiceNow's "List All
+     * Records" on `'acr_user'`, NetSuite's "Get Record" on `'AccountingPeriod'`.
+     */
+    object?: string;
+}
+````
+
 ## BuiltBpmn (interface)
 
 ````ts
@@ -315,6 +386,7 @@ export interface BuiltBpmn {
     variables: BpmnVarDecl[];
     messages: MessageDecl[];
     errors: ErrorDecl[];
+    bindings: BindingDecl[];
     nodes: BpmnNode[];
     flows: BpmnFlow[];
 }
@@ -340,7 +412,7 @@ export type BpmnNode = {
     id: string;
     name?: string;
     default?: string;
-} | {
+} | (ActivityNodeFields & {
     kind: 'scriptTask';
     id: string;
     name?: string;
@@ -348,12 +420,12 @@ export type BpmnNode = {
     scriptFormat: string;
     inputs: Record<string, string>;
     outputs: Record<string, string>;
-} | {
+}) | (ActivityNodeFields & {
     kind: 'task';
     id: string;
     name?: string;
     set: Record<string, string>;
-} | {
+}) | (ActivityNodeFields & {
     kind: 'connector';
     id: string;
     name?: string;
@@ -367,16 +439,19 @@ export type BpmnNode = {
     /** Which OBJECT a generic operation addresses — see `ConnectorOpts.object`. */
     object?: string;
     inputs: Record<string, unknown>;
-} | {
+    /** Variable the response lands in; defaults to `<id>_response`. */
+    outputVar?: string;
+    /** `=`-expression that, when true, skips this activity (`uipath:activity/@skipCondition`). */
+    skipCondition?: string;
+}) | (ActivityNodeFields & {
     kind: 'subProcess';
     id: string;
     name?: string;
     triggeredByEvent?: boolean;
-    loop?: LoopSpec;
     nodes: BpmnNode[];
     flows: BpmnFlow[];
     variables: BpmnVarDecl[];
-};
+});
 ````
 
 ## BpmnFlow (interface)
@@ -449,6 +524,19 @@ export interface ErrorDecl {
 }
 ````
 
+## BindingDecl (interface)
+
+````ts
+export interface BindingDecl {
+    id: string;
+    name: string;
+    resource: string;
+    propertyAttribute: string;
+    default?: string;
+    resourceKey?: string;
+}
+````
+
 ## EventKind (type)
 
 ````ts
@@ -478,14 +566,12 @@ export type EventDef = {
 export type GatewayKind = 'exclusiveGateway' | 'parallelGateway' | 'inclusiveGateway' | 'eventBasedGateway';
 ````
 
-## LoopSpec (interface)
+## ActivityNodeFields (interface)
 
 ````ts
-export interface LoopSpec {
-    collection: string;
-    itemVar: string;
-    sequential?: boolean;
-    completion?: string;
+export interface ActivityNodeFields {
+    retry?: RetrySpec;
+    loop?: LoopSpec;
 }
 ````
 
@@ -520,5 +606,29 @@ export interface TimerSpec {
     duration?: string;
     date?: string;
     cycle?: string;
+}
+````
+
+## RetrySpec (interface)
+
+````ts
+export interface RetrySpec {
+    maxRetries: number;
+    backoff?: string;
+    backoffType?: 'static' | 'exponential';
+    exponentialBase?: number;
+    allErrors?: boolean;
+    maxDuration?: string;
+}
+````
+
+## LoopSpec (interface)
+
+````ts
+export interface LoopSpec {
+    collection: string;
+    itemVar: string;
+    sequential?: boolean;
+    completion?: string;
 }
 ````

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ 32331e4. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ fd0070d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -33,6 +33,13 @@ Exact function signatures and option shapes, including every builder method
 [`references/api.md`](references/api.md).
 
 ## Authoring
+
+> **Keep the source in the authoring directory.** Write `<Name>.case.ts` in the
+> current working directory—the directory containing this `SKILL.md` and the
+> workspace `package.json`—and run `check` / `compile` from there. If a
+> `<Name>/<Name>/` Case project was scaffolded for generated artifacts, do not
+> infer that the TypeScript source belongs inside it or `cd` there unless the
+> task explicitly says so.
 
 ```ts
 import { casePlan, rule } from '@uipath/flow-sdk/case';
@@ -382,19 +389,11 @@ export interface ExitOpts {
      * an exit that routes there).
      *
      * @remarks
-     * The destination still evaluates its own `entryWhen(...)`, and only
-     * STAGE-ENTRY rules are legal there: `selected-stage-completed` /
-     * `selected-stage-exited` / `user-selected-stage` / `case-entered`. Do NOT try to
-     * gate a destination on `selected-tasks-completed` — that is a task-entry /
-     * stage-exit rule, and `uip maestro case validate` rejects it at stage entry with
-     * "task selection missing" (`check` now catches this as RULE_PLACEMENT).
-     *
-     * Consequence for >2-way branching: `selected-stage-completed`/`-exited` name only
-     * the SOURCE stage, so sibling branches out of one stage cannot be told apart by
-     * the destination's entry rule alone. The workable pattern is to let exactly ONE
-     * exit carry `marksStageComplete: true` (the success path, matched by
-     * `selected-stage-completed`) and gate the others on `selected-stage-exited`; for
-     * a human-chosen path use `type: 'wait-for-user'` here plus a
+     * The destination still evaluates its own `entryWhen(...)`. At the product pin,
+     * `selected-tasks-completed` is valid at stage entry when its `{ tasks: [...] }`
+     * payload resolves; use it when a source-stage task identifies the branch. The
+     * checker validates those task references separately from placement legality.
+     * For a human-chosen path use `type: 'wait-for-user'` here plus a
      * `user-selected-stage` entry on each destination.
      */
     exitToStage?: string;
@@ -834,22 +833,24 @@ export interface RuleOpts {
 
 <!-- /GEN:conditions -->
 
-Rule **placement** (which the types cannot express):
+Common rule placement (the product-pin matrix accepts every node-rule type in
+all four node/metadata slots; these are the usual authoring patterns):
 
-| Rule | Legal position |
+| Rule | Common position |
 | --- | --- |
 | `case-entered` | stage entry (case start) |
 | `current-stage-entered` | task entry |
 | `required-tasks-completed` | stage exit |
 | `required-stages-completed` | case completion |
 | `selected-stage-completed` / `selected-stage-exited` | stage entry (needs `{ stage }`) |
-| `selected-tasks-completed` | task entry / stage exit ONLY (needs `{ tasks }`) — **illegal at stage entry**, `uip` rejects it with "task selection missing" |
+| `selected-tasks-completed` | task entry, stage entry/exit, or case exit (needs a non-empty `{ tasks }` payload) |
 | `user-selected-stage` | stage entry (with a `wait-for-user` exit elsewhere) |
 | `adhoc` | task entry, **and stage entry**. `{ expression }` is **optional** — bare `rule('adhoc')` is Valid (verified). Add an expression only to gate availability on case state. |
 | `runs-sequentially` | task entry |
 
 `stage`/`tasks` references use the **labels/names you gave** in the builder; the
-serializer resolves them to the generated ids.
+serializer resolves them to the generated ids. A `selected-tasks-completed`
+rule with no tasks is incomplete; `check` warns to add `{ tasks: [...] }`.
 
 ## Rules the validator enforces (common gotchas)
 
@@ -1187,7 +1188,8 @@ export interface EscalationOpts {
     notify: EscalationRecipient[];
     /**
      * For an `at-risk` trigger, the percentage of the SLA elapsed when it fires
-     * (e.g. `80` = at 80% of the deadline). Ignored for `sla-breached`.
+     * (e.g. `80` = at 80% of the deadline). Defaults to `100` when omitted and
+     * is ignored for `sla-breached`.
      */
     atRiskPercentage?: number;
     displayName?: string;
@@ -1277,15 +1279,22 @@ export default casePlan('claim-review')
 
 - **`escalation({ trigger, notify, atRiskPercentage?, displayName? })`** — `notify`
   is a list from **`toUser(target, value?)`** / **`toGroup(target, value?)`**
-  (`value` defaults to `target`). Give an `at-risk` escalation an
-  `atRiskPercentage`; `sla-breached` ignores it.
+  (`value` defaults to `target`). An omitted `atRiskPercentage` on an `at-risk`
+  escalation is emitted explicitly as 100; `sla-breached` never emits it.
 - **Conditional SLAs:** call `.sla(...)` more than once. A rule with `when: '=js:…'`
   applies only when its gate is truthy (e.g. a tighter deadline for high-priority
   cases); the **default** SLA (no `when`) must be **last** and emits the always-true
   gate `=js:true`.
-- **Guardrails (warnings, non-blocking):** `check` and `uip maestro case validate`
-  warn on an `at-risk` escalation with no `atRiskPercentage`, an escalation that
-  notifies no one, and a deadline with no escalations at all.
+- **Source guardrails:** `check` rejects an SLA `count` outside 0..1000 (engine
+  error 400019), and rejects `:` / `.` in case names or stage labels because
+  runtime event keys do not escape them. It warns when `atRiskPercentage` is 0
+  because the engine silently treats 0 as 100. Existing non-blocking warnings
+  also cover an escalation that notifies no one and a deadline with no
+  escalations at all.
+- **Do not call `.version()`.** The Case JSON schema version is owned by the
+  serializer's format profile (currently V20). The compatibility method is
+  deprecated; `check` warns on any use and rejects a value that differs from the
+  profile.
 - **`unit` is CALENDAR time, and there is no business-day unit.** `uip` enforces
   exactly `min|h|d|w|m` (`Invalid option: expected one of "min"|"h"|"d"|"w"|"m"`), so
   a requirement written in **business days** cannot be expressed exactly — `'d'` runs
@@ -1375,8 +1384,8 @@ directly with `node node_modules/@uipath/flow-sdk/dist/case/<name>-cli.js`.
 - **`check`** (`case-check <Name>.case.ts`) — fast static validation of the built
   case; surfaces the common validator failures (task without an entry rule,
   case/stage without a completion rule, unsatisfiable `required-tasks-completed`,
-  unresolved stage/task references) without writing a file. Exits non-zero on any
-  error.
+  unresolved stage/task references, unsafe case/stage names, and out-of-range SLA
+  counts) without writing a file. Exits non-zero on any error.
 - **`compile`** (`case-compile <Name>.case.ts [-o caseplan.json]`) — runs the
   static check, then serializes to `caseplan.json` (default output name). Pair it
   with `uip maestro case validate` for the authoritative gate.

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -97,7 +97,7 @@ export declare function casePlan(id: string): CaseBuilder;
 declare class CaseBuilder {
     /** Set the case plan's display name. */
     name(n: string): this;
-    /** Set the case plan's version. */
+    /** Set the case plan's schema version during the compatibility window. */
     version(v: string): this;
     /** Describe the case plan. */
     description(text: string): this;
@@ -328,7 +328,8 @@ export interface EscalationOpts {
     notify: EscalationRecipient[];
     /**
      * For an `at-risk` trigger, the percentage of the SLA elapsed when it fires
-     * (e.g. `80` = at 80% of the deadline). Ignored for `sla-breached`.
+     * (e.g. `80` = at 80% of the deadline). Defaults to `100` when omitted and
+     * is ignored for `sla-breached`.
      */
     atRiskPercentage?: number;
     displayName?: string;
@@ -552,7 +553,7 @@ export type TypeDesc = (typeof types)[keyof typeof types];
 export interface BuiltCase {
     id: string;
     name: string;
-    version: string;
+    readonly version: string;
     description?: string;
     identifier: string;
     identifierType: 'constant' | 'external';

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ 32331e4. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ fd0070d. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `32331e4` to current `UiPath/flow-builder-sdk@main` (`fd0070d`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)