### PR TITLE
chore(preview): re-sync Maestro SDK skills to flow-builder-sdk@efd27ce

### DIFF
--- a/preview/uipath-maestro-bpmn/SKILL.md
+++ b/preview/uipath-maestro-bpmn/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-bpmn.md` @ b384859. Canonical source lives there;
+`typescript/sdk/skill/SKILL-bpmn.md` @ efd27ce. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 -->
 
@@ -131,6 +131,7 @@ uip maestro bpmn validate <Name>.bpmn --output json
 | `.binding(id, { name?, value?, resource?, propertyAttribute? })` | `uipath:binding` (top level only) — an identifier supplied per environment, read as `=bindings.<id>` |
 | `.http(id, { url, method?, headers?, parameters?, body?, name?, outputVar?, skipCondition?, retry?, loop? })` | `bpmn:sendTask` (`uipath:activity` / `Intsvc.UnifiedHttpRequest`) — an HTTP request. See **HTTP request** below. |
 | `.humanTask(id, { app, title?, actions?, input?, outputs?, appVersion?, key?, … })` | `bpmn:userTask` (`uipath:activity` / `Actions.HITL`) — a task a person completes. See **Human task** below. |
+| `.businessRule(id, { process, folder?, input?, outputs?, … })` | `bpmn:businessRuleTask` (`uipath:activity` / `Orchestrator.BusinessRules`) — executes a business rule. Despite the element, this is a **job start**, not a decision table. See **Orchestrator** below. |
 | `.sequenceFlow(source, target, { id?, name?, condition? })` | `bpmn:sequenceFlow` |
 
 - **Timers** accept an ISO-8601 string shorthand (`timer: 'PT15M'`) or a full
@@ -242,7 +243,7 @@ flow-debug Invoice.bpmn --mock --virtual-time --hitl-response 'approve={"Action"
 
 ## Orchestrator: start work elsewhere
 
-Six methods over nine registry types — the sync/async and wait choices are
+Seven methods over ten registry types — the sync/async and wait choices are
 options, not separate methods.
 
 | Method | What it starts |
@@ -253,6 +254,7 @@ options, not separate methods.
 | `.startCaseProcess(id, { …, async? })` | a case-management process (call activity) |
 | `.executeApiWorkflow(id, opts)` | an API workflow, fire-and-forget |
 | `.queueItem(id, { queue, folder, item?, wait? })` | adds an Orchestrator queue item |
+| `.businessRule(id, opts)` | a business rule, and waits |
 
 ```ts
 export default bpmn('nightly')
@@ -275,8 +277,16 @@ export default bpmn('nightly')
   the runtime refuses to dispatch without it.
 - `.startAgent()` needs its process and folder supplied as **bindings**; the SDK
   declares them for you from the plain names you pass, so just pass names.
-- **Business rules are not available** and are tracked separately — see
-  `docs/BPMN_BUSINESS_RULES_PLAN.md`.
+- `.businessRule()` is in this table, not a separate section, because that is what
+  it is. `Orchestrator.BusinessRules` rides a `bpmn:businessRuleTask` and its label
+  reads "Execute business rule", so it looks like a DMN decision table — but its
+  registry spec is `releaseKey`/`folderPath`/`name` + `JobArguments`, identical to
+  `.startProcess()`. `process` names a package whose Orchestrator process type is
+  `BusinessRules`; the decision logic lives inside that package, not in your `.bpmn`.
+  Nothing to do with the Case SDK's `rule()`, which declares stage lifecycle
+  conditions. Its response lands in `<id>_businessRuleResponse` — pinned by the SDK,
+  not derived, because the registry's output name for this type is its
+  `[Preview]` label. The extension type is marked `[Preview]`: its shape can change.
 - `metadata.*` (e.g. `metadata.instanceId`) is **empty in a local run**, so an
   `item`/`input` field built from it silently arrives as nothing. Use `vars.*` or a
   literal when you want to see the value in a `flow-debug` dry run.
@@ -339,17 +349,16 @@ export default bpmn('notify')
 
 ## Importing an existing `.bpmn`
 
-`bpmn-decompile <Name.bpmn>` writes `<Name>.bpmn.ts` whose default export
+`npx flow-sdk bpmn decompile <Name.bpmn>` writes `<Name>.bpmn.ts` whose default export
 recompiles to an **equivalent** process — every element, id, extension type,
 graph edge and metadata row survives. Use it to bring a process authored in
 Studio Web (or handed over as a file) under SDK authoring.
 
-There is no `uip maestro bpmn decompile`; run the package bin. It is installed into
-`node_modules/.bin`, which is not always on `PATH` — `npx` finds it either way:
+Use the package's family-first CLI for the complete round-trip:
 
 ```bash
-npx bpmn-decompile Invoice.bpmn                 # -> Invoice.bpmn.ts
-npx bpmn-compile   Invoice.bpmn.ts -o out.bpmn  # equivalent to Invoice.bpmn
+npx flow-sdk bpmn decompile Invoice.bpmn                 # -> Invoice.bpmn.ts
+npx flow-sdk bpmn compile   Invoice.bpmn.ts -o out.bpmn  # equivalent to Invoice.bpmn
 ```
 
 ### Editing an existing `.bpmn`: decompile, edit, compile, **merge**
@@ -360,11 +369,11 @@ alone — add a merge step. Recompiling rewrites every element in the file, incl
 ones you never looked at; merging rewrites only the ones you actually changed.
 
 ```bash
-npx bpmn-decompile Invoice.bpmn                             # -> Invoice.bpmn.ts
-npx bpmn-compile   Invoice.bpmn.ts -o baseline.bpmn         # BEFORE editing — keep this
+npx flow-sdk bpmn decompile Invoice.bpmn                             # -> Invoice.bpmn.ts
+npx flow-sdk bpmn compile   Invoice.bpmn.ts -o baseline.bpmn         # BEFORE editing — keep this
 #   ... make your change in Invoice.bpmn.ts ...
-npx bpmn-compile   Invoice.bpmn.ts -o edited.bpmn
-npx bpmn-merge     Invoice.bpmn edited.bpmn --baseline baseline.bpmn -o Invoice.bpmn
+npx flow-sdk bpmn compile   Invoice.bpmn.ts -o edited.bpmn
+npx flow-sdk bpmn merge     Invoice.bpmn edited.bpmn --baseline baseline.bpmn -o Invoice.bpmn
 uip maestro bpmn format Invoice.bpmn                        # only if you ADDED elements
 ```
 
