### PR TITLE
test(uipath-governance): cover aops-policy capabilities (batch 1 of 3)

### DIFF
--- a/tests/tasks/uipath-governance/aops-policy/aops_analyzer_rules_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_analyzer_rules_e2e.yaml
@@ -1,0 +1,58 @@
+task_id: skill-gov-aops-policy-analyzer-rules-e2e
+description: >
+  End-to-end (outcome-graded): a Studio governance recipe (S1 + S3) that needs both a
+  plain toggle and a repeating-row (editgrid) edit — enforce the Workflow Analyzer before
+  publish and enable analyzer rule ST-NMG-001 as an Error. Once governance is enforced the
+  built-in analyzer rules are all off unless listed, so a policy that only flips the toggle
+  silently disables the analyzer. Graded on the stored policy: the toggle's key is resolved
+  from the live template labels and the rules grid must hold an enabled ST-NMG-001 row.
+tags: [uipath-governance, e2e, mode:build, lifecycle:setup, aops-policy, create]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-analyzer" AOPS_PRODUCT="Development" AOPS_DESCRIPTION="Analyzer gate with naming rule" AOPS_PLAN_ONLY="1" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 90
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''cleanup_aops_policy.py''))"'
+    timeout: 120
+
+run_limits:
+  expected_turns: 26
+
+initial_prompt: |
+  Register a Studio (product `Development`) AOps governance policy for our developers:
+
+  - Name: exactly the `policy.name` value from `seed.json`.
+  - Description: exactly the `policy.description` value from `seed.json`.
+  - Nobody may publish a project until the Workflow Analyzer has passed.
+  - The analyzer must enforce our naming convention: rule ST-NMG-001, enabled, at Error level.
+
+  Register it only - do NOT deploy it to any tenant, user or group.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-governance skill and follow its workflow.
+
+success_criteria:
+  - type: run_command
+    description: "the Development policy enforces the analyzer before publish and its rules grid holds an enabled ST-NMG-001 row"
+    command: 'AOPS_SEED_KEY="policy" AOPS_PRODUCT="Development" AOPS_FIELD_LABEL="analy[sz]er.*publish" AOPS_FIELD_EXPECT="true" AOPS_ROW_KEY_REGEX="embedded-rules" AOPS_ROW_CODE="ST-NMG-001" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''verify_aops_policy_data.py''))"'
+    timeout: 180
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the policy data was composed from the product template, not hand-written"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+template\s+(list|get)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "nothing was deployed — governance deployment state is left untouched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_deploy_group_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deploy_group_e2e.yaml
@@ -1,0 +1,63 @@
+task_id: skill-gov-aops-policy-deploy-group-e2e
+description: >
+  End-to-end (outcome-graded): a registered policy is deployed at group scope to a marker
+  directory group created in pre_run under this run's own name. The group is unknown to
+  governance, so `deployment group list` cannot resolve it — the agent has to fall back to
+  the directory (`uip admin groups list`) and let `group configure` auto-register it. The
+  group has no members, so nobody's effective policy changes; post_run removes it. Graded on
+  `deployment group get` read back live.
+tags: [uipath-governance, e2e, mode:operate, lifecycle:setup, aops-policy, deployment]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-deploy-group" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="Deployed to one team" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 120
+  - command: 'AOPS_SNAPSHOT_SCOPES="" AOPS_GROUP_BASE="ce-gov-aops-team" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
+    timeout: 120
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''restore_deployment.py''))"'
+    timeout: 180
+
+run_limits:
+  expected_turns: 24
+
+initial_prompt: |
+  Deploy the AOps governance policy named in `seed.json` (the `policy.name` field) to the
+  team whose directory group is named in `seed.json` (the `subjects.groupName` field),
+  for the `E2E` product. Apply it to that group only - do not change user or tenant scope.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-governance skill and follow its workflow.
+
+success_criteria:
+  - type: run_command
+    description: "the marker group carries the seeded policy for E2E (auto-registered on first configure)"
+    command: 'AOPS_DEPLOY_CHECK="group_pinned" AOPS_SEED_KEY="policy" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''verify_deployment.py''))"'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the group id came from the directory — governance does not list a group with no overrides"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+admin\s+groups\s+(list|get)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the assignment was written with group configure --input (the --group display-name flag, not --group-name)"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+group\s+configure\s+\S+.*--group\s'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "narrowest scope only — no user or tenant assignment was touched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+(user|tenant)\s+(configure|remove|delete)'
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_deploy_tenant_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deploy_tenant_e2e.yaml
@@ -1,0 +1,67 @@
+task_id: skill-gov-aops-policy-deploy-tenant-e2e
+description: >
+  End-to-end (outcome-graded): a tenant-scope round trip on the shared E2E test product —
+  pin a registered policy for (E2E product, E2E license type), record the tenant's
+  assignments while pinned, then remove exactly that pin. `deployment tenant configure` is a
+  full replace keyed by the license-type NAME, so the saved pinned record must show every
+  pre-existing assignment alongside the new one, and the live tenant must equal its pre_run
+  snapshot afterwards. post_run restores the snapshot in any case.
+tags: [uipath-governance, e2e, mode:operate, lifecycle:setup, aops-policy, deployment]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-deploy-tenant" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="Tenant baseline for the E2E product" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 120
+  - command: 'AOPS_SNAPSHOT_SCOPES="tenant" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
+    timeout: 120
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''restore_deployment.py''))"'
+    timeout: 180
+
+run_limits:
+  expected_turns: 28
+
+initial_prompt: |
+  On the tenant I am logged into, make the AOps governance policy named in `seed.json`
+  (the `policy.name` field) the tenant-wide baseline for the `E2E` product under the
+  `E2E` license type - every other tenant assignment must stay exactly as it is.
+
+  Once it is saved, save the tenant's full deployment record verbatim to ./pinned.json.
+  Then remove that one assignment again (only that one) so the tenant ends up exactly as
+  it started.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-governance skill and follow its workflow.
+
+success_criteria:
+  - type: run_command
+    description: "pinned.json shows the E2E/E2E baseline plus every prior assignment, and the live tenant is back to its snapshot"
+    command: 'AOPS_DEPLOY_CHECK="tenant_roundtrip" AOPS_SEED_KEY="policy" AOPS_PINNED_FILE="pinned.json" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''verify_deployment.py''))"'
+    timeout: 150
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the tenant assignment was written with tenant configure --input"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+tenant\s+configure\s+\S+.*--input'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the single assignment was dropped with the scoped tenant remove, not a second full-replace"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+tenant\s+remove\s+\S+.*--product-name'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "tenant scope only — no user or group assignment was touched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+(user|group)\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_deploy_user_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deploy_user_e2e.yaml
@@ -1,0 +1,62 @@
+task_id: skill-gov-aops-policy-deploy-user-e2e
+description: >
+  End-to-end (outcome-graded): a registered policy is deployed at user scope — to the
+  caller's own account, for the shared E2E test product, so no other subject's
+  governance changes. `deployment user configure` is a full replace, so the check also
+  requires every pin the user already had (snapshotted in pre_run) to survive; post_run
+  restores the snapshot. Graded on `deployment user get` read back live.
+tags: [uipath-governance, e2e, mode:operate, lifecycle:setup, aops-policy, deployment]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-deploy-user" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="Deployed to one user only" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 120
+  - command: 'AOPS_SNAPSHOT_SCOPES="user" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
+    timeout: 120
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''restore_deployment.py''))"'
+    timeout: 180
+
+run_limits:
+  expected_turns: 22
+
+initial_prompt: |
+  Deploy the AOps governance policy named in `seed.json` (the `policy.name` field) to my
+  own user account - the account this CLI is logged in as - for the `E2E` product.
+  Apply it to me only: do not touch group or tenant scope, and keep any other policy
+  assignments my account already has.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-governance skill and follow its workflow.
+
+success_criteria:
+  - type: run_command
+    description: "the caller's user now carries the seeded policy for E2E and every pre-existing user pin survived"
+    command: 'AOPS_DEPLOY_CHECK="user_pinned" AOPS_SEED_KEY="policy" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''verify_deployment.py''))"'
+    timeout: 120
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the assignment was written with the non-interactive user configure --input path"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+user\s+configure\s+\S+.*--input'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "narrowest scope only — no group or tenant assignment was touched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+(group|tenant)\s+(configure|remove|delete)'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "the user's assignments were not wiped with a delete"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+user\s+delete'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -85,9 +85,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_not_executed
-    description: "no attempt to mint an S2S token — no client-credential / re-login, tenant switch, or external-app change"
+    description: "no attempt to mint an S2S token — no client-credential or bare re-login, tenant switch, or external-app mutation (help/status/list reads are fine)"
     tool_name: "Bash"
-    command_pattern: 'uip\s+(login\s+(--|tenant\s+set)|admin\s+external)'
+    command_pattern: 'uip\s+login\s+(--client-id|--client-secret|--authority|--tenant\b|-t\s|tenant\s+set\b|--output\s+\S+\s*($|[;&|)]))|uip\s+login\s*($|[;&|)])|uip\s+admin\s+external-apps\s+(create|update|delete|generate-secret|federated-credentials)'
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -1,14 +1,17 @@
 task_id: skill-gov-aops-policy-deployed-s2s-mode-smoke
 description: >
-  Smoke test (outcome-graded): the user wants the tenant-level policy only, bypassing user
-  and group overrides. On `deployed-policy get` that is the `--tenant-only` mode, which needs
-  an S2S bearer token (`UIP_S2S_TOKEN`) the sandbox does not have. The skill must recognise
-  the S2S requirement instead of faking it, and fall back to the explicit tenant assignment
-  (`deployment tenant get` / `tenant list`). Graded on the fallback record being this tenant's own, on the
-  explanation naming the S2S limitation, and on nothing being deployed. The sandbox shares the
-  runner's `uip` login, so the prompt forbids — and guards assert — any attempt to mint a token
-  by re-logging in as another identity or registering an external application.
-tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployed-policy]
+  Integration test (outcome-graded, error path): the user wants the tenant-level policy only,
+  bypassing user and group overrides. On `deployed-policy get` that is the `--tenant-only`
+  mode, which needs an S2S bearer token (`UIP_S2S_TOKEN`) the sandbox does not have. The skill
+  must recognise the S2S requirement instead of faking it, and fall back to the explicit tenant
+  assignment (`deployment tenant get` / `tenant list`). Graded on the fallback record being this
+  tenant's own, on the explanation naming the S2S limitation, and on nothing being deployed. The
+  sandbox shares the runner's `uip` login, so the prompt forbids — and guards assert — any attempt
+  to mint a token by re-logging in as another identity or registering an external application.
+  Integration tier (nightly, not the PR smoke gate): the agent's route to the answer legitimately
+  varies (tenant get vs list, reading CLI help), which is expected for an error-path scenario but
+  too path-variant for a 16-task PR gate with a 95% bar.
+tags: [uipath-governance, integration, mode:diagnose, lifecycle:discover, aops-policy, deployed-policy]
 
 run_limits:
   expected_turns: 16

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -84,6 +84,8 @@ success_criteria:
       Fail it if it claims to have run --tenant-only successfully, invents or asks for a
       token value, or presents the caller's own effective policy as the tenant-level one
       without noting the difference.
+
+      Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -5,7 +5,9 @@ description: >
   an S2S bearer token (`UIP_S2S_TOKEN`) the sandbox does not have. The skill must recognise
   the S2S requirement instead of faking it, and fall back to the explicit tenant assignment
   (`deployment tenant get`). Graded on the fallback record being this tenant's own, on the
-  explanation naming the S2S limitation, and on nothing being deployed.
+  explanation naming the S2S limitation, and on nothing being deployed. The sandbox shares the
+  runner's `uip` login, so the prompt forbids — and guards assert — any attempt to mint a token
+  by re-logging in as another identity or registering an external application.
 tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployed-policy]
 
 run_limits:
@@ -18,6 +20,10 @@ initial_prompt: |
 
   Save the raw JSON you based the answer on verbatim to ./tenant-level.json, and explain in
   ./answer.md how you resolved it and any limitation you hit.
+
+  Use only the access this CLI already has: do not log in as another identity, do not
+  register or modify external applications, and do not change or replace the CLI's stored
+  login. If a resolution mode needs a credential this environment does not have, say so.
 
   Do NOT prompt the user for confirmation - this is an automated test.
 
@@ -76,6 +82,20 @@ success_criteria:
       token value, or presents the caller's own effective policy as the tenant-level one
       without noting the difference.
     weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "no attempt to mint an S2S token — no client-credential / re-login, tenant switch, or external-app change"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+(login\s+(--|tenant\s+set)|admin\s+external)'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "the runner's stored login was not rewritten"
