### PR TITLE
fix(uipath-maestro-flow): stop grading slow debug runs as flow failures

### DIFF
--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -81,7 +81,7 @@ uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
 uip maestro flow validate <Name>Sol/<Name>/<Name>.flow --output json
 # Only for a stated runtime-behavior claim:
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )
 ```
@@ -160,7 +160,7 @@ diagnostics in one read-back instead of printing the full execution envelope:
 
 ```bash
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --inputs @inputs.json \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )

--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -81,7 +81,7 @@ uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
 uip maestro flow validate <Name>Sol/<Name>/<Name>.flow --output json
 # Only for a stated runtime-behavior claim:
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )
 ```
@@ -160,7 +160,7 @@ diagnostics in one read-back instead of printing the full execution envelope:
 
 ```bash
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --inputs @inputs.json \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )

--- a/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
@@ -88,7 +88,7 @@ Capability index for the lifecycle of a flow as a deployed asset. Operate owns e
 <!--skill-flavor:upload-shared-cli-entry:start-->
 - [shared/cli-commands.md](../shared/cli-commands.md) — flat CLI lookup including `solution upload`, `solution resources refresh`, `flow pack`, `flow debug`, `flow process`, `flow job`, `flow instance`
 <!--skill-flavor:upload-shared-cli-entry:end-->
-- [shared/cli-conventions.md](../shared/cli-conventions.md) — login states, FOLDER_KEY, UIPCLI_LOG_LEVEL, JSON output shape
+- [shared/cli-conventions.md](../shared/cli-conventions.md) — login states, FOLDER_KEY, UIP_LOG_LEVEL, JSON output shape
 - [shared/variables-and-expressions.md](../shared/variables-and-expressions.md) — `--inputs` JSON shape for `flow debug`
 
 <!--skill-flavor:upload-orchestrator-pointer:start-->

