### PR TITLE
test(maestro-flow): align loop-neutral task batch

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py
@@ -3,12 +3,13 @@
 to a production bar, not left on the toy scaffold defaults.
 
 Usage (from a task's run_command, cwd = sandbox root):
-    python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py <glob>
+    python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py [--check <scope>] [<glob>]
 
   <glob>  Shell-style glob for the inline agent.json. The inline agent dir is a
           UUID, so the path is not statically knowable — pass e.g.
           "EmailTriage/EmailTriage/*/agent.json". Defaults to
           "**/agent.json" if omitted.
+  <scope> One of ``exists``, ``model``, or ``quality`` (the default).
 
 Asserts, on the first matching agent.json (excluding generated .agent-builder/):
   1. settings.model is set and is NOT the stale scaffold default gpt-4o-2024-11-20.
@@ -54,8 +55,23 @@ EXCLUDED_PARTS = {
 }
 
 
+def _parse_args() -> tuple[str, str]:
+    args = sys.argv[1:]
+    scope = "quality"
+    if args[:1] == ["--check"]:
+        if len(args) < 2 or args[1] not in {"exists", "model", "quality"}:
+            print("FAIL: --check must be one of exists, model, or quality")
+            raise SystemExit(1)
+        scope = args[1]
+        args = args[2:]
+    if len(args) > 1:
+        print("FAIL: expected at most one agent.json glob")
+        raise SystemExit(1)
+    return scope, args[0] if args else "**/agent.json"
+
+
 def main() -> int:
-    pattern = sys.argv[1] if len(sys.argv) > 1 else "**/agent.json"
+    scope, pattern = _parse_args()
     paths = [
         path
         for path in glob.glob(pattern, recursive=True)
@@ -66,6 +82,10 @@ def main() -> int:
         return 1
 
     path = min(paths)
+    if scope == "exists":
+        print(f"OK ({path}): inline agent sidecar exists")
+        return 0
+
     try:
         with open(path) as source:
             agent = json.load(source)
@@ -80,6 +100,13 @@ def main() -> int:
         errs.append("settings.model is empty")
     elif model == SCAFFOLD_MODEL:
         errs.append(f"settings.model not overridden ({model})")
+
+    if scope == "model":
+        if errs:
+            print(f"FAIL ({path}): " + "; ".join(errs))
+            return 1
+        print(f"OK ({path}): model={model}")
+        return 0
 
     sys_msgs = [m.get("content", "") for m in agent.get("messages", []) if m.get("role") == "system"]
     prompt = (sys_msgs[0] if sys_msgs else "").strip()

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_advisories.py
@@ -222,6 +222,35 @@ def test_inline_agent_ignores_staging_trees(tmp_path: Path) -> None:
     assert "Solution" in result.stdout
 
 
+def test_inline_agent_scoped_checks_preserve_artifact_outcomes(tmp_path: Path) -> None:
+    agent = tmp_path / "agent-id" / "agent.json"
+    agent.parent.mkdir()
+    agent.write_text(json.dumps({"settings": {"model": "gpt-4.1"}}))
+
+    exists = run_script(
+        "check_inline_agent.py", "--check", "exists", "**/agent.json", cwd=tmp_path
+    )
+    model = run_script(
+        "check_inline_agent.py", "--check", "model", "**/agent.json", cwd=tmp_path
+    )
+
+    assert exists.returncode == 0, exists.stdout + exists.stderr
+    assert model.returncode == 0, model.stdout + model.stderr
+
+
+def test_inline_agent_model_scope_rejects_scaffold_default(tmp_path: Path) -> None:
+    agent = tmp_path / "agent-id" / "agent.json"
+    agent.parent.mkdir()
+    agent.write_text(json.dumps({"settings": {"model": "gpt-4o-2024-11-20"}}))
+
+    result = run_script(
+        "check_inline_agent.py", "--check", "model", "**/agent.json", cwd=tmp_path
+    )
+
+    assert result.returncode != 0
+    assert "not overridden" in result.stdout
+
+
 def test_reachability_excludes_the_loop_back_edge() -> None:
     """A loop body must not reach the End nodes that follow the loop.
 

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -38,9 +38,6 @@ V1_AUTHORING_ALLOWLIST = {
     "ixp/routing_listing.yaml",
     "ixp/scaffold_minimal.yaml",
     "ixp/scaffold_multinode.yaml",
-    "smoke/init_validate.yaml",
-    "smoke/inline_agent_robust.yaml",
-    "smoke/registry_discovery.yaml",
 }
 
 SKILL_TELEMETRY_ALLOWLIST = {
@@ -64,13 +61,6 @@ FORBIDDEN_PROMPT_ALLOWLIST = {
     "ixp/routing_negative.yaml",
     "ixp/scaffold_minimal.yaml",
     "ixp/scaffold_multinode.yaml",
-    "single_node/delay/delay.yaml",
-    "single_node/outlook_waitfor_email/outlook_waitfor_email.yaml",
-    "single_node/transform_filter/transform_filter.yaml",
-    "single_node/transform_group_by/transform_group_by.yaml",
-    "single_node/transform_map/transform_map.yaml",
-    "smoke/merge_parallel_sync.yaml",
-    "smoke/scheduled_trigger.yaml",
 }
 
 # These born-neutral escalation tasks are outside the recipe-edit sweep. Their
@@ -101,26 +91,6 @@ DEBUG_SOLUTION_ALLOWLIST = {
     "interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml",
     "interactive/customer_escalation_triage/customer_escalation_triage.yaml",
     "interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml",
-    "multi_node/bellevue_weather/bellevue_weather.yaml",
-    "multi_node/calculator/calculator.yaml",
-    "multi_node/customer_escalation/customer_escalation.yaml",
-    "multi_node/dice_roller/dice_roller.yaml",
-    "multi_node/feet_inches/feet_inches.yaml",
-    "multi_node/loop_multiply/loop_multiply.yaml",
-    "multi_node/multi_city_weather/multi_city_weather.yaml",
-    "multi_node/reading_list/reading_list.yaml",
-    "multi_node/slack_channel_description/slack_channel_description.yaml",
-    "multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml",
-    "multi_node/wiki_pageviews/wiki_pageviews.yaml",
-    "single_node/api_workflow/api_workflow.yaml",
-    "single_node/decision/decision.yaml",
-    "single_node/file_attachment/file_attachment.yaml",
-    "single_node/lowcode_agent/lowcode_agent.yaml",
-    "single_node/openmeteo_weather/openmeteo_weather.yaml",
-    "single_node/rpa/rpa.yaml",
-    "single_node/subflow/subflow.yaml",
-    "single_node/switch/switch.yaml",
-    "single_node/terminate/terminate.yaml",
     "connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml",
 }
 
@@ -178,7 +148,10 @@ def _is_debug_graded(task_path: Path, text: str) -> bool:
     for criterion_type, criterion in _criterion_blocks(text):
         if criterion_type == "command_not_executed":
             continue
-        normalized = criterion.lower().replace("\\\\", "\\")
+        executable = "\n".join(
+            line for line in criterion.splitlines() if not line.lstrip().startswith("#")
+        )
+        normalized = executable.lower().replace("\\\\", "\\")
         if "flow\\s+debug" in normalized or "flow debug" in normalized:
             return True
         if criterion_type != "run_command":
@@ -221,9 +194,12 @@ def test_v1_only_authoring_commands_match_the_temporary_allowlist() -> None:
     offenders = set()
     for relative, _, text in _tagged_tasks():
         for criterion_type, criterion in _criterion_blocks(text):
-            if criterion_type == "command_executed" and _has_v1_authoring_grammar(
+            if criterion_type != "command_executed" or not _has_v1_authoring_grammar(
                 criterion
             ):
+                continue
+            threshold = re.search(r"(?m)^\s+pass_threshold:\s*([0-9.]+)", criterion)
+            if threshold is None or float(threshold.group(1)) > 0:
                 offenders.add(relative)
     assert offenders == V1_AUTHORING_ALLOWLIST
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/bellevue_weather/bellevue_weather.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bellevue-weather
 description: >
   Create a UiPath Flow that fetches today's weather in Bellevue from open-meteo,
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "BellevueWeather" that gets today's weather
   in Bellevue from open-meteo, formats a summary with a script, and if the
   temperature is greater than 60F returns a summary with a message field 'nice day',

--- a/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/calculator/calculator.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-calculator
 description: >
   Create a UiPath Flow that takes two number inputs and calculates their product
@@ -9,6 +13,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "Calculator" that takes two numbers as
   input and calculates their product. The result should be returned as an
   output variable.

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/check_customer_escalation_flow.py
@@ -25,15 +25,13 @@ Asserts:
 
 from __future__ import annotations
 
-import glob
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any, NoReturn
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
-from _shared.flow_check import find_project_dir  # noqa: E402
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 
 def fail(msg: str) -> NoReturn:
@@ -41,23 +39,7 @@ def fail(msg: str) -> NoReturn:
 
 
 def load_flow() -> dict[str, Any]:
-    # Discover the Flow project rather than hardcoding
-    # `CustomerEscalation/CustomerEscalation/CustomerEscalation.flow`: the prompt
-    # names only the FLOW ('a Maestro Flow called "CustomerEscalation"'), never
-    # the enclosing solution, and the two names are independent — `uip solution
-    # init <S> && cd <S> && uip maestro flow init <F>` yields `<S>/<F>/<F>.flow`
-    # for any <S>, while a bare `uip maestro flow init <F>` auto-scaffolds
-    # `<F>Solution/<F>/<F>.flow`. A path-pinned glob graded the solution name,
-    # an unstated requirement: skill-flow-customer-escalation scored 0.0 on this
-    # criterion with a fully valid flow at
-    # `CustomerEscalationSolution/CustomerEscalation/CustomerEscalation.flow`.
-    # Mirrors the discovery in `_shared/validate_flow.py`, so this criterion and
-    # the validate criterion address the same file.
-    project_dir = find_project_dir()
-    matches = sorted(glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True))
-    if not matches:
-        fail(f"No .flow file found under {project_dir}")
-    path = Path(matches[0])
+    path = Path(find_flow_file(flow_glob="CustomerEscalation*.flow"))
     try:
         return json.loads(path.read_text())
     except json.JSONDecodeError as exc:

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/customer_escalation.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-customer-escalation
 description: >
   Complex multi-branch escalation flow: Outlook email-received trigger →
@@ -58,4 +62,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 10.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
+++ b/tests/tasks/uipath-maestro-flow/multi_node/customer_escalation/test_check_customer_escalation_flow.py
@@ -11,8 +11,8 @@ These tests pin down the contract that:
 - Structural requirements (>=5 nodes, exactly one decision with >=2
   branches, >=2 scripts, Slack reference, non-trigger Outlook/Graph
   reference) are still enforced.
-- The verdict is independent of the enclosing SOLUTION directory's name,
-  which the prompt never specifies (see `test_any_solution_name_passes`).
+- The verdict is independent of the authoring layout: any solution directory
+  name or one root-level SDK emit is accepted.
 """
 
 from __future__ import annotations
@@ -42,8 +42,7 @@ def _flow_dir(tmp_path: Path, solution: str = "CustomerEscalationSolution") -> P
     against a layout the CLI cannot emit, which is why the checker's
     path-coupling survived to fail a real run.
 
-    `project.uiproj` is required: `find_project_dir` selects the project whose
-    manifest declares `ProjectType: "Flow"`.
+    `project.uiproj` makes this the live-v1 solution-layout fixture.
     """
     d = tmp_path / solution / "CustomerEscalation"
     d.mkdir(parents=True)
@@ -151,6 +150,16 @@ def test_any_solution_name_passes(tmp_path: Path, solution: str) -> None:
     nodes, edges = _outlook_connector_shape()
     _write_flow(tmp_path, nodes, edges, solution=solution)
     result = _run(tmp_path)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_root_level_sdk_emit_passes(tmp_path: Path) -> None:
+    nodes, edges = _outlook_connector_shape()
+    payload = {"version": "1.0.0", "nodes": nodes, "edges": edges}
+    (tmp_path / "CustomerEscalation.flow").write_text(json.dumps(payload))
+
+    result = _run(tmp_path)
+
     assert result.returncode == 0, result.stdout + result.stderr
 
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/dice_roller/dice_roller.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-dice-roller
 description: >
   Create a UiPath Flow from scratch that simulates rolling a fair six-sided die.
@@ -11,6 +15,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "DiceRoller" that simulates rolling a six-sided
   die and outputs the result.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/feet_inches/feet_inches.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-feet-inches
 description: >
   Create a UiPath Flow that converts a value between feet and inches based on
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "FeetInches" that takes `value` (number)
   and `direction` (string: "f2i", "i2f", or "y2f") as inputs, converts feet
   to inches (× 12), inches to feet (÷ 12), or yards to feet (× 3) accordingly,

--- a/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/loop_multiply/loop_multiply.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-loop-multiply
 description: >
   Create a UiPath Flow that uses a Loop node to multiply the numbers
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "LoopMultiply" that multiplies the
   numbers [13, 15, 17] together using a Loop node and returns the product.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/multi_city_weather/multi_city_weather.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-multi-city-weather
 description: >
   Loop over 3 cities, fetch weather from open-meteo for each, classify warm/cold
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a flow called "MultiCityWeather". Loop over Seattle, Phoenix, and New York — for each city, fetch the current temperature from open-meteo (fahrenheit) and classify it as 'warm' (> 60F) or 'cold'. Output an array with all 3 results, each having the city name, temperature, and verdict.
   Use a Managed HTTP Request node (core.action.http.v2) to call the open-meteo API directly — do not use an Integration Service connector.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/reading_list/reading_list.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-reading-list
 description: >
   Create a UiPath Flow that curates a reading list from a catalog of math/ML/stats
@@ -11,6 +15,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "ReadingList" that curates a reading list
   from a catalog of math and data science books.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_channel_description/slack_channel_description.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-channel-description
 description: >
   Create a UiPath Flow that uses the Slack IS connector to retrieve the
@@ -11,6 +15,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow named "SlackChannelDescription" that retrieves
   the channel description of #office-bellevue and outputs it.
 

--- a/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/slack_weather_pipeline/slack_weather_pipeline.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-weather-pipeline
 description: >
   Multi-step pipeline: read Slack channel description, extract city with a script,
@@ -11,11 +15,13 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a flow called "SlackWeatherPipeline". Read the #office-bellevue Slack channel description — it holds the office's full US mailing address (street, suite/unit, city, state, ZIP) — identify the city (the locality, not the street or suite line). Then fetch the current weather for that city from open-meteo. If it's above 60F the flow must output the text in variable `weatherVerdict` 'warm office today', otherwise 'cold office today'.
 
   All connections for this task live in Orchestrator folder `Shared/uipath-maestro-flow`.
 
-  Validate the flow, then run `uip maestro flow debug` and iterate until it completes without incidents.
+  Validate the flow, then run it and iterate until it completes without incidents.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:

--- a/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/wiki_pageviews/wiki_pageviews.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-wiki-pageviews
 description: >
   Create a UiPath Flow that fetches a range of Wikipedia pageviews, keeps
@@ -12,6 +16,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "WikiPageviews" that takes `article`
   (string) and `date1`, `date2` (strings in `YYYYMMDD` format) as inputs.
   Fetch the daily view counts in the range from the Wikimedia pageviews API

--- a/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/api_workflow/api_workflow.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-api-workflow
 description: >
   Create a UiPath Flow that invokes the name-to-age API workflow with the
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "NameToAge" that invokes the name-to-age
   API workflow with the name 'tomasz' and returns his age as an output.
 

--- a/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/decision/decision.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-decision
 description: >
   Create a UiPath Flow that takes a temperature in Fahrenheit and uses a Decision
@@ -11,6 +15,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "TemperatureChecker" that takes a
   temperature in Fahrenheit as input. If the temperature is greater than 75,
   the flow should output "warm". Otherwise it should output "cool".

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/check_delay_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/check_delay_flow.py
@@ -19,10 +19,13 @@ live engine). Verifies:
      `sourceNodeId` is the delay node id (outgoing).
 """
 
-import glob
 import json
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.logic.delay"
 VALID_TIMER_TYPES = {"timeDuration", "timeDate"}
@@ -33,10 +36,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/DelayDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no DelayDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="DelayDemo*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/delay/delay.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-delay
 description: >
   Create a UiPath Flow with a single OOTB Delay node (`core.logic.delay`)
@@ -20,18 +24,16 @@ initial_prompt: |
     - `inputs.timerType` must be `"timeDuration"`.
     - `inputs.timerPreset` must be a fixed ISO 8601 duration preset such as
       `"PT15M"` (15 minutes). Do NOT use `"custom"` for this smoke test.
-    - Set `typeVersion` from the node registry for `core.logic.delay` —
-      do NOT hardcode a guessed version.
+    - Set `typeVersion` from the authoritative definition for
+      `core.logic.delay`.
 
   Wire the Delay node so that it has an incoming edge from the trigger and an
   outgoing edge to the End node (an `edges[]` entry whose `targetNodeId` is
   the delay node id, and one whose `sourceNodeId` is the delay node id).
 
-  Do NOT run flow debug — just validate the flow.
+  Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, follow the documented workflow steps exactly — in particular, the delay plugin's `inputs` shape
-  (`timerType` + `timerPreset`).
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/file_attachment/file_attachment.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-file-attachment-debug
 description: >
   Build a Flow whose trigger exposes a file-typed input variable, read the
@@ -21,13 +25,15 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "AttachmentEcho" that accepts a file as
   input and echoes the uploaded file's name back as a flow output. Use a
   file-typed input variable named `inputDoc` and surface the name as an output
   variable named `fileName`.
 
-  Validate the flow, then run it with `uip maestro flow debug`, binding a local
-  file to the input. The task is not complete until the debug run reports
+  Validate the flow, then run it with a local file bound to the input. The
+  task is not complete until the run reports
   `finalStatus: "Completed"` and the output reflects the attached file's name.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between

--- a/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/lowcode_agent/lowcode_agent.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-lowcode-agent
 description: >
   Create a UiPath Flow that wires in the existing CountLetters low-code agent
@@ -15,6 +19,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "CountLettersLowCode" that uses the
   existing CountLetters low-code agent to count the number of r's in 'arrow'
   and return the answer. The agent already exists — discover it and wire it

--- a/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/openmeteo_weather/openmeteo_weather.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-openmeteo-weather
 description: >
   End-to-end: build a Flow whose process fetches the CURRENT weather in Bellevue
@@ -24,13 +28,15 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "OpenMeteoWeather".
   The process must fetch the CURRENT weather in Bellevue using the Open-Meteo
   connector, then surface the current temperature as a flow output variable.
 
   Use the Open-Meteo Integration Service connector. Validate the flow.
 
-  The task is not complete until `uip maestro flow validate` passes.
+  The task is not complete until the flow validates.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build and validate the complete flow end-to-end

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/check_outlook_trigger_inbox.py
@@ -4,6 +4,8 @@
 Two checks:
 
   check_trigger_node      Structural — flow contains the email-received trigger.
+  check_folder_binding    Structural — trigger binds both an Outlook connection
+                          and a non-empty MailFolder reference.
   check_folder_id_fresh   Regression — parentFolderId written into the flow is
                           a live MailFolder ID on the currently-bound Outlook
                           connection. Catches "agent resolved-but-reused a
@@ -16,11 +18,13 @@ YAML description for the infrastructure rationale.
 Privacy: never logs folder display names. Only counts + truncated IDs.
 """
 
-import glob
 import json
-import os
 import subprocess
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 CONNECTOR_KEY = "uipath-microsoft-outlook365"
 TRIGGER_TYPE_MARKER = "uipath.connector.trigger.uipath-microsoft-outlook365.email-received"
@@ -75,11 +79,9 @@ def _uip_resources_run(tail_args: list[str]) -> dict:
 
 
 def _read_flow() -> tuple[dict, str]:
-    flows = glob.glob("**/OutlookTriggerInbox*.flow", recursive=True)
-    if not flows:
-        sys.exit("FAIL: no OutlookTriggerInbox*.flow found under cwd")
-    with open(flows[0]) as f:
-        return json.load(f), flows[0]
+    path = find_flow_file(flow_glob="OutlookTriggerInbox*.flow")
+    with open(path) as f:
+        return json.load(f), path
 
 
 def _find_test_folder_key() -> str:
@@ -138,6 +140,19 @@ def check_trigger_node():
     print("OK: Outlook email-received trigger node present")
 
 
+def check_folder_binding():
+    flow, _ = _read_flow()
+    trigger = _find_trigger_node(flow)
+    detail = trigger.get("inputs", {}).get("detail", {}) or {}
+    connection_id = detail.get("connectionId")
+    parent_folder_id = (detail.get("eventParameters") or {}).get("parentFolderId")
+    if not connection_id:
+        sys.exit("FAIL: trigger.inputs.detail.connectionId is missing")
+    if not parent_folder_id:
+        sys.exit("FAIL: trigger.inputs.detail.eventParameters.parentFolderId is missing")
+    print("OK: Outlook connection and MailFolder reference are both bound")
+
+
 # ── subcommand: check_folder_id_fresh ──────────────────────────────────
 def check_folder_id_fresh():
     flow, _ = _read_flow()
@@ -180,6 +195,7 @@ def check_folder_id_fresh():
 
 DISPATCH = {
     "check_trigger_node": check_trigger_node,
+    "check_folder_binding": check_folder_binding,
     "check_folder_id_fresh": check_folder_id_fresh,
 }
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/outlook_trigger_inbox.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-outlook-trigger-inbox
 description: >
   Regression test for PR #348: verifies the agent freshly resolves the
@@ -67,16 +71,11 @@ success_criteria:
     weight: 0
     pass_threshold: 0
 
-  - type: command_executed
-    description: "Agent resolved MailFolder against the current --connection-id (PR #348 regression)"
-    tool_name: "Bash"
-    # `[\s\S]` matches across newlines — agents often split `uip` commands with
-    # backslash line-continuation, which `.*` would miss.
-    # Verb alternation tolerates both the post-rename verb ("run", current)
-    # and the legacy "execute" verb that older CLIs in the sandbox PATH may
-    # still expose (MST-9674).
-    command_pattern: 'uip\s+is\s+resources\s+(?:run|execute)\s+list[\s\S]+?MailFolder[\s\S]+?--connection-id'
-    min_count: 1
+  - type: run_command
+    description: "Flow carries a MailFolder reference on its bound Outlook connection"
+    command: "python3 $TASK_DIR/check_outlook_trigger_inbox.py check_folder_binding"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_trigger_inbox/test_check_outlook_trigger_inbox.py
@@ -132,6 +132,32 @@ def test_handles_pascalcase_item_id(monkeypatch) -> None:
     checker.check_folder_id_fresh()  # must NOT raise (id resolves on the connection)
 
 
+def test_folder_binding_requires_connection_and_reference(monkeypatch) -> None:
+    checker = _load_checker()
+    monkeypatch.setattr(
+        checker,
+        "_read_flow",
+        lambda: (
+            {
+                "nodes": [
+                    {
+                        "type": checker.TRIGGER_TYPE_MARKER,
+                        "inputs": {
+                            "detail": {
+                                "connectionId": "connection-1",
+                                "eventParameters": {"parentFolderId": "mail-folder-1"},
+                            }
+                        },
+                    }
+                ]
+            },
+            "OutlookTriggerInbox.flow",
+        ),
+    )
+
+    checker.check_folder_binding()
+
+
 def test_folder_id_mismatch_fails_with_pr348_signature(monkeypatch) -> None:
     """If the flow's parentFolderId is not in the live ID set, the checker
     fails with the PR #348 regression marker (independent of the verb)."""

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/check_outlook_waitfor_email.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/check_outlook_waitfor_email.py
@@ -24,9 +24,12 @@ source:
      MST-8802) cannot satisfy the check on its own.
 """
 
-import glob
 import json
 import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 EVENT_MARKERS = (
     "uipath.connector.event",
@@ -71,10 +74,7 @@ def _filter_trees(detail: dict):
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/OutlookWaitForEmail*.flow", recursive=True)
-    if not flows:
-        _fail("no OutlookWaitForEmail*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="OutlookWaitForEmail*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/outlook_waitfor_email/outlook_waitfor_email.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-outlook-waitfor-email
 description: >
   Build-and-validate: a Flow with a manual start trigger, a mid-flow
@@ -39,7 +43,7 @@ initial_prompt: |
   is received in the **Inbox** folder whose SUBJECT CONTAINS the string
   "TestWaitFor". Then End the flow.
 
-  Validate the flow. Do not debug the flow.
+  Validate the flow.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single

--- a/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/rpa/rpa.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-rpa
 description: >
   Create a UiPath Flow that uses the ProjectEuler RPA workflow to retrieve the
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "ProjectEulerTitle" that uses the
   ProjectEuler RPA workflow to retrieve the title for problem 123 and
   return it as an output.

--- a/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/subflow/subflow.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-subflow
 description: >
   Create a UiPath Flow that uses a Subflow node to encapsulate string-reversal
@@ -12,6 +16,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "SubflowDemo" that takes a string input
   called "text" and reverses it. The string reversal logic should be
   encapsulated inside a subflow rather than done directly in the main flow.

--- a/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/switch/switch.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-switch
 description: >
   Create a UiPath Flow that takes a quarter number (1-4) and uses a Switch node
@@ -10,6 +14,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "SeasonLookup" that takes a quarter number
   (1, 2, 3, or 4) as input and returns the corresponding season name:
     - 1 -> "Spring"

--- a/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/terminate/terminate.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-terminate
 description: >
   Create a UiPath Flow with two parallel branches from the trigger. One branch
@@ -12,6 +16,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
+  Build the flow inside a solution of the same name.
+
   Create a UiPath Flow project named "TerminateParallel" with two parallel
   branches from the trigger:
 

--- a/tests/tasks/uipath-maestro-flow/single_node/test_transform_output_envelopes.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/test_transform_output_envelopes.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SINGLE_NODE = Path(__file__).resolve().parent
+
+
+@pytest.mark.parametrize(
+    ("task", "flow_name", "node_type", "inputs"),
+    [
+        (
+            "transform_map",
+            "TransformMapDemo.flow",
+            "core.action.transform.map",
+            {
+                "collection": "$vars.people",
+                "operations": [
+                    {
+                        "type": "map",
+                        "config": {
+                            "mappings": [{"field": "name", "transformation": "uppercase"}]
+                        },
+                    }
+                ],
+            },
+        ),
+        (
+            "transform_filter",
+            "TransformFilterDemo.flow",
+            "core.action.transform.filter",
+            {
+                "collection": "$vars.items",
+                "operations": [
+                    {
+                        "type": "filter",
+                        "config": {
+                            "filters": [
+                                {"field": "amount", "condition": "greater_equal", "value": 100}
+                            ]
+                        },
+                    }
+                ],
+            },
+        ),
+        (
+            "transform_group_by",
+            "TransformGroupByDemo.flow",
+            "core.action.transform.group-by",
+            {
+                "collection": "$vars.employees",
+                "operations": [
+                    {
+                        "type": "groupBy",
+                        "config": {
+                            "groupByField": "department",
+                            "aggregations": [{"operation": "count", "alias": "headcount"}],
+                        },
+                    }
+                ],
+            },
+        ),
+    ],
+)
+def test_transform_checkers_accept_sdk_literal_output_envelopes(
+    tmp_path: Path, task: str, flow_name: str, node_type: str, inputs: dict
+) -> None:
+    flow = {
+        "nodes": [
+            {
+                "id": "transform",
+                "type": node_type,
+                "typeVersion": "1.0.0",
+                "inputs": inputs,
+                "outputs": {
+                    "output": {
+                        "source": {
+                            "type": "literal",
+                            "expression": "=result.response",
+                            "fieldType": "string",
+                        }
+                    },
+                    "error": {
+                        "source": {
+                            "type": "literal",
+                            "expression": "=Error",
+                            "fieldType": "string",
+                        }
+                    },
+                },
+            }
+        ]
+    }
+    (tmp_path / flow_name).write_text(json.dumps(flow))
+
+    result = subprocess.run(
+        [sys.executable, str(SINGLE_NODE / task / f"check_{task}_flow.py")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
@@ -29,6 +29,7 @@ from pathlib import Path
 from typing import NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.advisory_flow_utils import unwrap  # noqa: E402
 from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.filter"
@@ -169,12 +170,12 @@ def _check_operations(inputs: dict) -> None:
 
 def _check_output_sources(node: dict) -> None:
     outputs = node.get("outputs") or {}
-    out_src = ((outputs.get("output")) or {}).get("source")
+    out_src = unwrap(((outputs.get("output")) or {}).get("source"))
     if out_src != EXPECTED_OUTPUT_SOURCE:
         _fail(
             f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}"
         )
-    err_src = ((outputs.get("error")) or {}).get("source")
+    err_src = unwrap(((outputs.get("error")) or {}).get("source"))
     if err_src != EXPECTED_ERROR_SOURCE:
         _fail(
             f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}"

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/check_transform_filter_flow.py
@@ -23,10 +23,13 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      NOT pin a specific version).
 """
 
-import glob
 import json
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.filter"
 EXPECTED_OUTPUT_SOURCE = "=result.response"
@@ -55,10 +58,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/TransformFilterDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no TransformFilterDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="TransformFilterDemo*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_filter/transform_filter.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-filter
 description: >
   Create a UiPath Flow that uses a dedicated `core.action.transform.filter`
@@ -34,14 +38,13 @@ initial_prompt: |
       templates. Use the exact condition name `greater_equal`.
     - Wire the node `outputs.output.source` to `=result.response` and
       `outputs.error.source` to `=Error`.
-    - Set `typeVersion` from the node registry for
-      `core.action.transform.filter` — do not hardcode a guessed value.
+    - Set `typeVersion` from the authoritative definition for
+      `core.action.transform.filter`.
 
-  Do NOT run flow debug — just validate the flow.
+  Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single
-  pass. Before starting, follow the documented workflow steps exactly — in particular the transform plugin's filter
-  node shape (`operations[].type == "filter"` with `config.filters`).
+  pass.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.advisory_flow_utils import unwrap  # noqa: E402
 from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.group-by"
@@ -114,12 +115,12 @@ def _check_operations(inputs: dict) -> None:
 
 def _check_ports(node: dict) -> None:
     outputs = node.get("outputs") or {}
-    out_src = ((outputs.get("output") or {}).get("source"))
+    out_src = unwrap((outputs.get("output") or {}).get("source"))
     if out_src != EXPECTED_OUTPUT_SOURCE:
         _fail(
             f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}."
         )
