### PR TITLE
fix(maestro-flow tests): name the Script node in the calculator prompt

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -10,8 +10,8 @@ run_limits:
 
 initial_prompt: |
   Create a UiPath Flow project named "Calculator" that takes two numbers as
-  input and calculates their product. The result should be returned as an
-  output variable.
+  input and calculates their product using a Script node. The result should be
+  returned as an output variable.
 
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/check_calculator_flow.py
@@ -20,6 +20,10 @@ EXPECTED = INPUT_A * INPUT_B  # 391
 
 def main():
     # A Script node must be present — prevents hardcoding 391 as a literal.
+    # The prompt names the Script node for this reason: an End-node output
+    # mapping (`=js:$vars.numberA * $vars.numberB`) is a skill-documented way
+    # to compute the product and does run to 391, so without that instruction
+    # this assert fails a correct flow. Keep prompt and assert in sync.
     assert_flow_has_node_type(["core.action.script"])
 
     project_dir = find_project_dir()


### PR DESCRIPTION
## What

One-line prompt change to `skill-flow-calculator`, plus a maintainer note on the assert it's coupled to.

```diff
-  input and calculates their product. The result should be returned as an
-  output variable.
+  input and calculates their product using a Script node. The result should be
+  returned as an output variable.
```

## Why

The task fails at **0.375** on its gating execution criterion:

```
FAIL: No node matches type hint 'core.action.script'.
Node types seen: ['core.control.end', 'core.trigger.manual']
```

The agent built `manual trigger → End`, computing the product in the End node's output mapping (`=js:$vars.numberA * $vars.numberB`). **That flow is correct.** Reproduced locally against alpha/popoc:

| Variant | `validate` | `flow debug --inputs '{"numberA":17,"numberB":23}'` |
|---|---|---|
| Failing artifact (End-only) | Valid | Completed, `globals: {"product": 391}` |
| End-only, trigger-scoped read | Valid | Completed, `product: 391` |
| Script node (what the assert wants) | Valid | Completed, `product: 391` |

The criterion's own second half — `assert_output_value(payload, 391)` — **passes** against the failing artifact's real debug payload. Only the structural node assert rejects it.

Nothing visible to the agent asked for a Script node. The prompt asked for a product returned as an output variable; the harness-side `description` is the only place "script node" appears. The skill, meanwhile, documents the shape the agent chose:

- `references/shared/variables-and-expressions.md` § *Output Mapping on End Nodes* — computed `=js:` sources on End outputs, including a compound expression.
- `references/author/references/greenfield.md` Step 4 — "End-node `outputs` mapping goes here too if you declared an `out` variable"; the canonical 3-turn build is trigger → End.
- `greenfield.md` § *Should you plan first?* says **don't** plan a straightforward linear pipeline, so a trivial calculator never reaches `planning-arch.md`'s node-selection index.

The agent wasn't unaware of the node — it ran `registry get core.action.script` and chose End anyway. The skill gave it no reason to prefer a node.

## Why fix the prompt, not the assert

Repo convention already does this: sibling tasks whose checkers pin a node type name it in the prompt — `feet_inches` ("Use a Switch node on `direction`"), `loop_multiply` ("using a Loop node"). Naming it keeps what the task exists to exercise (its description: "Exercises input variables, script logic, and output mapping") and keeps the anti-hardcoding guard. Relaxing the assert instead would leave a task that no longer covers script logic at all. Changing the *skill* to forbid End-node computation was the third option and was rejected — it would invent a product opinion to satisfy a test.

## Verification

- Unmodified `check_calculator_flow.py` against a Script-node build: `OK: Script node present; output contains 391`, exit 0.
- Same checker against the failing shape: reproduces the eval error byte-for-byte.
- Three Studio Web solutions created by the debug runs were deleted (`cleanup_solutions.py`: `deleted=3 failed=0`).
- Not re-run through the full eval harness — this is a prompt clarification; the checker-side proof is above.

## Follow-ons (deliberately not in this PR)

1. **`dice_roller` has the same latent coupling** — same `core.action.script` assert, prompt never names it, and `Math.floor(Math.random()*6)+1` fits an End mapping just as well. It passes today by luck of model choice; no failing run to point at, so changing a green task's prompt without evidence is left separate.
2. **Missing `triggerNodeId` on `in` globals** is a real skill-adherence miss in the artifact that **no criterion here can catch** — `validate` is green and `flow debug --inputs` binds inputs regardless. It bites at pack time: packing the artifact's shape yields `"input": {"type": "object", "properties": {}}` in `content/entry-points.json`, versus `numberA`/`numberB` with types and defaults when set. A deployed process would expose no inputs. Catching it needs a new pack-time entry-point-contract criterion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)