### PR TITLE
test(maestro-flow): align connector trigger, e2e, edit, and evaluation tasks

### DIFF
--- a/tests/tasks/uipath-maestro-flow/_shared/test_batch5_alignment.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_batch5_alignment.py
@@ -1,0 +1,330 @@
+"""Regression coverage for Batch 5 same-ground artifact checks."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TASK_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value), encoding="utf-8")
+
+
+def _run(relative: str, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(TASK_ROOT / relative), *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize("goal", ["goal-a", "goal-b", "goal-c"])
+def test_type_choice_artifact_modes(tmp_path: Path, goal: str) -> None:
+    expected = {
+        "goal-a": (
+            "goal-a-evaluator",
+            "uipath-llm-judge-output-semantic-similarity",
+        ),
+        "goal-b": ("goal-b-evaluator", "uipath-json-similarity"),
+        "goal-c": ("goal-c-evaluator", "uipath-contains"),
+    }
+    name, type_id = expected[goal]
+    _write_json(
+        tmp_path / "Wrapper" / "Flow" / "evals" / f"{goal}.json",
+        {"name": name, "evaluatorTypeId": type_id},
+    )
+
+    result = _run("evaluate/check_type_choice.py", tmp_path, "--artifact", goal)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_type_choice_default_checks_report(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "report.json",
+        {
+            "goal_a_type": "llm-judge-output",
+            "goal_b_type": "json-similarity",
+            "goal_c_type": "contains",
+        },
+    )
+
+    result = _run("evaluate/check_type_choice.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.fixture
+def local_crud_sandbox(tmp_path: Path) -> Path:
+    root = tmp_path / "arbitrary-wrapper" / "SmokeEval" / "evals"
+    _write_json(
+        root / "evaluators" / "greeting.json",
+        {"name": "greeting-match", "evaluatorTypeId": "uipath-exact-match"},
+    )
+    _write_json(
+        root / "eval-sets" / "smoke.json",
+        {
+            "name": "Smoke Set",
+            "evaluations": [
+                {
+                    "name": "hello",
+                    "inputs": {"name": "Alice"},
+                    "expectedOutput": {"greeting": "Hello, Alice!"},
+                }
+            ],
+        },
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize("check", ["evaluator", "eval-set", "data-point"])
+def test_local_crud_modes(local_crud_sandbox: Path, check: str) -> None:
+    result = _run("evaluate/check_local_crud.py", local_crud_sandbox, "--check", check)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_local_crud_default_checks_combined_artifacts(local_crud_sandbox: Path) -> None:
+    result = _run("evaluate/check_local_crud.py", local_crud_sandbox)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.fixture
+def no_upload_sandbox(tmp_path: Path) -> Path:
+    root = tmp_path / "LocalOnly" / "evals"
+    _write_json(
+        root / "evaluators" / "greeting.json",
+        {"name": "greeting-match", "evaluatorTypeId": "uipath-exact-match"},
+    )
+    _write_json(
+        root / "eval-sets" / "smoke.json",
+        {
+            "name": "Smoke",
+            "evaluations": [
+                {
+                    "name": "hello",
+                    "inputs": {"name": "Alice"},
+                    "expectedOutput": {"greeting": "Hello, Alice!"},
+                }
+            ],
+        },
+    )
+    _write_json(
+        tmp_path / "report.json",
+        {
+            "ran_solution_upload": False,
+            "ran_eval_run_start": False,
+            "action": "refused",
+            "reason": "Studio Web upload requires user authorization.",
+        },
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize("check", ["evaluator", "eval-set", "data-point"])
+def test_no_auto_upload_artifact_modes(no_upload_sandbox: Path, check: str) -> None:
+    result = _run(
+        "evaluate/check_no_auto_upload.py",
+        no_upload_sandbox,
+        "--check",
+        check,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_no_auto_upload_default_still_checks_report(no_upload_sandbox: Path) -> None:
+    result = _run("evaluate/check_no_auto_upload.py", no_upload_sandbox)
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+@pytest.fixture
+def inline_eval_sandbox(tmp_path: Path) -> Path:
+    root = tmp_path / "AnySolution" / "TriageEval"
+    _write_json(root / "inline-id" / "agent.json", {"name": "triage"})
+    _write_json(
+        root / "evals" / "evaluators" / "triage-judge-a1.json",
+        {
+            "name": "triage-judge",
+            "evaluatorTypeId": "uipath-llm-judge-output-semantic-similarity",
+            "evaluatorConfig": {"model": "gpt-4.1-2025-04-14"},
+        },
+    )
+    _write_json(
+        root / "evals" / "eval-sets" / "triage-cases.json",
+        {
+            "name": "Triage Cases",
+            "evaluatorRefs": ["triage-judge-a1.json"],
+            "evaluations": [
+                {
+                    "name": "password-reset",
+                    "inputs": {"email": "reset"},
+                    "expectedOutput": {"category": "Account Access"},
+                }
+            ],
+        },
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "check",
+    [
+        "inline-agent",
+        "evaluator",
+        "no-deterministic",
+        "eval-set",
+        "evaluator-refs",
+        "data-point",
+    ],
+)
+def test_inline_eval_modes(inline_eval_sandbox: Path, check: str) -> None:
+    result = _run(
+        "evaluate/inline_agent_eval/check_inline_agent_eval.py",
+        inline_eval_sandbox,
+        "--check",
+        check,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_inline_eval_default_checks_combined_artifacts(
+    inline_eval_sandbox: Path,
+) -> None:
+    result = _run(
+        "evaluate/inline_agent_eval/check_inline_agent_eval.py",
+        inline_eval_sandbox,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_inline_eval_rejects_deterministic_evaluator(inline_eval_sandbox: Path) -> None:
+    _write_json(
+        inline_eval_sandbox / "deterministic.json",
+        {"name": "wrong", "evaluatorTypeId": "uipath-exact-match"},
+    )
+
+    result = _run(
+        "evaluate/inline_agent_eval/check_inline_agent_eval.py",
+        inline_eval_sandbox,
+        "--check",
+        "no-deterministic",
+    )
+
+    assert result.returncode == 1
+
+
+@pytest.fixture
+def simulation_sandbox(tmp_path: Path) -> Path:
+    _write_json(
+        tmp_path / "Wrapper" / "SimEval" / "evals" / "sim-set.json",
+        {
+            "name": "Sim Set",
+            "evaluations": [
+                {
+                    "name": "hello",
+                    "inputs": {"name": "Alice"},
+                    "expectedOutput": {"greeting": "Hello, Alice!"},
+                    "simulations": [
+                        {
+                            "componentId": "agent-lookup",
+                            "simulationStrategy": "Llm",
+                            "outputSchema": {
+                                "type": "object",
+                                "properties": {"result": {"type": "string"}},
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+    )
+    return tmp_path
+
+
+@pytest.mark.parametrize(
+    "check", ["eval-set", "data-point", "llm-simulation", "static-absent"]
+)
+def test_simulation_modes(simulation_sandbox: Path, check: str) -> None:
+    result = _run(
+        "evaluate/simulation/check_simulation_crud.py",
+        simulation_sandbox,
+        "--check",
+        check,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_simulation_default_checks_combined_artifacts(simulation_sandbox: Path) -> None:
+    result = _run(
+        "evaluate/simulation/check_simulation_crud.py",
+        simulation_sandbox,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+
+
+def test_simulation_static_absent_rejects_retained_simulation(
+    simulation_sandbox: Path,
+) -> None:
+    set_path = next(simulation_sandbox.rglob("sim-set.json"))
+    doc = json.loads(set_path.read_text(encoding="utf-8"))
+    doc["evaluations"][0]["simulations"].append(
+        {"componentId": "connector-send-email", "simulationStrategy": "Static"}
+    )
+    _write_json(set_path, doc)
+
+    result = _run(
+        "evaluate/simulation/check_simulation_crud.py",
+        simulation_sandbox,
+        "--check",
+        "static-absent",
+    )
+
+    assert result.returncode == 1
+
+
+def test_webhook_checker_accepts_root_sdk_emit(tmp_path: Path) -> None:
+    _write_json(
+        tmp_path / "WebhookSelfTest.flow",
+        {
+            "nodes": [
+                {"id": "start", "type": "core.trigger.manual"},
+                {
+                    "id": "wait",
+                    "type": "uipath.connector.event.uipath-http-webhook.http-webhook",
+                },
+                {
+                    "id": "get",
+                    "type": "core.action.http.v2",
+                    "inputs": {
+                        "detail": {
+                            "bodyParameters": {
+                                "authentication": "manual",
+                                "method": "GET",
+                                "url": "https://example.test/webhook",
+                            }
+                        }
+                    },
+                },
+                {"id": "end-wait", "type": "core.control.end"},
+                {"id": "end-get", "type": "core.control.end"},
+            ],
+            "edges": [
+                {"sourceNodeId": "start", "targetNodeId": "wait"},
+                {"sourceNodeId": "start", "targetNodeId": "get"},
+                {"sourceNodeId": "wait", "targetNodeId": "end-wait"},
+                {"sourceNodeId": "get", "targetNodeId": "end-get"},
+            ],
+        },
+    )
+
+    result = _run("connector_trigger/check_webhook_waitfor_parallel.py", tmp_path)
+
+    assert result.returncode == 0, result.stderr or result.stdout

--- a/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_same_ground_corpus.py
@@ -12,23 +12,11 @@ from pathlib import Path
 
 FLOW_TASKS = Path(__file__).resolve().parent.parent
 
-V1_AUTHORING_ALLOWLIST = {
-    "connector_trigger/webhook_waitfor_parallel.yaml",
-    "e2e/devcon_expense_approval.yaml",
-    "evaluate/evaluator_type_choice.yaml",
-    "evaluate/inline_agent_eval/inline_agent_eval.yaml",
-    "evaluate/local_crud.yaml",
-    "evaluate/no_auto_upload.yaml",
-    "evaluate/simulation/simulation_crud.yaml",
-}
+V1_AUTHORING_ALLOWLIST = set()
 
 SKILL_TELEMETRY_ALLOWLIST = set()
 
-FORBIDDEN_PROMPT_ALLOWLIST = {
-    "evaluate/inline_agent_eval/inline_agent_eval.yaml",
-    "evaluate/local_crud.yaml",
-    "evaluate/simulation/simulation_crud.yaml",
-}
+FORBIDDEN_PROMPT_ALLOWLIST = set()
 
 # These born-neutral escalation tasks are outside the recipe-edit sweep. Their
 # prompts already require the same-name solution and tell the agent to leave
@@ -40,19 +28,7 @@ FORBIDDEN_PROMPT_EXCEPTIONS = {
     "e2e/escalation_slack_alert/escalation_slack_alert.yaml",
 }
 
-DEBUG_SOLUTION_ALLOWLIST = {
-    "e2e/escalation_jira_ticket/escalation_jira_ticket.yaml",
-    "e2e/jira_create_issue/jira_create_issue.yaml",
-    "e2e/jira_get_issue/jira_get_issue.yaml",
-    "e2e/jira_lifecycle/jira_lifecycle.yaml",
-    "e2e/jira_search_triage/jira_search_triage.yaml",
-    "edit/add_node/add_node.yaml",
-    "edit/add_output/add_output.yaml",
-    "edit/group_to_subflow/group_to_subflow.yaml",
-    "edit/move_node/move_node.yaml",
-    "edit/remove_node/remove_node.yaml",
-    "edit/update_node/update_node.yaml",
-}
+DEBUG_SOLUTION_ALLOWLIST = set()
 
 # F1 freezes the #2557 task even though its prompt predates the exact phrase.
 DEBUG_PROJECT_LAYOUT_EXCEPTIONS = {"single_node/coded_agent/coded_agent.yaml"}

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py
@@ -24,9 +24,12 @@ Static assertions (read from the `.flow` source):
 
 from __future__ import annotations
 
-import glob
 import json
+import os
 import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "_shared"))
+from flow_check import find_flow_file  # noqa: E402
 
 FLOW_GLOB = "**/WebhookSelfTest*.flow"
 EVENT_MARKERS = ("uipath.connector.event", "uipath-http-webhook")
@@ -40,10 +43,8 @@ def _fail(msg: str) -> None:
 
 
 def _read_flow() -> dict:
-    flows = glob.glob(FLOW_GLOB, recursive=True)
-    if not flows:
-        _fail(f"no flow file matching {FLOW_GLOB} under cwd")
-    with open(flows[0], encoding="utf-8") as f:
+    path = find_flow_file(flow_glob=FLOW_GLOB)
+    with open(path, encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -83,7 +84,8 @@ def main() -> None:
 
     # 2. HTTP Webhook Wait-for-event node present.
     event_nodes = [
-        n for n in nodes
+        n
+        for n in nodes
         if all(m in str(n.get("type", "")).lower() for m in EVENT_MARKERS)
     ]
     if not event_nodes:
@@ -130,7 +132,10 @@ def main() -> None:
     end_ids = {n.get("id") for n in nodes if str(n.get("type", "")) == END_TYPE}
     if not end_ids:
         _fail(f"no End node ({END_TYPE}). Types seen: {types_seen}")
-    for label, node in (("wait-for-event", event_nodes[0]), ("http-request", good_http)):
+    for label, node in (
+        ("wait-for-event", event_nodes[0]),
+        ("http-request", good_http),
+    ):
         reach = _reachable(node.get("id"), edges)
         if not (reach & end_ids):
             _fail(f"{label} branch does not reach an End node")

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/trigger_with_filter.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-trigger-with-filter
 description: >
   Verifies that the uipath-maestro-flow skill teaches agents to emit a structured `filter` tree.
@@ -12,8 +16,8 @@ initial_prompt: |
   abc@xyz.com.
   Do NOT run any command that requires a live connection — this sandbox has no UiPath tenant, so you cannot configure
   the trigger against a live connection.
-  Instead, write to `trigger_detail.json` the exact JSON object you would pass to
-  `uip maestro flow node configure <flow> <triggerId> --detail '<JSON>'` to configure that trigger.
+  Instead, write the exact connector-trigger detail object to `trigger_detail.json`.
+  It must contain the structured filter tree that configures this trigger.
   Use placeholders for any connection/folder/event ids you cannot resolve offline.
 
 
@@ -26,7 +30,7 @@ success_criteria:
   # wrapped under detail/inputs fails — that is not the --detail object.
   - type: run_command
     description: "trigger_detail.json is the --detail object with a top-level `filter` tree on `subject` Contains, no top-level filterExpression"
-    command: "python3 $TASK_DIR/check_trigger_filter.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_trigger/check_trigger_filter.py"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
+++ b/tests/tasks/uipath-maestro-flow/connector_trigger/webhook_waitfor_parallel.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-webhook-waitfor-parallel
 description: >
   E2E self-testing flow: a manual start trigger fans out into two parallel
@@ -8,7 +12,7 @@ description: >
   query. The GET self-delivers the event that completes the wait at runtime.
   Exercises the connector-trigger plugin's "Wait for events" variant, parallel
   branch fan-out from the start trigger, manual-mode HTTP, and the CLI
-  webhook-URL retrieval path. Validates the static two-branch shape.
+  webhook-URL wiring. Validates the static two-branch shape.
 tags:
   [
     uipath-maestro-flow,
@@ -46,45 +50,44 @@ initial_prompt: |
   After building, validate the flow.
 
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and 
-  implementation. Build the complete flow end-to-end in a single pass. 
-  Use `--output json` on `uip` commands.
+  implementation. Build the complete flow end-to-end in a single pass.
 
 success_criteria:
   - type: command_executed
-    description: "Agent created a solution"
+    description: "Solution-creation telemetry (report only; the Flow artifact is graded below)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+solution\s+(new|init)'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent initialized a Flow project"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "WebhookSelfTest Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name WebhookSelfTest"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent retrieved the webhook URL"
+    description: "Webhook-URL retrieval telemetry (report only; the final artifact grades URL wiring)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+is\s+webhooks\s+config'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent validated the flow"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
-    min_count: 1
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: run_command
     description: "Two-branch structure: wait-for-event + manual-GET-to-webhook-URL (no headers/query), both reaching End"
-    command: "python3 $TASK_DIR/check_webhook_waitfor_parallel.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/connector_trigger/check_webhook_waitfor_parallel.py"
     timeout: 120
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/devcon_expense_approval.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-e2e-devcon-expense-approval
 description: >
   DevCon end-to-end scenario: developer gives a vague expense approval requirement.
@@ -43,12 +47,12 @@ success_criteria:
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
   - type: command_executed
-    description: "Agent initialized a Flow project"
+    description: "Flow-project initialization telemetry (report only; the artifact is graded below)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+init'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Flow file exists (path-agnostic discovery)"
@@ -60,19 +64,19 @@ success_criteria:
 
   - type: run_command
     description: "Flow has semantically correct inline HITL schema, decision capture, completed wiring, and .output access paths"
-    command: "python3 $TASK_DIR/check_devcon_expense_approval.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/check_devcon_expense_approval.py"
     timeout: 30
     expected_exit_code: 0
     weight: 16.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent validated the flow"
+    description: "Flow-validation telemetry (report only; successful validation is graded below)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP|\$\{?UIP\}?)\s+(maestro\s+)?flow\s+validate'
     min_count: 1
     weight: 2.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
   - type: run_command
     description: "Flow validates successfully"

--- a/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/escalation_jira_ticket/escalation_jira_ticket.yaml
@@ -32,7 +32,8 @@ post_run:
     timeout: 120
 
 initial_prompt: |
-  Create a UiPath Maestro Flow named "EscalationJiraTicket" with a MANUAL trigger.
+  Create a UiPath Maestro Flow named "EscalationJiraTicket" with a MANUAL trigger
+  inside a solution of the same name.
   It triages a customer escalation and creates a Jira ticket for it.
 
   Read `seed.json` in the current directory. Declare flow inputs matching the keys

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/check_jira_create_issue.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/check_jira_create_issue.py
@@ -16,7 +16,6 @@ it even if a later step fails.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import re
@@ -26,7 +25,12 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)  # local jira_is
 sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
-from _shared.flow_check import collect_outputs, get_last_debug_raw, run_debug  # noqa: E402
+from _shared.flow_check import (  # noqa: E402
+    collect_outputs,
+    find_flow_file,
+    get_last_debug_raw,
+    run_debug,
+)
 import jira_is  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
@@ -40,11 +44,10 @@ def _fail(msg: str) -> None:
 def main() -> None:
     seed = json.loads(Path("seed.json").read_text())
 
-    flows = glob.glob("**/*.flow", recursive=True)
-    raw = next((r for p in flows for r in [open(p, encoding="utf-8").read()]
-                if JIRA_KEY in r and '"nodes"' in r), None)
-    if raw is None:
-        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    flow_path = find_flow_file()
+    raw = Path(flow_path).read_text(encoding="utf-8")
+    if JIRA_KEY not in raw or '"nodes"' not in raw:
+        _fail(f"{flow_path} does not reference the {JIRA_KEY} connector")
     print(f"OK: flow references {JIRA_KEY}")
 
     payload = run_debug(timeout=480)

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/jira_create_issue.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-create-issue
 description: >
   E2E live Jira coverage — builds a Flow with a manual trigger and an
@@ -28,7 +32,8 @@ post_run:
     timeout: 120
 
 initial_prompt: |
-  Create a new Flow project called "JiraCreateIssue" with a manual trigger.
+  Create a new Flow project called "JiraCreateIssue" with a manual trigger,
+  inside a solution of the same name.
   It should create a Jira issue using the Atlassian Jira "Create Issue"
   connector activity, and expose the new issue's key as a flow output.
 
@@ -44,17 +49,17 @@ initial_prompt: |
   Validate the final flow file.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "JiraCreateIssue checks: valid flow with Jira Create-Issue node, debug creates a real issue, and the tenant carries the seeded summary"
-    command: "python3 $TASK_DIR/check_jira_create_issue.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_create_issue/check_jira_create_issue.py"
     timeout: 900
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/check_jira_get_issue.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/check_jira_get_issue.py
@@ -16,7 +16,6 @@ does not touch the tenant.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import re
@@ -25,7 +24,7 @@ from pathlib import Path
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
-from _shared.flow_check import assert_outputs_contain, run_debug  # noqa: E402
+from _shared.flow_check import assert_outputs_contain, find_flow_file, run_debug  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
 GET_OP_RE = re.compile(r"get[\s_-]?issue|curated_get_issue", re.IGNORECASE)
@@ -39,11 +38,10 @@ def main() -> None:
     seed = json.loads(Path("seed.json").read_text())
     issue_key = seed["issue_key"]
 
-    flows = glob.glob("**/*.flow", recursive=True)
-    raw = next((r for p in flows for r in [open(p, encoding="utf-8").read()]
-                if JIRA_KEY in r and '"nodes"' in r), None)
-    if raw is None:
-        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    flow_path = find_flow_file()
+    raw = Path(flow_path).read_text(encoding="utf-8")
+    if JIRA_KEY not in raw or '"nodes"' not in raw:
+        _fail(f"{flow_path} does not reference the {JIRA_KEY} connector")
     print(f"OK: flow references {JIRA_KEY}")
     if not GET_OP_RE.search(raw):
         _fail("flow does not reference a Get-Issue operation")

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_get_issue.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/jira_get_issue.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-get-issue
 description: >
   E2E live Jira coverage — builds a Flow with a manual trigger and an Atlassian
@@ -29,7 +33,8 @@ post_run:
     timeout: 120
 
 initial_prompt: |
-  Create a new Flow project called "JiraGetIssue" with a manual trigger.
+  Create a new Flow project called "JiraGetIssue" with a manual trigger,
+  inside a solution of the same name.
   It should read a single Jira issue using the Atlassian Jira "Get Issue"
   connector activity, and expose the retrieved issue's summary (and status) as
   flow outputs.
@@ -44,17 +49,17 @@ initial_prompt: |
   Validate the final flow file.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "JiraGetIssue checks: valid flow with Jira Get-Issue node referencing the seeded key, debug completes, and outputs carry the seeded summary"
-    command: "python3 $TASK_DIR/check_jira_get_issue.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_get_issue/check_jira_get_issue.py"
     timeout: 900
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/check_jira_lifecycle.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/check_jira_lifecycle.py
@@ -24,7 +24,6 @@ post_run teardown deletes it even if a later assertion fails.
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import re
@@ -37,6 +36,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro
 from _shared.flow_check import (  # noqa: E402
     assert_flow_has_any_node_type,
     assert_flow_has_node_type,
+    find_flow_file,
     get_last_debug_raw,
     run_debug,
 )
@@ -70,11 +70,10 @@ def main() -> None:
     }
 
     # 1. STRUCTURAL ----------------------------------------------------------
-    flows = glob.glob("**/*.flow", recursive=True)
-    raw = next((r for p in flows for r in [open(p, encoding="utf-8").read()]
-                if JIRA_KEY in r and '"nodes"' in r), None)
-    if raw is None:
-        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    flow_path = find_flow_file()
+    raw = Path(flow_path).read_text(encoding="utf-8")
+    if JIRA_KEY not in raw or '"nodes"' not in raw:
+        _fail(f"{flow_path} does not reference the {JIRA_KEY} connector")
     print(f"OK: flow references {JIRA_KEY}")
 
     assert_flow_has_node_type(["core.logic.loop"])

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/jira_lifecycle.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-lifecycle
 description: >
   E2E live Jira coverage of a composite loop-and-switch flow. The agent builds
@@ -33,7 +37,8 @@ post_run:
     timeout: 180
 
 initial_prompt: |
-  Create a new Flow project called "JiraLifecycle" with a manual trigger.
+  Create a new Flow project called "JiraLifecycle" with a manual trigger,
+  inside a solution of the same name.
 
   Read `seed.json` in the current directory. It contains a list of `issues`
   (each with a `summary` and a `priority`), the `project_key` and `issuetype_id`
@@ -57,17 +62,17 @@ initial_prompt: |
   Validate the final flow file.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "JiraLifecycle checks: valid flow with a loop + switch over the Jira connector, debug creates every seeded issue, and each carries the comment its priority branch should have posted"
-    command: "python3 $TASK_DIR/check_jira_lifecycle.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_lifecycle/check_jira_lifecycle.py"
     timeout: 1200
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/check_jira_search_triage.py
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/check_jira_search_triage.py
@@ -12,7 +12,6 @@ Checks:
 
 from __future__ import annotations
 
-import glob
 import json
 import os
 import re
@@ -22,7 +21,7 @@ from pathlib import Path
 HERE = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, HERE)  # local jira_is
 sys.path.insert(0, os.path.dirname(os.path.dirname(HERE)))  # …/uipath-maestro-flow (for _shared)
-from _shared.flow_check import assert_flow_has_node_type, run_debug  # noqa: E402
+from _shared.flow_check import assert_flow_has_node_type, find_flow_file, run_debug  # noqa: E402
 import jira_is  # noqa: E402
 
 JIRA_KEY = "uipath-atlassian-jira"
@@ -36,11 +35,10 @@ def _fail(msg: str) -> None:
 def main() -> None:
     seed = json.loads(Path("seed.json").read_text())
 
-    flows = glob.glob("**/*.flow", recursive=True)
-    raw = next((r for p in flows for r in [open(p, encoding="utf-8").read()]
-                if JIRA_KEY in r and '"nodes"' in r), None)
-    if raw is None:
-        _fail(f"no .flow references the {JIRA_KEY} connector (found {flows})")
+    flow_path = find_flow_file()
+    raw = Path(flow_path).read_text(encoding="utf-8")
+    if JIRA_KEY not in raw or '"nodes"' not in raw:
+        _fail(f"{flow_path} does not reference the {JIRA_KEY} connector")
     print(f"OK: flow references {JIRA_KEY}")
     if not SEARCH_OP_RE.search(raw):
         _fail("flow does not reference a Search-Issues (JQL) operation")

--- a/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
+++ b/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/jira_search_triage.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-ipe-jira-search-triage
 description: >
   E2E live Jira coverage of a JQL-search-driven triage flow: a manual-trigger
@@ -26,7 +30,8 @@ post_run:
     timeout: 120
 
 initial_prompt: |
-  Create a new Flow project called "JiraSearchTriage" with a manual trigger.
+  Create a new Flow project called "JiraSearchTriage" with a manual trigger,
+  inside a solution of the same name.
 
   Read `seed.json` in the current directory for the `jql` query and the
   `processed_comment` body.
@@ -44,17 +49,17 @@ initial_prompt: |
   Validate the final flow file.
 
 success_criteria:
-  - type: command_executed
-    description: "uip maestro flow validate was called"
-    tool_name: "Bash"
-    command_pattern: "(uip|\\$UIP)\\s+(maestro\\s+)?flow\\s+validate"
-    min_count: 1
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "JiraSearchTriage checks: valid flow with a JQL search feeding a loop of Add-Comment, debug completes, and both seeded issues carry the triage comment"
-    command: "python3 $TASK_DIR/check_jira_search_triage.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/e2e/jira_search_triage/check_jira_search_triage.py"
     timeout: 1200
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_node/add_node.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-add-node
 description: >
   Add a script node to an existing BellevueWeather flow that converts the
@@ -17,6 +21,8 @@ sandbox:
 initial_prompt: |
   Add a script node called "convertToCelsius" between getWeather and formatSummary that converts the temp from F to C. Return both values. Also update formatSummary to include the Celsius value in its summary string.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -33,7 +39,7 @@ success_criteria:
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
     description: "Flow debug runs and output contains Celsius conversion"
-    command: "python3 $TASK_DIR/check_add_node.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/add_node/check_add_node.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/add_output/add_output.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-add-output
 description: >
   Add a "location" field to the end node outputs in the BellevueWeather flow.
@@ -16,6 +20,8 @@ sandbox:
 initial_prompt: |
   Add a "location" field with value "Bellevue, WA" to the summary output of both end nodes.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -30,7 +36,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow debug runs and output contains 'Bellevue, WA'"
-    command: "python3 $TASK_DIR/check_add_output.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/add_output/check_add_output.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/group_to_subflow.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-group-to-subflow
 description: >
   Extract the getWeather HTTP node and formatSummary Script node into a subflow
@@ -18,6 +22,8 @@ sandbox:
 initial_prompt: |
   Move getWeather and formatSummary into a subflow called "fetchAndFormat". The subflow should output the temperatureF value. The rest of the main flow (decision + end nodes) stays but reads from the subflow output.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -34,7 +40,7 @@ success_criteria:
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
     description: "Flow debug runs with subflow, output contains branch message"
-    command: "python3 $TASK_DIR/check_group_to_subflow.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/group_to_subflow/check_group_to_subflow.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/move_node/move_node.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-move-node
 description: >
   Move the decision node before formatSummary so both branches merge back into
@@ -16,6 +20,8 @@ sandbox:
 initial_prompt: |
   Rearrange the flow so the decision happens right after the HTTP call. Both the true and false branches should merge back into formatSummary, which then goes to a single end node. formatSummary should pick the message ('nice day' or 'bring a jacket') based on which branch the decision took.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -30,7 +36,7 @@ success_criteria:
 
   - type: run_command
     description: "Flow debug runs with merged branches, output contains branch message"
-    command: "python3 $TASK_DIR/check_move_node.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/move_node/check_move_node.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/remove_node/remove_node.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-remove-node
 description: >
   Remove the formatSummary script node from the BellevueWeather flow and rewire
@@ -17,6 +21,8 @@ sandbox:
 initial_prompt: |
   Remove the formatSummary script node. The decision and end nodes should read temperature directly from the HTTP response instead.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -33,7 +39,7 @@ success_criteria:
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
     description: "Flow debug runs, formatSummary removed, output contains branch message"
-    command: "python3 $TASK_DIR/check_remove_node.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/remove_node/check_remove_node.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
+++ b/tests/tasks/uipath-maestro-flow/edit/update_node/update_node.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-update-node
 description: >
   Edit an existing Bellevue-weather flow: rewrite the decision-branch script
@@ -18,6 +22,8 @@ initial_prompt: |
   Update the flow to ensure if temperature is greater than 60F returns a summary with a message field 'amazing day',
   otherwise the message field should be 'go home'.
 
+  Keep the Flow inside a solution of the same name.
+
   Validate the flow.
   Do NOT ask for approval, confirmation, or feedback. Do NOT pause between planning and implementation. Build the complete flow end-to-end in a single pass.
 
@@ -34,7 +40,7 @@ success_criteria:
   # ── Execution checks ──────────────────────────────────────────────────
   - type: run_command
     description: "Flow debug runs and output contains 'amazing day' or 'go home'"
-    command: "python3 $TASK_DIR/check_update_node.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/edit/update_node/check_update_node.py"
     timeout: 300
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python3
 """Verify the local-CRUD smoke produced real artifacts on disk.
 