-    err_src = ((outputs.get("error") or {}).get("source"))
+    err_src = unwrap((outputs.get("error") or {}).get("source"))
     if err_src != EXPECTED_ERROR_SOURCE:
         _fail(
             f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}."

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/check_transform_group_by_flow.py
@@ -21,10 +21,13 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      deliberately NOT pinned to a specific value here).
 """
 
-import glob
 import json
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.group-by"
 EXPECTED_OUTPUT_SOURCE = "=result.response"
@@ -36,10 +39,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/TransformGroupByDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no TransformGroupByDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="TransformGroupByDemo*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_group_by/transform_group_by.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-group-by
 description: >
   Create a UiPath Flow with a single Group By transform node
@@ -35,14 +39,12 @@ initial_prompt: |
       `average`) and a non-empty `alias` for the output field.
     - The node's `outputs.output.source` must be `=result.response` and
       `outputs.error.source` must be `=Error`.
-    - Set the node's `typeVersion` from the node registry for
-      `core.action.transform.group-by` — do NOT hardcode a guessed version.
+    - Set the node's `typeVersion` from the authoritative definition for
+      `core.action.transform.group-by`.
 
-  Validate the flow. Do NOT run flow debug — just validate.
+  Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, follow the documented workflow steps exactly — in particular, the transform plugin's Group By JSON
-  shape and the collection-input contract.
 
 success_criteria:
   # -- Flow file validity --

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
@@ -21,10 +21,13 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      pin a specific version string here).
 """
 
