### PR TITLE
test(functions): stop smoke trigger on skill read, allow three tool calls

### DIFF
--- a/tests/tasks/uipath-functions/smoke/smoke_trigger.yaml
+++ b/tests/tasks/uipath-functions/smoke/smoke_trigger.yaml
@@ -3,18 +3,25 @@ description: >
   Smoke test: agent should trigger the uipath-functions skill when asked to
   build a deterministic Python coded function with typed I/O that runs as a
   UiPath job. Fans out over five direct "scaffold a coded function" requests
-  (one agent turn each, which forces an invoke-or-don't decision rather than a
-  prose answer) and grades the trigger RATE (recall.yes) so single-run LLM
-  routing nondeterminism doesn't flake the gate. Verifies the skill fires on
-  the Python Functions signal (no LLM reasoning) and is NOT routed elsewhere.
+  (a budget of three tool calls each — enough to force an invoke-or-don't
+  decision, not enough for a full build) and grades the trigger RATE
+  (recall.yes) so single-run LLM routing nondeterminism doesn't flake the gate.
+  Verifies the skill fires on the Python Functions signal (no LLM reasoning)
+  and is NOT routed elsewhere.
 tags: [uipath-functions, smoke, mode:build, lifecycle:discover]
 
 run_limits:
-  # One turn forces invoke-or-don't on the first response — the agent can't
-  # answer in prose and skip the Skill tool, and can't burn turns doing a full
-  # build. Mirrors the activation eval, where direct build prompts trigger
-  # functions reliably.
-  max_turns: 1
+  # For Codex, coder-eval counts max_turns in tool calls (one per resolved tool
+  # call — see EventCollector.visible_turn_count), so this is a budget of three
+  # shell commands: still far short of a build. With stop_early on_pass the run
+  # ends the moment SKILL.md is read, so this cap only bounds a miss. It gives
+  # slack for the habit Codex shows on ~10% of runs — it announces the skill in
+  # prose, spends the first call on a workspace listing (`rg --files`), and only
+  # reads SKILL.md on the second. With max_turns=1 that read never happened and
+  # the row scored a miss even though routing was correct. Observed reads land
+  # on call 1 or 2; 3 is one step of margin. skill_triggered scans every
+  # recorded command, so a later read still counts.
+  max_turns: 3
 
 dataset:
   id_field: id
@@ -57,3 +64,8 @@ success_criteria:
     # 0.66 → 4/5 (0.8) passes, 3/5 (0.6) fails. Rate-grading instead of a single
     # run avoids n=1 routing-nondeterminism flake.
     suite_thresholds: {recall.yes: 0.66}
+    # Pass-stop: end the run the moment SKILL.md is read, so a hit finishes in
+    # one or two tool calls and is reported as a clean stop rather than as the
+    # turn cap running out. Only a miss burns the whole max_turns budget.
+    stop_early:
+      on_pass: stop


### PR DESCRIPTION
Fixes the flaky `skill-functions-python-smoke-trigger` suite by giving Codex room for a one-command recon before it reads `SKILL.md`, and ending the run as soon as the read happens.

## Why

The task ran with `max_turns: 1`. For Codex, coder-eval counts `max_turns` in tool calls (`EventCollector.visible_turn_count`), so that was one shell command. On ~10% of runs Codex announces the skill in prose, spends the one call on `rg --files`, and only reads `SKILL.md` on the next call — the row then scores `skill_triggered: observed='no'` even though it routed correctly. Three of the last ~30 CI/Azure runs ([run 32827775913](https://github.com/UiPath/skills/actions/runs/32827775913) attempt 5, plus two Azure runs) failed exactly this way, each on a different prompt.

## Change

- `run_limits.max_turns: 1 → 3`. Observed reads land on call 1 or 2; 3 is one step of margin. Still nowhere near a build.
- `stop_early: {on_pass: stop}` on the `skill_triggered` criterion, same pattern as `tests/tasks/activation/activation.yaml`. The run ends the moment `SKILL.md` is read, so the cap only bounds a genuine miss and passing runs no longer log `Agent exhausted max_turns … without passing criteria`.

## Verification

Local, coder-eval 0.11.2 (the CI pin), codex / gpt-5.6-terra, `experiments/default.yaml`:

| Config | Runs | Pass | Recon-first rescued by call 2 |
|---|---|---|---|
| cap=2 | 15 | 15 | 2 |
| cap=2 + pass-stop | 10 | 10 | 1 |
| cap=3 + pass-stop (this PR) | 10 | 10 | 0 occurred |

Not run in docker / on the GH workflow; the smoke test doesn't touch a tenant, so the tempdir driver exercises the same path.

## Not in this PR

- The workflow's verdict step in `run-coder-eval.yml` is all-or-nothing per task and never reads the `suite_thresholds: {recall.yes: 0.66}` rollup that coder-eval computes (`gate=PASS` at 4/5 while the job went red). This PR lowers the miss rate; it doesn't make the gate rate-based.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