--- a/skills/uipath-maestro-flow/references/operate/references/run.md
+++ b/skills/uipath-maestro-flow/references/operate/references/run.md
@@ -16,7 +16,7 @@ Execute a flow on demand and monitor progress. Three modes: **debug** (controlle
 > **Confirm consent first.** `flow debug` executes the flow for real — sends emails, posts messages, calls APIs. See the consent-before-debug rule in [SKILL.md](../../../SKILL.md). Do not run without explicit user authorization.
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 ```
 
 The argument is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir.
@@ -24,7 +24,7 @@ The argument is the **project directory path** (the folder containing `project.u
 Pass input arguments when the flow has input parameters:
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --inputs '{"numberA": 5, "numberB": 7}'
 ```
 
@@ -32,7 +32,7 @@ Bind local files to file-typed input variables with `--attachment <variableId>=<
 
 ```bash
 # Replace <variableId> and <localPath> placeholders below with your own values.
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --attachment <variableId>=<localPath> \
   --attachment <variableId>=<localPath>
 ```

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -152,15 +152,15 @@ uip solution upload <SolutionDir> --output json
 Debug a Flow in the cloud via Studio Web + Orchestrator. **Requires `uip login`.**
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 
 # Pass input arguments to the flow
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --inputs '{"numberA": 5, "numberB": 7}'
 
 # Bind local files to file-typed input variables (repeatable).
 # Replace <variableId> and <localPath> with your own values.
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --attachment <variableId>=<localPath> \
   --attachment <variableId>=<localPath>
 ```

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -158,15 +158,19 @@ uip or folders list --output json
 
 Or pull it from the job/process context (e.g., `Data.folderKey` on a job status response, or from the debug output's surrounding metadata).
 
-## 7. `UIPCLI_LOG_LEVEL=info` for debug runs
+## 7. `UIP_LOG_LEVEL=info` for debug runs
 
-Set `UIPCLI_LOG_LEVEL=info` on `flow debug` invocations to surface progress and diagnostic detail in the CLI output. Without it, debug runs return only the final result.
+Set `UIP_LOG_LEVEL=info` on `flow debug` invocations to surface progress and diagnostic detail in the CLI output. Without it, debug runs return only the final result.
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 ```
 
-The env var has no effect on other subcommands.
+At `info` the run narrates the `jobKey`, the `instanceId`, and the Studio Web URL to **stderr**. Capture stderr, not just stdout: when a run overruns its poll budget the CLI reports only `Debug polling timed out after <N>s` on stdout, with no instance identifier — the stderr narration is then the only way to find the instance and inspect it (`uip maestro flow debug-instance incidents <instanceId>`).
+
+> **The variable is `UIP_LOG_LEVEL`, not `UIPCLI_LOG_LEVEL`.** The CLI reads only the former; the latter is silently ignored, so a command prefixed with it produces no extra output at all. `--log-level <level>` is the equivalent global flag.
+
+The level applies to every `uip` command, not just `flow debug`.
 
 ## 8. Global options
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -68,40 +68,26 @@ _LAST_DEBUG_INPUT_IDS: set[str] = set()
 _LAST_DEBUG_PROJECT_DIR: str | None = None
 
 
-# The CLI polls the debug instance for `--timeout` seconds and only then gives
-# up with `Debug polling timed out after Ns`. Its default budget is 600s
-# (maxPolls 300 × pollInterval 2000ms), while every call site here caps the
-# subprocess well below that — 180/240/300s at most of them. Without an explicit
-# `--timeout` the checker therefore SIGKILLs the CLI mid-poll and keeps NOTHING:
-# no payload, no instanceId, no incidents, just a `subprocess.TimeoutExpired`
-# traceback. A merely slow cloud round-trip then reads as "the agent built the
-# flow wrong" (skill-flow-wiki-pageviews scored 0 on a gating criterion whose
-# artifact passes this same checker on re-run).
-#
-# So derive the CLI's budget from the subprocess cap and reserve this much for
-# the phases `--timeout` does NOT bound — solution upload, Studio Web debug
-# provisioning, begin-session, create-instance, all unbounded `fetch` calls in
-# the CLI. The CLI then self-terminates with a parseable envelope *before* the
-# subprocess cap fires, and the failure is diagnosable.
+# The CLI polls for `--timeout` seconds (default 600) before giving up, while
+# call sites here cap the subprocess at 180-300s. Without an explicit
+# `--timeout` we SIGKILL the CLI mid-poll and keep nothing — no payload, no
+# instanceId, no incidents. The headroom covers the phases `--timeout` does not
+# bound (upload, provisioning, begin-session, create-instance), so the CLI
+# always self-terminates first, with a parseable envelope.
 _CLI_TIMEOUT_HEADROOM_SECONDS = 60
 _MIN_CLI_TIMEOUT_SECONDS = 30
 
-# `UIP_LOG_LEVEL` — NOT `UIPCLI_LOG_LEVEL`, which the CLI never reads (see
-# packages/common/src/logger.ts; the string is absent from the shipped bundle).
-# At `info` the run narrates jobKey, instanceId and the Studio Web URL to
-# stderr. That is the ONLY way to find the instance after a timeout: the
-# polling-timeout error envelope carries none of them.
+# `UIP_LOG_LEVEL`, not `UIPCLI_LOG_LEVEL` — the CLI never reads the latter. At
+# `info` it narrates jobKey / instanceId / Studio Web URL to stderr, the only
+# way to find the instance after a timeout.
 _DEBUG_LOG_LEVEL = "info"
 
-# The CLI's own poll-budget expiry, matched on the message because the CLI
-# labels this path `Retry: "RetryWillNotFix"` — wrong for a poll timeout, which
-# is precisely the case worth one more attempt.
+# Matched on the message: the CLI labels this path `Retry: RetryWillNotFix`,
+# which is wrong for a poll timeout.
 _DEBUG_POLL_TIMEOUT_MARKER = "debug polling timed out"
 
-# A poll timeout burns the whole subprocess budget on every attempt, so cap it
-# below `retries`: 3 × a 300s cap is 900s against task YAMLs that allow 600s for
-# the criterion, i.e. the third attempt could never finish. Other transient
-# markers fail fast and keep the full `retries` budget.
+# Each attempt costs the full subprocess budget, so cap below `retries`:
+# 3 x 300s would exceed the 600s criterion budget in the task YAMLs.
 _POLL_TIMEOUT_ATTEMPTS = 2
 
 # A `uip maestro flow debug` run can die on a transient server-side error — a
@@ -120,6 +106,11 @@ _DEBUG_RETRY_MARKERS = (
 )
 
 
+def _output_blob(result: subprocess.CompletedProcess) -> str:
+    """Both streams, lowercased, for case-insensitive marker matching."""
+    return f"{result.stdout}\n{result.stderr}".lower()
+
+
 def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     """True iff a failed ``flow debug`` invocation looks like a transient
     server-side error (5xx / RetryLater / poll-budget expiry) worth retrying,
@@ -127,8 +118,7 @@ def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     slip past."""
     if result.returncode == 0:
         return False
-    blob = f"{result.stdout}\n{result.stderr}".lower()
-    if any(marker in blob for marker in _DEBUG_RETRY_MARKERS):
+    if any(marker in _output_blob(result) for marker in _DEBUG_RETRY_MARKERS):
         return True
     # Fall back to an explicit 5xx HttpStatus in the error Context.
     data = _parse_json(result.stdout)
@@ -138,21 +128,16 @@ def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
 
 
 def _is_poll_timeout(result: subprocess.CompletedProcess) -> bool:
-    """True iff the CLI gave up on its own poll budget, as opposed to any other
-    transient error. Retried, but on a shorter leash — see
-    :data:`_POLL_TIMEOUT_ATTEMPTS`."""
-    if result.returncode == 0:
-        return False
-    return _DEBUG_POLL_TIMEOUT_MARKER in f"{result.stdout}\n{result.stderr}".lower()
+    """True iff the CLI gave up on its own poll budget, rather than any other
+    transient error — see :data:`_POLL_TIMEOUT_ATTEMPTS`."""
+    return result.returncode != 0 and (
+        _DEBUG_POLL_TIMEOUT_MARKER in _output_blob(result)
+    )
 
 
 def _as_text(raw: bytes | str | None) -> str:
-    """Decode captured child output defensively.
-
-    ``subprocess.TimeoutExpired`` carries the partial output as **bytes** even
-    when ``run()`` was called with ``text=True`` — unlike ``CompletedProcess``,
-    which honours it. Without this the diagnostic dump would be a ``b'...'``
-    repr, or crash on a str/bytes mismatch."""
+    """Decode captured child output. ``subprocess.TimeoutExpired`` carries it as
+    bytes even under ``text=True``, unlike ``CompletedProcess``."""
     if raw is None:
         return ""
     if isinstance(raw, bytes):
@@ -175,21 +160,16 @@ def run_debug(
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
     parsed ``Data`` payload. Exits on any step failing.
 
-    ``timeout`` is the hard subprocess cap. The CLI is given a strictly smaller
-    ``--timeout`` (minus :data:`_CLI_TIMEOUT_HEADROOM_SECONDS`) so that a run
-    which overruns is ended *by the CLI*, with a parseable error envelope and
-    the stderr narration, rather than SIGKILLed by us with nothing retained.
-    The run also sets ``UIP_LOG_LEVEL=info`` so that narration carries the
-    jobKey / instanceId / Studio Web URL needed to inspect the instance after
-    the fact.
+    ``timeout`` is the hard subprocess cap; the CLI gets a strictly smaller
+    ``--timeout`` so an overrun ends with its own diagnosable envelope instead
+    of a SIGKILL.
 
-    Transient server-side errors (5xx / ``RetryLater`` while polling the debug
-    instance, or the CLI's own poll-budget expiry — see
-    :func:`_is_transient_debug_error`) are retried up to ``retries`` times with
-    ``backoff_seconds`` between attempts; poll timeouts get
-    :data:`_POLL_TIMEOUT_ATTEMPTS` tries, since each one costs the full budget.
-    A real flow fault (non-transient failure, or a run that completes with the
-    wrong ``finalStatus``) fails immediately without burning retries.
+    Transient server-side errors (5xx / ``RetryLater``, or the CLI's own
+    poll-budget expiry — see :func:`_is_transient_debug_error`) are retried up
+    to ``retries`` times with ``backoff_seconds`` between attempts; poll
+    timeouts get :data:`_POLL_TIMEOUT_ATTEMPTS`. A real flow fault
+    (non-transient failure, or a run that completes with the wrong
+    ``finalStatus``) fails immediately without burning retries.
 
     ``attachments`` maps a file-typed input variable ``id`` to a local file path;
     each pair is passed as ``--attachment <id>=<path>`` (repeatable). The variable
@@ -229,11 +209,8 @@ def run_debug(
                 cmd, capture_output=True, text=True, timeout=timeout, env=env
             )
         except subprocess.TimeoutExpired as exc:
-            # The CLI outran even the subprocess cap, so its own --timeout never
-            # fired: the stall is in a phase --timeout does not bound (upload /
-            # Studio Web provisioning / begin-session / create-instance). Keep
-            # whatever it emitted — stderr in particular, which carries the
-            # instanceId — instead of dying with a bare traceback.
+            # The CLI's own --timeout never fired, so the stall is upstream of
+            # polling. Keep the partial output rather than dying on a traceback.
             _LAST_DEBUG_RAW = _as_text(exc.stdout)
             _fail_with_capture(
                 f"flow debug exceeded the {timeout}s subprocess cap without returning "

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -68,6 +68,42 @@ _LAST_DEBUG_INPUT_IDS: set[str] = set()
 _LAST_DEBUG_PROJECT_DIR: str | None = None
 
 
+# The CLI polls the debug instance for `--timeout` seconds and only then gives
+# up with `Debug polling timed out after Ns`. Its default budget is 600s
+# (maxPolls 300 × pollInterval 2000ms), while every call site here caps the
+# subprocess well below that — 180/240/300s at most of them. Without an explicit
+# `--timeout` the checker therefore SIGKILLs the CLI mid-poll and keeps NOTHING:
+# no payload, no instanceId, no incidents, just a `subprocess.TimeoutExpired`
+# traceback. A merely slow cloud round-trip then reads as "the agent built the
+# flow wrong" (skill-flow-wiki-pageviews scored 0 on a gating criterion whose
+# artifact passes this same checker on re-run).
+#
+# So derive the CLI's budget from the subprocess cap and reserve this much for
+# the phases `--timeout` does NOT bound — solution upload, Studio Web debug
+# provisioning, begin-session, create-instance, all unbounded `fetch` calls in
+# the CLI. The CLI then self-terminates with a parseable envelope *before* the
+# subprocess cap fires, and the failure is diagnosable.
+_CLI_TIMEOUT_HEADROOM_SECONDS = 60
+_MIN_CLI_TIMEOUT_SECONDS = 30
+
+# `UIP_LOG_LEVEL` — NOT `UIPCLI_LOG_LEVEL`, which the CLI never reads (see
+# packages/common/src/logger.ts; the string is absent from the shipped bundle).
+# At `info` the run narrates jobKey, instanceId and the Studio Web URL to
+# stderr. That is the ONLY way to find the instance after a timeout: the
+# polling-timeout error envelope carries none of them.
+_DEBUG_LOG_LEVEL = "info"
+
+# The CLI's own poll-budget expiry, matched on the message because the CLI
+# labels this path `Retry: "RetryWillNotFix"` — wrong for a poll timeout, which
+# is precisely the case worth one more attempt.
+_DEBUG_POLL_TIMEOUT_MARKER = "debug polling timed out"
+
+# A poll timeout burns the whole subprocess budget on every attempt, so cap it
+# below `retries`: 3 × a 300s cap is 900s against task YAMLs that allow 600s for
+# the criterion, i.e. the third attempt could never finish. Other transient
+# markers fail fast and keep the full `retries` budget.
+_POLL_TIMEOUT_ATTEMPTS = 2
+
 # A `uip maestro flow debug` run can die on a transient server-side error — a
 # gateway timeout / 5xx while polling the debug instance, which the CLI reports
 # as `Result:Failure`, `ErrorCode:server_error`, `Retry:RetryLater` (the CLI's
@@ -77,13 +113,18 @@ _LAST_DEBUG_PROJECT_DIR: str | None = None
 # check (customer-escalation-triage). Distinct from a real flow failure (a
 # `finalStatus` that completed-with-fault, or wrong outputs), which must fail
 # immediately. Retry ONLY on the transient markers below.
-_DEBUG_RETRY_MARKERS = ('"retry": "retrylater"', '"errorcode": "server_error"')
+_DEBUG_RETRY_MARKERS = (
+    '"retry": "retrylater"',
+    '"errorcode": "server_error"',
+    _DEBUG_POLL_TIMEOUT_MARKER,
+)
 
 
 def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     """True iff a failed ``flow debug`` invocation looks like a transient
-    server-side error (5xx / RetryLater) worth retrying, rather than a real
-    flow fault. Case-insensitive so CLI key casing can't slip past."""
+    server-side error (5xx / RetryLater / poll-budget expiry) worth retrying,
+    rather than a real flow fault. Case-insensitive so CLI key casing can't
+    slip past."""
     if result.returncode == 0:
         return False
     blob = f"{result.stdout}\n{result.stderr}".lower()
@@ -94,6 +135,29 @@ def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     status = _get_ci(data or {}, "Context", default={})
     http = _get_ci(status if isinstance(status, dict) else {}, "HttpStatus")
     return isinstance(http, int) and 500 <= http < 600
+
+
+def _is_poll_timeout(result: subprocess.CompletedProcess) -> bool:
+    """True iff the CLI gave up on its own poll budget, as opposed to any other
+    transient error. Retried, but on a shorter leash — see
+    :data:`_POLL_TIMEOUT_ATTEMPTS`."""
+    if result.returncode == 0:
+        return False
+    return _DEBUG_POLL_TIMEOUT_MARKER in f"{result.stdout}\n{result.stderr}".lower()
+
+
+def _as_text(raw: bytes | str | None) -> str:
+    """Decode captured child output defensively.
+
+    ``subprocess.TimeoutExpired`` carries the partial output as **bytes** even
+    when ``run()`` was called with ``text=True`` — unlike ``CompletedProcess``,
+    which honours it. Without this the diagnostic dump would be a ``b'...'``
+    repr, or crash on a str/bytes mismatch."""
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return raw
 
 
 # ── Public helpers ──────────────────────────────────────────────────────────
@@ -111,22 +175,47 @@ def run_debug(
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
     parsed ``Data`` payload. Exits on any step failing.
 
+    ``timeout`` is the hard subprocess cap. The CLI is given a strictly smaller
+    ``--timeout`` (minus :data:`_CLI_TIMEOUT_HEADROOM_SECONDS`) so that a run
+    which overruns is ended *by the CLI*, with a parseable error envelope and
+    the stderr narration, rather than SIGKILLed by us with nothing retained.
+    The run also sets ``UIP_LOG_LEVEL=info`` so that narration carries the
+    jobKey / instanceId / Studio Web URL needed to inspect the instance after
+    the fact.
+
     Transient server-side errors (5xx / ``RetryLater`` while polling the debug
-    instance — see :func:`_is_transient_debug_error`) are retried up to
-    ``retries`` times with ``backoff_seconds`` between attempts. A real flow
-    fault (non-transient failure, or a run that completes with the wrong
-    ``finalStatus``) fails immediately without burning retries.
+    instance, or the CLI's own poll-budget expiry — see
+    :func:`_is_transient_debug_error`) are retried up to ``retries`` times with
+    ``backoff_seconds`` between attempts; poll timeouts get
+    :data:`_POLL_TIMEOUT_ATTEMPTS` tries, since each one costs the full budget.
+    A real flow fault (non-transient failure, or a run that completes with the
+    wrong ``finalStatus``) fails immediately without burning retries.
 
     ``attachments`` maps a file-typed input variable ``id`` to a local file path;
     each pair is passed as ``--attachment <id>=<path>`` (repeatable). The variable
     ``id`` must match a ``variables.globals[]`` entry with ``direction:"in"`` and
     ``type:"file"`` — see :func:`read_flow_file_input_vars`."""
     project_dir = _find_project(project_glob)
-    cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]
+    cli_timeout = max(
+        _MIN_CLI_TIMEOUT_SECONDS, timeout - _CLI_TIMEOUT_HEADROOM_SECONDS
+    )
+    cmd = [
+        "uip",
+        "maestro",
+        "flow",
+        "debug",
+        project_dir,
+        "--output",
+        "json",
+        "--timeout",
+        str(cli_timeout),
+    ]
     if inputs is not None:
         cmd.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
+    env = dict(os.environ)
+    env.setdefault("UIP_LOG_LEVEL", _DEBUG_LOG_LEVEL)
     global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS, _LAST_DEBUG_PROJECT_DIR
     # Record what we bound as input, and where the project lives, so output
     # assertions can discount echoes of our own inputs.
@@ -135,9 +224,28 @@ def run_debug(
     }
     _LAST_DEBUG_PROJECT_DIR = project_dir
     for attempt in range(retries):
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        try:
+            r = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, env=env
+            )
+        except subprocess.TimeoutExpired as exc:
+            # The CLI outran even the subprocess cap, so its own --timeout never
+            # fired: the stall is in a phase --timeout does not bound (upload /
+            # Studio Web provisioning / begin-session / create-instance). Keep
+            # whatever it emitted — stderr in particular, which carries the
+            # instanceId — instead of dying with a bare traceback.
+            _LAST_DEBUG_RAW = _as_text(exc.stdout)
+            _fail_with_capture(
+                f"flow debug exceeded the {timeout}s subprocess cap without returning "
+                f"(CLI --timeout was {cli_timeout}s, so the stall is upstream of "
+                "polling: solution upload, Studio Web debug provisioning, "
+                "begin-session, or create-instance).\n"
+                f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
+            )
         _LAST_DEBUG_RAW = r.stdout
         if r.returncode == 0 or not _is_transient_debug_error(r):
+            break
+        if _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
             break
         if attempt + 1 < retries:
             time.sleep(backoff_seconds)

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -776,6 +776,16 @@ _COMPLETED = (
     '  "Data": {"finalStatus": "Completed", "variables": {"globalVariables": '
     '[{"name": "severity", "value": "Sev1"}]}}\n}'
 )
+# Verbatim envelope from `uip maestro flow debug --timeout 1`. Note the
+# `RetryWillNotFix` label — wrong for a poll timeout, which is exactly the case
+# worth another attempt, so classification matches the Message instead.
+_POLL_TIMEOUT = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Debug polling timed out after 180s",\n'
+    '  "Instructions": "Check that the flow project is valid, the selected folder '
+    'is accessible, and Studio Web debug is available, then retry.",\n'
+    '  "ErrorCode": "unknown_error",\n  "Retry": "RetryWillNotFix"\n}'
+)
 
 
 def _cp(returncode, stdout="", stderr=""):
