### PR TITLE
fix(data-fabric): clarify schema `name` vs query `fieldName`; accept `--file` in entity-scope create check

### DIFF
--- a/tests/tasks/uipath-platform/data-fabric/integration_entity_scope.yaml
+++ b/tests/tasks/uipath-platform/data-fabric/integration_entity_scope.yaml
@@ -71,7 +71,7 @@ success_criteria:
   - type: command_executed
     description: "Agent created CE_FolderScopeTest in a folder with a valid schema body"
     tool_name: "Bash"
-    command_pattern: '(?s)uip\s+df\s+entities\s+create\s+"?CE_FolderScopeTest"?(?=.*--folder-key)(?=.*\\?\"name\\?\")'
+    command_pattern: '(?s)uip\s+df\s+entities\s+create\s+"?CE_FolderScopeTest"?(?=.*--folder-key)(?=.*(\\?\"name\\?\"|--file))'
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0


### PR DESCRIPTION
Follow-up to the field-`name`-shape work (merged), from two coder-eval failures.

## 1. Skill: `name` vs `fieldName` (root cause of an expense-tracker failure)
Data Fabric uses **two keys for "a field's name" depending on context**:
- **Entity schema** (`create` / `addFields`) → `name`
- **Query filters / `sortOptions`** (`records query`) → `fieldName`

When a task mixes both (create entities *and* query them), agents conflate the keys and send `fieldName` in a create body. The field then arrives with no name and CEP rejects the **whole** atomic create with `"Field name is not provided in request."`, collapsing the task. Observed live on gpt-5.6-terra (CLI `1.201.0-dev.8272`, which includes the `fieldName`→`name` rename).

`entity-schema.md` now calls this out explicitly at the field-definition rules.

## 2. Eval task: entity-scope create check should accept `--file`
`integration_entity_scope`'s "created CE_FolderScopeTest with a valid schema" `command_executed` check required the field schema **inline** (`(?=.*"name")`). An agent (Sonnet) that writes the schema to a file and runs `entities create … --file schema.json --folder-key …` — a valid approach — false-failed, since `"name"` is in the file, not the command. Loosened the pattern to accept `--file` as valid schema evidence.

No checks deleted; correctness stays gated by outcome checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)