### PR TITLE
docs(agents): document %ASSETS/<ASSET_NAME>% in coded agent env vars

### DIFF
--- a/skills/uipath-agents/SKILL.md
+++ b/skills/uipath-agents/SKILL.md
@@ -44,6 +44,7 @@ Determine the agent mode before proceeding:
 | Create/build/deploy coded agent | Coded | [coded/quickstart.md](references/coded/quickstart.md) | `coded/lifecycle/*`, `coded/frameworks/*` |
 | Select coded framework | Coded | [coded/quickstart.md](references/coded/quickstart.md) § Framework Selection | |
 | Add coded capabilities (HITL, RAG, tracing) | Coded | [coded/quickstart.md](references/coded/quickstart.md) | `coded/capabilities/*` |
+| Set a coded agent's environment variables, or reference an Orchestrator asset from one (`%ASSETS/<ASSET_NAME>%`) | Coded | [coded/lifecycle/environment-variables.md](references/coded/lifecycle/environment-variables.md) | `coded/lifecycle/file-sync.md` for what `.env` does and does not carry |
 | Call an Integration Service connector (Slack, Jira, Web Search) from a coded agent | Coded | [coded/capabilities/integration-service.md](references/coded/capabilities/integration-service.md) **+ then immediately read** [`uipath-platform/references/integration-service/agent-workflow.md`](../uipath-platform/references/integration-service/agent-workflow.md) — discovery lives there, not in `uipath-agents` | `coded/capabilities/sdk-services.md` § Connections |
 | Run coded evaluations | Coded | [coded/quickstart.md](references/coded/quickstart.md) § Evaluate | `coded/lifecycle/evaluate.md` |
 | Create or scaffold a new low-code agent project | Low-code | [lowcode/lowcode.md](references/lowcode/lowcode.md) § Quick Start | `lowcode/project-lifecycle.md`, `lowcode/agent-definition.md` |

--- a/skills/uipath-agents/references/coded/lifecycle/deployment.md
+++ b/skills/uipath-agents/references/coded/lifecycle/deployment.md
@@ -122,8 +122,11 @@ In all three cases, when the downstream goal is consumption rather than upgrade:
 | `pyproject.toml` | You | Project name, version, dependencies |
 | `entry-points.json` | `uip codedagent init` | Entry points and input/output schemas |
 | `bindings.json` | `uip codedagent init` | Runtime bindings |
+| `.env` | You | Local-run environment variables + `UIPATH_PROJECT_ID`. Neither packaged nor pushed — see [environment-variables.md](environment-variables.md) |
 
 `uip codedagent deploy` and `invoke` read credentials (`UIPATH_URL`, `UIPATH_ACCESS_TOKEN`, org/tenant identifiers) from your active `uip login` session — no manual `.env` wiring is required.
+
+A deployed agent's environment variables come from Orchestrator (process- or job-level), not `.env`. To supply one from an asset instead of a literal, set its value to `%ASSETS/<ASSET_NAME>%` — resolved against the **job's** folder at dispatch. See [environment-variables.md](environment-variables.md).
 
 ## Typical Flow
 