@@ -786,15 +796,26 @@ def _cp(returncode, stdout="", stderr=""):
 
 def _stub_debug(monkeypatch, results):
     """Feed run_debug a queue of CompletedProcess results, stub sleep to be
-    instant, and stub project discovery so no real tree is needed."""
-    calls = {"n": 0}
+    instant, and stub project discovery so no real tree is needed.
+
+    A queued ``BaseException`` is raised instead of returned, which is how the
+    ``subprocess.TimeoutExpired`` path is exercised. The last invocation's
+    ``cmd`` / ``env`` / ``timeout`` are recorded so tests can assert on what we
+    actually handed the CLI."""
+    calls = {"n": 0, "cmd": None, "env": None, "timeout": None}
     queue = list(results)
     monkeypatch.setattr(flow_check, "_find_project", lambda pattern: "/tmp/proj")
     monkeypatch.setattr(flow_check.time, "sleep", lambda *_: None)
 
     def fake_run(cmd, **kwargs):
         calls["n"] += 1
-        return queue.pop(0)
+        calls["cmd"] = cmd
+        calls["env"] = kwargs.get("env")
+        calls["timeout"] = kwargs.get("timeout")
+        result = queue.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
 
     monkeypatch.setattr(flow_check.subprocess, "run", fake_run)
     return calls
@@ -844,7 +865,107 @@ def test_run_debug_exhausts_retries_on_persistent_504(monkeypatch):
         (_cp(1, '{"Context": {"HttpStatus": 503}}'), True),            # 5xx via HttpStatus
         (_cp(1, '{"ErrorCode": "invalid_argument", "Retry": "RetryWillNotFix"}'), False),
         (_cp(1, '{"Context": {"HttpStatus": 404}}'), False),           # 4xx is not transient
+        (_cp(1, _POLL_TIMEOUT), True),                                 # CLI poll-budget expiry
     ],
 )
 def test_is_transient_debug_error(cp, expected):
     assert flow_check._is_transient_debug_error(cp) is expected
+
+
+# ── run_debug timeout budget + diagnostics ───────────────────────────────────
+#
+# Regression cover for skill-flow-wiki-pageviews, which scored 0 on a gating
+# criterion whose artifact passes this checker on re-run: the subprocess cap
+# fired below the CLI's own poll budget, SIGKILLing it mid-run so the failure
+# surfaced as a bare TimeoutExpired traceback with no payload, no instanceId
+# and no incidents to diagnose from.
+
+
+def test_run_debug_passes_derived_cli_timeout(monkeypatch):
+    """The CLI gets a --timeout strictly below our subprocess cap, so an
+    overrun is ended by the CLI (parseable envelope) not by SIGKILL."""
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug(timeout=240)
+    cmd = calls["cmd"]
+    assert "--timeout" in cmd
+    assert cmd[cmd.index("--timeout") + 1] == "180"  # 240 - 60 headroom
+    assert calls["timeout"] == 240
+    assert int(cmd[cmd.index("--timeout") + 1]) < calls["timeout"]
+
+
+def test_run_debug_cli_timeout_never_goes_below_floor(monkeypatch):
+    """A call site with a tiny cap still gets a usable CLI budget rather than
+    zero or a negative."""
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug(timeout=45)
+    cmd = calls["cmd"]
+    assert cmd[cmd.index("--timeout") + 1] == str(flow_check._MIN_CLI_TIMEOUT_SECONDS)
+
+
+def test_run_debug_sets_uip_log_level_for_instance_id(monkeypatch):
+    """UIP_LOG_LEVEL=info is the only channel that emits jobKey / instanceId /
+    Studio Web URL — the polling-timeout envelope carries none of them.
+    (UIPCLI_LOG_LEVEL, which the docs used to show, is never read by the CLI.)"""
+    monkeypatch.delenv("UIP_LOG_LEVEL", raising=False)
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug()
+    assert calls["env"]["UIP_LOG_LEVEL"] == "info"
+
+
+def test_run_debug_keeps_operator_log_level(monkeypatch):
+    """An explicitly set level wins, so a human debugging locally can raise it."""
+    monkeypatch.setenv("UIP_LOG_LEVEL", "debug")
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug()
+    assert calls["env"]["UIP_LOG_LEVEL"] == "debug"
+
+
+def test_run_debug_retries_poll_timeout_then_completes(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(1, _POLL_TIMEOUT), _cp(0, _COMPLETED)])
+    payload = run_debug()
+    assert calls["n"] == 2
+    assert flow_check._get_ci(payload, "finalStatus") == "Completed"
+
+
+def test_run_debug_caps_poll_timeout_attempts(monkeypatch):
+    """A poll timeout burns the full subprocess budget each try, so it stops at
+    _POLL_TIMEOUT_ATTEMPTS even when `retries` allows more — 3 x a 300s cap
+    would overrun the 600s criterion budget in the task YAMLs."""
+    calls = _stub_debug(monkeypatch, [_cp(1, _POLL_TIMEOUT)] * 3)
+    with pytest.raises(SystemExit):
+        run_debug(retries=3)
+    assert calls["n"] == flow_check._POLL_TIMEOUT_ATTEMPTS == 2
+
+
+def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch, capsys):
+    """A stall upstream of polling (upload / provisioning / begin-session — the
+    phases --timeout cannot bound) must exit as a graded FAIL carrying the
+    partial output, not as an uncaught TimeoutExpired traceback."""
+    exc = subprocess.TimeoutExpired(
+        cmd=["uip", "maestro", "flow", "debug"],
+        timeout=240,
+        output=b'{"partial": true}',
+        stderr=b"Debug instance created - instanceId: abc-123\n",
+    )
+    calls = _stub_debug(monkeypatch, [exc])
+    with pytest.raises(SystemExit) as excinfo:
+        run_debug(timeout=240)
+    assert calls["n"] == 1
+    message = str(excinfo.value)
+    assert "240s subprocess cap" in message
+    # The instanceId is the whole point: without it the run is unrecoverable.
+    assert "abc-123" in message
+    assert flow_check._LAST_DEBUG_RAW == '{"partial": true}'
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (b"bytes payload", "bytes payload"),   # TimeoutExpired hands back bytes...
+        ("str payload", "str payload"),        # ...CompletedProcess hands back str
+        (None, ""),
+        (b"\xff\xfe bad utf8", "�� bad utf8"),
+    ],
+)
+def test_as_text_decodes_defensively(raw, expected):
+    assert flow_check._as_text(raw) == expected

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -776,9 +776,8 @@ _COMPLETED = (
     '  "Data": {"finalStatus": "Completed", "variables": {"globalVariables": '
     '[{"name": "severity", "value": "Sev1"}]}}\n}'
 )
-# Verbatim envelope from `uip maestro flow debug --timeout 1`. Note the
-# `RetryWillNotFix` label — wrong for a poll timeout, which is exactly the case
-# worth another attempt, so classification matches the Message instead.
+# Verbatim envelope from `uip maestro flow debug --timeout 1`. The
+# `RetryWillNotFix` label is wrong for a poll timeout, so we match the Message.
 _POLL_TIMEOUT = (
     '{\n  "Result": "Failure",\n'
     '  "Message": "Debug polling timed out after 180s",\n'
@@ -798,10 +797,9 @@ def _stub_debug(monkeypatch, results):
     """Feed run_debug a queue of CompletedProcess results, stub sleep to be
     instant, and stub project discovery so no real tree is needed.
 
