### PR TITLE
test(maestro-flow): align HITL and interactive task batch

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/check_simulated_hitl.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/check_simulated_hitl.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Check source semantics for the simulated HITL tasks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from flow_check import find_flow_file
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def load_flow() -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    path = Path(find_flow_file())
+    try:
+        flow = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"could not read {path}: {error}")
+    nodes = flow.get("nodes")
+    if not isinstance(nodes, list):
+        fail(f"{path} has no nodes array")
+    return flow, nodes
+
+
+def hitl_nodes(nodes: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        node
+        for node in nodes
+        if str(node.get("type", "")).startswith("uipath.human-in-the-loop")
+    ]
+
+
+def field_text(field: dict[str, Any], key: str) -> str:
+    value = field.get(key)
+    return value.lower() if isinstance(value, str) else ""
+
+
+def check_schema(flow: dict[str, Any], nodes: list[dict[str, Any]]) -> None:
+    candidates = hitl_nodes(nodes)
+    if not candidates:
+        fail("need a HITL quickform node")
+    fields = (candidates[0].get("inputs") or {}).get("schema", {}).get("fields", [])
+    directions = {field.get("direction") for field in fields}
+    if "input" not in directions:
+        fail("need an input-direction (read-only) field")
+    if not directions.intersection({"output", "inOut"}):
+        fail("need an output/inOut (fill-in) field")
+    rendered = json.dumps(flow).lower()
+    if "approve" not in rendered or "reject" not in rendered:
+        fail("need Approve and Reject outcomes")
+    print("OK: HITL schema has input/output fields and Approve/Reject outcomes")
+
+
+def check_priority(_flow: dict[str, Any], nodes: list[dict[str, Any]]) -> None:
+    candidates = hitl_nodes(nodes)
+    if not candidates:
+        fail("need a HITL quickform node")
+    if "high" not in json.dumps(candidates[0]).lower():
+        fail("priority should be High")
+    print("OK: HITL priority is High")
+
+
+def check_expense(flow: dict[str, Any], nodes: list[dict[str, Any]]) -> None:
+    edges = flow.get("edges")
+    if not isinstance(edges, list):
+        fail("Flow must contain edges[]")
+    candidates = hitl_nodes(nodes)
+    if len(candidates) != 1:
+        fail(f"need exactly 1 HITL node, found {len(candidates)}")
+    hitl = candidates[0]
+    hitl_id = hitl.get("id")
+    schema = (hitl.get("inputs") or {}).get("schema", {})
+    fields = schema.get("fields", [])
+    outcomes = schema.get("outcomes", []) or []
+    if not fields:
+        fail("HITL needs fields")
+    if not any(
+        (field_text(field, "id") == "amount" or "amount" in field_text(field, "label"))
+        and field.get("type") == "number"
+        for field in fields
+    ):
+        fail("amount must be a number field")
+    decision_fields = [
+        field
+        for field in fields
+        if field.get("direction") in {"output", "inOut"}
+        and any(
+            key in field_text(field, "id")
+            for key in ("approval", "approved", "decision")
+        )
+    ]
+    outcome_names = {
+        str(outcome.get("name") or outcome.get("id") or "").lower()
+        for outcome in outcomes
+    }
+    has_decision = any(field.get("type") == "boolean" for field in decision_fields)
+    has_outcomes = any("approve" in name for name in outcome_names) and any(
+        "reject" in name for name in outcome_names
+    )
+    if not (has_decision or has_outcomes):
+        fail("need a boolean decision field or approve/reject outcomes")
+    reason_keys = ("reason", "comment", "explanation", "justification", "note")
+    if not any(
+        field.get("direction") in {"output", "inOut"}
+        and field.get("type") in {"text", "string", "textarea"}
+        and any(
+            key in field_text(field, "id") or key in field_text(field, "label")
+            for key in reason_keys
+        )
+        for field in fields
+    ):
+        fail("need a text reason output field")
+    if not any(
+        edge.get("sourceNodeId") == hitl_id
+        and edge.get("sourcePort") in {"completed", "outcome-completed"}
+        for edge in edges
+    ):
+        fail("HITL completed handle must be wired")
+    scripts = [
+        str((node.get("inputs") or {}).get("script", ""))
+        for node in nodes
+        if node.get("type") == "core.action.script"
+    ]
+    expected = f"$vars.{hitl_id}.output"
+    if not any(expected in script for script in scripts):
+        fail(f"downstream script must read HITL output via {expected}")
+    print("OK: expense HITL schema, routing, and downstream output access are correct")
+
+
+CHECKS = {
+    "expense": check_expense,
+    "priority": check_priority,
+    "schema": check_schema,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("check", choices=sorted(CHECKS))
+    args = parser.parse_args()
+    flow, nodes = load_flow()
+    CHECKS[args.check](flow, nodes)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch2_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch2_alignment.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parent
+FLOW_TASKS = SHARED.parent
+
+
+def run_script(script: Path, *args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(script), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_simulated_hitl_checks_accept_root_sdk_emit(tmp_path: Path) -> None:
+    flow = {
+        "nodes": [
+            {
+                "id": "review",
+                "type": "uipath.human-in-the-loop",
+                "inputs": {
+                    "priority": "High",
+                    "schema": {
+                        "fields": [
+                            {
+                                "id": "amount",
+                                "label": "Amount",
+                                "type": "number",
+                                "direction": "input",
+                            },
+                            {
+                                "id": "reason",
+                                "label": "Reason",
+                                "type": "text",
+                                "direction": "output",
+                            },
+                        ],
+                        "outcomes": [{"name": "Approve"}, {"name": "Reject"}],
+                    },
+                },
+            },
+            {
+                "id": "log",
+                "type": "core.action.script",
+                "inputs": {"script": "return $vars.review.output.reason;"},
+            },
+        ],
+        "edges": [
+            {
+                "sourceNodeId": "review",
+                "sourcePort": "completed",
+                "targetNodeId": "log",
+                "targetPort": "input",
+            }
+        ],
+    }
+    (tmp_path / "Review.flow").write_text(json.dumps(flow))
+    script = SHARED / "check_simulated_hitl.py"
+
+    for check in ("expense", "priority", "schema"):
+        result = run_script(script, check, cwd=tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_solution_select_checks_use_selected_solution(tmp_path: Path) -> None:
+    for name in ("SolarReports", "TideTracker"):
+        directory = tmp_path / name
+        directory.mkdir()
+        (directory / f"{name}.uipx").write_text(json.dumps({"Projects": []}))
+
+    selected = tmp_path / "WeatherSelection-7K4M"
+    project = selected / "WeatherAlert"
+    project.mkdir(parents=True)
+    (selected / "WeatherSelection-7K4M.uipx").write_text(
+        json.dumps({"Projects": [{"Name": "WeatherAlert", "Type": "Flow"}]})
+    )
+    (project / "project.uiproj").write_text(
+        json.dumps({"Name": "WeatherAlert", "ProjectType": "Flow"})
+    )
+    (project / "WeatherAlert.flow").write_text(json.dumps({"nodes": []}))
+    script = FLOW_TASKS / "interactive" / "check_solution_select.py"
+
+    for check in (
+        "existing-untouched",
+        "flow",
+        "no-extra-solution",
+        "project",
+        "solution",
+    ):
+        result = run_script(script, check, cwd=tmp_path)
+        assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_solution_select_advisory_reports_extra_default_solution(
+    tmp_path: Path,
+) -> None:
+    extra = tmp_path / "WeatherAlertSol"
+    extra.mkdir()
+    (extra / "WeatherAlertSol.uipx").write_text(json.dumps({"Projects": []}))
+    script = FLOW_TASKS / "interactive" / "check_solution_select.py"
+
+    result = run_script(script, "no-extra-solution", cwd=tmp_path)
+
+    assert result.returncode != 0
+    assert "unexpected default solution" in result.stderr

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -31,7 +31,6 @@ V1_AUTHORING_ALLOWLIST = {
     "evaluate/local_crud.yaml",
     "evaluate/no_auto_upload.yaml",
     "evaluate/simulation/simulation_crud.yaml",
-    "interactive/solution_select.yaml",
     "ixp/e2e_02_project_selection.yaml",
     "ixp/integration_handle_routing.yaml",
     "ixp/routing.yaml",
@@ -41,7 +40,6 @@ V1_AUTHORING_ALLOWLIST = {
 }
 
 SKILL_TELEMETRY_ALLOWLIST = {
-    "interactive/customer_escalation_triage/customer_escalation_triage.yaml",
     "ixp/e2e_02_project_selection.yaml",
     "ixp/integration_handle_routing.yaml",
     "ixp/scaffold_minimal.yaml",
@@ -87,10 +85,6 @@ DEBUG_SOLUTION_ALLOWLIST = {
     "edit/move_node/move_node.yaml",
     "edit/remove_node/remove_node.yaml",
     "edit/update_node/update_node.yaml",
-    "interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml",
-    "interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml",
-    "interactive/customer_escalation_triage/customer_escalation_triage.yaml",
-    "interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml",
     "connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml",
 }
 
@@ -117,6 +111,10 @@ def _criterion_blocks(text: str) -> list[tuple[str, str]]:
             section,
         )
     ]
+
+
+def _prompt_text(text: str) -> str:
+    return "\n".join((_block(text, "initial_prompt"), _block(text, "simulation")))
 
 
 def _tagged_tasks() -> list[tuple[str, Path, str]]:
@@ -219,7 +217,7 @@ def test_gating_skill_telemetry_matches_the_temporary_allowlist() -> None:
 def test_forbidden_prompt_phrases_match_the_temporary_allowlist() -> None:
     offenders = set()
     for relative, _, text in _tagged_tasks():
-        prompt = " ".join(_block(text, "initial_prompt").lower().split())
+        prompt = " ".join(_prompt_text(text).lower().split())
         if re.search(r"do not [^.]*\bdebug\b", prompt) or UUID_PATTERN.search(prompt):
             offenders.add(relative)
     assert offenders == FORBIDDEN_PROMPT_ALLOWLIST | FORBIDDEN_PROMPT_EXCEPTIONS
@@ -230,7 +228,7 @@ def test_debug_graded_prompts_name_a_same_name_solution() -> None:
     for relative, path, text in _tagged_tasks():
         if not _is_debug_graded(path, text):
             continue
-        prompt = " ".join(_block(text, "initial_prompt").lower().split())
+        prompt = " ".join(_prompt_text(text).lower().split())
         if not re.search(r"\b(?:in|inside) a solution of the same name\b", prompt):
             offenders.add(relative)
     assert offenders == DEBUG_SOLUTION_ALLOWLIST | DEBUG_PROJECT_LAYOUT_EXCEPTIONS

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_01_schema_design.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-schema-design
 description: >
   Quality test: agent correctly maps a business description to a quickform
@@ -66,4 +70,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_02_result_downstream.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-result-downstream
 description: >
   Quality test: agent correctly references the HITL node's output via
@@ -60,4 +64,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_03_boolean_decision.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-boolean-decision
 description: >
   Quality test: agent correctly wires a boolean HITL output field into a
@@ -61,4 +65,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/quality_04_brownfield_insert.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-quality-brownfield-insert
 description: >
   Quality test: agent inserts a HITL node into an existing flow without
@@ -70,4 +74,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_01_hitl_node_placed.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-node-placed
 description: >
   Smoke test: agent builds a simple invoice approval flow containing an inline
@@ -48,4 +52,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_02_completed_port_wired.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-completed-port
 description: >
   Smoke test: agent wires the HITL node's `outcome-completed` output port

--- a/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/hitl/smoke_03_multi_outcome_routing.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-smoke-multi-outcome-routing
 description: >
   Smoke test: agent builds a flow where a Decision node reads the HITL
@@ -70,4 +74,3 @@ success_criteria:
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/bellevue_weather_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bellevue-weather-simulated
 description: >
   Bellevue weather flow (HTTP → script → decision), but driven by a simulated
@@ -36,10 +40,10 @@ simulation:
     or below 60 should say 'bring a jacket'; and you want a short written
     summary of the weather rather than raw numbers. Say that it has to be
     built as a UiPath Maestro Flow — not an API workflow, not a standalone
-    script — and that you want it validated before you sign off. Do not name
-    files or paths and do not use technical wording. Close by inviting the
-    agent to ask you anything it needs before it starts building. Keep the
-    withheld items below to yourself until it asks.
+    script — inside a solution of the same name, and that you want it validated
+    before you sign off. Do not name files or paths and do not use technical
+    wording. Close by inviting the agent to ask you anything it needs before it
+    starts building. Keep the withheld items below to yourself until it asks.
 
     WITHHELD — reveal each of these ONLY if the agent asks about it:
       - The project name should be "BellevueWeather".
@@ -62,12 +66,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0
@@ -76,7 +79,7 @@ success_criteria:
   # Runtime check:
   - type: run_command
     description: "Flow debug runs; weather-API node executed and output contains a verdict"
-    command: "python3 $TASK_DIR/check_weather_flow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/bellevue_weather_simulated/check_weather_flow.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0
@@ -89,7 +92,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named BellevueWeather (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/BellevueWeather.flow',recursive=True) else 'expected a flow named BellevueWeather.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name BellevueWeather"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py
+++ b/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Check solution-selection outcomes without depending on authoring commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SHARED = Path(__file__).resolve().parents[1] / "_shared"
+sys.path.insert(0, str(SHARED))
+from flow_check import find_flow_file, find_project_dir  # noqa: E402
+
+SELECTED = Path("WeatherSelection-7K4M")
+PROJECT_PATTERN = "WeatherSelection-7K4M/**/project.uiproj"
+
+
+def fail(message: str) -> None:
+    raise SystemExit(f"FAIL: {message}")
+
+
+def selected_flow() -> Path:
+    path = Path(find_flow_file(PROJECT_PATTERN, flow_glob="WeatherAlert.flow"))
+    if SELECTED not in path.parents:
+        fail(f"WeatherAlert.flow is outside {SELECTED}: {path}")
+    return path
+
+
+def read_solution(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        fail(f"could not read {path}: {error}")
+    if not isinstance(value, dict):
+        fail(f"{path} is not a JSON object")
+    return value
+
+
+def check_flow() -> None:
+    print(f"OK: selected solution contains {selected_flow()}")
+
+
+def check_existing_untouched() -> None:
+    for name in ("SolarReports", "TideTracker"):
+        path = Path(name) / f"{name}.uipx"
+        projects = read_solution(path).get("Projects")
+        if projects != []:
+            fail(f"{path} should still contain no projects, found {projects!r}")
+    print("OK: pre-existing solutions contain no registered projects")
+
+
+def check_project() -> None:
+    project_dir = Path(find_project_dir(PROJECT_PATTERN))
+    if SELECTED not in project_dir.parents:
+        fail(f"Flow project is outside {SELECTED}: {project_dir}")
+    print(f"OK: selected solution contains a Flow project at {project_dir}")
+
+
+def check_solution() -> None:
+    path = SELECTED / f"{SELECTED.name}.uipx"
+    projects = read_solution(path).get("Projects")
+    if not isinstance(projects, list) or not any(
+        project.get("Type") == "Flow"
+        for project in projects
+        if isinstance(project, dict)
+    ):
+        fail(f"{path} does not register a Flow project")
+    print(f"OK: {path} registers a Flow project")
+
+
+def check_no_extra_solution() -> None:
+    allowed = {"SolarReports", "TideTracker", SELECTED.name}
+    extras = sorted(
+        str(path)
+        for path in Path.cwd().glob("*/*.uipx")
+        if path.parent.name not in allowed
+    )
+    if extras:
+        fail(f"unexpected default solution created before selection: {extras}")
+    print("OK: no extra default solution was created")
+
+
+def check_validate() -> None:
+    path = selected_flow()
+    result = subprocess.run(
+        ["uip", "maestro", "flow", "validate", str(path), "--output", "json"],
+        capture_output=True,
+        text=True,
+    )
+    sys.stdout.write(result.stdout)
+    sys.stderr.write(result.stderr)
+    if result.returncode:
+        raise SystemExit(result.returncode)
+
+
+CHECKS = {
+    "existing-untouched": check_existing_untouched,
+    "flow": check_flow,
+    "no-extra-solution": check_no_extra_solution,
+    "project": check_project,
+    "solution": check_solution,
+    "validate": check_validate,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("check", choices=sorted(CHECKS))
+    args = parser.parse_args()
+    CHECKS[args.check]()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/cli_dice_roller_simulated.yaml
@@ -1,6 +1,10 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-cli-dice-roller-simulated
 description: >
-  Dice-roller flow via CLI mode, but driven by a simulated non-technical user
+  Dice-roller flow in interactive mode, driven by a simulated non-technical user
   who withholds requirements until asked. Tests the agent's ability to
   clarify ambiguous asks before building.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, simulation]
@@ -40,16 +44,15 @@ simulation:
     die, six sides, numbers 1 through 6, and you want the rolled number shown
     as the result rather than buried somewhere nobody looks. Say that it has
     to be built as a UiPath Maestro Flow — not an API workflow, not a
-    standalone script — and that you want it validated before you sign off. Do
-    not name files or paths and do not use technical wording. How the agent
-    builds it is its own business — you have no opinion on CLI commands vs
-    editing files. Close by inviting the agent to ask you anything it needs
-    before it starts building. Keep the withheld items below to yourself until
-    it asks.
+    standalone script — inside a solution of the same name, and that you want
+    it validated before you sign off. Do not name files or paths and do not use
+    technical wording. How the agent builds it is its own business. Close by
+    inviting the agent to ask you anything it needs before it starts building.
+    Keep the withheld items below to yourself until it asks.
 
     WITHHELD — reveal each of these ONLY if the agent asks about it:
       - The project name should be "DiceRoller".
-      - You want "uip maestro flow validate" to pass before you sign off.
+      - You want the completed flow to validate before you sign off.
       - You want to see it actually produce a number when it runs before you sign off.
 
   constraints:
@@ -66,12 +69,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 4.0
@@ -82,7 +84,7 @@ success_criteria:
   # static grep for "random", which a flow that never executes would still pass.
   - type: run_command
     description: "Flow debug runs; Script node executed and output is an integer in [1,6]"
-    command: "python3 $TASK_DIR/check_dice_runs.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/cli_dice_roller_simulated/check_dice_runs.py"
     # Cloud `flow debug` on this task regularly exceeds the old 240s inner
     # budget (measured: 2 of 3 codex runs raised subprocess.TimeoutExpired), so
     # the criterion was scoring 0 on runner latency rather than on the flow.
@@ -99,7 +101,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named DiceRoller (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/DiceRoller.flow',recursive=True) else 'expected a flow named DiceRoller.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DiceRoller"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/check_escalation_behavior.py
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/check_escalation_behavior.py
@@ -34,13 +34,16 @@ so a working-but-misnamed flow keeps most of its credit.
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import sys
 from pathlib import Path
 from typing import Any, NoReturn
 
-FLOW_GLOB = "**/*.flow"
+sys.path.insert(
+    0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+)
+from _shared.flow_check import find_flow_file  # noqa: E402
 
 
 def fail(msg: str) -> NoReturn:
@@ -48,10 +51,7 @@ def fail(msg: str) -> NoReturn:
 
 
 def load_flow() -> dict[str, Any]:
-    matches = [m for m in glob.glob(FLOW_GLOB, recursive=True) if "/." not in "/" + m]
-    if not matches:
-        fail(f"No .flow file found (searched {FLOW_GLOB})")
-    path = Path(sorted(matches)[0])
+    path = Path(find_flow_file())
     try:
         return json.loads(path.read_text())
     except json.JSONDecodeError as exc:
@@ -75,9 +75,12 @@ def node_refs(node: dict, *needles: str) -> bool:
     return any(needle in blob for needle in needles)
 
 
-def any_node_refs(nodes: list[dict], *needles: str, exclude_triggers: bool = False) -> bool:
+def any_node_refs(
+    nodes: list[dict], *needles: str, exclude_triggers: bool = False
+) -> bool:
     return any(
-        (not exclude_triggers or not is_trigger(n)) and node_refs(n, *needles) for n in nodes
+        (not exclude_triggers or not is_trigger(n)) and node_refs(n, *needles)
+        for n in nodes
     )
 
 
@@ -102,17 +105,27 @@ def main() -> None:
         or "agent" in node_type(n)
     ]
     if not routing_nodes:
-        fail("No routing construct found (need a decision / switch / if / agent-based classifier)")
+        fail(
+            "No routing construct found (need a decision / switch / if / agent-based classifier)"
+        )
 
     def out_edge_count(node_id: Any) -> int:
         return sum(
             1
             for e in edges
-            if node_id in (e.get("sourceNodeId"), e.get("source"), e.get("from"), e.get("sourceId"))
+            if node_id
+            in (
+                e.get("sourceNodeId"),
+                e.get("source"),
+                e.get("from"),
+                e.get("sourceId"),
+            )
         )
 
     max_branches = max((out_edge_count(n.get("id")) for n in routing_nodes), default=0)
-    terminals = [n for n in nodes if "end" in node_type(n) or "terminate" in node_type(n)]
+    terminals = [
+        n for n in nodes if "end" in node_type(n) or "terminate" in node_type(n)
+    ]
     if max_branches < 2 and len(terminals) < 2:
         fail("Routing does not fan out into >=2 branches (VIP-urgent vs standard)")
 
@@ -120,18 +133,26 @@ def main() -> None:
     if not any_node_refs(nodes, "urgent", "urgen"):
         fail("No 'urgency' signal on any node (flow should classify emails by urgency)")
     if not any_node_refs(nodes, "vip"):
-        fail("No 'VIP' signal on any node (flow should classify the sender as VIP or not)")
+        fail(
+            "No 'VIP' signal on any node (flow should classify the sender as VIP or not)"
+        )
 
     # 4. Slack notification (VIP+urgent branch)
     if not any_node_refs(nodes, "slack"):
         fail("No Slack node (the high-touch branch should notify on Slack)")
 
     # 5. Reply to sender by email on a non-trigger node
-    if not any_node_refs(nodes, "outlook", "office365", "graph.microsoft.com", exclude_triggers=True):
-        fail("No non-trigger Outlook/Graph email-reply node (flow should reply to the sender)")
+    if not any_node_refs(
+        nodes, "outlook", "office365", "graph.microsoft.com", exclude_triggers=True
+    ):
+        fail(
+            "No non-trigger Outlook/Graph email-reply node (flow should reply to the sender)"
+        )
 
     # 6. Support ticket on the standard branch (connector or a script that builds one)
-    if not any_node_refs(nodes, "jira", "servicenow", "create-issue", "createissue", "ticket"):
+    if not any_node_refs(
+        nodes, "jira", "servicenow", "create-issue", "createissue", "ticket"
+    ):
         fail("No support-ticket node (standard branch should create a ticket)")
 
     print(

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/customer_escalation_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-customer-escalation-simulated
 description: >
   Multi-branch Outlook→classify→decision escalation flow, but driven by a
@@ -67,12 +71,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 5.0
@@ -86,7 +89,7 @@ success_criteria:
   # provide. See check_escalation_behavior.py for the rationale.
   - type: run_command
     description: "Flow performs the triage: trigger, urgency+VIP routing, Slack notify, email reply, ticket creation"
-    command: "python3 $TASK_DIR/check_escalation_behavior.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_simulated/check_escalation_behavior.py"
     timeout: 30
     expected_exit_code: 0
     weight: 10.0
@@ -99,7 +102,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named CustomerEscalation (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/CustomerEscalation.flow',recursive=True) else 'expected a flow named CustomerEscalation.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name CustomerEscalation"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/customer_escalation_triage.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-interactive-customer-escalation-triage
 description: >
   Interactive end-to-end Flow evaluation. A simulated support-operations
@@ -47,40 +51,40 @@ simulation:
     solution of the same name, that classifies an escalation and returns these
     named outputs: severity, engineeringNeeded, responseMode, and caseKey.
     The flow inputs are customerTier, productionDown, workaroundAvailable,
-    businessImpact, and correlationId. The completed flow must validate. Do not
-    ask the coding agent to run it; the grader supplies seeded cases and runs it.
+    businessImpact, and correlationId. The completed flow must validate. The
+    grader supplies seeded cases and handles execution after validation.
   constraints:
     - "In the opening request, state the goal and that you need a UiPath Maestro Flow validated before sign-off. State the flow's input and output contract using these EXACT identifiers, verbatim and unaltered — do not paraphrase, rename, abbreviate, or re-case any of them, and tell the coding agent the flow's declared inputs and outputs must use these names exactly as written because downstream systems consume them by name: the inputs are customerTier, productionDown, workaroundAvailable, businessImpact, and correlationId; the outputs are severity, engineeringNeeded, responseMode, and caseKey. Also state, in business terms and in your own words, the policy it has to encode: an Enterprise customer with production unavailable and no workaround is Sev1; informational or routine follow-up with no production impact is Sev3; engineering gets pulled in for Sev1 but not for Sev3; customer acknowledgements are always drafted for a human to review and never sent automatically, so the response mode is Draft; and the incoming correlationId must be carried through as the case key so downstream systems can correlate the run. Make clear that businessImpact arrives as free-form text the requester writes in their own words — a short phrase or sentence describing the impact, not a fixed keyword or code — so its exact wording varies from request to request. Close by inviting the coding agent to ask you anything it needs before it starts building."
     - "Do NOT volunteer the Sev2 rules. Only if the agent asks about degraded production, partial impact, or what happens when a workaround exists: Sev2 means production is degraded or unavailable but a viable workaround exists, and engineering is needed for Sev2 as well."
     - "If asked a finite-choice question, choose the option matching these policies."
     - "Keep each reply concise and internally consistent."
-    - "If asked for permission to run or debug the flow, decline and say the grader will execute it after validation."
+    - "If asked about execution, say the grader will handle it after validation."
     - "If the coding agent asks you anything before it starts building, answer every outstanding question in ONE message and then let it build."
     - "The moment the coding agent reports the flow is built and validated, the conversation is over: reply with exactly <<<END>>> on its own line. Do not ask for a rebuild, polish, re-checks, or alternative designs, and do not raise a requirement you have not mentioned yet — the grader verifies the result from here."
   max_turns: 8
 
 success_criteria:
   - type: skill_triggered
-    description: "Agent invoked the uipath-maestro-flow skill"
+    description: "Advisory: agent invoked the uipath-maestro-flow skill"
     skill_name: "uipath-maestro-flow"
     expected_skill: "uipath-maestro-flow"
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_not_executed
-    description: "Agent left execution to the grader instead of running flow debug"
+    description: "Advisory: agent left execution to the grader instead of running flow debug"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug'
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent validated the generated Flow"
+    description: "Advisory: agent validated the generated Flow"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Generated customer-escalation Flow validates without errors"
@@ -92,7 +96,7 @@ success_criteria:
 
   - type: run_command
     description: "Seeded Sev1 and Sev3 runs produce the elicited severity, engineering, draft-response, and correlation outcomes"
-    command: "python3 $TASK_DIR/check_customer_escalation_triage.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/customer_escalation_triage/check_customer_escalation_triage.py"
     timeout: 660
     expected_exit_code: 0
     weight: 8.0

--- a/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/expense_approval_simulated/expense_approval_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-expense-approval-simulated
 description: >
   Expense-approval flow with an inline HITL review step (trigger → script →
@@ -69,12 +73,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0
@@ -87,7 +90,7 @@ success_criteria:
   # $vars.<hitl>.output.
   - type: run_command
     description: "Flow has a correct inline HITL schema, decision capture, completed wiring, and downstream .output access"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/*.flow',recursive=True); assert flows,'No flow file'; f=json.load(open(flows[0])); nodes=f['nodes']; edges=f.get('edges',[]); hitl=[n for n in nodes if str(n.get('type','')).startswith('uipath.human-in-the-loop')]; assert len(hitl)==1,'need exactly 1 HITL node'; h=hitl[0]; hid=h.get('id'); schema=h.get('inputs',{}).get('schema',{}); fields=schema.get('fields',[]); outcomes=schema.get('outcomes',[]) or []; assert fields,'HITL needs fields'; ft=lambda fl,k:(fl.get(k) or '').lower() if isinstance(fl.get(k),str) else ''; assert any((ft(x,'id')=='amount' or 'amount' in ft(x,'label')) and x.get('type')=='number' for x in fields),'amount must be a number field'; dec=[x for x in fields if x.get('direction') in ('output','inOut') and any(k in ft(x,'id') for k in ('approval','approved','decision'))]; onames={str(o.get('name') or o.get('id') or '').lower() for o in outcomes}; okdec=any(x.get('type')=='boolean' for x in dec) or (any('approve' in o for o in onames) and any('reject' in o for o in onames)); assert okdec,'need boolean decision field or approve/reject outcomes'; rk=('reason','comment','explanation','justification','note'); assert any(x.get('direction') in ('output','inOut') and x.get('type') in ('text','string','textarea') and any(k in ft(x,'id') or k in ft(x,'label') for k in rk) for x in fields),'need a text reason output field'; assert any(e.get('sourceNodeId')==hid and e.get('sourcePort') in ('completed','outcome-completed') for e in edges),'HITL completed handle must be wired'; scripts=[str(n.get('inputs',{}).get('script','')) for n in nodes if n.get('type')=='core.action.script']; assert any((chr(36)+'vars.'+str(hid)+'.output') in s for s in scripts),'downstream script must read HITL output via vars.<hitl>.output'; print('OK')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_simulated_hitl.py expense"
     timeout: 15
     expected_exit_code: 0
     weight: 6.0
@@ -100,7 +103,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named ExpenseApproval (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/ExpenseApproval.flow',recursive=True) else 'expected a flow named ExpenseApproval.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ExpenseApproval"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/hitl_schema_design_simulated/hitl_schema_design_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-hitl-schema-design-simulated
 description: >
   Purchase-order review flow with an inline HITL quickform (trigger → script →
@@ -68,12 +72,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0
@@ -85,7 +88,7 @@ success_criteria:
   # below so a missing priority does not zero out an otherwise-correct schema.
   - type: run_command
     description: "HITL quickform has input + output fields and Approve/Reject outcomes"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/*.flow',recursive=True); assert flows,'No flow file'; f=json.load(open(flows[0])); nodes=f['nodes']; hitl=[n for n in nodes if str(n.get('type','')).startswith('uipath.human-in-the-loop')]; assert hitl,'need a HITL quickform node'; fields=hitl[0].get('inputs',{}).get('schema',{}).get('fields',[]); dirs={x.get('direction') for x in fields}; assert 'input' in dirs,'need an input-direction (read-only) field'; assert 'output' in dirs or 'inOut' in dirs,'need an output/inOut (fill-in) field'; s=json.dumps(f).lower(); assert 'approve' in s and 'reject' in s,'need Approve and Reject outcomes'; print('OK')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_simulated_hitl.py schema"
     timeout: 15
     expected_exit_code: 0
     weight: 4.0
@@ -97,7 +100,7 @@ success_criteria:
   # expected to elicit urgency when the persona flags the review as time-sensitive).
   - type: run_command
     description: "HITL review priority is set to High (elicited from the user)"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/*.flow',recursive=True); assert flows,'No flow file'; f=json.load(open(flows[0])); hitl=[n for n in f['nodes'] if str(n.get('type','')).startswith('uipath.human-in-the-loop')]; assert hitl,'need a HITL quickform node'; assert 'high' in json.dumps(hitl[0]).lower(),'priority should be High'; print('OK')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/check_simulated_hitl.py priority"
     timeout: 15
     expected_exit_code: 0
     weight: 1.5
@@ -110,7 +113,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named VendorPOReview (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/VendorPOReview.flow',recursive=True) else 'expected a flow named VendorPOReview.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name VendorPOReview"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/ixp_invoice_extraction_simulated/ixp_invoice_extraction_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-invoice-extraction-simulated
 description: >
   Invoice-processing flow (SharePoint trigger → IxP extraction → HTTP POST to
@@ -72,12 +76,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0
@@ -88,7 +91,7 @@ success_criteria:
   # node, and a $vars. reference consuming the extraction output downstream.
   - type: run_command
     description: "Flow has IxP extraction + SharePoint + HTTP nodes and a $vars downstream reference"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/*.flow',recursive=True); assert flows,'No flow file'; txt=open(flows[0]).read(); low=txt.lower(); f=json.loads(txt); types=[str(n.get('type','')).lower() for n in f.get('nodes',[])]; assert 'uipath.ixp' in low or 'core.logic.mock' in low,'no IxP extraction node (or mock fallback)'; assert 'sharepoint' in low,'no SharePoint trigger/connector'; assert any('http' in t for t in types),'no HTTP action node'; assert (chr(36)+'vars.') in txt,'no vars downstream reference to extraction output'; print('OK')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.' --regex '(?i)(uipath\\.ixp|core\\.logic\\.mock)' --regex '(?i)sharepoint' --regex '(?i)\"type\"\\s*:\\s*\"[^\"]*http'"
     timeout: 15
     expected_exit_code: 0
     weight: 6.0
@@ -101,7 +104,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named InvoiceProcessing (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/InvoiceProcessing.flow',recursive=True) else 'expected a flow named InvoiceProcessing.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name InvoiceProcessing"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/slack_channel_description_simulated.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-channel-description-simulated
 description: >
   Single-connector Slack flow (read a channel's description and output it),
@@ -37,11 +41,11 @@ simulation:
     you: the channel is #office-bellevue in Slack, you want that channel's
     description text as the result, and it has to work on its own without you
     supplying the channel every time it runs. Say that it has to be built as a
-    UiPath Maestro Flow — not an API workflow, not a standalone script — and
-    that you want it validated before you sign off. Do not name files or paths
-    and do not use technical wording. Close by inviting the agent to ask you
-    anything it needs before it starts building. Keep the withheld items below
-    to yourself until it asks.
+    UiPath Maestro Flow — not an API workflow, not a standalone script — inside
+    a solution of the same name, and that you want it validated before you sign
+    off. Do not name files or paths and do not use technical wording. Close by
+    inviting the agent to ask you anything it needs before it starts building.
+    Keep the withheld items below to yourself until it asks.
 
     WITHHELD — reveal each of these ONLY if the agent asks about it:
       - The project name should be "SlackChannelDescription".
@@ -62,12 +66,11 @@ simulation:
   n_trials: 1
 
 success_criteria:
-  # Name-agnostic: any .flow the agent built must validate. The exact project
-  # name is scored separately below so a working-but-misnamed flow still earns
-  # most of the credit. (`**` skips dot-dirs, so .uipath/.skills flows are ignored.)
+  # Name-agnostic: any unambiguous generated .flow must validate. The exact
+  # project name is scored separately below.
   - type: run_command
     description: "uip flow validate passes (any .flow)"
-    command: "python3 -c \"import glob,subprocess,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow file found') if not flows else sys.exit(subprocess.run(['uip','maestro','flow','validate',flows[0],'--output','json']).returncode)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 3.0
@@ -81,7 +84,7 @@ success_criteria:
   # unresolved channel fails here regardless of what the static check below reports.
   - type: run_command
     description: "Flow debug runs; Slack connector executed and output has the channel description"
-    command: "python3 $TASK_DIR/check_channel_description.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/slack_channel_description_simulated/check_channel_description.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0
@@ -107,7 +110,7 @@ success_criteria:
   # hard-fail the whole task — see the block comment; scored for signal only.
   - type: run_command
     description: "Flow targets the #office-bellevue channel (elicited from the user)"
-    command: "python3 -c \"import glob,re,sys; flows=glob.glob('**/*.flow',recursive=True); t=(open(flows[0]).read() if flows else ''); sys.exit('no .flow file found') if not flows else sys.exit(0 if ('office-bellevue' in t.lower() or re.search(r'conversationsInfoId[^A-Za-z0-9]+C[A-Z0-9]{6,}', t)) else 'flow neither names #office-bellevue nor hardwires a resolved Slack channel ID')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '(?i)(office-bellevue|conversationsInfoId[^A-Za-z0-9]+C[A-Z0-9]{6,})'"
     timeout: 15
     expected_exit_code: 0
     weight: 3.0
@@ -120,7 +123,7 @@ success_criteria:
   # keeps it from dominating the score.
   - type: run_command
     description: "Project/flow is named SlackChannelDescription (elicited from the user)"
-    command: "python3 -c \"import glob,sys; sys.exit(0 if glob.glob('**/SlackChannelDescription.flow',recursive=True) else 'expected a flow named SlackChannelDescription.flow')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SlackChannelDescription"
     timeout: 15
     expected_exit_code: 0
     weight: 1.0

--- a/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
+++ b/tests/tasks/uipath-maestro-flow/interactive/solution_select.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-solution-select-ask
 description: >
   Interactive-mode variant of init-validate. The working directory already
@@ -39,7 +43,7 @@ simulation:
     You are a UiPath developer working in a directory that already holds a
     couple of unrelated solutions (SolarReports and TideTracker). You want a
     fresh, separate solution for this new work and you trust the agent to
-    drive the CLI.
+    drive the work.
   goal: |
     Get a new Flow project called WeatherAlert created in a separate solution
     and validated successfully.
@@ -69,19 +73,20 @@ success_criteria:
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: file_exists
+  - type: run_command
     description: "Flow file created inside the user-selected solution"
-    path: "WeatherSelection-7K4M/WeatherAlert/WeatherAlert.flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py flow"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   # ── Did NOT silently adopt an existing solution ────────────────────────
-  - type: command_executed
+  - type: run_command
     description: "Agent did not init the Flow project inside a pre-existing solution"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init\b.*(SolarReports|TideTracker)'
-    min_count: 0
-    max_count: 0
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py existing-untouched"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
@@ -108,32 +113,33 @@ success_criteria:
   # ── Build is valid in the selected solution ────────────────────────────
   - type: run_command
     description: "Flow validates in the selected solution"
-    command: "uip maestro flow validate WeatherSelection-7K4M/WeatherAlert/WeatherAlert.flow --output json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py validate"
     timeout: 60
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent initialized a Flow project with uip maestro flow init"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "Selected solution contains an initialized Flow project"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py project"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   # ── Advisory: recorded in the report, never gates the run ──────────────
-  - type: command_executed
-    description: "Agent created a solution with uip solution init (or legacy new)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+solution\s+(init|new)'
-    min_count: 1
+  - type: run_command
+    description: "Agent created the selected solution artifact"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py solution"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 0.0  # advisory: outcome already enforced by the WeatherSelection-7K4M json_check; records the explicit-init convention only
 
-  - type: command_not_executed
+  - type: run_command
     description: "Advisory: no default WeatherAlert solution before the name was given — records the default-then-repair inefficiency; nondeterministic on simulator name-timing, so non-gating"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+solution\s+(init|new)\s+["'']?WeatherAlert(?:["'']?\s|$)'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/interactive/check_solution_select.py no-extra-solution"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 0.0


### PR DESCRIPTION
## Summary

- apply the ratified same-ground recipe to the exact 16-task HITL/interactive static roster
- route validation, name, semantic, and solution-selection witnesses through deterministic arm-neutral artifact discovery
- make the three escalation-triage telemetry checks report-only under D-2/D-3 while keeping their weights
- add the required same-name-solution phrase to the three simulator-driven tasks that the grader debug-executes

## Measurement-contract disclosure

This intentionally changes only how the existing outcomes are witnessed. Root-level SDK emits and solution-wrapped v1 artifacts now reach the same checks; v1-only command telemetry no longer gates. Criterion weights and business intent are unchanged. The `customer_escalation_simulated` Bucket-D behavior criterion is untouched apart from routing its checker through shared discovery.

## Verification

- `uv run --with pytest pytest tests/tasks/uipath-maestro-flow -q` — 222 passed
- `uvx --from coder-eval==0.10.2 coder-eval plan <16 Batch-2 YAMLs>` — all valid
- targeted Ruff F/E402 checks — passed
- all 16 YAMLs carry the campaign header; 0 weight-line changes; 0 raw recursive Flow globs; 0 `$TASK_DIR` checker paths
- preserved preview artifacts pass the new HITL, IxP, Slack, and name-discovery witnesses
- newest same-agent archive baseline: `runs/2026-08-20_17-22-24`, 12/16 success

## Shakeout note

The local UiPath credential currently reports `Refresh Failed` because the stored refresh token expired. No task was changed on that infrastructure signal. A paired branch-tip run will be recorded when authentication is available; repository CI remains authoritative for this PR.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)