### PR TITLE
fix(tests): resolve _shared import in uipath-functions checkers under $TASK_DIR

### DIFF
--- a/tests/tasks/uipath-functions/deploy_tenant/check_deploy_tenant.py
+++ b/tests/tasks/uipath-functions/deploy_tenant/check_deploy_tenant.py
@@ -27,7 +27,17 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make the `_shared` helper package importable. In the repo it sits at
+# tests/tasks/uipath-functions/_shared (parent-of-parent of this file). Under
+# the eval harness the checker is copied flat into $TASK_DIR without that
+# sibling, so also add $SKILLS_REPO_PATH/tests/tasks/uipath-functions. Both are
+# inserted; the directory that exists wins at import time.
+for _cand in (
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.path.join(os.environ.get("SKILLS_REPO_PATH", ""), "tests", "tasks", "uipath-functions"),
+):
+    if _cand and _cand not in sys.path:
+        sys.path.insert(0, _cand)
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("tenant-echo")

--- a/tests/tasks/uipath-functions/diagnose_deploy_failure/check_diagnose_deploy_failure.py
+++ b/tests/tasks/uipath-functions/diagnose_deploy_failure/check_diagnose_deploy_failure.py
@@ -26,7 +26,17 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make the `_shared` helper package importable. In the repo it sits at
+# tests/tasks/uipath-functions/_shared (parent-of-parent of this file). Under
+# the eval harness the checker is copied flat into $TASK_DIR without that
+# sibling, so also add $SKILLS_REPO_PATH/tests/tasks/uipath-functions. Both are
+# inserted; the directory that exists wins at import time.
+for _cand in (
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.path.join(os.environ.get("SKILLS_REPO_PATH", ""), "tests", "tasks", "uipath-functions"),
+):
+    if _cand and _cand not in sys.path:
+        sys.path.insert(0, _cand)
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("daily-digest")

--- a/tests/tasks/uipath-functions/file_attachment_input/check_file_attachment_input.py
+++ b/tests/tasks/uipath-functions/file_attachment_input/check_file_attachment_input.py
@@ -27,7 +27,17 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make the `_shared` helper package importable. In the repo it sits at
+# tests/tasks/uipath-functions/_shared (parent-of-parent of this file). Under
+# the eval harness the checker is copied flat into $TASK_DIR without that
+# sibling, so also add $SKILLS_REPO_PATH/tests/tasks/uipath-functions. Both are
+# inserted; the directory that exists wins at import time.
+for _cand in (
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.path.join(os.environ.get("SKILLS_REPO_PATH", ""), "tests", "tasks", "uipath-functions"),
+):
+    if _cand and _cand not in sys.path:
+        sys.path.insert(0, _cand)
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402
 

--- a/tests/tasks/uipath-functions/simple_echo/check_simple_echo.py
+++ b/tests/tasks/uipath-functions/simple_echo/check_simple_echo.py
@@ -32,7 +32,17 @@ import re
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make the `_shared` helper package importable. In the repo it sits at
+# tests/tasks/uipath-functions/_shared (parent-of-parent of this file). Under
+# the eval harness the checker is copied flat into $TASK_DIR without that
+# sibling, so also add $SKILLS_REPO_PATH/tests/tasks/uipath-functions. Both are
+# inserted; the directory that exists wins at import time.
+for _cand in (
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.path.join(os.environ.get("SKILLS_REPO_PATH", ""), "tests", "tasks", "uipath-functions"),
+):
+    if _cand and _cand not in sys.path:
+        sys.path.insert(0, _cand)
 from _shared.bindings_assertions import load_bindings, count_resources_by_type  # noqa: E402
 from _shared.ast_lazy_init_check import find_module_level_llm_clients  # noqa: E402
 from _shared.project_root import find_project_root  # noqa: E402

--- a/tests/tasks/uipath-functions/tracing_redaction/check_tracing_redaction.py
+++ b/tests/tasks/uipath-functions/tracing_redaction/check_tracing_redaction.py
@@ -20,7 +20,17 @@ import os
 import sys
 from pathlib import Path
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Make the `_shared` helper package importable. In the repo it sits at
+# tests/tasks/uipath-functions/_shared (parent-of-parent of this file). Under
+# the eval harness the checker is copied flat into $TASK_DIR without that
+# sibling, so also add $SKILLS_REPO_PATH/tests/tasks/uipath-functions. Both are
+# inserted; the directory that exists wins at import time.
+for _cand in (
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    os.path.join(os.environ.get("SKILLS_REPO_PATH", ""), "tests", "tasks", "uipath-functions"),
+):
+    if _cand and _cand not in sys.path:
+        sys.path.insert(0, _cand)
 from _shared.project_root import find_project_root  # noqa: E402
 
 ROOT = find_project_root("credential-validator")


### PR DESCRIPTION
## Problem

The `skill-functions-deploy-tenant` eval failed (status FAILURE, weighted 0.467) **even though the agent completed the task correctly** — it scaffolded, recovered from the langgraph template, set `packOptions.directoriesExcluded: ["data"]`, ran `init`, packed to `.uipath/tenant-echo.0.0.1.nupkg`, and verified `data/` was excluded. All three `command_executed` criteria passed.

The gating `run_command` criterion crashed:

```
python3 $TASK_DIR/check_deploy_tenant.py  → exit 1
ModuleNotFoundError: No module named '_shared'
  File "/work/task_dir/check_deploy_tenant.py", line 31
    from _shared.project_root import find_project_root
```

**Root cause:** the harness copies each checker *flat* into `$TASK_DIR` (`/work/task_dir`) **without** its sibling `_shared/` package. The checkers computed the shared-package parent as `dirname(dirname(__file__))`, which under `$TASK_DIR` resolves to `/work` — where `_shared/` does not exist — so the import raised `ModuleNotFoundError`. That only works in the repo layout (`tests/tasks/uipath-functions/<task>/check.py` with `_shared/` one level up).

**Blast radius:** all five functions checkers importing `_shared` — `deploy_tenant`, `simple_echo`, `file_attachment_input`, `tracing_redaction`, `diagnose_deploy_failure`.

## Fix

Add **both** candidate parents to `sys.path`: the repo-relative path (local `pytest`) and `$SKILLS_REPO_PATH/tests/tasks/uipath-functions` (the sandbox, env var already passed through) — the same absolute-via-`$SKILLS_REPO_PATH` pattern the `uipath-ixp` tests already use. The directory that exists wins at import.

## Verification

- **Sandbox reproduction** (checker copied flat, no `_shared` sibling, `$SKILLS_REPO_PATH` set): all 5 imports resolve; scripts proceed to real logic instead of `ModuleNotFoundError`.
- **Local pytest layout** (no env var, run in place): all imports still resolve.
- **End-to-end against the real deploy_tenant artifact:** `check_deploy_tenant.py` now runs all three checks and exits **0** when the pack artifact is present (as it was at grading time).
- All five checkers byte-compile.

## Scope

Only the five checker `sys.path` blocks changed. The three `smoke-trigger` failures in the same run are a **separate** cause (codex/`gpt-5.6-terra` narrated the skill but ran Bash instead of invoking the `Skill` tool under `max_turns: 1`) and are intentionally **not** addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)