-import glob
 import json
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.map"
 EXPECTED_OUTPUT_SOURCE = "=result.response"
@@ -36,10 +39,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/TransformMapDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no TransformMapDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="TransformMapDemo*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/check_transform_map_flow.py
@@ -27,6 +27,7 @@ from pathlib import Path
 from typing import NoReturn
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from _shared.advisory_flow_utils import unwrap  # noqa: E402
 from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.action.transform.map"
@@ -105,12 +106,12 @@ def _check_operations(inputs: dict) -> None:
 
 def _check_output_sources(node: dict) -> None:
     outputs = node.get("outputs") or {}
-    out_src = ((outputs.get("output")) or {}).get("source")
+    out_src = unwrap(((outputs.get("output")) or {}).get("source"))
     if out_src != EXPECTED_OUTPUT_SOURCE:
         _fail(
             f"outputs.output.source={out_src!r}; must be {EXPECTED_OUTPUT_SOURCE!r}."
         )
-    err_src = ((outputs.get("error")) or {}).get("source")
+    err_src = unwrap(((outputs.get("error")) or {}).get("source"))
     if err_src != EXPECTED_ERROR_SOURCE:
         _fail(
             f"outputs.error.source={err_src!r}; must be {EXPECTED_ERROR_SOURCE!r}."

--- a/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
+++ b/tests/tasks/uipath-maestro-flow/single_node/transform_map/transform_map.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-transform-map
 description: >
   Smoke test: agent builds a pure-OOTB UiPath Flow with a single
@@ -32,15 +36,12 @@ initial_prompt: |
       `transformation: "uppercase"`.
     - The node `outputs.output.source` must be `=result.response` and
       `outputs.error.source` must be `=Error`.
-    - Set the node's `typeVersion` from the node registry for
-      `core.action.transform.map` — do NOT hardcode a guessed version (the
-      skill's workflow teaches how to read the registry).
+    - Set the node's `typeVersion` from the authoritative definition for
+      `core.action.transform.map`.
 
-  Do NOT run flow debug — just validate the flow.
+  Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
-  Before starting, follow the documented workflow steps exactly — in particular, the transform plugin's Map JSON
-  shape and the `collection` path contract.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_merge_parallel_sync_flow.py
@@ -22,11 +22,14 @@ node:
      source node that feeds the merge itself has an incoming edge.
 """
 
-import glob
 import json
 import sys
 from collections import Counter
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "core.logic.merge"
 
@@ -36,14 +39,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = sorted(glob.glob("**/ParallelSync*.flow", recursive=True))
-    if not flows:
-        _fail("no ParallelSync*.flow found under cwd")
-    # Prefer the canonical project path; fall back to the first match so the
-    # read is deterministic even if stray *.flow files exist.
-    canonical = "ParallelSync/ParallelSync/ParallelSync.flow"
-    path = canonical if canonical in flows else flows[0]
-    with open(path) as f:
+    with open(find_flow_file(flow_glob="ParallelSync*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
+++ b/tests/tasks/uipath-maestro-flow/smoke/check_scheduled_trigger_flow.py
@@ -34,11 +34,14 @@ trigger and carries a valid recurring schedule:
        - zero `definitions[]` entries with `nodeType == "core.trigger.manual"`.
 """
 
-import glob
 import json
 import re
 import sys
+from pathlib import Path
 from typing import NoReturn
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 SCHEDULED = "core.trigger.scheduled"
 MANUAL = "core.trigger.manual"
@@ -60,10 +63,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/ScheduledReport*.flow", recursive=True)
-    if not flows:
-        _fail("no ScheduledReport*.flow found under cwd")
-    with open(flows[0]) as f:
+    with open(find_flow_file(flow_glob="ScheduledReport*.flow")) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -25,8 +25,8 @@ success_criteria:
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
   - type: run_command
-    description: "Flow artifact is discoverable in either supported authoring layout"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert"
+    description: "Initialized flow has the default manual trigger"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert 'core.trigger.manual'"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/init_validate.yaml
@@ -1,8 +1,11 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-init-validate
 description: >
-  Skill-guided evaluation: agent uses the uipath-maestro-flow skill to create
-  a new UiPath Flow project inside a solution and validate it. Tests whether
-  the skill teaches the correct solution-first workflow and CLI usage.
+  Skill-guided evaluation: agent creates a new UiPath Flow project and
+  validates it. Tests whether the skill produces a valid Flow artifact.
 tags: [uipath-maestro-flow, smoke, lifecycle:generate]
 
 run_limits:
@@ -12,36 +15,20 @@ initial_prompt: |
   Create a new UiPath Flow project called "WeatherAlert" and make sure it
   validates successfully.
 
-  A Flow project MUST be created
-  inside a solution:
-  1. Create the solution first.
-  2. Create the Flow project inside that solution.
-  3. Confirm the flow project is registered in the parent solution.
-
-  The correct flow-file path is:
-    WeatherAlert/WeatherAlert/WeatherAlert.flow
-
-  The task is NOT complete until `uip maestro flow validate` has passed for
-  that exact file path.
-
-  Important:
-  - The `uip` CLI is already available in the environment.
-  - Validate locally with `uip maestro flow validate`.
-
 success_criteria:
   - type: command_executed
-    description: "Agent created a solution with uip solution init (or legacy new)"
+    description: "Advisory: live-v1 agent created a solution"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+solution\s+(init|new)'
     min_count: 1
     weight: 1.5
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
-  - type: command_executed
-    description: "Agent initialized a Flow project with uip maestro flow init"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "Flow artifact is discoverable in either supported authoring layout"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
@@ -53,10 +40,10 @@ success_criteria:
     weight: 1.5
     pass_threshold: 1.0
 
-  # Outcome-based check (auto-registration via `flow init` OR explicit
-  # `uip solution project add` both populate Projects[] in the .uipx).
+  # Solution registration is a live-v1 layout detail. Keep it visible without
+  # gating the SDK arm, whose native output is a root-level .flow artifact.
   - type: json_check
-    description: "Flow project is registered in the parent solution .uipx"
+    description: "Advisory: live-v1 Flow project is registered in the parent solution .uipx"
     path: "WeatherAlert/WeatherAlert.uipx"
     assertions:
       - expression: "length(Projects)"
@@ -66,11 +53,12 @@ success_criteria:
         operator: "gte"
         expected: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: file_exists
-    description: "Flow file was created inside the solution"
-    path: "WeatherAlert/WeatherAlert/WeatherAlert.flow"
+  - type: run_command
+    description: "Flow file was created in a supported authoring layout"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WeatherAlert"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-inline-agent-robust
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to build a
@@ -12,13 +16,9 @@ run_limits:
   max_turns: 90
 
 initial_prompt: |
-  Create a new UiPath Flow project called "EmailTriage" (inside a solution) and
+  Create a new UiPath Flow project called "EmailTriage" and
   add an inline agent node that classifies an inbound support email into a
   category and priority.
-
-  A Flow project MUST be created
-  inside a solution, so the inline agent lands at:
-    EmailTriage/EmailTriage/<agent-uuid>/agent.json
 
   Configure the inline agent to a production standard, not the scaffold default:
   - Pick an appropriate current model (do not keep the scaffold default).
@@ -26,41 +26,38 @@ initial_prompt: |
   - Declare a typed outputSchema (e.g. category, priority) — not a bare
     `content` string.
 
-  The task is NOT complete until `uip maestro flow validate` passes for
-  EmailTriage/EmailTriage/EmailTriage.flow.
-
-  Important:
-  - The `uip` CLI is already available in the environment.
-  - Validate locally with `uip maestro flow validate`.
+  Validate the flow.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent scaffolded the inline agent with uip agent init --inline-in-flow"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+agent\s+init\s+.*--inline-in-flow'
-    min_count: 1
+  - type: run_command
+    description: "Inline agent sidecar was created"
+    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" --check exists "**/agent.json"'
+    timeout: 15
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent discovered available models with uip agent model list"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+agent\s+model\s+list'
-    min_count: 1
+  - type: run_command
+    description: "Inline agent uses an explicitly selected current model"
+    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" --check model "**/agent.json"'
+    timeout: 15
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Flow file was created inside the solution"
-    path: "EmailTriage/EmailTriage/EmailTriage.flow"
+  - type: run_command
+    description: "Flow file was created in a supported authoring layout"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EmailTriage"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_contains
+  - type: run_command
     description: "Flow contains the inline agent node type"
-    path: "EmailTriage/EmailTriage/EmailTriage.flow"
-    includes:
-      - '"uipath.agent.autonomous"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EmailTriage 'uipath.agent.autonomous'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
@@ -72,7 +69,7 @@ success_criteria:
   # _shared is its sibling.
   - type: run_command
     description: "Inline agent.json: model overridden, real system prompt, typed outputSchema"
-    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" "EmailTriage/EmailTriage/*/agent.json"'
+    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" "**/agent.json"'
     timeout: 15
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/inline_agent_robust.yaml
@@ -31,7 +31,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Inline agent sidecar was created"
-    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" --check exists "**/agent.json"'
+    command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py" --check exists "**/agent.json"'
     timeout: 15
     expected_exit_code: 0
     weight: 1.5
@@ -39,7 +39,7 @@ success_criteria:
 
   - type: run_command
     description: "Inline agent uses an explicitly selected current model"
-    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" --check model "**/agent.json"'
+    command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py" --check model "**/agent.json"'
     timeout: 15
     expected_exit_code: 0
     weight: 1.0
@@ -65,11 +65,11 @@ success_criteria:
   # knowable — the shared checker globs it (excluding generated .agent-builder/)
   # and asserts the three production-quality properties the skill now teaches:
   # model overridden off gpt-4o, real (non-placeholder) system prompt, and a
-  # typed outputSchema beyond bare `content`. $TASK_DIR is this YAML's dir;
-  # _shared is its sibling.
+  # typed outputSchema beyond bare `content`. Use the mounted checker repository
+  # because preview freezes only this task directory at $TASK_DIR.
   - type: run_command
     description: "Inline agent.json: model overridden, real system prompt, typed outputSchema"
-    command: 'python3 "$TASK_DIR/../_shared/check_inline_agent.py" "**/agent.json"'
+    command: 'python3 "$SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_inline_agent.py" "**/agent.json"'
     timeout: 15
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-merge-parallel-sync
 description: >
   Build a UiPath Flow with two parallel branches that fork from the trigger and
@@ -17,12 +21,6 @@ initial_prompt: |
   Create a UiPath Flow project named "ParallelSync" that runs two branches in
   parallel and synchronizes them with a Merge node before finishing.
 
-  A Flow project MUST live inside a solution:
-    1. Create the solution first (`uip solution init`).
-    2. Create the Flow project inside it (`uip maestro flow init`). The correct
-       flow-file path is:
-         ParallelSync/ParallelSync/ParallelSync.flow
-
   Build this exact fork/join topology (the default manual trigger is fine — keep
   it as the start node and use it as the fork):
 
@@ -38,7 +36,7 @@ initial_prompt: |
       `display` object with a `label` — validate rejects a node without it.
     - Wire these FIVE edges. Every edge needs both `sourcePort` and
       `targetPort` (validate rejects an edge missing either). Use the correct
-      port ids per the registry/skill:
+    port ids from the authoritative node definitions:
         - trigger `output` → branchA `input`
         - trigger `output` → branchB `input`   (this fork = trigger has 2 outgoing edges)
         - branchA `success` → merge `input`
@@ -46,23 +44,13 @@ initial_prompt: |
         - merge `output` → end `input`
       The two edges into the merge must have `targetNodeId` = the merge node id;
       the edge out of the merge must have `sourceNodeId` = the merge node id.
-    - Set every node's `typeVersion` from the registry — do NOT hardcode guessed
-      versions (`uip maestro flow registry get core.logic.merge --output json`,
-      etc.). Append each node type's definition to `definitions[]` (the merge
-      definition carries `model.type: "bpmn:ParallelGateway"`).
+  - Set every node's `typeVersion` from its authoritative node definition.
+    Include each node type's definition in `definitions[]`; the Merge
+    definition carries `model.type: "bpmn:ParallelGateway"`.
 
-  The task is NOT complete until `uip maestro flow validate` passes for that
-  exact flow-file path.
-
-  Important:
-    - The `uip` CLI is already available; use `--output json` on uip commands.
-    - After wiring, you may run `uip maestro flow format <file>` to normalize
-      layout/variables, then validate with `uip maestro flow validate` — do NOT
-      run `uip maestro flow debug` (the parallel join only synchronizes in a
-      live engine).
-    - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
-      planning and implementation. Build the complete flow end-to-end in a
-      single pass.
+  Validate the flow. Do NOT ask for approval, confirmation, or feedback. Do
+  NOT pause between planning and implementation. Build the complete flow
+  end-to-end in a single pass.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────

--- a/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/merge_parallel_sync.yaml
@@ -36,7 +36,7 @@ initial_prompt: |
       `display` object with a `label` — validate rejects a node without it.
     - Wire these FIVE edges. Every edge needs both `sourcePort` and
       `targetPort` (validate rejects an edge missing either). Use the correct
-    port ids from the authoritative node definitions:
+      port ids from the authoritative node definitions:
         - trigger `output` → branchA `input`
         - trigger `output` → branchB `input`   (this fork = trigger has 2 outgoing edges)
         - branchA `success` → merge `input`

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-registry-discovery
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to explore
@@ -10,48 +14,40 @@ run_limits:
   max_turns: 28
 
 initial_prompt: |
-  I want to build a UiPath Flow that makes an HTTP request and processes the
-  response with a script. Before building anything, explore what node types
-  are available in the Flow registry and find the right ones for this task.
-
-  Important:
-  - The `uip` CLI is already available in the environment.
-  - Start by refreshing the registry cache with `uip maestro flow registry pull --output json`.
-  - After list/search identifies the candidates, inspect the exact schemas with
-    `uip maestro flow registry get core.action.http --output json` and
-    `uip maestro flow registry get core.action.script --output json`.
-  - Use `--output json` on all uip commands.
-  - Do not build the flow — just explore.
+  Explore the available Flow authoring capabilities for a flow that makes an
+  HTTP request and processes the response with a script. Identify the exact
+  HTTP and Script node types and inspect their input and output schemas.
+  Do not build the flow; report what you find.
 
 success_criteria:
   - type: command_executed
-    description: "Agent pulled registry data"
+    description: "Advisory: live-v1 agent refreshed registry data"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent listed or searched registry nodes"
+    description: "Advisory: live-v1 agent listed or searched registry nodes"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+(list|search)'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent retrieved details on the HTTP node type via registry get"
+    description: "Advisory: live-v1 agent retrieved details on the HTTP node type"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+get\s+.*core\.action\.http'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent retrieved details on the script node type via registry get"
+    description: "Advisory: live-v1 agent retrieved details on the Script node type"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+registry\s+get\s+.*core\.action\.script'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0

--- a/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/registry_discovery.yaml
@@ -20,6 +20,8 @@ initial_prompt: |
   Do not build the flow; report what you find.
 
 success_criteria:
+  # This task deliberately produces no artifact. Under ratified ruling D-2,
+  # v1-only registry telemetry remains report-only rather than gating the SDK arm.
   - type: command_executed
     description: "Advisory: live-v1 agent refreshed registry data"
     tool_name: "Bash"

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -29,7 +29,7 @@ initial_prompt: |
     - `inputs.timerType` must be `"timeCycle"`.
     - `inputs.timerPreset` must be `"R/PT1H"` (every hour — an ISO 8601
       repeating interval). Do NOT use `"custom"` for this smoke test.
-  - Set the node `typeVersion` from its authoritative node definition.
+    - Set the node `typeVersion` from its authoritative node definition.
     - Remove the `core.trigger.manual` node AND its `definitions[]` entry, and
     include the authoritative `core.trigger.scheduled` definition
       (it carries `model.type: "bpmn:StartEvent"` and

--- a/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
+++ b/tests/tasks/uipath-maestro-flow/smoke/scheduled_trigger.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-scheduled-trigger
 description: >
   Scaffold a UiPath Flow whose start node is a Scheduled Trigger
@@ -17,40 +21,24 @@ initial_prompt: |
   Create a UiPath Flow project named "ScheduledReport" whose flow is started by
   a **scheduled trigger** that runs every hour.
 
-  A Flow project MUST live inside a solution:
-    1. Create the solution first (`uip solution init`).
-    2. Create the Flow project inside it (`uip maestro flow init`). The correct
-       flow-file path is:
-         ScheduledReport/ScheduledReport/ScheduledReport.flow
-
-  `uip maestro flow init` scaffolds the flow with a default **manual** trigger
-  (`core.trigger.manual`). REPLACE that manual trigger with a **scheduled**
-  trigger so the flow's start node is a scheduled trigger:
+  Replace the default **manual** trigger (`core.trigger.manual`) with a
+  **scheduled** trigger so the flow's start node is a scheduled trigger:
 
     - The start node `type` must be `core.trigger.scheduled`.
     - Keep the existing `entryPointId` from the manual trigger's `inputs`.
     - `inputs.timerType` must be `"timeCycle"`.
     - `inputs.timerPreset` must be `"R/PT1H"` (every hour — an ISO 8601
       repeating interval). Do NOT use `"custom"` for this smoke test.
-    - Set the node `typeVersion` from the registry for `core.trigger.scheduled`
-      — do NOT hardcode a guessed version
-      (`uip maestro flow registry get core.trigger.scheduled --output json`).
+  - Set the node `typeVersion` from its authoritative node definition.
     - Remove the `core.trigger.manual` node AND its `definitions[]` entry, and
-      append the `core.trigger.scheduled` definition from the registry get above
+    include the authoritative `core.trigger.scheduled` definition
       (it carries `model.type: "bpmn:StartEvent"` and
       `model.eventDefinition: "bpmn:TimerEventDefinition"`). A flow must have
       exactly one trigger.
 
-  The task is NOT complete until `uip maestro flow validate` passes for that
-  exact flow-file path.
-
-  Important:
-    - The `uip` CLI is already available; use `--output json` on uip commands.
-    - Validate locally with `uip maestro flow validate` — do NOT run
-      `uip maestro flow debug` (the schedule fires only in a live engine).
-    - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
-      planning and implementation. Build the complete flow end-to-end in a
-      single pass.
+  Validate the flow. Do NOT ask for approval, confirmation, or feedback. Do
+  NOT pause between planning and implementation. Build the complete flow
+  end-to-end in a single pass.
 
 success_criteria:
   # ── Flow file validity ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- apply the ratified same-ground recipe to the 31-task Batch 1 roster
- replace v1-only authoring gates with arm-neutral artifact checks while preserving intent and weights
- route frozen checkers through shared discovery and accept both supported output-source representations
- add corpus and regression coverage for the aligned contracts

## Verification

- `uvx --with pyyaml pytest tests/tasks/uipath-maestro-flow -q` — 219 passed
- coder-eval 0.10.2 schema plan — all 31 tasks valid
- live-v1 paired shakeout — 29/31 success
- preview-SDK paired shakeout — 25/31 success before evidence-backed checker fixes
- preserved preview artifacts now pass the three corrected transform checks and all inline-agent quality checks
- remaining reds classified from paired evidence: Bellevue content variance in both arms; scheduled-trigger one-sample live miss; multi-city retry blocked by expired external auth

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)