### PR TITLE
fix(uipath-maestro-flow): stop grading slow debug runs as flow failures

### DIFF
--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -81,7 +81,7 @@ uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
 uip maestro flow validate <Name>Sol/<Name>/<Name>.flow --output json
 # Only for a stated runtime-behavior claim:
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )
 ```
@@ -160,7 +160,7 @@ diagnostics in one read-back instead of printing the full execution envelope:
 
 ```bash
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --inputs @inputs.json \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )

--- a/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
+++ b/skills/uipath-maestro-flow/references/operate/CAPABILITY.md
@@ -88,7 +88,7 @@ Capability index for the lifecycle of a flow as a deployed asset. Operate owns e
 <!--skill-flavor:upload-shared-cli-entry:start-->
 - [shared/cli-commands.md](../shared/cli-commands.md) — flat CLI lookup including `solution upload`, `solution resources refresh`, `flow pack`, `flow debug`, `flow process`, `flow job`, `flow instance`
 <!--skill-flavor:upload-shared-cli-entry:end-->
-- [shared/cli-conventions.md](../shared/cli-conventions.md) — login states, FOLDER_KEY, UIPCLI_LOG_LEVEL, JSON output shape
+- [shared/cli-conventions.md](../shared/cli-conventions.md) — login states, FOLDER_KEY, UIP_LOG_LEVEL, JSON output shape
 - [shared/variables-and-expressions.md](../shared/variables-and-expressions.md) — `--inputs` JSON shape for `flow debug`
 
 <!--skill-flavor:upload-orchestrator-pointer:start-->