-    A queued ``BaseException`` is raised instead of returned, which is how the
+    A queued ``BaseException`` is raised rather than returned, which is how the
     ``subprocess.TimeoutExpired`` path is exercised. The last invocation's
-    ``cmd`` / ``env`` / ``timeout`` are recorded so tests can assert on what we
-    actually handed the CLI."""
+    ``cmd`` / ``env`` / ``timeout`` are recorded for assertions."""
     calls = {"n": 0, "cmd": None, "env": None, "timeout": None}
     queue = list(results)
     monkeypatch.setattr(flow_check, "_find_project", lambda pattern: "/tmp/proj")
@@ -874,28 +872,20 @@ def test_is_transient_debug_error(cp, expected):
 
 # ── run_debug timeout budget + diagnostics ───────────────────────────────────
 #
-# Regression cover for skill-flow-wiki-pageviews, which scored 0 on a gating
-# criterion whose artifact passes this checker on re-run: the subprocess cap
-# fired below the CLI's own poll budget, SIGKILLing it mid-run so the failure
-# surfaced as a bare TimeoutExpired traceback with no payload, no instanceId
-# and no incidents to diagnose from.
+# Regression cover for skill-flow-wiki-pageviews: the subprocess cap fired below
+# the CLI's own poll budget, SIGKILLing it mid-run, so a correct artifact scored
+# 0 with nothing left to diagnose from.
 
 
 def test_run_debug_passes_derived_cli_timeout(monkeypatch):