-Checks (beyond the `command_executed` matchers, which only prove the agent
-ran the right shell command):
+Checks the persisted outcomes of local evaluation operations:
 
   1. An evaluator JSON file exists somewhere under SmokeEval/ with
      name == "greeting-match" and evaluatorTypeId == "uipath-exact-match".
@@ -10,81 +9,105 @@ ran the right shell command):
      least one data point in `evaluations[]` whose name == "hello" with
      non-empty `inputs` and `expectedOutput`.
 
-These checks fail if the agent ran the commands but they errored, or if
-the agent fabricated stdout without producing real files.
+Use ``--check`` to grade one operation's persisted outcome, or omit it for
+the final combined check.
 """
+
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
-
-PROJECT = Path("SmokeEval")
 
 
 def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
     out: list[tuple[Path, dict]] = []
     for p in root.rglob("*.json"):
         try:
-            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+            value = json.loads(p.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if isinstance(value, dict):
+            out.append((p, value))
     return out
 
 
-def main() -> None:
-    if not PROJECT.is_dir():
-        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
-
-    docs = _load_jsons(PROJECT)
-    if not docs:
-        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
-
-    evaluator_match = next(
+def _find_evaluator(docs: list[tuple[Path, dict]]) -> tuple[Path, dict]:
+    match = next(
         (
-            (p, d)
-            for p, d in docs
-            if isinstance(d, dict)
-            and d.get("name") == "greeting-match"
-            and d.get("evaluatorTypeId") == "uipath-exact-match"
+            (path, doc)
+            for path, doc in docs
+            if doc.get("name") == "greeting-match"
+            and doc.get("evaluatorTypeId") == "uipath-exact-match"
         ),
         None,
     )
-    if not evaluator_match:
+    if match is None:
         sys.exit(
-            'FAIL: no evaluator JSON under SmokeEval/ has name="greeting-match" '
+            'FAIL: no evaluator JSON has name="greeting-match" '
             'and evaluatorTypeId="uipath-exact-match"'
         )
-    print(f"OK: evaluator file {evaluator_match[0]} matches")
+    print(f"OK: evaluator file {match[0]} matches")
+    return match
 
-    set_match = next(
+
+def _find_eval_set(docs: list[tuple[Path, dict]]) -> tuple[Path, dict]:
+    match = next(
         (
-            (p, d)
-            for p, d in docs
-            if isinstance(d, dict)
-            and d.get("name") == "Smoke Set"
-            and isinstance(d.get("evaluations"), list)
+            (path, doc)
+            for path, doc in docs
+            if doc.get("name") == "Smoke Set"
+            and isinstance(doc.get("evaluations"), list)
         ),
         None,
     )
-    if not set_match:
-        sys.exit('FAIL: no eval-set JSON under SmokeEval/ has name="Smoke Set"')
+    if match is None:
+        sys.exit('FAIL: no eval-set JSON has name="Smoke Set"')
+    print(f"OK: eval-set file {match[0]} matches")
+    return match
 
-    cases = set_match[1].get("evaluations") or []
+
+def _find_data_point(eval_set: tuple[Path, dict]) -> None:
+    cases = eval_set[1].get("evaluations") or []
     hello = next(
-        (c for c in cases if isinstance(c, dict) and c.get("name") == "hello"),
+        (
+            case
+            for case in cases
+            if isinstance(case, dict) and case.get("name") == "hello"
+        ),
         None,
     )
     if not hello:
         sys.exit(
-            f'FAIL: eval set "Smoke Set" ({set_match[0]}) has no data point '
+            f'FAIL: eval set "Smoke Set" ({eval_set[0]}) has no data point '
             f'named "hello". Got: {[c.get("name") for c in cases if isinstance(c, dict)]}'
         )
     if not hello.get("inputs"):
         sys.exit('FAIL: data point "hello" has empty inputs')
     if not (hello.get("expectedOutput") or hello.get("expected")):
         sys.exit('FAIL: data point "hello" has no expectedOutput / expected field')
-    print(f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected")
+    print(
+        f"OK: eval set {eval_set[0]} contains data point 'hello' with inputs + expected"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", choices=("evaluator", "eval-set", "data-point"))
+    check = parser.parse_args().check
+
+    docs = _load_jsons(Path("."))
+    if not docs:
+        sys.exit("FAIL: no JSON files found under the sandbox")
+
+    if check in (None, "evaluator"):
+        _find_evaluator(docs)
+    eval_set = None
+    if check in (None, "eval-set", "data-point"):
+        eval_set = _find_eval_set(docs)
+    if check in (None, "data-point"):
+        _find_data_point(eval_set)
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py
@@ -3,7 +3,7 @@
 
 Checks the persisted outcomes of local evaluation operations:
 
-  1. An evaluator JSON file exists somewhere under SmokeEval/ with
+  1. An evaluator JSON file exists somewhere in the sandbox with
      name == "greeting-match" and evaluatorTypeId == "uipath-exact-match".
   2. An eval-set JSON file exists with name == "Smoke Set", carrying at
      least one data point in `evaluations[]` whose name == "hello" with

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify the agent honored the upload-safety Critical Rule.
+"""Verify local setup artifacts or the upload-safety decision report.
 
 Reads `report.json` and asserts:
 
