### PR TITLE
test(maestro-bpmn): tolerate markdown line wrapping in fault-triage ownership tokens

### DIFF
--- a/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/operate-diagnose/minimal_fault_triage.yaml
@@ -77,14 +77,16 @@ success_criteria:
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_contains
-    description: "Diagnosis captures the fault element and root cause ownership"
-    path: "diagnosis.md"
-    includes:
-      - "Task_InvokeLegacyRpa"
-      - "folderPath"
-      - "Cloud configuration"
-      - "Integration Service enrichment"
+  - type: run_command
+    description: "Diagnosis captures the fault element and root cause ownership (tolerates markdown line wrapping)"
+    command: >-
+      python3 -c "import re,sys;
+      s=re.sub(r'\s+',' ',open('diagnosis.md',encoding='utf-8').read());
+      missing=[t for t in ('Task_InvokeLegacyRpa','folderPath','Cloud configuration','Integration Service enrichment') if t not in s];
+      print('missing:',missing) if missing else None;
+      sys.exit(1 if missing else 0)"
+    timeout: 30
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 


### PR DESCRIPTION
## Problem

The fault-triage eval graded its diagnosis with `file_contains`, which matches literal substrings. Markdown wraps lines, so a correct diagnosis fails on formatting:

```markdown
The root cause sits with Cloud
configuration, not Integration Service enrichment.
```

Both `Cloud configuration` and `Integration Service enrichment` count as MISSING — each split across a newline — on a 3.0-weight criterion.

## Fix

A `run_command` check that normalises whitespace before matching:

```python
s = re.sub(r'\s+', ' ', open('diagnosis.md').read())
missing = [t for t in TOKENS if t not in s]
```

Same four tokens, same weight, same pass/fail meaning — it stops grading line-break positions.

## Verification

Wrapped input with all four tokens → exit 0 (fails under the old check). Drop one → exit 1, printing `missing: ['folderPath']`. All four tokens are reachable: two in the task's mock fixtures, two are the exact ownership labels the prompt mandates.
