### PR TITLE
test(maestro-flow): align bindings and connector features

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch3_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch3_alignment.py
@@ -1,0 +1,90 @@
+"""Regression coverage for Batch 3 same-ground checker routing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+TASK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _run(relative: str, *args: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TASK_ROOT / relative), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _write_flow(path: Path, nodes: list[dict], bindings: list[dict] | None = None) -> None:
+    path.write_text(
+        json.dumps({"nodes": nodes, "edges": [], "bindings": bindings or []}),
+        encoding="utf-8",
+    )
+
+
+def test_bindings_checker_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    _write_flow(
+        tmp_path / "BindingsMulti.flow",
+        [
+            {"id": "a", "type": "uipath.connector.one.operation"},
+            {"id": "b", "type": "uipath.connector.two.operation"},
+        ],
+    )
+
+    result = _run(
+        "bindings/check_bindings.py",
+        "connector_node_count",
+        "**/BindingsMulti*.flow",
+        "2",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_multiselect_checker_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    _write_flow(
+        tmp_path / "ComplexArrayTest.flow",
+        [
+            {
+                "id": "slack",
+                "type": "uipath.connector.uipath-salesforce-slack.create-group-direct-message",
+                "inputs": {"detail": {"bodyParameters": {"users": ["U1", "U2"]}}},
+            }
+        ],
+    )
+
+    result = _run(
+        "connector_features/check_multiselect_flow.py",
+        "populated",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_enum_checker_prefers_solution_flow_over_root_scratch(tmp_path: Path) -> None:
+    _write_flow(tmp_path / "EnumTest.flow", [])
+    project = tmp_path / "EnumTest" / "project.uiproj"
+    project.parent.mkdir()
+    project.write_text('{"ProjectType":"Flow"}', encoding="utf-8")
+    _write_flow(
+        project.parent / "EnumTest.flow",
+        [{"id": "start", "type": "core.trigger.manual"}],
+    )
+
+    result = _run(
+        "connector_features/check_enum_flow.py",
+        "**/EnumTest*.flow",
+        "structure",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert "EnumTest/EnumTest.flow" in result.stdout

--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch3_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch3_alignment.py
@@ -88,3 +88,25 @@ def test_enum_checker_prefers_solution_flow_over_root_scratch(tmp_path: Path) ->
 
     assert result.returncode == 0, result.stderr or result.stdout
     assert "EnumTest/EnumTest.flow" in result.stdout
+
+
+def test_testmanager_execution_evidence_is_distinct_from_round_trip(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / "seed.json").write_text('{"name": "expected"}')
+    (tmp_path / "result.json").write_text(
+        '{"created_name": "different", "retrieved_name": "different", "id": "123"}'
+    )
+
+    evidence = _run(
+        "connector_features/testmanager_crud_grounded/check.py",
+        "--execution-evidence",
+        cwd=tmp_path,
+    )
+    semantic = _run(
+        "connector_features/testmanager_crud_grounded/check.py",
+        cwd=tmp_path,
+    )
+
+    assert evidence.returncode == 0, evidence.stderr or evidence.stdout
+    assert semantic.returncode == 1

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -13,17 +13,6 @@ from pathlib import Path
 FLOW_TASKS = Path(__file__).resolve().parent.parent
 
 V1_AUTHORING_ALLOWLIST = {
-    "bindings/idempotent_reconfigure.yaml",
-    "bindings/multi_connector_independence.yaml",
-    "bindings/no_duplicate_connection_bindings.yaml",
-    "bindings/reconfigure_different_connection.yaml",
-    "connector_features/testmanager_attachments/testmanager_attachments.yaml",
-    "connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml",
-    "connector_features/testmanager_execution_results/testmanager_execution_results.yaml",
-    "connector_features/testmanager_generic_records/testmanager_generic_records.yaml",
-    "connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml",
-    "connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml",
-    "connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml",
     "connector_trigger/webhook_waitfor_parallel.yaml",
     "e2e/devcon_expense_approval.yaml",
     "evaluate/evaluator_type_choice.yaml",
@@ -47,7 +36,6 @@ SKILL_TELEMETRY_ALLOWLIST = {
 }
 
 FORBIDDEN_PROMPT_ALLOWLIST = {
-    "connector_features/slack-http-fallback/slack_http_fallback.yaml",
     "context-grounding/batch_transform/batch_transform.yaml",
     "context-grounding/summarize/summarize.yaml",
     "evaluate/inline_agent_eval/inline_agent_eval.yaml",
@@ -72,8 +60,6 @@ FORBIDDEN_PROMPT_EXCEPTIONS = {
 }
 
 DEBUG_SOLUTION_ALLOWLIST = {
-    "connector_features/generic_dynamic_node/generic_dynamic_node.yaml",
-    "connector_features/slack-http-fallback/slack_http_fallback.yaml",
     "e2e/escalation_jira_ticket/escalation_jira_ticket.yaml",
     "e2e/jira_create_issue/jira_create_issue.yaml",
     "e2e/jira_get_issue/jira_get_issue.yaml",
@@ -85,7 +71,6 @@ DEBUG_SOLUTION_ALLOWLIST = {
     "edit/move_node/move_node.yaml",
     "edit/remove_node/remove_node.yaml",
     "edit/update_node/update_node.yaml",
-    "connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml",
 }
 
 # F1 freezes the #2557 task even though its prompt predates the exact phrase.

--- a/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
+++ b/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py
@@ -158,6 +158,23 @@ def cmd_structure(pattern: str) -> None:
     print(f"OK: {path} valid JSON with nodes + bindings")
 
 
+def cmd_connector_node_count(pattern: str, minimum: str) -> None:
+    path, flow = _load_one(pattern)
+    nodes = flow.get("nodes") or []
+    connector_nodes = [
+        node
+        for node in nodes
+        if "uipath.connector." in str(node.get("type") or "").lower()
+    ]
+    required = int(minimum)
+    if len(connector_nodes) < required:
+        _fail(
+            f"{path}: expected at least {required} connector node(s), "
+            f"found {len(connector_nodes)}"
+        )
+    print(f"OK: {path} has {len(connector_nodes)} connector node(s)")
+
+
 def cmd_no_empty_stubs(pattern: str) -> None:
     path, bindings = _load_flow_bindings(pattern)
     empty = [b for b in _connection_rows(bindings) if not b.get("resourceKey")]
@@ -329,6 +346,7 @@ def cmd_both_ids_present_from_json(pattern: str, json_path: str) -> None:
 
 _COMMANDS = {
     "structure": cmd_structure,
+    "connector_node_count": cmd_connector_node_count,
     "no_empty_stubs": cmd_no_empty_stubs,
     "no_duplicates": cmd_no_duplicates,
     "matched_default": cmd_matched_default,

--- a/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/idempotent_reconfigure.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-idempotent-reconfigure
 description: >
   Step 1 of the DAPField-mirrored upsert in `upsertConnectionResourceBinding`
@@ -15,31 +19,29 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow named "BindingsIdempotent" — Manual Trigger → IS connector
-  node → End — saved as `BindingsIdempotent/flow_files/BindingsIdempotent.flow`
-  with `BindingsIdempotent/project.uiproj`.
+  Build a flow named "BindingsIdempotent" with a Manual Trigger, an Integration
+  Service connector node, and an End node.
 
-  Snapshot the .flow after the first configure:
-      cp BindingsIdempotent/flow_files/BindingsIdempotent.flow after_first_configure.flow
+  Configure the connector node with an available connection. Save a copy of the
+  resulting flow at the sandbox root as `after_first_configure.flow`.
 
-  Then run the EXACT SAME `node configure` invocation a second time (same
-  node id, same --detail JSON). Snapshot again:
-      cp BindingsIdempotent/flow_files/BindingsIdempotent.flow after_second_configure.flow
+  Configure the exact same node a second time with the exact same connection
+  details. Save that result at the sandbox root as `after_second_configure.flow`.
 
-  Both snapshots go at the sandbox root.
+  Both snapshots must contain the configured connector bindings.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent called `node configure` at least twice"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 2
+  - type: run_command
+    description: "Both saved configure snapshots retain the same ConnectionId binding"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py same_connection_id 'after_first_configure.flow' 'after_second_configure.flow'"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Both snapshots exist, valid JSON with bindings"
-    command: "python3 $TASK_DIR/check_bindings.py structure 'after_first_configure.flow' && python3 $TASK_DIR/check_bindings.py structure 'after_second_configure.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py structure 'after_first_configure.flow' && python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py structure 'after_second_configure.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 1.5
@@ -47,7 +49,7 @@ success_criteria:
 
   - type: run_command
     description: "Bindings count did not grow on second configure (idempotent)"
-    command: "python3 $TASK_DIR/check_bindings.py count_equal 'after_first_configure.flow' 'after_second_configure.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py count_equal 'after_first_configure.flow' 'after_second_configure.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 4.0
@@ -55,7 +57,7 @@ success_criteria:
 
   - type: run_command
     description: "No empty-keyed Connection bindings in final snapshot"
-    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs 'after_second_configure.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_empty_stubs 'after_second_configure.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -63,7 +65,7 @@ success_criteria:
 
   - type: run_command
     description: "ConnectionId resourceKey stable across both snapshots"
-    command: "python3 $TASK_DIR/check_bindings.py same_connection_id 'after_first_configure.flow' 'after_second_configure.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py same_connection_id 'after_first_configure.flow' 'after_second_configure.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/multi_connector_independence.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-multi-connector-independence
 description: >
   Two distinct connector nodes (different connector keys) in the same flow,
@@ -19,10 +23,8 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow named "BindingsMulti" with TWO IS connector nodes backed
-  by DIFFERENT connector keys, saved as
-  `BindingsMulti/flow_files/BindingsMulti.flow` with
-  `BindingsMulti/project.uiproj`.
+  Build a flow named "BindingsMulti" with TWO Integration Service connector
+  nodes backed by DIFFERENT connector keys.
 
   Configure each node with its own distinct connection. Record the
   connection ids and connector keys at the sandbox root:
@@ -30,23 +32,19 @@ initial_prompt: |
       echo '{"a":"<conn-id-1>","ka":"<connector-key-1>","b":"<conn-id-2>","kb":"<connector-key-2>"}' > conn_ids.json
 
 success_criteria:
-  # min_count: 1 (not 2) — agents commonly chain two `uip ... node add` calls
-  # into a single Bash invocation with `&&`, which the checker counts as one
-  # match (re.search returns the first hit). Behavioral checks below verify
-  # both nodes actually exist in the flow.
-  - type: command_executed
-    description: "Agent used `uip flow node add` at least once"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+add"
-    min_count: 1
+  - type: run_command
+    description: "The flow contains at least two connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py connector_node_count '**/BindingsMulti*.flow' 2"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent used `uip flow node configure` at least once"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 1
+  - type: run_command
+    description: "Both recorded connection ids appear in the flow bindings"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py both_ids_present_from_json '**/BindingsMulti*.flow' conn_ids.json"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
@@ -60,7 +58,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $TASK_DIR/check_bindings.py structure '**/BindingsMulti*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py structure '**/BindingsMulti*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -68,7 +66,7 @@ success_criteria:
 
   - type: run_command
     description: "Both connection ids appear in Connection bindings, each on its own ConnectionId row"
-    command: "python3 $TASK_DIR/check_bindings.py both_ids_present_from_json '**/BindingsMulti*.flow' conn_ids.json"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py both_ids_present_from_json '**/BindingsMulti*.flow' conn_ids.json"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -76,7 +74,7 @@ success_criteria:
 
   - type: run_command
     description: "No empty-keyed Connection bindings (cross-node aliasing surface)"
-    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs '**/BindingsMulti*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_empty_stubs '**/BindingsMulti*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 4.0
@@ -84,7 +82,7 @@ success_criteria:
 
   - type: run_command
     description: "No (name, propertyAttribute, resourceKey) triplet duplicates"
-    command: "python3 $TASK_DIR/check_bindings.py no_triplet_dups '**/BindingsMulti*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_triplet_dups '**/BindingsMulti*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/no_duplicate_connection_bindings.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-no-duplicates
 description: >
   Regression - `uip maestro flow node configure` previously appended
@@ -17,26 +21,25 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Build a flow named "BindingsRegression" — Manual Trigger → IS connector
-  node → End — saved as `BindingsRegression/flow_files/BindingsRegression.flow`
-  with `BindingsRegression/project.uiproj`.
+  Build a flow named "BindingsRegression" with a Manual Trigger, an Integration
+  Service connector node, and an End node.
 
-  Configure the connector node exactly once. Do not invoke any "refresh
-  schema" workaround afterwards — the bindings shape immediately after
-  `node configure` is what this eval inspects.
+  Configure the connector node exactly once. Do not apply any schema-refresh
+  workaround afterwards — the bindings shape immediately after configuration
+  is what this eval inspects.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent called `node configure`"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 1
+  - type: run_command
+    description: "The connector is configured with a non-empty ConnectionId binding"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py matched_default '**/BindingsRegression*.flow'"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "Flow file exists and is valid JSON with nodes + bindings"
-    command: "python3 $TASK_DIR/check_bindings.py structure '**/BindingsRegression*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py structure '**/BindingsRegression*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -44,7 +47,7 @@ success_criteria:
 
   - type: run_command
     description: "No empty-keyed Connection bindings remain after configure"
-    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs '**/BindingsRegression*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_empty_stubs '**/BindingsRegression*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 4.0
@@ -52,7 +55,7 @@ success_criteria:
 
   - type: run_command
     description: "No duplicate (name, propertyAttribute) under Connection resource"
-    command: "python3 $TASK_DIR/check_bindings.py no_duplicates '**/BindingsRegression*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_duplicates '**/BindingsRegression*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 4.0
@@ -60,7 +63,7 @@ success_criteria:
 
   - type: run_command
     description: "ConnectionId binding has non-empty resourceKey matching default"
-    command: "python3 $TASK_DIR/check_bindings.py matched_default '**/BindingsRegression*.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py matched_default '**/BindingsRegression*.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -68,7 +71,7 @@ success_criteria:
 
   - type: run_command
     description: "bindings_v2.json (derived artifact), if emitted, also has no empty-keyed Connection rows"
-    command: "python3 $TASK_DIR/check_bindings.py bindings_v2_no_empty_stubs '**/bindings_v2.json'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py bindings_v2_no_empty_stubs '**/bindings_v2.json'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
+++ b/tests/tasks/uipath-maestro-flow/bindings/reconfigure_different_connection.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-bindings-reconfigure-different-connection
 description: >
   When the same connector node is reconfigured against a different connection,
@@ -15,55 +19,38 @@ run_limits:
 
 initial_prompt: |
   PRECONDITION CHECK — do this FIRST, before any flow work:
-  Run `uip is connections list --all-folders --output json` once. Group the
-  enabled connections by `ConnectorKey` and find a connector with two or
-  more enabled connections. That connector supplies A and B.
+  Inspect the available Integration Service connections once. Group the enabled
+  connections by connector key and find a connector with two or more enabled
+  connections. That connector supplies A and B.
 
   If no connector has two or more enabled connections, the precondition
   is not met for this tenant. Stop IMMEDIATELY: write
   `PRECONDITION_NOT_MET.txt` at the sandbox root containing one line per
   ConnectorKey with its enabled-connection count, then end your turn.
 
-  Do NOT try to create a second connection via `uip is connections create`
-  or `--no-wait`. OAuth authorization requires an interactive browser and
-  cannot complete in this sandbox; pending connections are not a valid
-  substitute. Do NOT scan for mocks or alternative connectors beyond the
-  single `connections list` call above.
+  Do NOT try to create a second connection. OAuth authorization requires an
+  interactive browser and cannot complete in this sandbox; pending connections
+  are not a valid substitute. Do NOT scan for mocks or alternative connectors
+  beyond that single connection inventory.
 
   If the precondition IS met, proceed:
 
-  Build a flow named "BindingsReconfigure" — Manual Trigger → IS connector
-  node → End — saved as `BindingsReconfigure/flow_files/BindingsReconfigure.flow`
-  with `BindingsReconfigure/project.uiproj`.
+  Build a flow named "BindingsReconfigure" with a Manual Trigger, an Integration
+  Service connector node, and an End node.
 
   Pick the connector that has two or more enabled connections, and use two
   distinct connection ids from that connector as A and B.
 
-  Record the ids at the sandbox root and snapshot the .flow after each configure:
-
-      echo '{"a":"<connection-a-id>","b":"<connection-b-id>"}' > conn_ids.json
-
-  After configuring with A:
-      cp BindingsReconfigure/flow_files/BindingsReconfigure.flow after_a.flow
-
-  After reconfiguring the SAME node with B:
-      cp BindingsReconfigure/flow_files/BindingsReconfigure.flow after_b.flow
+  Record the ids at the sandbox root in `conn_ids.json` as keys `a` and `b`.
+  Save the configured flow after A as `after_a.flow`, then reconfigure the SAME
+  node with B and save that result as `after_b.flow`, both at the sandbox root.
 
 success_criteria:
-  # min_count: 1 (not 2). Per uipath-maestro-flow SKILL.md rule #10, agents
-  # chain sequential `uip` calls — e.g. `node configure <A> && ... && node
-  # configure <B> && validate && format` — into ONE Bash event. command_executed
-  # counts matching Bash events, not command occurrences within an event, so a
-  # correct batched run registers only 1 match and this criterion false-fails.
-  # Multiplicity is instead proven by the A/B snapshot checks below: after_a
-  # references connection A while after_b references ONLY B (no leak, equal
-  # count) — a result a single configure cannot produce. Mirrors the min_count:1
-  # convention in multi_connector_independence.yaml / no_duplicate_connection_bindings.yaml.
-  - type: command_executed
-    description: "Agent used `uip flow node configure` at least once"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+node\\s+configure"
-    min_count: 1
+  - type: run_command
+    description: "The final snapshot is configured only with connection B"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py connection_id_is_from_json after_b.flow conn_ids.json b"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
@@ -77,7 +64,7 @@ success_criteria:
 
   - type: run_command
     description: "after_a.flow references connection A"
-    command: "python3 $TASK_DIR/check_bindings.py has_connection_key_from_json after_a.flow conn_ids.json a"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py has_connection_key_from_json after_a.flow conn_ids.json a"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -85,7 +72,7 @@ success_criteria:
 
   - type: run_command
     description: "after_b.flow has zero references to connection A (no stale rows)"
-    command: "python3 $TASK_DIR/check_bindings.py no_connection_leak_from_json after_b.flow conn_ids.json a"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_connection_leak_from_json after_b.flow conn_ids.json a"
     timeout: 10
     expected_exit_code: 0
     weight: 4.0
@@ -93,7 +80,7 @@ success_criteria:
 
   - type: run_command
     description: "after_b.flow ConnectionId binding points at connection B"
-    command: "python3 $TASK_DIR/check_bindings.py connection_id_is_from_json after_b.flow conn_ids.json b"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py connection_id_is_from_json after_b.flow conn_ids.json b"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -101,7 +88,7 @@ success_criteria:
 
   - type: run_command
     description: "Reconfigure did not grow bindings count"
-    command: "python3 $TASK_DIR/check_bindings.py count_equal 'after_a.flow' 'after_b.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py count_equal 'after_a.flow' 'after_b.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -109,7 +96,7 @@ success_criteria:
 
   - type: run_command
     description: "No empty-keyed Connection bindings in final snapshot"
-    command: "python3 $TASK_DIR/check_bindings.py no_empty_stubs 'after_b.flow'"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/bindings/check_bindings.py no_empty_stubs 'after_b.flow'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/ceql_where.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-ceql-where
 description: >
   Tests the CEQL where query IS feature — agent plans a structured filter
@@ -31,18 +35,16 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "where_detail.json (found anywhere under the solution) has a canonical CEQL filter tree on displayName='active'; flow references the registered Azure AD / Entra connector key with List Groups + Terminate nodes"
-    command: "python3 $TASK_DIR/check_ceql_where_flow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py"
     timeout: 60
     expected_exit_code: 0
     weight: 8.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
-    require_success: true
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_ceql_where_flow.py
@@ -23,7 +23,7 @@ import os
 import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), ".."))
-from _shared.flow_check import assert_flow_has_node_type  # noqa: E402
+from _shared.flow_check import assert_flow_has_node_type, find_flow_file  # noqa: E402
 
 CONNECTOR_KEY = "uipath-microsoft-azureactivedirectory"
 FLOW_GLOB = "**/CeqlWhereTest*.flow"
@@ -134,10 +134,7 @@ def _check_where_detail() -> None:
 
 
 def _find_flow() -> str:
-    flows = glob.glob(FLOW_GLOB, recursive=True)
-    if not flows:
-        sys.exit(f"FAIL: No flow file matching {FLOW_GLOB}")
-    return flows[0]
+    return find_flow_file(flow_glob=os.path.basename(FLOW_GLOB))
 
 
 def _check_flow_structure() -> None:

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py
@@ -13,10 +13,15 @@ Checks:
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any, NoReturn
+
+SHARED_DIR = Path(__file__).resolve().parent.parent / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_file  # noqa: E402
 
 
 def _fail(message: str) -> NoReturn:
@@ -24,16 +29,12 @@ def _fail(message: str) -> NoReturn:
 
 
 def _load_flow(pattern: str) -> tuple[str, dict[str, Any]]:
-    matches = sorted(glob.glob(pattern, recursive=True))
-    if not matches:
-        _fail(f"No flow found for {pattern!r}")
-    if len(matches) > 1:
-        _fail(f"Multiple flows found for {pattern!r}: {matches}")
+    path = find_flow_file(flow_glob=os.path.basename(pattern))
     try:
-        with open(matches[0], encoding="utf-8") as flow_file:
-            return matches[0], json.load(flow_file)
+        with open(path, encoding="utf-8") as flow_file:
+            return path, json.load(flow_file)
     except json.JSONDecodeError as exc:
-        _fail(f"Flow {matches[0]} is not valid JSON: {exc}")
+        _fail(f"Flow {path} is not valid JSON: {exc}")
 
 
 def _check_structure(flow_path: str, flow: dict[str, Any]) -> None:

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py
@@ -3,10 +3,15 @@
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any, NoReturn
+
+SHARED_DIR = Path(__file__).resolve().parent.parent / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_file  # noqa: E402
 
 
 def _fail(message: str) -> NoReturn:
@@ -14,12 +19,8 @@ def _fail(message: str) -> NoReturn:
 
 
 def _load_flow(pattern: str) -> dict[str, Any]:
-    matches = sorted(glob.glob(pattern, recursive=True))
-    if not matches:
-        _fail(f"No flow found for {pattern!r}")
-    if len(matches) > 1:
-        _fail(f"Multiple flows found for {pattern!r}: {matches}")
-    with open(matches[0], encoding="utf-8") as flow_file:
+    path = find_flow_file(flow_glob=os.path.basename(pattern))
+    with open(path, encoding="utf-8") as flow_file:
         return json.load(flow_file)
 
 

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py
@@ -11,13 +11,17 @@ The 'users' value counts whether it is a native JSON array
 multiselect field in a .flow.
 
 Name-agnostic: the prompt does not fix a project name, so every .flow file
-is checked ('**' glob skips dot-dirs, so .uipath/.skills flows are ignored).
+selected by the shared same-ground discovery helper is checked.
 """
 import ast
