### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@c0cf591

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ fd0070d. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ c0cf591. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 
@@ -129,6 +129,8 @@ uip maestro bpmn validate <Name>.bpmn --output json
 | `.connector(id, key, action, inputs, { connection?, folder?, name?, outputVar?, skipCondition?, retry?, loop? })` | `bpmn:sendTask` (`uipath:activity` / `Intsvc.ActivityExecution`) — an IS connector op. See **Connector service task** below. |
 | `.subProcess(id, sp => …, { name?, triggeredByEvent?, loop?, retry? })` | `bpmn:subProcess` (nested graph) |
 | `.binding(id, { name?, value?, resource?, propertyAttribute? })` | `uipath:binding` (top level only) — an identifier supplied per environment, read as `=bindings.<id>` |
+| `.http(id, { url, method?, headers?, parameters?, body?, name?, outputVar?, skipCondition?, retry?, loop? })` | `bpmn:sendTask` (`uipath:activity` / `Intsvc.UnifiedHttpRequest`) — an HTTP request. See **HTTP request** below. |
+| `.humanTask(id, { app, title?, actions?, input?, outputs?, appVersion?, key?, … })` | `bpmn:userTask` (`uipath:activity` / `Actions.HITL`) — a task a person completes. See **Human task** below. |
 | `.sequenceFlow(source, target, { id?, name?, condition? })` | `bpmn:sequenceFlow` |
 
 - **Timers** accept an ISO-8601 string shorthand (`timer: 'PT15M'`) or a full
@@ -152,6 +154,132 @@ uip maestro bpmn validate <Name>.bpmn --output json
 - **Bindings**: `.binding('apiBase', { value: 'https://api.example.com' })` declares
   an identifier configured per environment; read it as `=bindings.apiBase`. A
   connector's `connection`/`folder` already declare their own.
+
+## HTTP request
+
+`.http(id, opts)` emits an `Intsvc.UnifiedHttpRequest` node — the platform's HTTP
+activity, and the first **registry-backed** typed node. Its wire shape comes from
+the committed registry snapshot, so it cannot drift from what
+`uip maestro bpmn validate` accepts. No connector library and no tenant needed.
+
+```ts
+export default bpmn('sync')
+  .binding('apiBase', { name: 'API base URL', value: 'https://api.example.com' })
+  .var('orders', 'object')
+  .startEvent('start')
+  .http('fetch', {
+    method: 'GET',
+    url: '=js:bindings.apiBase + "/v1/orders"',
+    headers: { accept: 'application/json' },
+    parameters: { limit: 50 },
+    retry: { maxRetries: 2, backoff: 'PT5S', allErrors: true },
+  })
+  .task('keep', { set: { orders: '=js:vars.fetch_response' } })
+  .endEvent('done')
+  .sequenceFlow('start', 'fetch')
+  .sequenceFlow('fetch', 'keep')
+  .sequenceFlow('keep', 'done')
+  .build();
+```
+
+- The response lands in **`<id>_response`** (`fetch_response` above) unless
+  `outputVar` says otherwise, and it is readable downstream with no `.var()`.
+- `url` takes an `=`-expression, so `=bindings.<id>` works — which is how the same
+  process points at different environments.
+- `method` defaults to `GET`. `headers` / `parameters` / `body` are plain objects;
+  the SDK serializes them the way the platform reads them.
+- Accepts the shared activity options (`retry`, `loop`, `skipCondition`) and takes
+  a `boundaryEvent` like any other activity.
+
+## Human task (approval gates)
+
+`.humanTask(id, opts)` emits an `Actions.HITL` Action App task — work a person
+completes. `app` is the Action App id and comes from the tenant.
+
+**Always set `outputs` if anything branches on the decision.** The type's own
+output is a typed one the designer resolves but a local run leaves empty, so
+without a mapped field a gateway cannot read the outcome offline.
+
+```ts
+export default bpmn('invoice')
+  .var('outcome', 'string', { default: 'none' })
+  .startEvent('start')
+  .humanTask('approve', {
+    app: 'app-123',
+    title: 'Approve the invoice',
+    actions: ['approve', 'reject'],
+    input: { amount: 100 },
+    outputs: { decision: '=Action' },      // <- what the gateway reads
+  })
+  .exclusiveGateway('gw', { default: 'fReject' })
+  .task('ok', { set: { outcome: 'approved' } })
+  .task('no', { set: { outcome: 'rejected' } })
+  .exclusiveGateway('join', { default: 'fJoin' })
+  .endEvent('done')
+  .sequenceFlow('start', 'approve')
+  .sequenceFlow('approve', 'gw')
+  .sequenceFlow('gw', 'ok', { id: 'fApprove', condition: '=js:vars.decision == "approve"' })
+  .sequenceFlow('gw', 'no', { id: 'fReject' })
+  .sequenceFlow('ok', 'join', { id: 'fOk' })
+  .sequenceFlow('no', 'join', { id: 'fNo' })
+  .sequenceFlow('join', 'done', { id: 'fJoin' })
+  .build();
+```
+
+**Test both arms offline** — the runtime stands in for the person:
+
+```bash
+flow-debug Invoice.bpmn --mock --virtual-time --hitl-response 'approve={"Action":"approve"}'
+flow-debug Invoice.bpmn --mock --virtual-time --hitl-response 'approve={"Action":"reject"}'
+```
+
+- `=Action` is the response field the runtime's outcome routing reads.
+- With **no** outcome injected the mapped field is empty and the gateway takes its
+  `default` arm — an un-decided task does not hang, it falls through. Design the
+  default accordingly.
+- `actions` is comma-joined. The platform does not validate its encoding, so if a
+  live run mis-reads the outcomes, compare against a Studio Web export.
+
+## Orchestrator: start work elsewhere
+
+Six methods over nine registry types — the sync/async and wait choices are
+options, not separate methods.
+
+| Method | What it starts |
+| --- | --- |
+| `.startProcess(id, opts)` | an RPA process, and waits |
+| `.startAgent(id, opts)` | an agent, and waits |
+| `.startAgenticProcess(id, { …, async? })` | an agentic process (call activity) |
+| `.startCaseProcess(id, { …, async? })` | a case-management process (call activity) |
+| `.executeApiWorkflow(id, opts)` | an API workflow, fire-and-forget |
+| `.queueItem(id, { queue, folder, item?, wait? })` | adds an Orchestrator queue item |
+
+```ts
+export default bpmn('nightly')
+  .startEvent('start')
+  .startProcess('post', { process: 'InvoicePosting', folder: 'Finance', input: { batch: 42 } })
+  .queueItem('audit', { queue: 'AuditTrail', folder: 'Finance', item: { source: 'nightly', batch: 42 } })
+  .endEvent('done')
+  .sequenceFlow('start', 'post')
+  .sequenceFlow('post', 'audit')
+  .sequenceFlow('audit', 'done')
+  .build();
+```
+
+- A process is addressed by **name** (`process: 'InvoicePosting'`), not by key —
+  the runtime resolves the key, so the same artifact works on any tenant that has
+  a process by that name.
+- `input` becomes the job's arguments; a queue item's `item` becomes its content.
+- The response lands in `<id>_processResponse` (jobs) or `<id>_response` (queues).
+- `folder` is **required** for `.queueItem()` — queue items are folder-scoped and
+  the runtime refuses to dispatch without it.
+- `.startAgent()` needs its process and folder supplied as **bindings**; the SDK
+  declares them for you from the plain names you pass, so just pass names.
+- **Business rules are not available** and are tracked separately — see
+  `docs/BPMN_BUSINESS_RULES_PLAN.md`.
+- `metadata.*` (e.g. `metadata.instanceId`) is **empty in a local run**, so an
+  `item`/`input` field built from it silently arrives as nothing. Use `vars.*` or a
+  literal when you want to see the value in a `flow-debug` dry run.
 
 ## Connector service task
 
