### PR TITLE
chore(codeowners): AH team owns the uipath-automationhub skill

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -194,5 +194,5 @@
 /tests/tasks/activation/uipath-process-mining.jsonl @UiPath/team-backendhoven
 
 # Automation Hub skills (Open API publish/read of processes via the user's cloud token)
-/skills/uipath-automationhub/ @parth-patil-uipath @abhiram-vad
-/tests/tasks/uipath-automationhub/ @parth-patil-uipath @abhiram-vad
+/skills/uipath-automationhub/ @UiPath/automationhub @parth-patil-uipath @abhiram-vad
+/tests/tasks/uipath-automationhub/ @UiPath/automationhub @parth-patil-uipath @abhiram-vad


### PR DESCRIPTION
Switches ownership of the Automation Hub skill paths from two individuals to the **@UiPath/automationhub** team (the same handle that owns `packages/automation-hub-tool` in UiPath/cli since UiPath/cli#3650), keeping the current individuals as explicit co-owners.

**Why:** with only two individual owners — one of whom authored UiPath/skills#2725 and therefore cannot approve it — a single person's availability gates every AH-skill PR (`require_code_owner_review` is on for `main`). Team ownership matches the pattern already used throughout this CODEOWNERS file (`@UiPath/team-merlot`, `@UiPath/llmops-team`, …).

**Note for repo admins:** if `@UiPath/automationhub` doesn't yet have write access to this repo, the team token is ignored until access is granted — the individual owners keep the lines valid in the meantime. Please grant the team write access as part of merging this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)