### PR TITLE
fix(release): accept npm 12's npm pack --json payload shape (CP to release/v1.200)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,9 +133,17 @@ jobs:
           node-version: "22.x"
 
       # Node 22 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1.
+      #
+      # Pinned to a major, NOT `npm@latest`. This job is the only one that
+      # upgrades npm, so it is the only one exposed to a new npm major the
+      # moment it ships -- with no repo change to point at. npm 12 renamed the
+      # `npm pack --json` payload from an array to an object keyed by package
+      # name, which broke the nested pack inside our `prepack` hook and stalled
+      # npmjs at 1.199.0 for two release lines. Minor/patch upgrades still flow;
+      # moving majors is now a deliberate edit.
       - name: Upgrade npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@12
           echo "npm $(npm --version) / node $(node --version)"
 
       # `preview` when: dispatch channel=preview, OR an auto push to a

--- a/scripts/compose-skill-flavor.mjs
+++ b/scripts/compose-skill-flavor.mjs
@@ -1338,10 +1338,15 @@ function packStagedPackages(staged, npmRoot, runNpmPack) {
     let filename;
     try {
       const parsed = JSON.parse(result.stdout);
-      if (!Array.isArray(parsed) || parsed.length !== 1 || typeof parsed[0]?.filename !== "string") {
+      // npm <= 11 prints an array of pack results; npm >= 12 prints an object
+      // keyed by package name. Accept both -- the npm major in play is the
+      // runner's, not ours: publish.yml installs npm for OIDC trusted
+      // publishing, and a contributor's global npm is whatever they have.
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+      if (results.length !== 1 || typeof results[0]?.filename !== "string") {
         throw new Error("expected one npm pack result");
       }
-      filename = parsed[0].filename;
+      filename = results[0].filename;
     } catch (error) {
       throw new Error(`could not parse npm pack output for ${name}: ${result.stdout.trim()}`);
     }

--- a/tests/scripts/compose-skill-flavor.test.mjs
+++ b/tests/scripts/compose-skill-flavor.test.mjs
@@ -1100,6 +1100,54 @@ test("pack builds complete, marker-free default and custom npm packages", (t) =>
   }
 });
 
+test("npm pack output parses on both the npm 11 array and npm 12 object shapes", (t) => {
+  // npm <= 11 prints `[ { ...packResult } ]`; npm >= 12 prints
+  // `{ "<packageName>": { ...packResult } }`. Reshape the real npm output into
+  // each form so both are covered whatever npm major runs the suite -- the
+  // object shape broke publishing to npmjs when CI's unpinned `npm@latest`
+  // moved to npm 12.
+  for (const shape of ["array", "object"]) {
+    const repo = fixtureRepo(t);
+    addSkill(repo, "uipath-example");
+    addPackageManifest(repo);
+
+    const runNpmPack = (options) => {
+      const result = runRealNpmPack(options, repo);
+      if (result.status !== 0) return result;
+      const parsed = JSON.parse(result.stdout);
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed);
+      const reshaped =
+        shape === "array"
+          ? results
+          : Object.fromEntries(results.map((entry) => [entry.name, entry]));
+      return { ...result, stdout: JSON.stringify(reshaped, null, 2) };
+    };
+
+    const packages = withNpmCache(repo, () =>
+      packAllVariants(repo, { runNpmPack }),
+    );
+    assert.equal(packages.length, 1, `${shape}: expected one package`);
+    assert.equal(packages[0].packageName, "@uipath/skills", `${shape}: package name`);
+    assert.ok(existsSync(packages[0].tarball), `${shape}: tarball exists`);
+  }
+});
+
+test("npm pack output that names no tarball still fails loudly", (t) => {
+  const repo = fixtureRepo(t);
+  addSkill(repo, "uipath-example");
+  addPackageManifest(repo);
+
+  assert.throws(
+    () =>
+      withNpmCache(repo, () =>
+        packAllVariants(repo, {
+          runNpmPack: () => ({ status: 0, stdout: "{}", stderr: "" }),
+        }),
+      ),
+    /could not parse npm pack output/,
+  );
+});
+
 test("a failed npm pack preserves every last successful generated output", (t) => {
   const repo = fixtureRepo(t);
   addSkill(repo, "uipath-example", block("host", "Default."));


### PR DESCRIPTION
Cherry-pick of #2770 to `release/v1.200`.

## Why this line needs it

`release/v1.200` carries the identical `scripts/compose-skill-flavor.mjs:1341` (array-only parse) and the identical `npm install -g npm@latest` at `.github/workflows/publish.yml:138`, so fixing `main` alone does not let this line republish.

The failing run that surfaced this was **on this branch**: [run 32735569160](https://github.com/UiPath/skills/actions/runs/32735569160/job/97457945836), channel `latest`, version `1.200.0`. Its `guard` job passed; `npm publish` died in its own prepack hook because npm 12 renamed the `npm pack --json` payload from an array to an object keyed by package name.

npmjs `latest` is still `1.199.0`. With this merged, `1.200.0` can be dispatched to `latest` again.

## Contents

Unchanged from #2770 — `git cherry-pick` applied clean (`tests/scripts/compose-skill-flavor.test.mjs` auto-merged, no conflicts):

- Parse both the npm ≤ 11 array and npm ≥ 12 name-keyed object payloads.
- Pin the trusted-publishing upgrade to `npm@12` rather than `npm@latest`.
- Two tests: both payload shapes (re-emitted from real npm output, so coverage holds on any npm major), and a payload naming no tarball failing loudly.

## Verification on this branch

`npm run skills:test`: **47 pass / 1 fail**, both new tests passing.

The single failure is `pack builds complete, marker-free default and custom npm packages` — pre-existing on this line and on `main`, unrelated to this change. It is a separate npm-behaviour drift (`You must specify a tag using --tag when publishing a prerelease version`) in a test fixture, invisible to CI because the package-build check runs on npm 10.x. See #2770 for detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