@@ -208,6 +336,79 @@ export default bpmn('notify')
 - Warnings, not errors: a **superfluous gateway** (one in, one out) and an
   **implicit join** (an activity/event with more than one incoming flow) — the
   platform accepts both, but a gateway is clearer.
+
+## Importing an existing `.bpmn`
+
+`bpmn-decompile <Name.bpmn>` writes `<Name>.bpmn.ts` whose default export
+recompiles to an **equivalent** process — every element, id, extension type,
+graph edge and metadata row survives. Use it to bring a process authored in
+Studio Web (or handed over as a file) under SDK authoring.
+
+There is no `uip maestro bpmn decompile`; run the package bin. It is installed into
+`node_modules/.bin`, which is not always on `PATH` — `npx` finds it either way:
+
+```bash
+npx bpmn-decompile Invoice.bpmn                 # -> Invoice.bpmn.ts
+npx bpmn-compile   Invoice.bpmn.ts -o out.bpmn  # equivalent to Invoice.bpmn
+```
+
+### Editing an existing `.bpmn`: decompile, edit, compile, **merge**
+
+If the file is yours to own from now on, recompiling over it is fine. If you are making a
+**targeted change to a process someone else authored** — and must leave the rest of it
+alone — add a merge step. Recompiling rewrites every element in the file, including the
+ones you never looked at; merging rewrites only the ones you actually changed.
+
+```bash
+npx bpmn-decompile Invoice.bpmn                             # -> Invoice.bpmn.ts
+npx bpmn-compile   Invoice.bpmn.ts -o baseline.bpmn         # BEFORE editing — keep this
+#   ... make your change in Invoice.bpmn.ts ...
+npx bpmn-compile   Invoice.bpmn.ts -o edited.bpmn
+npx bpmn-merge     Invoice.bpmn edited.bpmn --baseline baseline.bpmn -o Invoice.bpmn
+uip maestro bpmn format Invoice.bpmn                        # only if you ADDED elements
+```
+
+`baseline.bpmn` is what a faithful round trip of the original produces before you touch
+anything. Comparing your `edited.bpmn` against it is how the merge tells which elements
+you changed: anything identical to the baseline you did not touch, so it is emitted from
+the **original**, byte for byte — original attribute order, original formatting, original
+`uipath:*` payloads, and the original diagram. It reports the split when it runs
+(`4 preserved, 1 authored, 0 removed`); if `authored` is larger than the change you meant
+to make, something else moved too.
+
+Skip `--baseline` for a two-way merge: takes your edited process and re-attaches the
+original diagram. Less precise, still better than a bare recompile, which drops layout.
+
+Run `format` only when you added elements — new ones have no diagram shape yet. It
+re-lays-out the whole file, so running it needlessly discards the geometry the merge just
+preserved.
+
+- **Not byte-for-byte, and not attribute-for-attribute.** One payload detail is
+  normalised, because the builder models authoring intent and not wire text: an
+  **output row keyed by a variable** loses a row `name` that differs from the
+  variable id — `name="total" var="Var_Total"` returns as `name="Var_Total"`.
+  `var` and `source` are intact, so the mapping still resolves the same way.
+
+  It is harmless to the runtime. It matters if something downstream compares XML
+  attribute-by-attribute — then a round trip is not a no-op. `bpmn-merge` above is
+  the answer: on an element you did not edit, the row comes from the original and
+  keeps its name.
+
+- **An `args` input row comes back with `type="json" target="bodyField"` added, and
+  that is a repair rather than a loss.** `uip maestro bpmn validate` REJECTS a bare
+  `<uipath:input name="args">`, so an artifact missing them is invalid and the
+  recompiled one is correct. Do not try to preserve the bare form.
+
+- **Diagram layout is not read or written.** The SDK emits semantic-only XML; run
+  `format`/`tidy` on the recompiled file when a canvas needs one.
+- **A connector task comes back as a generic `.activity()`**, not as a
+  `.connector()` call — the library's action slug is not in the XML, only its
+  `objectName`. Everything the platform needs IS in the artifact, so it recompiles
+  byte-identically with no connector library involved. Editing one means editing the
+  context/input rows directly rather than the friendlier `.connector()` arguments.
+- Types with no typed method decompile to `.activity(id, type, { … })`, the generic
+  form. That is faithful, just less readable than the typed methods.
+- Comments and method order are not preserved — the source is regenerated.
 
 ## Notes
 

