### PR TITLE
docs(guardrails): don't let fetched SDK docs override tenant availability

### DIFF
--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md
@@ -14,6 +14,11 @@ Both workflows are driven by live data — the catalog (`uip agent guardrails ca
 
 > Full three-fetch mandate applies to **Recommend mode**. In **Validate mode** of an existing guardrail the SDK docs are the authoritative, sufficient source for a validator's scope/stage — `catalog` (relevance metadata) and `list` (tenant entitlement) are recommended cross-checks, not a hard prerequisite for a scope/placement fix. See [Validate Mode](#validate-mode).
 
+> **The SDK docs are authoritative for shape, never for availability.** They carry `Platform Availability`
+> notes for features still rolling out (BYOG, LLM-as-judge). Those are product-wide statements, not facts
+> about this tenant — only `uip agent guardrails list` decides that. Never withhold or down-rank a
+> recommendation because a fetched page called the feature "not enabled on every tenant yet".
+
 **Required first operation in both modes:** use `WebFetch` on
 `https://uipath.github.io/uipath-python/core/guardrails/` before catalog calls,
 project inspection, analysis, or edits. A coded guardrail recommendation or

--- a/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
+++ b/skills/uipath-agents/references/coded/capabilities/guardrails/guardrails.md
@@ -24,6 +24,8 @@ Add guardrails to a Python coded agent (LangChain/LangGraph) in two styles: **mi
 - Entity type names or their allowed values
 - Import paths
 
+> **That authority covers shape, not availability.** These pages carry `Platform Availability` notes for features still rolling out (BYOG, LLM-as-judge). Those notes are product-wide, never a statement about the tenant in front of you — [Check Tenant Availability](#check-tenant-availability-mandatory-for-built-in-ai-validators) below is the only authority for that. A validator the docs describe as "not enabled on every tenant yet" can still be `Available` here; author it.
+
 When available, the `langchain/guardrails/` page documents three actions — **`LogAction`**, **`BlockAction`**, and
 **`EscalateAction`** (human-in-the-loop). Treat the fetched page as the source of truth for `EscalateAction`'s
 parameters, supported scopes, and stages; the operational wiring it doesn't cover (the suspend->resume UX, the

--- a/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
+++ b/skills/uipath-review/references/agents/guardrails/coded-guardrails-review.md
@@ -167,6 +167,10 @@ the mapping IS needed, fetch via `WebFetch`:
   (`uipath-langchain` in `pyproject.toml` or `from langchain…` / `from langgraph…` imports): middleware classes,
   their supported scopes/stages, and the `uipath_langchain.guardrails` import paths.
 
+The `Platform Availability` notes on these pages are product-wide, so never turn one into a review finding:
+tenant availability comes from `uip agent guardrails list`, and the fetched pages supply class, scope, and
+import names only.
+
 Build a `{ validator_id → { middleware_class, validator_class, entity_enum, allowed_scopes, allowed_stages,
 import_path } }` lookup by joining catalog entries with the SDK class names. Use the fetched content as the sole
 source of truth for class/enum/import names — never memory.


### PR DESCRIPTION
Three coded-guardrail references tell the agent to `WebFetch` `core/guardrails/` and `langchain/guardrails/` and treat them as a source of truth:

- `uipath-agents/references/coded/capabilities/guardrails/guardrails.md`
- `uipath-agents/references/coded/capabilities/guardrails/guardrails-recommend.md`
- `uipath-review/references/agents/guardrails/coded-guardrails-review.md`

Those pages just gained `Platform Availability` notes saying BYOG and LLM-as-judge aren't enabled on every tenant (UiPath/uipath-python#1868, UiPath/uipath-langchain-python#1045). Nothing told the agent that prose is **product-wide**, not a statement about the tenant in front of it.

The risk is a **false stop** — an agent refusing to author, or filing a review finding, for a validator that `uip agent guardrails list` reports as `Available` here. `guardrails-recommend.md` is the sharpest case: in Validate mode it already calls the SDK docs "authoritative, sufficient" and demotes the tenant list to a non-mandatory cross-check.

So this adds one precedence line to each file, placed where that file scopes what to take from the fetched pages. +11 lines, additive, no logic touched.

**No skill gets an availability note of the docs' kind, deliberately.** Skills already resolve availability the right way — at runtime, against the live tenant. A static "not available yet" line would go stale the moment the flag flips, and could cause the very refusal this PR guards against. The existing machinery is left alone: the mandatory `Check Tenant Availability` step, the low-code not-found/`Available`/`Unauthorised` ladder, `ByoGuardrailsUnavailable` in `uipath-platform`, and the disabled-configuration handling in `uipath-review` / `uipath-troubleshoot`.

Also checked and deliberately unchanged: `uipath-planner/references/platform-availability-guide.md`. It's a product × delivery-model matrix (Cloud vs Automation Suite) — wrong granularity for a per-tenant feature flag.

**Flavors:** only `studioweb` exists, it has no guardrail overrides, and none of the three files carry `skill-flavor:` markers. Plain canonical edit — no override work, no pack cycle needed.

## Verification

`npm run skills:validate` — OK on the rebased tree (26 skills / 1726 files, both flavors compose).

Evals run with `--type claude-code --model claude-sonnet-5`, `experiments/default.yaml`, `--driver tempdir`, `-D 'agent.setting_sources=[]'`. Scope is the **17** tasks covering these three files — the 13 under `uipath-agents/coded/guardrails/` plus the 4 `coded_review_guardrail_*`. Low-code and `uipath-platform` guardrail tasks are excluded; they don't fetch the Python SDK docs.

Two passes, because #2707 bumped the pin mid-review:

**1. Full 17 on coder-eval `0.10.2`** (the pin before this branch was rebased) — **15/17 pass**. Both LLM-as-judge and all four coded-review tasks at 1.000. Task logs confirm the runs read the checked-out repo, not a stale global `~/.agents/skills` copy.

**2. Re-verified on the current pin `0.11.2`.** 0.11.0 made `task.reference` directory-only — a load-time breaking change — so first `coder-eval plan` over all 17: **"All tasks are valid!"** (the migration touched 297 `uipath-troubleshoot` tasks, none here). Then a representative subset re-run — `smoke`, `llm_as_judge`, `recommend_scoped`, `coded_review_guardrail_misapplied` — **4/4 at 1.000**.

The full 17 were not re-run on 0.11.2: the first pass took hours (one task 7039s) for 11 lines of additive prose. Single run per task throughout, not `--repeats 3`.

### The two failures are pre-existing on `main`

| Task | Score | Checker |
|---|---|---|
| `coded-byog-middleware` | 0.000 | `UiPathByoGuardrailMiddleware` not spread with `*` into the middleware list |
| `coded-byog-decorator` | 0.231 | no `@guardrail(validator=ByoValidator(...))` — `ByoValidator` never wired |

Re-ran both against unmodified `main` (worktree, identical flags): they fail identically — same scores, same checker messages. Not caused by this change.

Worth a separate look, though: a prior recorded Sonnet regression run in this repo has both at 1.000, so something regressed independently of this PR.

## Follow-up worth its own issue

`getGuardrailDefinitions` (`packages/agent-sdk/src/governance.ts`, comment: *"FeatureDisabled is always dropped"*) filters `FeatureDisabled` out of `uip agent guardrails list`. A flagged-off validator — BYOG and LLM-as-judge today — therefore yields **no entry at all**, not an entry with a bad status. The coded authoring rule keys on `Status != "Available"`, so it never fires for that case; the low-code twin handles absence explicitly, the coded page has no not-found branch. Separately, `getGuardrailCatalog` does *not* filter and `GuardrailCatalogEntry.status` includes `"FeatureDisabled"` — yet no skill reads that status. So an agent currently can't tell "flagged off on this tenant" from "misspelled validator name".

🤖 Generated with [Claude Code](https://claude.com/claude-code)