### PR TITLE
fix(uipath-insights): name the casing layer in output-shape claims

### DIFF
--- a/skills/uipath-insights/references/filter-discovery-guide.md
+++ b/skills/uipath-insights/references/filter-discovery-guide.md
@@ -4,7 +4,7 @@ The `filter-*` commands list folders, processes, queues, and machines with recen
 
 Pass the returned values to `jobs` commands: `FolderKey` to `--folder-key`, `ProcessName` to `--process-name`, `MachineName` to `--machine-name`. There is no key-based flag for processes or machines, and `jobs` has no queue filter at all. Every `jobs` command also needs a time range, which these commands do not supply; see [`jobs-commands-guide.md`](jobs-commands-guide.md).
 
-Keys inside `Data` are PascalCase on the wire. Read `FolderKey`, not `folderKey`.
+Keys inside `Data` are PascalCase in the CLI's JSON output. Read `FolderKey`, not `folderKey`.
 
 ## Shared Options
 


### PR DESCRIPTION
https://uipath.atlassian.net/browse/IN-13526

## What

filter-discovery-guide.md says Data keys are "PascalCase on the wire". This changes the phrase to "PascalCase in the CLI's JSON output". Field names and every other claim are unchanged. The SKILL.md and jobs-commands-guide.md copies of the same wrong phrase were in this PR originally but landed on main with #2608, so after a rebase this is the last survivor and the diff is one line.

## Why

The wire is camelCase: the RTM service serializes through MVC's camelCase Newtonsoft default, and the CLI's projections read camelCase keys. PascalCase is the output layer, where OutputFormatter PascalCases every Data key. The wrong layer name has re-seeded casing regressions before (the #2552 regression commit and two review rounds on cli#3611 came from the same wire-vs-output conflation), so the sentence now names the layer it describes.

## Testing

`npm run skills:validate` and `hooks/validate-skill-descriptions.sh` pass on this branch. Wording-only change; no eval task or command behavior is touched.