### PR TITLE
fix(release): accept npm 12's npm pack --json payload shape

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,9 +133,17 @@ jobs:
           node-version: "22.x"
 
       # Node 22 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1.
+      #
+      # Pinned to a major, NOT `npm@latest`. This job is the only one that
+      # upgrades npm, so it is the only one exposed to a new npm major the
+      # moment it ships -- with no repo change to point at. npm 12 renamed the
+      # `npm pack --json` payload from an array to an object keyed by package
+      # name, which broke the nested pack inside our `prepack` hook and stalled
+      # npmjs at 1.199.0 for two release lines. Minor/patch upgrades still flow;
+      # moving majors is now a deliberate edit.
       - name: Upgrade npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@12
           echo "npm $(npm --version) / node $(node --version)"
 
       # `preview` when: dispatch channel=preview, OR an auto push to a

--- a/scripts/compose-skill-flavor.mjs
+++ b/scripts/compose-skill-flavor.mjs
@@ -1338,10 +1338,15 @@ function packStagedPackages(staged, npmRoot, runNpmPack) {
     let filename;
     try {
       const parsed = JSON.parse(result.stdout);
-      if (!Array.isArray(parsed) || parsed.length !== 1 || typeof parsed[0]?.filename !== "string") {
+      // npm <= 11 prints an array of pack results; npm >= 12 prints an object
+      // keyed by package name. Accept both -- the npm major in play is the
+      // runner's, not ours: publish.yml installs npm for OIDC trusted
+      // publishing, and a contributor's global npm is whatever they have.
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+      if (results.length !== 1 || typeof results[0]?.filename !== "string") {
         throw new Error("expected one npm pack result");
       }
-      filename = parsed[0].filename;
+      filename = results[0].filename;
     } catch (error) {
       throw new Error(`could not parse npm pack output for ${name}: ${result.stdout.trim()}`);
     }

--- a/tests/scripts/compose-skill-flavor.test.mjs
+++ b/tests/scripts/compose-skill-flavor.test.mjs
@@ -1216,6 +1216,54 @@ test("pack builds complete, marker-free default and custom npm packages", (t) =>
   }
 });
 
