### PR TITLE
test(maestro-flow): gate the resolution task on an agent-run flow debug

### DIFF
--- a/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
+++ b/tests/tasks/uipath-maestro-flow/multi_node/billing_dispute_resolution/billing_dispute_resolution.yaml
@@ -97,9 +97,12 @@ initial_prompt: |
           short literal string noting that no resolution email was drafted.
 
   ## Done criteria
-  Validate the final flow file — the task is not complete until `uip maestro
-  flow validate` passes. Grading then runs the flow under debug against live
-  tenant data, so build it to actually run, not merely validate.
+  Validate the final flow file, then run it once yourself. The task is not
+  complete until `uip maestro flow validate` passes AND one `uip maestro flow
+  debug` run with representative inputs of your own construction reports
+  `finalStatus: Completed`. When debug faults, read the incident, fix the flow,
+  and re-run — stop after 3 debug attempts and report the last incident instead
+  of looping. Grading then runs debug against live tenant data.
 
   Build the complete flow
   without stopping to ask me.


### PR DESCRIPTION
The prompt now requires the agent to run `uip maestro flow debug` itself and reach `finalStatus: Completed` before the task counts as done (max 3 attempts, then report the last incident).

Why: recent failures (input type mismatch, dangling refs, CEQL grammar) all surfaced only in the grader's post-hoc debug while the agent finished with ~50 minutes of unused budget. This turns them into in-loop signals the agent can fix. Cost: 2-3 minutes per debug attempt against a 90-minute limit.

Passing run: one local run under the gated prompt completed and passed all criteria.

https://github.com/UiPath/skills/actions/runs/32759019946/attempts/1
https://github.com/UiPath/skills/actions/runs/32759019946/attempts/2