### PR TITLE
fix(release): stage every derived manifest in the sprint-cut bump

### DIFF
--- a/.github/workflows/sprint-release-cut.yml
+++ b/.github/workflows/sprint-release-cut.yml
@@ -163,7 +163,19 @@ jobs:
             # here. Commit only if the version actually changed (no empty commit).
             npm version "$LINE.0" --no-git-tag-version --allow-same-version
             node scripts/sync-version.mjs
-            git add package.json version-manifest.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
+            # Stage exactly the file set sync-version.mjs owns, read back from
+            # the script itself. A hardcoded list silently drops any channel
+            # added later: that is how `.cursor-plugin/plugin.json` was left
+            # out of the 1.201 cut, which failed publish.yml's `guard` job and
+            # blocked every publish channel until #2767. Unquoted expansion is
+            # intended -- the list is newline-separated and no path contains
+            # whitespace.
+            MANIFESTS="$(node scripts/sync-version.mjs --list-paths)"
+            if [ -z "$MANIFESTS" ]; then
+              echo "::error::sync-version.mjs --list-paths returned nothing; refusing to commit a partial version bump."
+              exit 1
+            fi
+            git add $MANIFESTS
             if git diff --cached --quiet; then
               echo "release branch matches main at $LINE.0 — no version commit needed."
             else
@@ -271,7 +283,19 @@ jobs:
           git checkout -B "$PR_BRANCH" origin/main
           npm version "$NEXT_LINE.0" --no-git-tag-version --allow-same-version
           node scripts/sync-version.mjs
-          git add package.json version-manifest.json .claude-plugin/plugin.json .claude-plugin/marketplace.json .codex-plugin/plugin.json
+          # Stage exactly the file set sync-version.mjs owns, read back from
+          # the script itself. A hardcoded list silently drops any channel
+          # added later: that is how `.cursor-plugin/plugin.json` was left
+          # out of the 1.201 cut, which failed publish.yml's `guard` job and
+          # blocked every publish channel until #2767. Unquoted expansion is
+          # intended -- the list is newline-separated and no path contains
+          # whitespace.
+          MANIFESTS="$(node scripts/sync-version.mjs --list-paths)"
+          if [ -z "$MANIFESTS" ]; then
+            echo "::error::sync-version.mjs --list-paths returned nothing; refusing to commit a partial version bump."
+            exit 1
+          fi
+          git add $MANIFESTS
           if git diff --cached --quiet; then
             echo "main already at $NEXT_LINE.0 — no bump PR needed."
             exit 0

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -34,7 +34,14 @@ Run after any version change:
 ```bash
 npm run version:sync      # rewrite derived manifests from package.json
 npm run version:check     # CI guard — non-zero exit if drifted
+node scripts/sync-version.mjs --list-paths   # the file set this script owns
 ```
+
+`--list-paths` prints `package.json` plus every derived manifest, one
+repo-relative path per line. `sprint-release-cut.yml` stages exactly that set
+when it commits a bump, so adding a channel to `PATHS` is picked up by release
+automation with no second edit — a hardcoded `git add` list is what dropped
+`.cursor-plugin/plugin.json` from the 1.201 cut.
 
 `version:check` runs in two places. `validate-version-sync.yml` runs it on every
 pull request, so drift fails pre-merge. The `guard` job in `publish.yml` runs it
@@ -43,7 +50,8 @@ stale manifest blocks `dev`, `preview`, and every flavor package at once — wit
 no failure louder than nothing shipping. **A PR that adds a new derived manifest
 to `PATHS` in `sync-version.mjs` must run `npm run version:sync` as its last
 step before merge**, or it lands the stale value together with the check that
-rejects it.
+rejects it. Staging in release automation needs no matching edit — it reads
+`--list-paths`.
 
 ### Why lockstep with the CLI
 

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -34,10 +34,11 @@
  * Usage:
  *   node scripts/sync-version.mjs               # rewrite derived manifests
  *   node scripts/sync-version.mjs --check       # exit 1 if any are out of sync
