### PR TITLE
fix(uipath-test): make the steps-move reorder actually necessary

### DIFF
--- a/tests/tasks/uipath-test/testcase_steps_lifecycle_integration.yaml
+++ b/tests/tasks/uipath-test/testcase_steps_lifecycle_integration.yaml
@@ -37,9 +37,10 @@ initial_prompt: |
   CLAIM) and then tidying them up after a review — walk it through end to end.
   First create a new manual test case with a clear, unique name.
 
-  Add these one at a time as I give them to you:
-    - "Open the payments screen" — the tester should see the payments form.
+  Add these one at a time, in exactly the order I list them — I know the order
+  is wrong, we fix it in the review pass below:
     - "Enter valid card details" — the form should accept them.
+    - "Open the payments screen" — the tester should see the payments form.
 
   Now add these last two in one shot:
     - "Submit the payment" — expect a confirmation banner.


### PR DESCRIPTION
## Why

`skill-test-testcase-steps-lifecycle-integration` failed the [2026-08-20_17-22-24 nightly](https://coder-evalboard.uipath-dev.com/runs/2026-08-20_17-22-24) on claude-sonnet-5 at **0.875** — nine criteria at 1.0 and `steps move` at **0.0**. It was the only `uipath-test` failure, putting the skill at 17/18 (94%) and under the 95% bar.

**The agent was right and the task was wrong.** The prompt added the steps in this order:

1. `Open the payments screen`
2. `Enter valid card details`

…then asked to *"Move 'Enter valid card details' so it runs right after 'Open the payments screen'."* It was already there. The requested move was a no-op from the moment the steps were created, and the agent said so in its own final reply:

> "Final order is already correct … no explicit move was needed — the reorder requirement is satisfied."

So the criterion was grading **model temperament rather than skill quality**: codex issued the redundant call and passed, claude checked whether the action was warranted and failed. That is a systematic penalty on better reasoning, not noise — every model that gets better at spotting no-ops fails it. And a green codex run was never evidence the task was sound; it was evidence codex does not check.

Worth noting this is *not* a regression from #2705. That PR's Rule 6 carve-out is working: the cleanup `testcases delete` criterion scored 1.0 in the same failing run. #2705 verified this task on codex, where the defect is invisible.

## What changed

Prompt only — the two individually-added steps are now listed in the wrong order, so relocating `Enter valid card details` after `Open the payments screen` is a genuine move:

```diff
-  Add these one at a time as I give them to you:
-    - "Open the payments screen" — the tester should see the payments form.
-    - "Enter valid card details" — the form should accept them.
+  Add these one at a time, in exactly the order I list them — I know the order
+  is wrong, we fix it in the review pass below:
+    - "Enter valid card details" — the form should accept them.
+    - "Open the payments screen" — the tester should see the payments form.
```

Two properties this buys:

- **The later deletion cannot satisfy the move by accident.** `Submit the payment` sits after both steps, so removing it does not affect their adjacency. (The failing agent claimed the removal "closed the gap" — that was post-hoc rationalisation; the order was already correct at creation and the deletion was irrelevant to it.)
- **The agent cannot pre-sort its way back into a no-op.** The added clause states the order is deliberately wrong and gets fixed in the review pass. Without it, an agent could helpfully sort while adding and reproduce the same failure by a different route.

No criterion asserts step content or ordering — all ten are flag-shape assertions — so nothing else needed touching.

## Verification

Run on both harnesses, single task:

| Harness | Run | Result |
|---|---|---|
| claude-code | [32459409058](https://github.com/UiPath/skills/actions/runs/32459409058) | **10/10 criteria, score 1.000, SUCCESS** (was 0.875) |
| codex | [32459421532](https://github.com/UiPath/skills/actions/runs/32459421532) | **10/10 criteria, score 1.000, SUCCESS** (no regression) |

The claude run is the meaningful one: same skill, same criteria, only the task setup changed, and `steps move` went from unreachable to satisfied. The codex run is the no-regression check.

## Follow-up: the stronger fix

This makes the move *necessary*; it does not make the criterion *idempotent*. Grading the *resulting step order* instead of the `steps move` invocation would be strictly better — any route to the correct order would pass, and an agent that correctly skips an unnecessary move would still get credit.

That is not shipped here because **no criterion in this suite currently reaches the tenant**: all eight tasks using `run_command` do filesystem-only checks (`ls`, `grep`, `test -f`), and #2705 explicitly declined tenant-side verification because *"validating it needs an eval-tenant credential; shipping it unverified risks trading one chronic failure for another."* Proving that capability is its own change.

There is a general rule worth adding to `.claude/rules/test-writing.md`, this being the second instance in two days: **never grade a command whose necessity depends on state the prompt has already satisfied — either make it necessary, or grade the resulting state.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