-import glob
 import json
 import re
 import sys
+from pathlib import Path
+
+SHARED_DIR = Path(__file__).resolve().parent.parent / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_files  # noqa: E402
 
 
 def parse_users(value):
@@ -73,7 +77,7 @@ def find_users(obj):
     return None
 
 
-def check_flow(path):
+def check_flow(path, expected_count):
     """Return None on pass, else a failure reason."""
     try:
         flow = json.load(open(path))
@@ -91,21 +95,27 @@ def check_flow(path):
         users = find_users(node.get("inputs", {}))
         if users is None:
             continue
-        if len(users) == 3:
+        if expected_count == "populated" and users:
             print(f"OK: {path} — node '{node['id']}' users={users}")
             return None
-        return f"users field has {len(users)} entries, expected 3: {users}"
+        if isinstance(expected_count, int) and len(users) == expected_count:
+            print(f"OK: {path} — node '{node['id']}' users={users}")
+            return None
+        return f"users field has {len(users)} entries, expected {expected_count}: {users}"
     return "Slack node has no 'users' multiselect field"
 
 
 def main():
-    flows = glob.glob("**/*.flow", recursive=True)
-    if not flows:
-        sys.exit("no .flow file found")
+    expected_count = (
+        "populated"
+        if len(sys.argv) > 1 and sys.argv[1] == "populated"
+        else int(sys.argv[1]) if len(sys.argv) > 1 else 3
+    )
+    flows = find_flow_files()
 
     reasons = []
     for path in flows:
-        reason = check_flow(path)
+        reason = check_flow(path, expected_count)
         if reason is None:
             sys.exit(0)
         reasons.append(f"{path}: {reason}")

--- a/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py
@@ -16,10 +16,15 @@ rather than a stack trace.
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import sys
+from pathlib import Path
 from typing import Any, NoReturn
+
+SHARED_DIR = Path(__file__).resolve().parent.parent / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_file  # noqa: E402
 
 
 _JSONSTRING_PREFIX = "=jsonString:"
@@ -30,13 +35,9 @@ def _fail(message: str) -> NoReturn:
 
 
 def _load_flow(pattern: str) -> tuple[str, dict[str, Any]]:
-    matches = sorted(glob.glob(pattern, recursive=True))
-    if not matches:
-        _fail(f"No flow found for {pattern!r}")
-    if len(matches) > 1:
-        _fail(f"Multiple flows found for {pattern!r}: {matches}")
-    with open(matches[0], encoding="utf-8") as flow_file:
-        return matches[0], json.load(flow_file)
+    path = find_flow_file(flow_glob=os.path.basename(pattern))
+    with open(path, encoding="utf-8") as flow_file:
+        return path, json.load(flow_file)
 
 
 def _normalise_detail(raw: Any, node_id: str) -> dict[str, Any] | None:

--- a/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/complex_array.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-complex-array
 description: >
   Tests the complex array IS feature — configures the Slack
@@ -21,7 +25,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/ComplexArrayTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ComplexArrayTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -29,7 +33,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow has the Slack Create Group Direct Message node with its users complex array populated"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/ComplexArrayTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); nodes=[n for n in f['nodes'] if n.get('type','')=='uipath.connector.uipath-salesforce-slack.create-group-direct-message']; assert nodes, 'No create-group-direct-message node'; d=json.dumps(nodes[0].get('inputs',{})); assert 'users' in d, 'users complex array not populated'; print('OK: group DM node with users array present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py populated"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -37,18 +41,16 @@ success_criteria:
 
   - type: run_command
     description: "Advisory: group DM participants referenced in the project (names may resolve to Slack user IDs on a live connection)"
-    command: "python3 -c \"import glob,os,sys; files=[p for p in glob.glob('**/ComplexArrayTest*/**',recursive=True)+glob.glob('**/ComplexArrayTest*.*',recursive=True) if os.path.isfile(p) and not p.endswith('.uipx')]; blob=''.join(open(p,errors='ignore').read() for p in files); missing=[u for u in ('coder evals','e2e-testing') if u not in blob]; sys.exit(1 if missing else 0)\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name ComplexArrayTest 'coder evals' 'e2e-testing'"
     timeout: 10
     expected_exit_code: 0
     weight: 1.0
     pass_threshold: 0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
