### PR TITLE
fix(uipath-maestro-bpmn): accept the CLI's package metadata shape

### DIFF
--- a/skills/uipath-maestro-bpmn/SKILL.md
+++ b/skills/uipath-maestro-bpmn/SKILL.md
@@ -167,12 +167,14 @@ For registry-evidence-only tasks, be command-first and time-boxed:
    generated outputs, `bindings_v2.json`, and package metadata. Avoid softer
    wording such as "connection and process binding" because it hides the concrete
    artifact the CLI must supply.
-   If the user asks to package or operate, run
-   `uip maestro bpmn update-metadata <file.bpmn>` to generate the five package
-   metadata files. Only fall back to the minimal local metadata shape in
+   If the user asks for the package metadata files, or to package or operate,
+   run `uip maestro bpmn update-metadata <file.bpmn>` to generate the five
+   files, and keep its output as written — that shape is the contract `pack`
+   consumes. Only fall back to the equivalent hand-authored shape in
    [references/shared/local-metadata-regeneration-guide.md](references/shared/local-metadata-regeneration-guide.md#minimal-local-metadata-shape)
-   when the CLI is unavailable. Do not copy CLI scaffold metadata shapes into a
-   synthetic local project.
+   when the CLI is unavailable. Every root start event needs a
+   `<uipath:entryPointId value="<uuid>" />` child in its `extensionElements` or
+   the project generates zero entry points.
 4. **Validate.** Run the CLI validator — it runs the full PO.Frontend canvas
    rule set (structural rules plus variable, method-call, input-type, and
    event-object checks) offline, plus deploy-readiness checks:

--- a/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
+++ b/skills/uipath-maestro-bpmn/references/shared/local-metadata-regeneration-guide.md
@@ -10,20 +10,28 @@ Use this guide when BPMN source changed and local package metadata must be refre
 
 ## Local Synthetic Project Contract
 
-When no CLI generator is available and you must author a local-only synthetic
-BPMN project, make the project executable and package-shaped before packing:
+`uip maestro bpmn update-metadata <file.bpmn>` is the contract. It writes the
+same shape `uip maestro bpmn init` scaffolds, and `uip maestro bpmn pack`
+consumes it as written:
 
 - The root process must be `<bpmn:process ... isExecutable="true">`.
-- `project.uiproj` must use lowercase `"main"` pointing at the BPMN file.
-- `operate.json` must use `"main"` with the bare BPMN filename, not a
-  `/content/<file>.bpmn#<start-event-id>` entry-point path, plus
-  `"contentType": "ProcessOrchestration"`.
-- `package-descriptor.json` must use a top-level `"content"` array with
-  `content/<file>` entries. Do not use `contentFiles` or a CLI scaffold
-  `"files"` mapping for synthetic local metadata.
+- `project.uiproj` carries `"Name"` and `"ProjectType":
+  "ProcessOrchestration"`. The CLI does not write `"main"` here; it preserves a
+  hand-authored one, so do not add one expecting it to be required.
+- `operate.json` uses `"main"` with the entry-point path
+  `/content/<file>.bpmn#<start-event-id>` plus `"contentType":
+  "ProcessOrchestration"`. `update-metadata` rewrites this field every run — a
+  bare filename does not survive.
+- `package-descriptor.json` uses a top-level `"files"` map of name to path,
+  including the BPMN file, `operate.json`, `entry-points.json`, and
+  `"bindings.json": "bindings_v2.json"`. Do not use `contentFiles`.
 
-The minimal placeholder-safe JSON shape is shown below; keep it exact apart
-from project, file, and start event names.
+`pack` also accepts a hand-authored top-level `"content"` array of
+`content/<file>` paths, so pre-existing synthetic metadata in that shape stays
+valid. Prefer the CLI shape for anything new.
+
+The placeholder-safe JSON shape for a CLI-unavailable fallback is shown below;
+keep it exact apart from project, file, and start event names.
 
 ## Regeneration Inputs
 
@@ -74,18 +82,15 @@ Packaging is local and authoring-safe. Upload, publish, deploy, debug, and run a
 ## Minimal Local Metadata Shape
 
 When a local-only synthetic project needs package files and the CLI cannot
-regenerate them in place, use this placeholder-safe shape before running
-`uip maestro bpmn pack`. Replace only the BPMN file name and start event id;
-do not invent `contentFiles` as a substitute for `content`.
+regenerate them in place, mirror what `update-metadata` would have written.
+Replace only the BPMN file name and start event id.
 
 `project.uiproj`:
 
 ```json
 {
-  "projectVersion": "1.0.0",
-  "ProjectType": "ProcessOrchestration",
   "Name": "SyntheticProject",
-  "main": "SyntheticProject.bpmn"
+  "ProjectType": "ProcessOrchestration"
 }
 ```
 
@@ -93,7 +98,7 @@ do not invent `contentFiles` as a substitute for `content`.
 
 ```json
 {
-  "main": "SyntheticProject.bpmn",
+  "main": "/content/SyntheticProject.bpmn#Start_Manual",
   "contentType": "ProcessOrchestration"
 }
 ```
@@ -104,14 +109,18 @@ do not invent `contentFiles` as a substitute for `content`.
 {
   "entryPoints": [
     {
-      "id": "Entry_ManualStart",
       "filePath": "/content/SyntheticProject.bpmn#Start_Manual",
-      "inputSchema": { "type": "object", "properties": {} },
-      "outputSchema": { "type": "object", "properties": {} }
+      "uniqueId": "00000000-0000-0000-0000-000000000000",
+      "type": "ProcessOrchestration",
+      "input": { "type": "object", "properties": {} },
+      "output": { "type": "object", "properties": {} }
     }
   ]
 }
 ```
+
+Set each `uniqueId` to the start event's own `uipath:entryPointId` value, not to
+the placeholder above.
 
 `bindings_v2.json`:
 
@@ -130,23 +139,30 @@ imported an external process, queue, connector, or agent.
 
 ```json
 {
-  "content": [
-    "content/SyntheticProject.bpmn",
-    "content/bindings_v2.json",
-    "content/entry-points.json",
-    "content/operate.json"
-  ]
+  "files": {
+    "operate.json": "operate.json",
+    "entry-points.json": "entry-points.json",
+    "bindings.json": "bindings_v2.json",
+    "SyntheticProject.bpmn": "SyntheticProject.bpmn"
+  }
 }
 ```
 
 ## Entry Point Rules
 
-For each root start event with `uipath:entryPointId`, generated `entry-points.json` must include:
+For each root start event with a
+`<uipath:entryPointId value="<uuid>" />` child in its `extensionElements`,
+generated `entry-points.json` must include:
 
-- `id` equal to the `uipath:entryPointId` value.
 - `filePath` equal to `/content/<bpmn-file>#<start-event-id>`.
-- `inputSchema` from root input variables whose `elementId` matches the start event.
-- `outputSchema` from root output variables.
+- `uniqueId` equal to the `uipath:entryPointId` value.
+- `type` equal to `ProcessOrchestration`.
+- `input` from root input variables whose `elementId` matches the start event.
+- `output` from root output variables.
+
+A start event without that element yields no entry point at all —
+`update-metadata` reports `EntryPointCount: 0` and writes an empty
+`entryPoints` array rather than inventing an id.
 
 JSON schema variables use their CDATA body as the property schema. Strip `$schema` from generated package schemas. Other primitive variables map by type, such as `string`, `integer`, `number`, `boolean`, `array`, `object`, or `json`.
 

--- a/skills/uipath-maestro-bpmn/references/shared/project-layout.md
+++ b/skills/uipath-maestro-bpmn/references/shared/project-layout.md
@@ -61,10 +61,11 @@ For the regeneration and drift-check contract, see [local-metadata-regeneration-
 
 A synthetic local project authored without a CLI generator must still match the
 executable and metadata contract before packing: the BPMN root process includes
-`isExecutable="true"`, `project.uiproj` has lowercase `"main"`,
-`operate.json` has `"main"` plus `"contentType": "ProcessOrchestration"`, and
-`package-descriptor.json` has top-level `"content"` entries under `content/`.
-For the exact minimal JSON, see
+`isExecutable="true"`, each root start event carries
+`<uipath:entryPointId value="<uuid>" />`, `operate.json` has `"main"` plus
+`"contentType": "ProcessOrchestration"`, and `package-descriptor.json` maps the
+BPMN file and generated JSON. `uip maestro bpmn update-metadata <file.bpmn>`
+produces that shape; for the exact JSON, see
 [local-metadata-regeneration-guide.md](local-metadata-regeneration-guide.md#minimal-local-metadata-shape).
 
 A Process Orchestration package content folder contains:
@@ -75,7 +76,7 @@ A Process Orchestration package content folder contains:
 - `operate.json`.
 - `package-descriptor.json`.
 
-The package descriptor maps BPMN and generated JSON files under `content/`. The entry point file path references the BPMN file and start event, using the root start event's unique entry point ID.
+The package descriptor maps the BPMN file and generated JSON by name. The entry point file path references the BPMN file and start event as `/content/<bpmn-file>#<start-event-id>`, using the root start event's unique entry point ID.
 
 ## Authoring boundary
 

--- a/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
+++ b/tests/tasks/uipath-maestro-bpmn/_shared/bpmn_assertions.py
@@ -106,6 +106,24 @@ def assert_has_shape(root: ET.Element, bpmn_id: str) -> None:
         fail(f"missing BPMN DI shape for {bpmn_id}")
 
 
+def descriptor_file_names(descriptor: dict) -> set[str]:
+    # Two descriptor shapes are legal. `uip maestro bpmn init` and
+    # `uip maestro bpmn update-metadata` write a `files` name -> path map
+    # (`"bindings.json": "bindings_v2.json"`); hand-authored synthetic metadata
+    # uses a top-level `content` array of `content/<file>` paths. Compare
+    # basenames so either shape satisfies the same requirement.
+    names: set[str] = set()
+    content = descriptor.get("content")
+    if isinstance(content, list):
+        names.update(Path(str(item)).name for item in content)
+    files = descriptor.get("files")
+    if isinstance(files, dict):
+        for key, value in files.items():
+            names.add(Path(str(key)).name)
+            names.add(Path(str(value)).name)
+    return names
+
+
 def assert_package_lifecycle(project_dir: Path, bpmn_name: str, start_id: str) -> None:
     project = load_json(project_dir / "project.uiproj")
     operate = load_json(project_dir / "operate.json")
@@ -113,19 +131,28 @@ def assert_package_lifecycle(project_dir: Path, bpmn_name: str, start_id: str) -
     descriptor = load_json(project_dir / "package-descriptor.json")
     load_json(project_dir / "bindings_v2.json")
 
-    if project.get("main") != bpmn_name:
+    if project.get("ProjectType") != "ProcessOrchestration":
+        fail("project.uiproj must declare ProjectType ProcessOrchestration")
+    # The CLI never writes `main` into project.uiproj, but it preserves one
+    # authored by hand. Only check it when present, and then only for drift.
+    if project.get("main") not in (None, bpmn_name):
         fail("project.uiproj main does not reference the BPMN file")
-    if operate.get("main") != bpmn_name:
+
+    # `update-metadata` always rewrites operate.json `main` to the entry-point
+    # path `/content/<file>#<start-event-id>`; hand-authored metadata uses the
+    # bare filename. Accept both.
+    operate_main = str(operate.get("main") or "")
+    if Path(operate_main.split("#", 1)[0]).name != bpmn_name:
         fail("operate.json main does not reference the BPMN file")
     if operate.get("contentType") != "ProcessOrchestration":
         fail("operate.json contentType must be ProcessOrchestration")
 
-    content = set(descriptor.get("content") or [])
+    content = descriptor_file_names(descriptor)
     for required in (
-        f"content/{bpmn_name}",
-        "content/bindings_v2.json",
-        "content/entry-points.json",
-        "content/operate.json",
+        bpmn_name,
+        "bindings_v2.json",
+        "entry-points.json",
+        "operate.json",
     ):
         if required not in content:
             fail(f"package-descriptor.json missing {required}")

--- a/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
+++ b/tests/tasks/uipath-maestro-bpmn/authoring/api_workflow_task.yaml
@@ -1,11 +1,11 @@
 task_id: skill-bpmn-api-workflow-task
 description: >
   Author a Maestro BPMN API workflow invocation, covering the
-  Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval. This task
-  catches the Claude-vs-Codex metadata drift: Claude passed by using the
-  minimal local synthetic package shape, while Codex failed after copying
-  CLI-style metadata where operate.json main used /content/<bpmn>#<start> and
-  package-descriptor.json used a files object.
+  Orchestrator.ExecuteApiWorkflowAsync service-task row with an eval. The
+  package-metadata assertions accept either shape that ships today:
+  `uip maestro bpmn update-metadata` output (operate.json main as
+  /content/<bpmn>#<start>, package-descriptor.json as a files map) or
+  hand-authored synthetic metadata using bare names and a content array.
 tags: [uipath-maestro-bpmn, e2e, "mode:build", lifecycle:generate, "node:service-task", "feature:api-workflow"]
 
 run_limits:


### PR DESCRIPTION
## Problem

`assert_package_lifecycle` asserts a hand-authored package-metadata shape that **no CLI command produces**. Any agent that follows SKILL.md's primary path — `uip maestro bpmn update-metadata` — fails the check.

`skill-bpmn-business-rule-task` scored 0.20 on exactly this. The agent read both metadata references, ran `update-metadata` (exit 0, five files written), and the checker rejected the CLI's own output:

```
FAIL: project.uiproj main does not reference the BPMN file
```

Every BPMN-level assertion passed first — `businessRuleTask`, `Orchestrator.BusinessRules`, mappings, gateway, DI, start event. Only the JSON metadata was at issue, in three places.

## Root cause

#2622 made the CLI verbs the primary path. `_shared/bpmn_assertions.py` was last aligned in #1519, and no file under `tests/` mentions `update-metadata`. The docs at `local-metadata-regeneration-guide.md` had been tuned to match the checker (#2165, #2202), so both encoded a shape the product had moved past.

## Verified against CLI 1.202.0

| | CLI writes | Checker demanded |
|---|---|---|
| `project.uiproj` | `{Name, ProjectType}` — no `main` (`init` scaffolds the same) | `main` = bpmn filename |
| `operate.json` | `main` = `/content/<file>.bpmn#<start>`, rewritten every run | bare filename |
| `package-descriptor.json` | `files` name→path map | `content[]` of `content/<file>` |
| `entry-points.json` | `uniqueId`/`input`/`output` | `id`/`inputSchema`/`outputSchema` |

- `pack` succeeds on **both** shapes, copies metadata verbatim, flattens to the nupkg root, and drops `project.uiproj` — so the `content/` premise was never the package layout.
- `update-metadata` preserves a hand-authored `project.uiproj.main` but **always** overwrites `operate.json.main`, so the old assertion was unsatisfiable on the documented workflow.
- `uniqueId` comes from the start event's `<uipath:entryPointId value="..."/>` child element. Without it the CLI reports `EntryPointCount: 0` and writes an empty array — worth documenting, it was easy to miss as an attribute.

## Changes

- **`_shared/bpmn_assertions.py`** — accept either shape (basename comparison for the descriptor, `#`-tolerant compare for `operate.json main`, `project.uiproj.main` checked only when present). Matches how every other maestro-bpmn checker already asserts metadata: reference-based, not shape-pinned.
- **`local-metadata-regeneration-guide.md`** — CLI shape is the contract; hand-authored form kept as the CLI-unavailable fallback, now mirroring what `update-metadata` writes. Entry Point Rules corrected to the real field names.
- **`project-layout.md`** — same correction to the Package content section.
- **`SKILL.md`** — keep `update-metadata` output as written; note the `uipath:entryPointId` requirement.
- **`api_workflow_task.yaml`** — drops the now-inverted premise that CLI-style metadata is the failure mode.

## Verification

- Original failing eval artifacts (pure CLI shape) → **passes**.
- Pre-CLI hand-authored shape → **still passes**.
- Newly documented fallback JSON → `pack` succeeds.
- 8 negative cases still fail correctly: wrong BPMN target in `operate.json`, wrong `contentType`, descriptor missing `entry-points.json` / the BPMN, wrong `ProjectType`, `project.uiproj main` drift, wrong entry-point start event, missing `bindings_v2.json`.

Same helper backs `check_api_workflow_task.py` and `check_script_jint_lifecycle.py`, which fail identically today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)