--- a/preview/uipath-maestro-bpmn/references/api.md
+++ b/preview/uipath-maestro-bpmn/references/api.md
@@ -13,9 +13,9 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Builders** — [BpmnBuilder](#bpmnbuilder-class) · [ScopeBuilder](#scopebuilder-class) · [SubProcessBuilder](#subprocessbuilder-class)
 
-**Option shapes** — [BindingOpts](#bindingopts-interface) · [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [BpmnConnectorOpts](#bpmnconnectoropts-type) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface) · [ActivityOpts](#activityopts-interface) · [ConnectorOpts](#connectoropts-interface)
+**Option shapes** — [BindingOpts](#bindingopts-interface) · [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [PlainTaskOpts](#plaintaskopts-interface) · [BpmnConnectorOpts](#bpmnconnectoropts-type) · [HttpOpts](#httpopts-interface) · [OrchestratorOpts](#orchestratoropts-interface) · [OrchestratorAsyncOpts](#orchestratorasyncopts-interface) · [QueueItemOpts](#queueitemopts-interface) · [HumanTaskOpts](#humantaskopts-interface) · [ActivityNodeOpts](#activitynodeopts-interface) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface) · [ActivityOpts](#activityopts-interface) · [ConnectorOpts](#connectoropts-interface)
 
-**Supporting types** — [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [BindingDecl](#bindingdecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [ActivityNodeFields](#activitynodefields-interface) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface) · [RetrySpec](#retryspec-interface) · [LoopSpec](#loopspec-interface)
+**Supporting types** — [ProcessMetadata](#processmetadata-interface) · [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [BindingsRegistry](#bindingsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [BindingDecl](#bindingdecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [ActivityNodeFields](#activitynodefields-interface) · [TypedOutputRow](#typedoutputrow-interface) · [PlainTaskElement](#plaintaskelement-type) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface) · [RetrySpec](#retryspec-interface) · [LoopSpec](#loopspec-interface)
 
 ## bpmn (function)
 
@@ -35,6 +35,8 @@ export declare function bpmn(id: string): BpmnBuilder;
 export declare class BpmnBuilder extends ScopeBuilder {
     /** Set the process's display name. */
     name(n: string): this;
+    /** Process-level metadata — see `ProcessMetadata`. */
+    metadata(meta: ProcessMetadata): this;
     /**
      * Declare an external identifier the process needs supplied — a base URL, a
      * folder path, a process name (`uipath:binding`). Expressions read it as
@@ -81,6 +83,8 @@ declare abstract class ScopeBuilder {
     scriptTask(id: string, opts: ScriptTaskOpts): this;
     /** A plain task that assigns variables (`BPMN.Variables`). */
     task(id: string, opts?: TaskOpts): this;
+    /** A task element carrying NO `uipath:*` payload — an abstract task, in BPMN's terms. */
+    plainTask(id: string, opts?: PlainTaskOpts): this;
     /**
      * An Integration Service **connector** service task (`bpmn:sendTask` +
      * `uipath:activity` / `Intsvc.ActivityExecution`) — the typed form, where a
@@ -89,6 +93,45 @@ declare abstract class ScopeBuilder {
     connector<I extends Record<string, unknown>, O>(id: string, descriptor: ConnectorDescriptor<I, O>, inputs: I, opts?: BpmnConnectorOpts): this;
     /** Stringly form, for a connector with no prepared module. */
     connector(id: string, key: string, action: string, inputs?: Record<string, unknown>, opts?: BpmnConnectorOpts): this;
+    /**
+     * An **HTTP request** service task (`bpmn:sendTask` +
+     * `uipath:activity` / `Intsvc.UnifiedHttpRequest`).
+     */
+    http(id: string, opts: HttpOpts): this;
+    /** Start an **RPA process** and wait for it (`Orchestrator.StartJob`). */
+    startProcess(id: string, opts: OrchestratorOpts): this;
+    /** Start an **agent** and wait for it (`Orchestrator.StartAgentJob`). */
+    startAgent(id: string, opts: OrchestratorOpts): this;
+    /**
+     * Invoke an **agentic process** as a call activity
+     * (`Orchestrator.StartAgenticProcess`, or `…Async` when `async` is set).
+     */
+    startAgenticProcess(id: string, opts: OrchestratorAsyncOpts): this;
+    /**
+     * Invoke a **case-management process** as a call activity
+     * (`Orchestrator.StartCaseMgmtProcess`, or `…Async` when `async` is set).
+     */
+    startCaseProcess(id: string, opts: OrchestratorAsyncOpts): this;
+    /**
+     * Execute an **API workflow**, fire-and-forget
+     * (`Orchestrator.ExecuteApiWorkflowAsync`).
+     */
+    executeApiWorkflow(id: string, opts: OrchestratorOpts): this;
+    /**
+     * Add an item to an Orchestrator **queue** (`Orchestrator.CreateQueueItem`, or
+     * `Orchestrator.CreateAndWaitForQueueItem` when `wait` is set).
+     */
+    queueItem(id: string, opts: QueueItemOpts): this;
+    /**
+     * A **human task** — an Action App task a person completes (`bpmn:userTask` +
+     * `uipath:activity` / `Actions.HITL`).
+     */
+    humanTask(id: string, opts: HumanTaskOpts): this;
+    /**
+     * ANY registry-backed node, by extension type — the generic form the typed
+     * methods are sugar over.
+     */
+    activity(id: string, type: string, opts?: ActivityNodeOpts): this;
     /** A sub-process — a scope of its own, with its own elements and flows (`bpmn:subProcess`). */
     subProcess(id: string, fn: (sp: SubProcessBuilder) => void, opts?: SubProcessOpts): this;
     /** A sequence flow from `source` to `target` (1-1 with `bpmn:sequenceFlow`). */
@@ -133,6 +176,8 @@ export interface BindingOpts {
     propertyAttribute?: string;
     /** The resource's key, when it differs from `BindingOpts.value`. */
     resourceKey?: string;
+    /** Narrows the resource, e.g. `'Agent'` for an agent process. */
+    resourceSubType?: string;
 }
 ````
 
@@ -274,6 +319,18 @@ export interface TaskOpts extends ActivityOpts {
 }
 ````
 
+## PlainTaskOpts (interface)
+
+````ts
+/** Options for `.plainTask()`. */
+export interface PlainTaskOpts extends ActivityOpts {
+    /** Display name the designer shows. */
+    name?: string;
+    /** Which task element to emit. Defaults to `bpmn:task`. */
+    element?: PlainTaskElement;
+}
+````
+
 ## BpmnConnectorOpts (type)
 
 ````ts
@@ -302,6 +359,172 @@ export type BpmnConnectorOpts = ConnectorOpts & ActivityOpts & {
      */
     outputVar?: string;
 };
+````
+
+## HttpOpts (interface)
+
+````ts
+/** Options for `.http()` — an `Intsvc.UnifiedHttpRequest` node. */
+export interface HttpOpts extends ActivityOpts {
+    /** Display name the designer shows on the task. */
+    name?: string;
+    /** Request URL. Accepts an `=`-expression, including `=bindings.<id>`. */
+    url: string;
+    /** HTTP method. Defaults to `'GET'`, matching the registry's own default. */
+    method?: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'HEAD' | 'OPTIONS';
+    /** Request headers — serialized to the node's json context field. */
+    headers?: Record<string, unknown>;
+    /** Query parameters — serialized to the node's json context field. */
+    parameters?: Record<string, unknown>;
+    /** Request body — serialized to the node's json context field. */
+    body?: unknown;
+    /**
+     * EXTRA output rows: variable id → `=`-expression read against the node's own result,
+     * e.g. `{ runStatus: '=Status' }`.
+     */
+    outputs?: Record<string, string>;
+    /** Variable the response lands in. Defaults to `<id>_response`. */
+    outputVar?: string;
+    /** `=`-expression that skips the request when truthy. */
+    skipCondition?: string;
+}
+````
+
+## OrchestratorOpts (interface)
+
+````ts
+/**
+ * What every Orchestrator invocation needs: which process, in which folder, with
+ * what input.
+ */
+export interface OrchestratorOpts extends ActivityOpts {
+    /** Display name the designer shows on the node. */
+    name?: string;
+    /** The Orchestrator process to start, by name. */
+    process: string;
+    /** Folder path the process lives in. Omit for the personal/default folder. */
+    folder?: string;
+    /** Input arguments — serialized as the node's `JobArguments` body. */
+    input?: Record<string, unknown>;
+    /** The release key, when a binding supplies it (`=bindings.<id>`). */
+    releaseKey?: string;
+    /**
+     * EXTRA output rows: variable id → `=`-expression read against the node's own result,
+     * e.g. `{ runStatus: '=Status' }`.
+     */
+    outputs?: Record<string, string>;
+    /** Variable the job response lands in. Defaults to `<id>_processResponse`. */
+    outputVar?: string;
+    /** `=`-expression that skips the invocation when truthy. */
+    skipCondition?: string;
+}
+````
+
+## OrchestratorAsyncOpts (interface)
+
+````ts
+/** Options for the two agentic/case call activities, which come in sync and async forms. */
+export interface OrchestratorAsyncOpts extends OrchestratorOpts {
+    /**
+     * `true` starts the process and carries on without waiting (`…Async`), so only
+     * an error is mapped back. Default `false` — start and wait.
+     */
+    async?: boolean;
+}
+````
+
+## QueueItemOpts (interface)
+
+````ts
+/** Options for `.queueItem()`. */
+export interface QueueItemOpts extends ActivityOpts {
+    /** Display name the designer shows on the node. */
+    name?: string;
+    /** The queue to add the item to. */
+    queue: string;
+    /** Folder path the queue lives in. */
+    folder: string;
+    /** The item's content — serialized as the node's `ItemData` body. */
+    item?: Record<string, unknown>;
+    /**
+     * `true` waits for the item to be processed and maps its outcome back
+     * (`Orchestrator.CreateAndWaitForQueueItem`); default adds it and carries on.
+     */
+    wait?: boolean;
+    /**
+     * EXTRA output rows: variable id → `=`-expression read against the node's own result,
+     * e.g. `{ runStatus: '=Status' }`.
+     */
+    outputs?: Record<string, string>;
+    /** Variable the response lands in. Defaults to `<id>_response`. */
+    outputVar?: string;
+    /** `=`-expression that skips the enqueue when truthy. */
+    skipCondition?: string;
+}
+````
+
+## HumanTaskOpts (interface)
+
+````ts
+/** Options for `.humanTask()` — an `Actions.HITL` action-app task. */
+export interface HumanTaskOpts extends ActivityOpts {
+    /** Display name the designer shows on the task. */
+    name?: string;
+    /** The Action App's id (`appId`). Tenant-specific — see the remarks above. */
+    app: string;
+    /** The app version (`appVersion`). */
+    appVersion?: number;
+    /** The outcomes a human can pick, e.g. `['approve', 'reject']`. */
+    actions?: string[];
+    /** The task title a human sees (`taskTitle`). */
+    title?: string;
+    /** An existing task key, when resuming rather than creating (`key`). */
+    key?: string;
+    /** Data the task shows the human — the node's `HitlTaskArguments`. */
+    input?: Record<string, unknown>;
+    /**
+     * Fields to pull out of the human's response into variables, e.g.
+     * `{ decision: '=Action' }`.
+     */
+    outputs?: Record<string, string>;
+    /** Variable the whole typed response lands in. Defaults to `<id>_processResponse`. */
+    outputVar?: string;
+    /** `=`-expression that skips the task when truthy. */
+    skipCondition?: string;
+}
+````
+
+## ActivityNodeOpts (interface)
+
+````ts
+/** Options for `.activity()` — the generic registry-backed node. */
+export interface ActivityNodeOpts extends ActivityOpts {
+    /** Display name the designer shows. */
+    name?: string;
+    /** `uipath:context` values, by the registry's field names. */
+    context?: Record<string, unknown>;
+    /** The payload, shaped by the type's `inputPattern`. */
+    inputs?: Record<string, unknown>;
+    /** Variable the type's own output lands in. Defaults to `<id>_<outputName>`. */
+    outputVar?: string;
+    /** Extra output rows: variable id → `=`-expression against the node's result. */
+    outputs?: Record<string, string>;
+    /**
+     * The output rows spelled out, replacing `outputVar` and `outputs`. Set by
+     * `bpmn-decompile` when a row carries detail those cannot express — a
+     * connector's `jsonSchema` rows and their schema bodies. See
+     * `TypedOutputRow`.
+     */
+    outputRows?: TypedOutputRow[];
+    /** `=`-expression that skips the node when truthy (activity/event tags only). */
+    skipCondition?: string;
+    /**
+     * Emit `context` exactly as given, injecting no registry defaults. Set by
+     * `bpmn-decompile` so an imported artifact round-trips unchanged; an author
+     * writing `.activity()` by hand wants the defaults.
+     */
+    contextVerbatim?: boolean;
+}
 ````
 
 ## SubProcessOpts (interface)
@@ -377,6 +600,21 @@ export interface ConnectorOpts {
 }
 ````
 
+## ProcessMetadata (interface)
+
+````ts
+export interface ProcessMetadata {
+    migrationVersion?: string;
+    entryPointId?: string;
+    tags?: string[];
+    caseManagement?: {
+            version: string;
+            value?: string;
+        };
+    executable?: boolean;
+}
+````
+
 ## BuiltBpmn (interface)
 
 ````ts
@@ -389,6 +627,7 @@ export interface BuiltBpmn {
     bindings: BindingDecl[];
     nodes: BpmnNode[];
     flows: BpmnFlow[];
+    metadata?: ProcessMetadata;
 }
 ````
 
@@ -444,6 +683,32 @@ export type BpmnNode = {
     /** `=`-expression that, when true, skips this activity (`uipath:activity/@skipCondition`). */
     skipCondition?: string;
 }) | (ActivityNodeFields & {
+    kind: 'typed';
+    id: string;
+    name?: string;
+    /** The registry extension type, e.g. `'Intsvc.UnifiedHttpRequest'`. */
+    type: string;
+    /** `uipath:context` values, by field name. */
+    context: Record<string, unknown>;
+    /** The payload, shaped by the type's `inputPattern`. */
+    inputs: Record<string, unknown>;
+    /** Variable the output lands in; defaults to `<id>_<outputName>`. */
+    outputVar?: string;
+    /** Extra output rows: variable id → `=`-expression against the node's result. */
+    outputs?: Record<string, string>;
+    /** Output rows spelled out, replacing the derived ones — see `TypedOutputRow`. */
+    outputRows?: TypedOutputRow[];
+    /** `=`-expression that skips the node when truthy. */
+    skipCondition?: string;
+    /** Emit `context` exactly as given — for importers; see `TypedNodeInput`. */
+    contextVerbatim?: boolean;
+}) | (ActivityNodeFields & {
+    kind: 'plainTask';
+    id: string;
+    name?: string;
+    /** Which task element to emit. */
+    element: PlainTaskElement;
+}) | (ActivityNodeFields & {
     kind: 'subProcess';
     id: string;
     name?: string;
@@ -487,6 +752,16 @@ declare class DefinitionsRegistry {
     readonly errors: ErrorDecl[];
     messageRef(name: string): string;
     errorRef(name: string, code?: string): string;
+}
+````
+
+## BindingsRegistry (class)
+
+````ts
+declare class BindingsRegistry {
+    readonly bindings: BindingDecl[];
+    declare(decl: BindingDecl): BindingDecl;
+    has(id: string): boolean;
 }
 ````
 
@@ -534,6 +809,7 @@ export interface BindingDecl {
     propertyAttribute: string;
     default?: string;
     resourceKey?: string;
+    resourceSubType?: string;
 }
 ````
 
@@ -573,6 +849,24 @@ export interface ActivityNodeFields {
     retry?: RetrySpec;
     loop?: LoopSpec;
 }
+````
+
+## TypedOutputRow (interface)
+
+````ts
+export interface TypedOutputRow {
+    name: string;
+    type?: string;
+    var?: string;
+    source?: string;
+    schema?: unknown;
+}
+````
+
+## PlainTaskElement (type)
+
+````ts
+export type PlainTaskElement = 'bpmn:task' | 'bpmn:userTask' | 'bpmn:serviceTask' | 'bpmn:sendTask' | 'bpmn:manualTask' | 'bpmn:businessRuleTask' | 'bpmn:receiveTask';
 ````
 
 ## VarDirection (type)

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ fd0070d. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ c0cf591. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -17,7 +17,7 @@ belong upstream.
 
 Author a UiPath **Case plan** by writing TypeScript that builds a hierarchy of
 **stages** and **tasks**, then serialize it to a `caseplan.json` (schema
-**V20**). Like the Flow builder, this is a *builder*, not a program: you declare
+**V30**). Like the Flow builder, this is a *builder*, not a program: you declare
 the case's shape by calling methods, and flow between stages is expressed with
 **conditions** (`rule(...)`), not edges — a case plan has **no edges**.
 
@@ -210,7 +210,7 @@ export declare function casePlan(id: string): CaseBuilder;
     stage(label: string, fn: (s: StageBuilder) => void): this;
 
 /**
-     * Add a secondary/exception stage (`case-management:ExceptionStage`).
+     * Add a secondary/exception stage (`case-management:Stage` with `data.stageType: "secondary"`).
      *
      * @param label - The stage's display name.
      * @param fn - Receives a sub-builder for the stage's tasks and conditions.
@@ -221,11 +221,11 @@ export declare function casePlan(id: string): CaseBuilder;
 /**
      * Add a case-completion rule (`metadata.caseExitRules`, `marksCaseComplete: true` by default).
      *
-     * @param rules - One rule, or an array for an AND-group.
+     * @param rules - One rule, an AND-group, or the complete OR-of-AND grid.
      * @param opts - `displayName`, and whether meeting it completes the case.
      * @returns This builder, so calls chain.
      */
-    completeWhen(rules: CaseRule | CaseRule[], opts?: {
+    completeWhen(rules: CaseRuleGrid, opts?: {
         displayName?: string;
         marksCaseComplete?: boolean;
     }): this;
@@ -327,22 +327,22 @@ export interface JsonSchemaType {
     required(value?: boolean): this;
 
 /**
-     * Add a stage-entry condition (OR-group). Pass an array of rules for an AND-group.
+     * Add a stage-entry condition. Pass a nested array for the complete OR-of-AND grid.
      *
-     * @param rules - One rule, or an array for an AND-group.
+     * @param rules - One rule, an AND-group, or the complete OR-of-AND grid.
      * @param opts - `displayName`, and the entry behaviour flags.
      * @returns This builder, so calls chain.
      */
-    entryWhen(rules: CaseRule | CaseRule[], opts?: EntryOpts): this;
+    entryWhen(rules: CaseRuleGrid, opts?: EntryOpts): this;
 
 /**
-     * Add a stage-exit condition (OR-group). Pass an array of rules for an AND-group.
+     * Add a stage-exit condition. Pass a nested array for the complete OR-of-AND grid.
      *
-     * @param rules - One rule, or an array for an AND-group.
+     * @param rules - One rule, an AND-group, or the complete OR-of-AND grid.
      * @param opts - `displayName`, and whether meeting it completes the stage.
      * @returns This builder, so calls chain.
      */
-    exitWhen(rules: CaseRule | CaseRule[], opts?: ExitOpts): this;
+    exitWhen(rules: CaseRuleGrid, opts?: ExitOpts): this;
 
 /**
      * Add a task. `fn` receives a task sub-builder. `lane` selects a parallel lane (default 0).
@@ -597,13 +597,13 @@ export interface WaitConnectorSpec {
     }>): this;
 
 /**
-     * Add a task-entry condition (OR-group). Pass an array of rules for an AND-group.
+     * Add a task-entry condition. Pass a nested array for the complete OR-of-AND grid.
      *
-     * @param rules - One rule, or an array for an AND-group.
+     * @param rules - One rule, an AND-group, or the complete OR-of-AND grid.
      * @param opts - `displayName` for the condition.
      * @returns This builder, so calls chain.
      */
-    entryWhen(rules: CaseRule | CaseRule[], opts?: {
+    entryWhen(rules: CaseRuleGrid, opts?: {
         displayName?: string;
     }): this;
 
@@ -760,16 +760,16 @@ authored offline.
 
 ## Conditions — `rule(type, opts?)`
 
-Combine rules into an **AND-group** by passing an array to
-`entryWhen`/`exitWhen`/`completeWhen`; call those methods multiple times for
-**OR-groups** (DNF).
+Pass one rule, an array for an **AND-group**, or an array of arrays for the
+complete **OR-of-AND grid** to `entryWhen`/`exitWhen`/`completeWhen`.
 
 <!-- GEN:conditions -->
 
 ```ts
 /**
- * Declare a condition rule. Combine rules into AND-groups by passing an array to
- * `entryWhen`/`exitWhen`/etc.; call those methods multiple times for OR-groups.
+ * Declare a condition rule. Pass one rule, an array for an AND-group, or an
+ * array of arrays for the complete OR-of-AND grid to
+ * `entryWhen`/`exitWhen`/etc.
  *
  * @param type - Which condition, e.g. `'case-entered'` or `'selected-tasks-completed'`.
  * @param opts - What the rule needs, e.g. the `tasks` a task-completion rule waits on.
@@ -784,7 +784,7 @@ export interface RuleOpts {
      * Symbolic stage label (for `selected-stage-completed` / `selected-stage-exited`).
      *
      * @remarks
-     * Both rules serialize identically — to `selectedStageId` — so this SDK draws no
+     * Both rules serialize identically — to the one-element `selectedStageIds` array — so this SDK draws no
      * distinction between them; the difference is interpreted at runtime. Use
      * `selected-stage-exited` for an interrupting exception-stage entry (what the
      * shipped example does) and `selected-stage-completed` when you mean the stage
@@ -1002,7 +1002,7 @@ export interface TimerTriggerOpts {
 
 /**
  * An Integration Service **event** trigger — an external event (a new row, an
- * email, a webhook) starts the case. Emits `data.uipath.serviceType:
+ * email, a webhook) starts the case. Emits `data.inputs.serviceType:
  * "Intsvc.EventTrigger"`; payload fields map onto its `outputs[]`.
  *
  * @param opts - The connector event to subscribe to, and its connection.
@@ -1020,7 +1020,7 @@ export interface EventTriggerOpts {
      * emits a trigger `outputs[]` row plus a readable root `inputOutputs` companion.
      *
      * @remarks
-     * With **no** outputs the event trigger is a **placeholder** (`data.uipath`
+     * With **no** outputs the event trigger is a **placeholder** (`data.inputs`
      * carries only `serviceType`) — the offline shape for an event on a connector
      * not yet registered; attach the real connection after registering it.
      */
@@ -1068,16 +1068,17 @@ export default casePlan('nightly-sweep')
   .build();
 ```
 
-- **`manualTrigger({ name?, description? })`** — a `case-management:Trigger` node
-  with **no `data.uipath`** (that absence is the manual signature).
+- **`manualTrigger({ name?, description? })`** — a `uipath.case.trigger` node
+  with `data.typeVersion: '1.0.0'` and **no `data.inputs`** (that absence is the
+  manual signature). Its name is at `data.display.label`.
 - **`timerTrigger({ every, name?, description? })`** — `every` is an **ISO-8601
   repeating interval**, emitted verbatim as `timeCycle`: `R/PT1H` (hourly,
   unbounded), `R5/P1D` (5×, daily), `R5/<iso>/P1D` (5×, daily from an explicit
-  start). Emits `data.uipath = { serviceType: 'Intsvc.TimerTrigger', timerType:
-  'timeCycle', timeCycle }`.
+  start). Emits `data.inputs = { timerType: 'timeCycle', timeCycle,
+  serviceType: 'timer' }`.
 - **`eventTrigger({ name?, description?, outputs? })`** — an Integration Service
-  **event** start. Emits `data.uipath.serviceType: 'Intsvc.EventTrigger'`. With no
-  `outputs` it is a **placeholder** (`data.uipath` = only `serviceType`) — the
+  **event** start. Emits `data.inputs.serviceType: 'Intsvc.EventTrigger'`. With no
+  `outputs` it is a **placeholder** (`data.inputs` = only `serviceType`) — the
   offline shape for an event on a connector not yet registered. `outputs` maps
   payload fields to readable case variables, e.g.
   `eventTrigger({ name: 'Order', outputs: { orderId: '=response.id' } })` →
@@ -1134,9 +1135,9 @@ casePlan('intake').name('Intake').identifier('IN')
 A bound In-arg emits three coordinated pieces: a **formal slot**
 (`variables.inputs[]`, `elementId` = the trigger node), a **companion**
 (`variables.inputOutputs[]`, `id` = the arg name, what `=vars.<name>` resolves),
-and a **bridge** on the trigger node's `data.uipath.outputs[]` that copies the slot
+and a **bridge** on the trigger node's `data.inputs.outputs[]` that copies the slot
 into the companion at fire. Binding an In-arg to a **manual** trigger gives that
-node a `data.uipath = { outputs: … }` **with no `serviceType`** (it stays manual).
+node a `data.inputs = { outputs: … }` **with no `serviceType`** (it stays manual).
 An `.input(...)` **without** `{ from }` stays a bare declaration (no binding).
 `from` must be a trigger you added with `.trigger(...)`.
 
@@ -1292,7 +1293,7 @@ export default casePlan('claim-review')
   also cover an escalation that notifies no one and a deadline with no
   escalations at all.
 - **Do not call `.version()`.** The Case JSON schema version is owned by the
-  serializer's format profile (currently V20). The compatibility method is
+  serializer's format profile (currently V30). The compatibility method is
   deprecated; `check` warns on any use and rejects a value that differs from the
   profile.
 - **`unit` is CALENDAR time, and there is no business-day unit.** `uip` enforces
@@ -1390,16 +1391,18 @@ directly with `node node_modules/@uipath/flow-sdk/dist/case/<name>-cli.js`.
   static check, then serializes to `caseplan.json` (default output name). Pair it
   with `uip maestro case validate` for the authoritative gate.
 - **`decompile`** (`uip maestro case decompile <caseplan.json> [-o Name.case.ts]`)
-  — the reverse: reads an existing V20 caseplan and emits builder source whose
-  default export re-serializes to the same caseplan. This is how you edit a case
+  — the reverse: reads an existing V20–V30 caseplan and emits builder source
+  whose default export re-serializes it losslessly. This is how you edit a case
   you did not author in this session: **decompile → edit the `.case.ts` →
   recompile**. The emitted `import` resolves to `@uipath/flow-sdk/case`; override
-  it with `--import <specifier>` when placing the file elsewhere.
+  it with `--import <specifier>` when placing the file elsewhere. The generated
+  `preserveCaseJson(...)` call carries non-authoring designer metadata alongside
+  the typed source; leave it intact except when deleting the typed construct to
+  which an identity entry belongs.
 
-  > Not reconstructed by decompile: triggers of any kind (a manual trigger is
-  > assumed), SLAs/escalations, and the Gap-E action fields (labels, catalog,
-  > form `inputs`/`outputs`). Re-add those by hand after decompiling, or the
-  > recompiled caseplan will silently drop them.
+  > Unsupported Phase 3 constructs fail decompile with a named refusal; the
+  > command does not silently drop them. Do not edit `node_modules` or a compiled
+  > `caseplan.json` to work around a refusal.
 
 Programmatic equivalents (`checkCase(built)` / `serializeCase(built)`) exist on the
 barrel, but the barrel is not importable from the authoring workspace (see the

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -15,14 +15,15 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Option shapes** — [RuleOpts](#ruleopts-interface) · [EscalationOpts](#escalationopts-interface) · [ManualTriggerOpts](#manualtriggeropts-interface) · [TimerTriggerOpts](#timertriggeropts-interface) · [EventTriggerOpts](#eventtriggeropts-interface) · [SlaOpts](#slaopts-interface) · [EntryOpts](#entryopts-interface) · [ExitOpts](#exitopts-interface) · [ConnectorOpts](#connectoropts-interface)
 
-**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-interface) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TypeDesc](#typedesc-type) · [BuiltCase](#builtcase-interface) · [BuiltStage](#builtstage-interface) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [TimerSpecData](#timerspecdata-interface) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface)
+**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-interface) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TypeDesc](#typedesc-type) · [CaseRuleGrid](#caserulegrid-type) · [BuiltCase](#builtcase-interface) · [BuiltStage](#builtstage-interface) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [TimerSpecData](#timerspecdata-interface) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface)
 
 ## rule (function)
 
 ````ts
 /**
- * Declare a condition rule. Combine rules into AND-groups by passing an array to
- * `entryWhen`/`exitWhen`/etc.; call those methods multiple times for OR-groups.
+ * Declare a condition rule. Pass one rule, an array for an AND-group, or an
+ * array of arrays for the complete OR-of-AND grid to
+ * `entryWhen`/`exitWhen`/etc.
  */
 export declare function rule(type: CaseRuleType, opts?: RuleOpts): CaseRule;
 ````
@@ -67,7 +68,7 @@ export declare function timerTrigger(opts: TimerTriggerOpts): BuiltTrigger;
 ````ts
 /**
  * An Integration Service **event** trigger — an external event (a new row, an
- * email, a webhook) starts the case. Emits `data.uipath.serviceType:
+ * email, a webhook) starts the case. Emits `data.inputs.serviceType:
  * "Intsvc.EventTrigger"`; payload fields map onto its `outputs[]`.
  */
 export declare function eventTrigger(opts?: EventTriggerOpts): BuiltTrigger;
@@ -139,10 +140,10 @@ declare class CaseBuilder {
     trigger(t: BuiltTrigger): this;
     /** Add a primary stage. `fn` receives a stage sub-builder. */
     stage(label: string, fn: (s: StageBuilder) => void): this;
-    /** Add a secondary/exception stage (`case-management:ExceptionStage`). */
+    /** Add a secondary/exception stage (`case-management:Stage` with `data.stageType: "secondary"`). */
     exceptionStage(label: string, fn: (s: StageBuilder) => void): this;
     /** Add a case-completion rule (`metadata.caseExitRules`, `marksCaseComplete: true` by default). */
-    completeWhen(rules: CaseRule | CaseRule[], opts?: {
+    completeWhen(rules: CaseRuleGrid, opts?: {
             displayName?: string;
             marksCaseComplete?: boolean;
         }): this;
@@ -169,10 +170,10 @@ declare class StageBuilder {
     task(displayName: string, fn: (t: TaskBuilder) => void, opts?: {
             lane?: number;
         }): this;
-    /** Add a stage-entry condition (OR-group). Pass an array of rules for an AND-group. */
-    entryWhen(rules: CaseRule | CaseRule[], opts?: EntryOpts): this;
-    /** Add a stage-exit condition (OR-group). Pass an array of rules for an AND-group. */
-    exitWhen(rules: CaseRule | CaseRule[], opts?: ExitOpts): this;
+    /** Add a stage-entry condition. Pass a nested array for the complete OR-of-AND grid. */
+    entryWhen(rules: CaseRuleGrid, opts?: EntryOpts): this;
+    /** Add a stage-exit condition. Pass a nested array for the complete OR-of-AND grid. */
+    exitWhen(rules: CaseRuleGrid, opts?: ExitOpts): this;
     /**
      * Set an SLA (deadline + escalations) on this stage. Call more than once for
      * conditional SLAs (each with a `when` gate); the default SLA (no `when`) must
@@ -276,8 +277,8 @@ declare class TaskBuilder {
             source: string;
             type?: TypeDesc;
         }>): this;
-    /** Add a task-entry condition (OR-group). Pass an array of rules for an AND-group. */
-    entryWhen(rules: CaseRule | CaseRule[], opts?: {
+    /** Add a task-entry condition. Pass a nested array for the complete OR-of-AND grid. */
+    entryWhen(rules: CaseRuleGrid, opts?: {
             displayName?: string;
         }): this;
 }
@@ -545,6 +546,12 @@ export interface TaskOutputBinding {
 
 ````ts
 export type TypeDesc = (typeof types)[keyof typeof types];
+````
+
+## CaseRuleGrid (type)
+
+````ts
+export type CaseRuleGrid = CaseRule | CaseRule[] | CaseRule[][];
 ````
 
 ## BuiltCase (interface)

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ fd0070d. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ c0cf591. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in

--- a/preview/uipath-maestro-flow/references/connector-params.md
+++ b/preview/uipath-maestro-flow/references/connector-params.md
@@ -51,6 +51,96 @@ prepare-connector <connector-key> <action> \
 # Use --all-objects only when the task truly needs the full connected catalog.
 ```
 
+For many connectors that first command is **not enough on its own** — see the
+parent-field loop below before concluding a field does not exist.
+
+## Schema-dynamic operations: the parent-field loop
+
+A connection alone does not resolve these operations. Their real field set is a
+function of the **values** of a few *parent* fields, so the same operation on the
+same connection has many different shapes. Measured on one live Jira tenant,
+`create-issue`:
+
+| parent values | fields |
+| --- | --- |
+| none | **2** — just the parents themselves |
+| project `IN` + issue type `Task` | **19** |
+| project `IN` + issue type `Epic` | **22**, a different set |
+| project `AP` + issue type `Task` | **15** |
+
+Both dimensions matter independently, and `fields.summary` — *required* — appears
+in none of the snapshot's static inputs.
+
+**Two ways to get this wrong, and only one of them is loud.**
+
+*Naming too few parents is refused*, clearly:
+
+```
+Result:  Failure
+Message: No api-type ObjectAction matched for fields [fields.project.key]
+         on operation 'Create'
+```
+
+*Naming them all but passing a value the connection does not have is not.* The
+shape is accepted, the describe succeeds, and it resolves to exactly the parent
+fields again — the same 2-field answer as passing no `-f` at all, with no error.
+Treat "I passed `-f` and still got only the parents" as a wrong value, never as
+"this operation has no other inputs." `prepare-connector` fails on both cases
+rather than writing the overlay.
+
+**1. Find the parents.** Describe with no values and read the reference block of
+each input. A parent is any input whose `Reference.Path` contains a
+`{placeholder}` naming another field:
+
+```bash
+uip is resources describe <connector-key> <object> \
+  --connection-id <connection-id> --operation <Operation> --output json
+```
+
+```jsonc
+{ "Name": "fields.issuetype.id",
+  "Reference": { "ObjectName": "project",
+                 "Path": "/project/{fields.project.key}/issuetypes" } }
+```
+
+That placeholder is also the **ordering**: resolve `fields.project.key` before
+you can resolve `fields.issuetype.id`.
+
+**2. Resolve a value for each, outermost first.** Match the collection on
+`Reference.Path`, *not* on `Reference.ObjectName` — `ObjectName` is often the
+root resource shared by several fields (both Jira parents above report
+`project`), and the sub-collection the path names may not be a listable object at
+all. When it is not, find the object whose own path covers it:
+
+```bash
+uip is resources list <connector-key> --connection-id <connection-id> --output json   # find the object
+uip is resources describe <connector-key> <object> --connection-id <connection-id>    # confirm its Path
+uip is resources run list <connector-key> <object> --connection-id <connection-id> \
+  --query "<path-param>=<value-from-the-previous-parent>" --output json
+```
+
+For Jira, `/project/{key}/issuetypes` has no object of its own; `project_statuses`
+(`/project/{projectIdOrKey}/statuses`) covers it and returns the ids.
+
+**3. Prepare with every parent.** Pass them all as `-f NAME=VALUE`:
+
+```bash
+prepare-connector <connector-key> <action> --connection-id <connection-id> \
+  -f fields.project.key=IN -f fields.issuetype.id=10620
+```
+
+`prepare-connector` quotes the service's rejection, and separately fails when the
+values were accepted but resolved to nothing beyond the parents — so both
+mistakes surface here rather than as a puzzling compile error later.
+
+**Values are parent-scoped and non-portable.** A Jira issue-type id is valid only
+inside its project (`Task` is `10620` in `IN` and `10005` in `AP`), so ids cannot
+be copied between projects, connections, or tasks — resolve them against the
+connection the flow actually binds. The materialized field set is likewise
+tenant-specific: custom fields captured from one connection
+(`fields.storyPointEstimate_Customfield10016`) may not exist on another at deploy.
+Standard fields (`summary`, `description`) are portable.
+
 The command prints the generated descriptor import and `connector(...)` call.
 Use that descriptor directly: it carries the connection-resolved operation and
 object identity even when the live action id differs from the baked catalog.
@@ -95,12 +185,22 @@ Resolve them against the same connection the flow binds instead of copying an id
 from another connection or session:
 
 **Choose the collection from the prepared action definition before the first
-`resources run list` call.** Run `prepare-connector` first, find the target
-input's `reference` block in its generated `connectors-local/*.v1def.json`, and
-use the collection segment of `reference.objectName` (the part before `?`) as
-`<object-name>` below. Confirm it against `reference.path`. Do not guess or
-substitute a similar generic collection: two collections can return the same
-records while only the declared reference collection is the action's contract.
+`resources run list` call.** Run `prepare-connector` first and find the target
+input's `reference` block in its generated `connectors-local/*.v1def.json`.
+`reference.path` is the contract — it names the exact collection, and any
+`{placeholder}` in it names a field whose value must be resolved first.
+`reference.objectName` is only a starting point: it is frequently the shared root
+resource (several Jira inputs report `project` while their paths differ), so it
+cannot by itself identify the collection.
+
+Use `objectName` as `<object-name>` below **only when** `uip is resources
+describe <connector-key> <objectName>` reports a `Path` matching
+`reference.path`. When it does not — a sub-collection often has no listable
+object of its own — find the object whose declared `Path` covers
+`reference.path` and use that, passing the placeholder as a `--query` parameter.
+Do not substitute a similar generic collection on name resemblance alone: two
+collections can return the same records while only the one on `reference.path`
+is the action's contract.
 
 ```bash
 uip is resources run list <connector-key> <object-name> \


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `fd0070d` to current `UiPath/flow-builder-sdk@main` (`c0cf591`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)