### PR TITLE
fix: install httpx for Windows coder-eval smoke

### DIFF
--- a/.github/workflows/smoke-rpa-skills.yml
+++ b/.github/workflows/smoke-rpa-skills.yml
@@ -128,7 +128,9 @@ jobs:
       # deps). Windows RPA tasks run under the tempdir driver, so no agent image.
       - name: Install coder-eval
         shell: bash
-        run: uv pip install --system "coder-eval==${{ steps.ceref.outputs.version }}"
+        # The Windows tempdir job imports the llm_judge criterion in-process;
+        # coder-eval 0.10.2 omits its runtime httpx dependency.
+        run: uv pip install --system "coder-eval==${{ steps.ceref.outputs.version }}" "httpx==0.28.1"
 
       - name: Configure NuGet feed for Helm packages
         shell: bash


### PR DESCRIPTION
## Summary

- install `httpx==0.28.1` alongside coder-eval in the Windows tempdir smoke job
- keep the workaround out of the Maestro preview-eval PR and scoped to the only path currently failing

## Evidence

UiPath/skills#2726 check run 32450630199 failed all three RPA tasks before agent execution because coder-eval 0.10.2 could not import `coder_eval.criteria.llm_judge`: `No module named 'httpx'`. The same check passed with this pin in run 32431747385.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)