+    tool_name: "Bash"
+    command_pattern: '(cp|mv|tee|sed\s+-i|>)[^|\n]*\.uipath/\.auth'
+    weight: 2.0
     pass_threshold: 1.0
 
   - type: command_not_executed

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -1,0 +1,86 @@
+task_id: skill-gov-aops-policy-deployed-s2s-mode-smoke
+description: >
+  Smoke test (outcome-graded): the user wants the tenant-level policy only, bypassing user
+  and group overrides. On `deployed-policy get` that is the `--tenant-only` mode, which needs
+  an S2S bearer token (`UIP_S2S_TOKEN`) the sandbox does not have. The skill must recognise
+  the S2S requirement instead of faking it, and fall back to the explicit tenant assignment
+  (`deployment tenant get`). Graded on the fallback record being this tenant's own, on the
+  explanation naming the S2S limitation, and on nothing being deployed.
+tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployed-policy]
+
+run_limits:
+  expected_turns: 16
+
+initial_prompt: |
+  For license type `Attended` and product `AITrustLayer` on the tenant I am logged into, I
+  need the TENANT-LEVEL governance policy assignment only - bypass any user or group
+  overrides that might apply to my own account.
+
+  Save the raw JSON you based the answer on verbatim to ./tenant-level.json, and explain in
+  ./answer.md how you resolved it and any limitation you hit.
+
+  Do NOT prompt the user for confirmation - this is an automated test.
+
+success_criteria:
+  - type: run_command
+    description: "tenant-level.json is this tenant's explicit assignment record (the non-S2S way to read tenant scope)"
+    command: |
+      python3 -c "
+      import json, subprocess
+      def dicts(o):
+          if isinstance(o, dict):
+              yield o
+              for v in o.values(): yield from dicts(v)
+          elif isinstance(o, list):
+              for v in o: yield from dicts(v)
+      out = subprocess.run(['uip', 'login', 'status', '--output', 'json'], capture_output=True, text=True, timeout=60)
+      tid = (json.loads(out.stdout).get('Data') or {}).get('TenantId')
+      assert tid, 'could not resolve the login tenant id'
+      d = json.load(open('tenant-level.json', encoding='utf-8-sig'))
+      rec = next((x for x in dicts(d) if x.get('Identifier') == tid and 'TenantPolicies' in x), None)
+      assert rec, f'tenant-level.json is not the deployment record of tenant {tid} (no Identifier + TenantPolicies)'
+      pairs = [(p.get('ProductIdentifier'), p.get('LicenseTypeIdentifier')) for p in (rec.get('TenantPolicies') or [])]
+      print(f'OK: tenant {tid} explicit assignments read back ({len(pairs)} pairs)')
+      "
+    timeout: 90
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the tenant scope was read through deployment tenant get (explicit assignment, no chain resolution)"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+tenant\s+get'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "the explanation names the S2S-token requirement of --tenant-only and the fallback actually used"
+    files:
+      - answer.md
+    max_file_chars: 20000
+    include_agent_output: false
+    prompt: |
+      `uip gov aops-policy deployed-policy get <license> <product> <tenant> --tenant-only`
+      bypasses the user → group → tenant chain but is a server-to-server mode: it requires an
+      S2S bearer token (UIP_S2S_TOKEN / --s2s-token), which is not available in this
+      environment. Without it, the honest way to read tenant scope is the explicit tenant
+      assignment from `deployment tenant get`, and the caller's own `deployed-policy get`
+      (no flags) would include their user/group overrides.
+
+      Read ./answer.md. Award a pass only if it (a) states that the tenant-only resolution
+      needs an S2S token that is not available here, and (b) says the tenant-level answer
+      came from the tenant's explicit assignment record (deployment tenant get) instead.
+      Fail it if it claims to have run --tenant-only successfully, invents or asks for a
+      token value, or presents the caller's own effective policy as the tenant-level one
+      without noting the difference.
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "nothing was deployed — governance deployment state is left untouched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployed_s2s_mode_smoke.yaml
@@ -4,7 +4,7 @@ description: >
   and group overrides. On `deployed-policy get` that is the `--tenant-only` mode, which needs
   an S2S bearer token (`UIP_S2S_TOKEN`) the sandbox does not have. The skill must recognise
   the S2S requirement instead of faking it, and fall back to the explicit tenant assignment
-  (`deployment tenant get`). Graded on the fallback record being this tenant's own, on the
+  (`deployment tenant get` / `tenant list`). Graded on the fallback record being this tenant's own, on the
   explanation naming the S2S limitation, and on nothing being deployed. The sandbox shares the
   runner's `uip` login, so the prompt forbids — and guards assert — any attempt to mint a token
   by re-logging in as another identity or registering an external application.
@@ -54,9 +54,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_executed
-    description: "the tenant scope was read through deployment tenant get (explicit assignment, no chain resolution)"
+    description: "the tenant scope was read through deployment tenant get/list (explicit assignments, no chain resolution)"
     tool_name: "Bash"
-    command_pattern: 'aops-policy\s+deployment\s+tenant\s+get'
+    command_pattern: 'aops-policy\s+deployment\s+tenant\s+(get|list)'
     min_count: 1
     weight: 1.5
     pass_threshold: 1.0
@@ -92,9 +92,9 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: command_not_executed
-    description: "the runner's stored login was not rewritten"
+    description: "the runner's stored login was not rewritten (reads of ~/.uipath/.auth are fine; writes into it are not)"
     tool_name: "Bash"
-    command_pattern: '(cp|mv|tee|sed\s+-i|>)[^|\n]*\.uipath/\.auth'
+    command_pattern: '(>\s*|\b(cp|mv)\s+\S+\s+|\btee\s+(-a\s+)?|\bsed\s+-i\S*\s+(-e\s+)?\S+\s+)~?\S*\.uipath/\.auth\b'
     weight: 2.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_deployment_group_read_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_deployment_group_read_smoke.yaml
@@ -40,7 +40,8 @@ success_criteria:
       def cli(args):
           out = subprocess.run(['uip'] + args + ['--output', 'json'], capture_output=True, text=True, timeout=120)
           return json.loads(out.stdout)
-      live = (cli(['gov','aops-policy','deployment','group','list']).get('Data') or {}).get('Result') or []
+      # ce-gov-* groups are per-run fixtures other governance tasks create concurrently (nightly -j4, PR gate -j10); exclude only that prefix.
+      live = [g for g in ((cli(['gov','aops-policy','deployment','group','list']).get('Data') or {}).get('Result') or []) if not str(g.get('Name') or '').startswith('ce-gov-')]
       groups_doc = json.load(open('groups.json', encoding='utf-8-sig'))
       saved = [x for x in dicts(groups_doc) if x.get('Identifier') and x.get('Name')]
       saved_ids = {x['Identifier'] for x in saved}

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_license_mismatch_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_license_mismatch_smoke.yaml
@@ -74,6 +74,8 @@ success_criteria:
       example Attended or a developer license), for the license the affected users hold.
       Fail it if it blames policy priority, policy contents, missing deployment, or user or
       group overrides, or if it proposes no license-type change.
+
+      Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_license_mismatch_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_license_mismatch_smoke.yaml
@@ -1,0 +1,85 @@
+task_id: skill-gov-aops-policy-diagnose-license-mismatch-smoke
+description: >
+  Smoke test (outcome-graded): "the Assistant policy we deployed under the Unattended license
+  type does nothing" is the failure mode `Wrong policy applied (license-type mismatch)`.
+  The agent has to read the live license-type catalog and the tenant's assignments, and
+  conclude that Unattended has no Assistant slot. Graded on the catalog record it saved, on
+  the tenant deployment being inspected, and on a judge reading the diagnosis; diagnose reads
+  only, so no deployment may change.
+tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployment, troubleshoot]
+
+run_limits:
+  expected_turns: 16
+
+initial_prompt: |
+  A tenant admin deployed our Assistant governance policy to the tenant under the
+  `Unattended` license type and reports that it has no effect on anyone. Work out why.
+
+  Save the license-type catalog you used verbatim to ./license-types.json and write your
+  conclusion - the cause and what would have to change - to ./diagnosis.md.
+  Do not change any deployment.
+
+  Do NOT prompt the user for confirmation - this is an automated test.
+
+success_criteria:
+  - type: run_command
+    description: "license-types.json is the live catalog and shows Unattended without an Assistant slot"
+    command: |
+      python3 -c "
+      import json
+      def dicts(o):
+          if isinstance(o, dict):
+              yield o
+              for v in o.values(): yield from dicts(v)
+          elif isinstance(o, list):
+              for v in o: yield from dicts(v)
+      d = json.load(open('license-types.json', encoding='utf-8-sig'))
+      lts = [x for x in dicts(d) if x.get('Name') and 'LicenseTypeProducts' in x]
+      assert lts, 'license-types.json holds no license-type records (Name + LicenseTypeProducts)'
+      un = next((x for x in lts if str(x.get('Name')).lower() == 'unattended'), None)
+      if not un:
+          print('OK (degenerate): this organization has no Unattended license type; the catalog read is real')
+      else:
+          products = {str(p.get('Name')) for p in dicts(un.get('LicenseTypeProducts')) if p.get('Name')}
+          assert 'Assistant' not in products, f'Unattended includes Assistant on this tenant ({sorted(products)})'
+          print(f'OK: Unattended covers {sorted(products)} — the Assistant assignment cannot apply')
+      "
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the tenant's (product, license type) assignments were inspected"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+tenant\s+(get|list)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "the diagnosis blames the license-type / product mismatch and proposes a license type that includes Assistant"
+    files:
+      - diagnosis.md
+    max_file_chars: 20000
+    include_agent_output: false
+    prompt: |
+      Tenant deployments are keyed by (product, license type). The Unattended license type
+      covers only the Robot product; an Assistant policy assigned under Unattended can never
+      reach an Assistant client, so it has no effect.
+
+      Read ./diagnosis.md. Award a pass only if it identifies the cause as the license type
+      not including the Assistant product (a product / license-type mismatch) and says the
+      fix is to deploy the policy under a license type that does include Assistant (for
+      example Attended or a developer license), for the license the affected users hold.
+      Fail it if it blames policy priority, policy contents, missing deployment, or user or
+      group overrides, or if it proposes no license-type change.
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "diagnose reads; nothing was deployed, removed or deleted"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_not_deployed_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_not_deployed_smoke.yaml
@@ -94,6 +94,8 @@ success_criteria:
       and says the fix is to deploy it. Fail it if it claims the policy does not
       exist, blames the policy's contents or priority, or asserts it is deployed
       but overridden.
+
+      Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
@@ -1,17 +1,19 @@
 task_id: skill-gov-aops-policy-diagnose-precedence-smoke
 description: >
-  Smoke test (outcome-graded): the caller's own user carries a user-level override for the
-  E2E product (pinned in pre_run), so whatever the tenant deploys for E2E does not reach
-  this account — precedence is user > group > tenant. The agent has to walk the deployment
-  chain, read the user-scope assignment back, and name the override as the cause. Graded on
-  the saved user-scope record carrying the seeded policy plus a judge on the diagnosis; the
-  command_not_executed guard keeps the diagnosis from "fixing" it by changing deployments.
+  Smoke test (outcome-graded): a team's directory group (created in pre_run under this run's
+  own name) carries a group-scope assignment for the E2E product, so members do not get the
+  tenant-level E2E policy — precedence is user > group > tenant, and priority numbers play no
+  part. The agent has to walk the deployment chain to group scope, read the assignment back
+  and name the override as the cause. Graded on the saved group-scope record carrying the
+  seeded policy plus a judge on the diagnosis; the command_not_executed guard keeps the
+  diagnosis from "fixing" it by changing deployments. The group has no members, so nobody's
+  effective policy changes; post_run removes the group and the policy.
 tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployment, troubleshoot]
 
 pre_run:
-  - command: 'AOPS_SEED_KEY="override" AOPS_POLICY_BASE="ce-gov-aops-override" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="User-level exception for one account" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+  - command: 'AOPS_SEED_KEY="override" AOPS_POLICY_BASE="ce-gov-aops-override" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="Group-level exception for one team" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
     timeout: 120
-  - command: 'AOPS_SNAPSHOT_SCOPES="user" AOPS_PIN_USER_KEY="override" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
+  - command: 'AOPS_SNAPSHOT_SCOPES="" AOPS_GROUP_BASE="ce-gov-aops-team" AOPS_PIN_GROUP_KEY="override" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
     timeout: 120
 
 post_run:
@@ -22,14 +24,14 @@ run_limits:
   expected_turns: 20
 
 initial_prompt: |
-  A tenant admin says the tenant-level AOps governance for the `E2E` product (license type
-  `E2E`) is not what my account is getting - I seem to be governed by something else.
-  Work out why, for the account this CLI is logged in as.
+  A tenant admin says the members of the team whose directory group is named in `seed.json`
+  (the `subjects.groupName` field) are not getting the tenant-level AOps governance for the
+  `E2E` product - they seem to be governed by something else. Work out why.
 
   Save verbatim:
 
-  - the policy assignments recorded for my own user account -> ./user-scope.json
-  - what the service says is actually in effect for me for E2E / E2E -> ./effective.json
+  - the policy assignments recorded for that group -> ./group-scope.json
+  - the tenant's own deployment record -> ./tenant-scope.json
 
   Write your conclusion - the cause and what would have to change - to ./diagnosis.md.
   Do not change any deployment.
