### PR TITLE
docs(uipath-maestro-flow): use UIP_LOG_LEVEL in the preview CLI loop

### DIFF
--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -81,7 +81,7 @@ uip maestro flow compile <Name> -o <Name>Sol/<Name>/<Name>.flow
 uip maestro flow validate <Name>Sol/<Name>/<Name>.flow --output json
 # Only for a stated runtime-behavior claim:
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )
 ```
@@ -160,7 +160,7 @@ diagnostics in one read-back instead of printing the full execution envelope:
 
 ```bash
 ( cd <Name>Sol && uip solution resources refresh --solution-folder . --output json )
-( cd <Name>Sol && UIPCLI_LOG_LEVEL=warn uip maestro flow debug <Name> \
+( cd <Name>Sol && UIP_LOG_LEVEL=warn uip maestro flow debug <Name> \
   --inputs @inputs.json \
   --output-filter '{instanceId:instanceId,finalStatus:finalStatus,studioWebUrl:studioWebUrl,incomplete:elementExecutions[?status!=`Completed`],globals:variables.globals,incidents:incidents}' \
   --output json )


### PR DESCRIPTION
Two-line typo fix.

The CLI reads `UIP_LOG_LEVEL` (`packages/common/src/logger.ts`). `UIPCLI_LOG_LEVEL` is never read — the string does not appear anywhere in the shipped bundle, including 1.201 — so both `flow debug` invocations in this loop were prefixed with a variable that does nothing. I confirmed the behavior difference against a live tenant: with `UIPCLI_LOG_LEVEL` set, stderr carries no CLI narration; with `UIP_LOG_LEVEL`, it carries `jobKey`, `instanceId`, and the Studio Web URL.

Split out of #2776, which fixes the same typo across the canonical skill references. It was originally folded in there, but `preview/uipath-maestro-flow/` has its own CODEOWNERS entry, so two lines here blocked that PR on a different reviewer set. Separate PR so this directory's owners can review it on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