@@ -390,7 +399,7 @@ preserved.
   `var` and `source` are intact, so the mapping still resolves the same way.
 
   It is harmless to the runtime. It matters if something downstream compares XML
-  attribute-by-attribute — then a round trip is not a no-op. `bpmn-merge` above is
+  attribute-by-attribute — then a round trip is not a no-op. `flow-sdk bpmn merge` above is
   the answer: on an element you did not edit, the row comes from the original and
   keeps its name.
 
@@ -409,6 +418,47 @@ preserved.
 - Types with no typed method decompile to `.activity(id, type, { … })`, the generic
   form. That is faithful, just less readable than the typed methods.
 - Comments and method order are not preserved — the source is regenerated.
+
+## Project package files (`project.uiproj`, `operate.json`, …)
+
+The SDK emits the `.bpmn` and nothing else. A Maestro BPMN **project** — what packs,
+uploads, publishes, or deploys — also needs five local metadata files alongside it:
+
+    project.uiproj  operate.json  entry-points.json  bindings_v2.json  package-descriptor.json
+
+You author these yourself. Three details are enforced, and each has a plausible-looking
+wrong answer that still parses as JSON:
+
+- **`project.uiproj`** uses lowercase `"main"` pointing at the BPMN file.
+- **`operate.json`** uses `"main"` with the **bare BPMN filename** — *not* a
+  `/content/<file>.bpmn#<start-event-id>` entry-point path — plus
+  `"contentType": "ProcessOrchestration"`. Mixing up these two `main` formats is the
+  single most common mistake here, because `entry-points.json` genuinely does use the
+  `#<start-event-id>` form.
+- **`package-descriptor.json`** uses a top-level `"content"` array of `content/<file>`
+  entries. Not `contentFiles`, and not a CLI scaffold `"files"` map.
+
+`entry-points.json` carries one entry per root start event, its `filePath` written
+`/content/<file>.bpmn#<the start event's id>` — the id you gave `.startEvent()`.
+
+A minimal, placeholder-safe set for a process whose start event is `start`:
+
+```jsonc
+// project.uiproj
+{ "name": "Demo", "main": "Demo.bpmn", "designOptions": { "projectType": "ProcessOrchestration" } }
+// operate.json          — bare filename, NOT /content/Demo.bpmn#start
+{ "main": "Demo.bpmn", "contentType": "ProcessOrchestration" }
+// entry-points.json     — here the #<start-event-id> form IS correct
+{ "entryPoints": [ { "filePath": "/content/Demo.bpmn#start", "input": [], "output": [] } ] }
+// bindings_v2.json
+{ "version": "2.0", "resources": [] }
+// package-descriptor.json
+{ "content": ["content/Demo.bpmn", "content/bindings_v2.json",
+              "content/entry-points.json", "content/operate.json"] }
+```
+
+Treat all five as **derived** from the `.bpmn`: when the process changes its start
+event id, entry points, or root bindings, refresh them rather than hand-patching.
 
 ## Notes
 