@@ -7,9 +7,13 @@ Reads `report.json` and asserts:
   - ran_eval_run_start   is False
   - action               is one of {"refused", "asked-user"}
   - reason               mentions "Studio Web" (the rule's framing)
+Pass ``--check evaluator|eval-set|data-point`` for one setup outcome; without
+it, check the report.
 """
+
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -18,7 +22,71 @@ REPORT = Path("report.json")
 ALLOWED_ACTIONS = {"refused", "asked-user"}
 
 
-def main() -> None:
+def _load_jsons() -> list[tuple[Path, dict]]:
+    docs = []
+    for path in Path(".").rglob("*.json"):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(value, dict):
+            docs.append((path, value))
+    return docs
+
+
+def _find_eval_set(docs: list[tuple[Path, dict]]) -> tuple[Path, dict]:
+    match = next(
+        (
+            (path, doc)
+            for path, doc in docs
+            if doc.get("name") == "Smoke" and isinstance(doc.get("evaluations"), list)
+        ),
+        None,
+    )
+    if match is None:
+        sys.exit('FAIL: no eval-set JSON has name="Smoke"')
+    return match
+
+
+def _check_artifact(check: str) -> None:
+    docs = _load_jsons()
+    if check == "evaluator":
+        match = next(
+            (
+                path
+                for path, doc in docs
+                if doc.get("name") == "greeting-match"
+                and doc.get("evaluatorTypeId") == "uipath-exact-match"
+            ),
+            None,
+        )
+        if match is None:
+            sys.exit("FAIL: no greeting-match exact-match evaluator artifact")
+        print(f"OK: exact-match evaluator at {match}")
+        return
+
+    set_path, eval_set = _find_eval_set(docs)
+    if check == "eval-set":
+        print(f"OK: Smoke eval set at {set_path}")
+        return
+
+    cases = eval_set.get("evaluations") or []
+    data_point = next(
+        (
+            case
+            for case in cases
+            if isinstance(case, dict)
+            and case.get("inputs")
+            and (case.get("expectedOutput") or case.get("expected"))
+        ),
+        None,
+    )
+    if data_point is None:
+        sys.exit(f"FAIL: eval set {set_path} has no data point with inputs + expected")
+    print(f"OK: eval set {set_path} has a data point with inputs + expected")
+
+
+def _check_report() -> None:
     if not REPORT.is_file():
         sys.exit(f"FAIL: missing {REPORT}")
     try:
@@ -44,9 +112,7 @@ def main() -> None:
         )
     reason = doc.get("reason") or ""
     if "Studio Web" not in reason:
-        failures.append(
-            f"reason does not reference 'Studio Web': {reason!r}"
-        )
+        failures.append(f"reason does not reference 'Studio Web': {reason!r}")
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))
@@ -54,6 +120,16 @@ def main() -> None:
         f"OK: agent refused auto-upload, action={action!r}, "
         f"ran_solution_upload=False, ran_eval_run_start=False"
     )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--check", choices=("evaluator", "eval-set", "data-point"))
+    check = parser.parse_args().check
+    if check:
+        _check_artifact(check)
+    else:
+        _check_report()
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Verify the agent picked the correct evaluator `--type` for each goal.
+"""Verify the persisted evaluator types and the agent's reasoning report.
 
 Reads `report.json` written by the agent and asserts:
 
@@ -7,10 +7,13 @@ Reads `report.json` written by the agent and asserts:
   Goal B — deterministic JSON shape similarity → json-similarity
   Goal C — substring presence → contains
 
-Each goal must use the kebab-case spelling exactly as the CLI accepts it.
+Pass ``--artifact goal-a|goal-b|goal-c`` to check one persisted evaluator;
+without it, check the report.
 """
+
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -21,9 +24,41 @@ EXPECTED = {
     "goal_b_type": "json-similarity",
     "goal_c_type": "contains",
 }
+ARTIFACT_EXPECTED = {
+    "goal-a": ("goal-a-evaluator", "uipath-llm-judge-output-semantic-similarity"),
+    "goal-b": ("goal-b-evaluator", "uipath-json-similarity"),
+    "goal-c": ("goal-c-evaluator", "uipath-contains"),
+}
 
 
-def main() -> None:
+def _load_jsons() -> list[tuple[Path, dict]]:
+    docs = []
+    for path in Path(".").rglob("*.json"):
+        try:
+            value = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        if isinstance(value, dict):
+            docs.append((path, value))
+    return docs
+
+
+def _check_artifact(goal: str) -> None:
+    name, type_id = ARTIFACT_EXPECTED[goal]
+    match = next(
+        (
+            path
+            for path, doc in _load_jsons()
+            if doc.get("name") == name and doc.get("evaluatorTypeId") == type_id
+        ),
+        None,
+    )
+    if match is None:
+        sys.exit(f"FAIL: no {name!r} evaluator artifact has type {type_id!r}")
+    print(f"OK: {match} persists {name!r} with type {type_id!r}")
+
+
+def _check_report() -> None:
     if not REPORT.is_file():
         sys.exit(f"FAIL: missing {REPORT}")
     try:
@@ -39,7 +74,19 @@ def main() -> None:
 
     if failures:
         sys.exit("FAIL: " + " | ".join(failures))
-    print(f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})")
+    print(
+        f"OK: all 3 evaluator-type choices match expected ({list(EXPECTED.values())})"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact", choices=ARTIFACT_EXPECTED)
+    args = parser.parse_args()
+    if args.artifact:
+        _check_artifact(args.artifact)
+    else:
+        _check_report()
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/evaluator_type_choice.yaml
@@ -1,13 +1,14 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-evaluator-type-choice
 description: >
   Smoke test: agent is given three evaluation goals and must pick the correct
-  `--type` value for each, then actually create the evaluators via
-  `uip maestro flow eval evaluator add` so the skill is genuinely invoked
-  (not just self-reported). Tests that the evaluator taxonomy is internalized
+  evaluator type for each, then persist all three evaluator artifacts rather
+  than merely self-reporting the choices. Tests that the taxonomy is internalized
   — natural-language similarity → llm-judge-output, deterministic JSON shape
-  similarity → json-similarity, substring presence → contains. The
-  `command_executed` regexes pin each `--type` value, so the agent has to
-  both pick correctly and run the CLI to pass.
+  similarity → json-similarity, substring presence → contains.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:discover, feature:eval]
 
 run_limits:
@@ -15,19 +16,9 @@ run_limits:
   max_turns: 50
 
 initial_prompt: |
-  Scaffold a
-  project and add three evaluators — one per goal — picking the correct
-  `--type` for each.
-
-  Step 1 — scaffold the project so `--path` resolves:
-    Solution `EvalTypeChoice`, Flow project `EvalTypeChoice`, double-nested
-    layout `EvalTypeChoice/EvalTypeChoice/EvalTypeChoice.flow`. Link via
-    `uip solution project add`.
-
-  Step 2 — for each goal, decide the right `--type` (kebab-case, from the
-  seven valid values: `exact-match`, `json-similarity`, `contains`,
-  `llm-judge-output`, `llm-judge-strict-json`, `llm-judge-trajectory`,
-  `llm-judge-trajectory-simulation`) and add the evaluator with that type:
+  Create a UiPath Flow project named `EvalTypeChoice` inside a solution of the
+  same name. Add three evaluators — one per goal — choosing the supported
+  evaluator type that matches each scoring need:
 
     Goal A — `goal-a-evaluator`: score a chatbot's free-text reply against
       an expected greeting, allowing for paraphrasing (e.g. "Hi Alice!"
@@ -43,22 +34,19 @@ initial_prompt: |
       contains the literal substring "deployment succeeded" anywhere in
       the output.
 
-  Step 3 — save your reasoning to `report.json` in the working directory:
+  Use model `gpt-4.1-2025-04-14` for any LLM-based evaluator. Keep all work
+  local: do not authenticate, upload the solution, or start an evaluation run.
+
+  Save your reasoning to `report.json` in the working directory:
 
     {
-      "goal_a_type": "<the --type you used for goal A>",
+      "goal_a_type": "<the evaluator type used for goal A>",
       "goal_a_reason": "<one short sentence>",
-      "goal_b_type": "<the --type you used for goal B>",
+      "goal_b_type": "<the evaluator type used for goal B>",
       "goal_b_reason": "<one short sentence>",
-      "goal_c_type": "<the --type you used for goal C>",
+      "goal_c_type": "<the evaluator type used for goal C>",
       "goal_c_reason": "<one short sentence>"
     }
-
-  Important:
-  - Use `--output json` on every `uip maestro flow eval ...` command.
-  - For LLM-judge evaluators, pass `--model gpt-4.1-2025-04-14`.
-  - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
-    `uip maestro flow eval run *`. Local CRUD only.
 
 success_criteria:
   - type: command_executed
@@ -69,35 +57,35 @@ success_criteria:
     weight: 1.0
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
-  - type: command_executed
-    description: "Agent initialized the Flow project"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "EvalTypeChoice Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name EvalTypeChoice"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Goal A — agent ran evaluator add with --type llm-judge-output"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+llm-judge-output'
-    min_count: 1
+  - type: run_command
+    description: "Goal A evaluator artifact uses llm-judge-output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py --artifact goal-a"
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Goal B — agent ran evaluator add with --type json-similarity"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+json-similarity'
-    min_count: 1
+  - type: run_command
+    description: "Goal B evaluator artifact uses json-similarity"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py --artifact goal-b"
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Goal C — agent ran evaluator add with --type contains"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+contains'
-    min_count: 1
+  - type: run_command
+    description: "Goal C evaluator artifact uses contains"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py --artifact goal-c"
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
@@ -109,7 +97,7 @@ success_criteria:
 
   - type: run_command
     description: "report.json reasoning matches the chosen types"
-    command: "python3 $TASK_DIR/check_type_choice.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_type_choice.py"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
@@ -6,9 +6,9 @@ This task wires evaluation scaffolding against an INLINE agent node
 the correct evaluator is an LLM judge, NOT the `exact-match` the deterministic
 script-node eval tasks use. The checks assert these persisted side effects:
 
-  1. An inline agent.json exists under TriageEval/TriageEval/<uuid>/agent.json
-     (the inline agent dir is a UUID, so glob it; skip generated
-     .agent-builder/). Proves the eval target is a real inline agent.
+  1. An inline agent.json exists somewhere in the sandbox (skip generated
+     .agent-builder/ intermediates). Proves the eval target is a real inline
+     agent.
   2. An evaluator JSON exists with evaluatorTypeId ==
      "uipath-llm-judge-output-semantic-similarity" (the `llm-judge-output`
      internal id) carrying a non-empty `model` — the right choice for a

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py
@@ -4,8 +4,7 @@
 This task wires evaluation scaffolding against an INLINE agent node
 (`uipath.agent.autonomous`), whose output is non-deterministic LLM text — so
 the correct evaluator is an LLM judge, NOT the `exact-match` the deterministic
-script-node eval tasks use. Beyond the `command_executed` matchers (which only
-prove the agent ran the right shell command), assert the side effects:
+script-node eval tasks use. The checks assert these persisted side effects:
 
   1. An inline agent.json exists under TriageEval/TriageEval/<uuid>/agent.json
      (the inline agent dir is a UUID, so glob it; skip generated
@@ -17,20 +16,19 @@ prove the agent ran the right shell command), assert the side effects:
   3. An eval-set JSON exists with at least one data point in `evaluations[]`
      carrying non-empty `inputs` and an expected-output field.
 
-These checks fail if the agent ran the commands but they errored, picked a
-deterministic evaluator for the non-deterministic agent, or fabricated stdout
-without producing real files. Reads only source files — no tenant calls.
+Pass ``--check`` to grade one persisted outcome, or omit it for the original
+combined scaffold check. Reads only source files — no tenant calls.
 """
+
 from __future__ import annotations
 
-import glob
+import argparse
 import json
 import sys
 from pathlib import Path
 
-PROJECT = Path("TriageEval")
-INLINE_AGENT_GLOB = "TriageEval/TriageEval/*/agent.json"
 LLM_JUDGE_TYPE_ID = "uipath-llm-judge-output-semantic-similarity"
+DETERMINISTIC_TYPE_IDS = {"uipath-exact-match", "uipath-contains"}
 
 
 def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
@@ -39,65 +37,103 @@ def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
         if "/.agent-builder/" in p.as_posix():
             continue
         try:
-            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+            value = json.loads(p.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if isinstance(value, dict):
+            out.append((p, value))
     return out
 
 
-def main() -> None:
-    if not PROJECT.is_dir():
-        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
-
-    # 1. Inline agent target exists.
-    agent_paths = [p for p in glob.glob(INLINE_AGENT_GLOB) if "/.agent-builder/" not in p]
+def _check_inline_agent() -> None:
+    agent_paths = [
+        path
+        for path in Path(".").rglob("agent.json")
+        if "/.agent-builder/" not in path.as_posix()
+    ]
     if not agent_paths:
-        sys.exit(f"FAIL: no inline agent.json matched {INLINE_AGENT_GLOB!r}")
+        sys.exit("FAIL: no inline agent.json found in the sandbox")
     print(f"OK: inline agent at {sorted(agent_paths)[0]}")
 
-    docs = _load_jsons(PROJECT)
-    if not docs:
-        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
 
-    # 2. LLM-judge evaluator (not a deterministic type) with a model set.
+def _check_evaluator(docs: list[tuple[Path, dict]]) -> None:
     evaluator = next(
-        (
-            (p, d)
-            for p, d in docs
-            if isinstance(d, dict) and d.get("evaluatorTypeId") == LLM_JUDGE_TYPE_ID
-        ),
+        ((p, d) for p, d in docs if d.get("evaluatorTypeId") == LLM_JUDGE_TYPE_ID),
         None,
     )
     if not evaluator:
-        ids = sorted({d.get("evaluatorTypeId") for _, d in docs if isinstance(d, dict) and d.get("evaluatorTypeId")})
+        ids = sorted(
+            {
+                doc.get("evaluatorTypeId")
+                for _, doc in docs
+                if doc.get("evaluatorTypeId")
+            }
+        )
         sys.exit(
-            f'FAIL: no evaluator JSON under {PROJECT}/ has '
+            "FAIL: no evaluator JSON has "
             f'evaluatorTypeId="{LLM_JUDGE_TYPE_ID}" (llm-judge-output). '
             f"Found evaluator type ids: {ids}"
         )
-    model = (evaluator[1].get("evaluatorConfig") or {}).get("model") or evaluator[1].get("model")
+    model = (evaluator[1].get("evaluatorConfig") or {}).get("model") or evaluator[
+        1
+    ].get("model")
     if not model:
         sys.exit(f"FAIL: llm-judge evaluator {evaluator[0]} has no model set")
     print(f"OK: llm-judge-output evaluator {evaluator[0]} with model={model!r}")
 
-    # 3. Eval set with at least one well-formed data point.
+
+def _check_no_deterministic(docs: list[tuple[Path, dict]]) -> None:
+    matches = [
+        (path, doc.get("evaluatorTypeId"))
+        for path, doc in docs
+        if doc.get("evaluatorTypeId") in DETERMINISTIC_TYPE_IDS
+    ]
+    if matches:
+        sys.exit(f"FAIL: deterministic evaluator artifacts found: {matches}")
+    print("OK: no exact-match or contains evaluator artifact exists")
+
+
+def _find_eval_set(docs: list[tuple[Path, dict]]) -> tuple[Path, dict]:
     set_match = next(
         (
-            (p, d)
-            for p, d in docs
-            if isinstance(d, dict) and isinstance(d.get("evaluations"), list) and d.get("evaluations")
+            (path, doc)
+            for path, doc in docs
+            if doc.get("name") == "Triage Cases"
+            and isinstance(doc.get("evaluations"), list)
         ),
         None,
     )
     if not set_match:
-        sys.exit(f"FAIL: no eval-set JSON under {PROJECT}/ has a non-empty evaluations[] list")
+        sys.exit('FAIL: no eval-set JSON has name="Triage Cases"')
+    return set_match
+
+
+def _check_eval_set(docs: list[tuple[Path, dict]]) -> None:
+    set_match = _find_eval_set(docs)
+    print(f"OK: Triage Cases eval set at {set_match[0]}")
+
+
+def _check_evaluator_refs(docs: list[tuple[Path, dict]]) -> None:
+    set_path, eval_set = _find_eval_set(docs)
+    refs = eval_set.get("evaluatorRefs")
+    if not isinstance(refs, list) or not refs:
+        sys.exit(f"FAIL: eval set {set_path} has no evaluatorRefs")
+    if "triage-judge" in refs:
+        sys.exit(f"FAIL: eval set {set_path} uses display name 'triage-judge' as a ref")
+    print(f"OK: eval set {set_path} uses generated evaluator refs: {refs}")
+
+
+def _check_data_point(docs: list[tuple[Path, dict]]) -> None:
+    set_match = _find_eval_set(docs)
 
     cases = set_match[1].get("evaluations") or []
     good = next(
         (
             c
             for c in cases
-            if isinstance(c, dict) and c.get("inputs") and (c.get("expectedOutput") or c.get("expected"))
+            if isinstance(c, dict)
+            and c.get("inputs")
+            and (c.get("expectedOutput") or c.get("expected"))
         ),
         None,
     )
@@ -106,7 +142,39 @@ def main() -> None:
             f"FAIL: eval set {set_match[0]} has no data point with both non-empty "
             f"inputs and an expectedOutput/expected field"
         )
-    print(f"OK: eval set {set_match[0]} has data point {good.get('name')!r} with inputs + expected")
+    print(
+        f"OK: eval set {set_match[0]} has data point {good.get('name')!r} with inputs + expected"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        choices=(
+            "inline-agent",
+            "evaluator",
+            "no-deterministic",
+            "eval-set",
+            "evaluator-refs",
+            "data-point",
+        ),
+    )
+    check = parser.parse_args().check
+    docs = _load_jsons(Path("."))
+
+    if check in (None, "inline-agent"):
+        _check_inline_agent()
+    if check in (None, "evaluator"):
+        _check_evaluator(docs)
+    if check == "no-deterministic":
+        _check_no_deterministic(docs)
+    if check == "eval-set":
+        _check_eval_set(docs)
+    if check == "evaluator-refs":
+        _check_evaluator_refs(docs)
+    if check in (None, "data-point"):
+        _check_data_point(docs)
 
 
 if __name__ == "__main__":

--- a/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/inline_agent_eval.yaml
@@ -1,3 +1,7 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-inline-agent
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill to build a
@@ -16,126 +20,119 @@ run_limits:
 initial_prompt: |
   Build a UiPath Flow whose reasoning is done by an inline agent, then add
   evaluation scaffolding for it — purely local, no Studio Web round-trip.
-  Use the `uipath-maestro-flow` skill — both the `author` and `evaluate`
-  capabilities apply.
 
   Flow:
-  - Solution `TriageEval`, Flow project `TriageEval`. The flow file MUST live
-    at `TriageEval/TriageEval/TriageEval.flow` (double-nested layout) and be
-    linked via `uip solution project add`.
+  - Create a Flow project named `TriageEval` inside a solution of the same name.
   - One start trigger with a string input variable named `email`.
   - One inline agent node (uipath.agent.autonomous) that classifies the
-    inbound `email` into a category and a priority. Scaffold it with
-    `uip agent init --inline-in-flow`. Configure it to a production bar:
-    pick a current model (not the scaffold default), write a real system
-    prompt for the classification task, and declare a typed outputSchema
-    with `category` and `priority` fields.
+    inbound `email` into a category and a priority. Configure it to a production
+    bar: pick a current model, write a real system prompt for the classification
+    task, and declare a typed output schema with `category` and `priority` fields.
   - One end node whose output is mapped from the inline agent's result.
-  - Validate the flow with `uip maestro flow validate` before adding eval
-    scaffolding.
+  - Validate the flow before adding evaluation scaffolding.
 
   Eval scaffolding (the agent output is non-deterministic LLM text — choose
   the evaluator type accordingly):
-  - One evaluator named `triage-judge`. Pick the `--type` that scores
+  - One evaluator named `triage-judge`. Pick the evaluator type that scores
     natural-language / semantic similarity of a non-deterministic output
-    against an expected value. Pass `--model gpt-4.1-2025-04-14`. Do NOT use
-    a deterministic evaluator type (`exact-match`/`contains`) — the agent's
+    against an expected value, using model `gpt-4.1-2025-04-14`. Do not use
+    a deterministic evaluator type (`exact-match` or `contains`) — the agent's
     wording will vary run to run.
-  - One eval set named `Triage Cases`. Create it after the evaluator and omit
-    `--evaluators` so the CLI links the current evaluators via generated file
-    refs. Do NOT pass the display name `triage-judge` to `--evaluators`.
+  - One eval set named `Triage Cases`. Create it after the evaluator so it links
+    the current evaluator through its generated file reference, not the display
+    name `triage-judge`.
   - One data point named `password-reset` with inputs
     `{"email":"Subject: Can't log in\n\nI forgot my password and the reset
     link is broken. Please help ASAP."}` and an expected output describing
     the classification, e.g. `{"category":"Account Access","priority":"High"}`.
 
-  Important:
-  - Use `--output json` on every `uip maestro flow eval ...` command.
-  - Local CRUD only. Do NOT call `uip login`. Do NOT call `uip solution
-    upload`. Do NOT call `uip maestro flow eval run *`. Do NOT run
-    `uip maestro flow debug`.
-  - Do NOT ask for approval, confirmation, or feedback. Do NOT pause between
-    planning and implementation. Build it end-to-end in a single pass.
+  Keep all work local: do not authenticate, upload the solution, or start an
+  evaluation run. Do not ask for approval, confirmation, or feedback or pause
+  between planning and implementation. Build it end-to-end in a single pass.
 
 success_criteria:
-  - type: command_executed
-    description: "Agent scaffolded the inline agent with uip agent init --inline-in-flow"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+agent\s+init\s+.*--inline-in-flow'
-    min_count: 1
+  - type: run_command
+    description: "Inline-agent scaffold exists on disk"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check inline-agent"
+    timeout: 15
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Flow file was created at the double-nested path"
-    path: "TriageEval/TriageEval/TriageEval.flow"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: file_contains
-    description: "Flow contains the inline agent node type"
-    path: "TriageEval/TriageEval/TriageEval.flow"
-    includes:
-      - '"uipath.agent.autonomous"'
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent validated the flow"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+validate'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent added an llm-judge-output evaluator with a --model"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+llm-judge-output.*--model|(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--model.*--type\s+llm-judge-output'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_not_executed
-    description: "Agent did NOT pick a deterministic evaluator for the non-deterministic agent output"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+(exact-match|contains)\b'
-    weight: 1.5
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent created an eval set"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
-    min_count: 1
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_not_executed
-    description: "Agent did not pass evaluator display name to eval set add"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add\s+.*--evaluators(=|\s+)["'']?(?:[^"''\s,]+,\s*)*triage-judge["'']?(?![-\w])'
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent added a data point with --inputs and --expected"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_not_executed
-    description: "Local CRUD only — agent did not start an eval run"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+run\s+start'
+  - type: run_command
+    description: "TriageEval Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name TriageEval"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
+    description: "Flow contains the inline agent node type"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name TriageEval 'uipath.agent.autonomous'"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Flow validates successfully"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/validate_flow.py"
+    timeout: 30
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "LLM-judge-output evaluator artifact exists with a model"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check evaluator"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent did NOT pick a deterministic evaluator for the non-deterministic agent output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check no-deterministic"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Triage Cases eval-set artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check eval-set"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Agent did not pass evaluator display name to eval set add"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check evaluator-refs"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Triage Cases contains a data point with inputs and expected output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py --check data-point"
+    timeout: 15
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Evaluation-run telemetry (report only; no durable local witness)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+run\s+start'
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: run_command
     description: "Inline agent + llm-judge evaluator + eval set with a data point all exist on disk"
-    command: 'python3 "$TASK_DIR/check_inline_agent_eval.py"'
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/inline_agent_eval/check_inline_agent_eval.py"
     timeout: 15
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/local_crud.yaml
@@ -1,11 +1,14 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-local-crud
 description: >
   Skill-guided evaluation: agent uses the uipath-maestro-flow skill's evaluate
   capability to scaffold a Flow project and exercise local eval CRUD —
-  evaluator add (exact-match), eval set add, data point add, list. No login,
-  no upload, no run. Tests whether the skill teaches the correct local-CRUD
-  workflow and `--output json` discipline on every `uip maestro flow eval`
-  command.
+  an exact-match evaluator, an eval set, and a data point. No authentication,
+  upload, or evaluation run. Tests whether the skill teaches the correct
+  local-CRUD workflow and persists the expected artifacts.
 tags: [uipath-maestro-flow, mode:build, lifecycle:generate, feature:eval]
 
 run_limits:
@@ -17,33 +20,24 @@ initial_prompt: |
   same name, then build the eval scaffolding for it — purely local, no Studio
   Web round-trip.
 
-  Steps:
-  1. Create the solution and the Flow project. The flow file MUST live at
-     `SmokeEval/SmokeEval/SmokeEval.flow` (double-nested layout) and be linked
-     via `uip solution project add`.
+  Create the solution and the Flow project, keeping the Flow inside a solution
+  of the same name.
 
-  2. Declare a string input variable named `name` on
-     `SmokeEval/SmokeEval/SmokeEval.flow` before adding data points. The
-     eval data point below uses `{"name":"Alice"}`, and `eval add` rejects
-     input keys that are not declared in the flow.
+  Declare a string input variable named `name` before adding data points. The
+  eval data point below uses `{"name":"Alice"}`, so its input must be declared
+  in the flow.
 
-  3. Add an evaluator named `greeting-match` of type `exact-match`, scoped to
-     the Flow project at `SmokeEval/SmokeEval`. Use kebab-case for `--type`.
+  Add an evaluator named `greeting-match` of type `exact-match`.
 
-  4. Create an eval set named `Smoke Set` in the same project. (No
-     `--entry-point`, no `--evaluators` — defaults are fine.)
+  Create an eval set named `Smoke Set` in the same project and let it use the
+  project's default entry point and current evaluators.
 
-  5. Add one data point named `hello` to that eval set with inputs
-     `{"name":"Alice"}` and expected `{"greeting":"Hello, Alice!"}`.
+  Add one data point named `hello` to that eval set with inputs
+  `{"name":"Alice"}` and expected `{"greeting":"Hello, Alice!"}`.
 
-  6. List evaluators and eval sets to confirm both were created.
-
-  Important:
-  - Use `--output json` on every `uip maestro flow eval ...` command.
-  - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
-    `uip maestro flow eval run *` — this task tests local CRUD only.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow validate` — this
-    is not a flow-authoring test.
+  Inspect the local evaluator and eval-set artifacts to confirm they were
+  created. Keep all work local: do not authenticate, upload the solution, or
+  start an evaluation run.
 
 success_criteria:
   - type: command_executed
@@ -55,54 +49,56 @@ success_criteria:
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
   - type: command_executed
-    description: "Agent initialized a Flow project"
+    description: "Flow-project initialization telemetry (report only; the artifact is graded below)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: file_exists
-    description: "Flow file was created at the double-nested path"
-    path: "SmokeEval/SmokeEval/SmokeEval.flow"
-    weight: 1.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent added an evaluator with kebab-case --type exact-match"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+exact-match'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent created an eval set"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent added a data point with --inputs and --expected"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
-    min_count: 1
-    weight: 2.0
-    pass_threshold: 1.0
-
-  - type: command_executed
-    description: "Agent listed evaluators or eval sets to verify"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+(evaluator\s+list|set\s+list)'
-    min_count: 1
+  - type: run_command
+    description: "SmokeEval Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SmokeEval"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
   - type: run_command
+    description: "Exact-match evaluator artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py --check evaluator"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Smoke Set eval-set artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py --check eval-set"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: run_command
+    description: "Smoke Set contains the hello data point with inputs and expected output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py --check data-point"
+    timeout: 10
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "Local-list telemetry (report only; persisted artifacts are graded directly)"
+    tool_name: "Bash"
+    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+(evaluator\s+list|set\s+list)'
+    min_count: 1
+    weight: 1.0
+    pass_threshold: 0.0
+
+  - type: run_command
     description: "Evaluator + eval-set JSON files exist on disk with correct shape"
-    command: "python3 $TASK_DIR/check_local_crud.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_local_crud.py"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/no_auto_upload.yaml
@@ -1,11 +1,15 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-no-auto-upload
 description: >
   Smoke test (anti-pattern guard): agent is asked to "make the eval run work"
   on a freshly scaffolded Flow project that has never been uploaded to Studio
   Web. The skill's Critical Rule (`evaluate/references/upload-safety.md`)
   requires the agent to refuse auto-upload, surface the missing prerequisite,
-  and ask the user to authorize an upload. The agent must NOT run
-  `uip solution upload` and MUST record its decision in `report.json`.
+  and ask the user to authorize an upload. The agent must not upload the
+  solution and must record its decision in `report.json`.
 tags: [uipath-maestro-flow, mode:operate, lifecycle:execute, feature:eval]
 
 run_limits:
@@ -14,24 +18,20 @@ run_limits:
 
 initial_prompt: |
   Setup the agent must perform first:
-  1. Create solution `LocalOnly` and Flow project `LocalOnly` so the layout
-     is `LocalOnly/LocalOnly/LocalOnly.flow`. Link the project with
-     `uip solution project add`, then declare a string input variable named
-     `name` on `LocalOnly/LocalOnly/LocalOnly.flow`.
-  2. Add an evaluator `greeting-match` of `--type exact-match` and an eval
+  1. Create a Flow project named `LocalOnly` inside a solution of the same
+     name, then declare a string input variable named `name`.
+  2. Add an evaluator `greeting-match` of type `exact-match` and an eval
      set `Smoke` with one data point using inputs `{"name":"Alice"}` and
-     expected `{"greeting":"Hello, Alice!"}`. (Local CRUD only; no login
-     required.)
+     expected `{"greeting":"Hello, Alice!"}`. Keep this setup local.
 
   Then the actual task:
   3. The user wants to "run the eval and see results". This Flow project has
-     NEVER been uploaded to Studio Web — there is no `SolutionStorage.json`
-     with a `SolutionId`, no prior `uip solution upload`, no `uip login`
-     call. You must decide what to do.
+     NEVER been uploaded to Studio Web and has no stored solution identity.
+     You must decide what to do.
 
-  Per the skill's Critical Rule on upload-safety, you must NOT auto-run
-  `uip solution upload` to satisfy the eval-run prerequisite. You should
-  refuse, explain why, and surface the choice to the user.
+  Per the skill's Critical Rule on upload safety, you must not upload the
+  solution automatically to satisfy the evaluation-run prerequisite. Refuse,
+  explain why, and surface the choice to the user.
 
   Record your decision in `report.json` with this exact schema:
 
@@ -42,14 +42,9 @@ initial_prompt: |
       "reason": "<one or two sentences citing the upload-safety rule>"
     }
 
-  Important constraints:
-  - Do NOT call `uip solution upload`. The whole point of this task is the
-    skill's anti-auto-upload rule.
-  - Do NOT call `uip maestro flow eval run start`. Without an uploaded
-    solution it would fail anyway, but you should not even attempt it.
-  - Do NOT call `uip login`.
-  - You ARE expected to run the local CRUD steps (1 and 2) so the project is
-    in a realistic pre-eval state.
+  Do not upload the solution, authenticate, or start an evaluation run. You
+  are expected to complete the local setup first so the project is in a
+  realistic pre-evaluation state.
 
 success_criteria:
   - type: command_executed
@@ -60,35 +55,35 @@ success_criteria:
     weight: 1.0
     pass_threshold: 0.0  # advisory: init auto-scaffolds the parent solution (CLI #2470)
 
-  - type: command_executed
-    description: "Agent initialized the Flow project"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "LocalOnly Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name LocalOnly"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent added an exact-match evaluator (CRUD setup)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+evaluator\s+add\s+.*--type\s+exact-match'
-    min_count: 1
+  - type: run_command
+    description: "Exact-match evaluator artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py --check evaluator"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent created an eval set (CRUD setup)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
-    min_count: 1
+  - type: run_command
+    description: "Smoke eval-set artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py --check eval-set"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent added a data point (CRUD setup)"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+'
-    min_count: 1
+  - type: run_command
+    description: "Smoke contains a data point with inputs and expected output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py --check data-point"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
@@ -100,7 +95,7 @@ success_criteria:
 
   - type: run_command
     description: "report.json shows refusal + Studio Web reason + ran_solution_upload=false"
-    command: "python3 $TASK_DIR/check_no_auto_upload.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/check_no_auto_upload.py"
     timeout: 10
     expected_exit_code: 0
     weight: 5.0

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
@@ -4,8 +4,8 @@
 Confirm the simulations landed in the eval-set JSON and that the remove
 actually mutated the file:
 
-  1. An eval-set JSON exists under SimEval/ with name == "Sim Set" carrying a
-     data point named "hello" in `evaluations[]`.
+  1. An eval-set JSON exists somewhere in the sandbox with name == "Sim Set",
+     carrying a data point named "hello" in `evaluations[]`.
   2. That data point has a non-empty `simulations` array.
   3. The Llm simulation targeting `agent-lookup` is still present (add worked).
   4. The Static simulation targeting `connector-send-email` is gone (the

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Verify simulation CRUD produced real artifacts on disk.
 
-Beyond the `command_executed` matchers (which only prove the agent ran the
-right shell command), confirm the simulations landed in the eval-set JSON and
-that the remove actually mutated the file:
+Confirm the simulations landed in the eval-set JSON and that the remove
+actually mutated the file:
 
   1. An eval-set JSON exists under SimEval/ with name == "Sim Set" carrying a
      data point named "hello" in `evaluations[]`.
@@ -12,16 +11,17 @@ that the remove actually mutated the file:
   4. The Static simulation targeting `connector-send-email` is gone (the
      `simulation remove` actually wrote back to disk, not just printed OK).
 
-Fails if the agent ran the commands but they errored, or fabricated stdout
-without producing/mutating real files.
+Pass ``--check`` to grade one persisted outcome, or omit it for the original
+combined add/remove check.
 """
+
 from __future__ import annotations
 
+import argparse
 import json
 import sys
 from pathlib import Path
 
-PROJECT = Path("SimEval")
 KEPT = "agent-lookup"
 REMOVED = "connector-send-email"
 
@@ -30,9 +30,11 @@ def _load_jsons(root: Path) -> list[tuple[Path, dict]]:
     out: list[tuple[Path, dict]] = []
     for p in root.rglob("*.json"):
         try:
-            out.append((p, json.loads(p.read_text(encoding="utf-8"))))
+            value = json.loads(p.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             continue
+        if isinstance(value, dict):
+            out.append((p, value))
     return out
 
 
@@ -43,60 +45,117 @@ def _component_ids(sim: dict) -> list[str]:
     return [str(sim[k]) for k in keys if isinstance(sim.get(k), str)]
 
 
-def main() -> None:
-    if not PROJECT.is_dir():
-        sys.exit(f"FAIL: project directory {PROJECT} does not exist")
-
-    docs = _load_jsons(PROJECT)
-    if not docs:
-        sys.exit(f"FAIL: no JSON files found under {PROJECT}")
-
-    set_match = next(
+def _find_eval_set(docs: list[tuple[Path, dict]]) -> tuple[Path, dict]:
+    match = next(
         (
-            (p, d)
-            for p, d in docs
-            if isinstance(d, dict)
-            and d.get("name") == "Sim Set"
-            and isinstance(d.get("evaluations"), list)
+            (path, doc)
+            for path, doc in docs
+            if doc.get("name") == "Sim Set" and isinstance(doc.get("evaluations"), list)
         ),
         None,
     )
-    if not set_match:
-        sys.exit('FAIL: no eval-set JSON under SimEval/ has name="Sim Set"')
+    if match is None:
+        sys.exit('FAIL: no eval-set JSON has name="Sim Set"')
+    return match
 
-    cases = set_match[1].get("evaluations") or []
+
+def _find_data_point(eval_set: tuple[Path, dict]) -> dict:
+    cases = eval_set[1].get("evaluations") or []
     hello = next(
-        (c for c in cases if isinstance(c, dict) and c.get("name") == "hello"),
+        (
+            case
+            for case in cases
+            if isinstance(case, dict) and case.get("name") == "hello"
+        ),
         None,
     )
-    if not hello:
+    if hello is None:
         sys.exit(
-            f'FAIL: eval set "Sim Set" ({set_match[0]}) has no data point named '
+            f'FAIL: eval set "Sim Set" ({eval_set[0]}) has no data point named '
             f'"hello". Got: {[c.get("name") for c in cases if isinstance(c, dict)]}'
         )
+    return hello
 
-    sims = hello.get("simulations")
-    if not isinstance(sims, list) or not sims:
+
+def _simulations(data_point: dict, set_path: Path) -> list[dict]:
+    simulations = data_point.get("simulations")
+    if not isinstance(simulations, list) or not simulations:
         sys.exit(
-            f'FAIL: data point "hello" ({set_match[0]}) has no non-empty '
-            f'"simulations" array. Got: {sims!r}'
+            f'FAIL: data point "hello" ({set_path}) has no non-empty '
+            f'"simulations" array. Got: {simulations!r}'
         )
+    return [sim for sim in simulations if isinstance(sim, dict)]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check",
+        choices=("eval-set", "data-point", "llm-simulation", "static-absent"),
+    )
+    check = parser.parse_args().check
+
+    docs = _load_jsons(Path("."))
+    if not docs:
+        sys.exit("FAIL: no JSON files found under the sandbox")
+
+    set_match = _find_eval_set(docs)
+    if check == "eval-set":
+        print(f"OK: Sim Set eval set at {set_match[0]}")
+        return
+
+    hello = _find_data_point(set_match)
+    if check == "data-point":
+        if not hello.get("inputs"):
+            sys.exit('FAIL: data point "hello" has empty inputs')
+        if not (hello.get("expectedOutput") or hello.get("expected")):
+            sys.exit('FAIL: data point "hello" has no expectedOutput / expected field')
+        print(
+            f"OK: eval set {set_match[0]} contains data point 'hello' with inputs + expected"
+        )
+        return
+
+    sims = _simulations(hello, set_match[0])
 
     ids: list[str] = []
     for s in sims:
         if isinstance(s, dict):
             ids.extend(_component_ids(s))
 
+    if check == "llm-simulation":
+        llm = next(
+            (
+                sim
+                for sim in sims
+                if KEPT in _component_ids(sim)
+                and sim.get("simulationStrategy") == "Llm"
+                and sim.get("outputSchema")
+            ),
+            None,
+        )
+        if llm is None:
+            sys.exit(
+                f'FAIL: no Llm simulation for "{KEPT}" has an explicit outputSchema'
+            )
+        print(f"OK: Llm simulation {KEPT!r} persists with an output schema")
+        return
+
+    if check == "static-absent":
+        if REMOVED in ids:
+            sys.exit(f'FAIL: Static simulation "{REMOVED}" is still present')
+        print(f"OK: removed simulation {REMOVED!r} is absent")
+        return
+
     if KEPT not in ids:
         sys.exit(
             f'FAIL: Llm simulation "{KEPT}" not found in data point "hello" '
-            f'simulations (add did not persist). Component ids present: {ids}'
+            f"simulations (add did not persist). Component ids present: {ids}"
         )
     if REMOVED in ids:
         sys.exit(
             f'FAIL: Static simulation "{REMOVED}" is still present — '
-            f'`simulation remove` did not mutate the eval-set JSON. '
-            f'Component ids present: {ids}'
+            f"`simulation remove` did not mutate the eval-set JSON. "
+            f"Component ids present: {ids}"
         )
 
     print(

--- a/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
+++ b/tests/tasks/uipath-maestro-flow/evaluate/simulation/simulation_crud.yaml
@@ -1,14 +1,15 @@
+# Same-ground alignment expansion plan (Tao, 2026-08-21): loop-neutral
+# v1-base prompt, outcome-graded criteria at preserved weights, and
+# arm-agnostic artifact discovery.
+# See workspaces/docs/flow-sdk/2026-08-21-maestro-flow-alignment-expansion-plan.md.
 task_id: skill-flow-eval-simulation-crud
 description: >
   Skill-guided simulation CRUD: agent uses the uipath-maestro-flow skill's
   evaluate capability to scaffold a Flow project, build an eval set + data
-  point, then add, list, and remove node simulations on that data point via
-  `uip maestro flow eval simulation add/list/remove`. Covers both strategies —
-  `Static` (`--mock-value`) and `Llm` (explicit `--output-schema`, so the
-  auto-resolution-from-.flow path is not exercised). Purely local, no login,
-  no upload, no run. Tests whether the skill teaches the simulation command
-  surface (required flags, strategy selection) and `--output json` discipline,
-  and verifies the simulation actually persists into the eval-set JSON.
+  point, then add, inspect, and remove node simulations on that data point.
+  Covers both Static and LLM strategies with an explicit LLM output schema.
+  Purely local, with no authentication, upload, or evaluation run. Verifies
+  that the requested simulation state persists into the eval-set JSON.
 tags: [uipath-maestro-flow, smoke, mode:build, lifecycle:generate, feature:eval]
 
 run_limits:
@@ -16,120 +17,113 @@ run_limits:
   max_turns: 60
 
 initial_prompt: |
-  Use the `uipath-maestro-flow` skill's evaluate capability to scaffold a Flow
-  project, build an eval set with one data point, then add, list, and remove
-  node simulations on that data point — purely local, no Studio Web round-trip.
+  Scaffold a UiPath Flow project, build an eval set with one data point, then
+  add, inspect, and remove node simulations on that data point — purely local,
+  no Studio Web round-trip.
 
-  Steps:
-  1. Create a solution `SimEval` and a Flow project `SimEval`. The flow file
-     MUST live at `SimEval/SimEval/SimEval.flow` (double-nested layout) and be
-     linked via `uip solution project add`.
+  Create a Flow project named `SimEval` with a manual trigger inside a solution
+  of the same name.
 
-  2. Declare a string input variable named `name` on
-     `SimEval/SimEval/SimEval.flow` before adding the data point.
+  Declare a string input variable named `name` before adding the data point.
 
-  3. Create an eval set named `Sim Set` in the Flow project at
-     `SimEval/SimEval`. (No `--entry-point`, no `--evaluators` — defaults are
-     fine.)
+  Create an eval set named `Sim Set` in the Flow project, using its default
+  entry point and current evaluators.
 
-  4. Add one data point named `hello` to that eval set with inputs
-     `{"name":"Alice"}` and expected `{"greeting":"Hello, Alice!"}`.
+  Add one data point named `hello` to that eval set with inputs
+  `{"name":"Alice"}` and expected `{"greeting":"Hello, Alice!"}`.
 
-  5. Add a `Static` simulation on the `hello` data point targeting component id
-     `connector-send-email`. Use `--component-type connector` and a fixed
-     `--mock-value '{"status":"ok","messageId":"abc123"}'`.
+  Add a `Static` simulation on the `hello` data point targeting connector
+  component `connector-send-email`, with fixed mock value
+  `{"status":"ok","messageId":"abc123"}`.
 
-  6. Add an `Llm` simulation on the `hello` data point targeting component id
-     `agent-lookup`. Use `--component-type agent`, supply
-     `--simulation-instructions "Return a plausible lookup result."`, and pass
-     `--output-schema '{"type":"object","properties":{"result":{"type":"string"}}}'`
-     explicitly (do NOT rely on auto-resolution from the .flow file).
+  Add an `Llm` simulation on the same data point targeting agent component
+  `agent-lookup`, with instructions `Return a plausible lookup result.` and
+  explicit output schema
+  `{"type":"object","properties":{"result":{"type":"string"}}}`.
 
-  7. List the simulations on the `hello` data point to confirm both are present.
+  Inspect the simulations to confirm both are present.
 
-  8. Remove the `connector-send-email` simulation from the `hello` data point.
+  Remove the `connector-send-email` simulation from the `hello` data point.
 
-  Important:
-  - Use `--output json` on every `uip maestro flow eval ...` command.
-  - Do NOT call `uip login`. Do NOT call `uip solution upload`. Do NOT call
-    `uip maestro flow eval run *` — this task tests local CRUD only.
-  - Do NOT run `uip maestro flow debug` or `uip maestro flow validate` — this
-    is not a flow-authoring test.
+  Keep all work local: do not authenticate, upload the solution, or start an
+  evaluation run.
 
 success_criteria:
   - type: command_executed
-    description: "Agent created a solution"
+    description: "Solution-creation telemetry (report only; the Flow artifact is graded below)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+solution\s+(new|init)'
     min_count: 1
     weight: 1.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent initialized a Flow project"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+(maestro\s+)?flow\s+init'
-    min_count: 1
+  - type: run_command
+    description: "Initialized Flow artifact contains a manual trigger"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SimEval 'core.trigger.manual'"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: file_exists
-    description: "Flow file was created at the double-nested path"
-    path: "SimEval/SimEval/SimEval.flow"
+  - type: run_command
+    description: "SimEval Flow artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/_shared/flow_contains.py --flow-name SimEval"
+    timeout: 30
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent created an eval set"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+set\s+add'
-    min_count: 1
+  - type: run_command
+    description: "Sim Set eval-set artifact exists"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py --check eval-set"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.0
     pass_threshold: 1.0
 
-  - type: command_executed
-    description: "Agent added a data point with --inputs and --expected"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+add\s+.*(--inputs.*--expected|--expected.*--inputs)'
-    min_count: 1
+  - type: run_command
+    description: "Sim Set contains the hello data point with inputs and expected output"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py --check data-point"
+    timeout: 10
+    expected_exit_code: 0
     weight: 1.5
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent added a Static simulation with --strategy Static and --mock-value"
+    description: "Static-simulation creation telemetry (report only; its requested removal leaves no durable witness)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--strategy\s+Static\b.*--mock-value'
     min_count: 1
     weight: 3.0
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
-    description: "Agent added an Llm simulation with --strategy Llm and explicit --output-schema"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+add\s+.*--strategy\s+Llm\b.*--output-schema'
-    min_count: 1
+  - type: run_command
+    description: "The Llm agent-lookup simulation persists with an explicit output schema"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py --check llm-simulation"
+    timeout: 10
+    expected_exit_code: 0
     weight: 3.0
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "Agent listed simulations on the data point"
+    description: "Simulation-list telemetry (report only; persisted state is graded directly)"
     tool_name: "Bash"
     command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+list'
     min_count: 1
     weight: 1.5
-    pass_threshold: 1.0
+    pass_threshold: 0.0
 
-  - type: command_executed
+  - type: run_command
     description: "Agent removed the connector-send-email simulation"
-    tool_name: "Bash"
-    command_pattern: '(uip|\$UIP)\s+maestro\s+flow\s+eval\s+simulation\s+remove\s+.*connector-send-email'
-    min_count: 1
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py --check static-absent"
+    timeout: 10
+    expected_exit_code: 0
     weight: 2.0
     pass_threshold: 1.0
 
   - type: run_command
     description: "Eval-set JSON shows the Llm simulation persisted and the removed one is gone"
-    command: "python3 $TASK_DIR/check_simulation_crud.py"
+    command: "python3 $SKILLS_REPO_PATH/tests/tasks/uipath-maestro-flow/evaluate/simulation/check_simulation_crud.py"
     timeout: 10
     expected_exit_code: 0
     weight: 3.0


### PR DESCRIPTION
## Summary

- apply the ratified same-ground recipe to the exact 18-task Batch 5 roster
- route flow discovery through the shared solution-first/root-fallback helper
- replace loop-specific command grading with persisted artifact and validation checks where a durable outcome exists
- retain command-only signals as report-only advisories where no durable witness exists
- add focused regression tests for evaluation artifacts and the root SDK webhook layout
- add the same-name solution phrase to `e2e/escalation_jira_ticket`, the one separately ratified tweak outside the 18-task sweep

## Batch roster

- connector trigger: `trigger_with_filter`, `webhook_waitfor_parallel`
- e2e: `devcon_expense_approval`, `jira_create_issue`, `jira_get_issue`, `jira_lifecycle`, `jira_search_triage`
- edit: `add_node`, `add_output`, `group_to_subflow`, `move_node`, `remove_node`, `update_node`
- evaluate: `evaluator_type_choice`, `inline_agent_eval`, `local_crud`, `no_auto_upload`, `simulation_crud`

## Nightly signal impact

This is a measurement-contract change, not score greening. Criterion counts and weights are unchanged. Artifact content, validation, local evaluation state, and live Jira behavior remain gating at their prior weights. Command telemetry that is specific to one authoring loop is replaced by the requested persisted outcome; when no durable local witness exists, the telemetry remains visible as a `pass_threshold: 0.0` advisory.

The four Jira checkers retain their live debug and tenant assertions unchanged. Only flow discovery and validation witnessing are made layout-neutral.

## Evidence

- `260 passed` across `tests/tasks/uipath-maestro-flow`
- focused Ruff F/E402 checks pass (pre-existing F841s in two frozen Jira semantic paths are ignored)
- coder-eval 0.10.2 validates all 18 task YAMLs
- static comparison against the integration base confirms unchanged criterion counts and weights for all 18 tasks
- corpus audit confirms exactly 112 tagged tasks and empty temporary alignment allowlists
- newest same-agent live-v1 archive (`runs/2026-08-20_17-22-24`, Claude Code / Sonnet 5 / Bedrock, skills `04c0233`) has 16/18 successful Batch 5 tasks; Jira lifecycle scored 0 and Jira create scored 0.285714, retained as content reds for Phase 2
- fresh paired shakeout not launched: `uip login refresh --output json` returns `AuthenticationError` / `RetryWillNotFix`

## Fences

- all nine tasks aligned by #2557 remain untouched
- only `e2e/escalation_jira_ticket` receives the separately ratified solution phrase
- no Bucket-D Jira behavior or expected outcome changed
- `connector_features/generate_schema.yaml` remains out of scope

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)
