### PR TITLE
fix(release): unblock publish — sync .cursor-plugin version + guard drift on PRs

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "uipath",
   "displayName": "UiPath",
-  "version": "1.200.0",
+  "version": "1.201.0",
   "description": "UiPath plugin for Cursor — skills for building, running, testing, and deploying UiPath automations, agents, coded apps, and platform operations.",
   "author": {
     "name": "UiPath",

--- a/.github/workflows/validate-version-sync.yml
+++ b/.github/workflows/validate-version-sync.yml
@@ -1,0 +1,44 @@
+name: Validate Version Sync
+
+concurrency:
+  group: validate-version-sync-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+on:
+  # No `paths:` filter on purpose, for two reasons:
+  #
+  # 1. Required-check safety (same rationale as smoke-skills.yml): if `paths:`
+  #    excluded a PR the workflow wouldn't run, no check would be reported, and
+  #    merge would block forever. This job is cheap enough (checkout + node +
+  #    one dependency-free script) to just always run.
+  # 2. Drift can be introduced from more places than a path list reliably
+  #    covers — `package.json`, any of the four derived manifests, or
+  #    `sync-version.mjs` itself gaining a new mirror path. An out-of-date
+  #    `paths:` list is exactly how the drift this guard exists to catch got
+  #    through in the first place.
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-version-sync:
+    runs-on: uipath-ubuntu-latest
+    name: Validate version sync
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4.4.0
+        with:
+          node-version: "22.x"
+
+      # Byte-identical to the `guard` job in publish.yml, so a green check here
+      # means publish.yml's guard will pass on merge. Without this, version
+      # drift is only discoverable AFTER merge, at publish time — and because
+      # every publish job declares `needs: [guard]`, a single stale manifest
+      # silently blocks `dev`, `preview`, and every flavor package until someone
+      # notices nothing has shipped.
+      #
+      # `sync-version.mjs` has no dependencies, so there is no install step.
+      - name: Check manifests are in sync with package.json
+        run: node scripts/sync-version.mjs --check

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -25,7 +25,7 @@ All channels carry `package.json`'s version; the pre-release channels (`dev`, `p
 | `@uipath/skills` | `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per push to `main`, or dev dispatch |
 | `@uipath/skills-studioweb` | `preview` | GitHub Packages | `M.N.<release>-preview.<run>` | per push to `release/v*`, or preview dispatch |
 | `@uipath/skills-studioweb` | `dev` | GitHub Packages | `M.N.<release>-dev.<run>` | per push to `main`, or dev dispatch |
-| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`) | — | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex plugin auto-update |
+| plugin manifests (`.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`) | — | — | `M.N.<release>` (base version, no pre-release suffix) | per `package.json` bump — drives Claude Code / Codex / Cursor plugin auto-update |
 
 `sync-version.mjs` enforces the line: the plugin version always equals `package.json`'s base `M.N.P` — there is **no independent plugin patch counter**. It **refuses to downgrade** (plugin auto-update never goes backwards, so a reverted `package.json` would freeze users), and it strips pre-release suffixes so the `dev`/`preview` stamps from `publish.yml` never land in the plugin manifests. The marketplace, Codex, and Cursor versions must always equal the plugin version exactly. `--check` fails on any violation, so a hand-bumped plugin manifest cannot drift the line. To bump the plugin version, bump `package.json` and run the sync — that is the only lever.
 
@@ -35,6 +35,15 @@ Run after any version change:
 npm run version:sync      # rewrite derived manifests from package.json
 npm run version:check     # CI guard — non-zero exit if drifted
 ```
+
+`version:check` runs in two places. `validate-version-sync.yml` runs it on every
+pull request, so drift fails pre-merge. The `guard` job in `publish.yml` runs it
+again on merge; because every publish job declares `needs: [guard]`, a single
+stale manifest blocks `dev`, `preview`, and every flavor package at once — with
+no failure louder than nothing shipping. **A PR that adds a new derived manifest
+to `PATHS` in `sync-version.mjs` must run `npm run version:sync` as its last
+step before merge**, or it lands the stale value together with the check that
+rejects it.
 
 ### Why lockstep with the CLI
 


### PR DESCRIPTION
## Problem

**Publish has been broken on every channel since #2403 merged.**

The `guard` job in `.github/workflows/publish.yml` runs `node scripts/sync-version.mjs --check`, which exits 1:

```
✗ Version drift detected (run `npm run version:sync`):
  - .cursor-plugin/plugin.json: 1.200.0 -> 1.201.0