--- a/preview/uipath-maestro-bpmn/references/api.md
+++ b/preview/uipath-maestro-bpmn/references/api.md
@@ -13,7 +13,7 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Builders** — [BpmnBuilder](#bpmnbuilder-class) · [ScopeBuilder](#scopebuilder-class) · [SubProcessBuilder](#subprocessbuilder-class)
 
-**Option shapes** — [BindingOpts](#bindingopts-interface) · [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [PlainTaskOpts](#plaintaskopts-interface) · [BpmnConnectorOpts](#bpmnconnectoropts-type) · [HttpOpts](#httpopts-interface) · [OrchestratorOpts](#orchestratoropts-interface) · [OrchestratorAsyncOpts](#orchestratorasyncopts-interface) · [QueueItemOpts](#queueitemopts-interface) · [HumanTaskOpts](#humantaskopts-interface) · [ActivityNodeOpts](#activitynodeopts-interface) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface) · [ActivityOpts](#activityopts-interface) · [ConnectorOpts](#connectoropts-interface)
+**Option shapes** — [BindingOpts](#bindingopts-interface) · [StartOpts](#startopts-interface) · [EndOpts](#endopts-interface) · [CatchOpts](#catchopts-interface) · [ThrowOpts](#throwopts-interface) · [BoundaryOpts](#boundaryopts-interface) · [GatewayOpts](#gatewayopts-interface) · [ScriptTaskOpts](#scripttaskopts-interface) · [TaskOpts](#taskopts-interface) · [PlainTaskOpts](#plaintaskopts-interface) · [BpmnConnectorOpts](#bpmnconnectoropts-type) · [HttpOpts](#httpopts-interface) · [OrchestratorOpts](#orchestratoropts-interface) · [OrchestratorAsyncOpts](#orchestratorasyncopts-interface) · [QueueItemOpts](#queueitemopts-interface) · [HumanTaskOpts](#humantaskopts-interface) · [ReceiveMessageOpts](#receivemessageopts-interface) · [ActivityNodeOpts](#activitynodeopts-interface) · [SubProcessOpts](#subprocessopts-interface) · [FlowOpts](#flowopts-interface) · [VarOpts](#varopts-interface) · [ActivityOpts](#activityopts-interface) · [ConnectorOpts](#connectoropts-interface)
 
 **Supporting types** — [ProcessMetadata](#processmetadata-interface) · [BuiltBpmn](#builtbpmn-interface) · [BpmnNode](#bpmnnode-type) · [BpmnFlow](#bpmnflow-interface) · [BpmnVarDecl](#bpmnvardecl-interface) · [DefinitionsRegistry](#definitionsregistry-class) · [BindingsRegistry](#bindingsregistry-class) · [ConnectorDescriptor](#connectordescriptor-type) · [TypeDesc](#typedesc-type) · [MessageDecl](#messagedecl-interface) · [ErrorDecl](#errordecl-interface) · [BindingDecl](#bindingdecl-interface) · [EventKind](#eventkind-type) · [EventDef](#eventdef-type) · [GatewayKind](#gatewaykind-type) · [ActivityNodeFields](#activitynodefields-interface) · [TypedOutputRow](#typedoutputrow-interface) · [PlainTaskElement](#plaintaskelement-type) · [VarDirection](#vardirection-type) · [TimerLike](#timerlike-type) · [ConnectorMeta](#connectormeta-interface) · [TimerSpec](#timerspec-interface) · [RetrySpec](#retryspec-interface) · [LoopSpec](#loopspec-interface)
 
@@ -118,6 +118,11 @@ declare abstract class ScopeBuilder {
      */
     executeApiWorkflow(id: string, opts: OrchestratorOpts): this;
     /**
+     * Execute a **business rule** and wait for it (`Orchestrator.BusinessRules`, on a
+     * `bpmn:businessRuleTask`).
+     */
+    businessRule(id: string, opts: OrchestratorOpts): this;
+    /**
      * Add an item to an Orchestrator **queue** (`Orchestrator.CreateQueueItem`, or
      * `Orchestrator.CreateAndWaitForQueueItem` when `wait` is set).
      */
@@ -127,6 +132,11 @@ declare abstract class ScopeBuilder {
      * `uipath:activity` / `Actions.HITL`).
      */
     humanTask(id: string, opts: HumanTaskOpts): this;
+    /**
+     * Wait for an internal message from another Maestro process
+     * (`Maestro.ReceiveMessageEvent` on a `bpmn:intermediateCatchEvent`).
+     */
+    receiveMessage(id: string, opts: ReceiveMessageOpts): this;
     /**
      * ANY registry-backed node, by extension type — the generic form the typed
      * methods are sugar over.
@@ -195,6 +205,10 @@ export interface StartOpts {
     message?: string;
     /** Start on a timer — an ISO-8601 duration string, or a full `TimerSpec`. */
     timer?: TimerLike;
+    /** Also declare this timed start as a platform TRIGGER (`Intsvc.TimerTrigger`). */
+    trigger?: true | {
+            outputVar?: string;
+        };
 }
 ````
 
@@ -494,6 +508,26 @@ export interface HumanTaskOpts extends ActivityOpts {
 }
 ````
 
+## ReceiveMessageOpts (interface)
+
+````ts
+/** Options for `.receiveMessage()` — `Maestro.ReceiveMessageEvent`. */
+export interface ReceiveMessageOpts extends ActivityOpts {
+    /** Display name the designer shows on the event. */
+    name?: string;
+    /** The message name to wait for — the type's required `name` context field. */
+    message: string;
+    /** Correlation reference matching this receive to its sender. */
+    reference: string;
+    /** Variable the typed response lands in. Defaults to `<id>_response`. */
+    outputVar?: string;
+    /** `=`-expression that skips the event when truthy. */
+    skipCondition?: string;
+    /** There is deliberately NO `outputs` here, unlike `.humanTask()`. */
+    readonly outputs?: never;
+}
+````
+
 ## ActivityNodeOpts (interface)
 
 ````ts
@@ -639,6 +673,16 @@ export type BpmnNode = {
     id: string;
     name?: string;
     event?: EventDef;
+    /**
+     * A registry-backed TRIGGER declaration on this event, on top of its event
+     * definition — see `StartOpts.trigger`. The two are orthogonal halves
+     * of one element: the definition schedules, this names the node type and
+     * declares the payload variable.
+     */
+    trigger?: {
+        type: string;
+        outputVar?: string;
+    };
 } | {
     kind: 'boundaryEvent';
     id: string;

--- a/preview/uipath-maestro-case/SKILL.md
+++ b/preview/uipath-maestro-case/SKILL.md
@@ -5,7 +5,7 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL-case.md` @ b384859. Canonical source lives there;
+`typescript/sdk/skill/SKILL-case.md` @ efd27ce. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This is a snapshot of a generated file. In flow-builder-sdk,
@@ -497,7 +497,7 @@ export type StageExitType = 'exit-only' | 'wait-for-user' | 'return-to-origin';
 <!-- GEN:task-builder -->
 
 ```ts
-export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-management' | 'action' | 'connector' | 'wait-for-timer' | 'wait-for-connector';
+export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-management' | 'flow-process' | 'external-agent' | 'external-workflow' | 'action' | 'connector' | 'wait-for-timer' | 'wait-for-connector';
 
 /**
      * Reference a published Maestro process.
@@ -557,6 +557,17 @@ export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-mana
     }): this;
 
 /**
+     * Reference a published Maestro Flow.
+     *
+     * @param name - The published Flow's name.
+     * @param opts - `folder` — the Orchestrator folder it lives in.
+     * @returns This builder, so calls chain.
+     */
+    flowProcess(name: string, opts?: {
+        folder?: string;
+    }): this;
+
+/**
      * An Action Center human task. `recipient` may be an email (→ Type 2) or
      * `{ type, value }`. `inputs`/`outputs` declare the task's form fields — inputs
      * are read-only context the assignee sees, outputs are what they fill in.
@@ -577,6 +588,39 @@ export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-mana
         inputs?: ActionField[];
         outputs?: ActionField[];
     }): this;
+
+/**
+     * Invoke an external agent through its generated Integration Service descriptor.
+     *
+     * @param descriptor - An `AgentExecution` operation from a generated connector module.
+     * @param opts - Required connection/folder bindings, sync/async mode, and descriptor-typed inputs.
+     * @returns This builder, so calls chain.
+     */
+    externalAgent<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, opts: ExternalTaskOptions<I>): this;
+
+/**
+     * Invoke an external workflow through its generated Integration Service descriptor.
+     *
+     * @param descriptor - A `ProcessExecution` operation from a generated connector module.
+     * @param opts - Required connection/folder bindings, sync/async mode, and descriptor-typed inputs.
+     * @returns This builder, so calls chain.
+     */
+    externalWorkflow<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, opts: ExternalTaskOptions<I>): this;
+
+/** Required wiring and typed inputs for an external agent/workflow invocation. */
+export interface ExternalTaskOptions<I extends Record<string, unknown>> {
+    /** Symbolic Integration Service connection name declared in `bindings.json`. */
+    connection: string;
+    /** Symbolic Orchestrator folder binding name declared in `bindings.json`. */
+    folder: string;
+    /** Closed runtime mode; each family lowers this to its exact supported service type. */
+    mode: ExternalExecutionMode;
+    /** Inputs statically checked by the generated connector descriptor. */
+    inputs: I;
+}
+
+/** Whether an external Integration Service task blocks for its result or waits for a callback. */
+export type ExternalExecutionMode = 'sync' | 'async';
 
 /**
      * Stringly form, for a connector with no prepared module.
@@ -760,12 +804,17 @@ export interface TimerSpecData {
 
 <!-- /GEN:task-builder -->
 
+Calling `.waitForTimer()` without a specification creates an intentionally
+unconfigured placeholder, which product validation rejects. For a validating
+stand-in task, provide an explicit ISO-8601 value such as
+`.waitForTimer({ duration: 'PT1M' })`.
+
 ### Task io-binding — pass inputs, capture outputs
 
-Reference-mode tasks (`process`/`agent`/`rpa`/`api-workflow`, and
-`case-management` sub-cases) can bind input parameters and extract result fields
-into readable case variables, so a later task or a `=vars.<name>` gate consumes a
-task's result:
+Reference-mode tasks (`process`/`agent`/`rpa`/`api-workflow`,
+`case-management` sub-cases, and `flow-process` Maestro Flows) can bind input
+parameters and extract result fields into readable case variables, so a later
+task or a `=vars.<name>` gate consumes a task's result:
 
 ```ts
 .task('Lookup age', t => t
@@ -889,6 +938,9 @@ connection/type IDs in the `.case.ts`; bind symbolic names in `bindings.json`.
 
 Pass one rule, an array for an **AND-group**, or an array of arrays for the
 complete **OR-of-AND grid** to `entryWhen`/`exitWhen`/`completeWhen`.
+Each method call emits one condition. To emit two separate conditions, call
+the method twice; passing two rules in one array emits one condition that
+requires both rules.
 
 For a pure data gate, use `when(expression)`. The receiving slot supplies the
 platform's canonical event, so `stage.entryWhen(when('=js:vars.amount > 1000'))`
@@ -1524,19 +1576,48 @@ A full worked example ships at `examples/NotifyOnApproval.case.ts` (+
 `examples/bindings.json`): a human approval stage followed by a Slack
 connector task.
 
+### External agents and workflows
+
+External agents and Power Automate workflows use generated connector descriptors,
+but they are distinct Case task families with a mandatory execution mode:
+
+```text
+import { ExecuteGoogleVertexAgent } from './sdk/connectors/uipath-google-vertex.js';
+import { InvokeAMicrosoftPowerAutomateFlow } from './sdk/connectors/uipath-microsoft-powerautomate.js';
+
+.task('Ask support agent', t => t
+  .externalAgent(ExecuteGoogleVertexAgent, {
+    connection: 'vertex', folder: 'shared', mode: 'sync',
+    inputs: { parent: 'agents/support' },
+  })
+  .entryWhen(rule('current-stage-entered')))
+.task('Start approval flow', t => t
+  .externalWorkflow(InvokeAMicrosoftPowerAutomateFlow, {
+    connection: 'powerAutomate', folder: 'shared', mode: 'async',
+    inputs: { workflow_id: 'case-review' },
+  })
+  .entryWhen(rule('current-stage-entered')))
+```
+
+- Use only a generated descriptor from the matching catalog: `AgentExecution`
+  for `.externalAgent()` and `ProcessExecution` for `.externalWorkflow()`.
+- `mode` is required and closed to `'sync' | 'async'`. It selects the exact
+  runtime handler and input encoding; never substitute a service-type string.
+- `connection` and `folder` are required symbolic root bindings. These task
+  families cannot be authored as unconfigured placeholders.
+
 ## Compile & check (CLI)
 
 Author `<Name>.case.ts` with a default export ending in `.build()`, then:
 
-Both ship in the package: as the bins `case-check` / `case-compile`, or run
-directly with `node node_modules/@uipath/flow-sdk/dist/case/<name>-cli.js`.
+Run the package's family-first CLI with `npx flow-sdk case <verb>`.
 
-- **`check`** (`case-check <Name>.case.ts`) — fast static validation of the built
+- **`check`** (`npx flow-sdk case check <Name>.case.ts`) — fast static validation of the built
   case; surfaces the common validator failures (task without an entry rule,
   case/stage without a completion rule, unsatisfiable `required-tasks-completed`,
   unresolved stage/task references, unsafe case/stage names, and out-of-range SLA
   counts) without writing a file. Exits non-zero on any error.
-- **`compile`** (`case-compile <Name>.case.ts [-o caseplan.json]`) — runs the
+- **`compile`** (`npx flow-sdk case compile <Name>.case.ts [-o caseplan.json]`) — runs the
   static check, then serializes to `caseplan.json` (default output name). Pair it
   with `uip maestro case validate` for the authoritative gate.
 - **`decompile`** (`uip maestro case decompile <caseplan.json> [-o Name.case.ts]`)

--- a/preview/uipath-maestro-case/references/api.md
+++ b/preview/uipath-maestro-case/references/api.md
@@ -13,9 +13,9 @@ generated from the built types; longer tutorials stay in the node references.
 
 **Builders** — [CaseBuilder](#casebuilder-class) · [StageBuilder](#stagebuilder-class) · [TaskBuilder](#taskbuilder-class)
 
-**Option shapes** — [RuleOpts](#ruleopts-interface) · [EscalationOpts](#escalationopts-interface) · [ManualTriggerOpts](#manualtriggeropts-interface) · [TimerTriggerOpts](#timertriggeropts-interface) · [ResolvedEventTriggerOpts](#resolvedeventtriggeropts-interface) · [EventTriggerOpts](#eventtriggeropts-interface) · [EventSubscription](#eventsubscription-interface) · [TriggerOptions](#triggeroptions-interface) · [SlaOpts](#slaopts-interface) · [EntryOpts](#entryopts-interface) · [ExitOpts](#exitopts-interface) · [ConnectorOpts](#connectoropts-interface)
+**Option shapes** — [RuleOpts](#ruleopts-interface) · [EscalationOpts](#escalationopts-interface) · [ManualTriggerOpts](#manualtriggeropts-interface) · [TimerTriggerOpts](#timertriggeropts-interface) · [ResolvedEventTriggerOpts](#resolvedeventtriggeropts-interface) · [EventTriggerOpts](#eventtriggeropts-interface) · [EventSubscription](#eventsubscription-interface) · [TriggerOptions](#triggeroptions-interface) · [SlaOpts](#slaopts-interface) · [EntryOpts](#entryopts-interface) · [ExitOpts](#exitopts-interface) · [ExternalTaskOptions](#externaltaskoptions-interface) · [ConnectorOpts](#connectoropts-interface)
 
-**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [WhenExpression](#whenexpression-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-type) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TriggerMeta](#triggermeta-interface) · [TypeDesc](#typedesc-type) · [CaseAppConfig](#caseappconfig-interface) · [CaseLayout](#caselayout-interface) · [CaseRuleGrid](#caserulegrid-type) · [BuiltCase](#builtcase-interface) · [WaitConnectorPlaceholderSpec](#waitconnectorplaceholderspec-interface) · [EventFilter](#eventfilter-interface) · [CaseAppSection](#caseappsection-interface) · [CaseNodeLayout](#casenodelayout-interface) · [BuiltStage](#builtstage-interface) · [CaseRuleInput](#caseruleinput-type) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [CaseAppDetailValue](#caseappdetailvalue-type) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [ConnectorDescriptor](#connectordescriptor-type) · [TimerSpecData](#timerspecdata-interface) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [SelectNextStageSpec](#selectnextstagespec-interface) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface)
+**Supporting types** — [CaseRuleType](#caseruletype-type) · [CaseRule](#caserule-interface) · [WhenExpression](#whenexpression-interface) · [BuiltEscalation](#builtescalation-interface) · [EscalationRecipient](#escalationrecipient-interface) · [BuiltTrigger](#builttrigger-interface) · [TriggerDescriptor](#triggerdescriptor-type) · [JsonSchemaType](#jsonschematype-interface) · [WaitConnectorSpec](#waitconnectorspec-type) · [EscalationTrigger](#escalationtrigger-type) · [CaseTriggerKind](#casetriggerkind-type) · [TaskOutputBinding](#taskoutputbinding-interface) · [TriggerMeta](#triggermeta-interface) · [TypeDesc](#typedesc-type) · [CaseAppConfig](#caseappconfig-interface) · [CaseLayout](#caselayout-interface) · [CaseRuleGrid](#caserulegrid-type) · [BuiltCase](#builtcase-interface) · [WaitConnectorPlaceholderSpec](#waitconnectorplaceholderspec-interface) · [EventFilter](#eventfilter-interface) · [CaseAppSection](#caseappsection-interface) · [CaseNodeLayout](#casenodelayout-interface) · [BuiltStage](#builtstage-interface) · [CaseRuleInput](#caseruleinput-type) · [SlaUnit](#slaunit-type) · [CaseVarDecl](#casevardecl-interface) · [BuiltCaseExitCondition](#builtcaseexitcondition-interface) · [BuiltSla](#builtsla-interface) · [CaseAppDetailValue](#caseappdetailvalue-type) · [ConnectorDescriptor](#connectordescriptor-type) · [RecipientType](#recipienttype-type) · [ActionField](#actionfield-interface) · [TimerSpecData](#timerspecdata-interface) · [BuiltTask](#builttask-interface) · [StageExitType](#stageexittype-type) · [SelectNextStageSpec](#selectnextstagespec-interface) · [BuiltEntryCondition](#builtentrycondition-interface) · [BuiltExitCondition](#builtexitcondition-interface) · [ConnectorMeta](#connectormeta-interface) · [ExternalExecutionMode](#externalexecutionmode-type) · [TaskKind](#taskkind-type) · [TaskRef](#taskref-interface) · [ActionSpecData](#actionspecdata-interface) · [ConnectorSpecData](#connectorspecdata-type) · [ExternalTaskSpecData](#externaltaskspecdata-interface) · [TaskInputBinding](#taskinputbinding-interface) · [BuiltTaskEntryCondition](#builttaskentrycondition-interface)
 
 ## rule (function)
 
@@ -233,6 +233,14 @@ declare class TaskBuilder {
     caseManagement(name: string, opts?: {
             folder?: string;
         }): this;
+    /** Reference a published Maestro Flow. */
+    flowProcess(name: string, opts?: {
+            folder?: string;
+        }): this;
+    /** Invoke an external agent through its generated Integration Service descriptor. */
+    externalAgent<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, opts: ExternalTaskOptions<I>): this;
+    /** Invoke an external workflow through its generated Integration Service descriptor. */
+    externalWorkflow<I extends Record<string, unknown>, O>(descriptor: ConnectorDescriptor<I, O>, opts: ExternalTaskOptions<I>): this;
     /**
      * An Action Center human task. `recipient` may be an email (→ Type 2) or
      * `{ type, value }`. `inputs`/`outputs` declare the task's form fields — inputs
@@ -550,6 +558,22 @@ export interface ExitOpts {
 }
 ````
 
+## ExternalTaskOptions (interface)
+
+````ts
+/** Required wiring and typed inputs for an external agent/workflow invocation. */
+export interface ExternalTaskOptions<I extends Record<string, unknown>> {
+    /** Symbolic Integration Service connection name declared in `bindings.json`. */
+    connection: string;
+    /** Symbolic Orchestrator folder binding name declared in `bindings.json`. */
+    folder: string;
+    /** Closed runtime mode; each family lowers this to its exact supported service type. */
+    mode: ExternalExecutionMode;
+    /** Inputs statically checked by the generated connector descriptor. */
+    inputs: I;
+}
+````
+
 ## ConnectorOpts (interface)
 
 ````ts
@@ -845,6 +869,15 @@ export interface BuiltSla {
 export type CaseAppDetailValue = string | number | boolean | null;
 ````
 
+## ConnectorDescriptor (type)
+
+````ts
+export type ConnectorDescriptor<I = Record<string, unknown>, O = Record<string, unknown>> = ConnectorMeta & {
+    readonly __inputs?: I;
+    readonly __outputs?: O;
+};
+````
+
 ## RecipientType (type)
 
 ````ts
@@ -868,15 +901,6 @@ export interface ActionField {
 }
 ````
 
-## ConnectorDescriptor (type)
-
-````ts
-export type ConnectorDescriptor<I = Record<string, unknown>, O = Record<string, unknown>> = ConnectorMeta & {
-    readonly __inputs?: I;
-    readonly __outputs?: O;
-};
-````
-
 ## TimerSpecData (interface)
 
 ````ts
@@ -896,6 +920,7 @@ export interface BuiltTask {
     ref?: TaskRef;
     action?: ActionSpecData;
     connector?: ConnectorSpecData;
+    external?: ExternalTaskSpecData;
     timer?: TimerSpecData;
     waitConnector?: WaitConnectorSpec;
     required?: boolean;
@@ -967,10 +992,16 @@ export interface ConnectorMeta {
 }
 ````
 
+## ExternalExecutionMode (type)
+
+````ts
+export type ExternalExecutionMode = 'sync' | 'async';
+````
+
 ## TaskKind (type)
 
 ````ts
-export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-management' | 'action' | 'connector' | 'wait-for-timer' | 'wait-for-connector';
+export type TaskKind = 'process' | 'agent' | 'rpa' | 'api-workflow' | 'case-management' | 'flow-process' | 'external-agent' | 'external-workflow' | 'action' | 'connector' | 'wait-for-timer' | 'wait-for-connector';
 ````
 
 ## TaskRef (interface)
@@ -1005,6 +1036,15 @@ export interface ActionSpecData {
 export type ConnectorSpecData = Extract<ActionSpec, {
     kind: 'connector';
 }>;
+````
+
+## ExternalTaskSpecData (interface)
+
+````ts
+export interface ExternalTaskSpecData {
+    mode: ExternalExecutionMode;
+    connector: ConnectorSpecData;
+}
 ````
 
 ## TaskInputBinding (interface)

--- a/preview/uipath-maestro-flow/SKILL.md
+++ b/preview/uipath-maestro-flow/SKILL.md
@@ -5,11 +5,11 @@ allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 <!--
 Provenance: snapshot of UiPath/flow-builder-sdk
-`typescript/sdk/skill/SKILL.md` @ b384859. Canonical source lives there;
+`typescript/sdk/skill/SKILL.md` @ efd27ce. Canonical source lives there;
 edit upstream and re-sync (see UiPath/flow-builder-sdk#405).
 
 This file is deliberately a router. Node-specific detail belongs in
-`references/`; statically checkable rules belong in the SDK or flow-check.
+`references/`; statically checkable rules belong in the SDK's own `check`.
 -->
 
 # UiPath Flow — TypeScript Builder SDK
@@ -224,7 +224,7 @@ payload can exercise downstream wiring, but it is not a subscription witness.
 Standalone HTTP keeps non-2xx responses on its success output. Managed HTTP routes
 them through its error port. Both expose JSON response bodies as parsed values.
 
-Signature: `http({ method?, url, managed, headers?, query?, body?, contentType?, timeout?, retryCount?, returns?, branches? })`.
+Signature: `http({ method?, url, managed, connection?, folder?, headers?, query?, body?, contentType?, timeout?, retryCount?, returns?, branches? })`.
 
 ```ts
 .step('getPolicy', http({ method: 'GET', url: policyUrl,
@@ -234,8 +234,8 @@ Signature: `http({ method?, url, managed, headers?, query?, body?, contentType?,
 .step('limit', script({ code: 'return $vars.getPolicy.output.body.limit;' }))
 ```
 
-Match `managed` to the scenario's node. A branch is a `branch-<name>` side exit
-routed with `.stepToList`; the main path continues from the default port.
+Match `managed` to the scenario's node; connector auth needs both `connection` and `folder` from `bindings.json`.
+A `branch-<name>` side exit uses `.stepToList`; omit both bindings for manual/implicit mode.
 
 **Reference: [`references/http.md`](references/http.md)**
 
@@ -612,7 +612,7 @@ export default flow('parent').input({ text: types.string }).output({ clean: type
   .step('normalized', subflow(child, { raw: input('text') })).return({ clean: out('normalized', 'clean') }).build();
 ```
 
-Use a child for a meaningful contract or reuse boundary, not arbitrary splitting or speed.
+Use a child for a meaningful contract or reuse boundary, not arbitrary splitting or speed; children can be reused at any nesting depth.
 Read a child's inputs with `input(...)`: its start node is named `<callerStepId>Start`, so a bare `$vars.raw` is wrong.
 
 **Reference: [`references/subflow.md`](references/subflow.md)**

--- a/preview/uipath-maestro-flow/examples/ClubDirectory.flow.ts
+++ b/preview/uipath-maestro-flow/examples/ClubDirectory.flow.ts
@@ -10,7 +10,7 @@
  *     $vars.groups.output.length           // a member of the collection
  *     $vars.each.currentItem.displayName   // the loop item, typed from the collection
  *
- * Reading a field off the collection WITHOUT indexing is refused (FC510) — it is
+ * Reading a field off the collection WITHOUT indexing is refused — it is
  * undefined at run time. `connection` / `folder` are `bindings.json` ids (see
  * that file). Narrow a call with the operation's own `where` / `pageSize`
  * parameters — one call is one page.
@@ -42,7 +42,7 @@ export default flow('club-directory')
 
   // Iterate the collection — `currentItem` is typed from what it holds, so the
   // body's field reads are CHECKED. A loop runs for effect: its results are not
-  // readable after it, so what gates the read below is `check`/`flow-check`.
+  // readable after it, so what gates the read below is `check`.
   .loop('eachClub', out('groups'), (body) =>
     body.step('poster', script({
       code: 'return { line: "This week: " + $vars.eachClub.currentItem.displayName };',

--- a/preview/uipath-maestro-flow/examples/ObservatorySeeing.flow.ts
+++ b/preview/uipath-maestro-flow/examples/ObservatorySeeing.flow.ts
@@ -29,7 +29,7 @@ export default flow('observatory-seeing')
   .step('fetchSun', http({
     url: tmpl`https://api.sunrise-sunset.org/json?lat=${input('lat')}&lng=${input('lng')}&formatted=0`,
     managed: true,
-    // Declare what we read, or flow-check refuses the read (FC507).
+    // Declare what we read, or the read is refused.
     returns: { results: 'object' },
   }))
   // Service down / rate-limited / unknown coordinates: carry on with a stated
@@ -42,7 +42,7 @@ export default flow('observatory-seeing')
   // Success path — reached only when the call actually succeeded.
   .step('describe', script({
     // Read the DECLARED field (`body.results`) and index it in JS; reading
-    // `body.results.sunset` through $vars would be FC507 (declaration stops at
+    // `body.results.sunset` through $vars would not resolve (declaration stops at
     // `results`).
     code: 'const r = $vars.fetchSun.output.body.results || {};\nreturn { line: "best viewing after " + (r.sunset || "sunset") };',
   }))

--- a/preview/uipath-maestro-flow/references/CLI-LOOP.md
+++ b/preview/uipath-maestro-flow/references/CLI-LOOP.md
@@ -116,30 +116,27 @@ Match the final evidence to the stated acceptance bar after the last edit:
 If the requested evidence cannot be obtained inside that bound, report the
 evidence boundary instead of replacing it with repeated debug launches.
 
-### Managed HTTP: emitted-artifact bindings in emit-only projects
+### Managed HTTP: authored connection bindings
 
 `http({ managed: true, ... })` needs real connection and folder bindings for
-product debug. After **every emit**, select an enabled HTTP connection and add
-both bindings to the emitted artifact:
+connector-authenticated product debug. Select an enabled HTTP connection:
 
 ```bash
 uip is connections list --all-folders \
   --output-filter "[?ConnectorKey=='uipath-uipath-http'].{Id:Id,FolderKey:FolderKey,Name:Name}"
-
-uip maestro flow binding add <Name>Sol/<Name>/<Name>.flow \
-  "uipath-uipath-http connection" connection <connection-id> \
-  --resource-key <connection-id> --property-attribute ConnectionId --output json
-
-uip maestro flow binding add <Name>Sol/<Name>/<Name>.flow \
-  "FolderKey" folderKey <folder-key> \
-  --resource-key <folder-key> --property-attribute FolderKey --output json
 ```
 
-These are product bindings embedded in the emitted `.flow`, not the symbolic
-connector names authored in a root-level `bindings.json`. A managed-HTTP-only
-flow needs no authored `bindings.json`, but it still needs the two
-emitted-artifact bindings for product debug. Re-emission overwrites the artifact,
-so run both `binding add` commands again after the last compile.
+Declare symbolic entries in `bindings.json`, then pass both names to the node:
+
+```ts
+http({ managed: true, method: 'GET', url: '/me',
+  connection: 'spotifyHttp', folder: 'shared' })
+```
+
+Compilation resolves those names and writes both the connector-authenticated
+node detail and the required product bindings into the emitted `.flow`. Do not
+patch them into the artifact after emission; that edit would be lost on the next
+compile. Omit both options only when manual/implicit authentication is intended.
 
 ## Refresh, debug, and preserve evidence
 

--- a/preview/uipath-maestro-flow/references/api.md
+++ b/preview/uipath-maestro-flow/references/api.md
@@ -813,8 +813,14 @@ export interface ScheduledInputs {
 ````ts
 export type HttpInputs = HttpInputsBase & ({
     managed: false;
+    connection?: never;
+    folder?: never;
 } | {
     managed: true;
+    /** Symbolic HTTP connection name declared in bindings.json. */
+    connection?: string;
+    /** Symbolic folder name declared in bindings.json. */
+    folder?: string;
 });
 ````
 
@@ -1552,8 +1558,8 @@ export interface QueueItemInputs {
     folderPath: string;
     /**
      * The queue's own Orchestrator key (a GUID). It is the JOIN between this node
-     * and the flow's queue bindings — flow-check FC416 is the rule that says a node
-     * which does not reference its bindings cannot be dispatched — and it is what
+     * and the flow's queue bindings — a node which does not reference its bindings
+     * cannot be dispatched — and it is what
      * the designer's queue picker writes. The RUNTIME resolves the queue by
      * `queue` + `folderPath`, so all three are needed and none is redundant.
      */
@@ -1676,8 +1682,9 @@ interface HttpInputsBase {
      *   use `returns` to declare fields before reading them. The node choice does
      *   not decide whether application/json is parsed.
      *
-     * Authentication is the platform's (`ImplicitConnection`); a local run is
-     * unauthenticated, which matters only for APIs that need a key.
+     * With `managed: true`, omit `connection` and `folder` for the platform's
+     * manual/implicit mode, or provide both symbolic names to reuse an Integration
+     * Service HTTP connection. A local run remains unauthenticated.
      *
      * @enforcedBy HTTP_ONERROR_V1 `.onError()` on an http step needs `managed: true`; on
      *   the standalone node a 4xx arrives on the SUCCESS path and no handler runs.
@@ -1691,8 +1698,8 @@ interface HttpInputsBase {
      * Why you have to say: the platform's own definition declares the response as
      * a bare object, because only the API being called knows its shape. Without
      * this, `out('fetch','body','items')` reads from an object with no declared
-     * fields and flow-check rejects it (FC507) — correctly, since nothing could
-     * tell a real field from a typo. Same rule, and the same word, as
+     * fields, and nothing downstream can tell a real field from a typo. Same rule,
+     * and the same word, as
      * `rpaWorkflow`'s `returns`.
      */
     returns?: Record<string, 'string' | 'number' | 'boolean' | 'object' | 'array'>;
@@ -1720,7 +1727,7 @@ interface HttpInputsBase {
      * to three attempts in total.
      *
      * Must be a non-negative integer. Above **5** `check` warns rather than
-     * errors: 5 is where `fil-run`'s dispatcher clamps, the deployed corpus's
+     * errors: the deployed corpus's
      * largest author-set value is 3, and the platform's own ceiling is not
      * measured — so a bigger number may well work, and refusing it outright would
      * fence off something we have no evidence is wrong.

--- a/preview/uipath-maestro-flow/references/bindings.md
+++ b/preview/uipath-maestro-flow/references/bindings.md
@@ -106,13 +106,9 @@ next compile.
 
 ## Emitted-artifact bindings
 
-`uip maestro flow binding add` edits bindings inside an already emitted `.flow`.
-It does not create or update the symbolic root file. This distinction matters
-for managed HTTP: it has no authored connector symbol, but product debug still
-needs its connection and folder bindings added to the artifact as described in
-[the CLI loop](CLI-LOOP.md#product-validation-and-conditional-bindings).
-
-If a workflow requires `binding add`, run it after the final compile because
-re-emission replaces the artifact. For Integration Service connector source,
-keep using symbolic names plus `bindings.json`; do not substitute artifact edits
-for the authored mapping.
+`uip maestro flow binding add` edits bindings inside an already emitted `.flow`;
+it does not create or update the symbolic root file. SDK-authored Integration
+Service actions and managed HTTP nodes should instead keep symbolic names in
+source plus `bindings.json`, so recompilation deterministically restores the
+same node detail and product bindings. Use direct artifact edits only for a
+brownfield `.flow` with no source representation.

--- a/preview/uipath-maestro-flow/references/http.md
+++ b/preview/uipath-maestro-flow/references/http.md
@@ -10,7 +10,7 @@ The one factory selects two distinct product nodes:
   path.
 
 Signature:
-`http({ method?, url, managed, headers?, query?, body?, contentType?, timeout?, retryCount?, returns? })`.
+`http({ method?, url, managed, connection?, folder?, headers?, query?, body?, contentType?, timeout?, retryCount?, returns? })`.
 
 ```ts
 .step('policy', http({ method: 'GET', url: policyUrl,
@@ -29,13 +29,43 @@ error handler are not substitutes for that intent.
 Live product evidence shows that both nodes expose an `application/json` body as
 a parsed value. Declare its top-level fields with `returns` and read them
 directly; do not apply `JSON.parse` to a body declared by `returns`. A non-JSON
-body remains opaque unless its live media type establishes a scalar contract.
-The local `fil-run` standalone dispatcher currently preserves raw response text;
-that is an executor mismatch, not evidence for the product-CLI contract. Follow
+body remains opaque unless its live media type establishes a scalar contract. An
+offline local run is not evidence for the product-CLI contract either way: follow
 the task's named evidence mode and use live debug for product response shape.
 
 The definitions default `timeout` to `PT15M` and `retryCount` to `0`. Override
 them only when the scenario calls for different operational behavior.
+
+## Managed authentication
+
+Managed HTTP has two authentication modes. Omit `connection` and `folder` for
+manual/implicit mode. To reuse an Integration Service HTTP connection, provide
+both symbolic names from `bindings.json`; the compiler resolves them into the
+node detail and the emitted flow's resource bindings:
+
+```ts
+.step('profile', http({
+  managed: true,
+  method: 'GET',
+  url: '/me',
+  connection: 'spotifyHttp',
+  folder: 'shared',
+  returns: { display_name: 'string' },
+}))
+```
+
+```json
+{
+  "bindings": [
+    { "name": "spotifyHttp", "resourceKey": "<uipath-uipath-http connection id>" },
+    { "name": "shared", "resourceKey": "<folder key>" }
+  ]
+}
+```
+
+Connection mode emits `authentication: "connector"`, targets
+`uipath-uipath-http`, and treats `url` as a path relative to the connection's
+configured base URL. Supplying only one of `connection` or `folder` is an error.
 
 ## Response branches
 

--- a/preview/uipath-maestro-flow/references/subflow.md
+++ b/preview/uipath-maestro-flow/references/subflow.md
@@ -29,3 +29,5 @@ step's data path; it does not turn that boundary into a separate deployed job.
 
 Read a child output by its declared name — `out('reverse', 'reversed')`, never a bare
 `out('reverse')`. The compiler serializes each call's body under top-level `subflows`.
+The same child can be reused at any nesting depth; copied node ids and references
+are re-keyed together so every call site remains isolated.


### PR DESCRIPTION
Automated three-way re-sync from provenance pin `b384859` to current `UiPath/flow-builder-sdk@main` (`efd27ce`).

The job merged each snapshot file against its recorded upstream base, reapplied only the D1–D6 path/provenance adaptations, and passed the inventory, byte-exception, dead-link, frontmatter, router, conflict-marker, diff, and CLI verb gates.

Part of UiPath/flow-builder-sdk#405. This PR is intentionally **not** auto-merged; snapshot drift remains human-reviewed until the post-promotion C→B cutover.

🤖 Generated with Claude Code
Co-Authored-By: [Claude](mailto:noreply@anthropic.com)