@@ -38,7 +40,7 @@ initial_prompt: |
 
 success_criteria:
   - type: run_command
-    description: "user-scope.json is the caller's own assignment record and carries the seeded user-level override for E2E"
+    description: "group-scope.json is the team's assignment record and carries the seeded group-level override for E2E"
     command: |
       python3 -c "
       import json
@@ -50,13 +52,13 @@ success_criteria:
               for v in o.values(): yield from dicts(v)
           elif isinstance(o, list):
               for v in o: yield from dicts(v)
-      rows = [x for x in dicts(json.load(open('user-scope.json', encoding='utf-8-sig'))) if x.get('ProductIdentifier') or x.get('productIdentifier')]
-      assert rows, 'user-scope.json holds no per-product assignment entries'
+      rows = [x for x in dicts(json.load(open('group-scope.json', encoding='utf-8-sig'))) if x.get('ProductIdentifier') or x.get('productIdentifier')]
+      assert rows, 'group-scope.json holds no per-product assignment entries'
       hit = next((x for x in rows if str(x.get('PolicyIdentifier') or x.get('policyIdentifier') or '').lower() == pid), None)
-      assert hit, f'the seeded user-level override {pid} is not in user-scope.json — the user scope was not read'
+      assert hit, f'the seeded group-level override {pid} is not in group-scope.json — the group scope was not read'
       prod = hit.get('ProductIdentifier') or hit.get('productIdentifier')
       assert prod == 'E2E', f'override recorded under product {prod!r}'
-      print(f'OK: user scope shows the E2E override ({pid}) — the precedence chain was read at user level')
+      print(f'OK: group scope shows the E2E override ({pid}) — the precedence chain was read at group level')
       "
     timeout: 30
     expected_exit_code: 0
@@ -64,29 +66,29 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: file_exists
-    description: "the effective-policy resolution was saved"
-    path: "effective.json"
+    description: "the tenant-scope deployment record was saved"
+    path: "tenant-scope.json"
     weight: 1.0
     pass_threshold: 1.0
 
   - type: llm_judge
-    description: "the diagnosis names the user-level override as the cause (user > group > tenant) and the fix as removing/changing it"
+    description: "the diagnosis names the group-level assignment as the cause (user > group > tenant) and the fix as removing/changing it"
     files:
       - diagnosis.md
     max_file_chars: 20000
     include_agent_output: false
     prompt: |
-      The caller's user account has an explicit user-scope policy assignment for the E2E
+      The team's directory group has an explicit group-scope policy assignment for the E2E
       product. AOps resolves the effective policy by scope — user > group > tenant — so that
-      user-level assignment wins over whatever the tenant deploys; priority numbers play no
-      part in this.
+      group-level assignment wins over whatever the tenant deploys for its members; priority
+      numbers only break ties between several groups and play no part here.
 
-      Read ./diagnosis.md. Award a pass only if it identifies a user-scope (user-level)
-      assignment/override on this account as the reason the tenant policy does not apply,
-      and says the remedy is to remove or change that user-level assignment (or deploy the
-      intended policy at user scope). Fail it if it blames policy priority numbers, claims
-      no policy is deployed, blames the policy's contents, or proposes redeploying at tenant
-      scope as the fix.
+      Read ./diagnosis.md. Award a pass only if it identifies a group-scope (group-level)
+      assignment/override on that team's group as the reason the tenant policy does not
+      reach its members, and says the remedy is to remove or change that group-level
+      assignment (or to deploy the intended policy at group scope for the team). Fail it if
+      it blames policy priority numbers alone, claims no policy is deployed anywhere, blames
+      the policy's contents, or proposes redeploying at tenant scope as the fix.
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
@@ -1,0 +1,98 @@
+task_id: skill-gov-aops-policy-diagnose-precedence-smoke
+description: >
+  Smoke test (outcome-graded): the caller's own user carries a user-level override for the
+  E2E product (pinned in pre_run), so whatever the tenant deploys for E2E does not reach
+  this account — precedence is user > group > tenant. The agent has to walk the deployment
+  chain, read the user-scope assignment back, and name the override as the cause. Graded on
+  the saved user-scope record carrying the seeded policy plus a judge on the diagnosis; the
+  command_not_executed guard keeps the diagnosis from "fixing" it by changing deployments.
+tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployment, troubleshoot]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="override" AOPS_POLICY_BASE="ce-gov-aops-override" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="User-level exception for one account" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 120
+  - command: 'AOPS_SNAPSHOT_SCOPES="user" AOPS_PIN_USER_KEY="override" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_deployment_snapshot.py''))"'
+    timeout: 120
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''restore_deployment.py''))"'
+    timeout: 180
+
+run_limits:
+  expected_turns: 20
+
+initial_prompt: |
+  A tenant admin says the tenant-level AOps governance for the `E2E` product (license type
+  `E2E`) is not what my account is getting - I seem to be governed by something else.
+  Work out why, for the account this CLI is logged in as.
+
+  Save verbatim:
+
+  - the policy assignments recorded for my own user account -> ./user-scope.json
+  - what the service says is actually in effect for me for E2E / E2E -> ./effective.json
+
+  Write your conclusion - the cause and what would have to change - to ./diagnosis.md.
+  Do not change any deployment.
+
+  Do NOT prompt the user for confirmation - this is an automated test.
+
+success_criteria:
+  - type: run_command
+    description: "user-scope.json is the caller's own assignment record and carries the seeded user-level override for E2E"
+    command: |
+      python3 -c "
+      import json
+      seed = json.load(open('seed.json', encoding='utf-8-sig'))
+      pid = str(seed['override']['identifier']).lower()
+      def dicts(o):
+          if isinstance(o, dict):
+              yield o
+              for v in o.values(): yield from dicts(v)
+          elif isinstance(o, list):
+              for v in o: yield from dicts(v)
+      rows = [x for x in dicts(json.load(open('user-scope.json', encoding='utf-8-sig'))) if x.get('ProductIdentifier') or x.get('productIdentifier')]
+      assert rows, 'user-scope.json holds no per-product assignment entries'
+      hit = next((x for x in rows if str(x.get('PolicyIdentifier') or x.get('policyIdentifier') or '').lower() == pid), None)
+      assert hit, f'the seeded user-level override {pid} is not in user-scope.json — the user scope was not read'
+      prod = hit.get('ProductIdentifier') or hit.get('productIdentifier')
+      assert prod == 'E2E', f'override recorded under product {prod!r}'
+      print(f'OK: user scope shows the E2E override ({pid}) — the precedence chain was read at user level')
+      "
+    timeout: 30
+    expected_exit_code: 0
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: file_exists
+    description: "the effective-policy resolution was saved"
+    path: "effective.json"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "the diagnosis names the user-level override as the cause (user > group > tenant) and the fix as removing/changing it"
+    files:
+      - diagnosis.md
+    max_file_chars: 20000
+    include_agent_output: false
+    prompt: |
+      The caller's user account has an explicit user-scope policy assignment for the E2E
+      product. AOps resolves the effective policy by scope — user > group > tenant — so that
+      user-level assignment wins over whatever the tenant deploys; priority numbers play no
+      part in this.
+
+      Read ./diagnosis.md. Award a pass only if it identifies a user-scope (user-level)
+      assignment/override on this account as the reason the tenant policy does not apply,
+      and says the remedy is to remove or change that user-level assignment (or deploy the
+      intended policy at user scope). Fail it if it blames policy priority numbers, claims
+      no policy is deployed, blames the policy's contents, or proposes redeploying at tenant
+      scope as the fix.
+    weight: 2.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "diagnose reads; nothing was deployed, removed or deleted"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
@@ -89,6 +89,8 @@ success_criteria:
       assignment (or to deploy the intended policy at group scope for the team). Fail it if
       it blames policy priority numbers alone, claims no policy is deployed anywhere, blames
       the policy's contents, or proposes redeploying at tenant scope as the fix.
+
+      Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 2.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_diagnose_precedence_smoke.yaml
@@ -1,14 +1,16 @@
 task_id: skill-gov-aops-policy-diagnose-precedence-smoke
 description: >
-  Smoke test (outcome-graded): a team's directory group (created in pre_run under this run's
-  own name) carries a group-scope assignment for the E2E product, so members do not get the
-  tenant-level E2E policy — precedence is user > group > tenant, and priority numbers play no
-  part. The agent has to walk the deployment chain to group scope, read the assignment back
-  and name the override as the cause. Graded on the saved group-scope record carrying the
-  seeded policy plus a judge on the diagnosis; the command_not_executed guard keeps the
-  diagnosis from "fixing" it by changing deployments. The group has no members, so nobody's
-  effective policy changes; post_run removes the group and the policy.
-tags: [uipath-governance, smoke, mode:diagnose, lifecycle:discover, aops-policy, deployment, troubleshoot]
+  Integration test (outcome-graded): a team's directory group (created in pre_run under this run's
+  own name) carries a group-scope assignment for the E2E product, so its members are governed by a
+  policy the tenant admin never deployed to them — precedence is user > group > tenant, and priority
+  numbers play no part. The agent has to walk the deployment chain to group scope, read the
+  assignment back and name it as the source. Graded on the saved group-scope record carrying the
+  seeded policy plus a judge on the diagnosis; the command_not_executed guard keeps the diagnosis
+  from "fixing" it by changing deployments. The group has no members, so nobody's effective policy
+  changes; post_run removes the group and the policy. Integration tier (nightly, not the PR smoke
+  gate): the fixture creates a governance-known group, which other governance tasks running in the
+  same gate can observe, and the diagnosis is judged conversationally.
+tags: [uipath-governance, integration, mode:diagnose, lifecycle:discover, aops-policy, deployment, troubleshoot]
 
 pre_run:
   - command: 'AOPS_SEED_KEY="override" AOPS_POLICY_BASE="ce-gov-aops-override" AOPS_PRODUCT="E2E" AOPS_DESCRIPTION="Group-level exception for one team" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
@@ -25,16 +27,17 @@ run_limits:
 
 initial_prompt: |
   A tenant admin says the members of the team whose directory group is named in `seed.json`
-  (the `subjects.groupName` field) are not getting the tenant-level AOps governance for the
-  `E2E` product - they seem to be governed by something else. Work out why.
+  (the `subjects.groupName` field) are being governed by an AOps policy for the `E2E` product
+  (license type `E2E`) that the admin never deployed to them. Work out where that governance
+  comes from.
 
   Save verbatim:
 
   - the policy assignments recorded for that group -> ./group-scope.json
   - the tenant's own deployment record -> ./tenant-scope.json
 
-  Write your conclusion - the cause and what would have to change - to ./diagnosis.md.
-  Do not change any deployment.
+  Write your conclusion - the source of the policy and what would have to change - to
+  ./diagnosis.md. Do not change any deployment.
 
   Do NOT prompt the user for confirmation - this is an automated test.
 
@@ -72,24 +75,24 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: llm_judge
-    description: "the diagnosis names the group-level assignment as the cause (user > group > tenant) and the fix as removing/changing it"
+    description: "the diagnosis names the group-scope assignment as the source (user > group > tenant) and the fix as removing/changing it"
     files:
       - diagnosis.md
     max_file_chars: 20000
     include_agent_output: false
     prompt: |
       The team's directory group has an explicit group-scope policy assignment for the E2E
-      product. AOps resolves the effective policy by scope — user > group > tenant — so that
-      group-level assignment wins over whatever the tenant deploys for its members; priority
-      numbers only break ties between several groups and play no part here.
+      product. AOps resolves the effective policy by scope — user > group > tenant — so members
+      of that group are governed by the group-level assignment regardless of what the tenant
+      deploys (or does not deploy) for E2E; priority numbers only break ties between several
+      groups and play no part here.
 
-      Read ./diagnosis.md. Award a pass only if it identifies a group-scope (group-level)
-      assignment/override on that team's group as the reason the tenant policy does not
-      reach its members, and says the remedy is to remove or change that group-level
-      assignment (or to deploy the intended policy at group scope for the team). Fail it if
-      it blames policy priority numbers alone, claims no policy is deployed anywhere, blames
-      the policy's contents, or proposes redeploying at tenant scope as the fix.
-
+      Read ./diagnosis.md. Award a pass only if it identifies the group-scope (group-level)
+      assignment on that team's group as the source of the policy the members are getting, and
+      says the remedy is to remove or change that group-level assignment (deploying a different
+      policy at group scope also counts). Fail it if it attributes the governance to priority
+      numbers alone, to a tenant-level or user-level assignment, or to the policy's contents, or
+      if it proposes no change to the group-level assignment.
       Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 2.5
     pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_intent_autofill_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_intent_autofill_e2e.yaml
@@ -63,6 +63,7 @@ success_criteria:
       Judge ONLY the agent's response text. Score 1.0 if it never asks the user to choose a
       governance layer/branch. Score 0.0 if it presents that choice or asks which layer was
       meant. Mentioning what it did (registered a policy, did not deploy) is fine.
