### PR TITLE
test(case): fix tests failed in evals using sonnet-5

### DIFF
--- a/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
+++ b/tests/tasks/uipath-maestro-case/aged_invoice_structural/aged_invoice_structural.yaml
@@ -31,8 +31,8 @@ agent:
 
 run_limits:
   task_timeout: 5400
-  max_turns: 300
-  turn_timeout: 3600
+  max_turns: 450
+  turn_timeout: 5400
 
 sandbox:
   template_sources:

--- a/tests/tasks/uipath-maestro-case/sla_response/repair_any_escalation/repair_any_escalation.yaml
+++ b/tests/tasks/uipath-maestro-case/sla_response/repair_any_escalation/repair_any_escalation.yaml
@@ -1,12 +1,12 @@
 task_id: skill-case-sla-repair-any-escalation
 description: >
-  T4 of the SLA-response battery — diagnose mode. The staged caseplan is exactly one defect
-  away from valid: its SLA lane entry carries the Case Designer's `escalationId: "any"`
-  sentinel, which the frontend accepts but released `uip maestro case validate` rejects
-  ("The escalation referenced by rule ... no longer exists" — reproduced on
-  uip 1.198.0-preview.102). The correct repair is to drop the key, because a breach rule
-  references the SLA alone. The tempting wrong repair — inventing an escalation so the
-  reference resolves — also turns validate green, so the checker fails it explicitly.
+  T4 of the SLA-response battery — diagnose mode. The staged caseplan's SLA lane entry
+  still carries the Case Designer's `escalationId: "any"` sentinel — a frontend-only
+  placeholder that must not ship in an exported caseplan.json, whether or not
+  `uip maestro case validate` currently flags it. The correct repair is to drop the key,
+  because a breach rule references the SLA alone. The tempting wrong repair — inventing an
+  escalation so the reference resolves — also turns validate green, so the checker fails it
+  explicitly.
 tags: [uipath-maestro-case, smoke, mode:diagnose, lifecycle:generate, shape:multi-node, feature:sla, feature:escalation]
 max_iterations: 1
 
@@ -21,8 +21,10 @@ sandbox:
       path: ./templates
 
 initial_prompt: |
-  `uip maestro case validate SlaResponse/SlaResponse/caseplan.json` is failing on this
-  solution. Diagnose it and fix it.
+  The SLA lane in `SlaResponse/SlaResponse/caseplan.json` has an `sla-status-change` entry
+  rule left over from the Case Designer with `escalationId: "any"`. Diagnose whether that's
+  safe to ship and fix it. `uip maestro case validate` may already report the file Valid —
+  that alone does not mean there is nothing to fix.
 
   The Escalation Review lane and the fact that it is entered on a case-SLA event are both
   intentional — do not restructure the case, and do not delete the lane or its entry rule.


### PR DESCRIPTION
skill-case-sla-repair-any-escalation:
CLI version drift. The task (repair_any_escalation.yaml) was authored against uip 1.198.0-preview.102, where the Case Designer's "any" sentinel was rejected by validate. The sandbox's installed CLI (1.201.0-dev.8319) has since added a SLA_ANY_ESCALATION_VALUE special case that makes "any" pass validate — so the first success criterion (validate exit 0) is trivially satisfied by the untouched file, and the agent's diagnostic prompt ("is failing... diagnose it") is no longer true. That's why run_command criterion 1 scores 1.0 on an unmodified file while criterion 2 (the semantic checker requiring the sentinel actually be replaced with a plain breach rule) fails — it correctly still enforces the intended repair regardless of what validate currently accepts.

skill-case-aged-invoice-structural:
timeout needs to be consistent