+ *   node scripts/sync-version.mjs --list-paths  # print the files this script owns
  */
 
 import { readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -59,6 +60,24 @@ const PATHS = {
   codexPlugin: join(ROOT, ".codex-plugin", "plugin.json"),
   cursorPlugin: join(ROOT, ".cursor-plugin", "plugin.json"),
 };
+
+// `--list-paths` prints every file this script owns -- the authoritative
+// package.json plus each derived manifest -- as one repo-relative POSIX path
+// per line, then exits.
+//
+// Release automation stages exactly this set, so adding a channel to PATHS is
+// picked up automatically instead of needing a matching edit to a hardcoded
+// `git add` list. Skipping that edit is what dropped
+// `.cursor-plugin/plugin.json` from the 1.201 sprint-cut commit and blocked
+// every publish channel (#2767).
+//
+// Keep stdout to the paths alone: this is consumed via command substitution.
+if (process.argv.includes("--list-paths")) {
+  for (const p of Object.values(PATHS)) {
+    console.log(relative(ROOT, p).split(sep).join("/"));
+  }
+  process.exit(0);
+}
 
 function readJson(p) {
   return JSON.parse(readFileSync(p, "utf-8"));


### PR DESCRIPTION
## Problem

The automatic version bump does not bump Cursor.

`sprint-release-cut.yml` stages its bump commit with a hardcoded path list, in **two** places (the release-branch cut at line 166 and the bump PR against `main` at line 274):

```bash
git add package.json version-manifest.json .claude-plugin/plugin.json \
        .claude-plugin/marketplace.json .codex-plugin/plugin.json
```

`.cursor-plugin/plugin.json` was never added to that list when #2403 introduced the channel. `node scripts/sync-version.mjs` on the line above **does** rewrite the file correctly — git just never stages it, so the commit ships a partial bump and the rewrite is discarded.

## This is the mechanism behind the 1.201 outage

From the `skills-buddy` sprint-cut announcement in #team-coding-agents ([message](https://uipath-product.slack.com/archives/C0A2T23NJ59/p1787465680980059)):

> :warning: A dev/preview publish FAILED — `@uipath/skills@1.201.0-preview` ([see logs](https://github.com/UiPath/skills/actions/runs/32622368813))
> :white_check_mark: Version-bump PR opened anyway: `main` → `1.202.0` ([PR](https://github.com/UiPath/skills/pull/2760))

Both artifacts of that cut carry the partial bump. #2760's changed-file list is exactly the five hardcoded paths — no `.cursor-plugin/plugin.json`. So `package.json` advanced to `1.202.0` while the Cursor manifest stayed a minor behind, `publish.yml`'s `guard` job failed on the drift, and because every publish job declares `needs: [guard]`, `dev`, `preview`, and every flavor package were blocked until #2767 landed the one-line fix.

Without this PR the same thing happens on the **next** sprint cut, and on every cut after it.

## Fix

Both `git add` sites now read the file set back from the script that owns it:

```bash
MANIFESTS="$(node scripts/sync-version.mjs --list-paths)"
if [ -z "$MANIFESTS" ]; then
  echo "::error::sync-version.mjs --list-paths returned nothing; refusing to commit a partial version bump."
  exit 1
fi
git add $MANIFESTS
```

New `--list-paths` flag on `sync-version.mjs` prints `Object.values(PATHS)` as repo-relative POSIX paths, one per line, then exits before any drift work:

```
package.json
version-manifest.json
.claude-plugin/plugin.json
.claude-plugin/marketplace.json
.codex-plugin/plugin.json
.cursor-plugin/plugin.json
```

A channel added to `PATHS` is now staged automatically, instead of needing a matching edit in a workflow the author has no reason to look at. That decoupling is the actual bug — Cursor is just the instance of it.

### Two details worth reviewing

- **The empty-list check is not defensive boilerplate.** The "Cut release branch" step has no `set -euo pipefail` (unlike the two steps below it), and bare `git add` with no pathspec exits **0** with only a warning. Without the explicit check, a failing `node` would silently produce the same partial-bump commit this PR exists to prevent, one layer further down.
- **`git add $MANIFESTS` is deliberately unquoted** — the list is newline-separated and needs word splitting. No path contains whitespace. Noted in a comment at both sites.

## Verification

Simulated the bump locally on this branch — `npm version 1.202.0 --no-git-tag-version` + `node scripts/sync-version.mjs` + the new staging logic:

```
=== staged by the new logic ===
.claude-plugin/marketplace.json   -> 1.202.0
.claude-plugin/plugin.json        -> 1.202.0
.codex-plugin/plugin.json         -> 1.202.0
.cursor-plugin/plugin.json        -> 1.202.0     <-- previously dropped
package.json                      -> 1.202.0
version-manifest.json             -> 1.202.0
```

Six files staged; the old hardcoded list stages five. Simulation reverted — this PR carries no version change.

Also verified: `sprint-release-cut.yml` still parses as valid YAML, `npm run version:check` passes, and `--check` / no-flag behaviour is unchanged (`--list-paths` returns early only when the flag is present).

`docs/RELEASE.md` documents the flag and notes that release automation no longer needs a matching edit when a channel is added.

## Companion change

#2760 needs `.cursor-plugin/plugin.json` at `1.202.0` before it merges, since it was generated by the buggy staging logic. Pushed there separately — that PR fixes the one bad artifact, this PR fixes the generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