--- a/skills/uipath-agents/references/coded/lifecycle/environment-variables.md
+++ b/skills/uipath-agents/references/coded/lifecycle/environment-variables.md
@@ -1,0 +1,90 @@
+# Coded Agent Environment Variables
+
+Where a coded agent's environment variables are stored, which store the runtime reads, and how to pull a value from an Orchestrator asset instead of hardcoding it.
+
+## Three stores, one variable
+
+Not the same store. Only one is what the cloud runtime reads.
+
+| Store | Read by | Authored with |
+|-------|---------|---------------|
+| `<PROJECT_DIR>/.env` | Local runs only (`uip codedagent run`, `uipath run`) | Edit file directly |
+| Project configuration (AgentHub) | Cloud runtime, every debug and Studio Web run | Studio Web → agent properties → **Coded agent environment variables**. VS Code extension mirrors `.env` here on debug |
+| Orchestrator process / job environment variables | Published agent started as an Orchestrator job | `uip or processes update --environment-variables`, or per job on `jobs start` — see [`uipath-platform` run-jobs](../../../../uipath-platform/references/orchestrator/run-jobs.md) |
+
+Consequences:
+
+1. **`.env` is not pushed.** `uip codedagent push` excludes it — see [file-sync](file-sync.md) § Files Involved. Editing `.env` alone changes nothing in the cloud.
+2. **Local and cloud runs can disagree.** Different stores. Diagnose a cloud-only failure by comparing both, not by trusting `.env`.
+3. **No credentials in `.env`.** `UIPATH_URL`, `UIPATH_ACCESS_TOKEN`, org/tenant identifiers come from the `uip login` session. `UIPATH_PROJECT_ID` is the one identity value that belongs there.
+
+## Referencing an Orchestrator asset
+
+Set a variable's whole value to `%ASSETS/<ASSET_NAME>%`. The platform substitutes the asset's value before the agent process starts; the agent reads an ordinary environment variable and never calls the Assets API.
+
+```env
+MY_API_KEY=%ASSETS/ServiceApiKey%
+DATABASE_HOST=%ASSETS/DbHost%
+```
+
+```python
+import os
+
+api_key = os.getenv("MY_API_KEY")
+```
+
+The asset name stays out of the code, so it can be re-pointed per environment without a code change.
+
+### Format rules
+
+1. **Whole value only.** `%ASSETS/Name%` resolves. `https://%ASSETS/Host%/api` does not — passed through as literal text, no error.
+2. **Uppercase prefix: `%ASSETS/`.** One parser in the chain compares the prefix case-sensitively, so `%assets/Name%` silently fails to resolve on the published path even though the design-time editor accepts it.
+3. **Asset name matched case-insensitively.** Name only between the slash and closing `%` — no folder path.
+4. **One asset per variable.** No concatenation, no default value.
+
+### Lookup folder
+
+The reference carries no folder, so the folder comes from the launch path. Most common reason a reference resolves in one place but not another:
+
+| Launch path | Lookup folder |
+|-------------|---------------|
+| Debug run (Studio Web or VS Code extension) | User's **personal workspace** |
+| Published agent started as an Orchestrator job | The **job's** folder — not the agent's, not where the package was published |
+
+An asset that exists only in a solution folder resolves for the deployed agent but not while debugging. Create it in the personal workspace too when both paths are needed.
+
+### Asset value types
+
+`Text`, `Bool`, `Integer`, `Secret` resolve. `KeyValueList` and connection-string types have no single-string form and never resolve. Credential types behave differently across the debug and published paths — do not reference them from an environment variable.
+
+### Failures are silent
+
+> An unresolvable reference — asset missing from the lookup folder, no permission, unsupported value type, lowercase prefix — does NOT fail the job and does NOT log a user-visible error. The value resolves to empty and the variable is then dropped from the process environment, so the agent sees it as unset. Nothing anywhere reports why.
+
+Fail loudly in agent code instead:
+
+```python
+api_key = os.getenv("MY_API_KEY")
+if not api_key:
+    raise ValueError("MY_API_KEY is not set — check the referenced asset exists in the job's folder")
+```
+
+## Solution resources
+
+Saving env vars in Studio Web also registers each referenced asset as a resource on the surrounding solution.
+
+## Anti-patterns
+
+1. **Do not expect `%ASSETS/...%` to resolve locally.** Substitution is server-side. `uip codedagent run` reads `.env` verbatim, so `os.getenv` returns the literal `%ASSETS/Name%`. Put a real value in `.env` for local testing.
+2. **Do not embed a reference in a larger string.** Format rule 1 — no substitution, no warning.
+3. **Do not add a variable to `.env` and expect a cloud run to see it.** `.env` is not pushed. Update the project configuration, or debug from the VS Code extension, which mirrors the file.
+4. **Do not log a resolved secret.** After substitution it is an ordinary string in the process environment; dumping the environment exposes it.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Agent prints literal `%ASSETS/Name%` | Local run | Expected. Put a real value in `.env`. For a cloud run, check the project configuration, not `.env` |
+| Variable unset in a cloud run | Reference did not resolve, variable dropped | Confirm the asset exists in the lookup folder for that launch path: `uip or assets list --folder-path "<FOLDER_PATH>" --output json` |
+| Resolves when deployed, not when debugging | Asset is in the solution folder; debug looks in the personal workspace | Create the asset in the personal workspace too |
+| Stored with lowercase prefix | `%assets/` fails the case-sensitive prefix check on the published path | Rewrite as `%ASSETS/` |