--- a/skills/uipath-maestro-flow/references/operate/references/run.md
+++ b/skills/uipath-maestro-flow/references/operate/references/run.md
@@ -16,7 +16,7 @@ Execute a flow on demand and monitor progress. Three modes: **debug** (controlle
 > **Confirm consent first.** `flow debug` executes the flow for real — sends emails, posts messages, calls APIs. See the consent-before-debug rule in [SKILL.md](../../../SKILL.md). Do not run without explicit user authorization.
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 ```
 
 The argument is the **project directory path** (the folder containing `project.uiproj`). Use `<ProjectName>/` from the solution dir, or `.` if already inside the project dir.
@@ -24,7 +24,7 @@ The argument is the **project directory path** (the folder containing `project.u
 Pass input arguments when the flow has input parameters:
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --inputs '{"numberA": 5, "numberB": 7}'
 ```
 
@@ -32,7 +32,7 @@ Bind local files to file-typed input variables with `--attachment <variableId>=<
 
 ```bash
 # Replace <variableId> and <localPath> placeholders below with your own values.
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --attachment <variableId>=<localPath> \
   --attachment <variableId>=<localPath>
 ```

--- a/skills/uipath-maestro-flow/references/shared/cli-commands.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-commands.md
@@ -152,15 +152,15 @@ uip solution upload <SolutionDir> --output json
 Debug a Flow in the cloud via Studio Web + Orchestrator. **Requires `uip login`.**
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 
 # Pass input arguments to the flow
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --inputs '{"numberA": 5, "numberB": 7}'
 
 # Bind local files to file-typed input variables (repeatable).
 # Replace <variableId> and <localPath> with your own values.
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json \
   --attachment <variableId>=<localPath> \
   --attachment <variableId>=<localPath>
 ```

--- a/skills/uipath-maestro-flow/references/shared/cli-conventions.md
+++ b/skills/uipath-maestro-flow/references/shared/cli-conventions.md
@@ -158,15 +158,15 @@ uip or folders list --output json
 
 Or pull it from the job/process context (e.g., `Data.folderKey` on a job status response, or from the debug output's surrounding metadata).
 
-## 7. `UIPCLI_LOG_LEVEL=info` for debug runs
+## 7. `UIP_LOG_LEVEL=info` for debug runs
 
-Set `UIPCLI_LOG_LEVEL=info` on `flow debug` invocations to surface progress and diagnostic detail in the CLI output. Without it, debug runs return only the final result.
+Set `UIP_LOG_LEVEL=info` on `flow debug` invocations to surface progress and diagnostic detail. At `info` the run narrates `jobKey` / `instanceId` / Studio Web URL to **stderr** — capture stderr, since a poll-budget timeout reports no instanceId on stdout.
 
 ```bash
-UIPCLI_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
+UIP_LOG_LEVEL=info uip maestro flow debug <path-to-project-dir> --output json
 ```
 
-The env var has no effect on other subcommands.
+> The variable is `UIP_LOG_LEVEL`, not `UIPCLI_LOG_LEVEL` (the latter is never read). The level applies to every `uip` command.
 
 ## 8. Global options
 

--- a/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/flow_check.py
@@ -77,13 +77,38 @@ _LAST_DEBUG_PROJECT_DIR: str | None = None
 # check (customer-escalation-triage). Distinct from a real flow failure (a
 # `finalStatus` that completed-with-fault, or wrong outputs), which must fail
 # immediately. Retry ONLY on the transient markers below.
-_DEBUG_RETRY_MARKERS = ('"retry": "retrylater"', '"errorcode": "server_error"')
+#
+# The CLI's own poll-budget expiry (`Debug polling timed out after Ns`) is also
+# transient, but it labels that path `Retry:RetryWillNotFix` — wrong for a poll
+# timeout — so it is matched on the message. It burns the full subprocess budget
+# each attempt, so it gets fewer tries (_POLL_TIMEOUT_ATTEMPTS): 3 × a 300s cap
+# overruns the 600s criterion budget in the task YAMLs.
+_POLL_TIMEOUT_MARKER = "debug polling timed out"
+_POLL_TIMEOUT_ATTEMPTS = 2
+_DEBUG_RETRY_MARKERS = (
+    '"retry": "retrylater"',
+    '"errorcode": "server_error"',
+    _POLL_TIMEOUT_MARKER,
+)
+
+# Give the CLI a `--timeout` below the subprocess cap so an overrun ends by the
+# CLI (parseable envelope + stderr narration) rather than a SIGKILL that keeps
+# nothing. Headroom covers the phases --timeout does NOT bound: solution upload,
+# Studio Web provisioning, begin-session, create-instance.
+_CLI_TIMEOUT_HEADROOM_SECONDS = 60
+_MIN_CLI_TIMEOUT_SECONDS = 30
+
+# `UIP_LOG_LEVEL` (NOT `UIPCLI_LOG_LEVEL`, which the CLI never reads). At `info`
+# the run narrates jobKey/instanceId/Studio Web URL to stderr — the only way to
+# find the instance after a timeout, whose error envelope carries none of them.
+_DEBUG_LOG_LEVEL = "info"
 
 
 def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     """True iff a failed ``flow debug`` invocation looks like a transient
-    server-side error (5xx / RetryLater) worth retrying, rather than a real
-    flow fault. Case-insensitive so CLI key casing can't slip past."""
+    server-side error (5xx / RetryLater / poll-budget expiry) worth retrying,
+    rather than a real flow fault. Case-insensitive so CLI key casing can't slip
+    past."""
     if result.returncode == 0:
         return False
     blob = f"{result.stdout}\n{result.stderr}".lower()
@@ -94,6 +119,24 @@ def _is_transient_debug_error(result: subprocess.CompletedProcess) -> bool:
     status = _get_ci(data or {}, "Context", default={})
     http = _get_ci(status if isinstance(status, dict) else {}, "HttpStatus")
     return isinstance(http, int) and 500 <= http < 600
+
+
+def _is_poll_timeout(result: subprocess.CompletedProcess) -> bool:
+    """True iff the CLI gave up on its own poll budget (retried on a shorter
+    leash than other transient errors — see :data:`_POLL_TIMEOUT_ATTEMPTS`)."""
+    if result.returncode == 0:
+        return False
+    return _POLL_TIMEOUT_MARKER in f"{result.stdout}\n{result.stderr}".lower()
+
+
+def _as_text(raw: bytes | str | None) -> str:
+    """``subprocess.TimeoutExpired`` carries partial output as bytes even under
+    ``text=True`` (unlike ``CompletedProcess``); decode defensively."""
+    if raw is None:
+        return ""
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace")
+    return raw
 
 
 # ── Public helpers ──────────────────────────────────────────────────────────
@@ -111,22 +154,31 @@ def run_debug(
     """Locate the project, run ``uip maestro flow debug --output json``, and return the
     parsed ``Data`` payload. Exits on any step failing.
 
-    Transient server-side errors (5xx / ``RetryLater`` while polling the debug
-    instance — see :func:`_is_transient_debug_error`) are retried up to
-    ``retries`` times with ``backoff_seconds`` between attempts. A real flow
-    fault (non-transient failure, or a run that completes with the wrong
-    ``finalStatus``) fails immediately without burning retries.
+    ``timeout`` is the hard subprocess cap. The CLI gets a strictly smaller
+    ``--timeout`` (minus :data:`_CLI_TIMEOUT_HEADROOM_SECONDS`) plus
+    ``UIP_LOG_LEVEL=info`` so an overrun ends with a parseable envelope and the
+    stderr instanceId narration, not a SIGKILL that keeps nothing.
+
+    Transient server-side errors (5xx / ``RetryLater`` while polling, or the
+    CLI's own poll-budget expiry — see :func:`_is_transient_debug_error`) are
+    retried up to ``retries`` times with ``backoff_seconds`` between attempts;
+    poll timeouts get :data:`_POLL_TIMEOUT_ATTEMPTS` tries. A real flow fault
+    (non-transient failure, or a wrong ``finalStatus``) fails immediately.
 
     ``attachments`` maps a file-typed input variable ``id`` to a local file path;
     each pair is passed as ``--attachment <id>=<path>`` (repeatable). The variable
     ``id`` must match a ``variables.globals[]`` entry with ``direction:"in"`` and
     ``type:"file"`` — see :func:`read_flow_file_input_vars`."""
     project_dir = _find_project(project_glob)
-    cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json"]
+    cli_timeout = max(_MIN_CLI_TIMEOUT_SECONDS, timeout - _CLI_TIMEOUT_HEADROOM_SECONDS)
+    cmd = ["uip", "maestro", "flow", "debug", project_dir, "--output", "json",
+           "--timeout", str(cli_timeout)]
     if inputs is not None:
         cmd.extend(["--inputs", json.dumps(inputs)])
     for var_id, local_path in (attachments or {}).items():
         cmd.extend(["--attachment", f"{var_id}={local_path}"])
+    env = dict(os.environ)
+    env.setdefault("UIP_LOG_LEVEL", _DEBUG_LOG_LEVEL)
     global _LAST_DEBUG_RAW, _LAST_DEBUG_INPUT_IDS, _LAST_DEBUG_PROJECT_DIR
     # Record what we bound as input, and where the project lives, so output
     # assertions can discount echoes of our own inputs.
@@ -135,9 +187,26 @@ def run_debug(
     }
     _LAST_DEBUG_PROJECT_DIR = project_dir
     for attempt in range(retries):
-        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        try:
+            r = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=timeout, env=env
+            )
+        except subprocess.TimeoutExpired as exc:
+            # Outran even the subprocess cap, so --timeout never fired: the stall
+            # is in a phase --timeout can't bound. Keep the partial output
+            # (stderr carries the instanceId) instead of a bare traceback.
+            _LAST_DEBUG_RAW = _as_text(exc.stdout)
+            _fail_with_capture(
+                f"flow debug exceeded the {timeout}s subprocess cap without returning "
+                f"(CLI --timeout was {cli_timeout}s, so the stall is upstream of "
+                "polling: upload / Studio Web provisioning / begin-session / "
+                "create-instance).\n"
+                f"stdout: {_as_text(exc.stdout)}\nstderr: {_as_text(exc.stderr)}"
+            )
         _LAST_DEBUG_RAW = r.stdout
         if r.returncode == 0 or not _is_transient_debug_error(r):
+            break
+        if _is_poll_timeout(r) and attempt + 1 >= _POLL_TIMEOUT_ATTEMPTS:
             break
         if attempt + 1 < retries:
             time.sleep(backoff_seconds)

--- a/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
+++ b/tests/tasks/uipath-maestro-flow/_shared/test_flow_check.py
@@ -778,6 +778,15 @@ _COMPLETED = (
 )
 
 
+# Verbatim `flow debug` poll-timeout envelope. The `RetryWillNotFix` label is
+# wrong for a poll timeout, so classification matches the Message instead.
+_POLL_TIMEOUT = (
+    '{\n  "Result": "Failure",\n'
+    '  "Message": "Debug polling timed out after 180s",\n'
+    '  "ErrorCode": "unknown_error",\n  "Retry": "RetryWillNotFix"\n}'
+)
+
+
 def _cp(returncode, stdout="", stderr=""):
     return subprocess.CompletedProcess(
         args=["uip", "maestro", "flow", "debug"], returncode=returncode, stdout=stdout, stderr=stderr
@@ -785,16 +794,23 @@ def _cp(returncode, stdout="", stderr=""):
 
 
 def _stub_debug(monkeypatch, results):
-    """Feed run_debug a queue of CompletedProcess results, stub sleep to be
-    instant, and stub project discovery so no real tree is needed."""
-    calls = {"n": 0}
+    """Feed run_debug a queue of results, stub sleep + project discovery. A
+    queued ``BaseException`` is raised (exercises the ``TimeoutExpired`` path);
+    the last call's cmd/env/timeout are recorded for assertions."""
+    calls = {"n": 0, "cmd": None, "env": None, "timeout": None}
     queue = list(results)
     monkeypatch.setattr(flow_check, "_find_project", lambda pattern: "/tmp/proj")
     monkeypatch.setattr(flow_check.time, "sleep", lambda *_: None)
 
     def fake_run(cmd, **kwargs):
         calls["n"] += 1
-        return queue.pop(0)
+        calls["cmd"] = cmd
+        calls["env"] = kwargs.get("env")
+        calls["timeout"] = kwargs.get("timeout")
+        result = queue.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return result
 
     monkeypatch.setattr(flow_check.subprocess, "run", fake_run)
     return calls
@@ -844,7 +860,89 @@ def test_run_debug_exhausts_retries_on_persistent_504(monkeypatch):
         (_cp(1, '{"Context": {"HttpStatus": 503}}'), True),            # 5xx via HttpStatus
         (_cp(1, '{"ErrorCode": "invalid_argument", "Retry": "RetryWillNotFix"}'), False),
         (_cp(1, '{"Context": {"HttpStatus": 404}}'), False),           # 4xx is not transient
+        (_cp(1, _POLL_TIMEOUT), True),                                 # CLI poll-budget expiry
     ],
 )
 def test_is_transient_debug_error(cp, expected):
     assert flow_check._is_transient_debug_error(cp) is expected
+
+
+# ── run_debug timeout budget + diagnostics ───────────────────────────────────
+
+
+def test_run_debug_passes_derived_cli_timeout(monkeypatch):
+    """CLI --timeout is strictly below the subprocess cap (cap - 60 headroom)."""
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug(timeout=240)
+    cmd = calls["cmd"]
+    assert cmd[cmd.index("--timeout") + 1] == "180"
+    assert int(cmd[cmd.index("--timeout") + 1]) < calls["timeout"] == 240
+
+
+def test_run_debug_cli_timeout_never_goes_below_floor(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug(timeout=45)
+    cmd = calls["cmd"]
+    assert cmd[cmd.index("--timeout") + 1] == str(flow_check._MIN_CLI_TIMEOUT_SECONDS)
+
+
+def test_run_debug_sets_uip_log_level(monkeypatch):
+    """UIP_LOG_LEVEL=info is the only channel emitting instanceId after a timeout."""
+    monkeypatch.delenv("UIP_LOG_LEVEL", raising=False)
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug()
+    assert calls["env"]["UIP_LOG_LEVEL"] == "info"
+
+
+def test_run_debug_keeps_operator_log_level(monkeypatch):
+    monkeypatch.setenv("UIP_LOG_LEVEL", "debug")
+    calls = _stub_debug(monkeypatch, [_cp(0, _COMPLETED)])
+    run_debug()
+    assert calls["env"]["UIP_LOG_LEVEL"] == "debug"
+
+
+def test_run_debug_retries_poll_timeout_then_completes(monkeypatch):
+    calls = _stub_debug(monkeypatch, [_cp(1, _POLL_TIMEOUT), _cp(0, _COMPLETED)])
+    payload = run_debug()
+    assert calls["n"] == 2
+    assert flow_check._get_ci(payload, "finalStatus") == "Completed"
+
+
+def test_run_debug_caps_poll_timeout_attempts(monkeypatch):
+    """A poll timeout burns the full budget each try, so it stops at
+    _POLL_TIMEOUT_ATTEMPTS even when `retries` allows more."""
+    calls = _stub_debug(monkeypatch, [_cp(1, _POLL_TIMEOUT)] * 3)
+    with pytest.raises(SystemExit):
+        run_debug(retries=3)
+    assert calls["n"] == flow_check._POLL_TIMEOUT_ATTEMPTS == 2
+
+
+def test_run_debug_subprocess_timeout_fails_cleanly(monkeypatch):
+    """A stall upstream of polling exits as a graded FAIL retaining the partial
+    output (incl. the stderr instanceId), not a bare TimeoutExpired traceback."""
+    exc = subprocess.TimeoutExpired(
+        cmd=["uip", "maestro", "flow", "debug"],
+        timeout=240,
+        output=b'{"partial": true}',
+        stderr=b"Debug instance created - instanceId: abc-123\n",
+    )
+    calls = _stub_debug(monkeypatch, [exc])
+    with pytest.raises(SystemExit) as excinfo:
+        run_debug(timeout=240)
+    assert calls["n"] == 1
+    assert "240s subprocess cap" in str(excinfo.value)
+    assert "abc-123" in str(excinfo.value)
+    assert flow_check._LAST_DEBUG_RAW == '{"partial": true}'
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (b"bytes payload", "bytes payload"),
+        ("str payload", "str payload"),
+        (None, ""),
+        (b"\xff\xfe bad utf8", "�� bad utf8"),
+    ],
+)
+def test_as_text_decodes_defensively(raw, expected):
+    assert flow_check._as_text(raw) == expected


### PR DESCRIPTION
## Problem

`run_debug` capped the subprocess below the CLI's own poll budget (600s) at most call sites and never passed `--timeout`. A slow-but-valid cloud run was SIGKILLed mid-poll, so it surfaced as a bare `subprocess.TimeoutExpired` — no payload, no `instanceId`, no incidents — and scored 0 as if the flow were built wrong.

## Changes

`tests/tasks/uipath-maestro-flow/_shared/flow_check.py`:
- Pass `--timeout` = subprocess cap − 60s headroom (floored at 30s) so the CLI self-terminates with a parseable envelope before our cap fires. Fixes all call sites without touching them.
- Set `UIP_LOG_LEVEL=info` so stderr carries `jobKey`/`instanceId`/Studio Web URL — the only way to find the instance after a timeout.
- Treat the CLI's poll-budget expiry as transient and retry, capped at 2 attempts (each burns the full budget; 3× overruns the 600s criterion cap).
- Catch `subprocess.TimeoutExpired` and fail through `_fail_with_capture` with partial output retained (`_as_text` decodes the bytes `TimeoutExpired` returns under `text=True`).

Docs: `UIPCLI_LOG_LEVEL` is never read by the CLI — it reads `UIP_LOG_LEVEL` (global, not `flow debug`-only). Renamed across the flow references and `preview/`.

## Verification

`python3 -m pytest test_flow_check.py` — 79 pass, 12 new (derived `--timeout` + floor, log-level default + operator override, poll-timeout retry + 2-attempt cap, `TimeoutExpired` retaining the instanceId, `_as_text`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)