-    """The CLI gets a --timeout strictly below our subprocess cap, so an
-    overrun is ended by the CLI (parseable envelope) not by SIGKILL."""
     calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
     run_debug(timeout=240)
     cmd = calls["cmd"]
-    assert "--timeout" in cmd
     assert cmd[cmd.index("--timeout") + 1] == "180"  # 240 - 60 headroom
     assert calls["timeout"] == 240
-    assert int(cmd[cmd.index("--timeout") + 1]) < calls["timeout"]
 
 
 def test_run_debug_cli_timeout_never_goes_below_floor(monkeypatch):
-    """A call site with a tiny cap still gets a usable CLI budget rather than
-    zero or a negative."""
     calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
     run_debug(timeout=45)
     cmd = calls["cmd"]
@@ -903,9 +893,7 @@ def test_run_debug_cli_timeout_never_goes_below_floor(monkeypatch):
 
 
 def test_run_debug_sets_uip_log_level_for_instance_id(monkeypatch):
-    """UIP_LOG_LEVEL=info is the only channel that emits jobKey / instanceId /
-    Studio Web URL — the polling-timeout envelope carries none of them.
-    (UIPCLI_LOG_LEVEL, which the docs used to show, is never read by the CLI.)"""
+    """The only channel that emits jobKey / instanceId / Studio Web URL."""
     monkeypatch.delenv("UIP_LOG_LEVEL", raising=False)
     calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
     run_debug()