--- a/skills/uipath-agents/references/coded/lifecycle/file-sync.md
+++ b/skills/uipath-agents/references/coded/lifecycle/file-sync.md
@@ -35,6 +35,8 @@ UIPATH_PROJECT_ID=12345
 
 `UIPATH_URL`, `UIPATH_ACCESS_TOKEN`, and org/tenant identifiers come from the `uip login` session automatically — do not add them to `.env`.
 
+`.env` may also hold the agent's own runtime environment variables, but it is **not** pushed (see [Files Involved](#files-involved)) — editing it does not change what a cloud run sees. For the store the cloud runtime reads, and for referencing an Orchestrator asset with `%ASSETS/<ASSET_NAME>%`, see [environment-variables.md](environment-variables.md).
+
 ## Pull
 
 Downloads all files from the remote Studio Web project to your local workspace, preserving directory structure.
@@ -94,7 +96,7 @@ uip codedagent push --overwrite
 | `pyproject.toml`, `main.py`, `.py`, `.json`, `.yaml` | yes | Project source and metadata |
 | `uipath.json`, `entry-points.json`, `bindings.json` | yes | UiPath project configuration |
 | `uv.lock` | yes (skip with `--nolock`) | Dependency lockfile |
-| `__pycache__/`, `.git/`, `.uipath/`, `.env` | no | Build artifacts, VCS, secrets |
+| `__pycache__/`, `.git/`, `.uipath/`, `.env` | no | Build artifacts, VCS, secrets — for `.env` see [environment-variables.md](environment-variables.md) |
 
 Use `packOptions` in `uipath.json` to refine what gets included.
 

--- a/skills/uipath-agents/references/coded/quickstart.md
+++ b/skills/uipath-agents/references/coded/quickstart.md
@@ -59,6 +59,7 @@ Each stage has a reference file with detailed instructions. Read **only** the re
 | **Setup** | [lifecycle/setup.md](lifecycle/setup.md) | `uv venv --python 3.13`, `source .venv/bin/activate`, `uip codedagent setup --force`, `uip codedagent new <name>`, `uv add <framework-package>`, `uv add uipath-dev --dev`, `uv sync`, `uip codedagent init` |
 | **Build** | [lifecycle/build.md](lifecycle/build.md) | Code agent logic with framework patterns |
 | **Bindings** | [lifecycle/bindings-reference.md](lifecycle/bindings-reference.md) | Sync resource overrides in `bindings.json` |
+| **Env vars** | [lifecycle/environment-variables.md](lifecycle/environment-variables.md) | Which store the cloud runtime reads (not `.env`); `%ASSETS/<ASSET_NAME>%` to pull a value from an Orchestrator asset |
 | **Run** | [lifecycle/running-agents.md](lifecycle/running-agents.md) | `uip codedagent run` |
 | **Evaluate** | [lifecycle/evaluate.md](lifecycle/evaluate.md) | `uip codedagent eval` |
 | **Deploy** | [lifecycle/deployment.md](lifecycle/deployment.md) | `uip codedagent deploy`, `uip codedagent invoke` |


### PR DESCRIPTION
## What

A coded agent's environment variable can carry `%ASSETS/<ASSET_NAME>%` as its whole value; the platform substitutes the Orchestrator asset's value before the agent process starts. This documents that format, and — because nothing existed to hang it off — documents coded-agent runtime environment variables at all.

Before this PR, `%ASSETS`, `projectConfiguration`, `dotenv` and `load_dotenv` had **zero hits** repo-wide. `.env` was described only as the carrier for `UIPATH_PROJECT_ID`.

## New reference

`skills/uipath-agents/references/coded/lifecycle/environment-variables.md`