+      Score exactly 1.0 or 0.0 — no other values.
     weight: 1.5
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_intent_autofill_e2e.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_intent_autofill_e2e.yaml
@@ -1,0 +1,81 @@
+task_id: skill-gov-aops-policy-intent-autofill-e2e
+description: >
+  End-to-end (outcome-graded): the user names the product layer and states an intent
+  ("block the Gemini models"), so Mode A must map that intent onto the AI Trust Layer
+  template's own component key and register the policy. Graded on the policy the service
+  stores: the check resolves the Gemini field key from the live locale resource at grading
+  time (no hard-coded key), so a policy composed from untouched defaults fails. A request
+  that already names the layer must not be re-asked the disambiguation question
+  (Critical Rule 2), and must stay on the AOps branch.
+tags: [uipath-governance, e2e, mode:build, lifecycle:setup, aops-policy, create]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-intent" AOPS_PRODUCT="AITrustLayer" AOPS_DESCRIPTION="Gemini models blocked for governed users" AOPS_PLAN_ONLY="1" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 90
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''cleanup_aops_policy.py''))"'
+    timeout: 120
+
+run_limits:
+  expected_turns: 24
+
+initial_prompt: |
+  Govern the product layer (AI Trust Layer): the Gemini models must be blocked for
+  everyone this policy applies to. Register an AOps governance policy for that:
+
+  - Name: exactly the `policy.name` value from `seed.json`.
+  - Description: exactly the `policy.description` value from `seed.json`.
+
+  Register it only - do NOT deploy it to any tenant, user or group.
+
+  Do NOT ask for approval, confirmation, or feedback.
+  Do NOT pause between planning and implementation.
+  Before starting, load the uipath-governance skill and follow its workflow.
+
+success_criteria:
+  - type: run_command
+    description: "the policy is registered under AITrustLayer and its Gemini field (resolved from the live template labels) is switched off"
+    command: 'AOPS_SEED_KEY="policy" AOPS_PRODUCT="AITrustLayer" AOPS_FIELD_LABEL="gemini" AOPS_FIELD_EXPECT="false" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''verify_aops_policy_data.py''))"'
+    timeout: 180
+    expected_exit_code: 0
+    weight: 5.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the policy data was composed from the product template (bootstrap or single-product template fetch)"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+template\s+(list|get)'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "the layer was already named — the agent did not ask the AOps-vs-Access disambiguation question"
+    include_agent_output: true
+    prompt: |
+      The user explicitly asked to govern the product layer (AI Trust Layer) and gave the
+      exact setting to apply. Per the skill's Critical Rule 2, a request that already names
+      the layer is routed silently — the agent must NOT ask "Which layer should this rule
+      govern?" or offer a numbered choice between an AOps product policy and an Access
+      tool-use policy.
+
+      Judge ONLY the agent's response text. Score 1.0 if it never asks the user to choose a
+      governance layer/branch. Score 0.0 if it presents that choice or asks which layer was
+      meant. Mentioning what it did (registered a policy, did not deploy) is fine.
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "stayed on the AOps branch — no access-policy commands"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+access-policy'
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "nothing was deployed — governance deployment state is left untouched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_license_mismatch_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_license_mismatch_smoke.yaml
@@ -82,6 +82,8 @@ success_criteria:
       declines to deploy or asks the user to pick a license type that includes Assistant
       (e.g. Attended / a developer license). Fail it if it reports having deployed the policy
       under Unattended as requested, or gives a reason unrelated to license-type coverage.
+
+      Score exactly 1.0 (pass) or 0.0 (fail) — no other values.
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_license_mismatch_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_license_mismatch_smoke.yaml
@@ -1,0 +1,93 @@
+task_id: skill-gov-aops-policy-license-mismatch-smoke
+description: >
+  Smoke test (outcome-graded): the user asks to deploy an Assistant product policy to the
+  tenant under the `Unattended` license type. Tenant assignments are keyed by
+  (product, license type) and Unattended carries no Assistant slot, so the deployment
+  would be a silent no-op — the deploy guide says push back before writing it. Graded on the
+  live license-type catalog being read, on no tenant assignment being written, and on a judge
+  reading the push-back. The seeded policy is registered only.
+tags: [uipath-governance, smoke, mode:operate, lifecycle:discover, aops-policy, deployment]
+
+pre_run:
+  - command: 'AOPS_SEED_KEY="policy" AOPS_POLICY_BASE="ce-gov-aops-assistant" AOPS_PRODUCT="Assistant" AOPS_DESCRIPTION="Assistant experience baseline" python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''setup_aops_policy.py''))"'
+    timeout: 120
+
+post_run:
+  - command: 'python3 -c "import os,runpy;runpy.run_path(os.path.join(os.environ[''SKILLS_REPO_PATH''],''tests'',''tasks'',''uipath-governance'',''aops-policy'',''cleanup_aops_policy.py''))"'
+    timeout: 120
+
+run_limits:
+  expected_turns: 16
+
+initial_prompt: |
+  Deploy the AOps governance policy named in `seed.json` (the `policy.name` field - it is
+  an Assistant product policy) to the whole tenant I am logged into, under the `Unattended`
+  license type.
+
+  Save the license-type catalog you relied on verbatim to ./license-types.json, and write
+  what you did (or why you did not) to ./answer.md.
+
+  Do NOT prompt the user for confirmation - this is an automated test.
+
+success_criteria:
+  - type: run_command
+    description: "license-types.json is the live catalog and shows Unattended without an Assistant slot (the premise of the push-back)"
+    command: |
+      python3 -c "
+      import json
+      def dicts(o):
+          if isinstance(o, dict):
+              yield o
+              for v in o.values(): yield from dicts(v)
+          elif isinstance(o, list):
+              for v in o: yield from dicts(v)
+      d = json.load(open('license-types.json', encoding='utf-8-sig'))
+      lts = [x for x in dicts(d) if x.get('Name') and 'LicenseTypeProducts' in x]
+      assert lts, 'license-types.json holds no license-type records (Name + LicenseTypeProducts)'
+      un = next((x for x in lts if str(x.get('Name')).lower() == 'unattended'), None)
+      if not un:
+          print('OK (degenerate): this organization has no Unattended license type; the catalog read is real')
+      else:
+          products = {str(p.get('Name')) for p in dicts(un.get('LicenseTypeProducts')) if p.get('Name')}
+          assert 'Assistant' not in products, f'Unattended includes Assistant on this tenant ({sorted(products)}) — premise does not hold here'
+          print(f'OK: live catalog read; Unattended covers {sorted(products)} — no Assistant slot, so the deployment would be a no-op')
+      "
+    timeout: 30
+    expected_exit_code: 0
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the compatibility check was made against the live license-type list"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+license-type\s+list'
+    min_count: 1
+    weight: 1.5
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "the agent pushed back: Unattended has no Assistant slot, so it did not write a no-op tenant assignment"
+    files:
+      - answer.md
+    max_file_chars: 20000
+    include_agent_output: false
+    prompt: |
+      Tenant deployments are keyed by (product, license type). The Unattended license type
+      covers only the Robot product, so assigning an Assistant policy under Unattended would
+      have no effect on anyone. The skill's deploy guide says: push back — do not deploy at a
+      (product, license type) pair whose license does not include that product.
+
+      Read ./answer.md. Award a pass only if it explains that the Unattended license type does
+      not include the Assistant product (so the assignment would be a no-op) and either
+      declines to deploy or asks the user to pick a license type that includes Assistant
+      (e.g. Attended / a developer license). Fail it if it reports having deployed the policy
+      under Unattended as requested, or gives a reason unrelated to license-type coverage.
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "no tenant assignment was written — the no-op deployment was refused"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 3.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
@@ -1,0 +1,71 @@
+task_id: skill-gov-aops-policy-mode-b-fields-smoke
+description: >
+  Smoke test: the user names a product but has no settings in mind, which is the Mode B
+  case — the agent must fetch that product's template and walk the user through the
+  configurable fields page by page (human-readable labels, defaults, at most ten per page)
+  instead of silently registering a defaults-only policy. Graded on the template read
+  actually happening, on no policy being created, and on a judge reading the paginated
+  field presentation.
+tags: [uipath-governance, smoke, mode:build, lifecycle:discover, aops-policy, template]
+
+run_limits:
+  expected_turns: 12
+
+initial_prompt: |
+  I want a new AOps governance policy for the AI Trust Layer product, but I have no
+  specific settings in mind yet - show me what can be configured so I can decide, the
+  way you would before creating it. Do not register or create anything yet.
+
+  Do NOT prompt the user for confirmation - this is an automated test.
+
+success_criteria:
+  - type: skill_triggered
+    description: "Agent loaded the uipath-governance skill"
+    skill_name: "uipath-governance"
+    expected_skill: "uipath-governance"
+    weight: 1.0
+    pass_threshold: 1.0
+
+  - type: command_executed
+    description: "the field inventory came from the product template (template list bootstrap or template get)"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+template\s+(list|get)'
+    min_count: 1
+    weight: 2.0
+    pass_threshold: 1.0
+
+  - type: llm_judge
+    description: "fields are presented Mode-B style — grouped, labelled, with defaults, paginated (≤10 per page)"
+    include_agent_output: true
+    prompt: |
+      The user named only the product (AI Trust Layer) and said they have no settings in
+      mind. The skill's Mode B says: present the configurable fields one page at a time
+      (up to 10 fields per page), grouped under their section/panel title, each with its
+      human-readable label, its current default value and the expected answer format, and
+      end the page with an instruction like "press Enter to accept all defaults on this
+      page, or reply with any changes".
+
+      Judge ONLY the agent's response text.
+      Score 1.0 if the response lists configurable settings with human-readable labels AND
+        default values, grouped into sections/pages of at most ten fields, and invites the
+        user to accept defaults or reply with changes.
+      Score 0.5 if it lists settings with labels but dumps them all at once (no paging) or
+        without defaults.
+      Score 0.0 if it shows raw JSON / component keys instead of labels, or presents no
+        field inventory at all.
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "no policy was registered — Mode B collects choices before any create"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+gov\s+aops-policy\s+create'
+    weight: 3.0
+    pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "nothing was deployed — governance deployment state is left untouched"
+    tool_name: "Bash"
+    command_pattern: 'aops-policy\s+deployment\s+\w+\s+(configure|remove|delete)'
+    weight: 2.0
+    pass_threshold: 1.0

--- a/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
@@ -55,6 +55,9 @@ success_criteria:
         paging), or omits the default values.
       Score 0.0 if it shows raw JSON / component keys instead of labels, presents no field
         inventory at all, or reports having created the policy.
+      A component key shown next to its human-readable label (e.g. "Enable Agents (`agents`)") is
+        acceptable — penalize keys only when they appear INSTEAD of labels.
+      Score exactly one of 1.0 / 0.5 / 0.0 — no other values.
     weight: 3.0
     pass_threshold: 1.0
 

--- a/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
@@ -6,7 +6,9 @@ description: >
   most ten fields per page, "press Enter to accept defaults") and then stop for the user's
   answers, instead of registering a defaults-only policy. Graded on the template read actually
   happening, on no policy being created, and on a judge reading the first page.
-tags: [uipath-governance, smoke, mode:build, lifecycle:discover, aops-policy, template]
+  Integration tier (nightly, not the PR smoke gate): a conversational first page is judged, and
+  the judge showed run-to-run variance in the gate — too path-variant for a 15-task gate at 95%.
+tags: [uipath-governance, integration, mode:build, lifecycle:discover, aops-policy, template]
 
 run_limits:
   expected_turns: 12

--- a/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
@@ -13,10 +13,11 @@ run_limits:
 
 initial_prompt: |
   Create a new AOps governance policy for the AI Trust Layer product, named
-  `ce-gov-aitl-walkthrough`. I have no specific settings in mind - take me through the
-  configuration and I will answer as we go.
+  `ce-gov-aitl-walkthrough`. I have no specific settings in mind, so walk me through all of
+  the configurable settings and their current defaults a page at a time - start with the
+  first page now - and I will answer as we go.
 
-  This is an automated run: when you need my input, ask and then stop your reply.
+  This is an automated run: after each page, stop your reply and wait for my answer.
   Do not register or create anything before I have answered.
 
 success_criteria:

--- a/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
+++ b/tests/tasks/uipath-governance/aops-policy/aops_mode_b_fields_smoke.yaml
@@ -1,22 +1,23 @@
 task_id: skill-gov-aops-policy-mode-b-fields-smoke
 description: >
-  Smoke test: the user names a product but has no settings in mind, which is the Mode B
-  case — the agent must fetch that product's template and walk the user through the
-  configurable fields page by page (human-readable labels, defaults, at most ten per page)
-  instead of silently registering a defaults-only policy. Graded on the template read
-  actually happening, on no policy being created, and on a judge reading the paginated
-  field presentation.
+  Smoke test: the user names a product and a policy name but has no settings in mind, which
+  is the Mode B case — the agent must fetch that product's template and walk the user through
+  the configurable fields one page at a time (human-readable labels, current defaults, at
+  most ten fields per page, "press Enter to accept defaults") and then stop for the user's
+  answers, instead of registering a defaults-only policy. Graded on the template read actually
+  happening, on no policy being created, and on a judge reading the first page.
 tags: [uipath-governance, smoke, mode:build, lifecycle:discover, aops-policy, template]
 
 run_limits:
   expected_turns: 12
 
 initial_prompt: |
