### PR TITLE
fix(evals): anchor shared grader staging to its checkout

### DIFF
--- a/.github/workflows/test-helpers.yml
+++ b/.github/workflows/test-helpers.yml
@@ -140,6 +140,22 @@ jobs:
       - name: Run catalog guard tests
         run: pytest tests/scripts/test_catalog_build_guards.py -v
 
+  stage-shared-guard:
+    runs-on: uipath-ubuntu-latest
+    name: shared grader staging contract guard
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        with:
+          python-version: '3.13'
+
+      - name: Install pytest
+        run: pip install pytest
+
+      - name: Run staging contract guard
+        run: pytest tests/scripts/test_stage_shared.py -v
+
   telemetry-hook-tests:
     runs-on: uipath-ubuntu-latest
     name: telemetry hook contract guard

--- a/tests/scripts/stage_shared.sh
+++ b/tests/scripts/stage_shared.sh
@@ -19,7 +19,8 @@
 # mutates the checked-out tree, not the committed repo.
 set -euo pipefail
 
-cd "$(git rev-parse --show-toplevel)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$(git -C "$script_dir" rev-parse --show-toplevel)"
 
 count=0
 while IFS= read -r f; do

--- a/tests/scripts/test_stage_shared.py
+++ b/tests/scripts/test_stage_shared.py
@@ -1,0 +1,45 @@
+"""Regression tests for staging shared checker helpers."""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).with_name("stage_shared.sh")
+
+
+def test_stage_shared_resolves_its_checkout_from_the_script_path(tmp_path):
+    repo = tmp_path / "skills"
+    script = repo / "tests" / "scripts" / "stage_shared.sh"
+    shared = repo / "tests" / "tasks" / "example" / "_shared"
+    task = repo / "tests" / "tasks" / "example" / "scenario"
+
+    script.parent.mkdir(parents=True)
+    shared.mkdir(parents=True)
+    task.mkdir(parents=True)
+    shutil.copy2(SCRIPT, script)
+    (shared / "__init__.py").write_text("", encoding="utf-8")
+    (shared / "checker.py").write_text("VALUE = 42\n", encoding="utf-8")
+    (task / "check.py").write_text("from _shared.checker import VALUE\n", encoding="utf-8")
+
+    subprocess.run(["git", "init", "--quiet", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+
+    first = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    second = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert "co-located _shared into 1 task dir(s)" in first.stdout
+    assert "co-located _shared into 0 task dir(s)" in second.stdout
+    assert (task / "_shared" / "checker.py").read_text(encoding="utf-8") == "VALUE = 42\n"


### PR DESCRIPTION
## Summary

- resolve the skills checkout from `stage_shared.sh` itself instead of the caller's current directory
- preserve idempotent co-location of group-level `_shared` checker packages
- add a regression test that invokes the script by absolute path from outside the repository, plus a dedicated CI guard

## Root cause

The staging helper used `git rev-parse --show-toplevel` from the ambient working directory. Cross-repository callers can execute the script by absolute path while remaining in their own checkout, so the helper searched the wrong repository, reported zero staged directories, and coder-eval later copied leaf task folders without `_shared`. This surfaced in coder_eval_uipath Azure run 13130329 as `ModuleNotFoundError: No module named _shared` in both paired arms.

The script now anchors repository discovery to its own directory, making the staging contract independent of caller cwd.

## Verification

- `uvx --from pytest pytest tests/scripts/test_stage_shared.py -q` — 1 passed
- `bash -n tests/scripts/stage_shared.sh`
- `.github/workflows/test-helpers.yml` parses with PyYAML
- `git diff --check`

Dependency for UiPath/coder_eval_uipath#93 and UiPath/flow-builder-sdk#405.

🤖 Generated with Claude Code
Co-Authored-By: Claude <noreply@anthropic.com>