| Section | Why it's there |
| --- | --- |
| Three stores (`.env` / AgentHub project configuration / Orchestrator process-job) | An agent's first instinct is to edit `.env` and expect the cloud to see it. `.env` is not pushed, so it won't. |
| Format rules | Whole value only; case-sensitive `%ASSETS/` prefix; name matched case-insensitively; one asset per variable |
| Lookup folder | Personal workspace when debugging, the **job's** folder when published — this is the mechanism behind "resolves when deployed, not when debugging" |
| Value types | Text/Bool/Integer/Secret resolve; KeyValueList and connection-string types never do; credentials differ across paths |
| Failures are silent | No job failure, no log, variable dropped from the process environment |
| Anti-patterns + troubleshooting | |

Two behaviours get anti-pattern entries because they cost real debugging time and nothing warns you:

1. **Substitution is server-side.** `uip codedagent run` reads `.env` verbatim, so `os.getenv` returns the literal `%ASSETS/Name%`.
2. **An unresolvable reference is silent.** It neither fails the job nor logs anything — the variable is simply unset.

## Routing

- `uipath-agents/SKILL.md` — Task Navigation row
- `coded/quickstart.md` — Lifecycle Stages row, which is the table that tells an agent to load a reference only when it reaches that stage

Both insertions are **outside** all `skill-flavor` blocks (the first starts at quickstart line 233), so `studioweb` inherits them rather than needing an override.

## Corrections to existing content

Each of these previously made a claim that this change contradicts or leaves half-told:

| File | Was |
| --- | --- |
| `coded/lifecycle/file-sync.md` | Listed `.env` as excluded from push without saying where env vars *do* live; "do not add them to `.env`" invited over-generalising from credentials |
| `coded/lifecycle/deployment.md` | Configuration Files table had no `.env` row; "no manual `.env` wiring is required" (true of credentials) read as true of all environment variables |

## Deliberately not touched

- **Low-code references.** Low-code agents have no environment-variable concept. An earlier revision annotated `environmentVariables` / `referencedAssets` in `lowcode/capabilities/process/solution-files.md`; that was reverted and the citation removed from the new reference. Worth knowing separately: I could not substantiate `referencedAssets` — it is absent from the spec of a real cloud-refreshed agent process resource even for a solution that *does* reference an asset from an env var (where the asset instead appears as its own `asset/secretAsset/<Name>.json` resource). `solution-files.md:53` still asserts the field; that looks stale but is pre-existing and out of scope here.
- **`uipath-platform` / `run-jobs.md`.** An earlier revision added the `%ASSETS/` form next to the `KEY=VALUE` wire format there. Dropped — the shape is already clear from the new reference, which covers the published path and its lookup folder, so duplicating it in the platform skill only adds a second place to keep in sync.
- **A test task.** `tests/tasks/` needs tier/tag/sandbox decisions I'd rather agree first. Happy to follow `/test-coverage` → `/generate-task` → `/lint-task` in a follow-up. Nothing existing regresses: the tests asserting on `.env` (`push_pull_roundtrip`) cover push/pull behaviour, which is unchanged.
- **MCP server env vars** use the same `%ASSETS/` syntax — it's what AgentHub's substitutor was originally built for — and `skills/uipath-mcp-servers` documents no env vars at all. Out of scope for "coded agent env vars", but it's the obvious remaining gap.

## Reviewer note

The new reference links once into `uipath-platform` (`run-jobs.md`), as a pointer to where a published agent's environment variables are set. There is precedent for cross-skill links in `uipath-agents/SKILL.md`, and the sentence stands alone without following it (the `uip or processes update --environment-variables` command is given inline), so the skill still functions in isolation per the self-containment rule. Flagging it since it's on the PR checklist.

## Verification

- `npm run skills:validate` — `default: 26 skills, 1717 files`; `studioweb: 26 skills, 1717 files, 167 replacements`
- All three relative links in the new reference resolve to existing files
- `scripts/check-skill-verbs.py` on the new reference — `OK, no stale uip verbs found`
- CODEOWNERS needs no change: `uipath-agents` is covered by a directory-prefix entry; the new-skill rule doesn't apply
- Prose follows `.claude/rules/token-optimization.md`; placeholders use the `<UPPER_SNAKE_CASE>` convention from `.claude/rules/content-quality.md`

## Provenance

The format and its edge cases were established while implementing and debugging it end-to-end: server-side resolution in AgentHubService#1639, the editor and asset-registration in UiPath/flow-workbench#3123, and a live repro on alpha for the silent-failure and lookup-folder behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
