### PR TITLE
test(maestro-flow): align IxP and context-grounding tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -1397,6 +1397,19 @@ def find_flow_file(
     return matches[0]
 
 
+def assert_no_flow_files() -> None:
+    """Require that the sandbox contains no ``.flow`` artifact anywhere.
+
+    This is the negative counterpart to :func:`find_flow_files` for read-only
+    tasks. It deliberately scans every location because any emitted Flow is a
+    failure; there is no preferred artifact to select in the absence case.
+    """
+    matches = sorted(glob.glob("**/*.flow", recursive=True))
+    if matches:
+        joined = "\n  - ".join(matches)
+        _fail(f"Unexpected .flow file(s) found:\n  - {joined}")
+
+
 # ── Internals ───────────────────────────────────────────────────────────────
 
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py
@@ -24,6 +24,8 @@ Arguments:
                          expected_exit_code: 0) instead of inverting a
                          positive check — a bare exit 1 cannot distinguish
                          "pattern absent" from "no flow found"
+    --expect-none        require that no ``.flow`` file exists anywhere in the
+                         sandbox (for read-only tasks)
 
 With no arguments this asserts only that a ``.flow`` file exists. All positive
 assertions (substrings + ``--regex``) must be satisfied by a single file;
@@ -46,7 +48,7 @@ import re
 import sys
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
-from flow_check import find_flow_files  # noqa: E402
+from flow_check import assert_no_flow_files, find_flow_files  # noqa: E402
 
 
 def _parse(argv: list[str]):
@@ -54,6 +56,7 @@ def _parse(argv: list[str]):
     regexes: list[str] = []
     absent: list[str] = []
     flow_name: str | None = None
+    expect_none = False
     it = iter(argv)
     for arg in it:
         try:
@@ -63,16 +66,33 @@ def _parse(argv: list[str]):
                 absent.append(next(it))
             elif arg == "--flow-name":
                 flow_name = next(it)
+            elif arg == "--expect-none":
+                expect_none = True
             else:
                 substrings.append(arg)
         except StopIteration:
             print(f"FAIL: {arg} requires a value", file=sys.stderr)
             sys.exit(2)
-    return substrings, regexes, absent, flow_name
+    return substrings, regexes, absent, flow_name, expect_none
 
 
 def main(argv: list[str]) -> int:
-    substrings, regexes, absent, flow_name = _parse(argv)
+    substrings, regexes, absent, flow_name, expect_none = _parse(argv)
+
+    if expect_none:
+        if substrings or regexes or absent or flow_name is not None:
+            print(
+                "FAIL: --expect-none cannot be combined with other assertions",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            assert_no_flow_files()
+        except SystemExit as exc:
+            print(str(exc), file=sys.stderr)
+            return exc.code if isinstance(exc.code, int) else 1
+        print("OK: no .flow files found")
+        return 0
 
     try:
         flows = find_flow_files()

--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch4_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch4_alignment.py
@@ -1,0 +1,179 @@
+"""Regression coverage for Batch 4 same-ground checker routing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from flow_check import assert_no_flow_files  # noqa: E402
+
+TASK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_flow(path: Path, nodes: list[dict], **extra) -> None:
+    path.write_text(json.dumps({"nodes": nodes, "edges": [], **extra}), encoding="utf-8")
+
+
+def _run(relative: str, cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TASK_ROOT / relative)],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_no_flow_assertion_accepts_empty_sandbox(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert_no_flow_files()
+
+
+def test_no_flow_assertion_rejects_nested_flow(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    nested = tmp_path / "Solution" / "Project"
+    nested.mkdir(parents=True)
+    _write_flow(nested / "Unexpected.flow", [])
+
+    with pytest.raises(SystemExit, match="Unexpected .flow"):
+        assert_no_flow_files()
+
+
+def test_ixp_project_selection_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    row = tmp_path / "skill-flow-ixp-e2e-project-selection" / "aviation"
+    row.mkdir(parents=True)
+    model = "aviation-investigation-final-report-demo-a42b1d4d-ixp"
+    _write_flow(
+        row / "Aviation.flow",
+        [
+            {
+                "id": "extract",
+                "type": f"uipath.ixp.{model}.extract",
+                "inputs": {"modelName": model},
+            }
+        ],
+    )
+
+    result = _run("ixp/check_project_selection.py", cwd=row)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_ixp_project_selection_rejects_mismatched_model(tmp_path: Path) -> None:
+    row = tmp_path / "skill-flow-ixp-e2e-project-selection" / "birth-certificate"
+    row.mkdir(parents=True)
+    _write_flow(
+        row / "Birth.flow",
+        [
+            {
+                "id": "extract",
+                "type": "uipath.ixp.wrong-model.extract",
+                "inputs": {"modelName": "wrong-model"},
+            }
+        ],
+    )
+
+    result = _run("ixp/check_project_selection.py", cwd=row)
+
+    assert result.returncode == 1
+
+
+def test_batch_transform_checker_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    _write_flow(
+        tmp_path / "BatchTransformDemo.flow",
+        [
+            {"id": "trigger", "type": "core.trigger.manual"},
+            {
+                "id": "batch",
+                "type": "uipath.pattern.batch-transform",
+                "typeVersion": "1.0",
+                "inputs": {
+                    "attachment": "=js:$vars.trigger.output.csvFile",
+                    "prompt": "Classify each row",
+                    "outputColumns": [
+                        {"name": "Category", "description": "classification"}
+                    ],
+                },
+                "outputs": {"output": {"source": "=response"}},
+            },
+            {
+                "id": "end",
+                "type": "core.control.end",
+                "outputs": {"result": {"source": "=js:$vars.batch.output"}},
+            },
+        ],
+        variables={
+            "globals": [
+                {
+                    "id": "csvFile",
+                    "direction": "in",
+                    "type": "file",
+                    "triggerNodeId": "trigger",
+                },
+                {"id": "result", "direction": "out", "type": "file"},
+            ]
+        },
+    )
+
+    result = _run(
+        "context-grounding/batch_transform/check_batch_transform_flow.py",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_summarize_checker_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    _write_flow(
+        tmp_path / "SummarizeDemo.flow",
+        [
+            {"id": "trigger", "type": "core.trigger.manual"},
+            {
+                "id": "summary_node",
+                "type": "uipath.pattern.deep-rag",
+                "typeVersion": "1.0",
+                "inputs": {
+                    "attachment": "=js:$vars.trigger.output.documentFile",
+                    "prompt": "Summarize the document",
+                    "returnCitations": True,
+                },
+                "outputs": {"output": {"source": "=response"}},
+            },
+            {
+                "id": "end",
+                "type": "core.control.end",
+                "outputs": {
+                    "summary": {
+                        "source": "=js:$vars.summary_node.output.content.Text"
+                    },
+                    "citations": {
+                        "source": "=js:$vars.summary_node.output.content.Citations"
+                    },
+                },
+            },
+        ],
+        variables={
+            "globals": [
+                {
+                    "id": "documentFile",
+                    "direction": "in",
+                    "type": "file",
+                    "triggerNodeId": "trigger",
+                },
+                {"id": "summary", "direction": "out", "type": "string"},
+                {"id": "citations", "direction": "out", "type": "array"},
+            ]
+        },
+    )
+
+    result = _run(
+        "context-grounding/summarize/check_summarize_flow.py",
+        cwd=tmp_path,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch4_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch4_alignment.py
@@ -44,6 +44,18 @@ def test_no_flow_assertion_rejects_nested_flow(tmp_path: Path, monkeypatch) -> N
         assert_no_flow_files()
 
 
+def test_flow_contains_expect_none_cli(tmp_path: Path) -> None:
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).parent / "flow_contains.py"), "--expect-none"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
 def test_ixp_project_selection_accepts_root_sdk_emit(tmp_path: Path) -> None:
     row = tmp_path / "skill-flow-ixp-e2e-project-selection" / "aviation"
     row.mkdir(parents=True)

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -20,33 +20,14 @@ V1_AUTHORING_ALLOWLIST = {
     "evaluate/local_crud.yaml",
     "evaluate/no_auto_upload.yaml",
     "evaluate/simulation/simulation_crud.yaml",
-    "ixp/e2e_02_project_selection.yaml",
-    "ixp/integration_handle_routing.yaml",
-    "ixp/routing.yaml",
-    "ixp/routing_listing.yaml",
-    "ixp/scaffold_minimal.yaml",
-    "ixp/scaffold_multinode.yaml",
 }
 
-SKILL_TELEMETRY_ALLOWLIST = {
-    "ixp/e2e_02_project_selection.yaml",
-    "ixp/integration_handle_routing.yaml",
-    "ixp/scaffold_minimal.yaml",
-    "ixp/scaffold_multinode.yaml",
-}
+SKILL_TELEMETRY_ALLOWLIST = set()
 
 FORBIDDEN_PROMPT_ALLOWLIST = {
-    "context-grounding/batch_transform/batch_transform.yaml",
-    "context-grounding/summarize/summarize.yaml",
     "evaluate/inline_agent_eval/inline_agent_eval.yaml",
     "evaluate/local_crud.yaml",
     "evaluate/simulation/simulation_crud.yaml",
-    "ixp/e2e_02_project_selection.yaml",
-    "ixp/integration_handle_routing.yaml",
-    "ixp/routing.yaml",
-    "ixp/routing_negative.yaml",
-    "ixp/scaffold_minimal.yaml",
-    "ixp/scaffold_multinode.yaml",
 }
 
 # These born-neutral escalation tasks are outside the recipe-edit sweep. Their

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/batch_transform.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-batch-transform
 description: >
   Create a UiPath Flow that runs a Batch Transform pattern node over a CSV
@@ -41,7 +45,7 @@ initial_prompt: |
   the result file handle as a flow output variable named `result` mapped via
   `outputs.result.source: "=js:$vars.<bt-node-id>.output"`.
 
-  Do NOT run flow debug — just validate the flow.
+  Validate the completed flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, follow the documented workflow steps exactly — in particular, the batch-transform plugin's
@@ -60,7 +64,7 @@ success_criteria:
   # ── Structural checks (node type, inputs, outputColumns shape) ─────────
   - type: run_command
     description: "Flow has a Batch Transform node with required inputs and the {name,description} outputColumns shape"
-    command: "python3 $TASK_DIR/check_batch_transform_flow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/check_batch_transform_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/check_batch_transform_flow.py
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/batch_transform/check_batch_transform_flow.py
@@ -20,11 +20,14 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      reference.
 """
 
-import glob
 import json
+import os
 import re
 import sys
 from typing import NoReturn
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "_shared"))
+from flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "uipath.pattern.batch-transform"
 EXPECTED_TYPE_VERSION = "1.0"