@@ -913,7 +901,6 @@ def test_run_debug_sets_uip_log_level_for_instance_id(monkeypatch):
 
 
 def test_run_debug_keeps_operator_log_level(monkeypatch):
-    """An explicitly set level wins, so a human debugging locally can raise it."""
     monkeypatch.setenv("UIP_LOG_LEVEL", "debug")
     calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
     run_debug()
@@ -928,19 +915,16 @@ def test_run_debug_retries_poll_timeout_then_completes(monkeypatch):
 
 
 def test_run_debug_caps_poll_timeout_attempts(monkeypatch):
-    """A poll timeout burns the full subprocess budget each try, so it stops at
-    _POLL_TIMEOUT_ATTEMPTS even when `retries` allows more — 3 x a 300s cap
-    would overrun the 600s criterion budget in the task YAMLs."""
+    """Stops at _POLL_TIMEOUT_ATTEMPTS even when `retries` allows more."""
     calls = _stub_debug(monkeypatch, [_cp(1, _POLL_TIMEOUT)] * 3)
     with pytest.raises(SystemExit):
         run_debug(retries=3)
     assert calls["n"] == flow_check._POLL_TIMEOUT_ATTEMPTS == 2
 
 
-def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch, capsys):
-    """A stall upstream of polling (upload / provisioning / begin-session — the
-    phases --timeout cannot bound) must exit as a graded FAIL carrying the
-    partial output, not as an uncaught TimeoutExpired traceback."""
+def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch):
+    """A stall upstream of polling exits as a graded FAIL carrying the partial
+    output, not as an uncaught TimeoutExpired traceback."""
     exc = subprocess.TimeoutExpired(
         cmd=["uip", "maestro", "flow", "debug"],
         timeout=240,
@@ -953,16 +937,15 @@ def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch, capsys):
     assert calls["n"] == 1
     message = str(excinfo.value)
     assert "240s subprocess cap" in message