-    require_success: true
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_false.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-dtl-load-by-default-false
 description: >
   Tests the DTL loadByDefault=false IS feature — configures a connector node
@@ -20,7 +24,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultFalseTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultFalseTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -28,17 +32,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-automattic-woocommerce"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultFalseTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-automattic-woocommerce' in content, 'Connector key not found'; print('OK: connector key present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultFalseTest 'uipath-automattic-woocommerce'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/dtl_load_by_default_true.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-dtl-load-by-default-true
 description: >
   Tests the DTL loadByDefault=true IS feature — configures a connector node
@@ -21,7 +25,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultTrueTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultTrueTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -29,17 +33,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-microsoft-azure"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/DTLLoadByDefaultTrueTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-azure' in content, 'Connector key not found'; print('OK: connector key present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name DTLLoadByDefaultTrueTest 'uipath-microsoft-azure'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enhanced_enum.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-enhanced-enum
 description: >
   Tests the enhanced enum IS feature — configures a connector node with an
@@ -23,7 +27,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnhancedEnumTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EnhancedEnumTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -31,17 +35,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-automattic-woocommerce"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/EnhancedEnumTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-automattic-woocommerce' in content, 'Connector key not found'; print('OK: connector key present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EnhancedEnumTest 'uipath-automattic-woocommerce'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/enum.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-enum
 description: >
   Tests the enum IS feature — configures a connector node with an enum
