### PR TITLE
fix(tests): resolve uipath-review RPA grader shared-import under coder-eval 0.11 isolation

### DIFF
--- a/tests/tasks/uipath-review/rpa/coded-structural/check_coded_structural.py
+++ b/tests/tasks/uipath-review/rpa/coded-structural/check_coded_structural.py
@@ -13,7 +13,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "CodedProc"

--- a/tests/tasks/uipath-review/rpa/credential-security/check_credential_security.py
+++ b/tests/tasks/uipath-review/rpa/credential-security/check_credential_security.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 # SecureString / Get Credential are the FIX. Count them only when the report

--- a/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/check_e2e_multi_project_solution.py
+++ b/tests/tasks/uipath-review/rpa/e2e-multi-project-solution/check_e2e_multi_project_solution.py
@@ -15,7 +15,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "RetailSolution"

--- a/tests/tasks/uipath-review/rpa/e2e-reframework-process/check_e2e_reframework_process.py
+++ b/tests/tasks/uipath-review/rpa/e2e-reframework-process/check_e2e_reframework_process.py
@@ -22,7 +22,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "RefxFull"

--- a/tests/tasks/uipath-review/rpa/exception-classification/check_exception_classification.py
+++ b/tests/tasks/uipath-review/rpa/exception-classification/check_exception_classification.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "ExceptionBot"

--- a/tests/tasks/uipath-review/rpa/hardcoded-config/check_hardcoded_config.py
+++ b/tests/tasks/uipath-review/rpa/hardcoded-config/check_hardcoded_config.py
@@ -12,7 +12,11 @@ URL must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "HardcodedBot"

--- a/tests/tasks/uipath-review/rpa/logging-pii/check_logging_pii.py
+++ b/tests/tasks/uipath-review/rpa/logging-pii/check_logging_pii.py
@@ -14,7 +14,11 @@ import os
 import re
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "LoggingBot"

--- a/tests/tasks/uipath-review/rpa/performance-datatable/check_performance_datatable.py
+++ b/tests/tasks/uipath-review/rpa/performance-datatable/check_performance_datatable.py
@@ -12,7 +12,11 @@ must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "PerfBot"

--- a/tests/tasks/uipath-review/rpa/reframework-integrity/check_reframework_integrity.py
+++ b/tests/tasks/uipath-review/rpa/reframework-integrity/check_reframework_integrity.py
@@ -13,7 +13,11 @@ correctly" does not count. The planted swallow must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "REFrameworkBot"

--- a/tests/tasks/uipath-review/rpa/selector-brittle/check_selector_brittle.py
+++ b/tests/tasks/uipath-review/rpa/selector-brittle/check_selector_brittle.py
@@ -11,7 +11,11 @@ planted idx selector must still exist in the fixture.
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "BrittleBot"

--- a/tests/tasks/uipath-review/rpa/transaction-shape/check_transaction_shape.py
+++ b/tests/tasks/uipath-review/rpa/transaction-shape/check_transaction_shape.py
@@ -13,7 +13,11 @@ planted loop must also still exist in the sandbox fixture (guards shell edits).
 import os
 import sys
 
-sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
+                        "tests", "tasks", "uipath-review", "rpa", "_shared")
+           if os.environ.get("SKILLS_REPO_PATH")
+           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
+sys.path.insert(0, _shared)
 from grader_common import report_text, asserts, asserts_any, fixture_contains  # noqa: E402
 
 PROJECT = "TxnShapeBot"


### PR DESCRIPTION
## Problem

coder-eval 0.11 isolates each grader to a copy at `$TASK_DIR` (`/work/task_dir/`) and no longer exposes the task dir's parent. The uipath-review RPA graders imported their shared helper via a relative up-walk:

```python
sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
from grader_common import ...
```

Under isolation `../_shared` resolves to `/work/_shared` (missing) → `ModuleNotFoundError: grader_common`. The grader's `run_command` criterion then scored **0.0** and the task FAILED even though the agent ran fine — this false-negatived **8 RPA review tasks** in CI smoke (the graders crashed on import, not the automations).

### Why `stage_shared.sh` doesn't cover this

`tests/scripts/stage_shared.sh` does not stage these graders' helper:

- Its detector matches `from _shared` / `import _shared`; these graders say `from grader_common`.
- It stages the group-top `tests/tasks/uipath-review/_shared`, while `grader_common.py` lives in the **nested** `tests/tasks/uipath-review/rpa/_shared/`.

## Fix

Switch the 11 affected graders to a `SKILLS_REPO_PATH`-rooted absolute path, with the proven `../_shared` relative path as fallback:

```python
_shared = (os.path.join(os.environ["SKILLS_REPO_PATH"],
                        "tests", "tasks", "uipath-review", "rpa", "_shared")
           if os.environ.get("SKILLS_REPO_PATH")
           else os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "_shared"))
sys.path.insert(0, _shared)
```

- Env-var branch fixes CI/docker isolation.
- Fallback is identical to today's behavior → cannot regress stray local runs.
- `grader_common.py` stays in place; no de-nesting, no `__init__.py`, no changes to `grader_common.py` or `stage_shared.sh`.

Completes the coder-eval 0.11 migration for these graders. `legacy-precision` is untouched — it does not import `grader_common` and already uses `SKILLS_REPO_PATH` correctly.

## Scope

11 graders under `tests/tasks/uipath-review/rpa/` (one line each): coded-structural, credential-security, e2e-multi-project-solution, e2e-reframework-process, exception-classification, hardcoded-config, logging-pii, performance-datatable, reframework-integrity, selector-brittle, transaction-shape.

## Validation

Ran a representative of each variant + one e2e directly, with and without `SKILLS_REPO_PATH`. All get **past the import** (no `ModuleNotFoundError`) and fail on the expected missing `_review_report.md` fixture — proving the import now resolves:

```
$ SKILLS_REPO_PATH=$(pwd) python3 .../credential-security/check_credential_security.py
FAIL: .../_review_report.md not found        # import resolved ✓
$ (cd task dir) python3 check_credential_security.py
FAIL: .../_review_report.md not found        # import resolved ✓
```

Same for `coded-structural` (Variant A) and `e2e-reframework-process` (e2e). Docker gate not available in this environment (no coder-eval venv installed).

> Opened as its own focused PR (not folded into #2740) — it fixes a latent bug on `main` affecting all consumers and unblocks #2740's smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)