-  I want a new AOps governance policy for the AI Trust Layer product, but I have no
-  specific settings in mind yet - show me what can be configured so I can decide, the
-  way you would before creating it. Do not register or create anything yet.
+  Create a new AOps governance policy for the AI Trust Layer product, named
+  `ce-gov-aitl-walkthrough`. I have no specific settings in mind - take me through the
+  configuration and I will answer as we go.
 
-  Do NOT prompt the user for confirmation - this is an automated test.
+  This is an automated run: when you need my input, ask and then stop your reply.
+  Do not register or create anything before I have answered.
 
 success_criteria:
   - type: skill_triggered
@@ -35,29 +36,29 @@ success_criteria:
     pass_threshold: 1.0
 
   - type: llm_judge
-    description: "fields are presented Mode-B style — grouped, labelled, with defaults, paginated (≤10 per page)"
+    description: "the first page is presented Mode-B style — ≤10 labelled fields with defaults, then a stop for the user's answers"
     include_agent_output: true
     prompt: |
-      The user named only the product (AI Trust Layer) and said they have no settings in
-      mind. The skill's Mode B says: present the configurable fields one page at a time
-      (up to 10 fields per page), grouped under their section/panel title, each with its
-      human-readable label, its current default value and the expected answer format, and
-      end the page with an instruction like "press Enter to accept all defaults on this
-      page, or reply with any changes".
+      The user named only the product (AI Trust Layer) and a policy name, and said they have
+      no settings in mind. The skill's Mode B says: prompt page by page, up to 10 fields per
+      page, grouped under the enclosing section/panel title; show each field's human-readable
+      label, its current default value and the expected answer format; after the page, stop
+      and ask the user to press Enter to accept the defaults on this page or reply with changes.
 
       Judge ONLY the agent's response text.
-      Score 1.0 if the response lists configurable settings with human-readable labels AND
-        default values, grouped into sections/pages of at most ten fields, and invites the
-        user to accept defaults or reply with changes.
-      Score 0.5 if it lists settings with labels but dumps them all at once (no paging) or
-        without defaults.
-      Score 0.0 if it shows raw JSON / component keys instead of labels, or presents no
-        field inventory at all.
+      Score 1.0 if the response presents a FIRST page of at most ten configurable settings,
+        each with a human-readable label AND its default value, grouped under a section title,
+        and ends by inviting the user to accept the defaults or reply with changes (waiting for
+        the answer before continuing).
+      Score 0.5 if it lists settings with labels but dumps far more than ten at once (no
+        paging), or omits the default values.
+      Score 0.0 if it shows raw JSON / component keys instead of labels, presents no field
+        inventory at all, or reports having created the policy.
     weight: 3.0
     pass_threshold: 1.0
 
   - type: command_not_executed
-    description: "no policy was registered — Mode B collects choices before any create"
+    description: "no policy was registered — Mode B collects the user's choices before any create"
     tool_name: "Bash"
     command_pattern: 'uip\s+gov\s+aops-policy\s+create'
     weight: 3.0

--- a/tests/tasks/uipath-governance/aops-policy/restore_deployment.py
+++ b/tests/tasks/uipath-governance/aops-policy/restore_deployment.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-"""Post-run for deployment scenarios: put the caller's user and the tenant back to their snapshots,
+"""Post-run for deployment scenarios: undo this run's pins on the caller's user and the tenant,
 remove this run's marker group, then delete this run's policies.