+test("npm pack output parses on both the npm 11 array and npm 12 object shapes", (t) => {
+  // npm <= 11 prints `[ { ...packResult } ]`; npm >= 12 prints
+  // `{ "<packageName>": { ...packResult } }`. Reshape the real npm output into
+  // each form so both are covered whatever npm major runs the suite -- the
+  // object shape broke publishing to npmjs when CI's unpinned `npm@latest`
+  // moved to npm 12.
+  for (const shape of ["array", "object"]) {
+    const repo = fixtureRepo(t);
+    addSkill(repo, "uipath-example");
+    addPackageManifest(repo);
+
+    const runNpmPack = (options) => {
+      const result = runRealNpmPack(options, repo);
+      if (result.status !== 0) return result;
+      const parsed = JSON.parse(result.stdout);
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed);
+      const reshaped =
+        shape === "array"
+          ? results
+          : Object.fromEntries(results.map((entry) => [entry.name, entry]));
+      return { ...result, stdout: JSON.stringify(reshaped, null, 2) };
+    };
+
+    const packages = withNpmCache(repo, () =>
+      packAllVariants(repo, { runNpmPack }),
+    );
+    assert.equal(packages.length, 1, `${shape}: expected one package`);
+    assert.equal(packages[0].packageName, "@uipath/skills", `${shape}: package name`);
+    assert.ok(existsSync(packages[0].tarball), `${shape}: tarball exists`);
+  }
+});
+
+test("npm pack output that names no tarball still fails loudly", (t) => {
+  const repo = fixtureRepo(t);
+  addSkill(repo, "uipath-example");
+  addPackageManifest(repo);
+
+  assert.throws(
+    () =>
+      withNpmCache(repo, () =>
+        packAllVariants(repo, {
+          runNpmPack: () => ({ status: 0, stdout: "{}", stderr: "" }),
+        }),
+      ),
+    /could not parse npm pack output/,
+  );
+});
+
 test("a failed npm pack preserves every last successful generated output", (t) => {
   const repo = fixtureRepo(t);
   addSkill(repo, "uipath-example", block("host", "Default."));


### PR DESCRIPTION
## Problem

**npmjs has published nothing since 2026-08-10.** The 1.200 and 1.201 lines never reached either tag:

```
$ curl -s https://registry.npmjs.org/@uipath%2Fskills
dist-tags: { "latest": "1.199.0", "preview": "1.199.0-preview.276" }
```

Every attempt fails inside `npm publish`'s own prepack hook — e.g. [run 32735569160](https://github.com/UiPath/skills/actions/runs/32735569160/job/97457945836) (`release/v1.200`, channel `latest`):

```
npm notice run @uipath/skills@1.200.0 prepack
npm notice run node scripts/npm-package-lifecycle.mjs prepare
ERROR: could not parse npm pack output for @uipath/skills: {
  "@uipath/skills": { "id": "@uipath/skills@1.200.0", ... }
npm error command failed
```

The `guard` job passed in that run. This is **not** the version-drift outage fixed by #2767 — it is a second, independent break on the npmjs channel only.

## Root cause: npm 12 changed the `npm pack --json` payload shape

`scripts/compose-skill-flavor.mjs:1341` required an array:

```js
if (!Array.isArray(parsed) || parsed.length !== 1 || typeof parsed[0]?.filename !== "string") {
```

npm ≤ 11 prints `[ {...} ]`. npm 12 prints `{ "<packageName>": {...} }`. Verified directly against both majors rather than inferred from the log:

```
npm 11 (array)   current   OK   -> shape-probe-1.0.0.tgz
npm 11 (array)   proposed  OK   -> shape-probe-1.0.0.tgz
npm 12 (object)  current   THROW-> expected one npm pack result   <-- the CI failure
npm 12 (object)  proposed  OK   -> shape-probe-1.0.0.tgz
```

The failing path is a **nested** pack: root `npm publish` → `prepack` → `npm-package-lifecycle.mjs prepare` → `prepareRootDefaultPackage` → `packStagedPackages`, which composes and verifies the marker-free default tree before the real tarball is built.

**No repo change triggered this.** `publish-npmjs` is the only job in the repo that runs `npm install -g npm@latest` — it has to, because OIDC trusted publishing needs npm ≥ 11.5.1. So it was the only job to pick up npm 12 the day it shipped. `publish-dev`, both Studio Web flavor jobs, and every PR check keep Node 22's bundled npm 10.x, hit the array path, and stayed green. That asymmetry is exactly why the outage looked like "npmjs is broken" rather than "the packer is broken".

## Impact

- npmjs `latest` and `preview` frozen at `1.199.0` for two full release lines.
- Per `docs/RELEASE.md`, `uip skills install` resolves `@uipath/skills` from npmjs matched to the CLI's own `MAJOR.MINOR` (`pickMatchingSkillsVersion`). **A CLI on the 1.200 or 1.201 line currently resolves no skills package at all.**
- Locally, any contributor on npm 12+ cannot run `npm pack`, `npm publish`, or `npm run skills:pack`.
- Unaffected: GitHub Packages `dev` and the flavor publishes.

## Fix

Accept both shapes — the npm major in play belongs to the runner, not to us:

```js
const parsed = JSON.parse(result.stdout);
const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
if (results.length !== 1 || typeof results[0]?.filename !== "string") {
  throw new Error("expected one npm pack result");
}
filename = results[0].filename;
```

And pin the upgrade to `npm@12` instead of `npm@latest`. Minor/patch fixes still flow; crossing a major is now a deliberate edit instead of a silent outage. Worth a reviewer's call — the tradeoff is that someone must bump it on purpose, which is the point.

### Tests

Two new cases in `tests/scripts/compose-skill-flavor.test.mjs`:

- **Both shapes** — wraps the real `npm pack`, normalizes its output, then re-emits it as *both* an array and a name-keyed object. Real tarballs, so `verifyTarball` still runs, and coverage does not depend on the runner's npm major. The pre-existing stubs only covered the `status: 1` failure path.
- **A payload naming no tarball still fails loudly** — `{}` must not degrade into "zero packages, nothing to do".

## Verification

`npm run skills:test`: **49 pass / 1 fail**, both new tests passing.

The one failure — `pack builds complete, marker-free default and custom npm packages` — **also fails on clean `main`** (47 pass / 1 fail), so it is pre-existing and not introduced here. Its cause is a different npm-behaviour drift in the same area:

```
npm error You must specify a tag using --tag when publishing a prerelease version.
```

That test publishes a `1.2.3-preview.45` fixture with `--dry-run`, and newer npm now demands an explicit `--tag` for prereleases. CI does not catch it because the package-build check runs on npm 10.x. **Left out of this PR deliberately** — it is a test-only defect on a different npm behaviour, and this PR is the publish-blocking one. Happy to fix it in a follow-up; say the word.

## Cherry-picks

`release/v1.200` and `release/v1.201` both carry the identical line 1341, so fixing `main` alone does not let either line republish. Cherry-pick PRs opened against both — see the linked PRs below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