@@ -26,16 +30,16 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip is connections list` to discover available connections"
+    description: "Advisory: live-v1 agent listed connections before choosing one"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+is\\s+connections\\s+list"
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Tenant has at least one Gmail connection (precondition for `node configure`)"
-    command: "python3 $TASK_DIR/check_connection_available.py uipath-google-gmail"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_connection_available.py uipath-google-gmail"
     timeout: 35
     expected_exit_code: 0
     weight: 1.0
@@ -43,7 +47,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 $TASK_DIR/check_enum_flow.py '**/EnumTest*.flow' structure"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py '**/EnumTest*.flow' structure"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -51,7 +55,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow uses Gmail connector or task-specific managed HTTP fallback"
-    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/EnumTest*.flow' uipath-google-gmail enum"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py '**/EnumTest*.flow' uipath-google-gmail enum"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -59,7 +63,7 @@ success_criteria:
 
   - type: run_command
     description: "Connector node has inputs.detail.bodyParameters with to and importance"
-    command: "python3 $TASK_DIR/check_enum_flow.py '**/EnumTest*.flow' body_params"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py '**/EnumTest*.flow' body_params"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
@@ -67,16 +71,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has Decision and Terminate nodes"
-    command: "python3 $TASK_DIR/check_enum_flow.py '**/EnumTest*.flow' control"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_enum_flow.py '**/EnumTest*.flow' control"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py
@@ -31,7 +31,6 @@ returns FLATTENED records (top-level `sys_id`, …), which the check reports.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import sys
@@ -40,7 +39,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspa
 from _shared.flow_check import (  # noqa: E402
     _get_ci,
     assert_flow_uses_connector_target,
-    find_project_dir,
+    find_flow_file,
     run_debug,
 )
 
@@ -56,11 +55,9 @@ OPERATION_SLUGS = ("list-records", "list-all-records")
 OBJECT_NAME = "acr_user"
 
 
-def _load_flow_nodes(project_dir: str) -> list[dict]:
-    flows = glob.glob(os.path.join(project_dir, "**/*.flow"), recursive=True)
-    if not flows:
-        sys.exit(f"FAIL: No .flow file found under {project_dir}")
-    with open(flows[0]) as f:
+def _load_flow_nodes() -> list[dict]:
+    flow_path = find_flow_file(flow_glob="AcrUserList*.flow")
+    with open(flow_path) as f:
         flow = json.load(f)
     return flow.get("nodes") or []
 
@@ -132,7 +129,7 @@ def _assert_structure() -> None:
     # A real ServiceNow connector node must be present (native connector node).
     assert_flow_uses_connector_target(CONNECTOR_KEY)
 
-    nodes = _load_flow_nodes(find_project_dir())
+    nodes = _load_flow_nodes()
     list_nodes = []
     for n in nodes:
         if CONNECTOR_KEY not in str(n.get("type", "")).lower():

--- a/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/generic_dynamic_node.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-generic-dynamic-node
 description: >
   Connector feature: validate a generic (dynamic) connector node end-to-end. A
@@ -29,12 +33,13 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a UiPath Flow project named "AcrUserList" with a manual trigger.
+  Create a UiPath Flow project named "AcrUserList" inside a solution of the
+  same name, with a manual trigger.
   The process must call ServiceNow to list all records in the Acr User
   object, then surface the returned records as a flow output variable.
 
-  Bind it to the tenant's ServiceNow connection. Then run the flow with
-  `uip maestro flow debug` to confirm the connector call completes.
+  Bind it to the tenant's ServiceNow connection. Then debug the flow to confirm
+  the connector call completes.
 
   Use the connection present in Shared/uipath-maestro-flow.
 
@@ -55,17 +60,17 @@ success_criteria:
 
   # ── Agent invoked debug ────────────────────────────────────────────────
   - type: command_executed
-    description: "Agent ran flow debug"
+    description: "Advisory: live-v1 agent ran flow debug"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+debug'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   # ── Execution: connector calls ServiceNow and surfaces an array output ──
   - type: run_command
     description: "ServiceNow list-all-records node on acr_user executes and surfaces an array output"
-    command: "python3 $TASK_DIR/check_generic_dynamic_node.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/generic_dynamic_node/check_generic_dynamic_node.py"
     timeout: 320
     expected_exit_code: 0
     weight: 6.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/check_databricks_query.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/check_databricks_query.py
@@ -17,7 +17,6 @@ wiring described above.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import sys
@@ -27,6 +26,7 @@ from typing import NoReturn
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 from _shared.flow_check import (  # noqa: E402
     assert_flow_uses_connector_target,
+    find_flow_file,
 )
 
 FLOW_GLOB = "**/DatabricksQuery*.flow"
@@ -40,10 +40,7 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _flow_path() -> str:
-    flows = glob.glob(FLOW_GLOB, recursive=True)
-    if not flows:
-        _fail(f"no flow file matching {FLOW_GLOB}")
-    return flows[0]
+    return find_flow_file(flow_glob=os.path.basename(FLOW_GLOB))
 
 
 def _node_type(node: dict) -> str:

--- a/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/jdbc_databricks_query.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # Tenant-gated. Requires the Databricks-backed Database Hub (JDBC)
 # connection in the runner tenant, reaching the sandbox.globalmart schema whose
 # `employees` table is seeded with the fixture rows this task asserts on (Alice
@@ -38,7 +42,8 @@ run_limits:
   turn_timeout: 900
 
 initial_prompt: |
-  Create a new Flow project called "DatabricksQuery" with a manual trigger.
+  Create a new Flow project called "DatabricksQuery" inside a solution of the
+  same name, with a manual trigger.
 
   It should run a SQL query against a Databricks database using the Database Hub
   (JDBC) connector, and expose the query result as a flow output. Run an aggregate
@@ -56,25 +61,25 @@ initial_prompt: |
   Do NOT pause between planning and implementation.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "uip maestro flow debug was called"
+    description: "Advisory: live-v1 agent ran flow debug"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+debug'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "DatabricksQuery checks: valid flow wires the JDBC Execute-Query node with a bound connection, not the native Databricks connector or an HTTP fallback"
-    command: "python3 $TASK_DIR/check_databricks_query.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/jdbc_databricks_query/check_databricks_query.py"
     timeout: 600
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/multiselect.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-multiselect
 description: >
   Tests the multiselect IS feature — configures a Slack group direct message
@@ -20,7 +24,7 @@ success_criteria:
   # Name-agnostic: the prompt doesn't fix a project name.
   - type: run_command
     description: "A .flow file exists and is valid JSON with nodes and edges"
-    command: "python3 -c \"import json,glob,sys; flows=glob.glob('**/*.flow',recursive=True); sys.exit('no .flow found') if not flows else None; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; print('OK: %d nodes, %d edges'%(len(f['nodes']),len(f['edges'])))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 1.5
@@ -30,17 +34,16 @@ success_criteria:
   # field has exactly 3 entries (the three group-DM recipients).
   - type: run_command
     description: "Slack group-DM node present with 3 entries in the users multiselect"
-    command: "python3 $TASK_DIR/check_multiselect_flow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_multiselect_flow.py"
     timeout: 15
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py
@@ -28,11 +28,15 @@ JSON envelope (hand-authored). Both shapes are normalised before inspection.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Any, NoReturn
+
+SHARED_DIR = Path(__file__).resolve().parents[2] / "_shared"
+sys.path.insert(0, str(SHARED_DIR))
+from flow_check import find_flow_file  # noqa: E402
 
 FLOW_GLOB = "**/SpotifyProfileTest*.flow"
 # The generic HTTP connector — the only managed path to a service with no
@@ -48,16 +52,12 @@ def _fail(message: str) -> NoReturn:
 
 
 def _read_flow() -> dict[str, Any]:
-    flows = sorted(glob.glob(FLOW_GLOB, recursive=True))
-    if not flows:
-        _fail(f"No flow file matching {FLOW_GLOB}")
-    if len(flows) > 1:
-        _fail(f"Multiple flows match {FLOW_GLOB}: {flows}")
-    with open(flows[0], encoding="utf-8") as f:
+    path = find_flow_file(flow_glob=os.path.basename(FLOW_GLOB))
+    with open(path, encoding="utf-8") as f:
         try:
             return json.load(f)
         except json.JSONDecodeError as e:
-            _fail(f"{flows[0]} is not valid JSON: {e}")
+            _fail(f"{path} is not valid JSON: {e}")
 
 
 def _normalise_detail(raw: Any) -> dict[str, Any]:

--- a/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/non_catalog_http_fallback.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-non-catalog-http-fallback
 description: >
   Integration test: a NON-catalog service (Spotify) has no IS connector of its
@@ -27,22 +31,21 @@ initial_prompt: |
 
   Validate the final flow file.
 
-  Use `--output json` on every `uip` command whose output you parse.
   Do NOT ask for approval, confirmation, or feedback — build and validate the
   flow end-to-end in a single pass.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "Profile fetch uses a managed HTTP node with the uipath-uipath-http connector key (non-catalog fallback) and targets the /me endpoint"
-    command: "python3 $TASK_DIR/check_non_catalog_http_fallback.py check_fallback"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/non-catalog-http-fallback/check_non_catalog_http_fallback.py check_fallback"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/path_params.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-path-params
 description: >
   Tests the path parameters IS feature — configures a connector node with a
@@ -25,16 +29,16 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent invoked `uip is connections list` to discover available connections"
+    description: "Advisory: live-v1 agent listed connections before choosing one"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+is\\s+connections\\s+list"
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Tenant has at least one Jira connection (precondition for `node configure`)"
-    command: "python3 $TASK_DIR/check_connection_available.py uipath-atlassian-jira"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_connection_available.py uipath-atlassian-jira"
     timeout: 35
     expected_exit_code: 0
     weight: 1.0
@@ -42,7 +46,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/PathParamsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name PathParamsTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -50,7 +54,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow uses Jira connector or task-specific managed HTTP fallback"
-    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/PathParamsTest*.flow' uipath-atlassian-jira path_params"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py '**/PathParamsTest*.flow' uipath-atlassian-jira path_params"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -58,17 +62,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow path parameters carry the issue key ENGCE-00000"
-    command: "python3 $TASK_DIR/check_path_param_value.py '**/PathParamsTest*.flow' ENGCE-00000"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_path_param_value.py '**/PathParamsTest*.flow' ENGCE-00000"
     timeout: 10
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/query_params.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-query-params
 description: >
   Tests the query parameters IS feature — configures a connector node with a
@@ -23,7 +27,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/QueryParamsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name QueryParamsTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -31,17 +35,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow uses Google Tasks connector or task-specific managed HTTP fallback"
-    command: "python3 $TASK_DIR/check_managed_http_fallback.py '**/QueryParamsTest*.flow' uipath-google-tasks query_params"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/check_managed_http_fallback.py '**/QueryParamsTest*.flow' uipath-google-tasks query_params"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/required_groups.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-required-groups
 description: >
   Tests the required groups IS feature — configures a connector node where at
@@ -19,7 +23,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/RequiredGroupsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name RequiredGroupsTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -27,17 +31,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-microsoft-teams"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/RequiredGroupsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-microsoft-teams' in content, 'Connector key not found'; print('OK: connector key present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name RequiredGroupsTest 'uipath-microsoft-teams'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/searchable_joins.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-searchable-joins
 description: >
   Tests the searchable joins IS feature — configures a connector node with
@@ -20,7 +24,7 @@ initial_prompt: |
 success_criteria:
   - type: run_command
     description: "Flow file exists and is valid JSON"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/SearchableJoinsTest*.flow',recursive=True); assert flows, 'No flow found'; f=json.load(open(flows[0])); assert 'nodes' in f and 'edges' in f; nn=len(f['nodes']); ne=len(f['edges']); print('OK: %d nodes, %d edges'%(nn,ne))\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SearchableJoinsTest '\"nodes\"' '\"edges\"'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
@@ -28,17 +32,16 @@ success_criteria:
 
   - type: run_command
     description: "Flow has a connector node referencing uipath-salesforce-sfdc"
-    command: "python3 -c \"import json,glob; flows=glob.glob('**/SearchableJoinsTest*.flow',recursive=True); assert flows; content=open(flows[0]).read(); assert 'uipath-salesforce-sfdc' in content, 'Connector key not found'; print('OK: connector key present')\""
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SearchableJoinsTest 'uipath-salesforce-sfdc'"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
-

--- a/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/check_slack_http_fallback.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/check_slack_http_fallback.py
@@ -23,7 +23,6 @@ JSON envelope (hand-authored). Both shapes are normalised before inspection.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import sys
@@ -37,7 +36,7 @@ for _ in range(6):
         break
     _ROOT = os.path.dirname(_ROOT)
 sys.path.insert(0, _ROOT)
-from _shared.flow_check import run_debug  # noqa: E402
+from _shared.flow_check import find_flow_file, run_debug  # noqa: E402
 
 FLOW_GLOB = "**/SlackEmojiListTest*.flow"
 SLACK_KEY = "uipath-salesforce-slack"
@@ -53,16 +52,12 @@ def _fail(message: str) -> NoReturn:
 
 
 def _read_flow() -> dict[str, Any]:
-    flows = sorted(glob.glob(FLOW_GLOB, recursive=True))
-    if not flows:
-        _fail(f"No flow file matching {FLOW_GLOB}")
-    if len(flows) > 1:
-        _fail(f"Multiple flows match {FLOW_GLOB}: {flows}")
-    with open(flows[0], encoding="utf-8") as f:
+    path = find_flow_file(flow_glob=os.path.basename(FLOW_GLOB))
+    with open(path, encoding="utf-8") as f:
         try:
             return json.load(f)
         except json.JSONDecodeError as e:
-            _fail(f"{flows[0]} is not valid JSON: {e}")
+            _fail(f"{path} is not valid JSON: {e}")
 
 
 def _normalise_detail(raw: Any) -> dict[str, Any]:
@@ -90,7 +85,6 @@ def _is_slack_http_fallback(node: dict[str, Any]) -> bool:
     HTTP fallback and must not satisfy this check.
     """
     node_type = str(node.get("type") or "").lower()
-    blob = json.dumps(node).lower()
 
     # Shape 2: connector-scoped Slack HTTP request activity.
     if "http-request" in node_type and SLACK_KEY in node_type:

--- a/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/slack_http_fallback.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/slack_http_fallback.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-slack-http-fallback
 description: >
   E2E test: a catalog connector (Slack, uipath-salesforce-slack) has no native
@@ -16,38 +20,38 @@ run_limits:
   turn_timeout: 1200
 
 initial_prompt: |
-  Create a new Flow project called "SlackEmojiListTest" with a manual trigger
-  that lists the custom emoji for a team. Wire the manual trigger to the node that 
+  Create a new Flow project called "SlackEmojiListTest" inside a solution of the
+  same name, with a manual trigger that lists the custom emoji for a team. Wire
+  the manual trigger to the node that
   lists the emoji.
 
   Use the Slack connection in the `Shared/uipath-maestro-flow` folder.
 
   Validate the final flow file. Once it validates, debug it.
 
-  Use `--output json` on every `uip` command whose output you parse.
-  Do NOT ask for approval, confirmation, or feedback — build, validate, and
-  debug the flow end-to-end in a single pass.
+  Build, validate, and debug the flow end-to-end in a single pass. Do NOT ask
+  for approval, confirmation, or feedback.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent debugged the flow with uip maestro flow debug"
+    description: "Advisory: live-v1 agent invoked flow debug"
     tool_name: "Bash"
     command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+debug"
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Emoji list falls back to an HTTP-request node bound to the Slack connector (no native activity exists for it) and targets the emoji.list endpoint"
-    command: "python3 $TASK_DIR/check_slack_http_fallback.py check_fallback"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/check_slack_http_fallback.py check_fallback"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0
@@ -55,7 +59,7 @@ success_criteria:
 
   - type: run_command
     description: "uip maestro flow debug finishes with finalStatus Completed against the live Slack connection"
-    command: "python3 $TASK_DIR/check_slack_http_fallback.py check_debug"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/slack-http-fallback/check_slack_http_fallback.py check_debug"
     timeout: 360
     expected_exit_code: 0
     weight: 6.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_attachments/testmanager_attachments.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_attachments/testmanager_attachments.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   attachment group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -34,32 +38,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every attachment connector node type (4 nodes)"
-    command: 'for n in upload-attachment get-attachments download-attachment delete-attachment; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.upload-attachment' 'uipath-uipath-testmanager.get-attachments' 'uipath-uipath-testmanager.download-attachment' 'uipath-uipath-testmanager.delete-attachment'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py
@@ -27,6 +27,12 @@ def main():
     except OSError:
         fail("result.json missing — agent did not record the create/get round-trip")
 
+    if len(sys.argv) > 1 and sys.argv[1] == "--execution-evidence":
+        if not all(res.get(key) for key in ("created_name", "retrieved_name", "id")):
+            fail("result.json is missing created_name, retrieved_name, or id")
+        print("OK: execution result recorded")
+        return
+
     name = seed["name"]
     if res.get("created_name") != name:
         fail(f"created_name {res.get('created_name')!r} != seeded {name!r}")

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
@@ -69,7 +69,7 @@ success_criteria:
 
   - type: run_command
     description: "Execution produced the seeded create/get round-trip result"
-    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py --execution-evidence"
     timeout: 30
     expected_exit_code: 0
     weight: 1.5

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/testmanager_crud_grounded.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # PROTOTYPE — data-grounded on the Maestro Flow surface. skip:true.
 # Agent builds a flow (create-test-case node -> get-test-case node -> output the
 # retrieved name) and EXECUTES it (`uip maestro flow debug`) to produce the
@@ -10,8 +14,9 @@ description: >
   Data-grounded (Maestro Flow): agent builds a flow that creates a Test Case via
   the uipath-uipath-testmanager connector node with a unique seeded name, gets it
   back, outputs the retrieved name, and debugs (executes) the flow — then records
-  the round-trip. Graded on pull/node-add/validate/debug AND on retrieved ==
-  created (real data through the connector, executed).
+  the round-trip. Graded on the connector artifacts, successful validation, and
+  retrieved == created through the executed flow; registry-refresh telemetry is
+  advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -39,40 +44,40 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`)"
+    description: "Advisory: live-v1 agent refreshed the node manifest"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager create and get connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.create-test-case' 'uipath-uipath-testmanager.get-test-case'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent executed the flow (`uip maestro flow debug`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+debug'
-    min_count: 1
+  - type: run_command
+    description: "Execution produced the seeded create/get round-trip result"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Data-grounded: retrieved name == created (seeded) name — real data round-tripped through the executed flow"
-    command: "python3 $TASK_DIR/check.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_features/testmanager_crud_grounded/check.py"
     timeout: 30
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_execution_results/testmanager_execution_results.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_execution_results/testmanager_execution_results.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   execution and results group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -39,32 +43,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every execution and results connector node type (9 nodes)"
-    command: 'for n in get-test-execution delete-test-execution get-test-case-logs-of-test-execution get-test-case-log get-robot-logs get-assertions download-assertion get-test-steps get-test-step-logs; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.get-test-execution' 'uipath-uipath-testmanager.delete-test-execution' 'uipath-uipath-testmanager.get-test-case-logs-of-test-execution' 'uipath-uipath-testmanager.get-test-case-log' 'uipath-uipath-testmanager.get-robot-logs' 'uipath-uipath-testmanager.get-assertions' 'uipath-uipath-testmanager.download-assertion' 'uipath-uipath-testmanager.get-test-steps' 'uipath-uipath-testmanager.get-test-step-logs'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_generic_records/testmanager_generic_records.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_generic_records/testmanager_generic_records.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   generic record group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -35,32 +39,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every generic record connector node type (5 nodes)"
-    command: 'for n in insert-record get-record update-record delete-record list-records; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.insert-record' 'uipath-uipath-testmanager.get-record' 'uipath-uipath-testmanager.update-record' 'uipath-uipath-testmanager.delete-record' 'uipath-uipath-testmanager.list-records'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_requirement_lifecycle/testmanager_requirement_lifecycle.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   Requirement group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -36,32 +40,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every Requirement connector node type (6 nodes)"
-    command: 'for n in create-requirement get-requirement update-requirement delete-requirement assign-test-cases-to-requirement get-assigned-test-cases-for-req; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.create-requirement' 'uipath-uipath-testmanager.get-requirement' 'uipath-uipath-testmanager.update-requirement' 'uipath-uipath-testmanager.delete-requirement' 'uipath-uipath-testmanager.assign-test-cases-to-requirement' 'uipath-uipath-testmanager.get-assigned-test-cases-for-req'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testcase_lifecycle/testmanager_testcase_lifecycle.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   TestCase group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -35,32 +39,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every TestCase connector node type (5 nodes)"
-    command: 'for n in create-test-case get-test-case update-test-case delete-test-case execute-test-cases; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.create-test-case' 'uipath-uipath-testmanager.get-test-case' 'uipath-uipath-testmanager.update-test-case' 'uipath-uipath-testmanager.delete-test-case' 'uipath-uipath-testmanager.execute-test-cases'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_features/testmanager_testset_lifecycle/testmanager_testset_lifecycle.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 # skip:true, tenant-gated. CONFIRMED available in Maestro Flow (2026-06-16):
 # `uip maestro flow registry pull` then search returns the
 # uipath.connector.uipath-uipath-testmanager.<op> nodes for this object group. A stale manifest