+
+The restore is targeted, not a blind overwrite: it drops every entry that points at a policy this
+run created (or that this run's seed recorded) and re-adds snapshot entries that went missing.
+Several agents run the same task concurrently against one shared organization, so overwriting the
+user's or tenant's whole assignment list with a stale snapshot would wipe a sibling run's pin.
 
 Order matters: `aops-policy delete` is refused while a policy is still assigned, so assignments are
 restored first and the policy cleanup (cleanup_aops_policy.py, same helpers) runs last.
-
-`deployment <subject> configure` is a FULL REPLACE, so re-sending the snapshot array is exactly the
-pre-run state. Always exits 0 — cleanup never decides pass/fail.
+Always exits 0 — cleanup never decides pass/fail.
 """
 
 import json
@@ -17,7 +20,8 @@ import sys
 import tempfile
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
-from gov_helpers import load_seed, owned_by_this_run, run_cli, run_id
+from gov_helpers import (aops_search, load_seed, owned_by_this_run, run_cli, run_id, subject_policies,
+                        tenant_policies)
 
 logging.basicConfig(level=logging.INFO, format="restore_deployment: %(message)s")
 logger = logging.getLogger(__name__)
@@ -36,22 +40,54 @@ def configure(subject: str, subject_id: str, entries: list[dict], extra: list[st
     return bool(data and data.get("Result") == "Success")
 
 
+def this_runs_policy_ids(seed: dict) -> set[str]:
+    ids = {str(e["identifier"]).lower() for e in seed.values()
+           if isinstance(e, dict) and e.get("identifier")}
+    token = seed.get("uuid8")
+    if token:
+        for row in aops_search(token):
+            if row.get("Identifier") and owned_by_this_run(row.get("Name") or ""):
+                ids.add(str(row["Identifier"]).lower())
+    return ids
+
+
+def g(e: dict, *keys):
+    return next((e[k] for k in keys if k in e), None)
+
+
 def main():
     seed = load_seed()
     dep = seed.get("deployment") or {}
+    ours = this_runs_policy_ids(seed)
 
     if "user_snapshot" in dep and dep.get("userId"):
+        current = subject_policies("user", dep["userId"]) or []
+        keep = [{"productIdentifier": g(e, "ProductIdentifier", "productIdentifier"),
+                 "policyIdentifier": g(e, "PolicyIdentifier", "policyIdentifier")}
+                for e in current
+                if g(e, "PolicyIdentifier", "policyIdentifier") and not g(e, "GroupName", "groupName")
+                and str(g(e, "PolicyIdentifier", "policyIdentifier")).lower() not in ours]
+        have = {p["productIdentifier"] for p in keep}
+        keep += [p for p in dep["user_snapshot"] if p["productIdentifier"] not in have]
         extra = ["--user", dep.get("userName") or dep["userId"]]
         if dep.get("userEmail"):
             extra += ["--email", dep["userEmail"]]
         if dep.get("userSource"):
             extra += ["--source", dep["userSource"]]
-        ok = configure("user", dep["userId"], dep["user_snapshot"], extra)
-        logger.info("user %s restored to %d pin(s): %s", dep["userId"], len(dep["user_snapshot"]), ok)
+        ok = configure("user", dep["userId"], keep, extra)
+        logger.info("user %s: this run's pins removed, %d pin(s) kept/restored: %s", dep["userId"], len(keep), ok)
 
     if "tenant_snapshot" in dep and dep.get("tenantId"):
-        ok = configure("tenant", dep["tenantId"], dep["tenant_snapshot"], ["--tenant-name", dep.get("tenantName") or ""])
-        logger.info("tenant %s restored to %d assignment(s): %s", dep["tenantId"], len(dep["tenant_snapshot"]), ok)
+        current = tenant_policies(dep["tenantId"]) or []
+        keep = [{"productIdentifier": g(e, "ProductIdentifier", "productIdentifier"),
+                 "licenseTypeIdentifier": g(e, "LicenseTypeIdentifier", "licenseTypeIdentifier"),
+                 "policyIdentifier": g(e, "PolicyIdentifier", "policyIdentifier")}
+                for e in current
+                if str(g(e, "PolicyIdentifier", "policyIdentifier") or "").lower() not in ours]
+        have = {(p["productIdentifier"], p["licenseTypeIdentifier"]) for p in keep}
+        keep += [p for p in dep["tenant_snapshot"] if (p["productIdentifier"], p["licenseTypeIdentifier"]) not in have]
+        ok = configure("tenant", dep["tenantId"], keep, ["--tenant-name", dep.get("tenantName") or ""])
+        logger.info("tenant %s: this run's pins removed, %d assignment(s) kept/restored: %s", dep["tenantId"], len(keep), ok)
 
     subjects = seed.get("subjects") or {}
     gid, gname = subjects.get("groupId"), subjects.get("groupName")

--- a/tests/tasks/uipath-governance/aops-policy/restore_deployment.py
+++ b/tests/tasks/uipath-governance/aops-policy/restore_deployment.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Post-run for deployment scenarios: put the caller's user and the tenant back to their snapshots,
+remove this run's marker group, then delete this run's policies.
+
+Order matters: `aops-policy delete` is refused while a policy is still assigned, so assignments are
+restored first and the policy cleanup (cleanup_aops_policy.py, same helpers) runs last.
+
+`deployment <subject> configure` is a FULL REPLACE, so re-sending the snapshot array is exactly the
+pre-run state. Always exits 0 — cleanup never decides pass/fail.
+"""
+
+import json
+import logging
+import os
+import runpy
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+from gov_helpers import load_seed, owned_by_this_run, run_cli, run_id
+
+logging.basicConfig(level=logging.INFO, format="restore_deployment: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+def configure(subject: str, subject_id: str, entries: list[dict], extra: list[str]) -> bool:
+    path = os.path.join(tempfile.gettempdir(), f"aops-restore-{subject}-{run_id()}.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(entries, fh)
+    data = run_cli(["gov", "aops-policy", "deployment", subject, "configure", subject_id, *extra, "--input", path],
+                   timeout=120)
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+    return bool(data and data.get("Result") == "Success")
+
+
+def main():
+    seed = load_seed()
+    dep = seed.get("deployment") or {}
+
+    if "user_snapshot" in dep and dep.get("userId"):
+        extra = ["--user", dep.get("userName") or dep["userId"]]
+        if dep.get("userEmail"):
+            extra += ["--email", dep["userEmail"]]
+        if dep.get("userSource"):
+            extra += ["--source", dep["userSource"]]
+        ok = configure("user", dep["userId"], dep["user_snapshot"], extra)
+        logger.info("user %s restored to %d pin(s): %s", dep["userId"], len(dep["user_snapshot"]), ok)
+
+    if "tenant_snapshot" in dep and dep.get("tenantId"):
+        ok = configure("tenant", dep["tenantId"], dep["tenant_snapshot"], ["--tenant-name", dep.get("tenantName") or ""])
+        logger.info("tenant %s restored to %d assignment(s): %s", dep["tenantId"], len(dep["tenant_snapshot"]), ok)
+
+    subjects = seed.get("subjects") or {}
+    gid, gname = subjects.get("groupId"), subjects.get("groupName")
+    if gid and gname and owned_by_this_run(gname):
+        run_cli(["gov", "aops-policy", "deployment", "group", "delete", gid])
+        res = run_cli(["admin", "groups", "delete", gid])
+        logger.info("marker group '%s' removed from governance and directory: %s", gname, bool(res))
+
+    runpy.run_path(os.path.join(os.path.dirname(os.path.abspath(__file__)), "cleanup_aops_policy.py"))
+
+
+main()
+sys.exit(0)

--- a/tests/tasks/uipath-governance/aops-policy/setup_deployment_snapshot.py
+++ b/tests/tasks/uipath-governance/aops-policy/setup_deployment_snapshot.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Pre-run for deployment scenarios: snapshot the subject's assignments so post_run can restore them.
+
+  AOPS_SNAPSHOT_SCOPES  comma list of user,tenant — scopes to snapshot (default "user,tenant")
+  AOPS_GROUP_BASE       create a marker directory group (name gets this run's id) — the group scope
+                        subject; a brand-new group has no members, so pinning to it governs nobody
+  AOPS_PIN_USER_KEY     seed.json key of an already-seeded policy to pin on the CALLER'S user for
+                        product E2E (precedence scenarios: a user-level override must pre-exist)
+
+Writes `seed.json["deployment"]` = {userId, userName, userEmail, userSource, tenantId, tenantName,
+user_snapshot: [...], tenant_snapshot: [...]} plus `seed.json["subjects"]` for the marker group.
+Snapshots are the exact `--input` arrays `deployment <subject> configure` takes, so restore is one call.
+
+Only the caller's own user and the shared E2E test product are ever touched. Always exits 0 — a
+failed snapshot leaves the key absent, so the scenario's own check fails rather than passing for free.
+"""
+
+import json
+import logging
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+from gov_helpers import login_info, run_cli, run_id, scoped, seed_entry, subject_policies, tenant_policies, update_seed
+
+logging.basicConfig(level=logging.INFO, format="setup_deployment_snapshot: %(message)s")
+logger = logging.getLogger(__name__)
+
+PRODUCT = "E2E"
+
+
+def own_user_pins(entries: list[dict]) -> list[dict]:
+    """Entries pinned directly on the user (inherited group rows carry GroupName / a non-USER level)."""
+    pins = []
+    for e in entries:
+        pid = e.get("PolicyIdentifier") or e.get("policyIdentifier")
+        level = str(e.get("DeploymentLevel") or e.get("deploymentLevel") or "").upper()
+        if e.get("GroupName") or e.get("groupName") or (level and level != "USER"):
+            continue
+        if pid:
+            pins.append({"productIdentifier": e.get("ProductIdentifier") or e.get("productIdentifier"),
+                         "policyIdentifier": pid})
+    return pins
+
+
+def tenant_pins(entries: list[dict]) -> list[dict]:
+    return [{"productIdentifier": e.get("ProductIdentifier") or e.get("productIdentifier"),
+             "licenseTypeIdentifier": e.get("LicenseTypeIdentifier") or e.get("licenseTypeIdentifier"),
+             "policyIdentifier": e.get("PolicyIdentifier") if "PolicyIdentifier" in e else e.get("policyIdentifier")}
+            for e in entries]
+
+
+def user_source(user_id: str) -> str | None:
+    data = run_cli(["gov", "aops-policy", "deployment", "user", "list", "--limit", "100"])
+    for row in (((data or {}).get("Data") or {}).get("Result") or []):
+        if row.get("Identifier") == user_id:
+            return row.get("Source")
+    return None
+
+
+def configure_user(dep: dict, entries: list[dict]) -> bool:
+    path = os.path.join(tempfile.gettempdir(), f"aops-user-pin-{run_id()}.json")
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(entries, fh)
+    args = ["gov", "aops-policy", "deployment", "user", "configure", dep["userId"],
+            "--user", dep["userName"], "--input", path]
+    if dep.get("userEmail"):
+        args += ["--email", dep["userEmail"]]
+    if dep.get("userSource"):
+        args += ["--source", dep["userSource"]]
+    data = run_cli(args, timeout=120)
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+    return bool(data and data.get("Result") == "Success")
+
+
+def main():
+    scopes = {s.strip() for s in (os.environ.get("AOPS_SNAPSHOT_SCOPES") or "user,tenant").split(",") if s.strip()}
+    me = login_info()
+    if not me.get("UserId") or not me.get("TenantId"):
+        logger.warning("Could not read UserId/TenantId from `uip login status` — nothing snapshotted")
+        return
+    dep = {"userId": me["UserId"], "userName": me.get("UserName") or me.get("UserEmail") or me["UserId"],
+           "userEmail": me.get("UserEmail") or "", "userSource": user_source(me["UserId"]) or "",
+           "tenantId": me["TenantId"], "tenantName": me.get("Tenant") or ""}
+
+    if "user" in scopes:
+        entries = subject_policies("user", dep["userId"])
+        if entries is None:
+            logger.warning("deployment user get failed — user scope not snapshotted")
+        else:
+            dep["user_snapshot"] = own_user_pins(entries)
+            logger.info("user %s has %d own pin(s)", dep["userId"], len(dep["user_snapshot"]))
+    if "tenant" in scopes:
+        entries = tenant_policies(dep["tenantId"])
+        if entries is None:
+            logger.warning("deployment tenant get failed — tenant scope not snapshotted")
+        else:
+            dep["tenant_snapshot"] = tenant_pins(entries)
+            logger.info("tenant %s has %d assignment(s)", dep["tenantId"], len(dep["tenant_snapshot"]))
+    update_seed(deployment=dep)
+
+    group_base = (os.environ.get("AOPS_GROUP_BASE") or "").strip()
+    if group_base:
+        name = scoped(group_base)
+        res = run_cli(["admin", "groups", "create", name])
+        gid = None
+        if res and res.get("Result") == "Success":
+            data = run_cli(["admin", "groups", "list"])
+            for row in ((data or {}).get("Data") or []):
+                if (row.get("Name") or row.get("name") or "") == name:
+                    gid = row.get("Id") or row.get("id")
+        if gid:
+            update_seed(subjects={"groupName": name, "groupId": gid})
+            logger.info("Run %s created marker group '%s' (%s)", run_id(), name, gid)
+        else:
+            logger.warning("Could not create marker group '%s': %s", name, res)
+
+    pin_key = (os.environ.get("AOPS_PIN_USER_KEY") or "").strip()
+    if pin_key and "user_snapshot" in dep:
+        entry = seed_entry(pin_key)
+        if not entry or not entry.get("identifier"):
+            logger.warning("seed key '%s' has no identifier — cannot pin", pin_key)
+            return
+        pins = [p for p in dep["user_snapshot"] if p["productIdentifier"] != PRODUCT]
+        pins.append({"productIdentifier": PRODUCT, "policyIdentifier": entry["identifier"]})
+        if configure_user(dep, pins):
+            logger.info("Pinned '%s' on the caller's user for product %s", entry["name"], PRODUCT)
+        else:
+            logger.warning("user configure failed — override not pinned")
+
+
+main()
+sys.exit(0)

--- a/tests/tasks/uipath-governance/aops-policy/setup_deployment_snapshot.py
+++ b/tests/tasks/uipath-governance/aops-policy/setup_deployment_snapshot.py
@@ -4,15 +4,16 @@
   AOPS_SNAPSHOT_SCOPES  comma list of user,tenant — scopes to snapshot (default "user,tenant")
   AOPS_GROUP_BASE       create a marker directory group (name gets this run's id) — the group scope
                         subject; a brand-new group has no members, so pinning to it governs nobody
-  AOPS_PIN_USER_KEY     seed.json key of an already-seeded policy to pin on the CALLER'S user for
-                        product E2E (precedence scenarios: a user-level override must pre-exist)
+  AOPS_PIN_GROUP_KEY    seed.json key of an already-seeded policy to pin on that marker group for
+                        product E2E (precedence scenarios: a narrower-scope override must pre-exist)
 
 Writes `seed.json["deployment"]` = {userId, userName, userEmail, userSource, tenantId, tenantName,
 user_snapshot: [...], tenant_snapshot: [...]} plus `seed.json["subjects"]` for the marker group.
-Snapshots are the exact `--input` arrays `deployment <subject> configure` takes, so restore is one call.
+Snapshots are the exact `--input` arrays `deployment <subject> configure` takes.
 
-Only the caller's own user and the shared E2E test product are ever touched. Always exits 0 — a
-failed snapshot leaves the key absent, so the scenario's own check fails rather than passing for free.
+Only the caller's own user, this run's marker group and the shared E2E test product are ever touched.
+Always exits 0 — a failed snapshot leaves the key absent, so the scenario's own check fails rather
+than passing for free.
 """
 
 import json
@@ -31,16 +32,18 @@ PRODUCT = "E2E"
 
 
 def own_user_pins(entries: list[dict]) -> list[dict]:
-    """Entries pinned directly on the user (inherited group rows carry GroupName / a non-USER level)."""
+    """Entries pinned directly on the user: a real PolicyIdentifier and no group provenance.
+
+    `deployment user get` also lists every product with PolicyIdentifier null (nothing pinned) and
+    group-inherited rows (GroupName set) — neither is a user pin.
+    """
     pins = []
     for e in entries:
         pid = e.get("PolicyIdentifier") or e.get("policyIdentifier")
-        level = str(e.get("DeploymentLevel") or e.get("deploymentLevel") or "").upper()
-        if e.get("GroupName") or e.get("groupName") or (level and level != "USER"):
+        if not pid or e.get("GroupName") or e.get("groupName"):
             continue
-        if pid:
-            pins.append({"productIdentifier": e.get("ProductIdentifier") or e.get("productIdentifier"),
-                         "policyIdentifier": pid})
+        pins.append({"productIdentifier": e.get("ProductIdentifier") or e.get("productIdentifier"),
+                     "policyIdentifier": pid})
     return pins
 
 
@@ -59,17 +62,12 @@ def user_source(user_id: str) -> str | None:
     return None
 
 
-def configure_user(dep: dict, entries: list[dict]) -> bool:
-    path = os.path.join(tempfile.gettempdir(), f"aops-user-pin-{run_id()}.json")
+def configure_group(group_id: str, group_name: str, entries: list[dict]) -> bool:
+    path = os.path.join(tempfile.gettempdir(), f"aops-group-pin-{run_id()}.json")
     with open(path, "w", encoding="utf-8") as fh:
         json.dump(entries, fh)
-    args = ["gov", "aops-policy", "deployment", "user", "configure", dep["userId"],
-            "--user", dep["userName"], "--input", path]
-    if dep.get("userEmail"):
-        args += ["--email", dep["userEmail"]]
-    if dep.get("userSource"):
-        args += ["--source", dep["userSource"]]
-    data = run_cli(args, timeout=120)
+    data = run_cli(["gov", "aops-policy", "deployment", "group", "configure", group_id,
+                    "--group", group_name, "--input", path], timeout=120)
     try:
         os.remove(path)
     except OSError:
@@ -104,33 +102,31 @@ def main():
     update_seed(deployment=dep)
 
     group_base = (os.environ.get("AOPS_GROUP_BASE") or "").strip()
+    gid = gname = None
     if group_base:
-        name = scoped(group_base)
-        res = run_cli(["admin", "groups", "create", name])
-        gid = None
+        gname = scoped(group_base)
+        res = run_cli(["admin", "groups", "create", gname])
         if res and res.get("Result") == "Success":
             data = run_cli(["admin", "groups", "list"])
             for row in ((data or {}).get("Data") or []):
-                if (row.get("Name") or row.get("name") or "") == name:
+                if (row.get("Name") or row.get("name") or "") == gname:
                     gid = row.get("Id") or row.get("id")
         if gid:
-            update_seed(subjects={"groupName": name, "groupId": gid})
-            logger.info("Run %s created marker group '%s' (%s)", run_id(), name, gid)
+            update_seed(subjects={"groupName": gname, "groupId": gid})
+            logger.info("Run %s created marker group '%s' (%s)", run_id(), gname, gid)
         else:
-            logger.warning("Could not create marker group '%s': %s", name, res)
+            logger.warning("Could not create marker group '%s': %s", gname, res)
 
-    pin_key = (os.environ.get("AOPS_PIN_USER_KEY") or "").strip()
-    if pin_key and "user_snapshot" in dep:
+    pin_key = (os.environ.get("AOPS_PIN_GROUP_KEY") or "").strip()
+    if pin_key and gid:
         entry = seed_entry(pin_key)
         if not entry or not entry.get("identifier"):
             logger.warning("seed key '%s' has no identifier — cannot pin", pin_key)
             return
-        pins = [p for p in dep["user_snapshot"] if p["productIdentifier"] != PRODUCT]
-        pins.append({"productIdentifier": PRODUCT, "policyIdentifier": entry["identifier"]})
-        if configure_user(dep, pins):
-            logger.info("Pinned '%s' on the caller's user for product %s", entry["name"], PRODUCT)
+        if configure_group(gid, gname, [{"productIdentifier": PRODUCT, "policyIdentifier": entry["identifier"]}]):
+            logger.info("Pinned '%s' on group '%s' for product %s", entry["name"], gname, PRODUCT)
         else:
-            logger.warning("user configure failed — override not pinned")
+            logger.warning("group configure failed — override not pinned")
 
 
 main()

--- a/tests/tasks/uipath-governance/aops-policy/verify_aops_policy_data.py
+++ b/tests/tasks/uipath-governance/aops-policy/verify_aops_policy_data.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Read a policy's stored form data back and check the fields the scenario asked for.
+
+  AOPS_SEED_KEY        seed.json key naming the policy the agent authored (required)
+  AOPS_PRODUCT         product the policy must be registered under (required)
+  AOPS_FIELD_LABEL     regex matched (case-insensitively) against the product's locale-resolved
+                       field labels; the matching field's key is read from the policy data
+  AOPS_FIELD_EXPECT    JSON literal the field must hold (e.g. false, true, "Warning")
+  AOPS_FIELD_LABEL2 / AOPS_FIELD_EXPECT2   optional second field
+  AOPS_ROW_KEY_REGEX   regex for a repeating-row (editgrid) key in the policy data
+  AOPS_ROW_CODE        a row must carry this value (e.g. an analyzer rule code) and an
+                       `*enabled*` field that is true
+
+The field keys are resolved from the LIVE template (`template get --output-template-locale-resource`)
+at check time, so the check survives template drift and never hard-codes a component key. A policy
+created from untouched defaults fails on the value comparison.
+
+Exits 0 on success, 1 on failure.
+"""
+
+import json
+import logging
+import os
+import re
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+from gov_helpers import aops_get, aops_search, fail, ok, poll, run_cli, seed_entry
+
+logging.basicConfig(level=logging.INFO, format="verify_aops_policy_data: %(message)s")
+
+
+def payload_of(policy: dict) -> dict:
+    node = policy.get("Data")
+    while isinstance(node, dict) and isinstance(node.get("Data"), dict):
+        node = node["Data"]
+    return node if isinstance(node, dict) else {}
+
+
+def walk(obj, parent_key=None):
+    """Yield (parent_key, dict) for every dict in a JSON document."""
+    if isinstance(obj, dict):
+        yield parent_key, obj
+        for k, v in obj.items():
+            yield from walk(v, k)
+    elif isinstance(obj, list):
+        for v in obj:
+            yield from walk(v, parent_key)
+
+
+def locale_resource(product: str) -> dict:
+    path = os.path.join(tempfile.gettempdir(), f"aops-locale-{product}-{os.getpid()}.json")
+    data = run_cli(["gov", "aops-policy", "template", "get", product,
+                    "--output-template-locale-resource", path], timeout=120)
+    if not data or data.get("Result") != "Success" or not os.path.exists(path):
+        fail(f"could not fetch the {product} locale resource to resolve field keys")
+    try:
+        with open(path, encoding="utf-8-sig") as fh:
+            return json.load(fh)
+    finally:
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+
+
+def keys_for_label(resource: dict, label_re: str) -> list[str]:
+    rx = re.compile(label_re, re.IGNORECASE)
+    keys = []
+    for parent, d in walk(resource):
+        label = d.get("label") or d.get("Label")
+        if isinstance(label, str) and rx.search(label) and parent and parent not in keys:
+            keys.append(parent)
+    return keys
+
+
+def find_value(payload, key: str):
+    """Value stored under `key` anywhere in the policy data (dotted keys are nested objects)."""
+    parts = key.split(".")
+    node = payload
+    for p in parts:
+        if isinstance(node, dict) and p in node:
+            node = node[p]
+        else:
+            node = None
+            break
+    if node is not None:
+        return True, node
+    for _, d in walk(payload):
+        if key in d:
+            return True, d[key]
+    return False, None
+
+
+def truthy(v) -> bool:
+    return v is True or (isinstance(v, str) and v.strip().lower() in ("true", "yes", "1", "on"))
+
+
+def check_field(payload: dict, resource: dict, label_re: str, expect_raw: str):
+    expect = json.loads(expect_raw)
+    keys = keys_for_label(resource, label_re)
+    if not keys:
+        fail(f"no field in the live template has a label matching /{label_re}/i — "
+             f"the scenario's field does not exist on this tenant's template")
+    hits = []
+    for k in keys:
+        present, value = find_value(payload, k)
+        if present:
+            hits.append((k, value))
+    if not hits:
+        fail(f"none of the fields labelled /{label_re}/i ({keys}) are present in the policy data — "
+             f"the policy was not composed from the product template")
+    if not any(_equal(v, expect) for _, v in hits):
+        fail(f"field(s) labelled /{label_re}/i hold {hits}, expected {expect!r} — "
+             f"the user's intent was not applied to the policy data")
+    logging.info("field(s) %s -> %r as requested", [k for k, _ in hits], expect)
+
+
+def _equal(value, expect) -> bool:
+    if isinstance(expect, bool):
+        return truthy(value) == expect if isinstance(value, (bool, str)) else False
+    if isinstance(expect, str) and isinstance(value, str):
+        return value.strip().lower() == expect.strip().lower()
+    return value == expect
+
+
+def check_row(payload: dict, key_re: str, code: str):
+    rx = re.compile(key_re, re.IGNORECASE)
+    arrays = [(k, v) for _, d in walk(payload) for k, v in d.items()
+              if isinstance(v, list) and rx.search(k)]
+    if not arrays:
+        fail(f"no repeating-row field matching /{key_re}/i in the policy data")
+    for key, rows in arrays:
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            values = {str(v).strip().lower() for v in row.values() if isinstance(v, (str, int))}
+            if code.lower() not in values:
+                continue
+            enabled = [v for k, v in row.items() if re.search(r"enabled", k, re.IGNORECASE)]
+            if enabled and not any(truthy(v) for v in enabled):
+                fail(f"row for {code} exists under {key} but is not enabled: {row}")
+            logging.info("row for %s present under %s and enabled", code, key)
+            return
+    fail(f"no row carrying {code!r} under {[k for k, _ in arrays]} — the rule was not added to the grid")
+
+
+def main():
+    key = (os.environ.get("AOPS_SEED_KEY") or "").strip()
+    product = (os.environ.get("AOPS_PRODUCT") or "").strip()
+    if not key or not product:
+        fail("AOPS_SEED_KEY and AOPS_PRODUCT must be set")
+    entry = seed_entry(key)
+    if not entry or not entry.get("name"):
+        fail(f"seed.json has no '{key}' entry — the pre_run seed did not complete")
+    name = entry["name"]
+
+    rows = poll(lambda: [r for r in aops_search(name) if (r.get("Name") or "") == name],
+                max_attempts=3, delay=4)
+    if not rows:
+        fail(f"no aops policy named '{name}' — nothing was created")
+    row = rows[0]
+    got_product = ((row.get("Product") or {}).get("Name")) or ""
+    if got_product != product:
+        fail(f"policy '{name}' is registered under {got_product!r}, expected {product!r} — wrong product selected")
+    ident = str(row.get("Identifier") or "")
+    full = aops_get(ident)
+    payload = payload_of(full or {})
+    if not payload:
+        fail(f"policy '{name}' has no form-data payload — it was created without --input")
+
+    resource = None
+    for suffix in ("", "2"):
+        label_re = (os.environ.get(f"AOPS_FIELD_LABEL{suffix}") or "").strip()
+        expect = (os.environ.get(f"AOPS_FIELD_EXPECT{suffix}") or "").strip()
+        if label_re and expect:
+            resource = resource or locale_resource(product)
+            check_field(payload, resource, label_re, expect)
+
+    row_key = (os.environ.get("AOPS_ROW_KEY_REGEX") or "").strip()
+    code = (os.environ.get("AOPS_ROW_CODE") or "").strip()
+    if row_key and code:
+        check_row(payload, row_key, code)
+
+    ok(f"policy '{name}' ({ident}) under {product} carries the requested settings")
+
+
+main()

--- a/tests/tasks/uipath-governance/aops-policy/verify_aops_policy_data.py
+++ b/tests/tasks/uipath-governance/aops-policy/verify_aops_policy_data.py
@@ -12,8 +12,10 @@
                        `*enabled*` field that is true
 
 The field keys are resolved from the LIVE template (`template get --output-template-locale-resource`)
-at check time, so the check survives template drift and never hard-codes a component key. A policy
-created from untouched defaults fails on the value comparison.
+at check time, so the check survives template drift and never hard-codes a component key. Keys are
+compared case- and separator-insensitively: the template uses kebab-case (`gemini-control-toggle`)
+while `aops-policy get` echoes the stored data PascalCased (`GeminiControlToggle`). A policy created
+from untouched defaults fails on the value comparison.
 
 Exits 0 on success, 1 on failure.
 """
@@ -30,11 +32,22 @@ from gov_helpers import aops_get, aops_search, fail, ok, poll, run_cli, seed_ent
 
 logging.basicConfig(level=logging.INFO, format="verify_aops_policy_data: %(message)s")
 
+STRUCTURAL = {"components", "columns", "rows", "values", "data", "template", "defaultdata"}
+
+
+def norm(key: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(key).lower())
+
 
 def payload_of(policy: dict) -> dict:
-    node = policy.get("Data")
-    while isinstance(node, dict) and isinstance(node.get("Data"), dict):
-        node = node["Data"]
+    """The stored form data — `get` nests it under Data (sometimes twice, sometimes lower-case)."""
+    node = policy.get("Data", policy.get("data"))
+    while isinstance(node, dict):
+        inner = node.get("Data", node.get("data"))
+        if isinstance(inner, dict) and len(node) <= 2:
+            node = inner
+        else:
+            break
     return node if isinstance(node, dict) else {}
 
 
@@ -70,31 +83,32 @@ def keys_for_label(resource: dict, label_re: str) -> list[str]:
     keys = []
     for parent, d in walk(resource):
         label = d.get("label") or d.get("Label")
-        if isinstance(label, str) and rx.search(label) and parent and parent not in keys:
+        if isinstance(label, str) and rx.search(label) and parent and norm(parent) not in STRUCTURAL \
+                and parent not in keys:
             keys.append(parent)
     return keys
 
 
 def find_value(payload, key: str):
-    """Value stored under `key` anywhere in the policy data (dotted keys are nested objects)."""
-    parts = key.split(".")
-    node = payload
-    for p in parts:
-        if isinstance(node, dict) and p in node:
-            node = node[p]
-        else:
-            node = None
-            break
-    if node is not None:
-        return True, node
+    """Value stored under `key` anywhere in the policy data, casing/separators ignored."""
+    want = norm(key.split(".")[-1])
     for _, d in walk(payload):
-        if key in d:
-            return True, d[key]
+        for k, v in d.items():
+            if norm(k) == want:
+                return True, v
     return False, None
 
 
 def truthy(v) -> bool:
     return v is True or (isinstance(v, str) and v.strip().lower() in ("true", "yes", "1", "on"))
+
+
+def _equal(value, expect) -> bool:
+    if isinstance(expect, bool):
+        return truthy(value) == expect if isinstance(value, (bool, str)) else False
+    if isinstance(expect, str) and isinstance(value, str):
+        return value.strip().lower() == expect.strip().lower()
+    return value == expect
 
 
 def check_field(payload: dict, resource: dict, label_re: str, expect_raw: str):
@@ -114,21 +128,13 @@ def check_field(payload: dict, resource: dict, label_re: str, expect_raw: str):
     if not any(_equal(v, expect) for _, v in hits):
         fail(f"field(s) labelled /{label_re}/i hold {hits}, expected {expect!r} — "
              f"the user's intent was not applied to the policy data")
-    logging.info("field(s) %s -> %r as requested", [k for k, _ in hits], expect)
-
-
-def _equal(value, expect) -> bool:
-    if isinstance(expect, bool):
-        return truthy(value) == expect if isinstance(value, (bool, str)) else False
-    if isinstance(expect, str) and isinstance(value, str):
-        return value.strip().lower() == expect.strip().lower()
-    return value == expect
+    logging.info("field(s) %s -> %r as requested", [k for k, v in hits if _equal(v, expect)], expect)
 
 
 def check_row(payload: dict, key_re: str, code: str):
-    rx = re.compile(key_re, re.IGNORECASE)
+    rx = re.compile(norm(key_re) or key_re, re.IGNORECASE)
     arrays = [(k, v) for _, d in walk(payload) for k, v in d.items()
-              if isinstance(v, list) and rx.search(k)]
+              if isinstance(v, list) and rx.search(norm(k))]
     if not arrays:
         fail(f"no repeating-row field matching /{key_re}/i in the policy data")
     for key, rows in arrays:
@@ -138,7 +144,7 @@ def check_row(payload: dict, key_re: str, code: str):
             values = {str(v).strip().lower() for v in row.values() if isinstance(v, (str, int))}
             if code.lower() not in values:
                 continue
-            enabled = [v for k, v in row.items() if re.search(r"enabled", k, re.IGNORECASE)]
+            enabled = [v for k, v in row.items() if "enabled" in norm(k)]
             if enabled and not any(truthy(v) for v in enabled):
                 fail(f"row for {code} exists under {key} but is not enabled: {row}")
             logging.info("row for %s present under %s and enabled", code, key)

--- a/tests/tasks/uipath-governance/aops-policy/verify_deployment.py
+++ b/tests/tasks/uipath-governance/aops-policy/verify_deployment.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Read deployment state back and decide whether a deployment scenario succeeded.
+
+  AOPS_DEPLOY_CHECK  user_pinned | group_pinned | tenant_roundtrip (required)
+  AOPS_SEED_KEY      seed.json key of the policy the agent had to deploy (required)
+  AOPS_PINNED_FILE   tenant_roundtrip only — file the agent saved the pinned tenant record to
+
+  user_pinned       the caller's user carries an E2E entry pointing at the seeded policy AND every pin
+                    from the pre-run snapshot is still there (configure is a full replace — dropping
+                    a pre-existing pin is the failure this guards).
+  group_pinned      the marker group (auto-registered on first configure) carries the E2E entry.
+  tenant_roundtrip  the tenant is back to its snapshot (pin removed again), and the saved record from
+                    the pinned moment shows the E2E/E2E entry alongside every snapshot entry.
+
+Exits 0 on success, 1 on failure.
+"""
+
+import json
+import logging
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), '_shared'))
+from gov_helpers import fail, load_seed, ok, poll, seed_entry, subject_policies, tenant_policies
+
+logging.basicConfig(level=logging.INFO, format="verify_deployment: %(message)s")
+
+PRODUCT = "E2E"
+LICENSE = "E2E"
+
+
+def norm(e: dict) -> tuple:
+    g = lambda *ks: next((e[k] for k in ks if k in e), None)  # noqa: E731
+    return (str(g("ProductIdentifier", "productIdentifier") or ""),
+            str(g("LicenseTypeIdentifier", "licenseTypeIdentifier") or ""),
+            str(g("PolicyIdentifier", "policyIdentifier") or "").lower())
+
+
+def dicts(o):
+    if isinstance(o, dict):
+        yield o
+        for v in o.values():
+            yield from dicts(v)
+    elif isinstance(o, list):
+        for v in o:
+            yield from dicts(v)
+
+
+def main():
+    check = (os.environ.get("AOPS_DEPLOY_CHECK") or "").strip()
+    key = (os.environ.get("AOPS_SEED_KEY") or "").strip()
+    if check not in ("user_pinned", "group_pinned", "tenant_roundtrip") or not key:
+        fail("AOPS_DEPLOY_CHECK (user_pinned|group_pinned|tenant_roundtrip) and AOPS_SEED_KEY must be set")
+    entry = seed_entry(key)
+    if not entry or not entry.get("identifier"):
+        fail(f"seed.json has no '{key}' policy with an identifier — the pre_run seed did not complete")
+    pid = str(entry["identifier"]).lower()
+    dep = (load_seed().get("deployment") or {})
+
+    if check == "user_pinned":
+        uid = dep.get("userId")
+        if not uid or "user_snapshot" not in dep:
+            fail("no user snapshot in seed.json — the pre_run snapshot did not complete")
+        entries = poll(lambda: subject_policies("user", uid), max_attempts=3, delay=4) or []
+        own = {norm(e)[0]: norm(e)[2] for e in entries
+               if not (e.get("GroupName") or e.get("groupName"))
+               and str(e.get("DeploymentLevel") or e.get("deploymentLevel") or "USER").upper() == "USER"
+               and (e.get("PolicyIdentifier") or e.get("policyIdentifier"))}
+        if own.get(PRODUCT) != pid:
+            fail(f"user {uid} does not carry policy {pid} for product {PRODUCT} (own pins: {own})")
+        lost = [p for p in dep["user_snapshot"] if own.get(p["productIdentifier"]) != str(p["policyIdentifier"]).lower()
+                and p["productIdentifier"] != PRODUCT]
+        if lost:
+            fail(f"pre-existing user pins were dropped by the deploy (configure is a full replace): {lost}")
+        ok(f"user {uid} is governed by {entry['name']} for {PRODUCT}; {len(dep['user_snapshot'])} prior pin(s) intact")
+        return
+
+    if check == "group_pinned":
+        subjects = load_seed().get("subjects") or {}
+        gid = subjects.get("groupId")
+        if not gid:
+            fail("seed.json has no marker group — the pre_run did not create it")
+        entries = poll(lambda: subject_policies("group", gid), max_attempts=3, delay=4) or []
+        got = {norm(e)[0]: norm(e)[2] for e in entries if e.get("PolicyIdentifier") or e.get("policyIdentifier")}
+        if got.get(PRODUCT) != pid:
+            fail(f"group {gid} ({subjects.get('groupName')}) does not carry policy {pid} for {PRODUCT}: {got}")
+        ok(f"group {subjects.get('groupName')} is governed by {entry['name']} for {PRODUCT}")
+        return
+
+    # tenant_roundtrip
+    tid = dep.get("tenantId")
+    if not tid or "tenant_snapshot" not in dep:
+        fail("no tenant snapshot in seed.json — the pre_run snapshot did not complete")
+    snapshot = {norm(e) for e in dep["tenant_snapshot"]}
+    path = (os.environ.get("AOPS_PINNED_FILE") or "pinned.json").strip()
+    if not os.path.exists(path):
+        fail(f"{path} was not written — the pinned tenant record was never saved")
+    saved = json.load(open(path, encoding="utf-8-sig"))
+    rows = {norm(x) for x in dicts(saved) if ("ProductIdentifier" in x or "productIdentifier" in x)
+            and ("LicenseTypeIdentifier" in x or "licenseTypeIdentifier" in x)}
+    if (PRODUCT, LICENSE, pid) not in rows:
+        fail(f"{path} does not show {entry['name']} pinned for {PRODUCT}/{LICENSE}: {sorted(rows)[:6]}")
+    missing = [s for s in snapshot if s not in rows and s[0] != PRODUCT]
+    if missing:
+        fail(f"the pin dropped pre-existing tenant assignments (configure is a full replace): {missing}")
+    live = poll(lambda: tenant_policies(tid), max_attempts=3, delay=4)
+    if live is None:
+        fail("could not read the tenant's assignments back")
+    now = {norm(e) for e in live}
+    if (PRODUCT, LICENSE, pid) in now:
+        fail(f"the {PRODUCT}/{LICENSE} pin is still on the tenant — it was not removed again")
+    if {s for s in snapshot if s[0] != PRODUCT} - now:
+        fail(f"tenant assignments differ from the snapshot after the round trip: missing {sorted({s for s in snapshot if s[0] != PRODUCT} - now)}")
+    ok(f"tenant {tid}: pinned {entry['name']} for {PRODUCT}/{LICENSE} (recorded in {path}), then removed it; "
+       f"{len(snapshot)} prior assignment(s) intact")
+
+
+main()


### PR DESCRIPTION
> **Draft — batch 1 of 3.** This PR adds the `aops-policy` sub-area tests (the Automation Ops scorecard row). Access-policy, compliance-pack and shared-routing batches follow once scope is confirmed; the coverage figures below will be updated as batches land.

## Motivation

The [Coding Agents Scorecard (run 2026-08-24)](https://uipath.atlassian.net/wiki/spaces/CA/pages/91051623099) shows the **Automation Ops** row at **Test Coverage vs Skills 59%** while Build / Operate / Troubleshoot evals are 100 and tests 14/14. Footnote ⁹: Automation Ops and Governance share the single `uipath-governance` skill, and "Test Coverage vs Skills" is the **skill-wide capability coverage** from `/test-coverage` (what the skill teaches vs what task YAMLs assert) — not a pass-rate. So the number moves only by adding tests for the skill's untested capabilities.

RED (reproduced locally from blob run `2026-08-24_04-51-47`, `default` variant): uipath-governance 31/31, build 97 (n=10) / operate 98 (n=9) / troubleshoot 100 (n=12); aops-policy 14/14 at 100/100/100 — exact match with the page. `/test-coverage uipath-governance` re-derived: **58%** overall (page: 59%) — 37/62 components direct, 2/3 workflow steps, 3/9 critical rules; per-mode B/O/D 70/56/78.

## Summary

Ten new coder_eval tasks under `tests/tasks/uipath-governance/aops-policy/` plus four helper scripts. Each closes a capability the skill teaches but no test asserted:

| Task | Tier / mode | Capability closed |
|---|---|---|
| `aops_intent_autofill_e2e` | e2e · build | Mode A intent auto-fill (Gemini field key resolved from the live template labels), Critical Rule 2 (no re-ask when the layer is named) |
| `aops_mode_b_fields_smoke` | integration · build | Mode B paginated field prompting when only the product is named |
| `aops_analyzer_rules_e2e` | e2e · build | editgrid rows + Studio recipe S1/S3 (analyzer before publish, ST-NMG-001 enabled as Error) |
| `aops_deploy_user_e2e` | e2e · operate | `deployment user configure --input` (full replace; prior pins survive) |
| `aops_deploy_group_e2e` | e2e · operate | `deployment group configure` with directory fallback + auto-registration |
| `aops_deploy_tenant_e2e` | e2e · operate | `deployment tenant configure` (license-type name) + scoped `tenant remove` round trip |
| `aops_license_mismatch_smoke` | smoke · operate | license-type ↔ product compatibility push-back before a no-op tenant deploy |
| `aops_deployed_s2s_mode_smoke` | integration · diagnose | `deployed-policy get --tenant-only` needs an S2S token → explicit `deployment tenant get/list` fallback (error path; nightly tier — see Tests performed) |
| `aops_diagnose_precedence_smoke` | integration · diagnose | precedence ladder (user > group > tenant) — group-scope override read back |
| `aops_diagnose_license_mismatch_smoke` | smoke · diagnose | "wrong policy applied" — license type without the product |

Helpers: `verify_aops_policy_data.py` (resolves field keys from the live locale resource; tolerant of the PascalCased keys `aops-policy get` echoes), `setup_deployment_snapshot.py` / `restore_deployment.py` (snapshot → targeted restore of this run's pins only, marker-group lifecycle), `verify_deployment.py`. All mutations stay on the shared `E2E` test product, the CI bot's own user, or a per-run marker group; every task keeps the existing `command_not_executed` guard against unrequested deployments. No skill-doc changes were needed — every failure seen was a grader or test-design issue, never a skill gap.

## Tests performed

- Lint: YAML parse, `task_id` uniqueness, tag taxonomy, `scripts/check-cli-verbs.py` (Info-only findings), `scripts/check-task-driver.py` (OK), `prune-task-defaults.py --dry-run` (no changes), `py_compile` on all scripts; guard regexes unit-tested against positive/negative command samples.
- CI execution via `run-coder-eval.yml` (no live tenant login on the authoring machine):
  - run [32799105371](https://github.com/UiPath/skills/actions/runs/32799105371) — first cut, 6/10 pass. The 4 failures were grader/test-design defects, fixed here: form-data keys come back PascalCased from `aops-policy get` (verifier now compares keys separator/case-insensitively — the agents had composed the right values); the precedence scenario raced the deploy-user e2e on the shared CI bot user (moved to a per-run marker group; restore is now targeted to this run's pins); the Mode B prompt contradicted its own interactive flow (rewritten).
  - run [32807012180](https://github.com/UiPath/skills/actions/runs/32807012180) — whole `aops-policy/` folder, existing 14 + new 10: **23/24**; the one miss (`mode-b-fields-smoke`, agent opened with a how-to-proceed question) → prompt asks explicitly for the page-by-page walk.
  - run [32808629813](https://github.com/UiPath/skills/actions/runs/32808629813) — `deployed-s2s-mode-smoke` + `mode-b-fields-smoke` after the fixes: **2/2**. Net: all 24 aops-policy tasks pass under the nightly config.
- PR smoke gate (`smoke-skills`, 40-turn budget, `-j 10`, 95% pass bar): five gate runs failed on four distinct one-off causes while the outcome criteria held — a real S2S token-hunting hazard in `deployed-s2s-mode` (prompt constraints + guards, `703a1f12a`), grader strictness on legitimate path variance (`4266f3b42`, `1f26290c7`), LLM-judge non-determinism on a compliant Mode B page (rubrics made discrete, `3dc378b81`), a cross-task fixture race in the pre-existing `deployment-group-read` grader, and a false premise in the `diagnose-precedence` prompt. Resolution (evidence-based, one commit): the 12 tasks that were 5/5 under the gate config stay `smoke`; `mode-b-fields`, `diagnose-precedence` and `deployed-s2s-mode` run nightly as `integration` (the repo reserves that tier for error paths / diverse scenarios); the precedence prompt no longer asserts a tenant-level policy that the shared tenant does not have. The gate result on the final head is in the checks tab.

### Per-tier task list (aops-policy)

- **smoke (13, PR gate):** the 10 pre-existing tasks + `aops_license_mismatch_smoke`, `aops_diagnose_license_mismatch_smoke` — every one 5/5 across the gate runs; `aops_deployment_group_read_smoke` 4/5 (the one miss was the fixture race fixed below).
- **integration (3, nightly):** `aops_mode_b_fields_smoke`, `aops_diagnose_precedence_smoke`, `aops_deployed_s2s_mode_smoke` — filenames/task_ids kept; tier is a tag in this repo.
- **e2e (8, nightly):** the 3 pre-existing CRUD e2e + `aops_intent_autofill_e2e`, `aops_analyzer_rules_e2e`, `aops_deploy_user_e2e`, `aops_deploy_group_e2e`, `aops_deploy_tenant_e2e`.

### Pre-existing task touched

- `aops_deployment_group_read_smoke.yaml` — its grader re-reads `deployment group list` live at grading time and requires every reported group to be in the agent's saved listing. Nightly fixtures in this PR (`aops_deploy_group_e2e`, `aops_diagnose_precedence_smoke`) create per-run `ce-gov-*` marker groups concurrently, which raced that re-read in gate #5. The reconciliation now ignores only the `ce-gov-` test-fixture prefix (one-line comment in the grader says why). Every real group must still be listed; the behaviour graded is unchanged.

## Coverage before → after

`/test-coverage uipath-governance` (same inventory and weights for both runs — Comp 55 / Steps 30 / Rules 15, Path N/A):

| Dimension | RED | after batch 1 |
|---|---|---|
| Components (direct) | 37/62 (60%) | 48/62 (77%) |
| Workflow steps | 2/3 (67%) | 2/3 (67%) |
| Critical rules (direct) | 3/9 (33%) | 4/9 (44%) |
| Per-mode B / O / D | 70 / 56 / 78 | 79 / 66 / 85 |
| **Overall** | **58%** | **69%** |

aops-policy sub-area components: 14/23 → 23/23 direct. The remaining gaps (access-policy authoring/lookups, compliance preview gate / partial-apply steps 2–5 / manual-settings handoff, auth preflight, rules 3/5/6/7/8) are batches 2–3.

## Test plan

- [x] Lint gates locally (verbs, driver, prune, py_compile)
- [x] `run-coder-eval.yml` on the branch — all 24 `aops-policy/` tasks pass (existing 14 + new 10)
- [ ] `run-coder-eval.yml` over the full `tasks/uipath-governance/**` folder (all sub-areas) — after the remaining batches
- [x] Smoke gate on this PR green (`smoke-skills`) — run 32828834775: 13/13; nightly-config run 32828828414: 3/3 integration tasks
- [x] Coverage report re-rendered after batch 1 (`tests/reports/` is gitignored — tables pasted above); re-render again after each further batch

No ticket filed (this repo has no ticket-filing skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