@@ -45,10 +48,8 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/BatchTransformDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no BatchTransformDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    path = find_flow_file(flow_glob="BatchTransformDemo*.flow")
+    with open(path) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/check_summarize_flow.py
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/check_summarize_flow.py
@@ -22,11 +22,14 @@ Generation-only — does not run `uip maestro flow debug`. Verifies:
      PascalCase; lowercase resolves to undefined at runtime).
 """
 
-import glob
 import json
+import os
 import re
 import sys
 from typing import NoReturn
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "_shared"))
+from flow_check import find_flow_file  # noqa: E402
 
 NODE_TYPE = "uipath.pattern.deep-rag"
 EXPECTED_TYPE_VERSION = "1.0"
@@ -43,10 +46,8 @@ def _fail(msg: str) -> NoReturn:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob("**/SummarizeDemo*.flow", recursive=True)
-    if not flows:
-        _fail("no SummarizeDemo*.flow found under cwd")
-    with open(flows[0]) as f:
+    path = find_flow_file(flow_glob="SummarizeDemo*.flow")
+    with open(path) as f:
         return json.load(f)
 
 

--- a/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
+++ b/tests/tasks/uipath-maestro-flow/context-grounding/summarize/summarize.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-summarize
 description: >
   Create a UiPath Flow that runs a Summarize pattern node (`uipath.pattern.deep-rag`)
@@ -43,7 +47,7 @@ initial_prompt: |
   Note the PascalCase nested field names — lowercase `text`/`citations` would
   resolve to `undefined` at runtime.
 
-  Do NOT run flow debug — just validate the flow.
+  Validate the completed flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
   planning and implementation. Build the complete flow end-to-end in a single pass.
   Before starting, follow the documented workflow steps exactly — in particular, note that the wire-level node type is
@@ -62,7 +66,7 @@ success_criteria:
   # ── Structural checks (node type, inputs, returnCitations boolean) ─────
   - type: run_command
     description: "Flow has a Summarize (deep-rag) node with prompt, attachment wired, and returnCitations=true"
-    command: "python3 $TASK_DIR/check_summarize_flow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/context-grounding/summarize/check_summarize_flow.py"
     timeout: 30
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/ixp/check_project_selection.py
+++ b/tests/tasks/uipath-maestro-flow/ixp/check_project_selection.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Verify that the dataset row selected its exact published IxP model."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+from flow_check import find_flow_file  # noqa: E402
+
+
+EXPECTED = {
+    "aviation": (
+        "aviation-investigation-final-report-demo-a42b1d4d-ixp",
+        "uipath.ixp.aviation-investigation-final-report-demo-a42b1d4d-ixp.",
+    ),
+    "birth-certificate": (
+        "birth_certificates_oob-6252526a-ixp",
+        "uipath.ixp.birth-certificates-oob-6252526a-ixp.",
+    ),
+}
+
+
+def _nested_values(value, key: str):
+    if isinstance(value, dict):
+        for nested_key, nested_value in value.items():
+            if nested_key == key:
+                yield nested_value
+            yield from _nested_values(nested_value, key)
+    elif isinstance(value, list):
+        for item in value:
+            yield from _nested_values(item, key)
+
+
+def main() -> int:
+    row = next((part for part in os.getcwd().split(os.sep) if part in EXPECTED), None)
+    if row is None:
+        print(f"FAIL: unknown dataset row in cwd: {os.getcwd()}", file=sys.stderr)
+        return 2
+
+    path = find_flow_file()
+    with open(path, encoding="utf-8") as f:
+        flow = json.load(f)
+
+    model_name, type_prefix = EXPECTED[row]
+    for node in flow.get("nodes", []):
+        has_model = any(
+            value == model_name for value in _nested_values(node, "modelName")
+        )
+        if str(node.get("type", "")).startswith(type_prefix) and has_model:
+            print(f"OK: {row} uses published model {model_name} in {path}")
+            return 0
+
+    print(
+        f"FAIL: no IxP node in {path} pairs type prefix {type_prefix!r} "
+        f"with modelName {model_name!r}",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/e2e_02_project_selection.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-e2e-project-selection
 description: >
   E2E (project selection): on a tenant where the demo IxP project set is
@@ -45,38 +49,28 @@ dataset:
 
 initial_prompt: |
   ${row.prompt}
-
-  Important:
-  - The `uip` CLI is already available and the runner is logged in.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
-    the `.flow` and re-run it. Do not exceed 3 validation runs.
+  Produce a complete flow that validates.
 
 success_criteria:
   - type: skill_triggered
     skill_name: "uipath-maestro-flow"
     expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
+    description: "Advisory: agent invoked the uipath-maestro-flow skill"
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent searched the registry for IxP node types"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  # `../..` cwd rationale: dataset-fanout cwd
-  # is <run>/artifacts/<outer_task_id>/<row_id>[/<iter>]/, so artifacts written
-  # by the agent live two levels up at most.
   - type: run_command
     description: "uip maestro flow validate passes on the generated flow"
-    command: 'f=$(find ../.. -name "*.flow" -print -quit); [ -n "$f" ] && uip maestro flow validate "$f" --output json'
-    timeout: 60
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
@@ -85,16 +79,14 @@ success_criteria:
   # a domain-matching IxP project IS published.
   - type: run_command
     description: "Generated flow contains a real uipath.ixp.* node"
-    command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"uipath\.ixp\." --include="*.flow" ../..'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '\"type\"\\s*:\\s*\"uipath\\.ixp\\.'"
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  # Inverted twin of the above. `! grep -q` exits 0 when no mock is found
-  # (PASS) and 1 when one exists (FAIL). Same `../..` rationale as above.
   - type: run_command
     description: "Generated flow does NOT contain a core.logic.mock fallback"
-    command: '! grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"core\.logic\.mock\"" --include="*.flow" ../..'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --absent-regex '\"type\"\\s*:\\s*\"core\\.logic\\.mock\"'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
@@ -107,36 +99,8 @@ success_criteria:
   # dataset IDs in scripts/ixp-demo-projects/datasets.jsonl.
   - type: run_command
     description: "IxP node references the exact published model for this row's domain (strict)"
-    command: |
-      case "$(pwd)" in
-        *aviation*)
-          model='aviation-investigation-final-report-demo-a42b1d4d-ixp'
-          nt='uipath\.ixp\.aviation-investigation-final-report-demo-a42b1d4d-ixp\.'
-          ;;
-        *birth*)
-          model='birth_certificates_oob-6252526a-ixp'
-          nt='uipath\.ixp\.birth-certificates-oob-6252526a-ixp\.'
-          ;;
-        *)
-          echo "Unknown row in pwd: $(pwd)" >&2
-          exit 2
-          ;;
-      esac
-      f=$(find ../.. -name "*.flow" -print -quit)
-      if [ -z "$f" ]; then
-        echo "no .flow file under ../.." >&2
-        exit 1
-      fi
-      if ! grep -qF "\"modelName\": \"${model}\"" "$f"; then
-        echo "modelName mismatch — expected '${model}' in $f" >&2
-        grep -E '"modelName"' "$f" >&2 || true
-        exit 1
-      fi
-      if ! grep -qE "\"type\"[[:space:]]*:[[:space:]]*\"${nt}" "$f"; then
-        echo "NodeType mismatch — expected prefix '${nt}' in $f" >&2
-        grep -E '"type"[[:space:]]*:[[:space:]]*"uipath\.ixp' "$f" >&2 || true
-        exit 1
-      fi
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/ixp/check_project_selection.py"
+    timeout: 30
     expected_exit_code: 0
     weight: 5.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/integration_handle_routing.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-integration-handle-routing
 description: >
   Integration: IxP extraction wired into a Decision node that routes on a
@@ -37,29 +41,23 @@ initial_prompt: |
   `$vars.<ixpNodeId>.output.ExtractionResult.ResultsDocument.Fields.find(f => f.FieldName === '<fieldName>')?.Values?.[0]`
   — per references/plugins/ixp/impl.md ("Accessing Output").
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
-    the `.flow` and re-run it. Do not exceed 3 validation runs.
+  Validate the completed flow.
 
 success_criteria:
   - type: skill_triggered
     skill_name: "uipath-maestro-flow"
     expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
+    description: "Advisory: agent invoked the uipath-maestro-flow skill"
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent searched the registry for IxP node types"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: 'uip\s+maestro\s+flow\s+registry\s+(search|list|get)\b[^\n]*ixp'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "uip maestro flow validate passes on InvoiceRouter.flow"
@@ -71,58 +69,37 @@ success_criteria:
 
   - type: run_command
     description: "Generated flow contains an IxP extraction node or core.logic.mock fallback"
-    command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '\"type\"\\s*:\\s*\"(uipath\\.ixp|core\\.logic\\.mock)'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
-  # The four checks below locate the .flow rather than hardcoding
-  # `<Name>/<Name>/<Name>.flow`. `uip maestro flow init <Name>` run outside a
-  # solution auto-scaffolds a `<Name>Solution/` wrapper (see greenfield.md),
-  # so the literal path only resolves when the agent happens to run
-  # `uip solution init` first — an authoring idiom these checks don't test.
-  # Each grep line is one `includes:` needle; all must match.
+  # The checks below use shared discovery rather than hardcoding a solution
+  # wrapper shape. Each set of strings must match within one Flow artifact.
   - type: run_command
     description: "Flow contains a Decision node (core.logic.decision)"
-    command: |
-      set -e
-      flow=$(find . -name '*.flow' -print -quit)
-      grep -qF 'core.logic.decision' "$flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'core.logic.decision'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "Decision condition references the canonical IxP output path ($vars.<ixp>.output.ExtractionResult.ResultsDocument.Fields)"
-    command: |
-      set -e
-      flow=$(find . -name '*.flow' -print -quit)
-      grep -qF '$vars.'           "$flow"
-      grep -qF 'ExtractionResult' "$flow"
-      grep -qF 'ResultsDocument'  "$flow"
-      grep -qF 'Fields'           "$flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.' 'ExtractionResult' 'ResultsDocument' 'Fields'"
     expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "Both branch script nodes are present by name"
-    command: |
-      set -e
-      flow=$(find . -name '*.flow' -print -quit)
-      grep -qF 'HighValueReview' "$flow"
-      grep -qF 'AutoApprove'     "$flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py 'HighValueReview' 'AutoApprove'"
     expected_exit_code: 0
     weight: 2.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Both Decision branches wired (true and false handles)"
-    command: |
-      set -e
-      flow=$(find . -name '*.flow' -print -quit)
-      grep -qF '"true"'  "$flow"
-      grep -qF '"false"' "$flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '\"true\"' '\"false\"'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing
 description: >
   IxP routing (positive) — document-extraction build prompts fanned out via
@@ -5,9 +9,9 @@ description: >
   identical across all rows.
 
   Scope: did the agent route to the IxP plugin, not did the flow work.
-  Assertions verify the agent ran the right CLI-command patterns (registry
-  search for uipath.ixp.*) and landed a uipath.ixp.* or core.logic.mock node —
-  NOT whether the resulting flow is correct or would execute.
+  The gating assertion verifies that the artifact contains a uipath.ixp.* or
+  core.logic.mock node. Registry-search telemetry remains report-only because
+  the two authoring loops use different commands.
 
   Failure here is signal about SKILL.md or the IxP Plugin Index entry —
   do NOT relax assertions; feed findings back in.
@@ -50,15 +54,6 @@ dataset:
 initial_prompt: |
   ${row.prompt}
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors or rewrite the flow to fix them. A broken flow is acceptable.
-  - You do not need a working flow — a skeleton whose nodes cover the steps of the request is enough. Leave a node unconfigured rather than leaving a step out.
-
 success_criteria:
   # What this checks: did the agent search the registry for IxP nodes?
   # Passes (case-insensitive) when the agent ran either:
@@ -68,20 +63,18 @@ success_criteria:
   # routing_listing.yaml drops `get` (read-only). Keep in sync with
   # scaffold_minimal.yaml, scaffold_multinode.yaml, routing_listing.yaml.
   - type: command_executed
-    description: "Agent searched the registry for IxP node types"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
-    suite_thresholds: {mean: 0.85}
+    pass_threshold: 0.0
 
-  # Greps the actual .flow artifact rather than the command stream — the
-  # command_executed checker truncates tool params at 2000 chars, which hides
-  # `"type": "core.logic.mock"` when the agent writes a large flow file in a
-  # single Write call.  Per references/plugins/ixp/impl.md, the agent must land
-  # either an `uipath.ixp.*` node or a `core.logic.mock` placeholder.
+  # Inspect the actual .flow artifact rather than the command stream. Per
+  # references/plugins/ixp/impl.md, the agent must land either an
+  # `uipath.ixp.*` node or a `core.logic.mock` placeholder.
   - type: run_command
     description: "Agent added an IxP or core.logic.mock placeholder node to a .flow file (per references/plugins/ixp/impl.md)"
-    command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '\"type\"\\s*:\\s*\"(uipath\\.ixp|core\\.logic\\.mock)'"
     expected_exit_code: 0
     suite_thresholds: {mean: 0.85}
 

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_listing.yaml
@@ -1,12 +1,16 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing-listing
 description: >
   IxP listing routing — user asks what IxP models / runtime projects are
   available from a Maestro flow. Read-only Q&A, not a build task.
 
-  Asserts the agent ran the IxP registry-search listing command (per
-  references/plugins/ixp/impl.md — Listing Published Models). Also asserts the
-  agent did NOT take the build path: no .flow file should be created for a
-  listing question.
+  Observes the live-v1 registry-search command as report-only telemetry (per
+  references/plugins/ixp/impl.md — Listing Published Models). The gating check
+  asserts that the agent did NOT take the build path: no .flow file should be
+  created for a listing question.
 
   Failure here is signal about the IxP plugin's Listing Published Models /
   Listing Available Models sections — do NOT relax assertions, tighten the
@@ -39,26 +43,21 @@ dataset:
 
 initial_prompt: |
   ${row.prompt}
-
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
+  Answer the question without creating a flow.
 
 success_criteria:
   # IxP registry-search check (omits `get`) — see routing.yaml for the pattern breakdown.
   - type: command_executed
-    description: "Agent searched the registry for IxP node types (listing path)"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
-    suite_thresholds: {mean: 0.85}
+    pass_threshold: 0.0
 
-  # Inverted check: a listing/Q&A task should NOT create a .flow file.
-  # `! find ... | grep -q .` exits 0 when no .flow file is found (PASS)
-  # and 1 when one exists (FAIL).
+  # A listing/Q&A task should not create a Flow artifact.
   - type: run_command
     description: "No .flow file was created (listing is read-only Q&A, not a build task)"
-    command: '! find . -name "*.flow" -type f | grep -q .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --expect-none"
     expected_exit_code: 0
     suite_thresholds: {mean: 0.85}
 

--- a/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/routing_negative.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-routing-negative
 description: >
   Negative IxP routing — verifies the agent does NOT add a uipath.ixp.*
@@ -55,23 +59,11 @@ dataset:
 initial_prompt: |
   ${row.prompt}
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most ONCE. If it fails, stop.
-  - Do NOT iterate on validation errors or rewrite the flow to fix them. A broken flow is acceptable.
-  - You do not need a working flow — a skeleton whose nodes cover the steps of the request is enough. Leave a node unconfigured rather than leaving a step out.
-
 success_criteria:
-  # Inverted twin of the positive routing.yaml grep.
-  # `shell=True` in coder_eval Sandbox.run_command means `!` works as a bash
-  # negator: grep -q exits 0 on match → ! flips to 1 (FAIL); exits 1 on
-  # no-match → ! flips to 0 (PASS).
+  # Inverted twin of the positive routing.yaml artifact check.
   - type: run_command
     description: "No uipath.ixp.* node landed in any .flow file (negative IxP routing)"
-    command: '! grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"uipath\.ixp" --include="*.flow" .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --absent-regex '\"type\"\\s*:\\s*\"uipath\\.ixp'"
     expected_exit_code: 0
     suite_thresholds: {mean: 0.85}
 

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_minimal.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-scaffold-minimal
 description: >
   Integration: minimal scaffold — manual trigger → IxP extract → script (logs "ok")
@@ -25,38 +29,32 @@ initial_prompt: |
   Script node: contains a JavaScript that logs OK when it receives the
   extraction result.
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
-    the `.flow` and re-run it. Do not exceed 3 validation runs.
+  Validate the completed flow.
 
 success_criteria:
   - type: skill_triggered
     skill_name: "uipath-maestro-flow"
     expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
+    description: "Advisory: agent invoked the uipath-maestro-flow skill"
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   # IxP registry-search check — see routing.yaml for the pattern breakdown.
   - type: command_executed
-    description: "Agent searched the registry for IxP node types"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent validated the .flow file"
+    description: "Advisory: live-v1 agent invoked flow validation"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "uip maestro flow validate passes on Smoke.flow"
@@ -68,7 +66,7 @@ success_criteria:
 
   - type: run_command
     description: "Generated flow contains an IxP extraction node or core.logic.mock fallback (per references/plugins/ixp/impl.md)"
-    command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '\"type\"\\s*:\\s*\"(uipath\\.ixp|core\\.logic\\.mock)'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
@@ -77,10 +75,7 @@ success_criteria:
   # integration_handle_routing.yaml for the `<Name>Solution/` wrapper rationale.
   - type: run_command
     description: "Script node consumes the extraction output via $vars expression"
-    command: |
-      set -e
-      flow=$(find . -name '*.flow' -print -quit)
-      grep -qF '$vars.' "$flow"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py '$vars.'"
     expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
+++ b/tests/tasks/uipath-maestro-flow/ixp/scaffold_multinode.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ixp-scaffold-multinode
 description: >
   Integration: multi-script fan-out from an IxP extraction — manual trigger →
@@ -29,38 +33,32 @@ initial_prompt: |
   the three script nodes logs OK when it receives its respective extraction
   result.
 
-  Important:
-  - The `uip` CLI is already available.
-  - Use `--output json` on all uip commands.
-  - Work inside the stated working directory — do NOT `cd` to a parent.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow deploy`.
-  - Run `uip maestro flow validate` at most 3 times. If it reports errors, fix
-    the `.flow` and re-run it. Do not exceed 3 validation runs.
+  Validate the completed flow.
 
 success_criteria:
   - type: skill_triggered
     skill_name: "uipath-maestro-flow"
     expected_skill: "uipath-maestro-flow"
-    description: "Agent invoked the uipath-maestro-flow Skill"
+    description: "Advisory: agent invoked the uipath-maestro-flow skill"
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   # IxP registry-search check — see routing.yaml for the pattern breakdown.
   - type: command_executed
-    description: "Agent searched the registry for IxP node types"
+    description: "Advisory: live-v1 agent searched the registry for IxP node types"
     tool_name: "Bash"
     command_pattern: '(?i)uip\s+maestro\s+flow\s+registry\s+(list\b|(search|list|get)\b[^\n]*\b(ixp|document|extract))'
     min_count: 1
     weight: 2.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: command_executed
-    description: "Agent validated the .flow file"
+    description: "Advisory: live-v1 agent invoked flow validation"
     tool_name: "Bash"
     command_pattern: 'uip\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "uip maestro flow validate passes on ReceiptIntake.flow"
@@ -72,7 +70,7 @@ success_criteria:
 
   - type: run_command
     description: "Generated flow contains an IxP extraction node or core.logic.mock fallback (per references/plugins/ixp/impl.md)"
-    command: 'grep -rqE "\"type\"[[:space:]]*:[[:space:]]*\"(uipath\.ixp|core\.logic\.mock)" --include="*.flow" .'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --regex '\"type\"\\s*:\\s*\"(uipath\\.ixp|core\\.logic\\.mock)'"
     expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0


### PR DESCRIPTION
## Summary

- apply the ratified same-ground recipe to the exact 9-task Batch 4 roster
- route context-grounding and IxP structure checks through shared solution-first/root-fallback discovery
- make loop-specific skill/registry/validation telemetry report-only while preserving every criterion weight
- remove CLI/debug coaching from prompts without changing requested flow behavior
- preserve the Summarize attachment criterion unchanged under the Bucket-D fence

## Nightly signal impact

This is a measurement-contract change, not score greening. Artifact and validation outcomes remain gating at their prior weights. Telemetry that one authoring loop cannot emit is retained for reporting with `pass_threshold: 0.0`. Positive assertions must still hold in one selected artifact, and negative assertions fail if no artifact exists. The read-only listing task uses the shared no-flow assertion.

## Evidence

- `232 passed` across `tests/tasks/uipath-maestro-flow`
- focused Ruff F/E402 checks pass
- coder-eval 0.10.2 validates all 9 task YAMLs
- static weight/skip comparison against the integration base passes
- newest same-agent live-v1 archive (`runs/2026-08-20_17-22-24`, Claude Code / Sonnet 5 / Bedrock, skills `04c0233`) is 30/30 across Batch 4 task/variant rows
- fresh paired shakeout not launched: `uip login refresh --output json` returns `AuthenticationError` / `RetryWillNotFix`

## Fences

- `ixp/e2e_01_invoice_extraction_greenfield.yaml` remains untouched (#2557)
- `context-grounding/summarize` semantic checks are unchanged
- `connector_features/generate_schema.yaml` remains out of scope

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)