@@ -8,9 +12,9 @@ description: >
   Coverage (Maestro Flow connector): agent uses the uipath-maestro-flow skill to
   build a Flow that uses every UiPath Test Manager connector node for the
   TestSet group — adding one connector node per operation. Drives
-  `registry pull` -> `registry search`/`get` -> `node add` -> `flow validate`.
-  Graded on those commands plus the produced .flow referencing each
-  uipath.connector.uipath-uipath-testmanager.* node type.
+  connector discovery, authoring, and validation. Graded on the produced .flow
+  referencing each uipath.connector.uipath-uipath-testmanager.* node type and
+  validating successfully; registry-refresh telemetry is advisory.
 tags: [uipath-maestro-flow, e2e, mode:build, lifecycle:generate, shape:multi-node, connector]
 skip: true
 
@@ -37,32 +41,32 @@ initial_prompt: |
 
 success_criteria:
   - type: command_executed
-    description: "Agent refreshed the node manifest (`uip maestro flow registry pull`) before searching"
+    description: "Advisory: live-v1 agent refreshed the node manifest before searching"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+registry\s+pull'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added connector nodes to the flow (`uip maestro flow node add`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+node\s+add'
-    min_count: 1
+  - type: run_command
+    description: "The flow contains Test Manager connector nodes"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent validated the flow (`uip maestro flow validate`)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "The completed flow validates"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Produced .flow references every TestSet connector node type (7 nodes)"
-    command: 'for n in create-test-set get-test-set update-test-set delete-test-set assign-test-cases-to-test-set get-assigned-test-cases-for-test-set execute-test-set; do grep -rqsF "uipath-uipath-testmanager.$n" --include="*.flow" . || { echo "missing node $n"; exit 1; }; done'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'uipath-uipath-testmanager.create-test-set' 'uipath-uipath-testmanager.get-test-set' 'uipath-uipath-testmanager.update-test-set' 'uipath-uipath-testmanager.delete-test-set' 'uipath-uipath-testmanager.assign-test-cases-to-test-set' 'uipath-uipath-testmanager.get-assigned-test-cases-for-test-set' 'uipath-uipath-testmanager.execute-test-set'"
     timeout: 30
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Summary
- apply the ratified same-ground alignment recipe to the exact 26-task Batch 3 roster
- replace v1-only authoring telemetry with artifact outcomes or report-only advisories while preserving every criterion weight
- route Flow discovery through the shared solution-first/root-emit fallback and keep all seven Test Manager tasks `skip: true`
- leave `connector_features/generate_schema.yaml`, `drive_to_slack.yaml`, and `paginated_reference_lookup.yaml` untouched

## Evidence
- `uv run --with pytest python -m pytest tests/tasks/uipath-maestro-flow -q` — 225 passed
- targeted Ruff F/E402 check — passed
- `coder-eval==0.10.2 plan` — all 26 task YAMLs valid
- exact Batch 3 audit — 26/26 campaign headers; 26/26 weights and all skip flags unchanged; no raw Flow glob remains in batch checkers
- newest same-agent live-v1 archive `runs/2026-08-20_17-22-24` at skills `04c0233`: 16/19 active tasks successful; multiselect, required-groups, and load-by-default-true failed; seven Test Manager tasks intentionally absent because skipped
- a fresh paired branch-tip run is blocked by the recorded expired UiPath refresh token (`authentication_required`); no Bucket-D semantic criterion was changed from that infrastructure signal

## Nightly signal
This intentionally changes task measurement from v1 authoring-command traces and first-match filesystem assumptions to arm-neutral artifact and validation outcomes. Registry/debug traces without an independent artifact witness remain visible but report-only. Semantic requirements, weights, task IDs, and Test Manager skip state are preserved.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)