### PR TITLE
fix(release): accept npm 12's npm pack --json payload shape (CP to release/v1.201)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,9 +133,17 @@ jobs:
           node-version: "22.x"
 
       # Node 22 ships npm 10.x; OIDC trusted publishing needs npm >= 11.5.1.
+      #
+      # Pinned to a major, NOT `npm@latest`. This job is the only one that
+      # upgrades npm, so it is the only one exposed to a new npm major the
+      # moment it ships -- with no repo change to point at. npm 12 renamed the
+      # `npm pack --json` payload from an array to an object keyed by package
+      # name, which broke the nested pack inside our `prepack` hook and stalled
+      # npmjs at 1.199.0 for two release lines. Minor/patch upgrades still flow;
+      # moving majors is now a deliberate edit.
       - name: Upgrade npm for trusted publishing
         run: |
-          npm install -g npm@latest
+          npm install -g npm@12
           echo "npm $(npm --version) / node $(node --version)"
 
       # `preview` when: dispatch channel=preview, OR an auto push to a

--- a/scripts/compose-skill-flavor.mjs
+++ b/scripts/compose-skill-flavor.mjs
@@ -1338,10 +1338,15 @@ function packStagedPackages(staged, npmRoot, runNpmPack) {
     let filename;
     try {
       const parsed = JSON.parse(result.stdout);
-      if (!Array.isArray(parsed) || parsed.length !== 1 || typeof parsed[0]?.filename !== "string") {
+      // npm <= 11 prints an array of pack results; npm >= 12 prints an object
+      // keyed by package name. Accept both -- the npm major in play is the
+      // runner's, not ours: publish.yml installs npm for OIDC trusted
+      // publishing, and a contributor's global npm is whatever they have.
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed ?? {});
+      if (results.length !== 1 || typeof results[0]?.filename !== "string") {
         throw new Error("expected one npm pack result");
       }
-      filename = parsed[0].filename;
+      filename = results[0].filename;
     } catch (error) {
       throw new Error(`could not parse npm pack output for ${name}: ${result.stdout.trim()}`);
     }

--- a/tests/scripts/compose-skill-flavor.test.mjs
+++ b/tests/scripts/compose-skill-flavor.test.mjs
@@ -1216,6 +1216,54 @@ test("pack builds complete, marker-free default and custom npm packages", (t) =>
   }
 });
 
+test("npm pack output parses on both the npm 11 array and npm 12 object shapes", (t) => {
+  // npm <= 11 prints `[ { ...packResult } ]`; npm >= 12 prints
+  // `{ "<packageName>": { ...packResult } }`. Reshape the real npm output into
+  // each form so both are covered whatever npm major runs the suite -- the
+  // object shape broke publishing to npmjs when CI's unpinned `npm@latest`
+  // moved to npm 12.
+  for (const shape of ["array", "object"]) {
+    const repo = fixtureRepo(t);
+    addSkill(repo, "uipath-example");
+    addPackageManifest(repo);
+
+    const runNpmPack = (options) => {
+      const result = runRealNpmPack(options, repo);
+      if (result.status !== 0) return result;
+      const parsed = JSON.parse(result.stdout);
+      const results = Array.isArray(parsed) ? parsed : Object.values(parsed);
+      const reshaped =
+        shape === "array"
+          ? results
+          : Object.fromEntries(results.map((entry) => [entry.name, entry]));
+      return { ...result, stdout: JSON.stringify(reshaped, null, 2) };
+    };
+
+    const packages = withNpmCache(repo, () =>
+      packAllVariants(repo, { runNpmPack }),
+    );
+    assert.equal(packages.length, 1, `${shape}: expected one package`);
+    assert.equal(packages[0].packageName, "@uipath/skills", `${shape}: package name`);
+    assert.ok(existsSync(packages[0].tarball), `${shape}: tarball exists`);
+  }
+});
+
+test("npm pack output that names no tarball still fails loudly", (t) => {
+  const repo = fixtureRepo(t);
+  addSkill(repo, "uipath-example");
+  addPackageManifest(repo);
+
+  assert.throws(
+    () =>
+      withNpmCache(repo, () =>
+        packAllVariants(repo, {
+          runNpmPack: () => ({ status: 0, stdout: "{}", stderr: "" }),
+        }),
+      ),
+    /could not parse npm pack output/,
+  );
+});
+
 test("a failed npm pack preserves every last successful generated output", (t) => {
   const repo = fixtureRepo(t);
   addSkill(repo, "uipath-example", block("host", "Default."));


### PR DESCRIPTION
Cherry-pick of #2770 to `release/v1.201`.

## Why this line needs it

`release/v1.201` carries the identical `scripts/compose-skill-flavor.mjs:1341` (array-only parse) and the identical `npm install -g npm@latest` at `.github/workflows/publish.yml:138`. npm 12 renamed the `npm pack --json` payload from an array to an object keyed by package name, which breaks the nested pack inside our `prepack` hook. npmjs `latest` is still `1.199.0`; this line has never published.

## Contents

Unchanged from #2770 — `git cherry-pick` applied clean, no conflicts:

- Parse both the npm ≤ 11 array and npm ≥ 12 name-keyed object payloads.
- Pin the trusted-publishing upgrade to `npm@12` rather than `npm@latest`.
- Two tests: both payload shapes (re-emitted from real npm output, so coverage holds on any npm major), and a payload naming no tarball failing loudly.

## ⚠️ Merge #2773 as well — this line is blocked by two independent bugs

This PR is necessary but **not sufficient** for `release/v1.201`. It clears the packer; it does not clear the version guard. On this branch:

```
$ node scripts/sync-version.mjs --check
✗ Version drift detected (run `npm run version:sync`):
  - .cursor-plugin/plugin.json: 1.200.0 -> 1.201.0
```

Every publish job declares `needs: [guard]`, so nothing downstream even starts. That is the drift #2767 fixed on `main` only. It also explains why the run that exposed the npm 12 bug was on `release/v1.200` rather than here: `release/v1.200` has no `.cursor-plugin` drift, so its guard passed and it got far enough to reach the packer — while [run 32622397288](https://github.com/UiPath/skills/actions/runs/32622397288) on *this* line reported `Validate version sync: failure` with all four publish jobs skipped.

**#2773** is the cherry-pick of #2767 to this branch, opened via the repo's `/cherrypick` automation. Verified against its head:

```
$ node scripts/sync-version.mjs --check
✓ All manifests in sync (package 1.201.0, plugin 1.201.0, targetCli ^1.201.0)
```

Merge **both** #2772 and #2773 before dispatching a publish from this line. Either order works.

`release/v1.200` needs only #2771 — its guard already passes.

## Verification on this branch

`npm run skills:test`: **49 pass / 1 fail**, both new tests passing.

The single failure is `pack builds complete, marker-free default and custom npm packages` — pre-existing on this line and on `main`, unrelated to this change. Separate npm-behaviour drift (`You must specify a tag using --tag when publishing a prerelease version`) in a test fixture, invisible to CI because the package-build check runs on npm 10.x. See #2770.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