-    # The instanceId is the whole point: without it the run is unrecoverable.
-    assert "abc-123" in message
+    assert "abc-123" in message  # without the instanceId the run is unrecoverable
     assert flow_check._LAST_DEBUG_RAW == '{"partial": true}'
 
 
 @pytest.mark.parametrize(
     "raw,expected",
     [
-        (b"bytes payload", "bytes payload"),   # TimeoutExpired hands back bytes...
-        ("str payload", "str payload"),        # ...CompletedProcess hands back str
+        (b"bytes payload", "bytes payload"),  # TimeoutExpired hands back bytes
+        ("str payload", "str payload"),  # CompletedProcess hands back str
         (None, ""),
         (b"\xff\xfe bad utf8", "�� bad utf8"),
     ],


### PR DESCRIPTION
## Motivation

`skill-flow-wiki-pageviews` failed a **gating** criterion with `weighted_score: 0.615`. The recorded cause in `review.json` was "the error output port was not connected."

It was connected. The artifact is correct, and it passes the unmodified checker — I re-ran it **9/9, 18–26 s per run**, on both CLI `1.202.0` and the eval image's own `1.201.0-dev.8319`. The element trace shows the error path executing exactly as designed:

```
_Implicit_HttpTask_fetchWikimediaPageviews1      SendTask          Failed
_Implicit_BoundaryError_fetchWikimediaPageviews1 BoundaryEvent     Completed
_Implicit_EndEvent_Failure_...                   EndEvent          Completed
_Implicit_PostSubprocessGateway_...              ExclusiveGateway  Completed
doneArticleNotFound                              EndEvent          Completed
```

The real failure was a `subprocess.TimeoutExpired` at `flow_check.py:138`. `run_debug` caps the subprocess **below** the CLI's own poll budget (600 s = `maxPolls 300 × pollInterval 2000ms`) at **41 of its 53 call sites**, and never passes `--timeout`. So a run that merely overran was SIGKILLed mid-poll, the exception escaped uncaught, and the criterion scored 0 with no payload, no `instanceId`, no incidents, and no retry. That erasure is also why the post-hoc review had to guess a cause — and guessed wrong.

This is suite-wide, not task-specific: 2 of 3 criteria in this task are live cloud execution, so infra variance is currently graded as agent error.

## Changes

**`tests/tasks/uipath-maestro-flow/_shared/flow_check.py`**

- **Pass `--timeout` to the CLI**, derived from the subprocess cap minus 60 s of headroom for the phases `--timeout` does *not* bound (solution upload, Studio Web debug provisioning, begin-session, create-instance — all unbounded `fetch` calls with no `AbortSignal`). The CLI now self-terminates with a parseable envelope *before* our cap fires. Fixes all 53 call sites without touching any of them.
- **Set `UIP_LOG_LEVEL=info`** so stderr carries `jobKey` / `instanceId` / Studio Web URL. The polling-timeout envelope carries none of them, so this is the only way to find the instance afterwards.
- **Treat the CLI's poll-budget expiry as transient** and retry it — matching on the message, because the CLI labels that path `Retry: "RetryWillNotFix"`, which is wrong for a poll timeout. Capped at 2 attempts: each burns the full budget, and 3 × a 300 s cap overruns the 600 s criterion budget in the task YAMLs.
- **Catch `subprocess.TimeoutExpired`** and fail through `_fail_with_capture` with partial stdout/stderr retained. `TimeoutExpired` returns **bytes** even under `text=True`, hence the `_as_text` helper.

**Docs — `UIPCLI_LOG_LEVEL` is a no-op.** The CLI reads `UIP_LOG_LEVEL` (`packages/common/src/logger.ts`); `UIPCLI_LOG_LEVEL` appears nowhere in the shipped bundle, including 1.201. Every documented `flow debug` invocation was prefixed with a variable that does nothing — the same blind spot that left this eval with no evidence. Renamed across the flow references and `preview/`, and corrected the claim that the level applies only to `flow debug` (it is global).

## Verification

- `207` flow-suite unit tests pass, `12` new — covering the derived `--timeout`, its floor, the env var (set + operator override), poll-timeout retry and its 2-attempt cap, the `TimeoutExpired` path retaining the `instanceId`, and `_as_text` decoding.
- The **unmodified** `check_wiki_pageviews_flow.py invalid_error` passes end-to-end against a live tenant with the patched `run_debug` — confirming the new `--timeout` flag does not break a real invocation. All solutions created during verification were deleted.
- The 2 collection errors in `tests/tasks/uipath-maestro-case/` are pre-existing on a clean `main` (verified via stash) and unrelated.

## Notes for reviewers

- **`preview/` is included** (2 lines, same env-var bug), which pulls in @dmetzgar / @tmatup. Happy to drop it into its own PR if you'd rather keep the reviewer set tight.
- **Not fixed here, deliberately:** `tests/tasks/uipath-maestro-case/_shared/case_check.py` has the identical defect with a 540 s cap under the same 600 s CLI budget — different skill and CODEOWNERS, so it wants its own PR. `tests/tasks/uipath-maestro-flow/canary/canary.py` uses 780 s, which is *above* the CLI budget, so it is not exposed to the SIGKILL path (it still lacks the log level and the `TimeoutExpired` guard).
- **Follow-up on the CLI side:** include `instanceId` / `jobKey` in the polling-timeout error envelope, fix the `RetryWillNotFix` label, and bound the pre-poll phases with an `AbortSignal`. This PR does not depend on any of it.
- **`skill-flow-wiki-pageviews` should be rescored** — its `FAILURE` is a false negative, and `review.json`'s stated cause retracted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
