### PR TITLE
test(maestro-flow): add arm-neutral flow discovery

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -34,6 +34,7 @@ Two distinct sources with two casings:
 from __future__ import annotations
 
 import glob
+import hashlib
 import json
 import os
 import re
@@ -345,8 +346,7 @@ def assert_loop_body_nodes_parented(
     loop's ID. Without ``parentId``, the runtime executes the node outside the
     loop context — per-iteration variables like ``currentItem`` are
     inaccessible and outputs come back null."""
-    project_dir = _find_project(project_glob)
-    for path in glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+    for path in find_flow_files(project_glob):
         with open(path) as f:
             flow = json.load(f)
         nodes_by_id = {n["id"]: n for n in flow.get("nodes") or []}
@@ -1153,12 +1153,10 @@ def node_output_leaves(payload: dict, node_ids) -> set:
 
 
 def _load_flow(project_glob: str) -> dict:
-    """Load the single .flow next to the matched project.uiproj."""
-    proj = _find_project(project_glob)
-    flows = glob.glob(os.path.join(proj, "*.flow"))
-    if not flows:
-        _fail(f"no .flow file under {proj}")
-    return json.loads(open(flows[0], encoding="utf-8").read())
+    """Load the single discovered flow artifact."""
+    path = find_flow_file(project_glob)
+    with open(path, encoding="utf-8") as f:
+        return json.load(f)
 
 
 def assert_decision_branches_reach(
@@ -1341,6 +1339,64 @@ def find_project_dir(pattern: str = "**/project.uiproj") -> str:
     return _find_project(pattern)
 
 
+def find_flow_files(
+    project_pattern: str = "**/project.uiproj", *, flow_glob: str = "*.flow"
+) -> list[str]:
+    """Return flow artifacts from the selected solution, or one root emit.
+
+    A Flow solution project wins whenever one exists. This keeps a root-level
+    SDK scratch file from competing with the linked solution copy.
+    When no project exists, validate and source-structure checks may consume a
+    root-level SDK emit. Multiple genuinely distinct root emits are ambiguous
+    and fail with their paths rather than selecting one by glob order.
+
+    Debug callers intentionally do not use this helper: ``uip maestro flow
+    debug`` is project-scoped and must continue through :func:`find_project_dir`.
+    """
+    project_candidates = sorted(glob.glob(project_pattern, recursive=True))
+    if any(_is_flow_project(path) for path in project_candidates):
+        project_dir = _find_project(project_pattern)
+        matches = sorted(
+            glob.glob(
+                os.path.join(project_dir, "**", os.path.basename(flow_glob)),
+                recursive=True,
+            )
+        )
+        if not matches:
+            _fail(
+                f"No .flow file matching {flow_glob!r} under selected Flow "
+                f"project {project_dir}"
+            )
+        return matches
+
+    root_matches = _dedupe_flow_candidates(
+        sorted(glob.glob(os.path.basename(flow_glob)))
+    )
+    if not root_matches:
+        _fail(
+            f"No Flow project found matching {project_pattern!r}, and no "
+            f"root-level .flow file matching {os.path.basename(flow_glob)!r}"
+        )
+    if len(root_matches) > 1:
+        joined = "\n  - ".join(root_matches)
+        _fail(
+            "Multiple distinct root-level .flow files found — refusing to "
+            f"guess:\n  - {joined}"
+        )
+    return root_matches
+
+
+def find_flow_file(
+    project_pattern: str = "**/project.uiproj", *, flow_glob: str = "*.flow"
+) -> str:
+    """Return one unambiguous flow artifact using :func:`find_flow_files`."""
+    matches = find_flow_files(project_pattern, flow_glob=flow_glob)
+    if len(matches) > 1:
+        joined = "\n  - ".join(matches)
+        _fail(f"Multiple .flow files match {flow_glob!r}:\n  - {joined}")
+    return matches[0]
+
+
 # ── Internals ───────────────────────────────────────────────────────────────
 
 
@@ -1382,8 +1438,7 @@ def _get_ci(mapping: Any, *candidate_keys: str, default: Any = None) -> Any:
 
 
 def _iter_flow_nodes(project_glob: str):
-    project_dir = _find_project(project_glob)
-    for path in glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True):
+    for path in find_flow_files(project_glob):
         with open(path) as f:
             flow = json.load(f)
         yield from flow.get("nodes") or []
@@ -1398,6 +1453,23 @@ def _non_empty_binding_value(value: Any) -> bool:
 # A project whose ``.flow`` declares at most this many nodes is an abandoned
 # `flow init` scaffold, not a build: init seeds a single trigger node.
 _HUSK_MAX_NODES = 1
+
+
+def _dedupe_flow_candidates(paths: list[str]) -> list[str]:
+    """Collapse aliases and byte-identical copies before ambiguity checks."""
+    by_realpath: dict[str, str] = {}
+    for path in paths:
+        by_realpath.setdefault(os.path.realpath(path), path)
+
+    by_content: dict[str, str] = {}
+    for path in by_realpath.values():
+        try:
+            with open(path, "rb") as f:
+                key = hashlib.sha256(f.read()).hexdigest()
+        except OSError:
+            key = f"unreadable:{path}"
+        by_content.setdefault(key, path)
+    return sorted(by_content.values())
 
 
 def _find_project(pattern: str) -> str:

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
@@ -41,13 +41,12 @@ module's discovery so both criteria address the same file.
 
 from __future__ import annotations
 
-import glob
 import os
 import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from flow_check import find_project_dir  # noqa: E402
+from flow_check import find_flow_files  # noqa: E402
 
 
 def _parse(argv: list[str]):
@@ -75,11 +74,11 @@ def _parse(argv: list[str]):
 def main(argv: list[str]) -> int:
     substrings, regexes, absent, flow_name = _parse(argv)
 
-    project_dir = find_project_dir()
-    flows = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
-    if not flows:
-        print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
-        return 1
+    try:
+        flows = find_flow_files()
+    except SystemExit as exc:
+        print(str(exc), file=sys.stderr)
+        return exc.code if isinstance(exc.code, int) else 1
     print(f"Found {len(flows)} .flow file(s): {', '.join(flows)}")
 
     if flow_name is not None:

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check_discovery.py
@@ -12,13 +12,20 @@ The real two-solution artifact from that run is reproduced by
 
 import json
 import os
+import subprocess
 import sys
 
 import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from flow_check import _find_project  # noqa: E402
+from flow_check import (  # noqa: E402
+    _find_project,
+    find_flow_file,
+    find_flow_files,
+    find_project_dir,
+)
+import validate_flow  # noqa: E402
 
 PATTERN = "**/project.uiproj"
 
@@ -143,3 +150,92 @@ def test_single_husk_project_is_still_selected(tmp_path, monkeypatch):
     _make_flow_project(tmp_path, "OnlySolution", "OnlyBuild", 1)
 
     assert _find_project(PATTERN) == os.path.join("OnlySolution", "OnlyBuild")
+
+
+def test_structure_discovery_falls_back_to_one_root_flow(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "BareEmit.flow").write_text(json.dumps({"nodes": []}))
+
+    assert find_flow_files() == ["BareEmit.flow"]
+    assert find_flow_file() == "BareEmit.flow"
+
+
+def test_structure_discovery_ignores_non_flow_sidecar_project(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    _make_flow_project(tmp_path, "AgentSidecar", "Agent", 0)
+    manifest = tmp_path / "AgentSidecar" / "Agent" / "project.uiproj"
+    manifest.write_text(json.dumps({"ProjectType": "Agent"}))
+    (tmp_path / "BareEmit.flow").write_text(json.dumps({"nodes": []}))
+
+    assert find_flow_file() == "BareEmit.flow"
+
+
+def test_solution_flow_beats_root_scratch_emit(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    project = _make_flow_project(tmp_path, "Solution", "Build", 4)
+    (tmp_path / "Build.flow").write_text(json.dumps({"nodes": [{"id": "scratch"}]}))
+
+    assert find_flow_files() == [os.path.join("Solution", "Build", "Build.flow")]
+    assert find_flow_file() == os.path.join("Solution", "Build", "Build.flow")
+    assert project.name == "Build"
+
+
+def test_root_fallback_refuses_distinct_candidates_and_lists_them(
+    tmp_path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "A.flow").write_text(json.dumps({"nodes": [{"id": "a"}]}))
+    (tmp_path / "B.flow").write_text(json.dumps({"nodes": [{"id": "b"}]}))
+
+    with pytest.raises(SystemExit) as excinfo:
+        find_flow_files()
+
+    message = str(excinfo.value)
+    assert "Multiple distinct root-level .flow files" in message
+    assert "A.flow" in message
+    assert "B.flow" in message
+
+
+def test_root_fallback_collapses_byte_identical_copies(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = json.dumps({"nodes": [{"id": "same"}]})
+    (tmp_path / "A.flow").write_text(body)
+    (tmp_path / "B.flow").write_text(body)
+
+    assert find_flow_files() == ["A.flow"]
+
+
+def test_debug_discovery_stays_project_scoped(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "BareEmit.flow").write_text(json.dumps({"nodes": []}))
+
+    with pytest.raises(SystemExit, match="No project.uiproj found"):
+        find_project_dir()
+
+
+def test_validate_flow_uses_root_fallback(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "BareEmit.flow").write_text(json.dumps({"nodes": []}))
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append((command, kwargs))
+        return subprocess.CompletedProcess(command, 0, stdout="valid\n", stderr="")
+
+    monkeypatch.setattr(validate_flow.subprocess, "run", fake_run)
+
+    assert validate_flow.main() == 0
+    assert calls == [
+        (
+            [
+                "uip",
+                "maestro",
+                "flow",
+                "validate",
+                "BareEmit.flow",
+                "--output",
+                "json",
+            ],
+            {"capture_output": True, "text": True},
+        )
+    ]

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_contains.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_contains.py
@@ -48,6 +48,22 @@ def test_no_args_asserts_flow_exists(sandbox):
     assert main([]) == 0
 
 
+def test_no_args_accepts_one_root_level_sdk_emit(tmp_path, monkeypatch):
+    (tmp_path / "Demo.flow").write_text(FLOW_BODY)
+    monkeypatch.chdir(tmp_path)
+
+    assert main([]) == 0
+
+
+def test_solution_flow_beats_root_level_scratch(tmp_path, monkeypatch):
+    _make_project(tmp_path)
+    (tmp_path / "Demo.flow").write_text('{"nodes": ["scratch-only"]}')
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["quick-form"]) == 0
+    assert main(["scratch-only"]) == 1
+
+
 def test_substring_present(sandbox):
     assert main(['"uipath.human-in-the-loop.quick-form"']) == 0
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -183,6 +183,27 @@ def test_bindings_checker_accepts_v2_symbolic_key_with_real_values(tmp_path: Pat
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_bindings_checker_prefers_solution_flow_over_root_scratch(tmp_path: Path) -> None:
+    checker = FLOW_TASKS / "bindings" / "check_bindings.py"
+    project = tmp_path / "BindingsMulti" / "BindingsMulti"
+    project.mkdir(parents=True)
+    (project / "project.uiproj").write_text(json.dumps({"ProjectType": "Flow"}))
+    good = {"nodes": [], "bindings": []}
+    (project / "BindingsMulti.flow").write_text(json.dumps(good))
+    (tmp_path / "BindingsMulti.flow").write_text(json.dumps({"nodes": []}))
+
+    result = subprocess.run(
+        [sys.executable, str(checker), "structure", "**/BindingsMulti*.flow"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert str(project.relative_to(tmp_path)) in result.stdout
+
+
 def test_inline_agent_ignores_staging_trees(tmp_path: Path) -> None:
     valid = {
         "settings": {"model": "gpt-4.1"},

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -1,0 +1,260 @@
+"""Permanent same-ground contract for uipath-maestro-flow eval tasks.
+
+The temporary allowlists name pre-campaign debt. Each family batch removes its
+own entries as the task contract becomes neutral; exact equality prevents stale
+allowlist entries from hiding completed work.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+FLOW_TASKS = Path(__file__).resolve().parent.parent
+
+V1_AUTHORING_ALLOWLIST = {
+    "bindings/idempotent_reconfigure.yaml",
+    "bindings/multi_connector_independence.yaml",
+    "bindings/no_duplicate_connection_bindings.yaml",
+    "bindings/reconfigure_different_connection.yaml",
+    "connector_features/testmanager_attachments/testmanager_attachments.yaml",
+    "connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml",
+    "connector_features/testmanager_execution_results/testmanager_execution_results.yaml",
+    "connector_features/testmanager_generic_records/testmanager_generic_records.yaml",
+    "connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml",
+    "connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml",
+    "connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml",
+    "connector_trigger/webhook_waitfor_parallel.yaml",
+    "e2e/devcon_expense_approval.yaml",
+    "evaluate/evaluator_type_choice.yaml",
+    "evaluate/inline_agent_eval/inline_agent_eval.yaml",
+    "evaluate/local_crud.yaml",
+    "evaluate/no_auto_upload.yaml",
+    "evaluate/simulation/simulation_crud.yaml",
+    "interactive/solution_select.yaml",
+    "ixp/e2e_02_project_selection.yaml",
+    "ixp/integration_handle_routing.yaml",
+    "ixp/routing.yaml",
+    "ixp/routing_listing.yaml",
+    "ixp/scaffold_minimal.yaml",
+    "ixp/scaffold_multinode.yaml",
+    "smoke/init_validate.yaml",
+    "smoke/inline_agent_robust.yaml",
+    "smoke/registry_discovery.yaml",
+}
+
+SKILL_TELEMETRY_ALLOWLIST = {
+    "interactive/customer_escalation_triage/customer_escalation_triage.yaml",
+    "ixp/e2e_02_project_selection.yaml",
+    "ixp/integration_handle_routing.yaml",
+    "ixp/scaffold_minimal.yaml",
+    "ixp/scaffold_multinode.yaml",
+}
+
+FORBIDDEN_PROMPT_ALLOWLIST = {
+    "connector_features/slack-http-fallback/slack_http_fallback.yaml",
+    "context-grounding/batch_transform/batch_transform.yaml",
+    "context-grounding/summarize/summarize.yaml",
+    "evaluate/inline_agent_eval/inline_agent_eval.yaml",
+    "evaluate/local_crud.yaml",
+    "evaluate/simulation/simulation_crud.yaml",
+    "ixp/e2e_02_project_selection.yaml",
+    "ixp/integration_handle_routing.yaml",
+    "ixp/routing.yaml",
+    "ixp/routing_negative.yaml",
+    "ixp/scaffold_minimal.yaml",
+    "ixp/scaffold_multinode.yaml",
+    "single_node/delay/delay.yaml",
+    "single_node/outlook_waitfor_email/outlook_waitfor_email.yaml",
+    "single_node/transform_filter/transform_filter.yaml",
+    "single_node/transform_group_by/transform_group_by.yaml",
+    "single_node/transform_map/transform_map.yaml",
+    "smoke/merge_parallel_sync.yaml",
+    "smoke/scheduled_trigger.yaml",
+}
+
+# These born-neutral escalation tasks are outside the recipe-edit sweep. Their
+# prompts already require the same-name solution and tell the agent to leave
+# the live execution to the grader; preserving them is part of the campaign's
+# explicit no-edit fence.
+FORBIDDEN_PROMPT_EXCEPTIONS = {
+    "e2e/escalation_jira_ticket/escalation_jira_ticket.yaml",
+    "e2e/escalation_orchestrator_paths/escalation_orchestrator_paths.yaml",
+    "e2e/escalation_slack_alert/escalation_slack_alert.yaml",
+}
+
+DEBUG_SOLUTION_ALLOWLIST = {
+    "connector_features/generic_dynamic_node/generic_dynamic_node.yaml",
+    "connector_features/slack-http-fallback/slack_http_fallback.yaml",
+    "e2e/escalation_jira_ticket/escalation_jira_ticket.yaml",
+    "e2e/jira_create_issue/jira_create_issue.yaml",
+    "e2e/jira_get_issue/jira_get_issue.yaml",
+    "e2e/jira_lifecycle/jira_lifecycle.yaml",
+    "e2e/jira_search_triage/jira_search_triage.yaml",
+    "edit/add_node/add_node.yaml",
+    "edit/add_output/add_output.yaml",
+    "edit/group_to_subflow/group_to_subflow.yaml",
+    "edit/move_node/move_node.yaml",
+    "edit/remove_node/remove_node.yaml",
+    "edit/update_node/update_node.yaml",
+    "interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml",
+    "interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml",
+    "interactive/customer_escalation_triage/customer_escalation_triage.yaml",
+    "interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml",
+    "multi_node/bellevue_weather/bellevue_weather.yaml",
+    "multi_node/calculator/calculator.yaml",
+    "multi_node/customer_escalation/customer_escalation.yaml",
+    "multi_node/dice_roller/dice_roller.yaml",
+    "multi_node/feet_inches/feet_inches.yaml",
+    "multi_node/loop_multiply/loop_multiply.yaml",
+    "multi_node/multi_city_weather/multi_city_weather.yaml",
+    "multi_node/reading_list/reading_list.yaml",
+    "multi_node/slack_channel_description/slack_channel_description.yaml",
+    "multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml",
+    "multi_node/wiki_pageviews/wiki_pageviews.yaml",
+    "single_node/api_workflow/api_workflow.yaml",
+    "single_node/decision/decision.yaml",
+    "single_node/file_attachment/file_attachment.yaml",
+    "single_node/lowcode_agent/lowcode_agent.yaml",
+    "single_node/openmeteo_weather/openmeteo_weather.yaml",
+    "single_node/rpa/rpa.yaml",
+    "single_node/subflow/subflow.yaml",
+    "single_node/switch/switch.yaml",
+    "single_node/terminate/terminate.yaml",
+    "connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml",
+}
+
+# F1 freezes the #2557 task even though its prompt predates the exact phrase.
+DEBUG_PROJECT_LAYOUT_EXCEPTIONS = {"single_node/coded_agent/coded_agent.yaml"}
+
+UUID_PATTERN = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+
+
+def _block(text: str, key: str) -> str:
+    match = re.search(rf"(?ms)^{re.escape(key)}:[^\n]*\n(.*?)(?=^[A-Za-z_][\w-]*:|\Z)", text)
+    return match.group(0) if match else ""
+
+
+def _criterion_blocks(text: str) -> list[tuple[str, str]]:
+    section = _block(text, "success_criteria")
+    return [
+        (match.group(1), match.group(0))
+        for match in re.finditer(
+            r"(?ms)^  - type:\s*([^\s#]+).*?(?=^  - type:|^[A-Za-z_][\w-]*:|\Z)",
+            section,
+        )
+    ]
+
+
+def _tagged_tasks() -> list[tuple[str, Path, str]]:
+    tasks = []
+    for path in sorted(FLOW_TASKS.rglob("*.yaml")):
+        text = path.read_text()
+        if "uipath-maestro-flow" in _block(text, "tags"):
+            tasks.append((path.relative_to(FLOW_TASKS).as_posix(), path, text))
+    return tasks
+
+
+def _referenced_python_files(task_path: Path, criterion: str) -> list[Path]:
+    paths = []
+    for token in re.findall(
+        r"(?:\$TASK_DIR/|\$SKILLS_REPO_PATH/)?[A-Za-z0-9_./-]+\.py", criterion
+    ):
+        if token.startswith("$TASK_DIR/"):
+            path = task_path.parent / token.removeprefix("$TASK_DIR/")
+        elif token.startswith("$SKILLS_REPO_PATH/"):
+            path = FLOW_TASKS.parents[2] / token.removeprefix("$SKILLS_REPO_PATH/")
+        else:
+            path = Path(token)
+        if path.is_file():
+            paths.append(path)
+    return paths
+
+
+def _is_debug_graded(task_path: Path, text: str) -> bool:
+    for criterion_type, criterion in _criterion_blocks(text):
+        if criterion_type == "command_not_executed":
+            continue
+        normalized = criterion.lower().replace("\\\\", "\\")
+        if "flow\\s+debug" in normalized or "flow debug" in normalized:
+            return True
+        if criterion_type != "run_command":
+            continue
+        for script in _referenced_python_files(task_path, criterion):
+            source = script.read_text(errors="replace")
+            if "run_debug(" in source or re.search(
+                r'["\']flow["\']\s*,\s*["\']debug["\']', source
+            ):
+                return True
+    return False
+
+
+def _has_v1_authoring_grammar(criterion: str) -> bool:
+    normalized = criterion.lower().replace("\\\\", "\\")
+    markers = (
+        "solution\\s+",
+        "flow\\s+init",
+        "flow\\s+node\\s+add",
+        "flow\\s+node\\s+configure",
+        "flow\\s+node\\s+remove",
+        "flow\\s+node\\s+update",
+        "flow\\s+registry",
+    )
+    return any(marker in normalized for marker in markers) or (
+        "agent\\s+init" in normalized and "inline-in-flow" in normalized
+    )
+
+
+def test_every_tagged_task_has_an_explicit_task_id() -> None:
+    missing = {
+        relative
+        for relative, _, text in _tagged_tasks()
+        if not re.search(r"(?m)^task_id:\s*\S+", text)
+    }
+    assert missing == set()
+
+
+def test_v1_only_authoring_commands_match_the_temporary_allowlist() -> None:
+    offenders = set()
+    for relative, _, text in _tagged_tasks():
+        for criterion_type, criterion in _criterion_blocks(text):
+            if criterion_type == "command_executed" and _has_v1_authoring_grammar(
+                criterion
+            ):
+                offenders.add(relative)
+    assert offenders == V1_AUTHORING_ALLOWLIST
+
+
+def test_gating_skill_telemetry_matches_the_temporary_allowlist() -> None:
+    offenders = set()
+    for relative, _, text in _tagged_tasks():
+        for criterion_type, criterion in _criterion_blocks(text):
+            if criterion_type != "skill_triggered":
+                continue
+            threshold = re.search(r"(?m)^\s+pass_threshold:\s*([0-9.]+)", criterion)
+            if threshold is None or float(threshold.group(1)) > 0:
+                offenders.add(relative)
+    assert offenders == SKILL_TELEMETRY_ALLOWLIST
+
+
+def test_forbidden_prompt_phrases_match_the_temporary_allowlist() -> None:
+    offenders = set()
+    for relative, _, text in _tagged_tasks():
+        prompt = " ".join(_block(text, "initial_prompt").lower().split())
+        if re.search(r"do not [^.]*\bdebug\b", prompt) or UUID_PATTERN.search(prompt):
+            offenders.add(relative)
+    assert offenders == FORBIDDEN_PROMPT_ALLOWLIST | FORBIDDEN_PROMPT_EXCEPTIONS
+
+
+def test_debug_graded_prompts_name_a_same_name_solution() -> None:
+    offenders = set()
+    for relative, path, text in _tagged_tasks():
+        if not _is_debug_graded(path, text):
+            continue
+        prompt = " ".join(_block(text, "initial_prompt").lower().split())
+        if not re.search(r"\b(?:in|inside) a solution of the same name\b", prompt):
+            offenders.add(relative)
+    assert offenders == DEBUG_SOLUTION_ALLOWLIST | DEBUG_PROJECT_LAYOUT_EXCEPTIONS

--- a/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
-"""Locate the Flow project's ``.flow`` file dynamically and run
-``uip maestro flow validate`` on it.
+"""Locate emitted ``.flow`` files and run ``uip maestro flow validate``.
 
 Usage (from a task's run_command, cwd = sandbox root):
     python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py
@@ -13,29 +12,25 @@ The hardcoded command then fails with "File not found" even though the flow
 itself is valid (observed on skill-flow-loop-multiply: criterion scored 0.0
 purely on the path, while the flow validated fine when addressed correctly).
 
-Discovery mirrors the ``check_*.py`` execution checks: find the lone
-``project.uiproj`` whose manifest declares ``ProjectType="Flow"`` (via
-:func:`flow_check.find_project_dir`), then validate every ``.flow`` file under
-it. Exit 0 iff every file validates; otherwise propagate the failing exit code.
+Discovery prefers the lone ``project.uiproj`` whose manifest declares
+``ProjectType="Flow"`` and validates every flow under it. If no project exists,
+it accepts one unambiguous root-level SDK emit instead. Exit 0 iff every selected
+file validates; otherwise propagate the failing exit code.
 """
 
 from __future__ import annotations
 
-import glob
-import os
 import subprocess
 import sys
 
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from flow_check import find_project_dir  # noqa: E402
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from flow_check import find_flow_files  # noqa: E402
 
 
 def main() -> int:
-    project_dir = find_project_dir()
-    flows = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
-    if not flows:
-        print(f"FAIL: No .flow file found under {project_dir}", file=sys.stderr)
-        return 1
+    flows = find_flow_files()
 
     rc = 0
     for flow in flows:

--- a/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
+++ b/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
@@ -67,13 +67,18 @@ Exit 0 on success; non-zero with stderr message on failure.
 
 from __future__ import annotations
 
+from collections import Counter
 import glob
 import hashlib
 import json
 import os
 import sys
-from collections import Counter
+from pathlib import Path
 from typing import Any, NoReturn
+
+SHARED_DIR = Path(__file__).resolve().parents[1] / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_files  # noqa: E402
 
 
 def _fail(message: str) -> NoReturn:
@@ -109,7 +114,10 @@ def _dedupe_aliases(paths: list[str]) -> list[str]:
 
 
 def _load_one(pattern: str) -> tuple[str, dict[str, Any]]:
-    matches = _dedupe_aliases(glob.glob(pattern, recursive=True))
+    if pattern.startswith("**/") and pattern.endswith(".flow"):
+        matches = find_flow_files(flow_glob=os.path.basename(pattern))
+    else:
+        matches = _dedupe_aliases(glob.glob(pattern, recursive=True))
     if not matches:
         _fail(f"No file found for {pattern!r}")
     if len(matches) > 1:

--- a/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py
@@ -9,13 +9,20 @@ outcomes.
 
 from __future__ import annotations
 
-import glob
 import json
 import sys
 from pathlib import Path
 
+SHARED_DIR = Path(__file__).resolve().parents[1] / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+try:
+    from flow_check import find_flow_file  # noqa: E402
+except ModuleNotFoundError as exc:
+    if exc.name != "flow_check":
+        raise
+    from _shared.flow_check import find_flow_file  # noqa: E402
 
-FLOW_GLOB = "ExpenseApproval/ExpenseApproval/ExpenseApproval.flow"
+FLOW_GLOB = "ExpenseApproval*.flow"
 
 
 def fail(message: str) -> None:
@@ -23,10 +30,7 @@ def fail(message: str) -> None:
 
 
 def load_flow() -> dict:
-    matches = glob.glob(FLOW_GLOB)
-    if not matches:
-        fail(f"No flow file matching {FLOW_GLOB}")
-    path = Path(matches[0])
+    path = Path(find_flow_file(flow_glob=FLOW_GLOB))
     try:
         return json.loads(path.read_text())
     except json.JSONDecodeError as exc:

--- a/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/test_check_devcon_expense_approval.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -58,6 +60,9 @@ def _flow_doc(
 def _write_flow(tmp_path: Path, doc: dict[str, Any]) -> None:
     project = tmp_path / "ExpenseApproval" / "ExpenseApproval"
     project.mkdir(parents=True)
+    (project / "project.uiproj").write_text(
+        json.dumps({"ProjectType": "Flow"}), encoding="utf-8"
+    )
     (project / "ExpenseApproval.flow").write_text(json.dumps(doc), encoding="utf-8")
 
 
@@ -117,6 +122,40 @@ def test_accepts_expression_hitl_input_binding(tmp_path: Path) -> None:
     _write_approve_reject_flow(tmp_path, "=js:$vars.fetchExpense.output.amount")
 
     result = _run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_root_level_sdk_emit(tmp_path: Path) -> None:
+    doc = _flow_doc(
+        fields=_approve_reject_fields("vars.fetchExpense.output.amount"),
+        outcomes=_APPROVE_REJECT_OUTCOMES,
+    )
+    (tmp_path / "ExpenseApproval.flow").write_text(json.dumps(doc), encoding="utf-8")
+
+    result = _run_checker(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_accepts_checker_frozen_without_sibling_shared_directory(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_approve_reject_flow(workspace, "vars.fetchExpense.output.amount")
+    frozen_checker = tmp_path / "frozen" / CHECKER.name
+    frozen_checker.parent.mkdir()
+    shutil.copyfile(CHECKER, frozen_checker)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(CHECKER.parents[1])
+
+    result = subprocess.run(
+        [sys.executable, str(frozen_checker)],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
     assert result.returncode == 0, result.stderr
 


### PR DESCRIPTION
## Summary

- discover Flow solution projects first and fall back to one root-level SDK-emitted `.flow`
- keep debug checks project-scoped and fail on genuinely distinct root candidates
- route shared, binding, and DevCon checkers through the arm-neutral discovery layer
- add corpus guardrails for the ratified alignment campaign

## Verification

- `uvx pytest tests/tasks/uipath-maestro-flow/ -q` — 212 passed
- live-v1 canaries — 2/2 tasks at 1.000
- preview SDK discovery canaries — both discovery paths passed; routed-checker mount defect fixed and focused retry passed 6/6 criteria at 1.000

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)