### PR TITLE
fix(tests): unblock the two process-mining tasks that grade chained ids

### DIFF
--- a/tests/tasks/uipath-process-mining/query_info_percentile.yaml
+++ b/tests/tasks/uipath-process-mining/query_info_percentile.yaml
@@ -26,9 +26,12 @@ initial_prompt: |
 
   Important:
   - The `uip` CLI is available but is not connected to a live tenant.
-    Commands WILL fail with auth errors — that is expected and acceptable.
+    Commands WILL fail — that is expected and acceptable.
     Run each command exactly once regardless of errors.
     Do NOT retry, do NOT attempt to login, do NOT troubleshoot errors.
+  - If a command you needed an id from fails, substitute a placeholder id
+    of the same shape and still run the remaining commands, so we can
+    verify their shape.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:
@@ -55,3 +58,9 @@ success_criteria:
     min_count: 1
     weight: 3.0
     pass_threshold: 1.0
+
+  - type: command_not_executed
+    description: "Agent must NOT pass a bare column name as the percentile field id"
+    tool_name: "Bash"
+    command_pattern: 'uip\s+pm\s+query\s+percentile\b.*--field\s+(?!\s)(?!["'']?F__)'
+    weight: 2.5

--- a/tests/tasks/uipath-process-mining/source_template_selection.yaml
+++ b/tests/tasks/uipath-process-mining/source_template_selection.yaml
@@ -36,9 +36,12 @@ initial_prompt: |
   - Do NOT build the data mapping or upload anything yet — stop once the app
     exists and you can tell me the expected input tables.
   - The `uip` CLI is available but is not connected to a live tenant.
-    Commands WILL fail with auth errors — that is expected and acceptable.
+    Commands WILL fail — that is expected and acceptable.
     Run each command exactly once regardless of errors.
     Do NOT retry, do NOT attempt to login, do NOT troubleshoot errors.
+  - If a command you needed an id from fails, substitute a placeholder id
+    of the same shape and still run the remaining commands, so we can
+    verify their shape.
   - Do NOT prompt the user for confirmation — this is an automated test.
 
 success_criteria:


### PR DESCRIPTION
## Problem

`skill-pm-query-info-percentile` (0.57) and `skill-pm-source-template-selection` (0.68) are the two red process-mining tasks on [run 2026-08-25_04-16-36](https://coder-evalboard.uipath-dev.com/runs/2026-08-25_04-16-36). Both were added in #2547 and this was their first board run.

Both grade a command whose **required argument only exists in an earlier command's output**. The eval sandbox has no Process Mining service — every `uip pm` call returns:

```
404 Not Found - Service: processmining not found in Organization: codereval Tenant: defaulttenant
```

So the agent has nothing to chain from, correctly concludes the follow-up command cannot be formed, and stops after one turn:

> "Without its field ID, a percentile query can't be formed." — percentile agent
> "The template's shipped model and exact required input tables cannot be determined without creating the app" — source-template agent

| Task | Missed criteria | Why |
|---|---|---|
| percentile | `query percentile … --field` | field id only comes from `query info`, which 404s |
| source-template | `transformations list\|get` | needs `--app <id>` from `apps create`, which 404s |
| source-template | `app-types get` | satisfiable, but the agent had already given up |

## Why this is the right fix

`grep -ri "from the output\|use the id returned\|id returned by" tests/tasks` returns **zero hits across all 1226 tasks**. Nothing else in the suite chains a graded command on live output — these two are the outlier, not an edge case the framework tolerates.

`uipath-admin` hit this exact wall and solved it with a one-line escape hatch (`identity/pat_regenerate_smoke.yaml:20`, `oms/oms_service_provisioning_e2e.yaml:21`):

> "If listing fails, use a placeholder token ID … and still run the regenerate command so we can verify the command shape."

Both of those scored 1.0 on the same board run. This PR adopts that convention, phrased generically rather than naming the graded commands — admin's prompts already enumerate numbered steps so naming costs them nothing, but PM's prompts are goal-shaped and naming both graded commands would leak the workflow the test measures.

**Discovery is still graded separately** (`query info`, `app-types list` remain their own criteria), so the placeholder cannot be used to skip it.

## Also in this PR

- **Drop "with auth errors"** from the boilerplate. The agent sees a 404 "service not found", not an auth failure — both board agents cited "service unavailable" as their reason to stop. Matches admin's wording, which is just "Commands WILL fail".
- **Add a `command_not_executed` guard** on the percentile field id. The criterion was `--field\b`, which accepts `--field ThroughputTime` — precisely the mistake the task's own description says it tests. Mirrors the bare-column guard in `query_group_by_sugar`.

## Verification

**Passing-run claim** — `coder-eval` run `2026-08-25_10-16-57`, experiment `default.yaml`:

```
skill-pm-query-info-percentile     SUCCESS  1.000  (4/4 criteria)   57.9s
skill-pm-source-template-selection SUCCESS  1.000  (6/6 criteria)  128.6s
Results: 2/2 succeeded
```

The run genuinely exercised the fix — every `uip pm` command still failed, and the agent pushed through anyway:

- percentile ran `--field F__Cases__Throughput_time__a1b2` after `query info` failed
- source-template ran `transformations list 00000000-0000-0000-0000-000000000001` after `apps create` failed, and `app-types get uipath.p2p.sap 1.0.0`

Those are exactly the three criteria that scored 0.0 on the board.

**Guard regex** tested against 9 cases through a `yaml.safe_load` round-trip, so the tested pattern is byte-identical to what the runner compiles. Valid ids (bare, double-quoted, single-quoted, multi-space) don't fire; bare column names (quoted and unquoted) do; sibling commands don't. The two negative lookaheads are both load-bearing — a naive `--field\s+["']?(?!F__)` false-positives on `--field "F__…"` and on multi-space, which would have docked correct agents.

**Also clean:** `scripts/check-cli-verbs.py` on both files, `coder-eval plan` on both.

## Caveats

- The local run resolved to `claude-code (claude-sonnet-4-6)`; the board failures were `codex (gpt-5.6-terra)`. The fix targets the prompt, which both agents read, but **the next board run is the real confirmation** — the codex agent is the one that bailed early.
- Local `uip` fails with "Not logged in" rather than the sandbox's 404. Arguably an easier failure to push through, which is the other reason to watch the board run.
- The negative criteria passing means nothing bad happened, not that the guard would catch a violation — no agent in this run tried a bare column name. Its catch behaviour rests on the regex test above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