```

All four publish jobs declare `needs: [guard]`, so `publish-dev`, `publish-npmjs`, `publish-studioweb-dev`, and `publish-studioweb-preview` have all been skipped on every push to `main` since then. No `dev`, `preview`, or flavor package has shipped — and nothing failed louder than nothing shipping.

## Root cause

Two commits raced past each other:

| Commit | What it did |
|---|---|
| #2530 — `chore(release): bump main to 1.201.0` | Bumped `package.json`, `version-manifest.json`, `.claude-plugin/plugin.json`, `marketplace.json`, `.codex-plugin/plugin.json` to `1.201.0`. `.cursor-plugin/` did not exist yet. |
| #2403 — `feat: add Cursor .cursor-plugin manifest` | Branched off the **1.200** line. Added `.cursor-plugin/plugin.json` with `"version": "1.200.0"` hardcoded, **and** taught `sync-version.mjs` to enforce that it equals the canonical plugin version. |

#2403 therefore shipped both the stale value and the check that rejects it. Nothing in the Cursor manifest is otherwise malformed — this is purely the version value.

## Commit 1 — unblock publish

One line, generated by the script that owns it:

```bash
npm run version:sync    # .cursor-plugin/plugin.json: 1.200.0 -> 1.201.0
npm run version:check   # ✓ All manifests in sync (package 1.201.0, plugin 1.201.0, targetCli ^1.201.0)
```

Verified locally — `--check` passes, so the `guard` job goes green and the publish jobs run again on the next push to `main`.

## Commit 2 — stop it recurring

`sync-version.mjs` was only invoked from `publish.yml`, `publish-skill-flavor.yml`, and `sprint-release-cut.yml` — **no `pull_request`-triggered workflow ran `npm run version:check`**. Drift was structurally undiscoverable until after merge. (`sprint-release-cut.yml` re-runs the sync at lines 165 and 273, so the next weekly cut would have silently masked this — with publish broken until then.)

New `.github/workflows/validate-version-sync.yml` reproduces `publish.yml`'s `guard` step verbatim on `pull_request`, so identical drift fails pre-merge.

**On the required-check question raised in the first revision of this PR — resolved by design.** The workflow has **no `paths:` filter**, for two reasons:

1. It is safe to promote to a required check as-is. A `paths:`-excluded PR reports no check and blocks merge forever — the trap documented at the top of `smoke-skills.yml`.
2. A path list cannot reliably enumerate where drift comes from: `package.json`, any of the four derived manifests, or `sync-version.mjs` itself gaining a new mirror path. An out-of-date `paths:` list is the same category of omission as the bug this guard exists to catch.

The job is a checkout plus one dependency-free script (no `npm ci`), so always running it costs less than maintaining the list. Action SHAs and `node-version` match `publish.yml`'s guard exactly, so a green check here means the merge-time guard passes.

Also folds in the `docs/RELEASE.md` hardening (originally listed as a separate follow-up):

- Records that `version:check` runs in two places, and that a stale manifest blocks all channels at once.
- States that a PR adding a new derived manifest to `PATHS` must run `npm run version:sync` as its last step before merge — the general class of this bug.
- Adds `.cursor-plugin/plugin.json` to the manifest table row on line 28, which #2403 missed when it updated the table above it.

## Verification

- `npm run version:check` → passes.
- `.github/workflows/validate-version-sync.yml` parses as valid YAML; action pins match the repo's SHA-pinned convention (`actions/checkout@11d5960a`, `actions/setup-node@49933ea5`).
- No CODEOWNERS change needed — `/.github/` is already owned by @uipreliga @bai-uipath @akshaylive.

## Suggested follow-up (not in this PR)

Add `Validate version sync` to the branch protection required-check list for `main`. The workflow is built for it, but flipping that setting is a repo-admin action, not a code change.

## Unrelated observation

`.codex-plugin` is **not** in `package.json`'s `files` array while `.cursor-plugin` is (added by #2403). If the Codex channel is meant to ship in the npm tarball, that is a separate gap — not what breaks publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
