### PR TITLE
chore(skills): own IXP flow-skill paths with @UiPath/communications-mining [RE-13333]

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -138,8 +138,8 @@
 /tests/tasks/uipath-maestro-flow/connector_features/ @baishalighosh @chandusailella @mukundbayyaram
 
 # IXP
-/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
-/tests/tasks/uipath-maestro-flow/ixp/ @jcalero @constantinmuraru @scallaway-uipath @tommilligan @joe-prosser @vlad-crisan @richsilv @AWilcke
+/skills/uipath-maestro-flow/references/author/references/plugins/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan
+/tests/tasks/uipath-maestro-flow/ixp/ @UiPath/communications-mining @constantinmuraru @vlad-crisan
 
 # Review skill
 /skills/uipath-review/ @AlvinStanescu @gabrielavaduva @roalexandru


### PR DESCRIPTION
Every PR that touches the flow skill's IXP paths currently requests eight IXP engineers by name — #2756 carries 25 individual review requests across its away-team blocks. The list is also maintained by hand, so it drifts as people join and leave and nothing keeps it honest.

Both IXP lines now point at `@UiPath/communications-mining`, matching how `@UiPath/team-merlot`, `@UiPath/llmops-team`, `@UiPath/team-coded-agents` and `@UiPath/DatafabricCodingAgent` are already listed in this file.

**Benefits**

- **One review request instead of eight.** Approval from any team member satisfies the code-owner gate, exactly as today.
- **Ownership follows team membership.** No CODEOWNERS PR needed when someone joins or leaves the team.

**Ownership delta**

- @constantinmuraru and @vlad-crisan are kept as individual owners — they aren't members of the team.
- Tom Milligan is removed; no longer at UiPath.
- The remaining five (@jcalero, @scallaway-uipath, @joe-prosser, @richsilv, @AWilcke) are all in the team, so they keep ownership through it.

The team was granted write access to this repo on 2026-08-24 (thanks @rockymadden) — GitHub only honours a team code owner when the team itself has write access, regardless of what its members already have individually.

**Test plan**

- CODEOWNERS validation reports no "Unknown owner" error on the two IXP lines.
- The next PR touching `tests/tasks/uipath-maestro-flow/ixp/` requests `@UiPath/communications-mining` as a single reviewer instead of eight individuals.

RE-13333
